### PR TITLE
PR-COMM-4 — transcript seq + liveness watchdog API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,38 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-COMM-4** — transcript `seq` column + liveness watchdog API on
+  `SessionTranscript` and `RunTranscript`. Two coupled observability
+  improvements:
+  - Per-instance monotonic `seq` stamped on every JSONL row
+    (`_append` + `record_lifecycle_event`). Lets multi-event timelines
+    sort deterministically when `ts` ties (sub-second clock drift /
+    NTP reset). Per-instance, not cross-process atomic — multi-writer
+    files produce interleaved seqs that readers re-sort by `(ts, seq)`.
+  - `last_touched_at()` returns the transcript file's mtime; `None`
+    when the file doesn't exist (a never-started run isn't "stale").
+    `is_stale(threshold_s, *, now=None)` checks if no event arrived
+    in the threshold window; `now` injectable for deterministic
+    tests. `RunTranscript` exposes the same passthrough so seed-gen
+    operators can poll `run_transcript.is_stale(900)` directly without
+    poking at the wrapped `SessionTranscript`.
+  - Existing `tests/core/self_improving_loop/test_run_transcript.py::test_append_writes_jsonl_row`
+    updated to include the new `"seq": 1` field in its exact-match
+    assertion (full-row regression pin — every existing field is
+    still grep-provable in the diff).
+  - **Thread-safety fix** (Codex MCP review catch): pre-fix the seq
+    stamp lock was released before the write lock was re-acquired,
+    letting concurrent same-instance callers allocate seq N+1 / N+2
+    and then write in the opposite order (seq monotonic but file
+    order broken). Now seq stamping + write are held under a single
+    `self._lock` acquisition. Pinned by
+    `test_seq_holds_under_concurrent_threads` (10 threads × 10
+    appends → 100 rows with seqs 1..100 in exact file order).
+  - Pinned by `tests/test_transcript_seq_liveness.py` (13 cases —
+    seq monotonic × 4, seq under threads × 1, seq across instances
+    × 1, last_touched_at × 2, is_stale × 3, RunTranscript passthrough
+    × 3).
+
 - **PR-COMM-3d** — AgenticLoop's main `_call_llm` path now emits
   `LLM_CALL_STARTED` / `LLM_CALL_ENDED` hooks with `session_id` +
   `usage` + `cost_usd` so the SQLite `agent_runtime_state.total_*_tokens`

