### PR TITLE
feat(adapter): PR-V — paperclip --resume + per-agent session.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,34 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR2 (V) — paperclip `--resume <sessionId>` + per-agent session.json.**
+  Spec doc §3 of `docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`.
+  paperclip `agent_runtime_state.sessionId` + `--resume` parity → quota
+  cache hit (5-10K tokens saved per turn per paperclip `execute.ts:680`).
+  Pre-PR-V every claude-cli call started a fresh backend session and
+  re-sent the full system prompt; PR-V threads the prior session_id
+  through `AdapterCallRequest.resume_session_id` → `--resume <id>` argv
+  → `system.init` event's `session_id` → persisted to
+  `<run_dir>/sub_agents/<task_id>/session.json` → loaded on the next turn.
+  - **V.1** `core/llm/adapters/base.py` — `AdapterCallRequest.resume_session_id`
+    + `AdapterCallResult.session_id` fields (backwards-compat empty default).
+  - **V.2** `plugins/petri_audit/claude_cli_provider.py` —
+    `build_claude_cli_argv(resume_session_id=...)` prepends `--resume <id>`
+    before `--model`. New `extract_session_id_from_events()` walks the
+    `system.init` event (paperclip `parse.ts:30-33` parity).
+  - **V.3** `core/llm/adapters/claude_cli.py` — `acomplete` wires both
+    directions (req → argv, events → result.session_id).
+  - **V.4** `core/agent/loop/agent_loop.py` — `_load_prior_session_id`
+    + `_persist_session_id` helpers read/write
+    `<run_dir>/sub_agents/<task_id>/session.json` (PR-Q's resolver
+    anchor). `_call_llm` reads before the adapter call, writes after.
+    Empty session_id is no-op (non-claude-cli / first turn / outside scope).
+  - `core/llm/adapters/translation.py` — `build_adapter_request`
+    threads the new `resume_session_id` kwarg.
+  - 11 new tests pin V.1 contract, V.2 argv ordering + parser, V.4
+    persistence round-trip + no-op semantics.
+
+### Added
 - **PR-COMM-1 — HookEvent → ActivityRow schema + union channel.**
   Spec doc at `docs/plans/2026-05-24-hookevent-activity-schema.md`
   (S2 scope: 32 lifecycle typed + 42 generic fall-through).

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -57,6 +57,77 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _load_prior_session_id(session_id: str) -> str:
+    """Return the claude-cli session_id from the prior turn of this
+    sub-agent, or empty string when no prior session exists / outside
+    a run_dir scope.
+
+    PR-V (2026-05-24, spec doc §3 V.4). Reads
+    ``<run_dir>/sub_agents/<session_id>/session.json``. Mirrors
+    paperclip's ``agent_runtime_state.sessionId`` SELECT — a per-agent
+    single-row store of "the sessionId my next ``--resume`` should use".
+    Returns empty on any I/O / parse error so the call falls back to
+    a fresh session rather than crashing.
+    """
+    try:
+        from core.observability.run_dir import resolve_sub_agent_path
+
+        session_path = resolve_sub_agent_path(session_id, "session.json")
+    except Exception:
+        return ""
+    if session_path is None or not session_path.exists():
+        return ""
+    try:
+        import json
+
+        payload = json.loads(session_path.read_text(encoding="utf-8"))
+        cached = payload.get("claude_cli_session_id", "")
+        return str(cached) if cached else ""
+    except Exception:
+        log.debug("session.json read failed for %s", session_id, exc_info=True)
+        return ""
+
+
+def _persist_session_id(session_id: str, emitted_session_id: str) -> None:
+    """Persist the claude-cli session_id this turn emitted so the next
+    turn of this sub-agent (or the same sub-agent in the next cycle)
+    can ``--resume <id>``.
+
+    PR-V (2026-05-24, spec doc §3 V.4). Writes
+    ``<run_dir>/sub_agents/<session_id>/session.json``. The on-disk
+    schema is intentionally one field (``claude_cli_session_id``) for
+    now; PR-COMM-3 (SQLite agent_runtime_state) replaces the file with
+    a DB row carrying the full paperclip
+    ``agent_runtime_state`` columns (totalInputTokens / lastError /
+    lastRunStatus / ...). Empty ``emitted_session_id`` is a no-op
+    (non-claude-cli adapters or claude-cli crash before init).
+    """
+    if not emitted_session_id:
+        return
+    try:
+        from core.observability.run_dir import resolve_sub_agent_path
+
+        session_path = resolve_sub_agent_path(session_id, "session.json")
+    except Exception:
+        return
+    if session_path is None:
+        return
+    try:
+        import json
+        import time
+
+        payload = {
+            "claude_cli_session_id": emitted_session_id,
+            "updated_at": time.time(),
+        }
+        session_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:
+        log.debug("session.json write failed for %s", session_id, exc_info=True)
+
+
 class AgenticLoop:
     """Claude Code-style agentic execution loop.
 
@@ -2027,6 +2098,17 @@ class AgenticLoop:
             build_adapter_request,
         )
 
+        # PR-V (2026-05-24, spec doc §3 V.4) — paperclip
+        # ``agent_runtime_state.sessionId`` parity. Read the prior
+        # session_id from ``<run_dir>/sub_agents/<task_id>/session.json``
+        # so the adapter resumes via ``--resume <id>``. claude-cli then
+        # reuses the cached system prompt + prior conversation context
+        # for the cached-marker input billing tier (5-10K tokens saved
+        # per turn per paperclip ``execute.ts:680``). Empty when no
+        # prior session (first turn of a fresh sub-agent or outside a
+        # run_dir scope) so first-call behaviour is unchanged.
+        prior_session_id = _load_prior_session_id(self._session_id)
+
         req = build_adapter_request(
             model=effective_model,
             system=system,
@@ -2037,6 +2119,7 @@ class AgenticLoop:
             temperature=loop_temperature,
             thinking_budget=adaptive_thinking,
             effort=adaptive_effort,
+            resume_session_id=prior_session_id,
         )
         try:
             result = await self._new_adapter.acomplete(req)
@@ -2050,6 +2133,11 @@ class AgenticLoop:
             response = None
         else:
             response = agentic_response_from_adapter_result(result)
+            # PR-V — persist the newly-emitted session_id so the next
+            # turn of THIS sub-agent (or the same sub-agent in the next
+            # cycle) can resume. Non-claude-cli adapters return empty
+            # session_id; the persistence helper is a no-op there.
+            _persist_session_id(self._session_id, getattr(result, "session_id", ""))
 
         if response is None:
             adapter_err = getattr(self._new_adapter, "_last_error", None)

--- a/core/llm/adapters/_subprocess_common.py
+++ b/core/llm/adapters/_subprocess_common.py
@@ -21,7 +21,16 @@ def build_subprocess_stdin(req: AdapterCallRequest) -> str:
     output).
     """
     parts: list[str] = []
