### PR TITLE
feat(observability): HookEvent → ActivityRow schema + union channel (PR-COMM-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ functional change.
     discriminated dispatch + generic fall-through + 74/74 cover) and
     M1-M3 (union channel mirror + no-op outside scope + malformed
     payload still emits row).
-  - Frontier alignment: paperclip `as const` 33 event tuple
+  - Frontier alignment: paperclip `as const` event tuple
     (`packages/shared/src/constants.ts:1029`), paperclip `PluginEvent`
     generic envelope (`packages/plugins/sdk/src/types.ts:180`),
     openclaw `NormalizedEventSchema = z.discriminatedUnion("type", [...])`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-COMM-1 — HookEvent → ActivityRow schema + union channel.**
+  Spec doc at `docs/plans/2026-05-24-hookevent-activity-schema.md`
+  (S2 scope: 32 lifecycle typed + 42 generic fall-through).
+  3-codebase audit GAP 1 + 4 (P1). Pre-PR-COMM-1 the pipeline transcript
+  carried 4 SessionTranscript mirrors + orchestrator phase events; the
+  remaining 70 HookEvent triggers were invisible in the unified timeline.
+  - `core/observability/activity.py` (NEW) — paperclip
+    `PluginEvent<TPayload>` envelope + openclaw `discriminatedUnion`
+    pattern: `ActivityRowBase` + 11 group base classes + 32 lifecycle
+    concrete classes (groups A/B/C/D) + `GenericActivityRow` escape
+    hatch + `TypedActivityRow` discriminator on `action`.
+  - `core/observability/activity_registry.py` (NEW) —
+    `HOOK_EVENT_TO_ROW_BUILDER` (32 typed) +
+    `map_hook_to_activity(event, data, run_id)` (typed dispatch +
+    generic fall-through for 42 non-lifecycle events).
+  - `core/hooks/system.py` — new `_mirror_hook_to_active_transcript`
+    helper called at the end of both `trigger()` and `trigger_async()`.
+    No-op outside an active `RunTranscript` scope (REPL / gateway /
+    tests unaffected). Swallow-and-warn contract (paperclip
+    `activity-log.ts:65` parity) so a mirror failure never breaks the
+    upstream caller.
+  - 17 new tests pin I1-I5 (envelope quintuple + concrete literals +
+    discriminated dispatch + generic fall-through + 74/74 cover) and
+    M1-M3 (union channel mirror + no-op outside scope + malformed
+    payload still emits row).
+  - Frontier alignment: paperclip `as const` 33 event tuple
+    (`packages/shared/src/constants.ts:1029`), paperclip `PluginEvent`
+    generic envelope (`packages/plugins/sdk/src/types.ts:180`),
+    openclaw `NormalizedEventSchema = z.discriminatedUnion("type", [...])`
+    (`extensions/voice-call/src/types.ts:90`).
+
 ## [0.99.51] - 2026-05-24
 
 > PR-T + PR-Q + PR-Q.5/U 3-PR bundle. PR-T (#1582): claude-cli transient

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -27,6 +27,60 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
+def _mirror_hook_to_active_transcript(event: HookEvent, data: dict[str, Any]) -> None:
+    """Mirror a HookSystem trigger into the active RunTranscript as a
+    paperclip-style activity_log row.
+
+    PR-COMM-1 (2026-05-24, spec doc §4). Pre-PR-COMM-1 the pipeline
+    transcript only carried 4 SessionTranscript mirrors (record_user_message
+    / record_assistant_message / record_tool_call / record_tool_result)
+    from PR-U + orchestrator phase events from cli.py. The remaining 70
+    HookEvent triggers were invisible in the unified timeline. Routing
+    every trigger through this helper closes that gap.
+
+    No-op when no orchestrator is bound (REPL / gateway / tests). Any
+    builder / registry / append failure is swallow-and-warn so a failed
+    mirror never breaks the upstream caller — same contract paperclip's
+    ``logActivity`` uses (``activity-log.ts:65``).
+    """
+    try:
+        from core.observability.activity_registry import map_hook_to_activity
+        from core.self_improving_loop.run_transcript import current_run_transcript
+
+        run_transcript = current_run_transcript()
+        if run_transcript is None:
+            return
+        row = map_hook_to_activity(event, data, run_id=run_transcript.session_id)
+        # Coerce details to a plain dict for the JSONL row. ``details``
+        # lives on every concrete ``ActivityRowBase`` subclass (typed
+        # rows carry pydantic ``BaseModel`` sub-schemas; generic rows
+        # carry a free-form ``dict``); we access via ``getattr`` so
+        # mypy doesn't trip over the base class's missing field.
+        row_details = getattr(row, "details", None)
+        details_payload: dict[str, Any]
+        if row_details is None:
+            details_payload = {}
+        elif hasattr(row_details, "model_dump"):
+            details_payload = row_details.model_dump()
+        elif isinstance(row_details, dict):
+            details_payload = row_details
+        else:
+            details_payload = {"_repr": repr(row_details)}
+        run_transcript.append(
+            event=event.value,
+            actor_type=row.actor_type,
+            actor_id=row.actor_id,
+            action=row.action,
+            entity_type=row.entity_type,
+            entity_id=row.entity_id,
+            task_id=row.task_id,
+            level=row.level,
+            payload=details_payload,
+        )
+    except Exception as exc:
+        log.debug("HookEvent → ActivityRow mirror failed for %s: %s", event.value, exc)
+
+
 class HookEvent(Enum):
     """Pipeline lifecycle events."""
 
@@ -346,6 +400,15 @@ class HookSystem:
                     )
                 )
 
+        # PR-COMM-1 (2026-05-24, spec doc §4 union channel wiring) —
+        # mirror this trigger into the active RunTranscript as a typed
+        # ActivityRow so the pipeline transcript carries every hook
+        # event, not just the 4 SessionTranscript record_* mirrors PR-U
+        # landed. No-op when no orchestrator is bound (REPL / gateway /
+        # tests). Failures are silent + warning-logged so the union
+        # channel never breaks an upstream hook handler.
+        _mirror_hook_to_active_transcript(event, data)
+
         return results
 
     async def trigger_async(
@@ -376,6 +439,11 @@ class HookSystem:
                         error=str(exc),
                     )
                 )
+
+        # PR-COMM-1 (2026-05-24) — async-path parity with the sync
+        # mirror call in :meth:`trigger` so both dispatch paths produce
+        # the same unified timeline.
+        _mirror_hook_to_active_transcript(event, data)
 
         return results
 

--- a/core/observability/activity.py
+++ b/core/observability/activity.py
@@ -15,9 +15,9 @@ After PR-COMM-1 (S2 scope):
     ``LifecycleFailedRow`` / ``LifecycleRetriedRow`` / ``CognitiveStepRow`` /
     ``AutoTriggerRow`` / ``StateChangeRow`` / ``CostBudgetRow`` /
     ``MemoryMutationRow`` / ``McpServerRow`` / ``GenericActivityRow``)
-  - 31 lifecycle-pair concrete classes (A+B+C+D groups) with
-    discriminator on ``action``
-  - 43 non-lifecycle events fall through to ``GenericActivityRow``
+  - 32 lifecycle-pair concrete classes (A+B+C+D groups: 9 started + 13
+    completed + 9 failed + 1 retried) with discriminator on ``action``
+  - 42 non-lifecycle events fall through to ``GenericActivityRow``
 
 Subsequent PRs (not in S2) will add concrete subclasses for the E-K
 groups as their schemas stabilise.
@@ -242,7 +242,7 @@ class GenericActivityRow(ActivityRowBase):
 
 
 # ---------------------------------------------------------------------------
-# Tier 3 — 31 lifecycle concrete classes (A + B + C + D groups, S2 scope)
+# Tier 3 — 32 lifecycle concrete classes (A + B + C + D groups, S2 scope)
 # ---------------------------------------------------------------------------
 
 # A — Lifecycle started (9)
@@ -463,7 +463,7 @@ TypedActivityRow = Annotated[
     ],
     Field(discriminator="action"),
 ]
-"""Discriminated union of 31 typed lifecycle ActivityRow subclasses.
+"""Discriminated union of 32 typed lifecycle ActivityRow subclasses.
 
 Mirrors openclaw's ``NormalizedEventSchema = z.discriminatedUnion("type", [...])``.
 The ``action`` field is the discriminator — pydantic dispatches to the

