### PR TITLE
release: v0.99.50 — PR-HELPERS-3SPLIT + claude-cli silent-success fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.50] - 2026-05-24
+
+> Two-PR bundle. PR-HELPERS-3SPLIT (#1578) splits the deferred-from-v0.99.48
+> ``core/agent/loop/_helpers.py`` umbrella into three domain-named
+> siblings (``_tool_factory`` / ``_sub_agent_announce`` /
+> ``_planner_dispatch``) and closes the last item from the cleanup arc.
+> PR #1579 fixes the claude-cli silent-success path discovered during
+> the 2026-05-24 seed-generation smoke — ``ClaudeCliAdapter.acomplete``
+> was returning raw stream-json stdout as the LLM's reply, so claude-cli's
+> ``! Unexpected error. Auto-retrying.`` retry-storm text was being
+> treated as a normal empty turn and the parent recorded a candidate
+> that was never written. Adapter now parses events through a
+> paperclip-ported transient-upstream classifier and raises loud.
+
 ### Fixed
 - **claude-cli silent-success / "ghost candidate" path** — ``ClaudeCliAdapter.acomplete``
   was returning raw ``--output-format stream-json`` stdout as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.49
+- **Version**: 0.99.50
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.49 — Long-running Autonomous Execution Harness
+# GEODE v0.99.50 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.49**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.50**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.49 — Long-running Autonomous Execution Harness
+# GEODE v0.99.50 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.49**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.50**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.49"
+version = "0.99.50"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.49"
+version = "0.99.50"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.50 stamp bump across 5 SoT files (pyproject.toml / CLAUDE.md / README.md / README.ko.md / CHANGELOG section header).
- ``[Unreleased]`` → ``[0.99.50] - 2026-05-24`` with release header summarising both PRs.
- No code changes — bundles #1578 (PR-HELPERS-3SPLIT) + #1579 (claude-cli silent-success fix) that already landed on develop since v0.99.49.

## Verification
- [x] ``uv run geode version`` → ``GEODE v0.99.50``
- [x] 5/5 version stamps consistent (grep ``0\.99\.50`` and ``0\.99\.49`` confirms no stragglers)
- [x] CHANGELOG ``[Unreleased]`` is empty (release content moved to ``[0.99.50]``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)