-    if req.system_prompt:
+    # PR-V (2026-05-24, Codex MCP review of #1588) — paperclip
+    # ``execute.ts:694-698`` parity. When resuming a prior claude-cli
+    # session the system prompt is already in the backend's session
+    # cache; re-injecting it via stdin wastes 5-10K tokens per turn
+    # (the exact saving PR-V's CHANGELOG claims). Skip the [SYSTEM]
+    # block when ``resume_session_id`` is set so the quota cache hit
+    # actually materialises. First-turn callers (empty
+    # ``resume_session_id``) keep the legacy behaviour — the prompt
+    # must be sent so claude-cli can cache it for the next turn.
+    if req.system_prompt and not req.resume_session_id:
         parts.append("[SYSTEM]")
         parts.append(req.system_prompt)
         parts.append("")

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -117,6 +117,13 @@ class AdapterCallRequest:
     stop_sequences: tuple[str, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)
     provider_options: dict[str, Any] = field(default_factory=dict)
+    # PR-V (2026-05-24, spec doc §3 — paperclip `--resume <sessionId>`
+    # parity). When non-empty the adapter passes ``--resume <session_id>``
+    # to claude-cli so the backend reuses the cached system prompt +
+    # prior conversation context — paperclip ``execute.ts:680`` says
+    # this saves 5-10K tokens per heartbeat. Empty = fresh session
+    # (pre-PR-V behaviour). Non-claude-cli adapters ignore this field.
+    resume_session_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -163,6 +170,13 @@ class AdapterCallResult:
     raw_response: Any = None
     reasoning_items: tuple[dict[str, Any], ...] = ()
     reasoning_summaries: tuple[str, ...] = ()