--- a/core/observability/activity.py
+++ b/core/observability/activity.py
@@ -1,0 +1,484 @@
+"""ActivityRow — paperclip activity_log envelope + per-event payload schemas.
+
+Spec: ``docs/plans/2026-05-24-hookevent-activity-schema.md``.
+
+Adapts paperclip's ``PluginEvent<TPayload>`` envelope
+(``~/workspace/paperclip/packages/plugins/sdk/src/types.ts:180``) and
+openclaw's ``z.discriminatedUnion("type")`` pattern
+(``~/workspace/openclaw/extensions/voice-call/src/types.ts:90``) to
+GEODE. Pre-PR-COMM-1 the 74 ``HookEvent`` payloads were untyped
+``dict[str, Any]`` — bugs only surfaced at the handler reading the dict.
+
+After PR-COMM-1 (S2 scope):
+  - 1 envelope (``ActivityRowBase``)
+  - 11 group bases (``LifecycleStartedRow`` / ``LifecycleCompletedRow`` /
+    ``LifecycleFailedRow`` / ``LifecycleRetriedRow`` / ``CognitiveStepRow`` /
+    ``AutoTriggerRow`` / ``StateChangeRow`` / ``CostBudgetRow`` /
+    ``MemoryMutationRow`` / ``McpServerRow`` / ``GenericActivityRow``)
+  - 31 lifecycle-pair concrete classes (A+B+C+D groups) with
+    discriminator on ``action``
+  - 43 non-lifecycle events fall through to ``GenericActivityRow``
+
+Subsequent PRs (not in S2) will add concrete subclasses for the E-K
+groups as their schemas stabilise.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "ActivityRow",
+    "ActivityRowBase",
+    "AnalystCompletedRow",
+    "AutoTriggerRow",
+    "CognitiveStepRow",
+    "CostBudgetRow",
+    "EvaluatorCompletedRow",
+    "GenericActivityRow",
+    "HandoffCompletedRow",
+    "HandoffFailedRow",
+    "HandoffTriggeredRow",
+    "LLMCallEndedRow",
+    "LLMCallFailedRow",
+    "LLMCallRetriedRow",
+    "LLMCallStartedRow",
+    "LifecycleCompletedDetails",
+    "LifecycleCompletedRow",
+    "LifecycleFailedDetails",
+    "LifecycleFailedRow",
+    "LifecycleRetriedDetails",
+    "LifecycleRetriedRow",
+    "LifecycleStartedDetails",
+    "LifecycleStartedRow",
+    "McpServerRow",
+    "MemoryMutationRow",
+    "NodeBootstrapRow",
+    "NodeEnteredRow",
+    "NodeErrorRow",
+    "NodeExitedRow",
+    "PipelineEndedRow",
+    "PipelineErrorRow",
+    "PipelineStartedRow",
+    "PipelineTimeoutRow",
+    "ScoringCompletedRow",
+    "SessionEndedRow",
+    "SessionStartedRow",
+    "StateChangeRow",
+    "SubAgentCompletedRow",
+    "SubAgentFailedRow",
+    "SubAgentStartedRow",
+    "ToolExecEndedRow",
+    "ToolExecFailedRow",
+    "ToolExecStartedRow",
+    "ToolRecoveryAttemptedRow",
+    "ToolRecoveryFailedRow",
+    "ToolRecoverySucceededRow",
+    "TurnCompletedRow",
+    "TurnVerifyFailedRow",
+    "TurnVerifyPassedRow",
+    "TypedActivityRow",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — paperclip-style envelope
+# ---------------------------------------------------------------------------
+
+
+class ActivityRowBase(BaseModel):
+    """paperclip ``PluginEvent`` envelope equivalent + GEODE run metadata.
+
+    Every ``HookSystem.trigger()`` call produces exactly one of the 74
+    concrete subclasses (when typed) or :class:`GenericActivityRow`
+    (fall-through). The pipeline transcript at
+    ``<run_dir>/transcript.jsonl`` carries a row for every hook event,
+    not just the 4 SessionTranscript mirrors PR-U landed.
+
+    Field semantics mirror paperclip's
+    ``packages/db/src/schema/activity_log.ts:6`` ``activity_log`` table:
+    actor / action / entity is the classification quintuple operators
+    can grep on for any cross-cycle / cross-agent question.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ts: float
+    run_id: str
+    actor_type: Literal["orchestrator", "agent", "system", "plugin"]
+    actor_id: str
+    action: str
+    entity_type: str
+    entity_id: str
+    task_id: str | None = None
+    level: Literal["info", "warn", "error"] = "info"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — 11 group bases (shared payload schemas)
+# ---------------------------------------------------------------------------
+
+
+class LifecycleStartedDetails(BaseModel):
+    """Group A — every ``*_STARTED`` / ``*_BOOTSTRAP`` / ``*_ENTERED``
+    / ``*_TRIGGERED`` / ``*_ATTEMPTED`` event carries the identifier
+    of the entity whose lifecycle just opened."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    identifier: str
+
+
+class LifecycleStartedRow(ActivityRowBase):
+    details: LifecycleStartedDetails
+
+
+class LifecycleCompletedDetails(BaseModel):
+    """Group B — every ``*_ENDED`` / ``*_COMPLETED`` / ``*_SUCCEEDED``
+    / ``*_PASSED`` event carries the duration and success flag."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    duration_ms: float
+    success: bool = True
+
+
+class LifecycleCompletedRow(ActivityRowBase):
+    details: LifecycleCompletedDetails
+
+
+class LifecycleFailedDetails(BaseModel):
+    """Group C — every ``*_ERROR`` / ``*_FAILED`` / ``*_TIMEOUT`` event
+    carries an error classification + message. ``duration_ms`` is
+    optional because some failures fire before the lifecycle pair's
+    start event (e.g. ``PIPELINE_TIMEOUT`` from a watchdog)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    duration_ms: float | None = None
+    error_type: str
+    message: str
+
+
+class LifecycleFailedRow(ActivityRowBase):
+    level: Literal["info", "warn", "error"] = "error"
+    details: LifecycleFailedDetails
+
+
+class LifecycleRetriedDetails(BaseModel):
+    """Group D — ``LLM_CALL_RETRIED`` carries the attempt number plus
+    the reason classification (rate_limit / connection / timeout / ...)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    attempt: int
+    reason: str
+
+
+class LifecycleRetriedRow(ActivityRowBase):
+    level: Literal["info", "warn", "error"] = "warn"
+    details: LifecycleRetriedDetails
+
+
+# Group E-K base classes (defined for forward-compat with subsequent PRs
+# that will add concrete subclasses; S2 routes these via GenericActivityRow).
+
+
+class CognitiveStepRow(ActivityRowBase):
+    """Group E — COGNITIVE_PERCEIVE / PLAN / ACT / OBSERVE / REFLECT /
+    UPDATE_MEMORY. Concrete subclasses pending."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class AutoTriggerRow(ActivityRowBase):
+    """Group F — SELF_IMPROVING_AUTO_TRIGGER_* (5 events). Concrete
+    subclasses pending."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class StateChangeRow(ActivityRowBase):
+    """Group G — MODEL_SWITCHED / TOOL_APPROVAL_* / VERIFICATION_* /
+    CONFIG_RELOADED. Concrete subclasses pending."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class CostBudgetRow(ActivityRowBase):
+    """Group H — COST_WARNING / COST_LIMIT_EXCEEDED. Concrete
+    subclasses pending."""
+
+    level: Literal["info", "warn", "error"] = "warn"
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class MemoryMutationRow(ActivityRowBase):
+    """Group I — MEMORY_SAVED / RULE_CREATED / RULE_UPDATED / RULE_DELETED.
+    Concrete subclasses pending."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class McpServerRow(ActivityRowBase):
+    """Group J — MCP_SERVER_CONNECTED / MCP_SERVER_FAILED. Concrete
+    subclasses pending."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class GenericActivityRow(ActivityRowBase):
+    """Group K — fall-through for the 18+ non-lifecycle events that
+    don't have a concrete subclass yet (PROMPT_ASSEMBLED /
+    SNAPSHOT_CAPTURED / TRIGGER_FIRED / etc.). The ``details`` dict is
+    free-form — subsequent PRs will tighten high-volume events.
+
+    Also serves as the ValidationError fall-through path so a typed
+    builder failure never silences a hook trigger."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — 31 lifecycle concrete classes (A + B + C + D groups, S2 scope)
+# ---------------------------------------------------------------------------
+
+# A — Lifecycle started (9)
+
+
+class PipelineStartedRow(LifecycleStartedRow):
+    action: Literal["pipeline.started"] = "pipeline.started"
+    entity_type: Literal["pipeline"] = "pipeline"
+
+
+class NodeBootstrapRow(LifecycleStartedRow):
+    action: Literal["node.bootstrap"] = "node.bootstrap"
+    entity_type: Literal["node"] = "node"
+
+
+class NodeEnteredRow(LifecycleStartedRow):
+    action: Literal["node.entered"] = "node.entered"
+    entity_type: Literal["node"] = "node"
+
+
+class SessionStartedRow(LifecycleStartedRow):
+    action: Literal["session.started"] = "session.started"
+    entity_type: Literal["session"] = "session"
+
+
+class SubAgentStartedRow(LifecycleStartedRow):
+    action: Literal["subagent.started"] = "subagent.started"
+    entity_type: Literal["task"] = "task"
+
+
+class LLMCallStartedRow(LifecycleStartedRow):
+    action: Literal["llm.call.started"] = "llm.call.started"
+    entity_type: Literal["llm_call"] = "llm_call"
+
+
+class ToolExecStartedRow(LifecycleStartedRow):
+    action: Literal["tool.exec.started"] = "tool.exec.started"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+class HandoffTriggeredRow(LifecycleStartedRow):
+    action: Literal["handoff.triggered"] = "handoff.triggered"
+    entity_type: Literal["handoff"] = "handoff"
+
+
+class ToolRecoveryAttemptedRow(LifecycleStartedRow):
+    action: Literal["tool.recovery.attempted"] = "tool.recovery.attempted"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+# B — Lifecycle completed (13)
+
+
+class PipelineEndedRow(LifecycleCompletedRow):
+    action: Literal["pipeline.ended"] = "pipeline.ended"
+    entity_type: Literal["pipeline"] = "pipeline"
+
+
+class NodeExitedRow(LifecycleCompletedRow):
+    action: Literal["node.exited"] = "node.exited"
+    entity_type: Literal["node"] = "node"
+
+
+class SessionEndedRow(LifecycleCompletedRow):
+    action: Literal["session.ended"] = "session.ended"
+    entity_type: Literal["session"] = "session"
+
+
+class SubAgentCompletedRow(LifecycleCompletedRow):
+    action: Literal["subagent.completed"] = "subagent.completed"
+    entity_type: Literal["task"] = "task"
+
+
+class LLMCallEndedRow(LifecycleCompletedRow):
+    action: Literal["llm.call.ended"] = "llm.call.ended"
+    entity_type: Literal["llm_call"] = "llm_call"
+
+
+class ToolExecEndedRow(LifecycleCompletedRow):
+    action: Literal["tool.exec.ended"] = "tool.exec.ended"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+class HandoffCompletedRow(LifecycleCompletedRow):
+    action: Literal["handoff.completed"] = "handoff.completed"
+    entity_type: Literal["handoff"] = "handoff"
+
+
+class ToolRecoverySucceededRow(LifecycleCompletedRow):
+    action: Literal["tool.recovery.succeeded"] = "tool.recovery.succeeded"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+class TurnCompletedRow(LifecycleCompletedRow):
+    action: Literal["turn.completed"] = "turn.completed"
+    entity_type: Literal["turn"] = "turn"
+
+
+class TurnVerifyPassedRow(LifecycleCompletedRow):
+    action: Literal["turn.verify.passed"] = "turn.verify.passed"
+    entity_type: Literal["turn_verify"] = "turn_verify"
+
+
+class AnalystCompletedRow(LifecycleCompletedRow):
+    action: Literal["analyst.completed"] = "analyst.completed"
+    entity_type: Literal["analyst"] = "analyst"
+
+
+class EvaluatorCompletedRow(LifecycleCompletedRow):
+    action: Literal["evaluator.completed"] = "evaluator.completed"
+    entity_type: Literal["evaluator"] = "evaluator"
+
+
+class ScoringCompletedRow(LifecycleCompletedRow):
+    action: Literal["scoring.completed"] = "scoring.completed"
+    entity_type: Literal["scoring"] = "scoring"
+
+
+# C — Lifecycle failed (9)
+
+
+class PipelineErrorRow(LifecycleFailedRow):
+    action: Literal["pipeline.error"] = "pipeline.error"
+    entity_type: Literal["pipeline"] = "pipeline"
+
+
+class PipelineTimeoutRow(LifecycleFailedRow):
+    action: Literal["pipeline.timeout"] = "pipeline.timeout"
+    entity_type: Literal["pipeline"] = "pipeline"
+
+
+class NodeErrorRow(LifecycleFailedRow):
+    action: Literal["node.error"] = "node.error"
+    entity_type: Literal["node"] = "node"
+
+
+class SubAgentFailedRow(LifecycleFailedRow):
+    action: Literal["subagent.failed"] = "subagent.failed"
+    entity_type: Literal["task"] = "task"
+
+
+class LLMCallFailedRow(LifecycleFailedRow):
+    action: Literal["llm.call.failed"] = "llm.call.failed"
+    entity_type: Literal["llm_call"] = "llm_call"
+
+
+class ToolExecFailedRow(LifecycleFailedRow):
+    action: Literal["tool.exec.failed"] = "tool.exec.failed"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+class ToolRecoveryFailedRow(LifecycleFailedRow):
+    action: Literal["tool.recovery.failed"] = "tool.recovery.failed"
+    entity_type: Literal["tool_call"] = "tool_call"
+
+
+class HandoffFailedRow(LifecycleFailedRow):
+    action: Literal["handoff.failed"] = "handoff.failed"
+    entity_type: Literal["handoff"] = "handoff"
+
+
+class TurnVerifyFailedRow(LifecycleFailedRow):
+    action: Literal["turn.verify.failed"] = "turn.verify.failed"
+    entity_type: Literal["turn_verify"] = "turn_verify"
+
+
+# D — Retry (1)
+
+
+class LLMCallRetriedRow(LifecycleRetriedRow):
+    action: Literal["llm.call.retried"] = "llm.call.retried"
+    entity_type: Literal["llm_call"] = "llm_call"
+
+
+# ---------------------------------------------------------------------------
+# Discriminated union — openclaw NormalizedEventSchema parity
+# ---------------------------------------------------------------------------
+
+
+TypedActivityRow = Annotated[
+    Union[  # noqa: UP007 — Annotated discriminator needs Union, not | syntax
+        # A
+        PipelineStartedRow,
+        NodeBootstrapRow,
+        NodeEnteredRow,
+        SessionStartedRow,
+        SubAgentStartedRow,
+        LLMCallStartedRow,
+        ToolExecStartedRow,
+        HandoffTriggeredRow,
+        ToolRecoveryAttemptedRow,
+        # B
+        PipelineEndedRow,
+        NodeExitedRow,
+        SessionEndedRow,
+        SubAgentCompletedRow,
+        LLMCallEndedRow,
+        ToolExecEndedRow,
+        HandoffCompletedRow,
+        ToolRecoverySucceededRow,
+        TurnCompletedRow,
+        TurnVerifyPassedRow,
+        AnalystCompletedRow,
+        EvaluatorCompletedRow,
+        ScoringCompletedRow,
+        # C
+        PipelineErrorRow,
+        PipelineTimeoutRow,
+        NodeErrorRow,
+        SubAgentFailedRow,
+        LLMCallFailedRow,
+        ToolExecFailedRow,
+        ToolRecoveryFailedRow,
+        HandoffFailedRow,
+        TurnVerifyFailedRow,
+        # D
+        LLMCallRetriedRow,
+    ],
+    Field(discriminator="action"),
+]
+"""Discriminated union of 31 typed lifecycle ActivityRow subclasses.
+
+Mirrors openclaw's ``NormalizedEventSchema = z.discriminatedUnion("type", [...])``.
+The ``action`` field is the discriminator — pydantic dispatches to the
+correct subclass at ``model_validate`` time, raising
+``ValidationError`` when ``action`` matches none. The fall-through
+escape hatch (``GenericActivityRow``) is intentionally a sibling type,
+not a union member, because pydantic requires every discriminator
+target to declare ``action`` as ``Literal`` — ``GenericActivityRow.action``
+is open ``str`` so unknown hook events still land in the timeline
+without forcing a literal per event.
+"""
+
+
+ActivityRow = Union[TypedActivityRow, GenericActivityRow]  # noqa: UP007 — pydantic Union semantics
+"""Public type alias — either a typed lifecycle row or the generic
+fall-through. Registry callers decide which type to construct; the
+TypedAdapter for validation should prefer ``TypedActivityRow`` first
+and fall back to ``GenericActivityRow`` on ``ValidationError``."""

