### PR TITLE
PR-COMM-3c — migrate session_id persistence to SQLite (dual-write + read-first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-COMM-3c** — migrates `core/agent/loop/agent_loop.py` claude-cli
+  sessionId persistence from file-based
+  `<run_dir>/sub_agents/<task_id>/session.json` (PR-V) to the SQLite
+  `agent_runtime_state.claude_cli_session_id` column landed by
+  PR-COMM-3 / PR-COMM-3b. Dual-write during the 1-release grace
+  window; legacy file path slated for deletion in v0.99.54.
+  - `_persist_session_id` writes to SQLite primary (via
+    `record_agent_session_end(agent_id, claude_cli_session_id=...)`)
+    then writes the legacy `session.json` file so existing on-disk
+    caches keep working through deploys that haven't ingested the
+    SQLite writer yet. Empty `emitted_session_id` is a no-op for both
+    stores (preserves prior cached values across cross-cycle adapter
+    switches).
+  - `_load_prior_session_id` reads SQLite first, falls back to
+    `session.json` on miss or SQLite error. REPL / gateway paths that
+    have no `run_dir` scope still get SQLite persistence (file write
+    no-ops, SQLite write lands) — that's the migration's whole point.
+  - Pinned by `tests/test_session_id_persistence.py` (9 cases —
+    SQLite-primary read × 1, file-fallback read × 2, dual-write × 3,
+    empty-noop × 2, SQLite-failure-falls-back × 1, plus a fresh
+    `isolate_sessions_db` autouse fixture added to
+    `tests/core/llm/adapters/test_claude_cli_resume.py` so the
+    existing V.4 round-trip tests no longer pollute the developer's
+    real `~/.geode/projects/.../sessions.db`).
+
 ### Added
 - **PR-COMM-3b** — wires the PR-COMM-3 SQLite `agent_runtime_state`
   writers into the running AgenticLoop. Three coupled changes:

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -59,16 +59,35 @@ log = logging.getLogger(__name__)
 
 def _load_prior_session_id(session_id: str) -> str:
     """Return the claude-cli session_id from the prior turn of this
-    sub-agent, or empty string when no prior session exists / outside
-    a run_dir scope.
+    sub-agent, or empty string when no prior session exists.
 
-    PR-V (2026-05-24, spec doc §3 V.4). Reads
-    ``<run_dir>/sub_agents/<session_id>/session.json``. Mirrors
-    paperclip's ``agent_runtime_state.sessionId`` SELECT — a per-agent
-    single-row store of "the sessionId my next ``--resume`` should use".
-    Returns empty on any I/O / parse error so the call falls back to
-    a fresh session rather than crashing.
+    PR-COMM-3c (2026-05-24) — SQLite primary, file fallback.
+    Reads ``agent_runtime_state.claude_cli_session_id`` first
+    (single source of truth introduced by PR-COMM-3 / PR-COMM-3b).
+    Falls back to the legacy
+    ``<run_dir>/sub_agents/<session_id>/session.json`` file from PR-V
+    so existing on-disk caches keep working through the 1-release
+    grace window (slated for removal in v0.99.54). Returns empty on
+    any I/O / parse error so the call falls back to a fresh session
+    rather than crashing.
     """
+    # SQLite primary — read from the per-agent row landed by
+    # PR-COMM-3b's record_agent_session_end hook handler.
+    try:
+        from core.observability.agent_runtime_state import get_agent_runtime_state
+
+        state = get_agent_runtime_state(session_id)
+        if state is not None and state.claude_cli_session_id:
+            return state.claude_cli_session_id
+    except Exception:
+        log.debug(
+            "agent_runtime_state read failed for %s — falling back to session.json",
+            session_id,
+            exc_info=True,
+        )
+
+    # Legacy file fallback (PR-V) — kept for 1 release so deploys that
+    # haven't ingested the SQLite writer yet still resume cleanly.
     try:
         from core.observability.run_dir import resolve_sub_agent_path
 
@@ -93,17 +112,40 @@ def _persist_session_id(session_id: str, emitted_session_id: str) -> None:
     turn of this sub-agent (or the same sub-agent in the next cycle)
     can ``--resume <id>``.
 
-    PR-V (2026-05-24, spec doc §3 V.4). Writes
-    ``<run_dir>/sub_agents/<session_id>/session.json``. The on-disk
-    schema is intentionally one field (``claude_cli_session_id``) for
-    now; PR-COMM-3 (SQLite agent_runtime_state) replaces the file with
-    a DB row carrying the full paperclip
-    ``agent_runtime_state`` columns (totalInputTokens / lastError /
-    lastRunStatus / ...). Empty ``emitted_session_id`` is a no-op
-    (non-claude-cli adapters or claude-cli crash before init).
+    PR-COMM-3c (2026-05-24) — dual-write. The primary store is the
+    SQLite ``agent_runtime_state.claude_cli_session_id`` column
+    (populated end-to-end by PR-COMM-3b's SESSION_ENDED hook handler
+    via the loop's ``_last_emitted_session_id`` cache; this function's
+    direct write covers the early-turn case where the loop emits a
+    session_id BEFORE its lifecycle hook fires for the round). The
+    legacy ``<run_dir>/sub_agents/<session_id>/session.json`` file
+    keeps being written for one release as a fallback so existing
+    deploys/readers don't break — scheduled for deletion in v0.99.54.
+    Empty ``emitted_session_id`` is a no-op (non-claude-cli adapters
+    or claude-cli crash before init).
     """
     if not emitted_session_id:
         return
+
+    # SQLite primary write — directly upsert the resumable session_id
+    # so the next turn's _load_prior_session_id sees it even if the
+    # round's SESSION_ENDED hook hasn't fired yet (early termination,
+    # round-budget exhaustion mid-turn, etc).
+    try:
+        from core.observability.agent_runtime_state import record_agent_session_end
+
+        record_agent_session_end(
+            agent_id=session_id,
+            claude_cli_session_id=emitted_session_id,
+        )
+    except Exception:
+        log.debug(
+            "agent_runtime_state write failed for %s — file fallback only",
+            session_id,
+            exc_info=True,
+        )
+
+    # Legacy file write (PR-V) — retained for 1-release grace.
     try:
         from core.observability.run_dir import resolve_sub_agent_path
 

--- a/tests/core/llm/adapters/test_claude_cli_resume.py
+++ b/tests/core/llm/adapters/test_claude_cli_resume.py
@@ -3,6 +3,14 @@
 Pins invariants from
 ``docs/plans/2026-05-24-transcript-standardization-and-claude-resume.md`` §3.4
 (V.1 contract + V.2 argv + V.2 parser + V.3 round-trip + V.4 persistence).
+
+PR-COMM-3c (2026-05-24) — adds the ``isolate_sessions_db`` autouse
+fixture so the V.4 round-trip tests don't pollute the developer's
+``~/.geode/projects/.../sessions.db`` via the dual-write path. The
+``_persist_session_id`` helper now writes to BOTH the legacy
+``session.json`` AND the SQLite ``agent_runtime_state.claude_cli_session_id``
+column; without isolation the SQLite write would land in the user's
+real DB.
 """
 
 from __future__ import annotations
@@ -10,6 +18,26 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_sessions_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the sessions.db default path to ``tmp_path`` for the
+    duration of each test + reset the ``agent_runtime_state`` module's
+    cached connection so it picks up the override."""
+    from core.memory.session_manager import SessionManager
+
+    from core.observability import agent_runtime_state as ars
+
+    db = tmp_path / "sessions.db"
+    SessionManager(db_path=db)
+    monkeypatch.setattr("core.memory.session_manager._get_default_db_path", lambda: db)
+    ars._reset_for_tests(db_path=db)
+    yield db
+    ars._reset_for_tests()
+
 
 # ---------------------------------------------------------------------------
 # V.1 — AdapterCallRequest / AdapterCallResult new fields

--- a/tests/test_session_id_persistence.py
+++ b/tests/test_session_id_persistence.py
@@ -1,0 +1,193 @@
+"""PR-COMM-3c — _persist_session_id / _load_prior_session_id SQLite
+migration tests.
+
+PR-V (#1588) introduced ``<run_dir>/sub_agents/<task_id>/session.json``
+as the on-disk cache for the claude-cli sessionId the next
+``--resume`` should use. PR-COMM-3 (#1593) + PR-COMM-3b (#1594) landed
+the SQLite ``agent_runtime_state.claude_cli_session_id`` column and
+wired the SESSION_ENDED hook handler to populate it.
+
+PR-COMM-3c flips ``_persist_session_id`` to dual-write (SQLite primary
++ file fallback) and ``_load_prior_session_id`` to SQLite-first read.
+The legacy file path is retained for 1-release grace so existing
+on-disk caches still resume cleanly during the transition; scheduled
+for deletion in v0.99.54.
+
+Coverage map:
+
+* :class:`TestSqlitePrimaryRead` — SQLite has the value, file has a
+  stale value → reader returns SQLite.
+* :class:`TestFileFallbackRead` — SQLite empty, file has a value →
+  reader returns the file value (legacy deploys unaffected).
+* :class:`TestDualWrite` — single persist call lands in BOTH stores
+  with the same value.
+* :class:`TestEmptySessionIdNoop` — empty emitted_session_id touches
+  neither store (preserves prior cached values for cross-cycle resume
+  when a non-claude-cli adapter ran in the middle).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_sessions_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect sessions.db to tmp_path + reset module-level cache."""
+    from core.memory.session_manager import SessionManager
+
+    from core.observability import agent_runtime_state as ars
+
+    db = tmp_path / "sessions.db"
+    SessionManager(db_path=db)
+    monkeypatch.setattr("core.memory.session_manager._get_default_db_path", lambda: db)
+    ars._reset_for_tests(db_path=db)
+    yield db
+    ars._reset_for_tests()
+
+
+class TestSqlitePrimaryRead:
+    """SQLite is the authoritative source — when both stores have a
+    value, the reader returns the SQLite value (the file is a fallback
+    for legacy on-disk caches only)."""
+
+    def test_sqlite_wins_over_file(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _load_prior_session_id
+        from core.observability.agent_runtime_state import record_agent_session_end
+        from core.observability.run_dir import run_dir_scope
+
+        task_id = "gen-sqlite-primary"
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            # Stale file value — simulates a legacy deploy that wrote
+            # session.json before the SQLite writer landed.
+            session_path = Path(tmp) / "sub_agents" / task_id / "session.json"
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(json.dumps({"claude_cli_session_id": "stale-file-value"}))
+
+            # SQLite carries the current value.
+            record_agent_session_end(agent_id=task_id, claude_cli_session_id="current-sqlite-value")
+
+            assert _load_prior_session_id(task_id) == "current-sqlite-value"
+
+
+class TestFileFallbackRead:
+    """SQLite-miss falls back to session.json so existing on-disk
+    caches keep working through the 1-release grace window."""
+
+    def test_file_fallback_when_sqlite_empty(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _load_prior_session_id
+        from core.observability.run_dir import run_dir_scope
+
+        task_id = "gen-file-fallback"
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            session_path = Path(tmp) / "sub_agents" / task_id / "session.json"
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(json.dumps({"claude_cli_session_id": "legacy-only-value"}))
+            # SQLite has no row — fallback path triggers.
+            assert _load_prior_session_id(task_id) == "legacy-only-value"
+
+    def test_both_empty_returns_empty(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _load_prior_session_id
+
+        # No run_dir scope, no SQLite row — fresh-session fallback.
+        assert _load_prior_session_id("unknown-task") == ""
+
+
+class TestDualWrite:
+    """``_persist_session_id`` writes the value to both stores in one
+    call so subsequent reads see consistent state regardless of which
+    backend the reader prefers."""
+
+    def test_persist_lands_in_sqlite(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _persist_session_id
+        from core.observability.agent_runtime_state import get_agent_runtime_state
+        from core.observability.run_dir import run_dir_scope
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            _persist_session_id("gen-dual-1", "cli-dual-001")
+            state = get_agent_runtime_state("gen-dual-1")
+            assert state is not None
+            assert state.claude_cli_session_id == "cli-dual-001"
+
+    def test_persist_lands_in_file(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _persist_session_id
+        from core.observability.run_dir import run_dir_scope
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            _persist_session_id("gen-dual-2", "cli-dual-002")
+            session_path = Path(tmp) / "sub_agents" / "gen-dual-2" / "session.json"
+            assert session_path.exists()
+            data = json.loads(session_path.read_text())
+            assert data["claude_cli_session_id"] == "cli-dual-002"
+
+    def test_persist_outside_run_dir_still_writes_sqlite(self, tmp_path: Path) -> None:
+        """REPL / gateway path has no run_dir scope so the file write
+        no-ops, but the SQLite write must still land — that's the
+        whole point of the migration."""
+        from core.agent.loop.agent_loop import _persist_session_id
+        from core.observability.agent_runtime_state import get_agent_runtime_state
+
+        # No run_dir_scope here — simulates REPL / gateway.
+        _persist_session_id("repl-no-rundir", "cli-repl-001")
+        state = get_agent_runtime_state("repl-no-rundir")
+        assert state is not None
+        assert state.claude_cli_session_id == "cli-repl-001"
+
+
+class TestEmptySessionIdNoop:
+    """Empty ``emitted_session_id`` (non-claude-cli adapters) must NOT
+    touch either store — preserves prior cached values when a
+    different adapter ran in the middle of a cross-cycle chain."""
+
+    def test_empty_does_not_clear_sqlite(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _load_prior_session_id, _persist_session_id
+
+        _persist_session_id("gen-noop-1", "cli-original")
+        _persist_session_id("gen-noop-1", "")  # noop
+        assert _load_prior_session_id("gen-noop-1") == "cli-original"
+
+    def test_empty_does_not_clear_file(self, tmp_path: Path) -> None:
+        from core.agent.loop.agent_loop import _persist_session_id
+        from core.observability.run_dir import run_dir_scope
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            _persist_session_id("gen-noop-2", "cli-original")
+            _persist_session_id("gen-noop-2", "")
+            session_path = Path(tmp) / "sub_agents" / "gen-noop-2" / "session.json"
+            data = json.loads(session_path.read_text())
+            assert data["claude_cli_session_id"] == "cli-original"
+
+
+class TestSqliteFailureFallsBackToFile:
+    """Even if the SQLite layer is broken (DB locked, permission
+    denied), the file fallback keeps reads working — defensive
+    contract that the dual-write earns."""
+
+    def test_load_falls_back_when_sqlite_read_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.agent.loop.agent_loop import _load_prior_session_id
+        from core.observability.run_dir import run_dir_scope
+
+        task_id = "gen-fallback-on-error"
+
+        with tempfile.TemporaryDirectory() as tmp, run_dir_scope(tmp):
+            session_path = Path(tmp) / "sub_agents" / task_id / "session.json"
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(json.dumps({"claude_cli_session_id": "file-survivor"}))
+
+            def _boom(_agent_id: str) -> None:
+                raise RuntimeError("simulated SQLite outage")
+
+            monkeypatch.setattr(
+                "core.observability.agent_runtime_state.get_agent_runtime_state",
+                _boom,
+            )
+
+            assert _load_prior_session_id(task_id) == "file-survivor"


### PR DESCRIPTION
## Summary

- `_persist_session_id` dual-writes (SQLite primary + legacy file) and `_load_prior_session_id` reads SQLite-first with file fallback so claude-cli sessionId caching migrates from file-based to SQLite cleanly.
- Legacy `session.json` file path retained for 1-release grace (slated for deletion in v0.99.54).
- Adds `isolate_sessions_db` autouse fixture to existing PR-V resume tests so they no longer pollute the developer's real `~/.geode/projects/.../sessions.db`.

## Why

PR-V (#1588) introduced `<run_dir>/sub_agents/<task_id>/session.json` as the on-disk cache for the claude-cli sessionId the next `--resume` should use. PR-COMM-3 (#1593) + PR-COMM-3b (#1594) landed the SQLite `agent_runtime_state.claude_cli_session_id` column AND wired the SESSION_ENDED hook handler to populate it end-to-end.

That left two SoTs in production: the file (written by `_persist_session_id`) and the SQLite row (written by the SESSION_ENDED handler). Without active migration the file would be the read SoT forever — defeating the PR-COMM-3 / -3b investment and leaving the REPL/gateway path (no `run_dir` scope) unable to resume across cycles.

This PR flips the SoT: SQLite is now the read primary, file is fallback for legacy on-disk caches during the 1-release grace window. The write side becomes dual so existing readers (legacy deploys that haven't ingested the SQLite path yet) keep working uninterrupted.

## Changes

| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | `_load_prior_session_id` reads SQLite first via `get_agent_runtime_state(session_id).claude_cli_session_id`; falls back to `session.json` on miss / SQLite outage (log.debug + continue). `_persist_session_id` writes SQLite first via `record_agent_session_end(agent_id, claude_cli_session_id=...)` then writes the legacy file. Empty `emitted_session_id` is a no-op for both (preserves prior cached values across cross-cycle adapter switches via the PR-COMM-3 CASE-WHEN guard). |
| `tests/test_session_id_persistence.py` | NEW. 9 cases: SQLite-primary-wins-over-file × 1, file-fallback-when-SQLite-empty × 2, dual-write-lands-in-both-stores × 3, empty-noop-preserves-both × 2, SQLite-failure-falls-back-to-file × 1. |
| `tests/core/llm/adapters/test_claude_cli_resume.py` | Adds `isolate_sessions_db` autouse fixture (monkeypatches `_get_default_db_path` + `ars._reset_for_tests`) so existing V.4 round-trip tests don't write to the developer's real `~/.geode/projects/.../sessions.db` via the new SQLite dual-write path. |
| `CHANGELOG.md` | Unreleased entry under Changed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| SQLite-first read | Implemented | `agent_loop.py:_load_prior_session_id` |
| Dual-write | Implemented | `agent_loop.py:_persist_session_id` |
| File fallback retained | Implemented | Removal scheduled v0.99.54 |
| REPL/gateway no-`run_dir` coverage | Implemented | SQLite write lands even when file write no-ops |
| Existing test isolation | Implemented | Codex MCP review reminder — PR-V tests would have polluted user DB |
| New test coverage | Implemented | 9 cases pin every dual-write/read branch |
| `session.json` deletion (v0.99.54) | **Deferred** | This PR ships the dual-write; deletion follows once production traffic confirms SQLite read works |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — 878 files unchanged
- [x] `uv run mypy core/ plugins/` — 432 source files, 0 errors
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_session_id_persistence.py tests/core/llm/adapters/test_claude_cli_resume.py -q` — 22 pass
- [x] `uv run python -m pytest tests/test_agent_runtime_state.py tests/test_agent_runtime_state_wiring.py tests/test_agentic_loop.py tests/test_session_resume.py` — 158 pass (influence radius)
- [x] Full pytest suite — green at PR push time
- [x] Codex MCP review — caught test-count drift (10 → 9), fix applied

## Reference

- PR-V #1588 — file-based session.json that this PR migrates from
- PR-COMM-3 #1593 — agent_runtime_state schema + writer module
- PR-COMM-3b #1594 — emit-site augmentation + bootstrap handler registration
- Spec doc §10 — original plan listed this migration as deferred follow-up
