### PR TITLE
feat(claude-cli): TransientSignal classifier + post-mortem dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-T — claude-cli transient classifier observability 보강.** Pre-PR-T
+  `is_claude_transient_upstream_error` 는 ``bool`` 만 반환했고
+  `ClaudeCliTransientUpstreamError` 는 ``stderr_tail`` 만 메시지에
+  넣었음. claude-cli 가 stderr 에 안 쓰니 항상 ``<empty>`` —
+  진단 가치 0 (5-hour quota vs RPM cap vs backend 5xx vs OAuth slot
+  cap 식별 불가). 변경:
+  - 새 `classify_transient_signal(...) -> TransientSignal | None` 이
+    matched substring + source (``stdout`` / ``stderr`` / ``event``) +
+    event_type + event_field 의 structured dataclass 반환. 기존
+    `is_claude_transient_upstream_error` 는 backwards-compat
+    ``bool`` wrapper 로 유지.
+  - `ClaudeCliTransientUpstreamError` 에 ``signal: TransientSignal |
+    None`` + ``dump_path: str | None`` structured field 추가. 메시지에
+    ``source=`` / ``matched=`` / ``dump=`` 인라인 노출 → log 한 줄로
+    즉시 triage.
+  - `ClaudeCliAdapter.acomplete` 가 transient hit 시 full
+    ``(stdout, stderr, parsed events, classifier signal, rc)`` 를
+    ``~/.geode/diagnostics/claude-cli-transient/<ts>-<model>.json`` 에
+    dump. classification 이후 버리던 raw 데이터 영구화 → 사후 분석으로
+    claude-cli 가 ``result`` event 에 실은 실제 upstream message 회수.
+  - 11개 신규 테스트 + 변수 alias 정리
+    (`stream_events` / `transient_signal` / `postmortem_path` /
+    `assistant_text` / `hit_ts` — feedback_no_naive_variable_names).
+
 ## [0.99.50] - 2026-05-24
 
 > Two-PR bundle. PR-HELPERS-3SPLIT (#1578) splits the deferred-from-v0.99.48

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from core.llm.adapters._subprocess_common import build_subprocess_stdin
 from core.llm.adapters.base import (
@@ -33,6 +35,9 @@ from core.llm.adapters.base import (
     StreamEvent,
     UsageSummary,
 )
+
+if TYPE_CHECKING:
+    from plugins.petri_audit.claude_cli_provider import StreamJsonEvent, TransientSignal
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +78,7 @@ class ClaudeCliAdapter:
             _resolve_claude_binary,
             _run_claude_subprocess,
             build_claude_cli_argv,
-            is_claude_transient_upstream_error,
+            classify_transient_signal,
             parse_stream_json_events,
         )
 
@@ -90,12 +95,50 @@ class ClaudeCliAdapter:
             self._last_error = exc
             raise
 
-        events = parse_stream_json_events(stdout)
-        if is_claude_transient_upstream_error(stdout=stdout, stderr=stderr, events=events):
-            stderr_tail = stderr.strip().splitlines()[-1] if stderr.strip() else "<empty>"
+        # ``stream_events`` is the parsed stream-json sequence — used for
+        # both the transient classifier walk and (on the happy path) the
+        # assistant-text + stop_reason extractors. Renamed from the
+        # naive ``events`` to make the lifecycle (parse once, consume
+        # in two branches) obvious to the next reader.
+        stream_events = parse_stream_json_events(stdout)
+        # ``transient_signal`` is non-None when ``stdout``/``stderr``/
+        # any parsed event carried an upstream rate-limit / overload /
+        # quota / retry-failure signature (see classifier docstring).
+        # ``None`` = healthy call, continue to text extraction below.
+        transient_signal = classify_transient_signal(
+            stdout=stdout, stderr=stderr, events=stream_events
+        )
+        if transient_signal is not None:
+            # ``postmortem_path`` is the on-disk JSON dump under
+            # ``~/.geode/diagnostics/claude-cli-transient/`` carrying
+            # the full ``(stdout, stderr, parsed events, classifier
+            # signal, rc)`` — the four diagnostic dimensions the
+            # pre-PR-T ``stderr_tail`` log line discarded. ``None``
+            # when the dump write itself failed (disk full / permission
+            # denied) — diagnostic is best-effort, never blocks the
+            # raise below.
+            postmortem_path = _dump_transient_postmortem(
+                model=req.model,
+                rc=rc,
+                stdout=stdout,
+                stderr=stderr,
+                events=stream_events,
+                signal=transient_signal,
+            )
             transient_exc = ClaudeCliTransientUpstreamError(
-                f"claude-cli upstream transient error (rc={rc}, model={req.model}). "
-                f"stderr_tail={stderr_tail!r}"
+                f"claude-cli upstream transient (rc={rc}, model={req.model}, "
+                f"source={transient_signal.source}"
+                + (
+                    f"/{transient_signal.event_type}"
+                    + (f".{transient_signal.event_field}" if transient_signal.event_field else "")
+                    if transient_signal.event_type
+                    else ""
+                )
+                + f", matched={transient_signal.matched_text!r}"
+                + (f", dump={postmortem_path}" if postmortem_path else "")
+                + ")",
+                signal=transient_signal,
+                dump_path=str(postmortem_path) if postmortem_path else None,
             )
             self._last_error = transient_exc
             raise transient_exc
@@ -107,14 +150,14 @@ class ClaudeCliAdapter:
         # No events but rc==0 means claude-cli emitted nothing — treat
         # as a hard failure so the caller doesn't process empty text
         # as a legitimate assistant reply.
-        if not events:
+        if not stream_events:
             raise ClaudeCliInvocationError(
                 f"claude-cli rc=0 but emitted no stream-json events. "
                 f"stderr={stderr.strip()[:200]!r}"
             )
 
-        text = _extract_assistant_text(events)
-        stop_reason = _extract_stop_reason(events)
+        assistant_text = _extract_assistant_text(stream_events)
+        stop_reason = _extract_stop_reason(stream_events)
         # ``_extract_stop_reason`` returns ``"unknown"`` when no
         # ``message_delta`` / ``result`` stop event was seen; coerce
         # to the adapter-canonical ``"end_turn"`` so the translator's
@@ -122,7 +165,7 @@ class ClaudeCliAdapter:
         if stop_reason == "unknown":
             stop_reason = "end_turn"
         return AdapterCallResult(
-            text=text,
+            text=assistant_text,
             usage=UsageSummary(),  # subscription path does not expose token usage
             stop_reason=stop_reason,
         )
@@ -237,6 +280,84 @@ class ClaudeCliAdapter:
             provider=self.provider,
             source_path="~/.claude/oauth-token.json (via claude binary)",
         )