+    # PR-V (2026-05-24, spec doc §3) — sessionId emitted by claude-cli's
+    # ``system.init`` event (paperclip ``parse.ts:30``). Callers persist
+    # this so the next turn can resume the same backend session via
+    # ``AdapterCallRequest.resume_session_id``. Mirrors paperclip's
+    # ``heartbeat_runs.sessionIdBefore/After`` capture. Empty for
+    # non-claude-cli adapters (they don't have a resumable session).
+    session_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -85,7 +85,19 @@ class ClaudeCliAdapter:
         from core.orchestration.claude_cli_lane import acquire_claude_cli_lane_async
 
         binary = _resolve_claude_binary()
-        argv = build_claude_cli_argv(binary=binary, model_name=req.model, max_turns=1)
+        # PR-V (2026-05-24) — paperclip `--resume <sessionId>` parity.
+        # ``req.resume_session_id`` is non-empty when the caller has a
+        # prior session from this sub-agent's previous turn (or a
+        # cross-cycle continuity slot like
+        # ``<run_dir>/sub_agents/<task_id>/session.json``); claude-cli
+        # then reuses the cached system prompt + conversation context,
+        # dropping input billing to the cached-marker tier.
+        argv = build_claude_cli_argv(
+            binary=binary,
+            model_name=req.model,
+            max_turns=1,
+            resume_session_id=req.resume_session_id or None,
+        )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"
         try:
@@ -164,10 +176,20 @@ class ClaudeCliAdapter:
         # ``("tool_use" | "tool_calls")`` branch isn't tripped.
         if stop_reason == "unknown":
             stop_reason = "end_turn"
+        # PR-V (2026-05-24) — paperclip ``parse.ts:30`` parity.
+        # Capture the session_id claude-cli emitted in its
+        # ``system.init`` event so the caller can persist it for the
+        # next turn's ``resume_session_id`` (cross-call cache hit).
+        from plugins.petri_audit.claude_cli_provider import (
+            extract_session_id_from_events,
+        )
+
+        emitted_session_id = extract_session_id_from_events(stream_events)
         return AdapterCallResult(
             text=assistant_text,
             usage=UsageSummary(),  # subscription path does not expose token usage
             stop_reason=stop_reason,
+            session_id=emitted_session_id,
         )
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:

--- a/core/llm/adapters/translation.py
+++ b/core/llm/adapters/translation.py
@@ -41,6 +41,7 @@ def build_adapter_request(
     temperature: float,
     thinking_budget: int,
     effort: str,
+    resume_session_id: str = "",
 ) -> AdapterCallRequest:
     """Translate AgenticLoop's call-site args → :class:`AdapterCallRequest`.
 
@@ -95,6 +96,7 @@ def build_adapter_request(
         temperature=temperature,
         thinking_budget=thinking_budget,
         effort=effort,
+        resume_session_id=resume_session_id,
     )
 
 

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -93,6 +93,7 @@ __all__ = [
     "TransientSignal",
     "build_claude_cli_argv",
     "classify_transient_signal",
+    "extract_session_id_from_events",
     "is_claude_transient_upstream_error",
     "parse_stream_json_events",
     "register",
@@ -320,6 +321,7 @@ def build_claude_cli_argv(
     allowed_tools: list[str] | None = None,
     disable_builtin_tools: bool = False,
     extra_args: Iterable[str] | None = None,
+    resume_session_id: str | None = None,
 ) -> list[str]:
     """Construct the ``claude --print`` argv.
 
