### PR TITLE
PR-MAINPATH-67 — delete legacy AgenticLLMPort surface (final main-path migration step)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,61 @@ functional change.
 
 ### Removed
 
+- **PR-MAINPATH-67 — final delete of the legacy `AgenticLLMPort` surface.**
+  Closes the AgenticLoop main-path migration sprint started by
+  PR-MAINPATH-1. Two source files deleted (599 LOC total):
+  ``core/llm/adapters/_legacy.py`` (422 LOC; held the
+  ``AgenticLLMPort`` Protocol, ``resolve_agentic_adapter`` factory,
+  ``_ADAPTER_MAP`` registry) and ``core/llm/adapters/_legacy_bridge.py``
+  (177 LOC; held ``build_adapter_request`` +
+  ``agentic_response_from_adapter_result``).
+  Symbols still in production use that lived in the deleted file
+  moved to **domain-named modules** per the Naming CANNOTs (no
+  ``_legacy`` / ``_helpers`` suffix once a caller appears):
+  - ``core/llm/adapters/paperclip.py`` (285 LOC, new) — host of
+    ``LLMClientPort`` Protocol + ``ClaudeAdapter`` wrapper +
+    ``LLM*Callable`` Protocols. Name borrows from the paperclip-style
+    abstraction the J-b.1 series established.
+  - ``core/llm/adapters/provider_inference.py`` (68 LOC, new) — host
+    of ``infer_provider_from_model`` (used by ``plugins/petri_audit``).
+  - ``core/llm/adapters/translation.py`` (173 LOC, new) — host of
+    ``build_adapter_request`` + ``agentic_response_from_adapter_result``
+    (sole consumer is now ``AgenticLoop._call_llm``).
+  Re-exports stripped: ``core/llm/adapters/__init__.py`` drops
+  ``AgenticLLMPort`` + ``resolve_agentic_adapter`` + ``_ADAPTER_MAP``;
+  ``core/llm/router/__init__.py`` + ``core/agent/loop/__init__.py``
+  drop ``resolve_agentic_adapter`` re-export.
+  AgenticLoop:
+  - ``core/agent/loop/agent_loop.py.__init__`` no longer constructs
+    ``self._adapter``. ``_call_llm`` is Path-B-only — the
+    ``if self._new_adapter is not None:`` guard + the
+    ``else: response = await self._adapter.agentic_call(...)``
+    fallback branch are both gone. ``last_error`` reads
+    ``self._new_adapter._last_error`` / ``self._last_llm_error``
+    directly.
+  - ``core/agent/loop/_model_switching.py`` — the
+    ``_resolve_agentic_adapter`` shim deleted; ``_apply_model_update``
+    only re-resolves ``_new_adapter``.
+  Provider-level ``agentic_call`` methods (in
+  ``core/llm/providers/{anthropic,openai,glm,codex}.py``) **stay**
+  because they're independently tested and not in the AgenticLoop's
+  call path — their migration is out of scope for this PR.
+  Test rewires: ``tests/test_model_failover.py::TestAgenticLoopFailover``
+  4 tests now mock ``_new_adapter.acomplete`` via a new
+  ``_install_acomplete_stub`` helper; ``tests/test_provider_switching.py``
+  no longer asserts on ``resolve_agentic_adapter``;
+  ``tests/core/llm/adapters/test_legacy_bridge.py`` →
+  ``tests/core/llm/adapters/test_translation.py`` (file moved + import
+  paths updated); ``tests/test_agentic_loop.py::test_adapter_initialized_at_construction``
+  now asserts ``_new_adapter.provider == "anthropic"``;
+  ``tests/test_model_escalation.py``, ``tests/test_startup.py``,
+  ``tests/test_provider_label_consistency.py``, ``tests/test_codex_provider.py``,
+  ``tests/test_model_switch_guard.py``, ``tests/core/agent/test_agent_loop_source_route.py``
+  all migrate to read ``_new_adapter``. **Resolves deferred-item #4
+  from the v0.99.48 sprint summary.**
+
+### Removed
+
 - **PR-MAINPATH-5 — `CircuitBreaker` removed entirely.** The
   module-level breaker singleton in
   ``core/llm/fallback.py:CircuitBreaker`` (62 LOC) plus every

--- a/core/agent/loop/__init__.py
+++ b/core/agent/loop/__init__.py
@@ -11,13 +11,18 @@ external callers rely on::
         get_agentic_tools,
     )
 
-Some lower-level names (``_resolve_provider``, ``resolve_agentic_adapter``,
-``_EFFORT_LEVELS``) are also addressable on the package because tests
-monkey-patch them via the legacy dotted path
-``core.agent.loop.<name>``. v0.57.0 R6 — the run loop emits each
-reasoning summary the adapter attaches via ``emit_reasoning_summary``;
-the call site lives in ``agent_loop._call_llm`` but the symbol is
-mentioned here so introspection tests reading this file can find it.
+The lower-level ``_resolve_provider`` / ``_EFFORT_LEVELS`` names are
+also addressable on the package because tests monkey-patch them via the
+legacy dotted path ``core.agent.loop.<name>``. v0.57.0 R6 — the run
+loop emits each reasoning summary the adapter attaches via
+``emit_reasoning_summary``; the call site lives in
+``agent_loop._call_llm`` but the symbol is mentioned here so
+introspection tests reading this file can find it.
+
+PR-MAINPATH-67 (2026-05-24) — the legacy ``resolve_agentic_adapter``
+re-export was deleted alongside the AgenticLoop fallback branch; all
+dispatch now flows through ``LLMAdapter.acomplete`` via
+``core.llm.adapters.resolve_for``.
 """
 
 from __future__ import annotations
@@ -28,7 +33,6 @@ from __future__ import annotations
 # similar patches reach the call sites in ``_model_switching``. The
 # split-into-package refactor preserves this surface.
 from core.config import _resolve_provider as _resolve_provider
-from core.llm.router import resolve_agentic_adapter as resolve_agentic_adapter
 
 from ._helpers import AGENTIC_TOOLS, MAX_TOOL_RESULT_TOKENS, get_agentic_tools
 from .agent_loop import AgenticLoop
@@ -49,5 +53,4 @@ __all__ = [
     "_context_exhausted_message",
     "_resolve_provider",
     "get_agentic_tools",
-    "resolve_agentic_adapter",
 ]

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -24,26 +24,8 @@ def _resolve_provider(model: str) -> str:
     return _loop_pkg._resolve_provider(model)
 
 
-def _resolve_agentic_adapter(provider: str):  # type: ignore[no-untyped-def]
-    """Late-bound lookup so ``monkeypatch.setattr("core.agent.loop.resolve_agentic_adapter", ...)``
-    reaches this module's call sites.
-
-    PR-MAINPATH-1 (2026-05-24) flipped ``AgenticLoop.__init__`` to
-    populate the Path-B ``_new_adapter`` by default. PR-MAINPATH-4
-    (2026-05-24) extends the same routing to ``_apply_model_update``
-    so a runtime ``/model`` switch updates *both* the legacy adapter
-    surface (``loop._adapter``) and the Path-B adapter
-    (``loop._new_adapter``). Without that, ``/model`` between providers
-    would leave the agentic loop calling the previous provider's
-    Path-B adapter on the next round.
-    """
-    from core.agent import loop as _loop_pkg
-
-    return _loop_pkg.resolve_agentic_adapter(provider)
-
-
 def _resolve_path_b_adapter(provider: str, source: str):  # type: ignore[no-untyped-def]
-    """Path-B counterpart of :func:`_resolve_agentic_adapter`.
+    """Resolve a Path-B :class:`LLMAdapter` for ``(provider, source)``.
 
     PR-MAINPATH-4 (2026-05-24) — mirrors the
     ``AgenticLoop.__init__``-side normalisation introduced in
@@ -52,8 +34,12 @@ def _resolve_path_b_adapter(provider: str, source: str):  # type: ignore[no-unty
     with the Codex source encoded on the ``source`` axis as
     ``subscription``). Hard-fail contract preserved per Codex MCP
     2026-05-23 HIGH 2 — ``resolve_for`` raises when the registered
-    ``(provider, source)`` pair is missing rather than silently
-    falling back to the legacy adapter.
+    ``(provider, source)`` pair is missing.
+
+    PR-MAINPATH-67 (2026-05-24) — the legacy
+    ``_resolve_agentic_adapter`` shim was deleted alongside the rest
+    of the legacy resolver surface; this function is now the sole
+    adapter factory used by ``/model`` switching.
     """
     from core.llm.adapters import CONCRETE_SOURCES, resolve_for
 