+
+
+def _dump_transient_postmortem(
+    *,
+    model: str,
+    rc: int,
+    stdout: str,
+    stderr: str,
+    events: list[StreamJsonEvent],
+    signal: TransientSignal,
+) -> Path | None:
+    """Persist a full post-mortem for every claude-cli transient hit so
+    operators can recover the upstream error message the classifier
+    matched on (which is otherwise discarded). Returns the dump path on
+    success, ``None`` on any I/O error (best-effort — diagnostic, not
+    correctness-critical).
+
+    Pre-PR-T the adapter discarded stdout / parsed events after the
+    classifier hit, surfacing only ``stderr_tail`` in the log line —
+    but claude-cli writes its errors to stdout, not stderr, so the
+    tail was invariably ``<empty>``. The dump records everything the
+    classifier saw so operators can identify the actual upstream
+    signature (5-hour quota vs RPM cap vs backend 5xx vs OAuth slot
+    cap) without re-running the cycle.
+    """
+    import json
+    import time
+
+    from core.paths import GLOBAL_DIAGNOSTICS_DIR
+
+    try:
+        # ``postmortem_dir`` is the parent of every transient dump.
+        # Co-located under ``~/.geode/diagnostics/`` with the existing
+        # smoke/oauth diagnostic outputs (see ``core.paths.GLOBAL_DIAGNOSTICS_DIR``)
+        # so the operator's "diagnostics tar-up" command catches it
+        # without a separate registration.
+        postmortem_dir = GLOBAL_DIAGNOSTICS_DIR / "claude-cli-transient"
+        postmortem_dir.mkdir(parents=True, exist_ok=True)
+        # ``hit_ts`` = wall-clock seconds of the transient hit. Used as
+        # the filename prefix so directory listing sorts chronologically
+        # (newest last), and as the ``ts`` field in the payload so a
+        # consumer reading multiple dumps can reconstruct the cycle's
+        # transient timeline without filesystem mtime ambiguity.
+        hit_ts = int(time.time())
+        # ``postmortem_path`` = absolute path the JSON will land at.
+        # Filename pattern ``<ts>-<model>.json`` lets ``ls -t`` show
+        # newest first and groups by model when sorted alphabetically.
+        postmortem_path = postmortem_dir / f"{hit_ts}-{model}.json"
+        # ``payload`` is the JSON body. Carries the four diagnostic
+        # dimensions the pre-PR-T ``stderr_tail`` log line discarded:
+        # (1) signal — which regex / which source fired
+        # (2) stdout — raw stream-json bytes claude-cli emitted
+        # (3) stderr — empty in practice but kept for completeness
+        # (4) events — parsed StreamJsonEvent sequence for structured
+        #     post-mortem analysis (which result.error / result.message
+        #     carried the upstream message). ``rc`` + ``model`` round
+        #     out the run identity.
+        payload = {
+            "ts": hit_ts,
+            "model": model,
+            "rc": rc,
+            "signal": {
+                "matched_text": signal.matched_text,
+                "source": signal.source,
+                "event_type": signal.event_type,
+                "event_field": signal.event_field,
+            },
+            "stdout": stdout,
+            "stderr": stderr,
+            "events": [{"type": e.type, "payload": e.payload} for e in events],
+        }
+        postmortem_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        return postmortem_path
+    except Exception:
+        log.debug("claude-cli transient post-mortem dump failed", exc_info=True)
+        return None
 
 
 __all__ = ["ClaudeCliAdapter"]

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -90,7 +90,9 @@ __all__ = [
     "CLAUDE_TRANSIENT_UPSTREAM_RE",
     "ClaudeCliInvocationError",
     "ClaudeCliTransientUpstreamError",
+    "TransientSignal",
     "build_claude_cli_argv",
+    "classify_transient_signal",
     "is_claude_transient_upstream_error",
     "parse_stream_json_events",
     "register",
@@ -143,7 +145,66 @@ class ClaudeCliTransientUpstreamError(ClaudeCliInvocationError):
     as the LLM's assistant message — the worker then terminated
     "successfully" with no tool calls and the caller recorded a
     ghost candidate. Failing loud here is the only way the parent
-    sees an actual error to react to."""
+    sees an actual error to react to.
+
+    ``signal`` (added 2026-05-24) carries the *matched* classifier hit
+    so log readers can tell *which* upstream signature fired. The
+    pre-signal path emitted only ``stderr_tail`` — invariably ``<empty>``
+    because claude-cli writes its errors to stdout, not stderr — and
+    log readers had to guess between rate_limit / overloaded / quota.
+
+    ``dump_path`` is the optional full ``(stdout, stderr, parsed events,
+    classifier signal, rc)`` post-mortem JSON that the adapter writes to
+    ``~/.geode/diagnostics/`` on every transient hit. Reading the dump
+    recovers the upstream error message claude-cli emitted in its
+    ``result`` event (which is otherwise discarded after classification).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        signal: TransientSignal | None = None,
+        dump_path: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.signal = signal
+        self.dump_path = dump_path
+
+
+@dataclass(frozen=True, slots=True)
+class TransientSignal:
+    """One classifier hit on the transient-upstream regex.
+
+    Returned by :func:`classify_transient_signal`. Pre-PR-T the
+    classifier returned ``bool`` so callers could not distinguish
+    *rate_limit* from *overloaded* from *quota-reset* — the diagnostic
+    that drives the operator's next action (wait vs retry vs swap
+    account) was lost. This dataclass carries the matched substring
+    + the *source field* (stdout / stderr / which event type) so
+    post-mortem operators can act on the actual upstream signature.
+    """
+
+    matched_text: str
+    """The exact substring that matched ``CLAUDE_TRANSIENT_UPSTREAM_RE``,
+    bounded to the first 200 chars to keep log lines tractable."""
+
+    source: str
+    """One of ``"stdout"`` / ``"stderr"`` / ``"event"`` — which raw
+    field the regex hit."""
+
+    event_type: str | None = None
+    """When ``source == "event"`` this is the ``type`` of the
+    :class:`StreamJsonEvent` carrying the matched text
+    (``"result"`` / ``"assistant"`` / etc.). ``None`` for raw
+    stdout/stderr hits."""
+
+    event_field: str | None = None
+    """When ``source == "event"`` and ``event_type == "result"`` this
+    is the inner field key that carried the matched text
+    (``"result"`` / ``"error"`` / ``"message"`` / ``"stderr"``).
+    ``None`` for assistant events (those always carry the text in
+    ``message.content[].text``)."""
 
 
 # Ported from paperclip ``packages/adapters/claude-local/src/server/
@@ -445,35 +506,57 @@ def _extract_assistant_text(events: list[StreamJsonEvent]) -> str:
     return ""
 
 
-def is_claude_transient_upstream_error(
+def classify_transient_signal(
     *,
     stdout: str,
     stderr: str,
     events: list[StreamJsonEvent] | None = None,
-) -> bool:
-    """True when claude-cli's output matches an upstream rate-limit
-    / overload / quota signature (see :data:`CLAUDE_TRANSIENT_UPSTREAM_RE`).
+) -> TransientSignal | None:
+    """Return the first :class:`TransientSignal` hit on the union of
+    raw stdout, raw stderr, every parsed ``result`` event's free-text
+    fields, and every ``assistant`` text block's ``text``. ``None``
+    when nothing matches.
 
-    Matches the union of: raw stdout, raw stderr, every parsed
-    ``result`` event's free-text fields (``result``, ``error``,
-    ``message``, ``stderr``), and every ``assistant`` text block's
-    ``text``. The wide haystack mirrors paperclip's
-    ``buildClaudeTransientHaystack`` — claude-cli has shipped the
-    same phrase to four different fields across versions and we want
-    a single classifier that covers all of them.
+    Pre-PR-T this was :func:`is_claude_transient_upstream_error`
+    returning ``bool`` — callers couldn't tell which signal fired so
+    the post-mortem could not act on the actual upstream signature
+    (rate_limit vs overloaded vs quota-reset). The dataclass-returning
+    form preserves the matched substring + source field so
+    log readers and operators get an actionable diagnostic.
+
+    Search order matches paperclip's ``buildClaudeTransientHaystack``:
+    raw stdout / stderr first, then events in arrival order.
     """