--- a/core/observability/activity_registry.py
+++ b/core/observability/activity_registry.py
@@ -1,0 +1,386 @@
+"""HookEvent → ActivityRow mapping registry.
+
+Spec: ``docs/plans/2026-05-24-hookevent-activity-schema.md`` §3.
+
+Each of the 31 lifecycle events maps to a builder that produces the
+appropriate concrete ``ActivityRow`` subclass with validated payload.
+The 43 non-lifecycle events fall through to
+:class:`GenericActivityRow` so they still land in the timeline — but
+without the type-safety + IDE autocomplete benefit. Subsequent PRs
+(E-K group concretes) will move events out of the fall-through.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import ValidationError
+
+from core.hooks.system import HookEvent
+from core.observability.activity import (
+    ActivityRowBase,
+    AnalystCompletedRow,
+    EvaluatorCompletedRow,
+    GenericActivityRow,
+    HandoffCompletedRow,
+    HandoffFailedRow,
+    HandoffTriggeredRow,
+    LifecycleCompletedDetails,
+    LifecycleCompletedRow,
+    LifecycleFailedDetails,
+    LifecycleFailedRow,
+    LifecycleRetriedDetails,
+    LifecycleRetriedRow,
+    LifecycleStartedDetails,
+    LifecycleStartedRow,
+    LLMCallEndedRow,
+    LLMCallFailedRow,
+    LLMCallRetriedRow,
+    LLMCallStartedRow,
+    NodeBootstrapRow,
+    NodeEnteredRow,
+    NodeErrorRow,
+    NodeExitedRow,
+    PipelineEndedRow,
+    PipelineErrorRow,
+    PipelineStartedRow,
+    PipelineTimeoutRow,
+    ScoringCompletedRow,
+    SessionEndedRow,
+    SessionStartedRow,
+    SubAgentCompletedRow,
+    SubAgentFailedRow,
+    SubAgentStartedRow,
+    ToolExecEndedRow,
+    ToolExecFailedRow,
+    ToolExecStartedRow,
+    ToolRecoveryAttemptedRow,
+    ToolRecoveryFailedRow,
+    ToolRecoverySucceededRow,
+    TurnCompletedRow,
+    TurnVerifyFailedRow,
+    TurnVerifyPassedRow,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = ["map_hook_to_activity"]
+
+
+# ---------------------------------------------------------------------------
+# Per-event row builders (31 lifecycle events typed in S2 scope)
+# ---------------------------------------------------------------------------
+
+
+def _lifecycle_started(
+    row_cls: type[LifecycleStartedRow],
+    *,
+    actor_type_default: str = "system",
+    actor_key: str = "session_id",
+    identifier_key: str = "task_id",
+) -> Callable[[dict[str, Any], str], ActivityRowBase]:
+    """Curry a builder for ``LifecycleStartedRow`` subclasses. The
+    actor / identifier names are passed by keyword so each event can
+    pick from its actual data dict (e.g. SUBAGENT_STARTED uses
+    ``task_id``, SESSION_STARTED uses ``session_id``)."""
+
+    def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+        identifier = str(data.get(identifier_key) or data.get("session_id") or "")
+        actor_id = str(data.get(actor_key) or data.get("session_id") or actor_type_default)
+        return row_cls(  # type: ignore[call-arg]  # concrete row_cls overrides action/entity_type with Literal defaults; mypy can't see through dynamic type[]
+            ts=time.time(),
+            run_id=run_id,
+            actor_type=_infer_actor_type(actor_type_default),
+            actor_id=actor_id,
+            entity_id=identifier or actor_id,
+            task_id=str(data["task_id"]) if data.get("task_id") else None,
+            details=LifecycleStartedDetails(identifier=identifier or actor_id),
+        )
+
+    return _build
+
+
+def _lifecycle_completed(
+    row_cls: type[LifecycleCompletedRow],
+    *,
+    actor_type_default: str = "system",
+    actor_key: str = "session_id",
+    identifier_key: str = "task_id",
+) -> Callable[[dict[str, Any], str], ActivityRowBase]:
+    """Curry a builder for ``LifecycleCompletedRow`` subclasses."""
+
+    def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+        identifier = str(data.get(identifier_key) or data.get("session_id") or "")
+        actor_id = str(data.get(actor_key) or data.get("session_id") or actor_type_default)
+        duration_ms = float(data.get("duration_ms", 0.0) or 0.0)
+        success = bool(data.get("success", True))
+        return row_cls(  # type: ignore[call-arg]  # concrete row_cls overrides action/entity_type with Literal defaults; mypy can't see through dynamic type[]
+            ts=time.time(),
+            run_id=run_id,
+            actor_type=_infer_actor_type(actor_type_default),
+            actor_id=actor_id,
+            entity_id=identifier or actor_id,
+            task_id=str(data["task_id"]) if data.get("task_id") else None,
+            details=LifecycleCompletedDetails(duration_ms=duration_ms, success=success),
+        )
+
+    return _build
+
+
+def _lifecycle_failed(
+    row_cls: type[LifecycleFailedRow],
+    *,
+    actor_type_default: str = "system",
+    actor_key: str = "session_id",
+    identifier_key: str = "task_id",
+) -> Callable[[dict[str, Any], str], ActivityRowBase]:
+    """Curry a builder for ``LifecycleFailedRow`` subclasses."""
+
+    def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+        identifier = str(data.get(identifier_key) or data.get("session_id") or "")
+        actor_id = str(data.get(actor_key) or data.get("session_id") or actor_type_default)
+        duration_ms = data.get("duration_ms")
+        return row_cls(  # type: ignore[call-arg]  # concrete row_cls overrides action/entity_type with Literal defaults; mypy can't see through dynamic type[]
+            ts=time.time(),
+            run_id=run_id,
+            actor_type=_infer_actor_type(actor_type_default),
+            actor_id=actor_id,
+            entity_id=identifier or actor_id,
+            task_id=str(data["task_id"]) if data.get("task_id") else None,
+            details=LifecycleFailedDetails(
+                duration_ms=float(duration_ms) if duration_ms is not None else None,
+                error_type=str(data.get("error_type") or data.get("error") or "unknown"),
+                message=str(data.get("message") or data.get("error") or ""),
+            ),
+        )
+
+    return _build
+
+
+def _lifecycle_retried(
+    row_cls: type[LifecycleRetriedRow],
+    *,
+    actor_type_default: str = "system",
+) -> Callable[[dict[str, Any], str], ActivityRowBase]:
+    """Curry a builder for ``LifecycleRetriedRow`` subclasses."""
+
+    def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+        actor_id = str(data.get("session_id") or actor_type_default)
+        attempt = int(data.get("attempt", 1) or 1)
+        reason = str(data.get("reason") or data.get("error_type") or "unknown")
+        return row_cls(  # type: ignore[call-arg]  # concrete row_cls overrides action/entity_type with Literal defaults; mypy can't see through dynamic type[]
+            ts=time.time(),
+            run_id=run_id,
+            actor_type=_infer_actor_type(actor_type_default),
+            actor_id=actor_id,
+            entity_id=str(data.get("call_id") or actor_id),
+            task_id=str(data["task_id"]) if data.get("task_id") else None,
+            details=LifecycleRetriedDetails(attempt=attempt, reason=reason),
+        )
+
+    return _build
+
+
+def _infer_actor_type(default: str) -> str:
+    """Coerce the loose ``actor_type_default`` string into one of the
+    four envelope-allowed literal values."""
+    if default in {"orchestrator", "agent", "system", "plugin"}:
+        return default
+    return "system"
+
+
+# ---------------------------------------------------------------------------
+# 31 lifecycle event → builder mapping
+# ---------------------------------------------------------------------------
+
+
+HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any], str], ActivityRowBase]] = {
+    # A — lifecycle started (9)
+    HookEvent.PIPELINE_STARTED: _lifecycle_started(
+        PipelineStartedRow, actor_type_default="orchestrator", actor_key="pipeline_id"
+    ),
+    HookEvent.NODE_BOOTSTRAP: _lifecycle_started(
+        NodeBootstrapRow, actor_type_default="orchestrator", actor_key="node"
+    ),
+    HookEvent.NODE_ENTERED: _lifecycle_started(
+        NodeEnteredRow, actor_type_default="orchestrator", actor_key="node"
+    ),
+    HookEvent.SESSION_STARTED: _lifecycle_started(
+        SessionStartedRow, actor_type_default="orchestrator", identifier_key="session_id"
+    ),
+    HookEvent.SUBAGENT_STARTED: _lifecycle_started(SubAgentStartedRow, actor_type_default="agent"),
+    HookEvent.LLM_CALL_STARTED: _lifecycle_started(
+        LLMCallStartedRow, actor_type_default="agent", identifier_key="call_id"
+    ),
+    HookEvent.TOOL_EXEC_STARTED: _lifecycle_started(
+        ToolExecStartedRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    HookEvent.HANDOFF_TRIGGERED: _lifecycle_started(
+        HandoffTriggeredRow, actor_type_default="orchestrator", identifier_key="handoff_id"
+    ),
+    HookEvent.TOOL_RECOVERY_ATTEMPTED: _lifecycle_started(
+        ToolRecoveryAttemptedRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    # B — lifecycle completed (13)
+    HookEvent.PIPELINE_ENDED: _lifecycle_completed(
+        PipelineEndedRow, actor_type_default="orchestrator", actor_key="pipeline_id"
+    ),
+    HookEvent.NODE_EXITED: _lifecycle_completed(
+        NodeExitedRow, actor_type_default="orchestrator", actor_key="node"
+    ),
+    HookEvent.SESSION_ENDED: _lifecycle_completed(
+        SessionEndedRow, actor_type_default="orchestrator", identifier_key="session_id"
+    ),
+    HookEvent.SUBAGENT_COMPLETED: _lifecycle_completed(
+        SubAgentCompletedRow, actor_type_default="agent"
+    ),
+    HookEvent.LLM_CALL_ENDED: _lifecycle_completed(
+        LLMCallEndedRow, actor_type_default="agent", identifier_key="call_id"
+    ),
+    HookEvent.TOOL_EXEC_ENDED: _lifecycle_completed(
+        ToolExecEndedRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    HookEvent.HANDOFF_COMPLETED: _lifecycle_completed(
+        HandoffCompletedRow, actor_type_default="orchestrator", identifier_key="handoff_id"
+    ),
+    HookEvent.TOOL_RECOVERY_SUCCEEDED: _lifecycle_completed(
+        ToolRecoverySucceededRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    HookEvent.TURN_COMPLETED: _lifecycle_completed(
+        TurnCompletedRow, actor_type_default="agent", identifier_key="turn_id"
+    ),
+    HookEvent.TURN_VERIFY_PASSED: _lifecycle_completed(
+        TurnVerifyPassedRow, actor_type_default="agent", identifier_key="turn_id"
+    ),
+    HookEvent.ANALYST_COMPLETED: _lifecycle_completed(
+        AnalystCompletedRow, actor_type_default="agent", identifier_key="analyst_id"
+    ),
+    HookEvent.EVALUATOR_COMPLETED: _lifecycle_completed(
+        EvaluatorCompletedRow, actor_type_default="agent", identifier_key="evaluator_id"
+    ),
+    HookEvent.SCORING_COMPLETED: _lifecycle_completed(
+        ScoringCompletedRow, actor_type_default="agent", identifier_key="scoring_id"
+    ),
+    # C — lifecycle failed (9)
+    HookEvent.PIPELINE_ERROR: _lifecycle_failed(
+        PipelineErrorRow, actor_type_default="orchestrator", actor_key="pipeline_id"
+    ),
+    HookEvent.PIPELINE_TIMEOUT: _lifecycle_failed(
+        PipelineTimeoutRow, actor_type_default="orchestrator", actor_key="pipeline_id"
+    ),
+    HookEvent.NODE_ERROR: _lifecycle_failed(
+        NodeErrorRow, actor_type_default="orchestrator", actor_key="node"
+    ),
+    HookEvent.SUBAGENT_FAILED: _lifecycle_failed(SubAgentFailedRow, actor_type_default="agent"),
+    HookEvent.LLM_CALL_FAILED: _lifecycle_failed(
+        LLMCallFailedRow, actor_type_default="agent", identifier_key="call_id"
+    ),
+    HookEvent.TOOL_EXEC_FAILED: _lifecycle_failed(
+        ToolExecFailedRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    HookEvent.TOOL_RECOVERY_FAILED: _lifecycle_failed(
+        ToolRecoveryFailedRow, actor_type_default="agent", identifier_key="tool_call_id"
+    ),
+    HookEvent.HANDOFF_FAILED: _lifecycle_failed(
+        HandoffFailedRow, actor_type_default="orchestrator", identifier_key="handoff_id"
+    ),
+    HookEvent.TURN_VERIFY_FAILED: _lifecycle_failed(
+        TurnVerifyFailedRow, actor_type_default="agent", identifier_key="turn_id"
+    ),
+    # D — retry (1)
+    HookEvent.LLM_CALL_RETRIED: _lifecycle_retried(LLMCallRetriedRow, actor_type_default="agent"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Top-level mapper used by the union channel wiring
+# ---------------------------------------------------------------------------
+
+
+def map_hook_to_activity(
+    event: HookEvent,
+    data: dict[str, Any] | None,
+    *,
+    run_id: str,
+) -> ActivityRowBase:
+    """Convert a ``HookEvent`` + ``data`` dict into a typed
+    :class:`ActivityRowBase` subclass.
+
+    Lifecycle events (31, see :data:`HOOK_EVENT_TO_ROW_BUILDER`) get
+    full pydantic validation against their per-event details schema —
+    a payload bug surfaces at dispatch time with a precise
+    ``ValidationError`` instead of much later at the handler. The 43
+    non-lifecycle events fall through to :class:`GenericActivityRow`
+    which keeps the timeline complete without forcing schema work
+    upfront; subsequent PRs will tighten high-volume events.
+
+    Any builder failure (pydantic ``ValidationError`` from a malformed
+    data dict, or a builder bug) also falls through to
+    :class:`GenericActivityRow` with a warning log — the policy is
+    "always emit a row so the timeline is complete, even when typing
+    fails", which mirrors paperclip's ``logActivity`` swallow-and-warn
+    contract.
+    """
+    payload = data or {}
+    builder = HOOK_EVENT_TO_ROW_BUILDER.get(event)
+    if builder is not None:
+        try:
+            return builder(payload, run_id)
+        except ValidationError as exc:
+            log.warning(
+                "ActivityRow builder for %s failed validation; falling back to generic: %s",
+                event.value,
+                exc,
+            )
+    return _build_generic(event, payload, run_id=run_id)
+
+
+def _build_generic(
+    event: HookEvent,
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> GenericActivityRow:
+    """Build the catch-all :class:`GenericActivityRow` for any event
+    without a registry entry (or whose typed builder failed). The
+    ``actor_type`` is heuristic — operators should treat
+    ``GenericActivityRow`` rows as candidates for promotion to a
+    typed subclass in a future PR."""
+    dotted_action = event.value.replace("_", ".")
+    actor_type = _infer_actor_type_from_event(event)
+    actor_id = str(data.get("session_id") or data.get("actor_id") or actor_type)
+    return GenericActivityRow(
+        ts=time.time(),
+        run_id=run_id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        action=dotted_action,
+        entity_type="system",
+        entity_id=event.value,
+        task_id=str(data["task_id"]) if data.get("task_id") else None,
+        details=data,
+    )
+
+
+def _infer_actor_type_from_event(event: HookEvent) -> str:
+    """Best-effort actor classification for the generic fall-through.
+
+    The 43 non-lifecycle events span four actor types — pre-typing the
+    fall-through helps operators filter the timeline by ``actor_type``
+    without waiting for the per-event concrete class. ``GenericActivityRow``
+    rows should still be considered "untyped" — promoting them to a
+    concrete class is the path to strict validation.
+    """
+    name = event.name
+    if name.startswith(("PIPELINE_", "NODE_", "SESSION_")):
+        return "orchestrator"
+    if name.startswith(
+        ("SUBAGENT_", "TURN_", "LLM_", "TOOL_", "COGNITIVE_", "MEMORY_", "RULE_", "PROMPT_")
+    ):
+        return "agent"
+    if name.startswith(("MCP_", "CONFIG_", "SHUTDOWN_")):
+        return "system"
+    return "system"

--- a/core/observability/activity_registry.py
+++ b/core/observability/activity_registry.py
@@ -2,9 +2,9 @@
 
 Spec: ``docs/plans/2026-05-24-hookevent-activity-schema.md`` §3.
 
-Each of the 31 lifecycle events maps to a builder that produces the
+Each of the 32 lifecycle events maps to a builder that produces the
 appropriate concrete ``ActivityRow`` subclass with validated payload.
-The 43 non-lifecycle events fall through to
+The 42 non-lifecycle events fall through to
 :class:`GenericActivityRow` so they still land in the timeline — but
 without the type-safety + IDE autocomplete benefit. Subsequent PRs
 (E-K group concretes) will move events out of the fall-through.
@@ -71,7 +71,7 @@ __all__ = ["map_hook_to_activity"]
 
 
 # ---------------------------------------------------------------------------
-# Per-event row builders (31 lifecycle events typed in S2 scope)
+# Per-event row builders (32 lifecycle events typed in S2 scope)
 # ---------------------------------------------------------------------------
 
 
@@ -193,7 +193,7 @@ def _infer_actor_type(default: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 31 lifecycle event → builder mapping
+# 32 lifecycle event → builder mapping
 # ---------------------------------------------------------------------------
 
 
@@ -309,7 +309,7 @@ def map_hook_to_activity(
     """Convert a ``HookEvent`` + ``data`` dict into a typed
     :class:`ActivityRowBase` subclass.
 
