### PR TITLE
release: v0.99.49 — AgenticLoop main-path Path-B migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,25 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.49] - 2026-05-24
+
+> AgenticLoop main-path Path-B migration sprint — 4 PRs that retire
+> the legacy ``AgenticLLMPort`` Protocol entirely. PR-MAINPATH-1
+> (#1572) flipped ``AgenticLoop.__init__`` to resolve ``_new_adapter``
+> via the Path-B registry by default with a hard-fail contract;
+> PR-MAINPATH-234 (#1573) bundled the runtime ``/model`` switch
+> migration with verification-only steps for streaming + tool_use_id
+> round-trip; PR-MAINPATH-5 (#1574) removed ``CircuitBreaker``
+> entirely (-386 LOC; per operator instruction in place of the
+> original "verify compatibility" plan); PR-MAINPATH-67 (#1575)
+> deleted ``core/llm/adapters/_legacy.py`` + ``_legacy_bridge.py``
+> (-599 LOC), migrating still-needed symbols to three new
+> domain-named modules (``paperclip.py`` / ``provider_inference.py``
+> / ``translation.py``). Resolves deferred-item #4 from the
+> v0.99.48 sprint summary. AgenticLoop is now Path-B-only — the
+> ``self._adapter`` field and the ``agentic_call`` fallback branch
+> are gone.
+
 ### Removed
 
 - **PR-MAINPATH-67 — final delete of the legacy `AgenticLLMPort` surface.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.48
+- **Version**: 0.99.49
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.48 — Long-running Autonomous Execution Harness
+# GEODE v0.99.49 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.48**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.49**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.48 — Long-running Autonomous Execution Harness
+# GEODE v0.99.49 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.48**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.49**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.48"
+version = "0.99.49"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.48"
+version = "0.99.49"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Release rotation for the 4-PR AgenticLoop main-path migration sprint. AgenticLoop is now Path-B-only; legacy `AgenticLLMPort` + `resolve_agentic_adapter` deleted; CircuitBreaker entirely removed. Resolves deferred-item #4 from v0.99.48 sprint summary.

## Verification
- [x] Version stamped across 5 locations (CHANGELOG / CLAUDE.md / README.md / README.ko.md / pyproject.toml)
- [x] `[Unreleased]` block moved to `## [0.99.49] - 2026-05-24`
- [x] `geode version` → `GEODE v0.99.49`
- [x] All 4 contributing PRs (MAINPATH-1/234/5/67) merged + CI green