-    if CLAUDE_TRANSIENT_UPSTREAM_RE.search(stdout or ""):
-        return True
-    if CLAUDE_TRANSIENT_UPSTREAM_RE.search(stderr or ""):
-        return True
+    if stdout:
+        match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(stdout)
+        if match:
+            return TransientSignal(
+                matched_text=_signal_excerpt(stdout, match),
+                source="stdout",
+            )
+    if stderr:
+        match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(stderr)
+        if match:
+            return TransientSignal(
+                matched_text=_signal_excerpt(stderr, match),
+                source="stderr",
+            )
     if not events:
-        return False
+        return None
     for event in events:
         if event.type == "result":
             for key in ("result", "error", "message", "stderr"):
                 value = event.payload.get(key)
-                if isinstance(value, str) and CLAUDE_TRANSIENT_UPSTREAM_RE.search(value):
-                    return True
+                if not isinstance(value, str):
+                    continue
+                match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(value)
+                if match:
+                    return TransientSignal(
+                        matched_text=_signal_excerpt(value, match),
+                        source="event",
+                        event_type="result",
+                        event_field=key,
+                    )
         elif event.type == "assistant":
             message = event.payload.get("message", {})
             if not isinstance(message, dict):
@@ -487,9 +570,59 @@ def is_claude_transient_upstream_error(
                 if block.get("type") != "text":
                     continue
                 text = block.get("text", "")
-                if isinstance(text, str) and CLAUDE_TRANSIENT_UPSTREAM_RE.search(text):
-                    return True
-    return False
+                if not isinstance(text, str):
+                    continue
+                match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
+                if match:
+                    return TransientSignal(
+                        matched_text=_signal_excerpt(text, match),
+                        source="event",
+                        event_type="assistant",
+                    )
+    return None
+
+
+def is_claude_transient_upstream_error(
+    *,
+    stdout: str,
+    stderr: str,
+    events: list[StreamJsonEvent] | None = None,
+) -> bool:
+    """Backwards-compatible ``bool`` wrapper around
+    :func:`classify_transient_signal`. New callers should use the
+    classifier directly so they keep the diagnostic context (matched
+    text, source field, event type) instead of throwing it away.
+    """
+    return classify_transient_signal(stdout=stdout, stderr=stderr, events=events) is not None
+
+
+def _signal_excerpt(haystack: str, match: re.Match[str], radius: int = 80) -> str:
+    """Slice ``[match.start()-radius : match.end()+radius]`` from
+    ``haystack`` so the log line carries the surrounding error sentence
+    without flooding when claude-cli emits a multi-KB result event.
+
+    Args:
+        haystack: The full text the classifier ran the regex against
+            (stdout / stderr / one event field). Named ``haystack``
+            instead of ``text`` because the same name appears in event
+            payloads (``content[].text``) and the alias keeps the two
+            distinct at the call site.
+        match: The ``re.Match`` object the classifier obtained.
+        radius: Characters of pre/post context to include around the
+            matched span. ``80`` is empirically enough to capture one
+            sentence on either side of common Anthropic upstream
+            errors (``rate_limit_error: ...``, ``overloaded_error: ...``).
+
+    Returns:
+        Whitespace-normalised excerpt bounded to 200 chars so the
+        eventual log line stays a single row.
+    """
+    excerpt_start = max(0, match.start() - radius)
+    excerpt_end = min(len(haystack), match.end() + radius)
+    raw_excerpt = haystack[excerpt_start:excerpt_end]
+    # Collapse whitespace runs so the log line is one row.
+    collapsed = " ".join(raw_excerpt.split())
+    return collapsed[:200]
 
 
 def _extract_stop_reason(events: list[StreamJsonEvent]) -> str:

--- a/tests/core/llm/adapters/test_claude_cli_adapter.py
+++ b/tests/core/llm/adapters/test_claude_cli_adapter.py
@@ -169,3 +169,130 @@ def test_adapter_raises_when_rc_zero_no_events() -> None:
         pytest.raises(ClaudeCliInvocationError),
     ):
         asyncio.run(adapter.acomplete(_build_request()))