-    Lifecycle events (31, see :data:`HOOK_EVENT_TO_ROW_BUILDER`) get
+    Lifecycle events (32, see :data:`HOOK_EVENT_TO_ROW_BUILDER`) get
     full pydantic validation against their per-event details schema —
     a payload bug surfaces at dispatch time with a precise
     ``ValidationError`` instead of much later at the handler. The 43
@@ -329,10 +329,19 @@ def map_hook_to_activity(
     if builder is not None:
         try:
             return builder(payload, run_id)
-        except ValidationError as exc:
+        except (ValidationError, ValueError, TypeError) as exc:
+            # PR-COMM-1 fix-up (Codex MCP review M3): typed-row builders
+            # do pre-pydantic coercion (``float()`` / ``int()`` /
+            # ``str()``) before constructing the model, so malformed
+            # *values* (e.g. ``{"duration_ms": "bad"}``) raise plain
+            # ``ValueError`` / ``TypeError`` before pydantic's
+            # ``ValidationError``. Catching all three preserves the
+            # "always emit a row" contract — the timeline stays
+            # complete even when an upstream caller sends garbage.
             log.warning(
-                "ActivityRow builder for %s failed validation; falling back to generic: %s",
+                "ActivityRow builder for %s failed (%s); falling back to generic row: %s",
                 event.value,
+                type(exc).__name__,
                 exc,
             )
     return _build_generic(event, payload, run_id=run_id)
@@ -368,7 +377,7 @@ def _build_generic(
 def _infer_actor_type_from_event(event: HookEvent) -> str:
     """Best-effort actor classification for the generic fall-through.
 
-    The 43 non-lifecycle events span four actor types — pre-typing the
+    The 42 non-lifecycle events span four actor types — pre-typing the
     fall-through helps operators filter the timeline by ``actor_type``
     without waiting for the per-event concrete class. ``GenericActivityRow``
     rows should still be considered "untyped" — promoting them to a

--- a/docs/plans/2026-05-24-hookevent-activity-schema.md
+++ b/docs/plans/2026-05-24-hookevent-activity-schema.md
@@ -120,7 +120,7 @@ class GenericActivityRow(ActivityRowBase):
     details: dict[str, Any] = Field(default_factory=dict)
 ```
 
-### 2.3 Tier 3 — 31 concrete lifecycle classes (S2 scope)
+### 2.3 Tier 3 — 32 concrete lifecycle classes (S2 scope)
 
 ```python
 class PipelineStartedRow(LifecycleStartedRow):
@@ -147,8 +147,8 @@ class SubAgentStartedRow(LifecycleStartedRow):
 
 ActivityRow = Annotated[
     Union[
-        PipelineStartedRow, NodeBootstrapRow, ...,  # 31 concrete
-        GenericActivityRow,  # 43 non-lifecycle fall-through
+        PipelineStartedRow, NodeBootstrapRow, ...,  # 32 concrete
+        GenericActivityRow,  # 42 non-lifecycle fall-through
     ],
     Field(discriminator="action"),
 ]
@@ -163,7 +163,7 @@ ActivityRow = Annotated[
 HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any]], ActivityRowBase]] = {
     HookEvent.PIPELINE_STARTED: _build_pipeline_started,
     HookEvent.PIPELINE_ENDED: _build_pipeline_ended,
-    # ... 31 lifecycle ...
+    # ... 32 lifecycle ...
     # nothing for K-group events — bridge falls back to GenericActivityRow
 }
 
@@ -174,7 +174,7 @@ def map_hook_to_activity(
 ) -> ActivityRowBase:
     """Convert a HookEvent + data dict into a typed ActivityRow.
 
-    Lifecycle events (31) get concrete subclass with full validation;
+    Lifecycle events (32) get concrete subclass with full validation;
     rest fall through to GenericActivityRow. Pre-PR-COMM-1 the data
     payload was never validated — typed lifecycle subclasses surface
     payload bugs at dispatch time."""
@@ -241,7 +241,7 @@ def _mirror_to_active_transcript(self, event: HookEvent, data: dict[str, Any]) -
 ### 5.2 신규 테스트
 - `tests/core/observability/test_activity_schema.py`:
   - I1: 11 base classes 정의 + Tier 1 envelope 필드 검증
-  - I2: 31 lifecycle concrete 의 action literal 정합 + entity_type literal 정합
+  - I2: 32 lifecycle concrete 의 action literal 정합 + entity_type literal 정합
   - I3: ActivityRow discriminated union 의 model_validate (PipelineStartedRow 입력 → 정확한 subclass)
   - I4: GenericActivityRow fall-through (typed lifecycle 외 event 가 generic 으로 라우팅)
   - I5: 74 HookEvent 전체가 매핑 cover (HOOK_EVENT_TO_ROW_BUILDER 누락 → generic, 매핑 있으면 concrete)
@@ -258,8 +258,8 @@ def _mirror_to_active_transcript(self, event: HookEvent, data: dict[str, Any]) -
 
 ## 6. Anti-deception 체크리스트
 
-- [ ] 11 base classes + 31 lifecycle concrete + 1 generic = 43 ActivityRow classes 가 union 에 모두 등록
-- [ ] HOOK_EVENT_TO_ROW_BUILDER 의 키 31 + generic fall-through 43 = 74 (전체 cover)
+- [ ] 11 base classes + 32 lifecycle concrete + 1 generic = 44 ActivityRow classes 가 union 에 모두 등록
+- [ ] HOOK_EVENT_TO_ROW_BUILDER 의 키 32 + generic fall-through 42 = 74 (전체 cover)
 - [ ] Pydantic ValidationError 가 trigger 자체를 break 하지 않음 (silent no-op + warning log)
 - [ ] 기존 SessionTranscript 의 4 mirror (PR-U) 는 그대로 동작
 - [ ] backwards-compat: `journal.append(event, payload=...)` 기존 patterns 회귀 없음
@@ -272,7 +272,7 @@ def _mirror_to_active_transcript(self, event: HookEvent, data: dict[str, Any]) -
 |---|---|
 | Spec doc | DONE (이 파일) |
 | Tier 1 + Tier 2 (11 base) | PENDING |
-| Tier 3 (31 lifecycle concrete) | PENDING |
+| Tier 3 (32 lifecycle concrete) | PENDING |
 | Registry (HOOK_EVENT_TO_ROW_BUILDER) | PENDING |
 | Union channel wiring | PENDING |
 | Tests (I1-I5 + M1-M3) | PENDING |

--- a/docs/plans/2026-05-24-hookevent-activity-schema.md
+++ b/docs/plans/2026-05-24-hookevent-activity-schema.md
@@ -1,0 +1,291 @@
+# PR-COMM-1 — HookEvent → ActivityRow schema + union channel (S2 scope)
+
+> **작성**: 2026-05-24
+> **목적**: 74 HookEvent 의 payload 를 paperclip activity_log + openclaw discriminatedUnion 패턴으로 정렬. HookSystem.trigger 호출이 active RunTranscript 에 자동 mirror — unified timeline 의 sub-agent dialogue 외 카테고리도 한 SoT 에서 가시화.
+> **검증**: ruff/format/mypy/lint-imports/pytest + Codex MCP review.
+> **SoT**: 이 문서. drift 시 코드/문서 동시 갱신.
+
+---
+
+## 0. 문제 진술 + frontier grounding
+
+`docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md` (PR1) 가 SessionTranscript record_user_message/assistant_message/tool_call/tool_result 4 event 만 RunTranscript 에 mirror. 나머지 70 HookEvent (phase / verification / cost / cognitive / auto-trigger 등) 는 여전히 in-proc HookSystem callback 으로 분산. 한 cycle 의 timeline 을 보려면 transcript.jsonl + hook handler 별 sink 를 join 필요.
+
+**frontier 5 시스템 의 event schema 패턴**:
+
+| 시스템 | 패턴 | 위치 | 정확성 |
+|---|---|---|---|
+| paperclip | `as const` tuple + `PluginEvent<TPayload>` envelope | `packages/shared/src/constants.ts:1029`, `packages/plugins/sdk/src/types.ts:180` | 중 (envelope strong, payload generic) |
+| openclaw | **zod `discriminatedUnion` on `type`** | `extensions/voice-call/src/types.ts:90` | **강 (runtime validation 자동)** |
+| claude-code-ref | thin enum + `dict[str, Any]` | `src/hooks/lifecycle.ts:30` | 낮음 (5 events만, validation 없음) |
+| hermes-agent | callback factory + signature contract | `acp_adapter/events.py` | 낮음 |
+| GEODE (pre-PR-COMM-1) | 74 enum + `dict[str, Any]` | `core/hooks/system.py:30` | 낮음 |
+
+**채택**: pydantic discriminatedUnion (openclaw 직접 parity + GEODE 이미 pydantic 2.13.4 + 17 site 사용 중).
+
+---
+
+## 1. 74 events → 11 groups (공통 payload 패턴)
+
+| Group | events 수 | 공통 키 | base class |
+|---|---|---|---|
+| A. Lifecycle started | 9 | `identifier` | `LifecycleStartedRow` |
+| B. Lifecycle completed | 13 | `duration_ms` + `success` | `LifecycleCompletedRow` |
+| C. Lifecycle failed | 9 | `duration_ms` + `error_type` + `message` | `LifecycleFailedRow` |
+| D. Retry | 1 | `attempt` + `reason` | `LifecycleRetriedRow` |
+| E. Cognitive step | 6 | `step_name` + `step_context` | `CognitiveStepRow` |
+| F. Auto-trigger | 5 | `trigger_id` + `outcome` | `AutoTriggerRow` |
+| G. State change | 5 | `previous` + `current` | `StateChangeRow` |
+| H. Cost/budget | 2 | `amount_usd` + `threshold_usd` | `CostBudgetRow` |
+| I. Memory mutation | 4 | `entity_id` + `mutation_kind` | `MemoryMutationRow` |
+| J. MCP server | 2 | `server_name` + `status` | `McpServerRow` |
+| K. Generic single-fire | 18 | `details: dict[str, Any]` | `GenericActivityRow` |
+
+**합계**: 74 ✓ (각 event 가 정확히 1 group).
+
+### 1.1 group → event 명시 매핑 (S2 typing 범위)
+
+**A — Lifecycle started (9, typed in S2)**:
+PIPELINE_STARTED / NODE_BOOTSTRAP / NODE_ENTERED / SESSION_STARTED / SUBAGENT_STARTED / LLM_CALL_STARTED / TOOL_EXEC_STARTED / HANDOFF_TRIGGERED / TOOL_RECOVERY_ATTEMPTED
+
+**B — Lifecycle completed (13, typed in S2)**:
+PIPELINE_ENDED / NODE_EXITED / SESSION_ENDED / SUBAGENT_COMPLETED / LLM_CALL_ENDED / TOOL_EXEC_ENDED / HANDOFF_COMPLETED / TOOL_RECOVERY_SUCCEEDED / TURN_COMPLETED / TURN_VERIFY_PASSED / ANALYST_COMPLETED / EVALUATOR_COMPLETED / SCORING_COMPLETED
+
+**C — Lifecycle failed (9, typed in S2)**:
+PIPELINE_ERROR / PIPELINE_TIMEOUT / NODE_ERROR / SUBAGENT_FAILED / LLM_CALL_FAILED / TOOL_EXEC_FAILED / TOOL_RECOVERY_FAILED / HANDOFF_FAILED / TURN_VERIFY_FAILED
+
+**D — Retry (1, typed in S2)**: LLM_CALL_RETRIED
+
+**S1 base classes (10) + generic (1)** — group E~K 도 base/mixin 정의는 들어가지만 concrete classes 는 후속 PR (점진).
+
+---
+
+## 2. 3-tier class hierarchy
+
+### 2.1 Tier 1 — paperclip-style envelope
+
+```python
+# core/observability/activity.py
+class ActivityRowBase(BaseModel):
+    """paperclip PluginEvent envelope 등가 + GEODE run-level metadata.
+
+    Every HookSystem.trigger() call produces exactly one of the 74
+    concrete subclasses (when typed) or GenericActivityRow (fall-through).
+    The pipeline transcript at <run_dir>/transcript.jsonl now carries
+    a row for every hook event, not just the 4 SessionTranscript mirrors.
+    """
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ts: float
+    run_id: str
+    actor_type: Literal["orchestrator", "agent", "system", "plugin"]
+    actor_id: str  # "pipeline" | sub-agent task_id | hook handler name | etc.
+    action: str  # discriminator — dotted notation per paperclip
+    entity_type: str
+    entity_id: str
+    task_id: str | None = None  # sub-agent worker task_id when applicable
+    level: Literal["info", "warn", "error"] = "info"
+```
+
+### 2.2 Tier 2 — 11 base classes (mixins per group)
+
+```python
+class LifecycleStartedRow(ActivityRowBase):
+    details: LifecycleStartedDetails
+class LifecycleStartedDetails(BaseModel):
+    identifier: str  # task_id / session_id / call_id / pipeline_id
+
+class LifecycleCompletedRow(ActivityRowBase):
+    details: LifecycleCompletedDetails
+class LifecycleCompletedDetails(BaseModel):
+    duration_ms: float
+    success: bool = True
+
+class LifecycleFailedRow(ActivityRowBase):
+    details: LifecycleFailedDetails
+class LifecycleFailedDetails(BaseModel):
+    duration_ms: float | None = None
+    error_type: str
+    message: str
+
+class LifecycleRetriedRow(ActivityRowBase):
+    details: LifecycleRetriedDetails
+class LifecycleRetriedDetails(BaseModel):
+    attempt: int
+    reason: str
+
+# ... E~K group base classes (defined but only used by GenericActivityRow in S2) ...
+
+class GenericActivityRow(ActivityRowBase):
+    details: dict[str, Any] = Field(default_factory=dict)
+```
+
+### 2.3 Tier 3 — 31 concrete lifecycle classes (S2 scope)
+
+```python
+class PipelineStartedRow(LifecycleStartedRow):
+    action: Literal["pipeline.started"] = "pipeline.started"
+    entity_type: Literal["pipeline"] = "pipeline"
+
+class NodeBootstrapRow(LifecycleStartedRow):
+    action: Literal["node.bootstrap"] = "node.bootstrap"
+    entity_type: Literal["node"] = "node"
+
+class NodeEnteredRow(LifecycleStartedRow):
+    action: Literal["node.entered"] = "node.entered"
+    entity_type: Literal["node"] = "node"
+
+class SessionStartedRow(LifecycleStartedRow):
+    action: Literal["session.started"] = "session.started"
+    entity_type: Literal["session"] = "session"
+
+class SubAgentStartedRow(LifecycleStartedRow):
+    action: Literal["subagent.started"] = "subagent.started"
+    entity_type: Literal["task"] = "task"
+
+# ... 27 more lifecycle concrete classes (B + C + D groups) ...
+
+ActivityRow = Annotated[
+    Union[
+        PipelineStartedRow, NodeBootstrapRow, ...,  # 31 concrete
+        GenericActivityRow,  # 43 non-lifecycle fall-through
+    ],
+    Field(discriminator="action"),
+]
+```
+
+---
+
+## 3. HookEvent → ActivityRow mapping registry
+
+```python
+# core/observability/activity_registry.py
+HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any]], ActivityRowBase]] = {
+    HookEvent.PIPELINE_STARTED: _build_pipeline_started,
+    HookEvent.PIPELINE_ENDED: _build_pipeline_ended,
+    # ... 31 lifecycle ...
+    # nothing for K-group events — bridge falls back to GenericActivityRow
+}
+
+def map_hook_to_activity(
+    event: HookEvent,
+    data: dict[str, Any],
+    run_id: str,
+) -> ActivityRowBase:
+    """Convert a HookEvent + data dict into a typed ActivityRow.
+
+    Lifecycle events (31) get concrete subclass with full validation;
+    rest fall through to GenericActivityRow. Pre-PR-COMM-1 the data
+    payload was never validated — typed lifecycle subclasses surface
+    payload bugs at dispatch time."""
+    builder = HOOK_EVENT_TO_ROW_BUILDER.get(event)
+    if builder is None:
+        return GenericActivityRow(
+            ts=time.time(),
+            run_id=run_id,
+            actor_type=_infer_actor_type(event),
+            actor_id=str(data.get("session_id", "system")),
+            action=f"{_infer_dotted_action(event)}",
+            entity_type="system",
+            entity_id=event.value,
+            details=data,
+        )
+    return builder(data, run_id=run_id)
+```
+
+---
+
+## 4. Union channel wiring
+
+```python
+# core/hooks/system.py (HookSystem.trigger 마지막)
+def trigger(self, event: HookEvent, data: dict[str, Any] | None = None) -> list[HookResult]:
+    results = self._dispatch(event, data or {})
+    self._mirror_to_active_transcript(event, data or {})  # ← NEW
+    return results
+
+def _mirror_to_active_transcript(self, event: HookEvent, data: dict[str, Any]) -> None:
+    """Mirror this hook trigger as an activity row into active RunTranscript."""
+    from core.self_improving_loop.run_transcript import current_run_transcript
+    from core.observability.activity_registry import map_hook_to_activity
+
+    run_transcript = current_run_transcript()
+    if run_transcript is None:
+        return
+    try:
+        row = map_hook_to_activity(event, data, run_id=run_transcript.session_id)
+        run_transcript.append(
+            event=event.value,
+            actor_type=row.actor_type,
+            actor_id=row.actor_id,
+            action=row.action,
+            entity_type=row.entity_type,
+            entity_id=row.entity_id,
+            task_id=row.task_id,
+            level=row.level,
+            payload=row.details.model_dump() if hasattr(row.details, "model_dump") else row.details,
+        )
+    except ValidationError:
+        log.warning("HookEvent %s payload failed validation; emitting generic row", event)
+        # Fall-through: still emit so the row is captured in the timeline.
+        ...
+```
+
+---
+
+## 5. 검증
+
+### 5.1 Quality gates
+- ruff / format / mypy (pydantic.mypy plugin) / lint-imports / pytest
+
+### 5.2 신규 테스트
+- `tests/core/observability/test_activity_schema.py`:
+  - I1: 11 base classes 정의 + Tier 1 envelope 필드 검증
+  - I2: 31 lifecycle concrete 의 action literal 정합 + entity_type literal 정합
+  - I3: ActivityRow discriminated union 의 model_validate (PipelineStartedRow 입력 → 정확한 subclass)
+  - I4: GenericActivityRow fall-through (typed lifecycle 외 event 가 generic 으로 라우팅)
+  - I5: 74 HookEvent 전체가 매핑 cover (HOOK_EVENT_TO_ROW_BUILDER 누락 → generic, 매핑 있으면 concrete)
+- `tests/core/hooks/test_activity_mirror.py`:
+  - M1: HookSystem.trigger 가 active RunTranscript 에 한 row append
+  - M2: 활성 RunTranscript 없으면 no-op
+  - M3: payload validation fail 시 generic row 로 fall-through (silent dispatch fail X)
+
+### 5.3 Codex MCP review
+- target files: `core/observability/activity.py`, `core/observability/activity_registry.py`, `core/hooks/system.py`, `tests/core/observability/test_activity_schema.py`, `tests/core/hooks/test_activity_mirror.py`
+- review focus: 74 events 전체 cover (누락 검출), pydantic discriminator 정합 (action literal 충돌), backwards-compat (기존 hook handler 들 변경 영향 X), `current_run_transcript() == None` 시 silent no-op (REPL / gateway 영향 X).
+
+---
+
+## 6. Anti-deception 체크리스트
+
+- [ ] 11 base classes + 31 lifecycle concrete + 1 generic = 43 ActivityRow classes 가 union 에 모두 등록
+- [ ] HOOK_EVENT_TO_ROW_BUILDER 의 키 31 + generic fall-through 43 = 74 (전체 cover)
+- [ ] Pydantic ValidationError 가 trigger 자체를 break 하지 않음 (silent no-op + warning log)
+- [ ] 기존 SessionTranscript 의 4 mirror (PR-U) 는 그대로 동작
+- [ ] backwards-compat: `journal.append(event, payload=...)` 기존 patterns 회귀 없음
+
+---
+
+## 7. Status
+
+| Item | 상태 |
+|---|---|
+| Spec doc | DONE (이 파일) |
+| Tier 1 + Tier 2 (11 base) | PENDING |
+| Tier 3 (31 lifecycle concrete) | PENDING |
+| Registry (HOOK_EVENT_TO_ROW_BUILDER) | PENDING |
+| Union channel wiring | PENDING |
+| Tests (I1-I5 + M1-M3) | PENDING |
+| Codex MCP review | PENDING |
+| CHANGELOG | PENDING |
+
+---
+
+## 8. Follow-up PRs (잔여 PR 영향 — 우선순위 boost 이유)
+
+- PR2 (V) — paperclip `--resume` + sessionId. `agent_runtime_state.sessionId` 등가물 추가. **본 PR 의 activity row 에 `agent_session_id` 필드 추가** 시 PR2 의 session.json 적재 흐름과 자연 연결.
+- PR-COMM-2 — `HookSystem.register` wildcard prefix. **본 PR 의 dotted action namespace** (`pipeline.*` / `subagent.*` / `llm.*`) 가 wildcard 의 prefix 가 됨. 본 PR 의 dotted naming 이 PR-COMM-2 의 전제.
+- PR-COMM-3 — SQLite `agent_runtime_state` + `run_lineage`. **본 PR 의 ActivityRow 가 직접 row 형식**이라 SQLite 마이그레이션 시 to_sql() 한 줄로 변환 가능.
+- PR-COMM-4 — `seq` monotonic + liveness. **본 PR 의 RunTranscript append 가 단일 진입점**이라 seq 추가가 한 곳만 변경.
+
+→ COMM-1 가 다른 4 PR 의 schema/naming 전제. **우선 처리 합리적**.

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -47,7 +47,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.hooks import HookEvent, HookSystem
-
 from plugins.seed_generation.agents.base import BaseSeedAgent, SeedAgentResult
 
 if TYPE_CHECKING:

--- a/tests/core/hooks/test_activity_mirror.py
+++ b/tests/core/hooks/test_activity_mirror.py
@@ -139,6 +139,66 @@ def test_m3_malformed_payload_still_produces_a_row() -> None:
         assert row["level"] == "error"
 
 
+def test_m3_malformed_value_still_produces_a_row() -> None:
+    """Codex MCP review of #1587 caught this: pre-pydantic coercion
+    (``float(data["duration_ms"])``) raises ``ValueError`` *before*
+    pydantic's ``ValidationError`` when the payload carries a bad
+    value (e.g. ``{"duration_ms": "bad"}``). The original M3 test only
+    covered missing fields (which get defaulted). This pins the broader
+    contract: malformed *values* must also fall through to
+    ``GenericActivityRow`` so the timeline stays complete."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            # ``duration_ms="bad"`` triggers ValueError inside the
+            # _lifecycle_completed builder. Pre-Codex-catch the row
+            # would have been dropped entirely.
+            hs.trigger(
+                HookEvent.LLM_CALL_ENDED,
+                {"session_id": "s1", "call_id": "c1", "duration_ms": "bad"},
+            )
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        # The row landed via GenericActivityRow fall-through (the builder
+        # raised ValueError → registry caught it → generic emit).
+        # The action keeps the dotted-name convention.
+        assert row["action"] == "llm.call.end"
+
+
+def test_m1_async_mirror_appends_one_row() -> None:
+    """``trigger_async`` must call the same mirror as ``trigger`` —
+    otherwise the async dispatch path silently drops events. Codex
+    MCP review of #1587 flagged this as a missing test."""
+    import asyncio
+
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            asyncio.run(
+                hs.trigger_async(
+                    HookEvent.SUBAGENT_STARTED,
+                    {"task_id": "gen-async-001", "task_type": "seed_generator"},
+                )
+            )
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        assert rows[0]["action"] == "subagent.started"
+        assert rows[0]["task_id"] == "gen-async-001"
+
+
 def test_m1_hook_handler_failure_does_not_break_mirror() -> None:
     """If a registered hook handler raises, the union-channel mirror
     must still run — we're capturing observability, not gating on

--- a/tests/core/hooks/test_activity_mirror.py
+++ b/tests/core/hooks/test_activity_mirror.py
@@ -1,0 +1,164 @@
+"""PR-COMM-1 (S2 scope) — HookSystem ↔ ActivityRow mirror tests.
+
+Pins union-channel invariants from
+``docs/plans/2026-05-24-hookevent-activity-schema.md`` §5.2 (M1-M3).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from core.hooks.system import HookEvent, HookSystem
+from core.observability.run_dir import run_dir_scope
+from core.self_improving_loop.run_transcript import RunTranscript, run_transcript_scope
+
+
+def _read_rows(transcript_path: Path) -> list[dict]:
+    return [json.loads(line) for line in transcript_path.read_text().splitlines() if line.strip()]
+
+
+def test_m1_trigger_appends_one_activity_row() -> None:
+    """``HookSystem.trigger(event, data)`` inside an active
+    ``run_transcript_scope`` appends exactly one row to
+    ``transcript.jsonl`` with the typed classification quintuple
+    (paperclip activity_log parity)."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            hs.trigger(
+                HookEvent.SUBAGENT_STARTED,
+                {"task_id": "gen-gen1-001", "task_type": "seed_generator"},
+            )
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["action"] == "subagent.started"
+        assert row["actor_type"] == "agent"
+        assert row["entity_type"] == "task"
+        assert row["task_id"] == "gen-gen1-001"
+
+
+def test_m1_typed_lifecycle_event_carries_typed_details() -> None:
+    """Group C ``LifecycleFailedRow`` carries the typed details
+    (``error_type`` + ``message``) plus ``level=error``."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            hs.trigger(
+                HookEvent.LLM_CALL_FAILED,
+                {
+                    "session_id": "s1",
+                    "call_id": "c1",
+                    "error_type": "rate_limit",
+                    "message": "429 Too Many Requests",
+                },
+            )
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["action"] == "llm.call.failed"
+        assert row["level"] == "error"
+        assert row["payload"]["error_type"] == "rate_limit"
+        assert "429" in row["payload"]["message"]
+
+
+def test_m1_non_lifecycle_event_falls_through_to_generic() -> None:
+    """Non-lifecycle events (43 of 74) have no registry entry, so
+    they land via ``GenericActivityRow`` with the dotted action
+    inferred from the enum value."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            hs.trigger(HookEvent.MEMORY_SAVED, {"memory_id": "m1", "kind": "episode"})
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        # Dotted action inferred from enum value
+        assert row["action"] == "memory.saved"
+        # actor_type heuristic put memory into "agent"
+        assert row["actor_type"] == "agent"
+        # Generic payload pass-through
+        assert row["payload"]["memory_id"] == "m1"
+
+
+def test_m2_mirror_no_op_outside_run_transcript_scope() -> None:
+    """Without an active ``RunTranscript`` (REPL / gateway / tests)
+    the mirror is a silent no-op — the trigger must NOT raise and
+    no file should be created."""
+    with tempfile.TemporaryDirectory() as tmp:
+        hs = HookSystem()
+        # No run_transcript_scope active.
+        hs.trigger(HookEvent.SUBAGENT_STARTED, {"task_id": "ghost"})
+        # No transcript file expected in tmp (which was never bound).
+        assert not (Path(tmp) / "transcript.jsonl").exists()
+
+
+def test_m3_malformed_payload_still_produces_a_row() -> None:
+    """A ``LifecycleFailedRow`` with a malformed payload (missing
+    ``error_type`` + ``message``) must still emit a row — the registry
+    fills defaults rather than letting the trigger silently fail.
+    The "always emit" contract mirrors paperclip's swallow-and-warn
+    pattern in ``activity-log.ts:65``."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+            # Empty payload — registry builder fills defaults.
+            hs.trigger(HookEvent.LLM_CALL_FAILED, {})
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["action"] == "llm.call.failed"
+        # Defaults present so the row is still classifier-clean.
+        assert row["payload"].get("error_type") == "unknown"
+        assert row["level"] == "error"
+
+
+def test_m1_hook_handler_failure_does_not_break_mirror() -> None:
+    """If a registered hook handler raises, the union-channel mirror
+    must still run — we're capturing observability, not gating on
+    handler success."""
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        journal = RunTranscript(
+            session_id="gen1-X",
+            gen_tag="gen1",
+            component="seed-generation",
+            path=Path(tmp) / "transcript.jsonl",
+        )
+        with run_transcript_scope(journal):
+            hs = HookSystem()
+
+            def _broken_handler(event: HookEvent, data: dict) -> None:
+                raise RuntimeError("simulated handler bug")
+
+            hs.register(HookEvent.SUBAGENT_STARTED, _broken_handler, name="broken")
+            hs.trigger(HookEvent.SUBAGENT_STARTED, {"task_id": "gen-gen1-001"})
+        # Handler raised but the mirror still wrote one row.
+        rows = _read_rows(Path(tmp) / "transcript.jsonl")
+        assert len(rows) == 1
+        assert rows[0]["action"] == "subagent.started"

--- a/tests/core/observability/test_activity_schema.py
+++ b/tests/core/observability/test_activity_schema.py
@@ -1,0 +1,236 @@
+"""PR-COMM-1 (S2 scope) — ActivityRow schema + HookEvent registry tests.
+
+Pins invariants from
+``docs/plans/2026-05-24-hookevent-activity-schema.md`` §5.2.
+
+* I1: Tier 1 envelope (``ActivityRowBase``) + 11 group base classes.
+* I2: 32 lifecycle concrete classes have correct ``action`` /
+  ``entity_type`` literals.
+* I3: ``TypedActivityRow`` discriminated union dispatches by ``action``.
+* I4: ``GenericActivityRow`` accepts any ``action`` (escape hatch).
+* I5: All 74 HookEvent values produce a row via ``map_hook_to_activity``
+  (typed → concrete subclass; non-lifecycle → generic).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.hooks.system import HookEvent
+from core.observability.activity import (
+    ActivityRowBase,
+    GenericActivityRow,
+    LifecycleFailedDetails,
+    LifecycleRetriedDetails,
+    LifecycleStartedDetails,
+    LLMCallFailedRow,
+    LLMCallRetriedRow,
+    PipelineStartedRow,
+    SubAgentCompletedRow,
+    SubAgentStartedRow,
+    TypedActivityRow,
+)
+from core.observability.activity_registry import (
+    HOOK_EVENT_TO_ROW_BUILDER,
+    map_hook_to_activity,
+)
+from pydantic import TypeAdapter, ValidationError
+
+# ---------------------------------------------------------------------------
+# I1 — envelope fields enforced
+# ---------------------------------------------------------------------------
+
+
+def test_i1_envelope_requires_classification_quintuple() -> None:
+    """``actor_type`` / ``actor_id`` / ``action`` / ``entity_type`` /
+    ``entity_id`` are the paperclip activity_log quintuple. Skipping
+    any must raise (envelope is ``extra="forbid"`` + non-optional)."""
+    with pytest.raises(ValidationError):
+        ActivityRowBase(  # type: ignore[call-arg]
+            ts=1.0,
+            run_id="r1",
+            # actor_type missing
+            actor_id="x",
+            action="x.y",
+            entity_type="t",
+            entity_id="i",
+        )
+
+
+def test_i1_envelope_actor_type_literal_enforced() -> None:
+    """``actor_type`` must be one of the 4 paperclip literals."""
+    with pytest.raises(ValidationError):
+        ActivityRowBase(
+            ts=1.0,
+            run_id="r1",
+            actor_type="random",  # type: ignore[arg-type]
+            actor_id="x",
+            action="x.y",
+            entity_type="t",
+            entity_id="i",
+        )
+
+
+# ---------------------------------------------------------------------------
+# I2 — concrete classes pin action + entity_type literals
+# ---------------------------------------------------------------------------
+
+
+def test_i2_pipeline_started_has_dotted_action() -> None:
+    row = PipelineStartedRow(
+        ts=1.0,
+        run_id="r1",
+        actor_type="orchestrator",
+        actor_id="pipeline",
+        entity_id="gen1-X",
+        details=LifecycleStartedDetails(identifier="gen1-X"),
+    )
+    assert row.action == "pipeline.started"
+    assert row.entity_type == "pipeline"
+
+
+def test_i2_subagent_started_has_task_entity() -> None:
+    row = SubAgentStartedRow(
+        ts=1.0,
+        run_id="r1",
+        actor_type="agent",
+        actor_id="gen-gen1-001",
+        entity_id="gen-gen1-001",
+        details=LifecycleStartedDetails(identifier="gen-gen1-001"),
+    )
+    assert row.action == "subagent.started"
+    assert row.entity_type == "task"
+
+
+def test_i2_failed_rows_default_to_error_level() -> None:
+    """Group C ``LifecycleFailedRow`` subclasses must default
+    ``level="error"`` so a generic ``tail -F | jq 'select(.level==\"error\")'``
+    catches every failure event."""
+    row = LLMCallFailedRow(
+        ts=1.0,
+        run_id="r1",
+        actor_type="agent",
+        actor_id="s1",
+        entity_id="call-1",
+        details=LifecycleFailedDetails(error_type="rate_limit", message="429"),
+    )
+    assert row.level == "error"
+
+
+def test_i2_retried_row_defaults_to_warn_level() -> None:
+    """``LLMCallRetriedRow`` (group D) defaults to ``warn`` — a
+    retry is not yet a failure but warrants attention."""
+    row = LLMCallRetriedRow(
+        ts=1.0,
+        run_id="r1",
+        actor_type="agent",
+        actor_id="s1",
+        entity_id="call-1",
+        details=LifecycleRetriedDetails(attempt=2, reason="rate_limit"),
+    )
+    assert row.level == "warn"
+
+
+# ---------------------------------------------------------------------------
+# I3 — discriminated union dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_i3_discriminator_dispatches_to_correct_subclass() -> None:
+    """openclaw ``NormalizedEventSchema`` parity — ``action`` is the
+    discriminator, pydantic picks the correct concrete subclass at
+    ``model_validate`` time."""
+    adapter = TypeAdapter(TypedActivityRow)
+    validated = adapter.validate_python(
+        {
+            "ts": 1.0,
+            "run_id": "r1",
+            "actor_type": "agent",
+            "actor_id": "gen-gen1-001",
+            "action": "subagent.completed",
+            "entity_id": "gen-gen1-001",
+            "details": {"duration_ms": 1234.5, "success": True},
+        }
+    )
+    assert isinstance(validated, SubAgentCompletedRow)
+    assert validated.details.duration_ms == 1234.5  # type: ignore[union-attr]
+
+
+def test_i3_discriminator_raises_on_unknown_action() -> None:
+    """``TypedActivityRow`` is the closed union (no generic member);
+    unknown ``action`` raises so callers can fall back to
+    ``GenericActivityRow``."""
+    adapter = TypeAdapter(TypedActivityRow)
+    with pytest.raises(ValidationError):
+        adapter.validate_python(
+            {
+                "ts": 1.0,
+                "run_id": "r1",
+                "actor_type": "system",
+                "actor_id": "x",
+                "action": "misc.event",
+                "entity_type": "misc",
+                "entity_id": "x",
+                "details": {},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# I4 — generic escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_i4_generic_accepts_arbitrary_action() -> None:
+    """``GenericActivityRow.action`` is open ``str`` — any
+    non-lifecycle event lands without forcing a per-event Literal."""
+    row = GenericActivityRow(
+        ts=1.0,
+        run_id="r1",
+        actor_type="system",
+        actor_id="x",
+        action="misc.event",
+        entity_type="misc",
+        entity_id="x",
+        details={"foo": "bar"},
+    )
+    assert row.action == "misc.event"
+    assert row.details == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# I5 — all 74 HookEvent values produce a row
+# ---------------------------------------------------------------------------
+
+
+def test_i5_all_74_hookevents_produce_a_row() -> None:
+    """No HookEvent should silently break the union channel. Every
+    enum value either has a typed builder entry or falls through to
+    ``GenericActivityRow`` — never raises."""
+    all_events = list(HookEvent)
+    assert len(all_events) >= 74, f"expected at least 74 HookEvents, got {len(all_events)}"
+
+    typed_count = 0
+    for event in all_events:
+        row = map_hook_to_activity(event, {}, run_id="r1")
+        assert isinstance(row, ActivityRowBase)
+        if event in HOOK_EVENT_TO_ROW_BUILDER:
+            typed_count += 1
+            assert not isinstance(row, GenericActivityRow), (
+                f"{event.value} has a registry entry but mapped to GenericActivityRow"
+            )
+
+    # 32 lifecycle events typed in S2 scope (A=9, B=13, C=9, D=1).
+    assert typed_count == 32, f"expected 32 typed lifecycle events, got {typed_count}"
+
+
+def test_i5_registry_action_matches_concrete_action_literal() -> None:
+    """Every registry entry's row class must declare an ``action``
+    literal matching the dotted-name convention. Drift between the
+    builder map and the concrete subclass would silently produce rows
+    with mismatched ``action`` values."""
+    for event, builder in HOOK_EVENT_TO_ROW_BUILDER.items():
+        row = builder({"task_id": "t1"}, "r1")
+        # Each builder returns a row whose action attribute is the
+        # subclass Literal; we just verify it's non-empty + dotted.
+        assert row.action, f"{event.value} produced empty action"
+        assert "." in row.action, f"{event.value} action {row.action!r} is not dotted"

--- a/tests/core/self_improving_loop/test_run_transcript.py
+++ b/tests/core/self_improving_loop/test_run_transcript.py
@@ -10,12 +10,13 @@ import json
 from pathlib import Path
 
 import pytest
-from core.hooks import HookEvent
 from core.self_improving_loop.run_transcript import (
     RunTranscript,
     current_run_transcript,
     run_transcript_scope,
 )
+
+from core.hooks import HookEvent
 
 
 def _make_journal(tmp_path: Path) -> RunTranscript:

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -21,9 +21,10 @@ from core.agent.tool_executor import (
     ToolCallProcessor,
     ToolExecutor,
 )
-from core.hooks import HookEvent, HookSystem
 from core.orchestration.isolated_execution import IsolatedRunner
 from core.tools.base import ToolContext
+
+from core.hooks import HookEvent, HookSystem
 
 
 def _run_executor(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,6 @@
-from core.hooks import HookEvent, HookSystem
 from core.orchestration.bootstrap import BootstrapContext, BootstrapManager
+
+from core.hooks import HookEvent, HookSystem
 
 
 def test_bootstrap_context_defaults_to_generic_subject() -> None:

--- a/tests/test_d4_x2_telemetry.py
+++ b/tests/test_d4_x2_telemetry.py
@@ -23,6 +23,7 @@ from core.agent.loop._model_switching import (
     purge_stale_model_switch_acks,
     update_model_async,
 )
+
 from core.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -23,6 +23,7 @@ from core.agent.error_recovery import (
 )
 from core.agent.loop import AgenticLoop
 from core.agent.tool_executor import ToolExecutor
+
 from core.hooks import HookEvent, HookSystem
 
 

--- a/tests/test_hook_discovery.py
+++ b/tests/test_hook_discovery.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from core.hooks import HookEvent, HookSystem
 from core.hooks.discovery import HookPluginLoader, discover_hooks
+
+from core.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------
 # Fixtures for creating temporary plugin directories

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 
 from core.agent.context_manager import ContextWindowManager
+
 from core.hooks import HookEvent, HookResult, HookSystem, InterceptResult
 
 

--- a/tests/test_isolated_execution.py
+++ b/tests/test_isolated_execution.py
@@ -7,13 +7,14 @@ import time
 from typing import Any
 
 import pytest
-from core.hooks import HookEvent, HookSystem
 from core.orchestration.isolated_execution import (
     IsolatedRunner,
     IsolationConfig,
     IsolationResult,
     PostToMainMode,
 )
+
+from core.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.hooks import HookEvent, HookSystem
 from core.llm.router import _fire_hook, set_router_hooks
+
+from core.hooks import HookEvent, HookSystem
 
 
 class TestLLMLifecycleEvents:

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -17,9 +17,10 @@ import signal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from core.hooks import HookEvent
 from core.mcp.manager import MCPServerManager
 from core.mcp.stdio_client import _CLOSE_TIMEOUT_S, StdioMCPClient
+
+from core.hooks import HookEvent
 
 # ---------------------------------------------------------------------------
 # HookEvent tests

--- a/tests/test_memory_writeback.py
+++ b/tests/test_memory_writeback.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from core.hooks import HookEvent, HookSystem
 from core.wiring.automation import build_automation
+
+from core.hooks import HookEvent, HookSystem
 
 
 class TestPipelineEndMemoryWrite:

--- a/tests/test_notification_hook.py
+++ b/tests/test_notification_hook.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
-from core.hooks import HookEvent, HookSystem
 from core.hooks.plugins.notification_hook.hook import (
     _format_message,
     register_notification_hooks,
 )
 from core.mcp.notification_port import NotificationResult, set_notification
+
+from core.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------
 # Message formatting

--- a/tests/test_ol_a15_telemetry.py
+++ b/tests/test_ol_a15_telemetry.py
@@ -96,8 +96,9 @@ def test_state_to_hook_event_map_covers_five_states_only() -> None:
 
 def test_state_to_hook_event_values_resolve_via_getattr() -> None:
     """Each mapped string MUST resolve via `getattr(HookEvent, name)`."""
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import STATE_TO_HOOK_EVENT
+
+    from core.hooks import HookEvent
 
     for hook_name in STATE_TO_HOOK_EVENT.values():
         assert hasattr(HookEvent, hook_name), f"HookEvent missing {hook_name}"
@@ -194,8 +195,9 @@ def test_history_entry_graceful_on_oserror(monkeypatch: pytest.MonkeyPatch, tmp_
 def test_fired_emits_hook_and_appends_history(
     trigger_paths: tuple[Path, Path, Path],
 ) -> None:
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    from core.hooks import HookEvent
 
     lock, ts, hist = trigger_paths
     runner = _FakeRunner(target_section="wrapper.intro")
@@ -227,12 +229,13 @@ def test_fired_emits_hook_and_appends_history(
 def test_lock_busy_emits_hook_and_appends_history(
     trigger_paths: tuple[Path, Path, Path],
 ) -> None:
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import (
         acquire_auto_trigger_lock,
         auto_trigger_mutator,
         release_auto_trigger_lock,
     )
+
+    from core.hooks import HookEvent
 
     lock, ts, hist = trigger_paths
     held = acquire_auto_trigger_lock(lock)
@@ -259,11 +262,12 @@ def test_lock_busy_emits_hook_and_appends_history(
 def test_interval_blocked_emits_hook_and_appends_history(
     trigger_paths: tuple[Path, Path, Path],
 ) -> None:
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import (
         auto_trigger_mutator,
         write_last_run_timestamp,
     )
+
+    from core.hooks import HookEvent
 
     lock, ts, hist = trigger_paths
     now = 1000000.0
@@ -287,8 +291,9 @@ def test_interval_blocked_emits_hook_and_appends_history(
 def test_runner_error_emits_hook_and_appends_history(
     trigger_paths: tuple[Path, Path, Path],
 ) -> None:
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    from core.hooks import HookEvent
 
     lock, ts, hist = trigger_paths
     runner = _FakeRunner(raises=RuntimeError("boom"))
@@ -310,8 +315,9 @@ def test_runner_error_emits_hook_and_appends_history(
 def test_parse_error_emits_hook_and_appends_history(
     trigger_paths: tuple[Path, Path, Path],
 ) -> None:
-    from core.hooks import HookEvent
     from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    from core.hooks import HookEvent
 
     lock, ts, hist = trigger_paths
     runner = _FakeRunner(raises=ValueError("malformed mutation"))

--- a/tests/test_ol_g_config_drift_invariants.py
+++ b/tests/test_ol_g_config_drift_invariants.py
@@ -121,6 +121,7 @@ def test_g_d_learning_extract_model_is_config_overridable() -> None:
     ``[llm] learning_extract_model`` config.
     """
     from core.config import settings
+
     from core.hooks import llm_extract_learning
 
     # 1. Settings field exists.

--- a/tests/test_project_journal.py
+++ b/tests/test_project_journal.py
@@ -118,8 +118,9 @@ class TestProjectJournal:
 
 class TestJournalHooks:
     def test_pipeline_end_records_run(self, tmp_path):
-        from core.hooks import HookEvent
         from core.memory.journal_hooks import make_journal_handlers
+
+        from core.hooks import HookEvent
 
         journal = ProjectJournal(tmp_path / "journal")
         handlers = make_journal_handlers(journal)
@@ -150,8 +151,9 @@ class TestJournalHooks:
         assert any("demo-subject" in p for p in patterns)
 
     def test_pipeline_error_records(self, tmp_path):
-        from core.hooks import HookEvent
         from core.memory.journal_hooks import make_journal_handlers
+
+        from core.hooks import HookEvent
 
         journal = ProjectJournal(tmp_path / "journal")
         handlers = make_journal_handlers(journal)
@@ -171,8 +173,9 @@ class TestJournalHooks:
         assert runs[0].status == "error"
 
     def test_wrong_event_ignored(self, tmp_path):
-        from core.hooks import HookEvent
         from core.memory.journal_hooks import make_journal_handlers
+
+        from core.hooks import HookEvent
 
         journal = ProjectJournal(tmp_path / "journal")
         handlers = make_journal_handlers(journal)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from core.hooks import HookEvent, HookSystem
 from core.memory.session import InMemorySessionStore
 from core.orchestration.hot_reload import ConfigWatcher
 from core.orchestration.lane_queue import LaneQueue
@@ -22,6 +21,8 @@ from core.runtime import (
 )
 from core.tools.policy import PolicyChain
 from core.tools.registry import ToolRegistry
+
+from core.hooks import HookEvent, HookSystem
 
 
 class TestGeodeRuntimeCreate:

--- a/tests/test_subagent_announce.py
+++ b/tests/test_subagent_announce.py
@@ -28,8 +28,9 @@ from core.agent.sub_agent import (
     drain_announced_results,
 )
 from core.agent.tool_executor import ToolExecutor
-from core.hooks import HookEvent, HookSystem
 from core.orchestration.isolated_execution import IsolatedRunner
+
+from core.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_task_bridge.py
+++ b/tests/test_task_bridge.py
@@ -1,6 +1,7 @@
-from core.hooks import HookEvent, HookSystem
 from core.orchestration.task_bridge import TaskGraphHookBridge
 from core.orchestration.task_system import Task, TaskGraph, TaskStatus
+
+from core.hooks import HookEvent, HookSystem
 
 
 def test_bridge_marks_node_enter_exit_complete() -> None:


### PR DESCRIPTION
## Summary
- Spec doc at ``docs/plans/2026-05-24-hookevent-activity-schema.md``.
- 74 HookEvent → 11 group patterns → 32 typed lifecycle concrete classes + 42 generic fall-through. paperclip ``activity_log`` envelope + openclaw ``z.discriminatedUnion("type")`` parity.
- ``HookSystem.trigger()`` + ``trigger_async()`` end with ``_mirror_hook_to_active_transcript()`` — every hook trigger appends one row to the active ``RunTranscript`` (pipeline transcript). No-op outside scope.

## Why
3-codebase audit (open-coscientist + paperclip + GEODE) GAP 1 (no union channel) + GAP 4 (no payload schema), both P1. Pre-PR the pipeline transcript at ``<run_dir>/transcript.jsonl`` carried only 4 SessionTranscript mirrors (record_user_message/assistant_message/tool_call/tool_result) from PR-U + orchestrator phase events from cli.py. The remaining 70 HookEvent triggers (SUBAGENT_STARTED / LLM_CALL_FAILED / TURN_VERIFY_PASSED / etc.) were invisible in the unified timeline — operators had to register per-event hook handlers manually. paperclip's ``activity_log`` table is the frontier reference: one row per inter-actor action, typed classification quintuple, with paperclip's ``logActivity`` swallow-and-warn so a mirror failure doesn't break the upstream caller.

## Changes
| File | Change |
|------|--------|
| ``core/observability/activity.py`` (NEW, ~340 LOC) | Tier 1 envelope (``ActivityRowBase``) + Tier 2 11 group bases + Tier 3 32 lifecycle concrete classes + ``TypedActivityRow = Annotated[Union[...], Field(discriminator="action")]`` + ``GenericActivityRow`` escape hatch. |
| ``core/observability/activity_registry.py`` (NEW, ~250 LOC) | ``HOOK_EVENT_TO_ROW_BUILDER`` (32 typed entries via 4 curried builder factories) + ``map_hook_to_activity(event, data, *, run_id)`` (typed dispatch + ``ValidationError`` → ``GenericActivityRow`` fall-through). |
| ``core/hooks/system.py`` | New module-level ``_mirror_hook_to_active_transcript`` called at end of both ``trigger`` and ``trigger_async``. Swallow-and-warn contract. |
| ``tests/core/observability/test_activity_schema.py`` (NEW) | 11 tests pinning I1-I5 (envelope quintuple + concrete literals + discriminated dispatch + generic escape + 74/74 cover). |
| ``tests/core/hooks/test_activity_mirror.py`` (NEW) | 6 tests pinning M1-M3 (mirror typed/generic rows / no-op outside scope / malformed payload still emits / handler failure doesn't break mirror). |
| ``docs/plans/2026-05-24-hookevent-activity-schema.md`` (NEW) | Single SoT: paperclip + openclaw frontier comparison, 74 events → 11 groups, S2 scope, Codex MCP review plan. |
| ``CHANGELOG.md`` | Unreleased entry. |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/`` clean
- [x] ``uv run ruff format --check core/ tests/ plugins/`` clean (874 files)
- [x] ``uv run mypy core/ plugins/`` clean (431 source files)
- [x] ``uv run lint-imports`` clean (4 contracts kept)
- [x] ``uv run pytest tests/core/observability/test_activity_schema.py tests/core/hooks/test_activity_mirror.py`` — 17/17 pass
- [x] ``uv run geode version`` → ``GEODE v0.99.51``

## Reference
- 3-codebase audit (this PR thread, sub-agent grounding)
- paperclip ``packages/db/src/schema/activity_log.ts:6`` ``activity_log`` table
- paperclip ``packages/plugins/sdk/src/types.ts:180`` ``PluginEvent<TPayload>`` envelope
- paperclip ``packages/shared/src/constants.ts:1029`` ``PLUGIN_EVENT_TYPES`` 33-tuple
- openclaw ``extensions/voice-call/src/types.ts:90`` ``NormalizedEventSchema = z.discriminatedUnion("type", [...])``

🤖 Generated with [Claude Code](https://claude.com/claude-code)