@@ -162,15 +148,16 @@ def _apply_model_update(
     new_provider = provider or _resolve_provider(model)
     if new_provider != loop._provider:
         loop._provider = new_provider
-        loop._adapter = _resolve_agentic_adapter(new_provider)
         # PR-MAINPATH-4 (2026-05-24) — re-resolve the Path-B adapter
-        # alongside the legacy one. Without this, ``/model`` between
-        # providers would leave ``loop._new_adapter`` pointing at the
-        # previous provider's adapter and the next ``_call_llm`` would
-        # dispatch to the wrong API. ``loop._source`` was set at init
-        # (defaults to ``"payg"``) and stays constant across the
-        # switch — operators don't expect ``/model`` to also flip the
-        # source axis.
+        # on a provider change so ``/model`` between providers points
+        # ``loop._new_adapter`` at the new provider's adapter (else the
+        # next ``_call_llm`` would dispatch to the wrong API).
+        # ``loop._source`` was set at init (defaults to ``"payg"``)
+        # and stays constant across the switch — operators don't
+        # expect ``/model`` to also flip the source axis.
+        # PR-MAINPATH-67 (2026-05-24) — the legacy ``loop._adapter``
+        # re-resolution was deleted with the rest of the resolver
+        # surface; Path-B is now the sole call path.
         loop._new_adapter = _resolve_path_b_adapter(new_provider, loop._source)
     loop.model = model
     loop._tool_processor._model = model
@@ -357,9 +344,14 @@ def fallback_chain_suggestions(loop: AgenticLoop) -> list[str]:
     Used by the loop to populate ``suggested_models`` in the
     ``model_action_required`` diagnostic. The user picks one and runs
     ``/model <id>``; we never auto-switch.
+
+    PR-MAINPATH-67 (2026-05-24) — reads from the Path-B adapter
+    (``loop._new_adapter``). Path-B adapters that don't expose a
+    ``fallback_chain`` attribute return an empty list, matching the
+    v0.99.19 shipped default (no silent fallback).
     """
     current = loop.model
-    chain = list(getattr(loop._adapter, "fallback_chain", []) or [])
+    chain = list(getattr(loop._new_adapter, "fallback_chain", []) or [])
     if current in chain:
         idx = chain.index(current)
         return chain[idx + 1 :]

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -29,9 +29,6 @@ from core.config import (
 from core.hooks import HookEvent, HookSystem
 from core.llm.agentic_response import AgenticResponse
 from core.llm.errors import BillingError, UserCancelledError
-from core.llm.router import (
-    resolve_agentic_adapter,
-)
 from core.ui.agentic_ui import OperationLogger
 from core.ui.status import TextSpinner
 
@@ -179,42 +176,33 @@ class AgenticLoop:
         # misconfiguration (Codex MCP 2026-05-23 HIGH 2).
         # PR-MAINPATH-1 (2026-05-24) — Path-B default cutover. The
         # ``source=""`` default previously landed on the legacy
-        # ``resolve_agentic_adapter`` branch; only sub-agent workers
-        # (``WorkerRequest.source``) explicitly opted into the Path-B
-        # route via ``resolve_for``. Step 1 of the AgenticLoop main-path
-        # migration makes Path-B the resolver default ("payg" matches
-        # the J-b.2 mutator runner + J-b.3 reflection node, so all three
-        # main callers now share one registry surface).
+        # ``resolve_agentic_adapter`` branch; Step 1 of the AgenticLoop
+        # main-path migration made Path-B the resolver default ("payg"
+        # matches the J-b.2 mutator runner + J-b.3 reflection node, so
+        # all three main callers share one registry surface).
+        # PR-MAINPATH-67 (2026-05-24) — final cutover: the legacy
+        # ``AgenticLLMPort`` resolver + ``self._adapter`` field were
+        # deleted. ``self._last_llm_error`` is now the sole error
+        # surface that feeds the agentic UI (see :meth:`_call_llm`).
         # The hard-fail contract from the Codex MCP 2026-05-23 HIGH 2
         # review ("no silent fallback") is preserved — if the requested
         # ``(provider, source)`` isn't in the registry, ``resolve_for``
-        # raises and the loop refuses to start rather than silently
-        # routing through the legacy adapter. The legacy ``self._adapter``
-        # stays initialised because ``getattr(self._adapter, "last_error", None)``
-        # at lines 1372 / 2013 still feeds the agentic UI's error
-        # surface; subsequent main-path PRs delete it once the error
-        # surface migrates.
+        # raises and the loop refuses to start.
         self._source = source or "payg"
-        self._new_adapter: Any | None = None
-        from core.llm.adapters import CONCRETE_SOURCES, resolve_for
+        from core.llm.adapters import resolve_for
 
-        if self._source in CONCRETE_SOURCES:
-            # Hard-fail on resolve mismatch — concrete source MUST resolve.
-            # The Path-B registry uses a narrower provider vocabulary
-            # than ``_resolve_provider``: gpt-5.x models map to
-            # ``openai-codex`` in the legacy AgenticLLMPort path but
-            # collapse to ``openai`` in the registry (the Codex source is
-            # encoded on the ``source`` axis as ``subscription``).
-            # Same shape as :func:`core.self_improving_loop.runner._normalize_provider_for_registry`
-            # and :func:`core.agent.loop._reflection._normalize_provider_for_registry`;
-            # this third copy stays inline rather than hoisted because
-            # the helper is 4 lines and PR-MAINPATH-4 (the
-            # ``_model_switching`` migration) will fold all three into
-            # one helper at that stage.
-            _PROVIDER_NORMALIZATION = {"openai-codex": "openai", "zhipuai": "glm"}
-            registry_provider = _PROVIDER_NORMALIZATION.get(self._provider, self._provider)
-            self._new_adapter = resolve_for(registry_provider, self._source)
-        self._adapter = resolve_agentic_adapter(self._provider)
+        # The Path-B registry uses a narrower provider vocabulary than
+        # ``_resolve_provider``: gpt-5.x models map to ``openai-codex``
+        # in the legacy provider key but collapse to ``openai`` in the
+        # registry (the Codex source is encoded on the ``source`` axis
+        # as ``subscription``).
+        # Same shape as :func:`core.self_improving_loop.runner._normalize_provider_for_registry`
+        # and :func:`core.agent.loop._reflection._normalize_provider_for_registry`;
+        # this third copy stays inline rather than hoisted because the
+        # helper is 4 lines.
+        _PROVIDER_NORMALIZATION = {"openai-codex": "openai", "zhipuai": "glm"}
+        registry_provider = _PROVIDER_NORMALIZATION.get(self._provider, self._provider)
+        self._new_adapter: Any = resolve_for(registry_provider, self._source)
         self._op_logger = OperationLogger(quiet=self._quiet)
         self._error_recovery = ErrorRecoveryStrategy(tool_executor)
 
@@ -1396,9 +1384,13 @@ class AgenticLoop:
                 # Classify error for type-specific retry strategy.
                 # Defaults cover the case where the adapter swallowed the
                 # original exception (None response without a trailing
-                # ``last_error``); the diagnostic builder still needs
-                # ``_sev`` / ``_hint`` populated.
-                adapter_exc = getattr(self._adapter, "last_error", None)
+                # ``_last_error``); the diagnostic builder still needs
+                # ``_sev`` / ``_hint`` populated. PR-MAINPATH-67
+                # (2026-05-24) — reads from the Path-B adapter's
+                # ``_last_error`` (preserved across providers); legacy
+                # ``self._adapter.last_error`` access was deleted with
+                # the resolver.
+                adapter_exc = getattr(self._new_adapter, "_last_error", None)
                 from core.llm.errors import _ERROR_CLASSIFICATION
 
                 _et, _sev, _hint = _ERROR_CLASSIFICATION["unknown"]
@@ -1931,9 +1923,9 @@ class AgenticLoop:
         round_idx: int = 0,
         model: str | None = None,
     ) -> AgenticResponse | None:
-        """Multi-provider LLM call via adapter (P1 Gateway pattern).
+        """Multi-provider LLM call via :class:`LLMAdapter` (P1 Gateway pattern).
 
-        Delegates to ``self._adapter.agentic_call()`` which handles
+        Delegates to ``self._new_adapter.acomplete()`` which handles
         provider-specific message/tool conversion, retry, and failover.
         Returns a normalized ``AgenticResponse`` or None on failure.
         Raises ``UserCancelledError`` on Ctrl+C (caught by ``arun()``).
@@ -1942,9 +1934,14 @@ class AgenticLoop:
         (verify judge, future Plan/Act split) request a non-default model
         for one call without mutating ``self.model``. Falls back to
         ``self.model`` when ``None``. The override threads through to
-        the adapter's ``agentic_call(model=...)`` parameter; the rest of
-        the loop (token tracker, retry budget, ContextVar metrics) is
-        unaffected.
+        the adapter request's ``model`` field; the rest of the loop
+        (token tracker, retry budget, ContextVar metrics) is unaffected.
+
+        PR-MAINPATH-67 (2026-05-24) — the legacy ``_adapter.agentic_call``
+        fallback branch was deleted; all dispatch now routes through the
+        Path-B ``LLMAdapter.acomplete`` surface unconditionally
+        (``self._new_adapter`` is resolved in :meth:`__init__` and
+        hard-fails on missing registration).
         """
         effective_model = model or self.model
         # Sandwich injection: prepend system reminder to messages (Claude Code pattern)
@@ -1992,54 +1989,44 @@ class AgenticLoop:
         # the frontier-API grounding behind the new 1.0 default.
         loop_temperature = _settings.temperature_agent_loop
 
-        if self._new_adapter is not None:
-            # v0.99.40 Follow-up A — opt-in adapter route. Build adapter-neutral
-            # request, call ``LLMAdapter.acomplete``, translate result back to
-            # ``AgenticResponse`` so the rest of the loop (tool dispatch, cost
-            # tracking, retry budget) is unchanged.
-            from core.llm.adapters._legacy_bridge import (
-                agentic_response_from_adapter_result,
-                build_adapter_request,
-            )
+        # PR-MAINPATH-67 (2026-05-24) — Path-B only. Build
+        # adapter-neutral request, call ``LLMAdapter.acomplete``,
+        # translate result back to ``AgenticResponse`` so the rest of
+        # the loop (tool dispatch, cost tracking, retry budget) is
+        # unchanged. The legacy ``self._adapter.agentic_call`` branch
+        # was deleted; ``self._new_adapter`` is guaranteed non-None by
+        # ``__init__``'s hard-fail :func:`resolve_for` call.
+        from core.llm.adapters.translation import (
+            agentic_response_from_adapter_result,
+            build_adapter_request,
+        )
 
-            req = build_adapter_request(
-                model=effective_model,
-                system=system,
-                messages=messages,
-                tools=self._tools,
-                tool_choice=tool_choice,
-                max_tokens=adaptive_max_tokens,
-                temperature=loop_temperature,
-                thinking_budget=adaptive_thinking,
-                effort=adaptive_effort,
+        req = build_adapter_request(
+            model=effective_model,
+            system=system,
+            messages=messages,
+            tools=self._tools,
+            tool_choice=tool_choice,
+            max_tokens=adaptive_max_tokens,
+            temperature=loop_temperature,
+            thinking_budget=adaptive_thinking,
+            effort=adaptive_effort,
+        )
+        try:
+            result = await self._new_adapter.acomplete(req)
+        except Exception as exc:
+            self._last_llm_error = str(exc)
+            log.warning(
+                "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
+                getattr(self._new_adapter, "name", "<unknown>"),
+                exc,
             )
-            try:
-                result = await self._new_adapter.acomplete(req)
-            except Exception as exc:
-                self._last_llm_error = str(exc)
-                log.warning(
-                    "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
-                    getattr(self._new_adapter, "name", "<unknown>"),
-                    exc,
-                )
-                response = None
-            else:
-                response = agentic_response_from_adapter_result(result)
+            response = None
         else:
-            response = await self._adapter.agentic_call(
-                model=effective_model,
-                system=system,
-                messages=messages,
-                tools=self._tools,
-                tool_choice=tool_choice,
-                max_tokens=adaptive_max_tokens,
-                temperature=loop_temperature,
-                thinking_budget=adaptive_thinking,
-                effort=adaptive_effort,
-            )
+            response = agentic_response_from_adapter_result(result)
 
         if response is None:
-            adapter_err = getattr(self._adapter, "last_error", None)
+            adapter_err = getattr(self._new_adapter, "_last_error", None)
             if adapter_err:
                 self._last_llm_error = str(adapter_err)
             elif not self._last_llm_error:

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -121,12 +121,14 @@ class SubTask:
 
     ``source`` (v0.99.40 Follow-up A): one of
     :data:`core.llm.adapters.CONCRETE_SOURCES` (``"payg"`` / ``"subscription"`` /
-    ``"adapter"``) or empty for legacy routing. When set, the spawned worker's
-    :class:`AgenticLoop` uses :func:`core.llm.adapters.resolve_for` to pick
-    the concrete :class:`LLMAdapter` instead of the legacy provider-only
-    ``resolve_agentic_adapter``. The picker (``plugins/seed_generation/
-    picker.py``) translates its ``RoleBinding.source`` into one of the
-    concrete values via :func:`binding_to_adapter_source`.
+    ``"adapter"``) or empty to inherit the parent loop's default
+    (``"payg"``). The spawned worker's :class:`AgenticLoop` uses
+    :func:`core.llm.adapters.resolve_for` to pick the concrete
+    :class:`LLMAdapter` (PR-MAINPATH-67 deleted the legacy provider-only
+    ``resolve_agentic_adapter`` fallback). The picker
+    (``plugins/seed_generation/picker.py``) translates its
+    ``RoleBinding.source`` into one of the concrete values via
+    :func:`binding_to_adapter_source`.
     """
 
     task_id: str
@@ -134,7 +136,7 @@ class SubTask:
     task_type: str  # "analyze", "search", "compare"
     args: dict[str, Any] = field(default_factory=dict)
     agent: str | None = None  # Explicit agent override
-    source: str = ""  # adapter source; empty = legacy routing
+    source: str = ""  # adapter source; empty falls back to "payg"
 
 
 @dataclass

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -78,8 +78,10 @@ class WorkerRequest:
     # v0.99.40 Follow-up A — adapter source for the new
     # :class:`core.llm.adapters.LLMAdapter` registry. Concrete value
     # (``"payg"`` / ``"subscription"`` / ``"adapter"``) when the parent's
-    # picker / orchestrator resolved a specific path; empty string falls
-    # back to legacy ``resolve_agentic_adapter(provider)`` routing.
+    # picker / orchestrator resolved a specific path; empty string is
+    # normalised to ``"payg"`` by ``AgenticLoop.__init__``
+    # (PR-MAINPATH-67 deleted the legacy ``resolve_agentic_adapter``
+    # fallback route — all dispatch now goes through Path-B).
     source: str = ""
 
     def to_dict(self) -> dict[str, Any]:

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -315,7 +315,7 @@ class MutatorConfig(BaseModel):
     """Mirrors :data:`Source`. The router's credential rotator
     consumes the same enum implicitly via ``[petri.source.<provider>]``."""
     max_tokens: Annotated[int, Field(ge=128, le=200_000)] = 1024
-    """Passed through to ``adapter.agentic_call``."""
+    """Passed through to ``adapter.acomplete``."""
 
 
 class SeedGenerationConfig(BaseModel):

--- a/core/llm/adapters/__init__.py
+++ b/core/llm/adapters/__init__.py
@@ -15,19 +15,15 @@ Layer 3 concrete adapters (one per provider × source pair):
 
 External plugins implement :class:`LLMAdapter` and register via
 :func:`register_adapter` from their entry point.
+
+PR-MAINPATH-67 (2026-05-24) — the legacy ``AgenticLLMPort`` /
+``resolve_agentic_adapter`` / ``_ADAPTER_MAP`` surface was deleted
+alongside the AgenticLoop fallback branch. Surviving paperclip
+contracts moved to :mod:`core.llm.adapters.paperclip` and
+:mod:`core.llm.adapters.provider_inference`; the AgenticLoop
+translation helpers moved to :mod:`core.llm.adapters.translation`.
 """
 
-from core.llm.adapters._legacy import (
-    _ADAPTER_MAP,
-    AgenticLLMPort,
-    ClaudeAdapter,
-    LLMClientPort,
-    LLMJsonCallable,
-    LLMParsedCallable,
-    LLMTextCallable,
-    infer_provider_from_model,
-    resolve_agentic_adapter,
-)
 from core.llm.adapters.base import (
     CONCRETE_SOURCES,
     SOURCE_ADAPTER,
@@ -47,6 +43,14 @@ from core.llm.adapters.base import (
     ToolSpec,
     UsageSummary,
 )
+from core.llm.adapters.paperclip import (
+    ClaudeAdapter,
+    LLMClientPort,
+    LLMJsonCallable,
+    LLMParsedCallable,
+    LLMTextCallable,
+)
+from core.llm.adapters.provider_inference import infer_provider_from_model
 from core.llm.adapters.registry import (
     AdapterAlreadyRegisteredError,
     AdapterNotFoundError,
@@ -65,13 +69,11 @@ __all__ = [
     "SOURCE_AUTO",
     "SOURCE_PAYG",
     "SOURCE_SUBSCRIPTION",
-    "_ADAPTER_MAP",
     "AdapterAlreadyRegisteredError",
     "AdapterBillingType",
     "AdapterCallRequest",
     "AdapterCallResult",
     "AdapterNotFoundError",
-    "AgenticLLMPort",
     "ClaudeAdapter",
     "CredentialDetection",
     "EnvironmentReport",
@@ -92,7 +94,6 @@ __all__ = [
     "infer_provider_from_model",
     "list_adapters",
     "register_adapter",
-    "resolve_agentic_adapter",
     "resolve_for",
     "unregister_adapter",
 ]

--- a/core/llm/adapters/paperclip.py
+++ b/core/llm/adapters/paperclip.py
@@ -1,39 +1,28 @@
-"""Legacy LLM Protocol interfaces — pre-v0.99.39 paperclip-style abstraction.
+"""Paperclip-style LLM port protocols + :class:`ClaudeAdapter` wrapper.
 
-DEPRECATED (v0.99.39, removal target: v1.0.0)
-===========================================
+PR-MAINPATH-67 (2026-05-24) — surviving half of the deleted ``_legacy``
+module. The legacy ``AgenticLLMPort`` / ``resolve_agentic_adapter`` /
+``_ADAPTER_MAP`` symbols were deleted alongside the agentic-loop fallback
+branch; the symbols here remain in active use:
 
-This module holds the "PR-1 G-A" paperclip-style abstraction (referenced in
-``core/agent/loop/_reflection.py:48``) that defined ``LLMClientPort`` /
-``AgenticLLMPort`` / ``resolve_agentic_adapter`` for provider-agnostic agentic
-calls. It is superseded by the unified :class:`core.llm.adapters.LLMAdapter`
-Protocol + registry (Layer 4 of the v0.99.39 adapter abstraction) which folds
-PAYG / OAuth / local-agent-cli into a single contract.
+- :class:`LLMClientPort` — Protocol consumed by ``core/runtime.py``,
+  ``core/wiring/container.py``, ``core/verification/cross_llm.py``.
+- :class:`LLMJsonCallable` / :class:`LLMTextCallable` /
+  :class:`LLMParsedCallable` — node-level DI Protocols consumed by
+  ``core/llm/router/_di.py``.
+- :class:`ClaudeAdapter` — thin wrapper that adapts the Protocol surface
+  to the router functions, consumed by ``core/wiring/container.py`` as
+  the default ``LLMClientPort`` implementation.
 
-Why kept under ``_legacy``:
-
-- Many internal callers (``core/agent/loop/_reflection.py``, ``core/llm/router``,
-  ``plugins/petri_audit/*``) still call ``resolve_agentic_adapter(provider)``.
-  Renaming them is out of scope for the v0.99.39 PR — the migration is
-  tracked in ``docs/plans/2026-05-23-llm-adapter-abstraction.md`` § Out of
-  scope.
-- External plugins that import from ``core.llm.adapters`` keep working
-  (``__init__.py`` re-exports the legacy symbols).
-- The new :class:`LLMAdapter` is the canonical entry point for new callers.
-
-Removal plan (v1.0.0): the in-tree call sites are migrated to
-``resolve_for(provider, source)`` (which carries explicit source binding the
-legacy ``resolve_agentic_adapter`` cannot express). This file is then deleted.
+This is **not** the Layer 4 ``LLMAdapter`` Protocol (``base.py``) used
+for agentic loop dispatch; the two contracts are independent and stay
+side-by-side until the paperclip surface is also migrated.
 """
 
 from __future__ import annotations
 
-import importlib
-import logging
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
-
-from core.llm.agentic_response import AgenticResponse
 
 if TYPE_CHECKING:
     # Pydantic is a heavy import (~100 ms cumulative). Push it behind
@@ -42,8 +31,6 @@ if TYPE_CHECKING:
     # forward-reference string at runtime so the annotation still type-
     # checks under mypy.
     from pydantic import BaseModel
-
-log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # LLMClientPort — Protocol interface for LLM provider adapters
@@ -168,139 +155,6 @@ class LLMParsedCallable(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# AgenticLLMPort — Protocol interface for agentic loop LLM adapters
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class AgenticLLMPort(Protocol):
-    """Protocol for agentic loop LLM calls.
-
-    Implementations: ClaudeAgenticAdapter, OpenAIAgenticAdapter, GlmAgenticAdapter.
-
-    ``fallback_chain`` stays as an opt-in knob (v0.99.19): the shipped
-    default in ``core/config/routing.toml`` is an empty list (no
-    silent fallback), but users can populate ``~/.geode/routing.toml``
-    ``[model.fallbacks]`` to explicitly opt into a same-provider chain.
-    """
-
-    @property
-    def provider_name(self) -> str: ...
-
-    @property
-    def fallback_chain(self) -> list[str]: ...
-
-    last_error: Exception | None
-
-    async def agentic_call(
-        self,
-        *,
-        model: str,
-        system: str,
-        messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]],
-        tool_choice: dict[str, str] | str,
-        max_tokens: int,
-        temperature: float,
-        thinking_budget: int = 0,
-        effort: str = "high",
-    ) -> AgenticResponse | None: ...
-
-    async def areset_client(self) -> None: ...
-
-
-# ---------------------------------------------------------------------------
-# resolve_agentic_adapter — factory
-# ---------------------------------------------------------------------------
-
-# Provider -> "module_path:ClassName"
-_ADAPTER_MAP: dict[str, str] = {
-    "anthropic": "core.llm.providers.anthropic:ClaudeAgenticAdapter",
-    "openai": "core.llm.providers.openai:OpenAIAgenticAdapter",
-    "glm": "core.llm.providers.glm:GlmAgenticAdapter",
-    "openai-codex": "core.llm.providers.codex:CodexAgenticAdapter",
-}
-
-# v0.53.0 removed cross-provider auto-swap; v0.99.19 removed the
-# empty-dict back-compat shim ``CROSS_PROVIDER_FALLBACK``. Quota
-# exhaustion surfaces ``BillingError`` → ``quota_exhausted`` IPC event
-# and the user picks the next provider via ``/model``.
-
-
-def resolve_agentic_adapter(provider: str) -> AgenticLLMPort:
-    """Create an agentic adapter for the given provider.
-
-    Uses dynamic import to avoid loading unused providers.
-    """
-    entry = _ADAPTER_MAP.get(provider)
-    if entry is None:
-        # Unknown provider -> default to OpenAI-compatible
-        log.warning("Unknown provider '%s', defaulting to openai adapter", provider)
-        entry = _ADAPTER_MAP["openai"]
-
-    module_path, class_name = entry.rsplit(":", 1)
-    mod = importlib.import_module(module_path)
-    cls = getattr(mod, class_name)
-    adapter: AgenticLLMPort = cls()
-    return adapter
-
-
-def infer_provider_from_model(model: str) -> str:
-    """Return the agentic provider key for a model id.
-
-    Maps a GEODE / inspect_ai model identifier to the matching
-    ``_ADAPTER_MAP`` key. Used by callers that pin a model (e.g. the
-    Petri audit target ``geode/gpt-5.5``) but did not pin a provider —
-    without this helper, ``AgenticLoop`` falls back to its
-    ``provider="anthropic"`` default and the orchestration layer
-    (GoalDecomposer, extract hooks) silent-fails on ``ANTHROPIC_API_KEY``
-    when the OAuth-only environment never had one.
-
-    Rules:
-
-    - ``gpt-*`` / ``o3`` / ``o4-mini`` → ``"openai-codex"`` when a
-      Codex OAuth token is resolvable, else ``"openai"`` (PAYG path).
-    - ``claude-*`` → ``"anthropic"``.
-    - ``glm-*`` → ``"glm"``.
-    - Provider-prefixed ids (``anthropic/...``, ``openai/...``,
-      ``openai-codex/...``, ``geode/<base>``) — the prefix wins for
-      ``openai-codex`` (OAuth-routed), otherwise the bare model id is
-      reclassified by the provider rules above.
-
-    The OAuth probe is read-only and tolerates a missing
-    ``plugins.petri_audit`` package (the predicate lives there because
-    the bridge is plugin-scoped). When the import fails the function
-    falls back to the per-token ``openai`` path.
-    """
-    if not model:
-        return "anthropic"
-
-    raw_prefix = model.split("/", 1)[0] if "/" in model else ""
-    if raw_prefix == "openai-codex":
-        return "openai-codex"
-    if raw_prefix == "anthropic":
-        return "anthropic"
-    if raw_prefix in ("openai", "openai-api"):
-        return "openai"
-
-    base = model.rsplit("/", 1)[-1]
-    if base.startswith("claude-"):
-        return "anthropic"
-    if base.startswith("glm-"):
-        return "glm"
-    if base.startswith("gpt-") or base in ("o3", "o4-mini"):
-        try:
-            from plugins.petri_audit.codex_provider import is_codex_oauth_available
-
-            if is_codex_oauth_available():
-                return "openai-codex"
-        except ImportError:
-            pass
-        return "openai"
-    return "anthropic"
-
-
-# ---------------------------------------------------------------------------
 # ClaudeAdapter — thin wrapper that delegates to router functions
 # ---------------------------------------------------------------------------
 
@@ -308,10 +162,10 @@ T = TypeVar("T", bound="BaseModel")
 
 
 class ClaudeAdapter:
-    """Anthropic Claude adapter implementing LLMClientPort.
+    """Anthropic Claude adapter implementing :class:`LLMClientPort`.
 
     Wraps the router functions into the port interface.
-    Uses lazy imports from core.llm.router to avoid circular imports.
+    Uses lazy imports from :mod:`core.llm.router` to avoid circular imports.
     """
 
     @property
@@ -420,3 +274,12 @@ class ClaudeAdapter:
             max_tool_rounds=max_tool_rounds,
         )
         return result
+
+
+__all__ = [
+    "ClaudeAdapter",
+    "LLMClientPort",
+    "LLMJsonCallable",
+    "LLMParsedCallable",
+    "LLMTextCallable",
+]

--- a/core/llm/adapters/provider_inference.py
+++ b/core/llm/adapters/provider_inference.py
@@ -1,0 +1,68 @@
+"""Provider inference from model id (Codex / Anthropic / GLM / OpenAI).
+
+Used by callers that pin a model (e.g. Petri audit target
+``geode/gpt-5.5``) but did not pin a provider — without this helper,
+:class:`AgenticLoop` falls back to its ``provider="anthropic"`` default
+and the orchestration layer (GoalDecomposer, extract hooks) silent-fails
+on ``ANTHROPIC_API_KEY`` when the OAuth-only environment never had one.
+
+PR-MAINPATH-67 (2026-05-24) — extracted from the deleted ``_legacy``
+module. The OAuth-routing logic survived the legacy adapter removal
+because it serves the broader Provider routing surface (not just the
+deleted ``AgenticLLMPort``).
+"""
+
+from __future__ import annotations
+
+
+def infer_provider_from_model(model: str) -> str:
+    """Return the provider key for a model id.
+
+    Maps a GEODE / inspect_ai model identifier to a provider string used
+    by :class:`AgenticLoop`'s ``provider=`` parameter.
+
+    Rules:
+
+    - ``gpt-*`` / ``o3`` / ``o4-mini`` → ``"openai-codex"`` when a
+      Codex OAuth token is resolvable, else ``"openai"`` (PAYG path).
+    - ``claude-*`` → ``"anthropic"``.
+    - ``glm-*`` → ``"glm"``.
+    - Provider-prefixed ids (``anthropic/...``, ``openai/...``,
+      ``openai-codex/...``, ``geode/<base>``) — the prefix wins for
+      ``openai-codex`` (OAuth-routed), otherwise the bare model id is
+      reclassified by the provider rules above.
+
+    The OAuth probe is read-only and tolerates a missing
+    ``plugins.petri_audit`` package (the predicate lives there because
+    the bridge is plugin-scoped). When the import fails the function
+    falls back to the per-token ``openai`` path.
+    """
+    if not model:
+        return "anthropic"
+
+    raw_prefix = model.split("/", 1)[0] if "/" in model else ""
+    if raw_prefix == "openai-codex":
+        return "openai-codex"
+    if raw_prefix == "anthropic":
+        return "anthropic"
+    if raw_prefix in ("openai", "openai-api"):
+        return "openai"
+
+    base = model.rsplit("/", 1)[-1]
+    if base.startswith("claude-"):
+        return "anthropic"
+    if base.startswith("glm-"):
+        return "glm"
+    if base.startswith("gpt-") or base in ("o3", "o4-mini"):
+        try:
+            from plugins.petri_audit.codex_provider import is_codex_oauth_available
+
+            if is_codex_oauth_available():
+                return "openai-codex"
+        except ImportError:
+            pass
+        return "openai"
+    return "anthropic"
+
+
+__all__ = ["infer_provider_from_model"]

--- a/core/llm/adapters/translation.py
+++ b/core/llm/adapters/translation.py
@@ -1,17 +1,14 @@
-"""Translation between the new :class:`LLMAdapter` Protocol and the legacy
-``AgenticResponse`` shape consumed by :class:`AgenticLoop`.
+"""Translation between :class:`LLMAdapter` and AgenticLoop's call surface.
 
-Used by ``AgenticLoop._call_llm`` when an explicit ``source`` is set: the loop
-builds an :class:`AdapterCallRequest`, calls ``adapter.acomplete``, and feeds
-the result back through :func:`agentic_response_from_adapter_result` so the
-downstream tool-use / cost / observability pipeline keeps the same data
-shape.
+Used by :meth:`core.agent.loop.agent_loop.AgenticLoop._call_llm`: the loop
+builds an :class:`AdapterCallRequest`, calls :meth:`LLMAdapter.acomplete`,
+and feeds the result back through :func:`agentic_response_from_adapter_result`
+so the downstream tool-use / cost / observability pipeline keeps the same
+data shape.
 
-This bridge is intentionally minimal — it does NOT replicate the full
-``AgenticLLMPort.agentic_call`` (retry, failover, streaming) surface. Those
-behaviours stay in the legacy adapter for callers that don't set ``source``.
-The new path is an opt-in alternative; once every in-tree caller has migrated
-(v1.0.0), the bridge + legacy path are removed together.
+PR-MAINPATH-67 (2026-05-24) — extracted from the deleted ``_legacy_bridge``
+module after the legacy ``AgenticLLMPort.agentic_call`` fallback branch
+was removed; this is now the sole call-site for both helpers.
 """
 
 from __future__ import annotations
@@ -102,15 +99,14 @@ def build_adapter_request(
 
 
 def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticResponse:
-    """Translate :class:`AdapterCallResult` → legacy :class:`AgenticResponse`.
+    """Translate :class:`AdapterCallResult` → :class:`AgenticResponse`.
 
-    The new adapter call returns a flat ``(text, usage, stop_reason,
-    tool_uses, raw_response)`` envelope; the legacy ``AgenticResponse`` is a
-    list of typed content blocks plus normalised usage. We rebuild the
-    content list — text block first (when non-empty), then one
+    :meth:`LLMAdapter.acomplete` returns a flat ``(text, usage, stop_reason,
+    tool_uses, raw_response)`` envelope; :class:`AgenticResponse` is a list
+    of typed content blocks plus normalised usage. We rebuild the content
+    list — text block first (when non-empty), then one
     :class:`ToolUseBlock` per tool_use entry — so ``ToolCallProcessor`` and
-    the rest of the loop see the same shape they did under the legacy
-    adapter.
+    the rest of the loop see the canonical shape.
     """
     blocks: list[TextBlock | ToolUseBlock] = []
     if result.text:
@@ -158,7 +154,7 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
 def _translate_stop_reason(stop: str) -> str:
     """Map provider-flavoured stop reasons → AgenticLoop's two-value enum.
 
-    Legacy ``AgenticResponse.stop_reason`` is one of ``"tool_use"`` /
+    :attr:`AgenticResponse.stop_reason` is one of ``"tool_use"`` /
     ``"end_turn"``. Provider strings map as follows:
 
     - Anthropic ``"tool_use"`` → ``"tool_use"``

--- a/core/llm/router/__init__.py
+++ b/core/llm/router/__init__.py
@@ -48,13 +48,11 @@ if TYPE_CHECKING:
 # name on the package. ``calls._route_provider`` calls the leaf binding from
 # ``core.config`` directly, so the supported test path is the leaf module.
 from core.config import _resolve_provider as _resolve_provider
-from core.llm.adapters import AgenticLLMPort as AgenticLLMPort
 from core.llm.adapters import ClaudeAdapter as ClaudeAdapter
 from core.llm.adapters import LLMClientPort as LLMClientPort
 from core.llm.adapters import LLMJsonCallable as LLMJsonCallable
 from core.llm.adapters import LLMParsedCallable as LLMParsedCallable
 from core.llm.adapters import LLMTextCallable as LLMTextCallable
-from core.llm.adapters import resolve_agentic_adapter as resolve_agentic_adapter
 
 # v0.88.0 — LLM*Error re-exports (LLMAPIStatusError, LLMAuthenticationError,
 # LLMBadRequestError, LLMConnectionError, LLMInternalServerError,

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -516,8 +516,8 @@ def _normalize_provider_for_registry(provider: str) -> str:
     Path-B registry's provider key vocabulary.
 
     Step J-b.2 (2026-05-23, Codex MCP HIGH fix-up) —
-    :func:`_resolve_provider` returns the legacy AgenticLLMPort provider
-    keys (``anthropic`` / ``openai`` / ``openai-codex`` / ``glm``). The
+    :func:`_resolve_provider` returns the broader provider keys
+    (``anthropic`` / ``openai`` / ``openai-codex`` / ``glm``). The
     Path-B :func:`~core.llm.adapters.registry.resolve_for` registry uses
     a narrower set: ``anthropic`` / ``openai`` / ``glm``. The Codex
     distinction is encoded on the ``source`` axis instead (``CodexOAuthAdapter``

--- a/tests/core/agent/test_agent_loop_source_route.py
+++ b/tests/core/agent/test_agent_loop_source_route.py
@@ -3,20 +3,18 @@
 Pins:
 - Empty source → PR-MAINPATH-1 (2026-05-24) cutover defaults source
   to ``"payg"``; ``_new_adapter`` is resolved through the Path-B
-  registry. Pre-cutover, empty source meant ``_new_adapter is None``
-  and the loop ran on the legacy ``resolve_agentic_adapter`` route.
+  registry. PR-MAINPATH-67 (2026-05-24) deleted the legacy
+  ``self._adapter`` field alongside ``resolve_agentic_adapter``, so
+  ``_new_adapter`` is now the sole dispatch surface.
 - Concrete source + ``provider="anthropic"`` → ``resolve_for`` resolves and
-  attaches a new_adapter; legacy adapter still constructed for the fallback
-  surface (unused on this path).
+  attaches a new_adapter.
 - Concrete source + ``provider="openai"`` → A2 (v0.99.44) extended the
   Path-B registry beyond Anthropic; OpenAI providers now also resolve
-  (`test_openai_provider_attaches_new_adapter`). The pre-A2 "anthropic
-  only" claim that lived in this docstring header is gone.
+  (`test_openai_provider_attaches_new_adapter`).
 - Concrete source + unregistered (provider, source) pair → hard-fail
-  (Codex MCP 2026-05-23 HIGH 2 — no silent fallback). The cutover preserves
-  this contract: if the Path-B default ``"payg"`` doesn't match a
-  registered adapter for the requested provider, ``AgenticLoop.__init__``
-  raises rather than silently routing through the legacy adapter.
+  (Codex MCP 2026-05-23 HIGH 2 — no silent fallback). Post-MAINPATH-67
+  this is the only failure mode — there is no longer a legacy adapter
+  to fall back to.
 """
 
 from __future__ import annotations
@@ -50,22 +48,20 @@ def _make_loop(*, source: str = "", provider: str = "anthropic") -> AgenticLoop:
 
 def test_empty_source_defaults_to_payg_after_mainpath_cutover() -> None:
     """PR-MAINPATH-1 (2026-05-24) — empty source defaults to "payg" and
-    resolves through the Path-B registry. Pre-cutover, this test asserted
-    the opposite (``_new_adapter is None``) because empty source landed
-    on the legacy ``resolve_agentic_adapter`` route.
+    resolves through the Path-B registry. PR-MAINPATH-67 (2026-05-24)
+    deleted the legacy ``_adapter`` field; ``_new_adapter`` is the
+    only dispatch surface.
     """
     loop = _make_loop(source="")
     assert loop._new_adapter is not None
     assert loop._new_adapter.name == "anthropic-payg"
     assert loop._source == "payg"
-    assert loop._adapter is not None  # legacy still wired for error surface
 
 
 def test_concrete_source_attaches_anthropic_adapter() -> None:
     loop = _make_loop(source="payg")
     assert loop._new_adapter is not None
     assert loop._new_adapter.name == "anthropic-payg"
-    assert loop._adapter is not None  # legacy also wired for fallback
 
 
 def test_concrete_source_each_anthropic_variant() -> None:
@@ -86,7 +82,6 @@ def test_openai_provider_attaches_new_adapter() -> None:
     loop = _make_loop(source="payg", provider="openai")
     assert loop._new_adapter is not None
     assert loop._new_adapter.name == "openai-payg"
-    assert loop._adapter is not None  # legacy adapter still wired as fallback
 
 
 def test_unregistered_pair_hard_fails() -> None:
@@ -100,13 +95,9 @@ def test_unregistered_pair_hard_fails() -> None:
 
 def test_runtime_model_switch_re_resolves_path_b_adapter() -> None:
     """PR-MAINPATH-4 (2026-05-24) — ``/model`` between providers must
-    re-resolve ``_new_adapter`` alongside the legacy ``_adapter``.
-
-    Pre-PR-MAINPATH-4 the runtime switch only updated ``_adapter``
-    (legacy ``resolve_agentic_adapter`` route); ``_new_adapter``
-    stayed pointed at the previous provider's Path-B adapter, so the
-    next ``_call_llm`` would dispatch to the wrong API. This test
-    pins the dual-adapter re-resolution invariant.
+    re-resolve ``_new_adapter``. PR-MAINPATH-67 (2026-05-24) deleted
+    the legacy ``_adapter`` re-resolution alongside the resolver, so
+    Path-B is now the sole adapter swapped on provider change.
     """
     from core.agent.loop._model_switching import _apply_model_update
 
@@ -123,4 +114,3 @@ def test_runtime_model_switch_re_resolves_path_b_adapter() -> None:
     assert loop._provider == "openai-codex"
     assert loop._new_adapter is not None
     assert loop._new_adapter.name == "openai-payg"
-    assert loop._adapter is not None  # legacy adapter also updated

--- a/tests/core/llm/adapters/test_codex_reasoning_replay.py
+++ b/tests/core/llm/adapters/test_codex_reasoning_replay.py
@@ -30,13 +30,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from core.llm.adapters._legacy_bridge import (
-    agentic_response_from_adapter_result,
-    build_adapter_request,
-)
 from core.llm.adapters._openai_common import translate_codex_response
 from core.llm.adapters.base import AdapterCallResult, UsageSummary
 from core.llm.adapters.codex_oauth import _build_codex_call_kwargs
+from core.llm.adapters.translation import (
+    agentic_response_from_adapter_result,
+    build_adapter_request,
+)
 
 
 def test_translate_codex_response_extracts_reasoning_items() -> None:

--- a/tests/core/llm/adapters/test_translation.py
+++ b/tests/core/llm/adapters/test_translation.py
@@ -1,18 +1,22 @@
-"""Legacy bridge tests — AgenticLoop ↔ LLMAdapter translation.
+"""Translation tests — AgenticLoop ↔ :class:`LLMAdapter` round-trip.
 
-Pins the contract between the new ``LLMAdapter.acomplete`` surface and the
-legacy ``AgenticResponse`` consumed by the agentic loop. Regression here
-means the v0.99.40 Follow-up A path silently drops tool_use blocks or
-mangles message content during the round trip.
+Pins the contract between :meth:`LLMAdapter.acomplete` and the
+``AgenticResponse`` consumed by the agentic loop. Regression here means
+the Path-B route silently drops tool_use blocks or mangles message
+content during the round trip.
+
+PR-MAINPATH-67 (2026-05-24) — file renamed from
+``test_legacy_bridge.py`` after the bridge module was inlined into
+:mod:`core.llm.adapters.translation`.
 """
 
 from __future__ import annotations
 
-from core.llm.adapters._legacy_bridge import (
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+from core.llm.adapters.translation import (
     agentic_response_from_adapter_result,
     build_adapter_request,
 )
-from core.llm.adapters.base import AdapterCallResult, UsageSummary
 
 
 def test_build_request_translates_user_message() -> None:

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -1387,10 +1387,16 @@ class TestAgenticLoopEdgeCases:
     def test_adapter_initialized_at_construction(
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
-        """Verify agentic adapter is created at construction time."""
+        """Verify the Path-B adapter is resolved at construction time.
+
+        PR-MAINPATH-67 (2026-05-24) — the legacy ``self._adapter``
+        field was deleted alongside ``resolve_agentic_adapter``; the
+        loop now exposes the resolved Path-B ``LLMAdapter`` via
+        ``self._new_adapter``.
+        """
         loop = AgenticLoop(context, executor, quiet=True)
-        assert loop._adapter is not None
-        assert loop._adapter.provider_name == "anthropic"
+        assert loop._new_adapter is not None
+        assert loop._new_adapter.provider == "anthropic"
 
 
 class TestSubAgentEdgeCases:

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -245,12 +245,23 @@ class TestNormalizeResponsesApi:
         assert tool_blocks[0].input == {"query": "test"}
 
 
-class TestAdapterMap:
-    def test_codex_in_adapter_map(self):
-        from core.llm.adapters import _ADAPTER_MAP
+class TestAdapterRegistry:
+    def test_codex_oauth_in_path_b_registry(self):
+        """PR-MAINPATH-67 (2026-05-24) — the legacy ``_ADAPTER_MAP``
+        was deleted; Codex routing now lives in the Path-B registry
+        under ``(provider="openai", source="subscription")``."""
+        from core.llm.adapters.registry import (
+            _reset_for_test,
+            bootstrap_builtins,
+            list_adapters,
+        )
 
-        assert "openai-codex" in _ADAPTER_MAP
-        assert "CodexAgenticAdapter" in _ADAPTER_MAP["openai-codex"]
+        _reset_for_test()
+        bootstrap_builtins()
+        entries = {(a.provider, a.source): a for a in list_adapters()}
+        assert ("openai", "subscription") in entries
+        codex = entries[("openai", "subscription")]
+        assert codex.__class__.__name__ == "CodexOAuthAdapter"
 
     def test_no_cross_provider_fallback_shim(self):
         """v0.99.19 — the empty-dict ``CROSS_PROVIDER_FALLBACK`` shim is

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -65,9 +65,13 @@ class TestNoAutoEscalation:
 
     def test_fallback_chain_suggestions_replaces_escalation(self) -> None:
         """The remaining chain is exposed only as *suggestions* for the
-        diagnostic, not as an auto-swap target."""
+        diagnostic, not as an auto-swap target.
+
+        PR-MAINPATH-67 (2026-05-24) — reads ``fallback_chain`` from the
+        Path-B ``_new_adapter`` (legacy ``_adapter`` was deleted).
+        """
         loop = _make_loop()
-        loop._adapter = MagicMock(fallback_chain=["a", "b", "c"])
+        loop._new_adapter = MagicMock(fallback_chain=["a", "b", "c"])
         loop.model = "a"
         assert loop._fallback_chain_suggestions() == ["b", "c"]
 
@@ -77,7 +81,7 @@ class TestModelActionDiagnostic:
 
     def test_build_model_action_result_carries_full_context(self) -> None:
         loop = _make_loop()
-        loop._adapter = MagicMock(fallback_chain=[ANTHROPIC_PRIMARY, "claude-sonnet-4-6"])
+        loop._new_adapter = MagicMock(fallback_chain=[ANTHROPIC_PRIMARY, "claude-sonnet-4-6"])
         loop._consecutive_llm_failures = 5
 
         result = loop._build_model_action_result(

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -351,7 +351,12 @@ class TestFallbackChainConfig:
 
 
 class TestAgenticLoopFailover:
-    """Verify AgenticLoop._call_llm delegates to adapter.agentic_call()."""
+    """Verify ``AgenticLoop._call_llm`` delegates to ``_new_adapter.acomplete()``.
+
+    PR-MAINPATH-67 (2026-05-24) — the legacy ``_adapter.agentic_call``
+    fallback branch was deleted; all dispatch now flows through the
+    Path-B ``LLMAdapter.acomplete`` surface unconditionally.
+    """
 
     def _make_loop(self, model: str | None = None) -> Any:
         """Create a minimal AgenticLoop instance for testing."""
@@ -368,49 +373,48 @@ class TestAgenticLoopFailover:
             max_rounds=5,
         )
 
-    def test_call_llm_uses_adapter(self) -> None:
-        """_call_llm should delegate to adapter.agentic_call() and return AgenticResponse.
-
-        PR-MAINPATH-1 (2026-05-24) — AgenticLoop now defaults to the
-        Path-B route (``_new_adapter.acomplete``); the legacy branch
-        (``_adapter.agentic_call``) only runs when ``_new_adapter`` is
-        ``None``. This test still asserts the legacy delegation
-        contract, so we force ``_new_adapter = None`` to drive the
-        fallback path. A sibling test for the Path-B branch lives in
-        ``tests/core/agent/test_agent_loop_source_route.py``.
+    def _install_acomplete_stub(self, loop: Any, result: Any) -> MagicMock:
+        """Replace ``loop._new_adapter`` with a stub whose ``acomplete``
+        coroutine returns ``result`` (or raises if ``result`` is an
+        Exception).
         """
-        from core.cli.agentic_response import AgenticResponse, ResponseUsage, TextBlock
 
-        mock_response = AgenticResponse(
-            content=[TextBlock(text="Hello")],
+        async def fake_acomplete(_req: Any) -> Any:
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        stub = MagicMock()
+        stub.name = "stub-adapter"
+        stub.acomplete = MagicMock(side_effect=fake_acomplete)
+        loop._new_adapter = stub
+        return stub
+
+    def test_call_llm_uses_adapter(self) -> None:
+        """``_call_llm`` should delegate to ``acomplete`` and return
+        ``AgenticResponse``."""
+        from core.llm.adapters.base import AdapterCallResult, UsageSummary
+
+        adapter_result = AdapterCallResult(
+            text="Hello",
+            usage=UsageSummary(input_tokens=100, output_tokens=50),
             stop_reason="end_turn",
-            usage=ResponseUsage(input_tokens=100, output_tokens=50),
         )
         loop = self._make_loop()
-        loop._new_adapter = None  # force legacy branch
-
-        async def fake_call(**kwargs: Any) -> AgenticResponse:
-            return mock_response
-
-        loop._adapter = MagicMock()
-        loop._adapter.agentic_call = MagicMock(side_effect=fake_call)
+        stub = self._install_acomplete_stub(loop, adapter_result)
 
         result = asyncio.run(
             loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
         )
         assert result is not None
         assert result.stop_reason == "end_turn"
-        loop._adapter.agentic_call.assert_called_once()
+        stub.acomplete.assert_called_once()
 
     def test_call_llm_returns_none_on_chain_exhaustion(self) -> None:
-        """When adapter returns None, _call_llm returns None with error message."""
+        """When ``acomplete`` raises, ``_call_llm`` returns None with an
+        error message."""
         loop = self._make_loop()
-
-        async def fake_call(**kwargs: Any) -> None:
-            return None
-
-        loop._adapter = MagicMock()
-        loop._adapter.agentic_call = MagicMock(side_effect=fake_call)
+        self._install_acomplete_stub(loop, RuntimeError("chain exhausted"))
 
         result = asyncio.run(
             loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
@@ -419,27 +423,26 @@ class TestAgenticLoopFailover:
         assert loop._last_llm_error is not None
 
     def test_call_llm_no_api_key_returns_none(self) -> None:
-        """When adapter returns None (no key), _call_llm returns None."""
+        """When ``acomplete`` raises an auth-style failure, ``_call_llm``
+        returns None."""
         loop = self._make_loop()
-
-        async def fake_call(**kwargs: Any) -> None:
-            return None
-
-        loop._adapter = MagicMock()
-        loop._adapter.agentic_call = MagicMock(side_effect=fake_call)
+        self._install_acomplete_stub(loop, RuntimeError("missing api key"))
 
         result = asyncio.run(loop._call_llm("system", [{"role": "user", "content": "hi"}]))
         assert result is None
 
     def test_failover_chain_available_on_adapter(self) -> None:
-        """The adapter exposes a ``fallback_chain`` knob (opt-in).
+        """The Path-B adapter exposes (or does not expose) a
+        ``fallback_chain`` knob — ``fallback_chain_suggestions`` reads
+        the attribute defensively.
 
-        v0.99.19 — shipped default is an empty list (no silent fallback).
-        The property must still exist on the adapter so user-tuned chains
-        from ``~/.geode/routing.toml`` propagate; verify type only.
+        v0.99.19 — shipped default is an empty list (no silent
+        fallback). Path-B adapters that don't override the attribute
+        return an empty list via the ``getattr(..., [])`` defensive
+        read in :func:`fallback_chain_suggestions`.
         """
         loop = self._make_loop(model=ANTHROPIC_PRIMARY)
-        chain = loop._adapter.fallback_chain
+        chain = list(getattr(loop._new_adapter, "fallback_chain", []) or [])
         assert isinstance(chain, list)
         # If the user opts in, the chain must be unique and start with primary.
         # If the default (empty list) holds, both checks are trivially true.

--- a/tests/test_model_switch_guard.py
+++ b/tests/test_model_switch_guard.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from core.agent.conversation import ConversationContext
 from core.agent.loop import AgenticLoop
@@ -321,15 +321,17 @@ class TestConversationContextWired:
 
 
 def _make_loop(ctx: ConversationContext, model: str = "claude-opus-4-6") -> AgenticLoop:
-    """Create a minimal AgenticLoop for testing context adaptation."""
-    adapter = MagicMock()
-    adapter.fallback_chain = [model]
-    executor = ToolExecutor()
+    """Create a minimal AgenticLoop for testing context adaptation.
 
-    with patch("core.agent.loop.resolve_agentic_adapter", return_value=adapter):
-        loop = AgenticLoop(
-            model=model,
-            context=ctx,
-            tool_executor=executor,
-        )
+    PR-MAINPATH-67 (2026-05-24) — the legacy ``resolve_agentic_adapter``
+    factory was deleted; the loop now resolves Path-B adapters via
+    ``core.llm.adapters.resolve_for``. ``conftest.py`` already calls
+    ``bootstrap_builtins`` so the registry is populated.
+    """
+    executor = ToolExecutor()
+    loop = AgenticLoop(
+        model=model,
+        context=ctx,
+        tool_executor=executor,
+    )
     return loop

--- a/tests/test_provider_label_consistency.py
+++ b/tests/test_provider_label_consistency.py
@@ -6,6 +6,10 @@ in the dispatch but `"zhipuai"` in the UI store). The Codex OAuth token
 therefore matched `ProfileRotator.resolve("openai")` and poisoned every
 plain GPT call. These tests pin the labels so a future rename can't
 silently re-open the cross-provider leak.
+
+PR-MAINPATH-67 (2026-05-24) — the legacy ``_ADAPTER_MAP`` was deleted
+alongside ``resolve_agentic_adapter``; the adapter alignment test now
+walks the Path-B registry (``list_adapters``) instead.
 """
 
 from __future__ import annotations
@@ -14,7 +18,10 @@ from core.cli.commands import MODEL_PROFILES
 from core.config import _resolve_provider
 
 from core.llm import adapters as _adapters_mod
-from core.llm.adapters import _ADAPTER_MAP
+
+# Path-B registry collapses ``openai-codex`` onto ``openai`` (the source
+# axis encodes the Codex distinction) and ``zhipuai`` onto ``glm``.
+_LEGACY_TO_REGISTRY = {"openai-codex": "openai", "zhipuai": "glm"}
 
 
 class TestProviderRouting:
@@ -35,8 +42,18 @@ class TestProviderRouting:
             assert _resolve_provider(model) == "anthropic", model
 
 
-class TestAdapterMapAlignment:
-    def test_every_resolver_target_has_an_adapter(self) -> None:
+class TestAdapterRegistryAlignment:
+    def test_every_resolver_target_has_a_registered_adapter(self) -> None:
+        """Every provider returned by :func:`_resolve_provider` must be
+        registered in the Path-B adapter registry (after the
+        ``openai-codex`` / ``zhipuai`` normalisation that
+        ``AgenticLoop.__init__`` applies)."""
+        from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins, list_adapters
+
+        _reset_for_test()
+        bootstrap_builtins()
+        registered = {entry.provider for entry in list_adapters()}
+
         targets = {
             _resolve_provider(m)
             for m in (
@@ -47,7 +64,8 @@ class TestAdapterMapAlignment:
             )
         }
         for provider in targets:
-            assert provider in _ADAPTER_MAP, provider
+            registry_key = _LEGACY_TO_REGISTRY.get(provider, provider)
+            assert registry_key in registered, (provider, registry_key, registered)
 
 
 class TestCrossProviderFallbackSafety:

--- a/tests/test_provider_switching.py
+++ b/tests/test_provider_switching.py
@@ -18,7 +18,7 @@ endpoint, or A's credentials into B's call?
 
 Each path asserts five contracts:
   1. ``_route_provider(target_model)`` returns the destination provider.
-  2. ``AgenticLoop.update_model`` swaps ``self._adapter`` to the
+  2. ``AgenticLoop.update_model`` swaps ``self._new_adapter`` to the
      destination provider's adapter class (cross-provider) or keeps
      the same class (within-provider Plan switch).
   3. ``resolve_routing(target_model)`` resolves to the destination
@@ -229,17 +229,6 @@ def test_path_a_codex_oauth_to_anthropic_apikey(isolated_auth) -> None:
     # No token leak from Codex into Anthropic.
     assert "oauth-codex-token" not in dest.profile.key
 
-    # Adapter swap: from CodexAgenticAdapter to ClaudeAgenticAdapter.
-    from core.llm.adapters import resolve_agentic_adapter
-
-    a_origin = resolve_agentic_adapter("openai-codex")
-    a_dest = resolve_agentic_adapter("anthropic")
-    assert type(a_origin).__name__ == "CodexAgenticAdapter"
-    assert type(a_dest).__name__ == "ClaudeAgenticAdapter"
-    # Round-trsubject: switching back returns a Codex adapter again
-    a_back = resolve_agentic_adapter("openai-codex")
-    assert type(a_back).__name__ == "CodexAgenticAdapter"
-
 
 # ---------------------------------------------------------------------------
 # Path B — Codex Plus OAuth → GLM Coding Plan (cross-provider)
@@ -261,10 +250,6 @@ def test_path_b_codex_oauth_to_glm_coding(isolated_auth) -> None:
     assert dest.profile.key == "glm-coding-key"
     assert "oauth-codex-token" not in dest.profile.key
 
-    from core.llm.adapters import resolve_agentic_adapter
-
-    assert type(resolve_agentic_adapter("glm")).__name__ == "GlmAgenticAdapter"
-
 
 # ---------------------------------------------------------------------------
 # Path C — Anthropic → GLM (cross-provider)
@@ -285,13 +270,6 @@ def test_path_c_anthropic_to_glm(isolated_auth) -> None:
     # Anthropic key must not leak into GLM call.
     assert "sk-ant" not in dest.profile.key
     assert dest.profile.key == "glm-coding-key"
-
-    from core.llm.adapters import resolve_agentic_adapter
-
-    a_origin = resolve_agentic_adapter("anthropic")
-    a_dest = resolve_agentic_adapter("glm")
-    assert type(a_origin).__name__ == "ClaudeAgenticAdapter"
-    assert type(a_dest).__name__ == "GlmAgenticAdapter"
 
 
 # ---------------------------------------------------------------------------
@@ -417,7 +395,13 @@ def test_update_model_swaps_adapter_on_provider_change(
     isolated_auth, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """End-to-end on AgenticLoop: starting with Codex adapter, calling
-    update_model('claude-opus-4-7') must swap the adapter to Claude."""
+    update_model('claude-opus-4-7') must swap the Path-B adapter to Claude.
+
+    PR-MAINPATH-67 (2026-05-24) — the legacy
+    ``resolve_agentic_adapter`` factory was deleted; ``/model``
+    re-resolution now goes through ``_resolve_path_b_adapter`` in
+    ``_model_switching``.
+    """
     _register_codex_oauth()
     _register_anthropic_payg()
 
@@ -430,8 +414,9 @@ def test_update_model_swaps_adapter_on_provider_change(
     stub = MagicMock()
     stub.model = "gpt-5.5"
     stub._provider = "openai-codex"
-    stub._adapter = MagicMock(name="CodexAgenticAdapter")
-    type(stub._adapter).__name__ = "CodexAgenticAdapter"  # type: ignore[misc]
+    stub._source = "payg"
+    stub._new_adapter = MagicMock(name="CodexOAuthAdapter")
+    type(stub._new_adapter).__name__ = "CodexOAuthAdapter"  # type: ignore[misc]
     stub._tool_processor = MagicMock()
     stub._hooks = None
     stub.context = MagicMock(is_empty=True)
@@ -441,15 +426,18 @@ def test_update_model_swaps_adapter_on_provider_change(
 
     monkeypatch.setattr("core.agent.loop._resolve_provider", lambda _m: "anthropic")
 
-    # Patch the factory so we can assert it was called with the new provider.
-    fake_claude = MagicMock(name="ClaudeAgenticAdapter")
-    type(fake_claude).__name__ = "ClaudeAgenticAdapter"  # type: ignore[misc]
-    monkeypatch.setattr("core.agent.loop.resolve_agentic_adapter", lambda p: fake_claude)
+    # Patch the Path-B factory so we can assert it was called with the new provider.
+    fake_claude = MagicMock(name="AnthropicPaygAdapter")
+    type(fake_claude).__name__ = "AnthropicPaygAdapter"  # type: ignore[misc]
+    monkeypatch.setattr(
+        "core.agent.loop._model_switching._resolve_path_b_adapter",
+        lambda p, s: fake_claude,
+    )
 
     asyncio.run(stub.update_model_async("claude-opus-4-7"))
 
     assert stub._provider == "anthropic"
-    assert stub._adapter is fake_claude
+    assert stub._new_adapter is fake_claude
     assert stub.model == "claude-opus-4-7"
     # Tool processor must see the new model so retries don't reuse the old name.
     assert stub._tool_processor._model == "claude-opus-4-7"
@@ -511,7 +499,8 @@ def test_update_model_marks_prompt_dirty_so_escalation_rebuilds(
     stub = MagicMock()
     stub.model = "gpt-5.4"
     stub._provider = "openai"
-    stub._adapter = MagicMock()
+    stub._source = "payg"
+    stub._new_adapter = MagicMock()
     stub._tool_processor = MagicMock()
     stub._hooks = None
     stub.context = MagicMock(is_empty=True)
@@ -520,7 +509,10 @@ def test_update_model_marks_prompt_dirty_so_escalation_rebuilds(
     stub._adapt_context_for_model = MagicMock()
 
     monkeypatch.setattr("core.agent.loop._resolve_provider", lambda _m: "openai")
-    monkeypatch.setattr("core.agent.loop.resolve_agentic_adapter", lambda p: MagicMock())
+    monkeypatch.setattr(
+        "core.agent.loop._model_switching._resolve_path_b_adapter",
+        lambda p, s: MagicMock(),
+    )
 
     asyncio.run(stub.update_model_async("gpt-5.3-codex", reason="failure_escalation"))
 
@@ -541,13 +533,14 @@ def test_update_model_keeps_adapter_on_within_provider_switch(
 
     import core.agent.loop as _loop_mod
 
-    initial_adapter = MagicMock(name="CodexAgenticAdapter")
-    type(initial_adapter).__name__ = "CodexAgenticAdapter"  # type: ignore[misc]
+    initial_adapter = MagicMock(name="CodexOAuthAdapter")
+    type(initial_adapter).__name__ = "CodexOAuthAdapter"  # type: ignore[misc]
 
     stub = MagicMock()
     stub.model = "gpt-5.5"
     stub._provider = "openai-codex"
-    stub._adapter = initial_adapter
+    stub._source = "payg"
+    stub._new_adapter = initial_adapter
     stub._tool_processor = MagicMock()
     stub._hooks = None
     stub.context = MagicMock(is_empty=True)
@@ -557,16 +550,16 @@ def test_update_model_keeps_adapter_on_within_provider_switch(
     monkeypatch.setattr("core.agent.loop._resolve_provider", lambda _m: "openai-codex")
 
     # Track factory calls — should NOT be invoked since provider unchanged.
-    factory_calls = []
+    factory_calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        "core.agent.loop.resolve_agentic_adapter",
-        lambda p: factory_calls.append(p) or MagicMock(),
+        "core.agent.loop._model_switching._resolve_path_b_adapter",
+        lambda p, s: factory_calls.append((p, s)) or MagicMock(),
     )
 
     asyncio.run(stub.update_model_async("gpt-5.4"))
 
     assert stub.model == "gpt-5.4"
-    assert stub._adapter is initial_adapter, "adapter rebuilt on within-provider switch"
+    assert stub._new_adapter is initial_adapter, "adapter rebuilt on within-provider switch"
     assert factory_calls == [], (
-        f"resolve_agentic_adapter called {factory_calls} for within-provider switch"
+        f"_resolve_path_b_adapter called {factory_calls} for within-provider switch"
     )

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -495,6 +495,8 @@ class TestUpdateModel:
     """Test AgenticLoop.update_model method."""
 
     def test_update_model_changes_provider(self):
+        """PR-MAINPATH-67 (2026-05-24) — reads the Path-B
+        ``_new_adapter`` field (legacy ``_adapter`` was deleted)."""
         from unittest.mock import MagicMock
 
         from core.agent.conversation import ConversationContext
@@ -510,9 +512,11 @@ class TestUpdateModel:
         asyncio.run(loop.update_model_async(GLM_PRIMARY))
         assert loop.model == GLM_PRIMARY
         assert loop._provider == "glm"
-        assert loop._adapter.provider_name == "glm"  # adapter re-created
+        assert loop._new_adapter.provider == "glm"  # adapter re-resolved
 
     def test_update_model_same_provider_keeps_adapter(self):
+        """PR-MAINPATH-67 (2026-05-24) — reads the Path-B
+        ``_new_adapter`` field (legacy ``_adapter`` was deleted)."""
         from unittest.mock import MagicMock
 
         from core.agent.conversation import ConversationContext
@@ -522,12 +526,12 @@ class TestUpdateModel:
         ctx = ConversationContext()
         executor = MagicMock(spec=ToolExecutor)
         loop = AgenticLoop(ctx, executor)
-        original_adapter = loop._adapter
+        original_adapter = loop._new_adapter
 
         asyncio.run(loop.update_model_async("claude-sonnet-4-6"))
         assert loop.model == "claude-sonnet-4-6"
         assert loop._provider == "anthropic"
-        assert loop._adapter is original_adapter  # kept — same provider
+        assert loop._new_adapter is original_adapter  # kept — same provider
 
 
 class TestGlmClient:


### PR DESCRIPTION
## Summary
- Delete `core/llm/adapters/_legacy.py` (422 LOC) + `_legacy_bridge.py` (177 LOC). Total 599 LOC removed.
- Migrate still-needed symbols to 3 new domain-named modules: `paperclip.py` (LLMClientPort + ClaudeAdapter), `provider_inference.py` (infer_provider_from_model), `translation.py` (request/response bridge helpers).
- AgenticLoop is now Path-B-only — no `self._adapter` field, no fallback `agentic_call` branch, `_model_switching` drops its legacy shim.
- Step 6 (plugins) was a verified no-op — plugin layer was already clean.

## Why
Closes the AgenticLoop main-path migration sprint that started with PR-MAINPATH-1. With:
- PR-MAINPATH-1 making `_new_adapter` resolution mandatory + hard-fail,
- PR-MAINPATH-234 migrating runtime `/model` switching,
- PR-MAINPATH-5 removing CircuitBreaker entirely,

…the legacy `AgenticLLMPort` Protocol + `resolve_agentic_adapter` factory + `_ADAPTER_MAP` registry are now reachable only from dead code paths and a handful of legacy-mock tests. PR-MAINPATH-67 removes them and resolves the **deferred-item #4** from the v0.99.48 sprint summary.

The `_legacy.py` file held more than just the agentic resolver — `LLMClientPort` Protocol, `ClaudeAdapter` wrapper, `infer_provider_from_model`, `LLM*Callable` Protocols. Those are still production-active (used by `core/runtime.py`, `core/wiring/container.py`, `core/verification/cross_llm.py`, `plugins/petri_audit/targets/geode_target.py`). They were migrated to 3 new domain-named files following the Naming CANNOTs: no `_legacy` / `_helpers` / `_utils` suffixes.

## Changes
| Layer | Action |
|-------|--------|
| Deleted | `core/llm/adapters/_legacy.py`, `core/llm/adapters/_legacy_bridge.py` |
| New (domain-named) | `core/llm/adapters/paperclip.py`, `core/llm/adapters/provider_inference.py`, `core/llm/adapters/translation.py` |
| Re-export pruning | `core/llm/adapters/__init__.py`, `core/llm/router/__init__.py`, `core/agent/loop/__init__.py` |
| AgenticLoop core | `core/agent/loop/agent_loop.py` (`_call_llm` Path-B-only), `core/agent/loop/_model_switching.py` (`_resolve_agentic_adapter` shim deleted) |
| Docstrings | `core/agent/worker.py`, `core/agent/sub_agent.py`, `core/config/self_improving_loop.py`, `core/self_improving_loop/runner.py` |
| Test rewires (10) | `tests/test_model_failover.py`, `tests/test_provider_switching.py`, `tests/test_model_switch_guard.py`, `tests/test_model_escalation.py`, `tests/test_provider_label_consistency.py`, `tests/test_codex_provider.py`, `tests/test_agentic_loop.py`, `tests/test_startup.py`, `tests/core/agent/test_agent_loop_source_route.py`, `tests/core/llm/adapters/test_legacy_bridge.py` → `test_translation.py` |
| CHANGELOG | `[Unreleased]` `### Removed` entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `AgenticLLMPort` removed | Implemented | `grep -rn 'AgenticLLMPort' core/ tests/ plugins/` returns zero live-code hits. |
| `resolve_agentic_adapter` removed | Implemented | Same — only historical docstring notes remain. |
| Both legacy files deleted | Implemented | `ls core/llm/adapters/_legacy*` errors. |
| AgenticLoop is Path-B-only | Implemented | `_call_llm` has no `else` branch, no `_adapter` field. |
| Domain-named replacement modules | Implemented | `paperclip.py`, `provider_inference.py`, `translation.py` all present with migrated content. |
| Plugin layer clean | Verified | Step 6 grep returned zero references in `plugins/` + `autoresearch/`. |
| Provider-level agentic_call methods | Kept | Independently tested, not in AgenticLoop's call path. Migration is a separate future task. |
| Test rewires don't drop coverage | Implemented | 524 scoped tests + full background suite all pass. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — clean
- [x] `uv run ruff format --check ...` — 890 files clean
- [x] `uv run mypy core/ plugins/` — 426 source files clean
- [x] `uv run lint-imports` — 4 kept, 0 broken
- [x] Scoped pytest (10 affected files + adjacent) — 524 passed
- [x] Full background suite — exit 0
- [x] Codex MCP read-only verification — 13 PASS / 1 FAIL (CHANGELOG missing, added in-commit)

## Reference
**Final step** of the AgenticLoop main-path migration sprint. Closes deferred-item #4 from the v0.99.48 sprint summary. Cleanup-arc + main-path sprint together total **11 PRs**: PR-DOCS-CANT-CAN, PR-CLEANUP-3 through 7, J-b.3, PR-MAINPATH-1, PR-MAINPATH-234, PR-MAINPATH-5, PR-MAINPATH-67.