+
+
+# ---------------------------------------------------------------------------
+# PR T — observability: structured exception + post-mortem dump
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_transient_carries_signal_dataclass() -> None:
+    """Adapter must populate ``ClaudeCliTransientUpstreamError.signal``
+    with the matched ``TransientSignal`` so downstream callers
+    (AgenticLoop, worker) can act on the actual upstream signature
+    instead of guessing from a generic 'transient' string."""
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliTransientUpstreamError
+
+    adapter = ClaudeCliAdapter()
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "! Unexpected error. Auto-retrying."}]
+                },
+            },
+            {"type": "result", "stop_reason": "end_turn", "result": ""},
+        ]
+    )
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            return_value=(stdout, "", 0),
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+    ):
+        try:
+            asyncio.run(adapter.acomplete(_build_request()))
+            raise AssertionError("expected ClaudeCliTransientUpstreamError")
+        except ClaudeCliTransientUpstreamError as exc:
+            assert exc.signal is not None
+            # The classifier walks stdout first (paperclip ordering); the
+            # raw stream-json stdout contains the JSON-encoded matched text
+            # so the hit lands on ``source="stdout"`` before the parser
+            # gets a chance to surface the ``assistant`` event source.
+            # That is correct behaviour — raw evidence beats parsed.
+            assert exc.signal.source == "stdout"
+            assert "Unexpected error" in exc.signal.matched_text
+            # Exception message includes the source/matched_text inline
+            # so a single log line is enough for triage.
+            msg = str(exc)
+            assert "source=stdout" in msg
+            assert "matched=" in msg
+
+
+def test_adapter_transient_writes_postmortem_dump(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Every transient hit must persist a JSON post-mortem under
+    ``~/.geode/diagnostics/claude-cli-transient/`` so operators can
+    recover the upstream error message claude-cli emitted in its
+    stream-json events (otherwise discarded after classification)."""
+    import json as _json
+
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliTransientUpstreamError
+
+    # ``tmp_path`` is pytest's per-test scratch directory fixture. Alias
+    # it to ``diagnostics_root`` at entry so the rest of the test reads
+    # in domain terms — we're substituting the operator's real
+    # ``~/.geode/diagnostics/`` with a throwaway directory so the dump
+    # write doesn't pollute the home tree.
+    diagnostics_root = tmp_path
+    adapter = ClaudeCliAdapter()
+    stdout = _make_stream_json(
+        [{"type": "result", "error": "anthropic.RateLimitError: 429", "result": ""}]
+    )
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            return_value=(stdout, "", 1),
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+        # Redirect ``core.paths.GLOBAL_DIAGNOSTICS_DIR`` (the lazy
+        # import inside _dump_transient_postmortem reads it at call
+        # time, so the monkeypatch propagates to the dump helper).
+        patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", diagnostics_root),
+    ):
+        try:
+            asyncio.run(adapter.acomplete(_build_request()))
+            raise AssertionError("expected ClaudeCliTransientUpstreamError")
+        except ClaudeCliTransientUpstreamError as exc:
+            assert exc.dump_path is not None
+            # ``postmortem_path`` = the absolute path the adapter wrote
+            # the JSON dump to (carried back on the exception so the
+            # caller can grep it without scanning the diagnostics dir).
+            postmortem_path = exc.dump_path
+            assert postmortem_path.startswith(str(diagnostics_root))
+            with open(postmortem_path, encoding="utf-8") as fp:
+                data = _json.loads(fp.read())
+            # Dump must carry the four diagnostic dimensions the
+            # bool-only classifier discarded: stdout / parsed events /
+            # classifier signal / rc.
+            assert set(data.keys()) >= {"signal", "stdout", "stderr", "events", "rc", "model"}
+            assert data["signal"]["matched_text"]
+            # Source is ``stdout`` (raw stream-json bytes win over parsed
+            # events — see classifier search order). The event payload is
+            # still persisted in ``events[]`` so post-mortem analysis can
+            # walk to the structured event regardless.
+            assert data["signal"]["source"] in {"stdout", "event"}
+            assert (
+                "RateLimitError" in data["signal"]["matched_text"]
+                or "429" in data["signal"]["matched_text"]
+            )
+            assert len(data["events"]) == 1
+            assert data["events"][0]["type"] == "result"
+            assert data["events"][0]["payload"]["error"] == "anthropic.RateLimitError: 429"

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -194,3 +194,177 @@ def test_transient_classifier_subclass_caught_by_invocation_error() -> None:
     )
 
     assert issubclass(ClaudeCliTransientUpstreamError, ClaudeCliInvocationError)
+
+
+# ---------------------------------------------------------------------------
+# PR T — classify_transient_signal returns structured TransientSignal
+# (replaces the bool-only is_claude_transient_upstream_error so callers
+# can act on which signature fired — rate_limit vs overloaded vs quota).
+# ---------------------------------------------------------------------------
+
+
+def test_classify_signal_stdout_source() -> None:
+    from plugins.petri_audit.claude_cli_provider import classify_transient_signal
+
+    signal = classify_transient_signal(
+        stdout="oops! Unexpected error. Auto-retrying.\n",
+        stderr="",
+    )
+    assert signal is not None
+    assert signal.source == "stdout"
+    assert "Unexpected error. Auto-retrying" in signal.matched_text
+    assert signal.event_type is None
+    assert signal.event_field is None
+
+
+def test_classify_signal_stderr_source() -> None:
+    from plugins.petri_audit.claude_cli_provider import classify_transient_signal
+
+    signal = classify_transient_signal(
+        stdout="",
+        stderr="HTTP 429 rate_limit_error from upstream\n",
+    )
+    assert signal is not None
+    assert signal.source == "stderr"
+    # Both '429' and 'rate_limit_error' match — whichever the engine
+    # picks first is fine; the assertion is just that the surrounding
+    # context made it into the excerpt.
+    assert "rate_limit" in signal.matched_text or "429" in signal.matched_text
+
+
+def test_classify_signal_result_event_with_field() -> None:
+    """``result`` event hit must carry the ``event_field`` so the
+    operator can tell whether the upstream error landed in
+    ``result.error`` vs ``result.message`` vs ``result.stderr``."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [{"type": "result", "error": "overloaded_error: upstream busy", "result": ""}]
+    )
+    signal = classify_transient_signal(
+        stdout="", stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.source == "event"
+    assert signal.event_type == "result"
+    assert signal.event_field == "error"
+    assert "overloaded_error" in signal.matched_text
+
+
+def test_classify_signal_assistant_event_no_field() -> None:
+    """``assistant`` events carry text in ``message.content[].text`` —
+    the ``event_field`` is ``None`` because there's only one canonical
+    text location."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Claude usage limit reached. Resets at 4pm.",
+                        }
+                    ]
+                },
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout="", stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.source == "event"
+    assert signal.event_type == "assistant"
+    assert signal.event_field is None
+    assert "usage limit reached" in signal.matched_text
+
+
+def test_classify_signal_negative_returns_none() -> None:
+    """Normal successful output must return ``None`` (not bool ``False``)
+    so callers can use ``if signal is not None:`` for clarity."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello"}]}},
+            {"type": "result", "result": "Hello", "stop_reason": "end_turn"},
+        ]
+    )
+    assert (
+        classify_transient_signal(stdout=stdout, stderr="", events=parse_stream_json_events(stdout))
+        is None
+    )
+
+
+def test_classify_signal_search_order_stdout_first() -> None:
+    """Raw stdout match wins over any event match — paperclip's
+    ``buildClaudeTransientHaystack`` walks raw fields first because
+    they're the rawest evidence (no parser intermediate)."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout_with_match = "429 throttling at the wrapper layer\n"
+    events_with_match = parse_stream_json_events(
+        _make_stream_json([{"type": "result", "error": "overloaded_error", "result": ""}])
+    )
+    signal = classify_transient_signal(
+        stdout=stdout_with_match, stderr="", events=events_with_match
+    )
+    assert signal is not None
+    assert signal.source == "stdout"
+    # Verifies stdout hit takes precedence — event hit (overloaded_error)
+    # is not the matched_text.
+    assert "overloaded" not in signal.matched_text
+
+
+def test_signal_excerpt_bounded_to_200_chars() -> None:
+    """``matched_text`` must stay ≤ 200 chars so log lines remain
+    readable even when claude-cli emits multi-KB error blobs."""
+    from plugins.petri_audit.claude_cli_provider import classify_transient_signal
+
+    long_pad = "x" * 500
+    stdout = f"{long_pad} 429 {long_pad}"
+    signal = classify_transient_signal(stdout=stdout, stderr="")
+    assert signal is not None
+    assert len(signal.matched_text) <= 200
+
+
+def test_transient_exception_carries_signal_and_dump_path() -> None:
+    """Structured fields on ``ClaudeCliTransientUpstreamError`` —
+    these are the diagnostic the bool-only path lost. ``signal`` and
+    ``dump_path`` together let downstream callers route on the
+    actual upstream signature without re-running the cycle."""
+    from plugins.petri_audit.claude_cli_provider import (
+        ClaudeCliTransientUpstreamError,
+        TransientSignal,
+    )
+
+    sig = TransientSignal(matched_text="429 rate_limit", source="stderr")
+    fixture_path = "/var/tmp/dump.json"  # noqa: S108 — symbolic fixture path; the file is never opened
+    exc = ClaudeCliTransientUpstreamError("test message", signal=sig, dump_path=fixture_path)
+    assert exc.signal is sig
+    assert exc.dump_path == fixture_path
+
+
+def test_transient_exception_default_signal_none_for_backwards_compat() -> None:
+    """Pre-PR-T callers that raise without keyword args must still
+    work — ``signal`` and ``dump_path`` default to ``None``."""
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliTransientUpstreamError
+
+    exc = ClaudeCliTransientUpstreamError("legacy")
+    assert exc.signal is None
+    assert exc.dump_path is None


### PR DESCRIPTION
## Summary
- Replace bool-only ``is_claude_transient_upstream_error`` with structured ``classify_transient_signal(...) -> TransientSignal | None`` (matched_text + source + event_type + event_field). Bool wrapper kept for backwards-compat callers.
- ``ClaudeCliTransientUpstreamError`` carries ``signal`` + ``dump_path`` structured attrs; exception ``str()`` now includes ``source=`` / ``matched=`` / ``dump=`` so a single log line is enough for triage.
- ``ClaudeCliAdapter.acomplete`` persists full ``(stdout, stderr, parsed events, classifier signal, rc)`` JSON to ``~/.geode/diagnostics/claude-cli-transient/<ts>-<model>.json`` on every transient hit.
- 11 new tests + naive local rename pass per `feedback_no_naive_variable_names`.

## Why
Operator-reported triage problem during the 2026-05-24 seed-generation smoke: 5-hour OAuth quota was only 26% utilised, yet 6 consecutive sub-agent spawns hit ``ClaudeCliTransientUpstreamError(rc=1, stderr_tail='<empty>')`` with no other diagnostic info. The pre-PR-T path discarded the parsed stream-json events and the matched substring after the classifier hit, so the operator could not distinguish:

| candidate cause | needs which signal |
|---|---|
| 5-hour token quota | quota-reset / usage-limit text in a ``result`` event |
| anthropic backend RPM cap | ``429`` / ``rate_limit_error`` in stderr or stdout |
| backend 5xx | ``overloaded_error`` / ``503`` / ``529`` |
| claude-cli internal retry exhaustion | ``Unexpected error. Auto-retrying.`` in an ``assistant`` event |
| OAuth slot cap (unlikely — paperclip runs 10 parallel) | not yet enumerated |

All five paths surfaced as one identical log line. PR-T fixes that — log line now identifies which regex / which source fired, and the on-disk dump records the upstream error message claude-cli embedded in its ``result`` event for forensic walk.

## Changes
| File | Change |
|------|--------|
| ``plugins/petri_audit/claude_cli_provider.py`` | New ``TransientSignal`` dataclass + ``classify_transient_signal(...) -> TransientSignal \| None`` (replaces internals of the bool wrapper). ``ClaudeCliTransientUpstreamError`` gains ``signal`` + ``dump_path`` kwargs. ``_signal_excerpt`` helper bounds matched substrings to 200 chars with ±80-char context. |
| ``core/llm/adapters/claude_cli.py`` | ``acomplete`` swaps the bool classifier for ``classify_transient_signal``. On hit, calls new ``_dump_transient_postmortem`` (writes JSON under ``~/.geode/diagnostics/claude-cli-transient/<ts>-<model>.json``) and raises with structured ``signal`` + ``dump_path`` + inline message. Local variables renamed (``events → stream_events``, ``signal → transient_signal``, ``dump_path → postmortem_path``, ``text → assistant_text``, ``ts → hit_ts``) per the naive-naming feedback. |
| ``tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`` | +8 tests: stdout source, stderr source, result event with field, assistant event without field, negative None return, search-order precedence, excerpt 200-char bound, exception structured attrs (default + populated). |
| ``tests/core/llm/adapters/test_claude_cli_adapter.py`` | +2 tests: adapter exception carries ``TransientSignal`` with correct ``source`` + ``matched_text``, adapter writes the post-mortem dump and the exception's ``dump_path`` resolves to the on-disk file. |
| ``CHANGELOG.md`` | Unreleased entry. |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/`` clean
- [x] ``uv run ruff format --check core/ tests/ plugins/`` clean (867 files already formatted)
- [x] ``uv run mypy core/ plugins/`` clean (428 source files, 0 errors)
- [x] ``uv run pytest tests/plugins/petri_audit/test_claude_cli_transient_classifier.py tests/core/llm/adapters/test_claude_cli_adapter.py`` — 26/26 pass
- [x] ``uv run geode version`` → ``GEODE v0.99.50``

## Reference
- 2026-05-24 seed-generation smoke ghost-cycle: ``~/.geode/workers/gen-gen1-001-bd2e3854.stderr.log`` (6 lines of identical ``stderr_tail='<empty>'`` — the symptom PR-T closes).
- paperclip ``packages/adapters/claude-local/src/server/parse.ts:370`` ``isClaudeTransientUpstreamError`` + ``buildClaudeTransientHaystack`` (search-order parity).
- paperclip ``packages/adapters/claude-local/src/server/quota.ts:213`` ``/api/oauth/usage`` endpoint (the five quota dimensions the dump enables operators to disambiguate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)