@@ -339,6 +341,16 @@ def build_claude_cli_argv(
             ``mcp_config_path``.
         extra_args: Additional flags to append (test injection,
             operator hooks). Validated only by claude CLI itself.
+        resume_session_id: PR-V (2026-05-24) paperclip parity. When
+            non-empty/non-None claude-cli resumes the named session —
+            the backend reuses the cached system prompt + prior
+            conversation context so input billing drops to the
+            cached-marker tier (paperclip ``execute.ts:680``: 5-10K
+            tokens saved per heartbeat). When supplied alongside
+            ``mcp_config_path`` the system prompt is NOT re-injected;
+            claude-cli pulls the cached one (paperclip
+            ``execute.ts:697`` "instructions are already in the
+            session cache").
 
     The output format is pinned to ``stream-json`` + ``--verbose`` —
     we need every event to construct ``ModelOutput`` faithfully.
@@ -350,6 +362,13 @@ def build_claude_cli_argv(
         "--output-format",
         "stream-json",
         "--verbose",
+    ]
+    if resume_session_id:
+        # PR-V — paperclip ``execute.ts:680`` argv parity. ``--resume``
+        # must precede ``--model`` because claude-cli pulls the cached
+        # model when the session is resumed.
+        argv += ["--resume", resume_session_id]
+    argv += [
         "--model",
         model_name,
         "--max-turns",
@@ -371,6 +390,27 @@ def build_claude_cli_argv(
     if extra_args:
         argv += list(extra_args)
     return argv
+
+
+def extract_session_id_from_events(events: list[StreamJsonEvent]) -> str:
+    """Pull the ``session_id`` claude-cli emits in its ``system.init``
+    event. Mirrors paperclip ``parse.ts:30-33`` — the first event
+    claude-cli emits is always ``{type:"system", subtype:"init", session_id:"..."}``
+    carrying the freshly-allocated session_id for this turn. Callers
+    persist this so the next turn can resume via ``--resume <id>``.
+
+    PR-V (2026-05-24). Returns empty string when no system.init event
+    was seen (e.g. claude-cli crashed before init) so caller can
+    distinguish "session unknown" from "session zero"."""
+    for event in events:
+        if event.type != "system":
+            continue
+        if event.payload.get("subtype") != "init":
+            continue
+        session_id = event.payload.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+    return ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/llm/adapters/test_claude_cli_resume.py
+++ b/tests/core/llm/adapters/test_claude_cli_resume.py
@@ -176,6 +176,113 @@ def test_v4_persist_empty_session_id_is_noop() -> None:
         assert _load_prior_session_id(task_id) == "sess-original-789"
 
 
+def test_v3_adapter_round_trip_threads_resume_and_emits_session_id() -> None:
+    """V.3 — request.resume_session_id → ``--resume`` argv → claude-cli
+    emits system.init session_id → result.session_id. Codex MCP review
+    of #1588 flagged this round-trip was implemented but not directly
+    tested."""
+    import asyncio
+    from unittest.mock import patch
+
+    from core.llm.adapters.base import AdapterCallRequest
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+
+    adapter = ClaudeCliAdapter()
+    # claude-cli stdout: system.init carries session_id + assistant + result
+    stdout = (
+        json.dumps({"type": "system", "subtype": "init", "session_id": "emitted-session-789"})
+        + "\n"
+        + json.dumps(
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+        + "\n"
+        + json.dumps({"type": "result", "stop_reason": "end_turn", "result": "hi"})
+        + "\n"
+    )
+    captured_argv: list[str] = []
+
+    async def _fake_subprocess(
+        argv: list[str], stdin_text: str, timeout_s: float
+    ) -> tuple[str, str, int]:
+        captured_argv.extend(argv)
+        return (stdout, "", 0)
+
+    def _passthrough_lane(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        # Sync function returning an async context manager — matches
+        # the actual ``acquire_claude_cli_lane_async`` shape (it's a
+        # sync helper that returns the CM, not itself an awaitable).
+        class _Ctx:
+            async def __aenter__(self):  # type: ignore[no-untyped-def]
+                return None
+
+            async def __aexit__(self, *_exc):  # type: ignore[no-untyped-def]
+                return None
+
+        return _Ctx()
+
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            _fake_subprocess,
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+    ):
+        req = AdapterCallRequest(
+            model="claude-opus-4-7", messages=(), resume_session_id="prior-sess-xyz"
+        )
+        result = asyncio.run(adapter.acomplete(req))
+    # argv must carry --resume <prior-sess-xyz>
+    assert "--resume" in captured_argv
+    assert captured_argv[captured_argv.index("--resume") + 1] == "prior-sess-xyz"
+    # result must carry the new session_id from system.init
+    assert result.session_id == "emitted-session-789"
+
+
+def test_v3_subprocess_stdin_skips_system_prompt_when_resuming() -> None:
+    """paperclip ``execute.ts:694-698`` parity (Codex MCP fix of #1588):
+    when resuming a session the system prompt is in the backend cache
+    — re-injecting via stdin wastes 5-10K tokens per turn. This is the
+    actual mechanism by which PR-V's CHANGELOG-claimed quota savings
+    materialise. First-turn callers (empty resume_session_id) must
+    still send the prompt so claude-cli caches it for next turn."""
+    from core.llm.adapters._subprocess_common import build_subprocess_stdin
+    from core.llm.adapters.base import AdapterCallRequest, Message
+
+    system_prompt = "You are a Petri seed generator. Output JSON only."
+    user_msg = Message(role="user", content="Generate seed for X")
+
+    # First turn — system prompt MUST be in stdin (cache priming).
+    req_first = AdapterCallRequest(
+        model="claude-opus-4-7",
+        messages=[user_msg],
+        system_prompt=system_prompt,
+        resume_session_id="",
+    )
+    stdin_first = build_subprocess_stdin(req_first)
+    assert "[SYSTEM]" in stdin_first
+    assert system_prompt in stdin_first
+
+    # Resume turn — system prompt MUST NOT be re-sent (cache hit).
+    req_resume = AdapterCallRequest(
+        model="claude-opus-4-7",
+        messages=[user_msg],
+        system_prompt=system_prompt,
+        resume_session_id="prior-sess-xyz",
+    )
+    stdin_resume = build_subprocess_stdin(req_resume)
+    assert "[SYSTEM]" not in stdin_resume
+    assert system_prompt not in stdin_resume
+    # User turn must still be present (only system is skipped).
+    assert "Generate seed for X" in stdin_resume
+
+
 def test_v4_load_prior_session_id_returns_empty_when_file_missing() -> None:
     """First turn of a fresh sub-agent — no session.json yet.
     Must return empty so the adapter falls back to fresh session."""

--- a/tests/core/llm/adapters/test_claude_cli_resume.py
+++ b/tests/core/llm/adapters/test_claude_cli_resume.py
@@ -1,0 +1,187 @@
+"""PR2 (V) — paperclip ``--resume`` + per-agent sessionId tests.
+
+Pins invariants from
+``docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`` §3.4
+(V.1 contract + V.2 argv + V.2 parser + V.3 round-trip + V.4 persistence).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# V.1 — AdapterCallRequest / AdapterCallResult new fields
+# ---------------------------------------------------------------------------
+
+
+def test_v1_request_has_resume_session_id_field() -> None:
+    """``AdapterCallRequest.resume_session_id`` defaults to empty
+    (legacy fresh-session behaviour). Non-empty value triggers
+    ``--resume`` in claude-cli adapter."""
+    from core.llm.adapters.base import AdapterCallRequest
+
+    req_default = AdapterCallRequest(model="claude-opus-4-7", messages=[])
+    assert req_default.resume_session_id == ""
+
+    req_resume = AdapterCallRequest(
+        model="claude-opus-4-7", messages=[], resume_session_id="prior-sess-xyz"
+    )
+    assert req_resume.resume_session_id == "prior-sess-xyz"
+
+
+def test_v1_result_has_session_id_field() -> None:
+    """``AdapterCallResult.session_id`` defaults to empty
+    (non-claude-cli adapters). claude-cli sets it from the
+    ``system.init`` event."""
+    from core.llm.adapters.base import AdapterCallResult, UsageSummary
+
+    res_default = AdapterCallResult(text="hi", usage=UsageSummary(), stop_reason="end_turn")
+    assert res_default.session_id == ""
+
+    res_with_session = AdapterCallResult(
+        text="hi", usage=UsageSummary(), stop_reason="end_turn", session_id="new-sess-456"
+    )
+    assert res_with_session.session_id == "new-sess-456"
+
+
+# ---------------------------------------------------------------------------
+# V.2 — build_claude_cli_argv + extract_session_id_from_events
+# ---------------------------------------------------------------------------
+
+
+def test_v2_argv_includes_resume_flag_when_session_id_supplied() -> None:
+    """paperclip ``execute.ts:680`` parity — ``--resume <session_id>``
+    precedes ``--model`` so claude-cli pulls the cached model from the
+    resumed session."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude", model_name="claude-opus-4-7", resume_session_id="abc123"
+    )
+    assert "--resume" in argv
+    resume_index = argv.index("--resume")
+    assert argv[resume_index + 1] == "abc123"
+    model_index = argv.index("--model")
+    # --resume comes BEFORE --model so the cached model wins.
+    assert resume_index < model_index
+
+
+def test_v2_argv_omits_resume_flag_when_session_id_empty() -> None:
+    """When ``resume_session_id`` is None/empty the argv is byte-equivalent
+    to the pre-PR-V form (no behaviour change for first-turn callers)."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv_none = build_claude_cli_argv(binary="/x/claude", model_name="claude-opus-4-7")
+    argv_empty = build_claude_cli_argv(
+        binary="/x/claude", model_name="claude-opus-4-7", resume_session_id=""
+    )
+    assert "--resume" not in argv_none
+    assert "--resume" not in argv_empty
+
+
+def test_v2_extract_session_id_from_system_init_event() -> None:
+    """paperclip ``parse.ts:30-33`` parity — ``system.init`` event's
+    ``session_id`` field is the freshly-allocated session for this turn."""
+    from plugins.petri_audit.claude_cli_provider import (
+        extract_session_id_from_events,
+        parse_stream_json_events,
+    )
+
+    stdout = (
+        json.dumps({"type": "system", "subtype": "init", "session_id": "sess-abc-123"})
+        + "\n"
+        + json.dumps({"type": "assistant", "message": {"content": []}})
+        + "\n"
+    )
+    events = parse_stream_json_events(stdout)
+    assert extract_session_id_from_events(events) == "sess-abc-123"
+
+
+def test_v2_extract_session_id_returns_empty_when_no_init() -> None:
+    """When claude-cli crashes before the ``system.init`` event the
+    extractor returns empty string (not None / not raise) so the
+    caller can fall back to a fresh next-turn session."""
+    from plugins.petri_audit.claude_cli_provider import (
+        extract_session_id_from_events,
+        parse_stream_json_events,
+    )
+
+    # Only assistant event, no system.init
+    stdout = json.dumps({"type": "assistant", "message": {"content": []}}) + "\n"
+    events = parse_stream_json_events(stdout)
+    assert extract_session_id_from_events(events) == ""
+
+
+def test_v2_extract_session_id_ignores_non_init_system_events() -> None:
+    """Only ``subtype == "init"`` events carry the session-id contract;
+    other system events (``error`` / ``warning``) must NOT be misread."""
+    from plugins.petri_audit.claude_cli_provider import (
+        extract_session_id_from_events,
+        parse_stream_json_events,
+    )
+
+    stdout = json.dumps({"type": "system", "subtype": "error", "session_id": "wrong"}) + "\n"
+    events = parse_stream_json_events(stdout)
+    assert extract_session_id_from_events(events) == ""
+
+
+# ---------------------------------------------------------------------------
+# V.4 — AgenticLoop session.json persistence (paperclip
+# agent_runtime_state equivalent)
+# ---------------------------------------------------------------------------
+
+
+def test_v4_session_json_roundtrip_under_run_dir_scope() -> None:
+    """``<run_dir>/sub_agents/<task_id>/session.json`` is the single-row
+    per-agent state (paperclip ``agent_runtime_state`` parity). Persist
+    then load returns the same session_id."""
+    from core.agent.loop.agent_loop import _load_prior_session_id, _persist_session_id
+    from core.observability.run_dir import run_dir_scope
+
+    task_id = "gen-gen1-001-bd2e3854"
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        _persist_session_id(task_id, "sess-abc-123")
+        session_path = Path(tmp) / "sub_agents" / task_id / "session.json"
+        assert session_path.exists()
+        data = json.loads(session_path.read_text())
+        assert data["claude_cli_session_id"] == "sess-abc-123"
+        assert "updated_at" in data
+        # Round-trip
+        assert _load_prior_session_id(task_id) == "sess-abc-123"
+
+
+def test_v4_load_prior_session_id_no_op_outside_scope() -> None:
+    """Outside ``run_dir_scope`` (REPL / gateway / tests) the load
+    returns empty string — non-seed-gen callers are unaffected and
+    fall back to fresh sessions."""
+    from core.agent.loop.agent_loop import _load_prior_session_id
+
+    assert _load_prior_session_id("any-task") == ""
+
+
+def test_v4_persist_empty_session_id_is_noop() -> None:
+    """Non-claude-cli adapters return ``session_id=""`` (no resumable
+    session). Persisting empty must NOT overwrite a prior session.json
+    so cross-cycle resume is preserved when a different adapter ran
+    in the middle."""
+    from core.agent.loop.agent_loop import _load_prior_session_id, _persist_session_id
+    from core.observability.run_dir import run_dir_scope
+
+    task_id = "gen-task-002"
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        _persist_session_id(task_id, "sess-original-789")
+        _persist_session_id(task_id, "")  # empty must be no-op
+        assert _load_prior_session_id(task_id) == "sess-original-789"
+
+
+def test_v4_load_prior_session_id_returns_empty_when_file_missing() -> None:
+    """First turn of a fresh sub-agent — no session.json yet.
+    Must return empty so the adapter falls back to fresh session."""
+    from core.agent.loop.agent_loop import _load_prior_session_id
+    from core.observability.run_dir import run_dir_scope
+
+    with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+        # Never persisted — file doesn't exist.
+        assert _load_prior_session_id("fresh-task") == ""


### PR DESCRIPTION
## Summary
- Spec doc §3 of ``docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`` (PR2 plan, already on develop).
- V.1 `AdapterCallRequest.resume_session_id` + `AdapterCallResult.session_id`. V.2 `build_claude_cli_argv(resume_session_id=...)` + `extract_session_id_from_events`. V.3 ClaudeCliAdapter wires both. V.4 AgenticLoop reads/writes `<run_dir>/sub_agents/<task_id>/session.json`.
- paperclip `agent_runtime_state.sessionId` + `--resume` parity → 5-10K tokens saved per turn (paperclip `execute.ts:680`).

## Why
Pre-PR-V every claude-cli call started a fresh backend session and re-sent the full system prompt. Single-OAuth seed-generation cycles burnt through the 5-hour quota in minutes because the same system prompt re-flooded the input window for every sub-agent turn. paperclip's heartbeat path solves this with `--resume <session_id>` — claude-cli reuses the cached system prompt + prior conversation context, dropping input billing to the cached-marker tier (5-10K tokens saved per turn).

PR-V threads the prior session_id end-to-end: AgenticLoop reads `session.json` before the call → `AdapterCallRequest.resume_session_id` → `--resume <id>` argv → claude-cli emits `system.init` with the (potentially new) session_id → `AdapterCallResult.session_id` → AgenticLoop persists to `session.json` for the next turn. PR-Q's `resolve_sub_agent_path` provides the per-task anchor.

## Changes
| File | Change |
|------|--------|
| ``core/llm/adapters/base.py`` (V.1) | `AdapterCallRequest.resume_session_id: str = ""` + `AdapterCallResult.session_id: str = ""` fields (backwards-compat default empty). |
| ``plugins/petri_audit/claude_cli_provider.py`` (V.2) | `build_claude_cli_argv(resume_session_id=...)` prepends `--resume <id>` before `--model`. New `extract_session_id_from_events()` walks the `system.init` event. |
| ``core/llm/adapters/claude_cli.py`` (V.3) | `acomplete` threads `req.resume_session_id` into the argv builder + surfaces emitted session_id on `result.session_id`. |
| ``core/agent/loop/agent_loop.py`` (V.4) | New `_load_prior_session_id` + `_persist_session_id` helpers around `<run_dir>/sub_agents/<task_id>/session.json`. `_call_llm` reads before adapter call, writes after. |
| ``core/llm/adapters/translation.py`` | `build_adapter_request` accepts + threads `resume_session_id` kwarg. |
| ``tests/core/llm/adapters/test_claude_cli_resume.py`` (NEW) | 11 tests pin V.1/V.2/V.4 contract + persistence + no-op semantics. |
| ``CHANGELOG.md`` | Unreleased entry. |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/`` clean
- [x] ``uv run ruff format --check core/ tests/ plugins/`` clean
- [x] ``uv run mypy core/ plugins/`` clean (431 source files)
- [x] ``uv run lint-imports`` clean (4 contracts kept)
- [x] ``uv run pytest tests/core/llm/adapters/ tests/plugins/petri_audit/ tests/core/agent/`` — 719 passed, 35 skipped
- [x] ``uv run geode version`` → ``GEODE v0.99.51``
- [x] In-process smoke: V.4 round-trip (`_persist_session_id` → `_load_prior_session_id` returns same value) + no-op outside scope + empty session_id no-op + missing-file empty.

## Reference
- ``docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`` §3 (PR2 plan, already merged via PR1 #1584)
- paperclip ``packages/adapters/claude-local/src/server/execute.ts:678-770`` `buildClaudeArgs` + `runAttempt`
- paperclip ``packages/adapters/claude-local/src/server/parse.ts:17-55`` `parseClaudeStreamJson`
- paperclip ``packages/db/src/schema/agent_runtime_state.ts:6`` `agent_runtime_state` table (PR-COMM-3 will SQLite-ify the `session.json` file into this row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)