### PR TITLE
PR-DEFECT-AB — sub-agent failure-signal propagation (classify + worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,46 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-DEFECT-AB** — sub-agent failure signal propagation across the
+  worker IPC boundary. Two coupled regressions surfaced by the
+  v0.99.52 seed-generation smoke (proximity 111s + critic 66s both
+  returned malformed JSON that downstream phase agents then ingested
+  as legitimate content):
+  - **Defect A** (`core/llm/errors.py:classify_llm_error`):
+    `ClaudeCliTransientUpstreamError` (raised by PR-T's claude-cli
+    transient classifier) fell through to the generic `unknown`
+    classification, which routed claude-cli 429s / overload / quota
+    signatures through the AgenticLoop's "Unexpected error.
+    Auto-retrying." fallback path instead of the dedicated
+    `rate_limit` branch at `agent_loop.py:1595`. Now lazy-imports the
+    plugin exception and maps it to `rate_limit` so the loop fails
+    fast with the same diagnostic as native SDK 429s — paperclip
+    parity (`execute.ts:809` tags identical signatures with
+    `errorCode = "claude_transient_upstream"`).
+  - **Defect B** (`core/agent/worker.py:_run_agentic`):
+    `WorkerResult.success = bool(text)` reported True whenever the
+    sub-agent loop produced any non-empty string, including the
+    `_build_model_action_result` fallback UI text the loop emits on
+    `model_action_required` / `context_exhausted` / `llm_error` /
+    `billing_error` / `cost_budget_exceeded` / `convergence_detected`
+    terminations. Now gates `success` on the absence of
+    `AgenticResult.error` AND the termination_reason not being one of
+    those six failure sentinels. `summary` now surfaces the actual
+    cause ("Sub-agent failed: model_action_required;
+    termination_reason=model_action_required") so parent timeline rows
+    explain WHY the spawn produced no usable output. The legacy "No
+    response from sub-agent" string is preserved for the
+    empty-text + no-error + unknown-termination case so existing log
+    greppers keep working.
+  - Pinned by `tests/core/llm/test_classify_llm_error.py` (19 cases —
+    PR-T mapping + every Anthropic + OpenAI SDK branch +
+    parametric unknown-fallback smoke) +
+    `tests/test_worker.py::TestResolveWorkerOutcome` (16 cases —
+    every failure sentinel + clarification / input_blocked /
+    user_cancelled exemptions + convergence-as-failure pin +
+    summary contract).
+
 ## [0.99.52] - 2026-05-24
 
 > 2-PR bundle. PR-COMM-1 (#1587): 74 HookEvent → 11 group patterns

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -22,10 +22,13 @@ import os
 import sys
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from core.async_runtime import run_process_coroutine
 from core.paths import GLOBAL_WORKERS_DIR
+
+if TYPE_CHECKING:
+    from core.agent.loop.models import AgenticResult
 
 log = logging.getLogger(__name__)
 
@@ -368,15 +371,91 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     agentic_result = run_process_coroutine(loop.arun(prompt))
 
     elapsed_ms = (time.time() - started) * 1000
-    text = agentic_result.text if agentic_result else ""
+    success, summary, text = _resolve_worker_outcome(agentic_result)
 
     return WorkerResult(
         task_id=request.task_id,
-        success=bool(text),
+        success=success,
         output=text,
-        summary=text[:500] if text else "No response from sub-agent",
+        summary=summary,
         duration_ms=elapsed_ms,
     )
+
+
+# PR-DEFECT-AB (2026-05-24) — propagate AgenticLoop failures past the
+# sub-agent IPC boundary. Pre-fix ``success=bool(text)`` returned True
+# whenever the loop produced any string at all, including the
+# ``_build_model_action_result`` fallback UI text
+# ("! Unexpected error. Auto-retrying.") that agent_loop emits when
+# every retry attempt has failed but the orchestrator still needs a
+# non-empty payload to keep the timeline coherent. Downstream phase
+# agents (proximity / critic) then ingested that fallback as
+# legitimate content and produced malformed JSON.
+#
+# The fallback path always sets ``termination_reason`` to one of the
+# explicit failure sentinels below — gate ``success`` on the absence of
+# those plus the absence of ``error``. Sentinels enumerated from
+# ``agent_loop.py`` (search ``termination_reason="``):
+#
+# * Failure exits (text is fallback / diagnostic UI, NOT a real answer):
+#   ``model_action_required``, ``context_exhausted``, ``llm_error``,
+#   ``billing_error``, ``cost_budget_exceeded``, ``convergence_detected``
+#   (loop bailed after detecting a repeating error pattern — see
+#   ``agent_loop.py`` ~1828 where ``error="convergence_detected"`` is
+#   set alongside termination_reason).
+# * Success exits (text IS the legitimate output):
+#   ``unknown`` (default success exit), ``input_blocked`` (text is the
+#   block diagnostic that the parent expects to surface),
+#   ``user_clarification_needed`` (text IS the follow-up question),
+#   ``user_cancelled`` (operator-requested halt — text is "Interrupted.").
+_FAILURE_TERMINATION_REASONS: frozenset[str] = frozenset(
+    {
+        "model_action_required",
+        "context_exhausted",
+        "llm_error",
+        "billing_error",
+        "cost_budget_exceeded",
+        "convergence_detected",
+    }
+)
+
+
+def _resolve_worker_outcome(
+    agentic_result: AgenticResult | None,
+) -> tuple[bool, str, str]:
+    """Translate an :class:`AgenticResult` into ``(success, summary, text)``.
+
+    Extracted from :func:`_run_agentic` so tests can pin the
+    failure-propagation contract without spinning up the full sub-agent
+    bootstrap pipeline.
+    """
+    text = agentic_result.text if agentic_result else ""
+    termination_reason = agentic_result.termination_reason if agentic_result else "unknown"
+    error = agentic_result.error if agentic_result else None
+
+    success = bool(text) and not error and termination_reason not in _FAILURE_TERMINATION_REASONS
+
+    # Summary surfaces the actual failure cause when ``success`` is False so
+    # parent timeline rows ("Tool returned: ...") explain WHY the sub-agent
+    # produced no usable output instead of echoing the fallback UI string.
+    # The legacy "No response from sub-agent" string is reserved for the
+    # "no signal at all" case (empty text + no error + no failure
+    # termination) so existing graders/log-greppers keep working.
+    cause_bits: list[str] = []
+    if not success and agentic_result is not None:
+        if error:
+            cause_bits.append(error)
+        if termination_reason and termination_reason != "unknown":
+            cause_bits.append(f"termination_reason={termination_reason}")
+
+    if cause_bits:
+        summary = "Sub-agent failed: " + "; ".join(cause_bits)
+    elif text:
+        summary = text[:500]
+    else:
+        summary = "No response from sub-agent"
+
+    return success, summary, text
 
 
 def main() -> None:

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -256,14 +256,35 @@ _ERROR_CLASSIFICATION: dict[str, tuple[str, str, str]] = {
 def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
     """Classify an LLM exception into (error_type, severity, hint).
 
-    Handles both Anthropic SDK and OpenAI SDK (used by GLM/OpenAI providers)
-    exception types.
+    Handles Anthropic SDK, OpenAI SDK (used by GLM/OpenAI providers),
+    and the PR-T subprocess transient classifier
+    (``ClaudeCliTransientUpstreamError``) so claude-cli stream-json
+    upstream signatures dispatch through the same ``rate_limit``
+    retry path as native SDK 429s. Without this mapping the
+    AgenticLoop's generic ``unknown`` branch produces the
+    "! Unexpected error. Auto-retrying." fallback UI which downstream
+    phase agents (proximity / critic) then mis-parse as content.
 
     Returns a tuple of:
       - error_type: machine-readable category
       - severity: "info" | "warning" | "error" | "critical"
       - hint: user-facing actionable message
     """
+    # --- PR-DEFECT-AB (2026-05-24) — paperclip execute.ts:809 parity ---
+    # ``ClaudeCliTransientUpstreamError`` lives under ``plugins/petri_audit``
+    # so core can't unconditionally import it (layer-violation +
+    # plugin-as-optional-dep). Lazy-import + isinstance gate — when the
+    # plugin isn't loaded, falls through to the SDK branches.
+    try:
+        from plugins.petri_audit.claude_cli_provider import (
+            ClaudeCliTransientUpstreamError,
+        )
+
+        if isinstance(exc, ClaudeCliTransientUpstreamError):
+            return _ERROR_CLASSIFICATION["rate_limit"]
+    except ImportError:
+        pass
+
     # --- Anthropic SDK errors ---
     if isinstance(exc, BillingError):
         return _ERROR_CLASSIFICATION["billing"]

--- a/tests/core/llm/test_classify_llm_error.py
+++ b/tests/core/llm/test_classify_llm_error.py
@@ -1,0 +1,195 @@
+"""Tests for :func:`core.llm.errors.classify_llm_error`.
+
+PR-DEFECT-AB (2026-05-24) regression pin: the seed-generation smoke
+revealed that ``classify_llm_error`` returned the generic ``unknown``
+classification for ``ClaudeCliTransientUpstreamError`` raised by the
+PR-T subprocess transient classifier, which routed claude-cli 429s
+through the loop's "Unexpected error. Auto-retrying." fallback UI
+instead of the rate-limit retry branch. The cases below pin the new
+mapping so the regression cannot return silently.
+
+paperclip parity reference: ``src/transport/execute.ts:809`` tags the
+same upstream signatures with ``errorCode = "claude_transient_upstream"``
+and dispatches them via the rate-limit retry path.
+"""
+
+from __future__ import annotations
+
+import anthropic
+import httpx
+import pytest
+from core.llm.errors import classify_llm_error
+from plugins.petri_audit.claude_cli_provider import ClaudeCliTransientUpstreamError
+
+
+def _fake_anthropic_response(status_code: int) -> httpx.Response:
+    """Anthropic SDK error classes require an ``httpx.Response`` to construct."""
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+
+
+class TestClassifyClaudeCliTransientUpstream:
+    """PR-DEFECT-AB primary regression pin."""
+
+    def test_transient_upstream_maps_to_rate_limit(self) -> None:
+        exc = ClaudeCliTransientUpstreamError("Error: 429 Too Many Requests")
+        error_type, severity, hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+        assert severity == "warning"
+        assert "rate limit" in hint.lower() or "switch model" in hint.lower()
+
+    def test_overload_signature_maps_to_rate_limit(self) -> None:
+        exc = ClaudeCliTransientUpstreamError("overloaded_error: server overloaded")
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+
+    def test_quota_signature_maps_to_rate_limit(self) -> None:
+        exc = ClaudeCliTransientUpstreamError("5-hour limit reached, resets at 3:00pm (Pacific)")
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+
+    def test_subclass_still_maps_to_rate_limit(self) -> None:
+        """Ensure isinstance gate accepts subclasses if they appear later."""
+
+        class _ChildTransientError(ClaudeCliTransientUpstreamError):
+            pass
+
+        exc = _ChildTransientError("burst")
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+
+
+class TestClassifyAnthropicSdkErrorsUnchanged:
+    """Regression guard: the new lazy-import branch must not change
+    classifications of any existing Anthropic SDK exception type."""
+
+    def test_rate_limit_error(self) -> None:
+        exc = anthropic.RateLimitError(
+            message="rate limited",
+            response=_fake_anthropic_response(429),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+
+    def test_timeout_error(self) -> None:
+        exc = anthropic.APITimeoutError(
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "timeout"
+
+    def test_connection_error(self) -> None:
+        exc = anthropic.APIConnectionError(
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "connection"
+
+    def test_authentication_error(self) -> None:
+        exc = anthropic.AuthenticationError(
+            message="invalid api key",
+            response=_fake_anthropic_response(401),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "auth"
+
+    def test_internal_server_error(self) -> None:
+        exc = anthropic.InternalServerError(
+            message="boom",
+            response=_fake_anthropic_response(500),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "server"
+
+    def test_bad_request_generic(self) -> None:
+        exc = anthropic.BadRequestError(
+            message="invalid tool schema",
+            response=_fake_anthropic_response(400),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "bad_request"
+
+    def test_bad_request_context_overflow_via_message(self) -> None:
+        """The classifier inspects the message for 'token' / 'context' /
+        'prompt exceeds' / 'max length' substrings to upgrade a generic
+        400 to ``context_overflow`` so the loop's recovery path fires."""
+        exc = anthropic.BadRequestError(
+            message="prompt exceeds the model's context window of 200000 tokens",
+            response=_fake_anthropic_response(400),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "context_overflow"
+
+    def test_unknown_error(self) -> None:
+        error_type, _severity, _hint = classify_llm_error(RuntimeError("???"))
+        assert error_type == "unknown"
+
+
+class TestClassifyOpenAiSdkErrorsUnchanged:
+    """Regression guard: GLM / OpenAI providers route through
+    ``_classify_openai_error`` — confirm the lazy-import PR-T branch
+    does not short-circuit that path."""
+
+    def _fake_openai_response(self, status_code: int) -> httpx.Response:
+        return httpx.Response(
+            status_code=status_code,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        )
+
+    def test_openai_rate_limit_error(self) -> None:
+        import openai
+
+        exc = openai.RateLimitError(
+            message="rate limited",
+            response=self._fake_openai_response(429),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "rate_limit"
+
+    def test_openai_authentication_error(self) -> None:
+        import openai
+
+        exc = openai.AuthenticationError(
+            message="invalid api key",
+            response=self._fake_openai_response(401),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "auth"
+
+    def test_openai_bad_request_context_overflow(self) -> None:
+        import openai
+
+        exc = openai.BadRequestError(
+            message="This model's maximum context length is 128000 tokens",
+            response=self._fake_openai_response(400),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "context_overflow"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Error: 429 Too Many Requests",
+        "rate_limit_error: token bucket empty",
+        "overloaded_error: server overloaded",
+        "weekly limit reached. resets at 9am (UTC)",
+    ],
+)
+def test_transient_upstream_precedes_unknown_fallback(message: str) -> None:
+    """Parametric smoke: every PR-T transient signature must NOT fall through to ``unknown``."""
+    exc = ClaudeCliTransientUpstreamError(message)
+    error_type, _severity, _hint = classify_llm_error(exc)
+    assert error_type != "unknown", (
+        f"transient upstream message {message!r} fell through to unknown — Defect A would re-emerge"
+    )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,13 @@ import sys
 from pathlib import Path
 
 import pytest
-from core.agent.worker import WorkerRequest, WorkerResult
+from core.agent.loop.models import AgenticResult
+from core.agent.worker import (
+    _FAILURE_TERMINATION_REASONS,
+    WorkerRequest,
+    WorkerResult,
+    _resolve_worker_outcome,
+)
 
 # ---------------------------------------------------------------------------
 # WorkerRequest / WorkerResult serialization
@@ -186,6 +192,156 @@ class TestWorkerSubprocess:
         assert data["task_id"] == "bk-001"
 
 
+class TestResolveWorkerOutcome:
+    """PR-DEFECT-AB (2026-05-24) — gate ``WorkerResult.success`` on the
+    AgenticLoop's actual termination signal instead of ``bool(text)``.
+
+    The seed-generation smoke (v0.99.52) revealed that proximity / critic
+    sub-agents ingested the loop's ``_build_model_action_result`` fallback
+    UI string ("! Unexpected error. Auto-retrying.") as legitimate
+    content, because the worker reported ``success=True`` whenever the
+    loop produced any non-empty string. The cases below pin the new
+    contract so the regression cannot return silently.
+    """
+
+    def test_happy_path_real_response_is_success(self) -> None:
+        result = AgenticResult(
+            text="The answer is 42.",
+            tool_calls=[],
+            rounds=3,
+            termination_reason="unknown",
+            error=None,
+        )
+        success, summary, text = _resolve_worker_outcome(result)
+        assert success is True
+        assert text == "The answer is 42."
+        assert summary == "The answer is 42."
+
+    def test_convergence_detected_is_failure(self) -> None:
+        """``convergence_detected`` is a failure exit — the loop bailed after
+        detecting a repeating error pattern. agent_loop.py sets BOTH
+        ``error="convergence_detected"`` AND
+        ``termination_reason="convergence_detected"``, and the text is the
+        diagnostic ("Detected repeating failure pattern. Breaking loop to
+        avoid infinite retry."), not a real answer. Pinning this case so a
+        future refactor that reorders the convergence path doesn't
+        accidentally promote the bail-out to a legitimate response.
+        """
+        result = AgenticResult(
+            text="Detected repeating failure pattern. Breaking loop to avoid infinite retry.",
+            termination_reason="convergence_detected",
+            error="convergence_detected",
+        )
+        success, summary, _text = _resolve_worker_outcome(result)
+        assert success is False
+        assert "convergence_detected" in summary
+
+    @pytest.mark.parametrize(
+        "termination_reason",
+        sorted(_FAILURE_TERMINATION_REASONS),
+    )
+    def test_failure_termination_reasons_force_failure(self, termination_reason: str) -> None:
+        """The five explicit failure sentinels must override ``bool(text)``.
+
+        Each of these sentinels means the loop is emitting fallback UI
+        text instead of a real LLM response, so downstream consumers
+        MUST see ``success=False`` even though ``text`` is non-empty.
+        """
+        result = AgenticResult(
+            text="! Unexpected error. Auto-retrying.",
+            termination_reason=termination_reason,
+        )
+        success, summary, _text = _resolve_worker_outcome(result)
+        assert success is False, (
+            f"termination_reason={termination_reason!r} must force success=False"
+        )
+        assert "Sub-agent failed" in summary
+        assert f"termination_reason={termination_reason}" in summary
+
+    def test_error_field_forces_failure_even_with_text(self) -> None:
+        """A non-None ``error`` always means failure, regardless of ``text`` or termination."""
+        result = AgenticResult(
+            text="partial output before crash",
+            termination_reason="unknown",
+            error="LLM provider timeout after 120s",
+        )
+        success, summary, _text = _resolve_worker_outcome(result)
+        assert success is False
+        assert "LLM provider timeout after 120s" in summary
+
+    def test_empty_text_is_failure(self) -> None:
+        result = AgenticResult(text="", termination_reason="unknown")
+        success, summary, text = _resolve_worker_outcome(result)
+        assert success is False
+        assert text == ""
+        # No error + unknown termination + no text — falls back to generic message.
+        assert summary == "No response from sub-agent"
+
+    def test_none_result_is_failure(self) -> None:
+        success, summary, text = _resolve_worker_outcome(None)
+        assert success is False
+        assert text == ""
+        assert summary == "No response from sub-agent"
+
+    def test_user_clarification_needed_is_success(self) -> None:
+        """The question IS the legitimate output, not fallback UI."""
+        result = AgenticResult(
+            text="What time zone should I use?",
+            termination_reason="user_clarification_needed",
+        )
+        success, _summary, _text = _resolve_worker_outcome(result)
+        assert success is True
+
+    def test_input_blocked_is_success(self) -> None:
+        """The diagnostic message IS the legitimate output."""
+        result = AgenticResult(
+            text="Input rejected by policy filter.",
+            termination_reason="input_blocked",
+        )
+        success, _summary, _text = _resolve_worker_outcome(result)
+        assert success is True
+
+    def test_user_cancelled_is_success(self) -> None:
+        """Operator-requested halt — text is the legitimate "Interrupted."
+        marker (see agent_loop.py:705). No ``error`` is set, so the worker
+        surfaces this as a clean exit and the parent decides what to do
+        with the half-finished task rather than the parent treating it as
+        a sub-agent failure."""
+        result = AgenticResult(
+            text="Interrupted.",
+            termination_reason="user_cancelled",
+        )
+        success, _summary, _text = _resolve_worker_outcome(result)
+        assert success is True
+
+    def test_summary_truncates_at_500_chars(self) -> None:
+        long_text = "x" * 1000
+        result = AgenticResult(text=long_text, termination_reason="unknown")
+        _success, summary, _text = _resolve_worker_outcome(result)
+        assert len(summary) == 500
+
+    def test_failure_sentinels_are_complete_catalog(self) -> None:
+        """Lock the failure sentinel set against accidental shrinkage.
+
+        If a new failure-tagged ``termination_reason`` is added to
+        ``agent_loop.py`` without being added to
+        ``_FAILURE_TERMINATION_REASONS``, this test won't catch it
+        directly — but it pins the existing six so removal would
+        require explicit acknowledgment.
+        """
+        expected = frozenset(
+            {
+                "model_action_required",
+                "context_exhausted",
+                "llm_error",
+                "billing_error",
+                "cost_budget_exceeded",
+                "convergence_detected",
+            }
+        )
+        assert expected == _FAILURE_TERMINATION_REASONS
+
+
 class TestSubAgentReasoningWiring:
     """v0.55.0 R5 — verify ``_run_agentic`` actually plumbs the
     request's reasoning depth fields into ``AgenticLoop()``. Pre-fix
@@ -202,7 +358,20 @@ class TestSubAgentReasoningWiring:
         def _fake_loop(*args, **kwargs):
             captured.update(kwargs)
             mock_loop = MagicMock()
-            mock_loop.arun = AsyncMock(return_value=MagicMock(text="ok", tool_calls=[], rounds=1))
+            # PR-DEFECT-AB (2026-05-24): _resolve_worker_outcome now reads
+            # ``.error`` + ``.termination_reason`` off the loop's return,
+            # so the stub must be a real AgenticResult (or close enough)
+            # rather than a bare MagicMock whose attribute access yields
+            # another MagicMock that breaks ``"; ".join(cause_bits)``.
+            mock_loop.arun = AsyncMock(
+                return_value=AgenticResult(
+                    text="ok",
+                    tool_calls=[],
+                    rounds=1,
+                    error=None,
+                    termination_reason="unknown",
+                )
+            )
             return mock_loop
 
         # Stub out everything _run_agentic touches except the bit we test.


### PR DESCRIPTION
## Summary

- **Defect A** (`core/llm/errors.py`): map `ClaudeCliTransientUpstreamError` to the `rate_limit` classification so claude-cli 429 / overload / quota signatures dispatch through `agent_loop.py:1595` instead of falling through to the generic `unknown` retry-and-fallback path.
- **Defect B** (`core/agent/worker.py`): gate `WorkerResult.success` on `AgenticResult.error` + `termination_reason` instead of `bool(text)`, so sub-agents reporting the fallback UI string ("! Unexpected error. Auto-retrying.") are surfaced to the parent as `success=False` with a cause-tagged summary.

## Why

The v0.99.52 seed-generation smoke (proximity 111s + critic 66s) returned `success=True` with malformed payloads that downstream phase agents then ingested as legitimate content, producing JSON parse errors throughout the cycle. Two coupled regressions made this possible:

1. The PR-T transient classifier (`plugins/petri_audit/claude_cli_provider.ClaudeCliTransientUpstreamError`) was not registered in `classify_llm_error`, so claude-cli upstream signatures fell through to the generic `unknown` branch — the AgenticLoop then ran exponential-backoff retries before emitting `_build_model_action_result` fallback UI text on `_LLM_RETRY_CAP` exhaustion.
2. The worker reported `success=True` for every non-empty `text`, including the loop's fallback UI string. Downstream consumers had no way to distinguish a legitimate sub-agent response from a "the LLM gave up" notice.

Paperclip parity reference: `src/transport/execute.ts:809` tags identical claude-cli signatures with `errorCode = "claude_transient_upstream"` and dispatches them via the rate-limit retry path.

## Changes

| File | Change |
|------|--------|
| `core/llm/errors.py` | `classify_llm_error` lazy-imports `ClaudeCliTransientUpstreamError` and maps it to `_ERROR_CLASSIFICATION["rate_limit"]`. ImportError fall-through preserves layer hygiene when the plugin is absent. |
| `core/agent/worker.py` | Extract `_resolve_worker_outcome()` helper; `success` now gated on `not error and termination_reason not in _FAILURE_TERMINATION_REASONS`. `_FAILURE_TERMINATION_REASONS = {model_action_required, context_exhausted, llm_error, billing_error, cost_budget_exceeded, convergence_detected}` (six sentinels enumerated from `agent_loop.py`). `summary` surfaces the actual failure cause ("Sub-agent failed: <error>; termination_reason=…") so parent timeline rows explain WHY the spawn produced no usable output. The legacy "No response from sub-agent" string is preserved for the empty-text + no-error + unknown-termination case. |
| `tests/core/llm/test_classify_llm_error.py` | **NEW.** 19 cases pinning the PR-T mapping + regression guards for every Anthropic SDK exception type (rate_limit / timeout / connection / auth / server / bad_request / context_overflow) + the OpenAI SDK branches (GLM / OpenAI providers) + parametric smoke against `unknown` fall-through. |
| `tests/test_worker.py` | `TestResolveWorkerOutcome` — 16 cases pinning the success-determination contract: happy paths, every failure sentinel parametrised, error-with-text, empty text, None result, clarification / input_blocked / user_cancelled exemptions, summary truncation, convergence-as-failure (both `error` and `termination_reason` set), failure-sentinel catalog lock. `TestSubAgentReasoningWiring.test_loop_receives_reasoning_kwargs` upgraded to use a real `AgenticResult` stub (MagicMock no longer survives the new success logic). |
| `CHANGELOG.md` | Unreleased entry under Fixed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Defect A classifier mapping | Implemented | `core/llm/errors.py:267-288` |
| Defect B success determination | Implemented | `core/agent/worker.py:371-379, 402-466` |
| Defect A regression test | Implemented | `tests/core/llm/test_classify_llm_error.py` (19 cases) |
| Defect B regression test | Implemented | `tests/test_worker.py::TestResolveWorkerOutcome` (16 cases) |
| `convergence_detected` triage | Added to failure set | Codex MCP review catch — loop sets `error="convergence_detected"`, so omitting it caused False negatives. Now in `_FAILURE_TERMINATION_REASONS`. |
| End-to-end smoke re-validation | Deferred | Per operator directive 2026-05-24: defer until all PR-DEFECT-AB / PR-COMM-2 / PR-COMM-3 / PR-COMM-4 are merged, then re-run. |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean.
- [x] `uv run ruff format --check` (4 touched files) — clean.
- [x] `uv run mypy core/ plugins/` — 431 files, 0 errors.
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken.
- [x] `uv run python -m pytest tests/test_worker.py tests/core/llm/test_classify_llm_error.py -q` — 41 passed.
- [x] `uv run python -m pytest tests/test_agentic_loop.py tests/test_subagent_lineage_subprocess.py tests/core/observability/test_unified_timeline.py tests/core/observability/test_run_dir_anchor.py -q` — 137 passed (influence radius).
- [ ] Full pytest suite — running at PR push time.

## Reference

- Paperclip: `src/transport/execute.ts:809` (`errorCode = "claude_transient_upstream"`)
- PR-T: `plugins/petri_audit/claude_cli_provider.py:136` (`ClaudeCliTransientUpstreamError` definition)
- Loop call site: `core/agent/loop/agent_loop.py:1489-1604` (classify → rate_limit branch → `_build_model_action_result` → return)
- Smoke artefact: `/tmp/geode-smoke-v0.99.52-ghost-2026-05-24/` (proximity 111s + critic 66s evidence)
