### PR TITLE
release: v0.99.51 — PR-T + PR-Q + PR-Q.5/U bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.51] - 2026-05-24
+
+> PR-T + PR-Q + PR-Q.5/U 3-PR bundle. PR-T (#1582): claude-cli transient
+> classifier observability — structured `TransientSignal` + full
+> post-mortem JSON dump under `~/.geode/diagnostics/`. PR-Q (#1583):
+> run-dir-as-anchor consolidation — 4 observability writers redirect
+> into `state/seed-generation/<run_id>/sub_agents/<task_id>/` via new
+> `core/observability/run_dir.py` ContextVar + `GEODE_RUN_DIR` env
+> bridge. PR-Q.5 + PR-U (#1584): single-anchor `task_id` invariant +
+> paperclip-style activity_log mirror in pipeline transcript. Spec doc
+> at `docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`
+> (PR1 = this release, PR2 queued). Codex MCP review of #1584 caught
+> ContextVar cross-process gap and got fixed in the same PR.
+
 ### Changed
 - **PR-Q.5 + PR-U — transcript 표준화 (식별자 정렬 + paperclip-style timeline mirror).**
   ``docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`` 의

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.50
+- **Version**: 0.99.51
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.50 — Long-running Autonomous Execution Harness
+# GEODE v0.99.51 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.50**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.51**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.50 — Long-running Autonomous Execution Harness
+# GEODE v0.99.51 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.50**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.51**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.50"
+version = "0.99.51"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.50"
+version = "0.99.51"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.51 stamp bump across 5 SoT files (pyproject.toml / CLAUDE.md / README.md / README.ko.md / CHANGELOG section).
- ``[Unreleased]`` → ``[0.99.51] - 2026-05-24`` with release header summarising 3 PRs.
- No code changes — bundles #1582 (PR-T) + #1583 (PR-Q) + #1584 (PR-Q.5 + PR-U) already on develop.

## Verification
- [x] ``uv run geode version`` → ``GEODE v0.99.51``
- [x] 5/5 version stamps consistent
- [x] CHANGELOG ``[Unreleased]`` empty; release content under ``[0.99.51]``

🤖 Generated with [Claude Code](https://claude.com/claude-code)