--- a/core/observability/transcript.py
+++ b/core/observability/transcript.py
@@ -67,6 +67,22 @@ def _truncate(text: str, max_len: int) -> str:
 class SessionTranscript:
     """Append-only JSONL event recorder for a single session.
 
+    PR-COMM-4 (2026-05-24) — every row now carries a per-instance
+    monotonic ``seq`` field (starts at 1, increments by 1 per
+    appended event) under :attr:`_event_count`. Concurrent same-
+    instance callers are serialised by ``self._lock`` so seq order
+    matches file write order. Multiple SessionTranscript instances
+    (different processes / different in-process objects) writing to
+    the *same* file each maintain their own counter, so cross-writer
+    timelines must be re-sorted by ``(ts, seq)`` — a fundamental
+    consequence of having no cross-process coordination on the seq
+    counter, intentional to keep the hot path lock-free across
+    process boundaries.
+
+    ``last_touched_at()`` + ``is_stale(threshold_s)`` expose the file
+    mtime so external watchdogs can detect hung runs that stopped
+    appending events without firing PIPELINE_TIMEOUT / PIPELINE_ERROR.
+
     Usage::
 
         tx = SessionTranscript("s-abc123")
@@ -78,6 +94,10 @@ class SessionTranscript:
         tx.record_vault_save("vault/profile/signal-report.md", "profile")
         tx.record_cost("claude-opus-4-6", 1200, 350, 0.015)
         tx.record_session_end(duration_s=20, total_cost=0.015, rounds=3)
+
+        # PR-COMM-4 liveness:
+        if tx.is_stale(threshold_s=300):
+            log.warning("Transcript %s has been idle for 5+ minutes", tx.session_id)
     """
 
     def __init__(
@@ -367,41 +387,85 @@ class SessionTranscript:
         legacy readers that only look at ``event`` / ``payload`` /
         ``session_id`` keep working.
         """
-        record: dict[str, Any] = {
-            "ts": ts if ts is not None else time.time(),
-            "session_id": session_id or self._session_id,
-            "gen_tag": gen_tag,
-            "component": component,
-            "level": level,
-            "event": event,
-            "payload": payload or {},
-        }
-        # PR-U classification quintuple — only emit when caller supplied
-        # them so legacy rows stay compact.
-        for field_name, field_value in (
-            ("actor_type", actor_type),
-            ("actor_id", actor_id),
-            ("action", action),
-            ("entity_type", entity_type),
-            ("entity_id", entity_id),
-            ("task_id", task_id),
-        ):
-            if field_value is not None:
-                record[field_name] = field_value
+        # PR-COMM-4 (2026-05-24) — seq stamping + write held under a
+        # single lock so concurrent same-instance callers can't
+        # interleave (Codex MCP review catch: releasing the seq lock
+        # before re-acquiring the write lock would let thread A stamp
+        # seq=N+1 then thread B stamp seq=N+2 and write before A).
+        # Per-instance counter; cross-process writers to the SAME file
+        # still produce interleaved seqs that readers must re-sort by
+        # ``(ts, seq)`` — documented at the class docstring.
         target_path = file_path if file_path is not None else self.file_path
-        line = json.dumps(record, ensure_ascii=False)
         with self._lock:
+            self._event_count += 1
+            record: dict[str, Any] = {
+                "ts": ts if ts is not None else time.time(),
+                "seq": self._event_count,
+                "session_id": session_id or self._session_id,
+                "gen_tag": gen_tag,
+                "component": component,
+                "level": level,
+                "event": event,
+                "payload": payload or {},
+            }
+            # PR-U classification quintuple — only emit when caller
+            # supplied them so legacy rows stay compact.
+            for field_name, field_value in (
+                ("actor_type", actor_type),
+                ("actor_id", actor_id),
+                ("action", action),
+                ("entity_type", entity_type),
+                ("entity_id", entity_id),
+                ("task_id", task_id),
+            ):
+                if field_value is not None:
+                    record[field_name] = field_value
+            line = json.dumps(record, ensure_ascii=False)
             try:
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 with target_path.open("a", encoding="utf-8") as fh:
                     fh.write(line + "\n")
-                self._event_count += 1
             except OSError as exc:
                 log.warning("Transcript lifecycle-event write failed: %s", exc)
 
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # PR-COMM-4 (2026-05-24) — liveness watchdog API
+    # ------------------------------------------------------------------
+
+    def last_touched_at(self) -> float | None:
+        """Return the transcript file's mtime, or None if the file
+        doesn't exist yet (no events appended in this run).
+
+        External watchdogs (operator daemons, stuck-run detectors) use
+        this to spot transcripts that have stopped receiving events —
+        evidence that the run hung or crashed without firing
+        ``PIPELINE_TIMEOUT`` / ``PIPELINE_ERROR``.
+        """
+        try:
+            return self.file_path.stat().st_mtime
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            log.debug("Transcript stat failed for %s: %s", self.file_path, exc)
+            return None
+
+    def is_stale(self, threshold_s: float, *, now: float | None = None) -> bool:
+        """Return True if the transcript hasn't been touched in
+        ``threshold_s`` seconds. False when the file doesn't exist
+        (a never-started run isn't "stale" — it just hasn't begun).
+
+        ``now`` is an injectable wall-clock for deterministic tests;
+        defaults to ``time.time()``.
+        """
+        touched = self.last_touched_at()
+        if touched is None:
+            return False
+        current = now if now is not None else time.time()
+        return (current - touched) > threshold_s
 
     def read_events(self, limit: int = 100) -> list[dict[str, Any]]:
         """Read most recent N events from this transcript."""
@@ -428,9 +492,16 @@ class SessionTranscript:
     # ------------------------------------------------------------------
 
     def _append(self, data: dict[str, Any]) -> None:
-        data["ts"] = time.time()
-        line = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+        # PR-COMM-4 (2026-05-24) — seq stamping + write held under a
+        # single lock so concurrent same-instance callers can't
+        # interleave (Codex MCP review catch). Per-instance monotonic;
+        # cross-process writers must re-sort by ``(ts, seq)`` —
+        # documented at the class docstring.
         with self._lock:
+            self._event_count += 1
+            data["seq"] = self._event_count
+            data["ts"] = time.time()
+            line = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
             self._dir.mkdir(parents=True, exist_ok=True)
             fpath = self.file_path
             # Size guard
@@ -439,7 +510,6 @@ class SessionTranscript:
             try:
                 with open(fpath, "a", encoding="utf-8") as f:
                     f.write(line + "\n")
-                self._event_count += 1
             except OSError as e:
                 log.warning("Transcript write failed: %s", e)
 

--- a/core/self_improving_loop/run_transcript.py
+++ b/core/self_improving_loop/run_transcript.py
@@ -100,6 +100,43 @@ class RunTranscript:
             transcript_dir=path.parent,
         )
 
+    # ------------------------------------------------------------------
+    # PR-COMM-4 (2026-05-24) — liveness watchdog passthrough
+    # ------------------------------------------------------------------
+
+    def last_touched_at(self) -> float | None:
+        """Delegate to the underlying SessionTranscript's mtime probe.
+
+        Operator watchdogs (stuck-run detectors, external monitors)
+        use this to spot self-improving-loop runs that have stopped
+        producing events.
+        """
+        # The underlying SessionTranscript was constructed with
+        # ``transcript_dir=path.parent`` and inherits the default
+        # ``<dir>/<session_id>.jsonl`` filename, but RunTranscript writes
+        # to ``self.path`` explicitly via ``file_path=`` on every
+        # ``record_lifecycle_event`` call (see :meth:`append`). So the
+        # mtime to consult is the run-level transcript path, NOT
+        # ``SessionTranscript.file_path`` which would point at a
+        # different (potentially nonexistent) sibling file.
+        try:
+            return self.path.stat().st_mtime
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+
+    def is_stale(self, threshold_s: float, *, now: float | None = None) -> bool:
+        """Return True if this run's transcript hasn't received an event
+        in ``threshold_s`` seconds. False on never-started runs."""
+        import time as _time
+
+        touched = self.last_touched_at()
+        if touched is None:
+            return False
+        current = now if now is not None else _time.time()
+        return (current - touched) > threshold_s
+
     def append(
         self,
         event: str,

--- a/tests/core/self_improving_loop/test_run_transcript.py
+++ b/tests/core/self_improving_loop/test_run_transcript.py
@@ -47,6 +47,9 @@ def test_append_writes_jsonl_row(tmp_path: Path) -> None:
     payload = json.loads(rows[0])
     assert payload == {
         "ts": 1700000000.0,
+        # PR-COMM-4 (2026-05-24) — per-instance monotonic seq is now
+        # stamped on every row. First append in a fresh transcript = 1.
+        "seq": 1,
         "session_id": "s-test",
         "gen_tag": "autoresearch-test",
         "component": "autoresearch",

--- a/tests/test_transcript_seq_liveness.py
+++ b/tests/test_transcript_seq_liveness.py
@@ -1,0 +1,194 @@
+"""PR-COMM-4 — transcript seq + liveness watchdog tests.
+
+Pins two coupled invariants:
+
+1. ``SessionTranscript._append`` + ``record_lifecycle_event`` stamp a
+   per-instance monotonic ``seq`` on every JSONL row so multi-event
+   timelines can be sorted deterministically even when ``ts`` ties
+   (sub-second clock drift / NTP reset).
+2. ``SessionTranscript.last_touched_at`` + ``is_stale`` expose the
+   transcript file's mtime so external watchdogs can spot runs that
+   hung without firing PIPELINE_TIMEOUT / PIPELINE_ERROR.
+
+``RunTranscript`` (self_improving_loop) gets the same liveness
+passthrough so seed-generation operators can poll
+``run_transcript.is_stale(900)`` without poking inside the underlying
+SessionTranscript.
+
+Coverage map:
+
+* :class:`TestSeqMonotonic` — seq starts at 1 and increments by 1 per
+  event for both ``_append`` and ``record_lifecycle_event``.
+* :class:`TestLastTouchedAt` — file mtime probed; None when file
+  doesn't exist; OSError → None (defensive).
+* :class:`TestIsStale` — threshold comparison; never-started run is
+  not stale; injectable ``now`` for determinism.
+* :class:`TestRunTranscriptLiveness` — passthrough from RunTranscript
+  delegates to its own ``path`` (NOT the wrapped SessionTranscript's
+  default file_path).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from core.observability.transcript import SessionTranscript
+from core.self_improving_loop.run_transcript import RunTranscript
+
+
+class TestSeqMonotonic:
+    def test_record_session_start_lands_seq_1(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-1", transcript_dir=tmp_path)
+        tx.record_session_start(model="x")
+        row = json.loads((tmp_path / "s-1.jsonl").read_text().splitlines()[0])
+        assert row["seq"] == 1
+
+    def test_consecutive_appends_increment(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-2", transcript_dir=tmp_path)
+        tx.record_session_start(model="x")
+        tx.record_user_message("hi")
+        tx.record_assistant_message("hello")
+        seqs = [
+            json.loads(line)["seq"] for line in (tmp_path / "s-2.jsonl").read_text().splitlines()
+        ]
+        assert seqs == [1, 2, 3]
+
+    def test_record_lifecycle_event_also_stamps_seq(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-3", transcript_dir=tmp_path)
+        tx.record_lifecycle_event(event="phase_started", payload={"phase": "init"})
+        tx.record_lifecycle_event(event="phase_finished", payload={"phase": "init"})
+        seqs = [
+            json.loads(line)["seq"] for line in (tmp_path / "s-3.jsonl").read_text().splitlines()
+        ]
+        assert seqs == [1, 2]
+
+    def test_seq_holds_under_concurrent_threads(self, tmp_path: Path) -> None:
+        """Codex MCP review catch: pre-fix the seq stamp lock was
+        released before the write lock was re-acquired, so two threads
+        could allocate seqs N+1 / N+2 and then write in the opposite
+        order. With the unified lock, seq order ALWAYS matches file
+        write order. 100 concurrent appends from 10 threads must
+        produce 100 rows with seqs 1..100 in file order."""
+        import threading
+
+        tx = SessionTranscript("s-concurrent", transcript_dir=tmp_path)
+
+        def _do_appends() -> None:
+            for _ in range(10):
+                tx.record_user_message("x")
+
+        threads = [threading.Thread(target=_do_appends) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        seqs = [
+            json.loads(line)["seq"]
+            for line in (tmp_path / "s-concurrent.jsonl").read_text().splitlines()
+        ]
+        assert seqs == list(range(1, 101)), (
+            f"seq order broken — first 10: {seqs[:10]}, last 10: {seqs[-10:]}"
+        )
+
+    def test_seq_independent_across_instances(self, tmp_path: Path) -> None:
+        """Per-instance counter — two SessionTranscripts writing to
+        different files each start at 1. Cross-process writers to the
+        SAME file are documented to produce interleaved seqs; readers
+        must re-sort by (ts, seq)."""
+        tx_a = SessionTranscript("s-a", transcript_dir=tmp_path / "a")
+        tx_b = SessionTranscript("s-b", transcript_dir=tmp_path / "b")
+        tx_a.record_session_start(model="x")
+        tx_b.record_session_start(model="x")
+        tx_a.record_user_message("hi")
+        seq_a = [
+            json.loads(line)["seq"]
+            for line in (tmp_path / "a" / "s-a.jsonl").read_text().splitlines()
+        ]
+        seq_b = [
+            json.loads(line)["seq"]
+            for line in (tmp_path / "b" / "s-b.jsonl").read_text().splitlines()
+        ]
+        assert seq_a == [1, 2]
+        assert seq_b == [1]
+
+
+class TestLastTouchedAt:
+    def test_none_when_file_missing(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-never", transcript_dir=tmp_path)
+        # No event recorded — file doesn't exist yet.
+        assert tx.last_touched_at() is None
+
+    def test_returns_mtime_after_write(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-touched", transcript_dir=tmp_path)
+        before = time.time()
+        tx.record_session_start(model="x")
+        touched = tx.last_touched_at()
+        assert touched is not None
+        # mtime should be ≥ wall clock at write time (within 5s slack
+        # for filesystem timestamp granularity on noisy CI runners).
+        assert touched >= before - 1.0
+
+
+class TestIsStale:
+    def test_never_started_run_is_not_stale(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-fresh", transcript_dir=tmp_path)
+        # File doesn't exist yet — a never-started run isn't "stale",
+        # it just hasn't begun. Distinguishes "hung" from "not yet run".
+        assert tx.is_stale(threshold_s=60.0) is False
+
+    def test_recent_write_not_stale(self, tmp_path: Path) -> None:
+        tx = SessionTranscript("s-recent", transcript_dir=tmp_path)
+        tx.record_session_start(model="x")
+        assert tx.is_stale(threshold_s=60.0) is False
+
+    def test_old_write_is_stale_with_injected_now(self, tmp_path: Path) -> None:
+        """Deterministic test using injectable ``now`` — actual wall
+        clock drift doesn't affect the assertion."""
+        tx = SessionTranscript("s-old", transcript_dir=tmp_path)
+        tx.record_session_start(model="x")
+        touched = tx.last_touched_at()
+        assert touched is not None
+        # Simulate "now" being 1000s later than the file mtime
+        future = touched + 1000.0
+        assert tx.is_stale(threshold_s=500.0, now=future) is True
+        assert tx.is_stale(threshold_s=2000.0, now=future) is False
+
+
+class TestRunTranscriptLiveness:
+    def test_run_transcript_last_touched_after_append(self, tmp_path: Path) -> None:
+        rt = RunTranscript(
+            session_id="run-live",
+            gen_tag="gen-1",
+            component="autoresearch",
+            path=tmp_path / "transcript.jsonl",
+        )
+        before = time.time()
+        rt.append("phase_started", payload={"phase": "x"})
+        touched = rt.last_touched_at()
+        assert touched is not None
+        assert touched >= before - 1.0
+
+    def test_run_transcript_is_stale_with_injected_now(self, tmp_path: Path) -> None:
+        rt = RunTranscript(
+            session_id="run-stale",
+            gen_tag="gen-1",
+            component="autoresearch",
+            path=tmp_path / "transcript.jsonl",
+        )
+        rt.append("phase_started")
+        touched = rt.last_touched_at()
+        assert touched is not None
+        assert rt.is_stale(threshold_s=100.0, now=touched + 200.0) is True
+        assert rt.is_stale(threshold_s=300.0, now=touched + 200.0) is False
+
+    def test_run_transcript_never_started_is_not_stale(self, tmp_path: Path) -> None:
+        rt = RunTranscript(
+            session_id="run-never",
+            gen_tag="gen-1",
+            component="autoresearch",
+            path=tmp_path / "transcript.jsonl",
+        )
+        assert rt.is_stale(threshold_s=10.0) is False


### PR DESCRIPTION
## Summary

- Per-instance monotonic `seq` field stamped on every transcript JSONL row (`SessionTranscript._append` + `record_lifecycle_event`).
- `last_touched_at()` + `is_stale(threshold_s, *, now=None)` API on both `SessionTranscript` and `RunTranscript` for external watchdogs.
- Thread-safety fix from Codex MCP review — seq stamping + write held under single lock so concurrent same-instance callers can't interleave.

## Why

GEODE's transcript files (`<run_dir>/sub_agents/<task_id>/dialogue.jsonl`, `self-improving-loop/<id>/transcript.jsonl`, default `<dir>/<session_id>.jsonl`) carry one JSONL row per event with a `ts` field. Sub-second clock drift / NTP reset can make `ts` order ambiguous when events fire in rapid succession — operators reading the timeline had no deterministic tiebreaker.

Separately, when a sub-agent crashes or hangs without firing `PIPELINE_TIMEOUT` / `PIPELINE_ERROR`, the transcript silently stops receiving events. There was no API for operator daemons to detect that — they had to roll their own mtime polling.

This PR closes both gaps:

1. **seq** — per-instance monotonic counter (`_event_count`, already existed) is now stamped onto every row. Combined with `ts` it gives a deterministic sort key. Cross-process writers to the same file still produce interleaved seqs (no cross-process atomic counter) but the rows can be re-sorted by `(ts, seq)`.
2. **liveness** — file mtime probe with a stale-threshold helper. `RunTranscript` exposes the same passthrough so seed-gen operators can poll `run_transcript.is_stale(900)` without poking the wrapped SessionTranscript.

Codex MCP review caught a concurrency bug mid-cycle: the seq stamp lock was released before the write lock was re-acquired, letting threads A and B allocate seq N+1 / N+2 and then write in the opposite order. Fixed by holding both under a single `self._lock` acquisition. Pinned by a 100-row 10-thread regression test.

## Changes

| File | Change |
|------|--------|
| `core/observability/transcript.py` | `_append` and `record_lifecycle_event` now increment `_event_count` and stamp `data["seq"]` under the same `self._lock` acquisition as the file write — Codex MCP review catch. New `last_touched_at()` returns `file_path.stat().st_mtime` (None on FileNotFoundError/OSError). New `is_stale(threshold_s, *, now=None)` returns False on never-started runs, True when elapsed > threshold; `now` injectable for deterministic tests. Class docstring documents the cross-process caveat. |
| `core/self_improving_loop/run_transcript.py` | `last_touched_at()` + `is_stale()` passthrough on `RunTranscript`. Both stat `self.path` (NOT the wrapped SessionTranscript's `file_path`) because RunTranscript writes via `record_lifecycle_event(file_path=self.path)` so the underlying SessionTranscript's default file_path points elsewhere. |
| `tests/test_transcript_seq_liveness.py` | NEW. 13 cases: seq monotonic × 4, concurrent-thread seq order × 1, cross-instance independence × 1, last_touched_at × 2, is_stale × 3, RunTranscript passthrough × 3. |
| `tests/core/self_improving_loop/test_run_transcript.py` | Updated `test_append_writes_jsonl_row` exact-match dict to include the new `"seq": 1` field. All other 41 existing transcript tests still pass without modification (they inspect specific fields, not dict-equal the row). |
| `CHANGELOG.md` | Unreleased entry under Added. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| seq on `_append` | Implemented | `transcript.py:_append` |
| seq on `record_lifecycle_event` | Implemented | `transcript.py:record_lifecycle_event` |
| Thread-safe seq+write | Implemented (Codex catch) | Both held under `self._lock` |
| `last_touched_at()` | Implemented | `transcript.py` |
| `is_stale()` with injectable now | Implemented | `transcript.py` |
| `RunTranscript` passthrough | Implemented | `run_transcript.py` |
| Cross-process atomic seq | **Deferred** | Documented as caveat; readers re-sort by (ts, seq). Real atomic counter would need flock + sidecar file — a separate PR if needed |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — 882 files unchanged
- [x] `uv run mypy core/ plugins/` — 432 source files, 0 errors
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_transcript_seq_liveness.py -q` — 13 pass
- [x] `uv run python -m pytest tests/test_session_transcript.py tests/test_transcript.py tests/core/self_improving_loop/test_run_transcript.py tests/test_autoresearch_train.py tests/test_m4_1_dpo_pack.py tests/test_self_improving_loop_config.py tests/test_m4_0_eval_event.py tests/test_retry_policy_sot.py tests/test_ol_c1_emit_eval_caller.py` — 222 pass (influence radius)
- [x] Full pytest suite — green at PR push time
- [x] Codex MCP review — caught thread-safety bug + doc-pointer nit, both fixed + new regression test added

## Reference

- PR-COMM-1 #1587 — paperclip activity_log envelope (seq was a TODO in that PR's spec doc)
- PR-COMM-3b #1594 — RunTranscript wiring that this PR now makes observable to watchdogs
- Codex MCP review session: caught the threaded-write race + docstring drift
