### PR TITLE
PR-DRIFT-CUT — drift sync + fallback chains 영구 제거 + OpenAI 모델 spec registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,73 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Drift sync + provider fallback chains deprecated.** The runtime no
+  longer reverts an operator's ``/model`` selection in the daemon
+  process. ``_settings_model_target`` /
+  ``sync_model_from_settings_async`` are now no-ops and clearly marked
+  deprecated. Cross-provider and same-provider automatic model
+  fallback is also cut at every site (``_get_fallback_chain``,
+  per-provider ``fallback_chain`` properties) so a 400 / credit /
+  rate-limit on the primary model never silently cascades to another
+  provider. Operators must invoke ``/model <id>`` explicitly. Trigger:
+  v0.99.52 post-merge smoke (gpt-5.5 selection reverted to
+  claude-opus-4-7 on first turn; a stale Anthropic credit-low cascaded
+  into a z.ai 200 but the UI surfaced the Anthropic error).
+
+- **OpenAI / Codex / GLM adapters now ground per-model API quirks in
+  an explicit registry** (``_OPENAI_MODELS`` in
+  ``core/llm/adapters/_openai_common.py``) instead of
+  ``startswith("gpt-5")`` prefix checks. Each entry records
+  ``uses_max_completion_tokens`` (replaces ``max_tokens`` for the
+  reasoning family), ``accepts_temperature`` (False for active
+  reasoning), ``reasoning_effort_values``, and the model's context
+  window. Unknown model ids fall back to legacy gpt-4.x semantics
+  with a one-shot WARNING so adding a new model cannot silently
+  drift behaviour. Replaces the prefix heuristic that mis-routed
+  ``max_tokens`` for gpt-5.5 → 400 ``Unsupported parameter``.
+
+- **Tools array hard-capped at 128 entries at the OpenAI-family
+  adapter edge.** Shared ``cap_tools`` truncates with an
+  operator-actionable warning when the registry layer delivers more
+  than the spec maximum (verified 2026-05-24 against OpenAI Chat
+  Completions + Codex Responses + applied defensively to GLM PAYG /
+  Coding Plan endpoints). Prevents the ``array_above_max_length``
+  400 the v0.99.52 smoke hit on gpt-5.5 with 176 tools.
+
+- **``classify_llm_error`` no longer mis-flags ``max_tokens`` errors
+  as context overflow.** The previous heuristic was a substring
+  match (``"token" in msg``) that fired on any 400 mentioning a
+  ``max_tokens`` parameter — including OpenAI's gpt-5.x
+  "Unsupported parameter: 'max_tokens'" 400. A new
+  ``_looks_like_context_overflow`` helper prefers the structured
+  ``error.code`` field (``context_length_exceeded`` /
+  ``prompt_too_long``) and falls back to a tight word-anchored
+  regex on the message body. Misclassification caused the v0.99.52
+  smoke to render "Context window exhausted" while the actual
+  cause was a parameter-name mismatch.
+
+- **Subscription terminology generalised.** Operator-facing copy +
+  comments + UI no longer hard-codes "ChatGPT Plus" / "Plus quota" /
+  "Plus subscription" — the Codex CLI works with Plus / Pro /
+  Business / Edu / Enterprise tiers, and the ``/login`` menu now
+  lists Claude Pro / Max ×5 / Max ×20 / Team alongside the ChatGPT
+  tiers for parity. Free-form mentions of "Plus" are replaced with
+  "subscription" so future tier additions do not require chasing
+  strings.
+
+### Fixed
+
+- **Raw SDK exception JSON no longer leaks into the assistant
+  transcript.** The bad_request termination branch in
+  ``AgenticLoop`` used to emit
+  ``"LLM call failed (Error code: 400 - {...})"`` verbatim. It now
+  routes through ``_build_model_action_result`` like the auth /
+  convergence branches, and ``summarize_error_detail`` strips the
+  raw exception body down to the underlying ``error.message`` so
+  the user sees a clean diagnostic + ``/model`` hint.
+
 ## [0.99.52] - 2026-05-24
 
 > 2-PR bundle. PR-COMM-1 (#1587): 74 HookEvent → 11 group patterns

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -54,63 +54,45 @@ def _resolve_path_b_adapter(provider: str, source: str):  # type: ignore[no-unty
 
 
 def _settings_model_target(loop: AgenticLoop) -> str | None:
-    """Return the action-model drift target when sync should apply, else None.
+    """**DEPRECATED — returns None unconditionally as of PR-DRIFT-CUT (2026-05-24).**
 
-    PR-CL-A6 (2026-05-23) — when ``settings.act_model`` is set, the drift
-    target is the action model (not ``settings.model``). Without this fix
-    a session that constructed the loop with ``act_model=sonnet`` would
-    revert to ``settings.model=opus`` on the next sync, undoing the
-    Plan/Act split (Codex MCP HIGH #1).
+    Pre-PR behaviour: compared ``loop.model`` against ``settings.model``
+    (or ``settings.act_model``) and forced the loop to swap back to the
+    settings value at the start of every round. The intent was to keep
+    the runtime aligned with the operator's persisted preference, but
+    in practice it *reverted* the operator's most-recent ``/model``
+    selection because the CLI process updates settings on disk while
+    the daemon's in-memory ``settings`` object stays stale — drift sync
+    then "synced" the loop back to the stale daemon value, and the
+    operator's choice silently evaporated until a second turn was
+    issued. Post-mortem: 2026-05-24 v0.99.52 smoke (gpt-5.5 picked
+    via ``/model`` → first turn reverted to ``claude-opus-4-7``).
+
+    The drift surface is intentionally cut at the root (this function)
+    rather than at each caller so the deprecation point is single. The
+    function is retained as a no-op so existing tests / callers keep
+    compiling without a same-PR rewrite. A future re-introduction of
+    *operator-explicit* drift sync should live behind a new opt-in
+    entry point — do not revive this name.
     """
-    if getattr(loop, "_disable_settings_drift", False):
-        return None
-
-    from core.config import settings
-
-    # Action loop's intended model — ``act_model`` wins when set; falls
-    # back to ``settings.model`` for callers that haven't configured the
-    # Plan/Act knob (pre-A6 behaviour). ``isinstance(..., str)`` filters
-    # MagicMock attrs in test fixtures that auto-create non-string values
-    # (Codex MCP CI catch 2026-05-23).
-    act_raw = getattr(settings, "act_model", "")
-    act_model = act_raw.strip() if isinstance(act_raw, str) else ""
-    target_model = act_model or settings.model
-    if target_model == loop.model:
-        return None
-    if not loop._drift_target_is_healthy(target_model):
-        log.warning(
-            "Model drift refused: target=%s has no eligible profile — "
-            "keeping loop=%s. Run `/login use <plan>` to enable target.",
-            target_model,
-            loop.model,
-        )
-        return None
-    log.info(
-        "Model drift detected: loop=%s target=%s — syncing",
-        loop.model,
-        target_model,
-    )
-    return str(target_model)
+    return None
 
 
 async def sync_model_from_settings_async(loop: AgenticLoop) -> bool:
-    """Async variant of ``sync_model_from_settings`` for the agent loop.
+    """**DEPRECATED — always returns ``False`` (PR-DRIFT-CUT, 2026-05-24).**
 
-    PR-MIC (2026-05-23) — passes ``reason="drift_sync"`` so the
-    ``MODEL_SWITCHED`` hook + UI surface the actual trigger (Settings
-    drift between rounds) instead of the default ``"user_switch"``
-    label, which mis-attributed automatic sync to the operator and
-    surfaced as a confusing ``Model: gpt-5.5 → claude-opus-4-6
-    (user_switch)`` line in the REPL header.
+    Was the per-turn entry point that called
+    :func:`_settings_model_target` and (when a target was returned)
+    rewrote ``loop.model`` to match ``settings.model``. The function is
+    now a no-op for the same reason that ``_settings_model_target``
+    short-circuits: settings-driven auto-revert was the load-bearing
+    cause of the v0.99.52 smoke incident. ``/model`` is the operator's
+    sole entry point — drift is no longer inferred.
+
+    The signature is kept so :class:`AgenticLoop` callers don't fork
+    on the rollout, and so a forensic ``grep`` can locate every site
+    that *used* to be touched by drift sync.
     """
-    try:
-        target = _settings_model_target(loop)
-        if target is None:
-            return False
-        await loop.update_model_async(target, reason="drift_sync")
-        return True
-    except Exception:
-        log.debug("Model drift check failed", exc_info=True)
     return False
 
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1160,7 +1160,7 @@ class AgenticLoop:
         silently swap to the next model, surface enough context for the
         user to pick one with ``/model``.
         """
-        from core.llm.errors import build_model_action_message
+        from core.llm.errors import build_model_action_message, summarize_error_detail
 
         cost: float | None = None
         try:
@@ -1169,6 +1169,12 @@ class AgenticLoop:
             cost = float(get_tracker().accumulator.total_cost_usd)
         except Exception:
             cost = None
+        # PR-DRIFT-CUT (2026-05-24) — strip raw SDK exception JSON
+        # ("Error code: 400 - {'error': {'message': ...}}") down to the
+        # underlying message before forwarding to the user-facing message
+        # builder. ``summarize_error_detail`` is a no-op when it cannot
+        # prove a clean extraction, so we never accidentally lose context.
+        clean_detail = summarize_error_detail(detail) if detail else None
         text = build_model_action_message(
             error_type=error_type,
             severity=severity,
@@ -1178,7 +1184,7 @@ class AgenticLoop:
             attempts=self._consecutive_llm_failures,
             cost_so_far_usd=cost,
             suggested_models=self._fallback_chain_suggestions() or None,
-            detail=detail,
+            detail=clean_detail,
         )
         return AgenticResult(
             text=text,
@@ -1541,17 +1547,26 @@ class AgenticLoop:
                         return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
                     # Non-retryable errors → immediate exit (no retry budget waste)
+                    # PR-DRIFT-CUT (2026-05-24) — replaced the raw
+                    # ``f"LLM call failed ({detail})."`` text emission with
+                    # the structured ``build_model_action_message`` shared
+                    # with the auth / convergence-break branches. Operators
+                    # were seeing the unfiltered SDK exception (e.g.
+                    # ``{'error': {'message': "Invalid 'tools': ..."}}``)
+                    # leak into the assistant transcript; the structured
+                    # message exposes the classified hint + a concrete
+                    # next-action (``/model <id>``) without the raw JSON.
                     if _et == "bad_request":
                         if not self._quiet:
                             from core.ui.agentic_ui import emit_llm_error
 
                             emit_llm_error(_et, _sev, _hint, self.model, self._provider)
-                        detail = self._last_llm_error or str(adapter_exc)
-                        result = AgenticResult(
-                            text=f"LLM call failed ({detail}).",
+                        result = self._build_model_action_result(
+                            error_type=_et,
+                            severity=_sev,
+                            hint=_hint,
                             rounds=round_idx + 1,
-                            error="llm_call_failed",
-                            termination_reason="llm_error",
+                            detail=self._last_llm_error or str(adapter_exc),
                         )
                         return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
@@ -1789,7 +1804,7 @@ class AgenticLoop:
                     "role": "assistant",
                     "content": assistant_content,
                 }
-                # v0.55.0 — Codex Plus encrypted reasoning passthrough.
+                # v0.55.0 — Codex subscription encrypted reasoning passthrough.
                 # Sidecar stays on the assistant message and is consumed
                 # by ``_convert_messages_to_responses`` (Codex adapter)
                 # to echo the reasoning items back into the next-turn

--- a/core/agent/loop/models.py
+++ b/core/agent/loop/models.py
@@ -41,7 +41,7 @@ def _context_exhausted_message(user_input: str) -> str:
     anthropic key, returns the static fallback — graceful, the loop
     surfaces the static notice to the user. No silent failure.
 
-    TODO (follow-up PR): add a Codex OAuth path so ChatGPT Plus
+    TODO (follow-up PR): add a Codex OAuth path so ChatGPT subscription
     subscription quota can drive the language-matching call. The Codex
     ``/v1/responses`` streaming request shape lives in
     ``plugins/petri_audit/codex_provider.py`` and would need to be

--- a/core/auth/credential_breadcrumb.py
+++ b/core/auth/credential_breadcrumb.py
@@ -105,7 +105,7 @@ def format(
         # v0.52.2 — when the active provider is fully exhausted, scan OTHER
         # providers for healthy profiles and surface them. Pre-fix the LLM
         # only saw rejections in the current provider and had no way to know
-        # that e.g. Codex Plus OAuth was registered and ready to take over.
+        # that e.g. Codex subscription OAuth was registered and ready to take over.
         # Pattern source: OpenClaw Lane fail-over (Session Lane → Global
         # Lane re-route when one Lane is unhealthy).
         alt = _suggest_alternative_providers(exclude=attempted_provider)

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -48,7 +48,7 @@ class ModelProfile:
 #
 # Label = canonical provider ID + cost ($) tier.
 # `gpt-5.5` default routes to `openai-codex` per equivalence-class
-# scan when Codex Plus OAuth is registered (v0.52.4 routing policy);
+# scan when Codex subscription OAuth is registered (v0.52.4 routing policy);
 # otherwise to `openai` PAYG. Both paths visible via /login dashboard.
 MODEL_PROFILES: list[ModelProfile] = [
     ModelProfile(ANTHROPIC_PRIMARY, "anthropic", "Opus 4.7", "$$$"),
@@ -232,7 +232,7 @@ def show_help() -> None:
     console.print("  [header]Commands[/header]")
     console.print("  [label]/verbose[/label]            — Toggle verbose mode")
     console.print("  [label]/login[/label]              — Plans + credentials dashboard (unified)")
-    console.print("  [label]/login openai[/label]       — Codex OAuth (Plus quota)")
+    console.print("  [label]/login openai[/label]       — Codex OAuth (subscription quota)")
     console.print("  [label]/login anthropic[/label]    — Claude subscription OAuth")
     console.print("  [label]/login add[/label]          — Interactive plan/key wizard")
     console.print("  [label]/key[/label] <value>        — Quick PAYG API key (legacy alias)")
@@ -300,7 +300,7 @@ def model_available(model_id: str) -> bool:
 # the ``/model`` picker. Pre-fix the picker silently honoured the user's
 # escape hatch (Codex CLI parity) so a user with
 # ``forced_login_method = {"openai": "apikey"}`` would pick ``gpt-5.5``
-# expecting Codex Plus and get PAYG instead. The badge below makes the
+# expecting Codex subscription and get PAYG instead. The badge below makes the
 # override visible at selection time.
 _FORCED_METHOD_DEFAULTS: frozenset[str] = frozenset({"subscription", "auto", ""})
 _FORCED_METHOD_APIKEY_ALIASES: frozenset[str] = frozenset({"apikey", "api", "api_key", "key"})

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -53,7 +53,7 @@ def cmd_login(args: str) -> None:
 
     Providers (case-insensitive, aliases accepted)::
 
-        /login openai      — Codex Plus device-code flow (aliases: codex, chatgpt)
+        /login openai      — Codex subscription device-code flow (aliases: codex, chatgpt)
         /login anthropic   — Claude subscription login via local `claude` CLI
                              (aliases: claude, claude-code)
 
@@ -238,7 +238,7 @@ def _login_help() -> None:
         "\n  [header]/login[/header] — credentials & subscription plans\n"
         "\n"
         "  [label]/login[/label]                       Show all plans, profiles, routing\n"
-        "  [label]/login openai[/label]                OAuth flow (Codex Plus quota)\n"
+        "  [label]/login openai[/label]                OAuth flow (Codex subscription quota)\n"
         "  [label]/login anthropic[/label]             OAuth flow (Claude subscription)\n"
         "  [label]/login add[/label]                   Interactive wizard\n"
         "  [label]/login source[/label] <prov> <type>   Pick credential source per provider\n"
@@ -471,7 +471,12 @@ def _login_add_interactive(_args: str) -> None:
         return
 
     kinds = [
-        ("subscription", "Subscription (GLM Coding Plan, ChatGPT Plus, Claude Pro)"),
+        (
+            "subscription",
+            "Subscription (GLM Coding Lite/Pro/Max · "
+            "ChatGPT Plus/Pro/Business/Enterprise · "
+            "Claude Pro/Max ×5/Max ×20/Team)",
+        ),
         ("payg", "Pay-as-you-go API key (Anthropic, OpenAI, GLM PAYG)"),
         ("oauth", "OAuth borrowed (Codex CLI / Claude Code)"),
     ]
@@ -628,7 +633,7 @@ def _login_oauth(target: str) -> None:
     caller has already resolved aliases via :data:`_PROVIDER_ALIASES`.
     Each branch is responsible for the provider-specific flow:
 
-    - ``openai``: GEODE-native device-code flow (Codex Plus quota).
+    - ``openai``: GEODE-native device-code flow (Codex subscription quota).
     - ``anthropic``: delegate to the local ``claude`` CLI's
       ``claude /login`` browser flow, then sync the keychain blob into
       ``ProfileStore`` so other parts of the system see the credential.
@@ -663,7 +668,7 @@ def _login_oauth(target: str) -> None:
 
     _pkg.console.print(
         f"  [warning]OAuth not implemented for '{target}'.[/warning]\n"
-        "  [muted]Available: openai (Codex Plus), anthropic (Claude subscription)[/muted]\n"
+        "  [muted]Available: openai (Codex subscription), anthropic (Claude subscription)[/muted]\n"
     )
 
 
@@ -1278,7 +1283,7 @@ def _login_providers() -> None:
     X3 — pre-fix the equivalence map (``openai ↔ openai-codex``,
     ``glm ↔ glm-coding``) lived only in ``core.llm.registry``; users
     saw the ``provider`` label in ``/login`` / ``/model`` and had no way
-    to discover that a Codex Plus token and an OpenAI PAYG key both
+    to discover that a Codex subscription token and an OpenAI PAYG key both
     serve a ``gpt-5.x`` request, or that a GLM Coding key shadows the
     PAYG endpoint. Surfacing the table makes the policy auditable
     without grep'ing ``PROVIDER_EQUIVALENCE`` in code.

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -121,7 +121,7 @@ _MODEL_DESCRIPTIONS: dict[str, str] = {
     "claude-sonnet-4-6": "Sonnet 4.6 · Best for everyday tasks",
     "claude-haiku-4-5": "Haiku 4.5 · Fastest for quick answers",
     # OpenAI / Codex
-    "gpt-5.5": "GPT-5.5 via Codex Plus · subscription-routed",
+    "gpt-5.5": "GPT-5.5 via Codex subscription · subscription-routed",
     "gpt-5.4": "GPT-5.4 · PAYG balanced reasoning",
     "gpt-5.4-mini": "GPT-5.4 Mini · cheap + fast",
     "gpt-5.3-codex": "GPT-5.3 Codex · code-tuned, reasoning-aware",

--- a/core/cli/onboarding.py
+++ b/core/cli/onboarding.py
@@ -56,7 +56,8 @@ def env_setup_wizard() -> bool:
         Panel(
             "[bold]Welcome to GEODE.[/bold]\n\n"
             "Pick how you want to talk to the model:\n"
-            "  [cyan]1[/cyan]  ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise)\n"
+            "  [cyan]1[/cyan]  ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise) "
+            "or Claude subscription (Pro / Max ×5 / Max ×20 / Team / Enterprise)\n"
             "  [cyan]2[/cyan]  API key (Anthropic / OpenAI / ZhipuAI GLM)\n"
             "  [cyan]3[/cyan]  Skip — explore in dry-run mode (fixture data, no LLM)\n\n"
             "[muted]Press Ctrl+C to abort at any time.[/muted]",
@@ -241,7 +242,7 @@ def key_registration_gate() -> str | None:
             "[bold]GEODE needs a credential to talk to an LLM.[/bold]\n\n"
             "  [cyan]/login add[/cyan]                — Interactive wizard "
             "(plans + keys + OAuth)\n"
-            "  [cyan]/login openai[/cyan]             — Codex OAuth (Plus quota)\n"
+            "  [cyan]/login openai[/cyan]             — Codex OAuth (subscription quota)\n"
             "  [cyan]/login anthropic[/cyan]          — Claude subscription OAuth\n"
             "  [cyan]/key <sk-ant-...>[/cyan]        — Quick paste (Anthropic)\n"
             "  [cyan]/key openai <sk-...>[/cyan]     — Quick paste (OpenAI)\n"

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -244,7 +244,7 @@ ANTHROPIC_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.anthropic)
 OPENAI_PRIMARY: str = _routing.defaults.openai
 OPENAI_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.openai)
 
-# OpenAI Codex — Plus quota via chatgpt.com/backend-api/codex (Responses API).
+# OpenAI Codex — subscription quota via chatgpt.com/backend-api/codex (Responses API).
 CODEX_PRIMARY: str = _routing.defaults.codex
 CODEX_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.codex)
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -447,7 +447,7 @@ class Settings(BaseSettings):
     # can serve the requested model (matches openai/codex CLI default).
     # Override per provider when the user deliberately wants metered PAYG:
     #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
-    #                                                  # if Codex Plus OAuth is registered
+    #                                                  # if Codex subscription OAuth is registered
     # Valid values: "subscription" (default), "apikey", "auto" (alias).
     # Reference: openai/codex#2733, #3286.
     forced_login_method: dict[str, str] = {}

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -74,7 +74,7 @@ __all__ = [
 # 에서 제거됨 (durable operator decision per ``project_payg_exclusion_decision.md``,
 # 2026-05-23) — autoresearch / Petri audit 의 provider 선택지에서 영구
 # exclude. 잔존 옵션: ``claude-cli`` (Claude Code Max OAuth) /
-# ``openai-codex`` (ChatGPT Plus OAuth) / ``auto`` (manifest cascade).
+# ``openai-codex`` (ChatGPT subscription OAuth) / ``auto`` (manifest cascade).
 # ``api_key`` 설정 시 Pydantic ValidationError 가 명시 PAYG 사용을 reject
 # — PR-C-P1 의 silent-fallback 차단 패턴 재사용.
 #
@@ -253,7 +253,7 @@ class AutoresearchConfig(BaseModel):
     source: Source = "claude-cli"
     """Credential source for the audit subprocess. PR-SIL-5THEME C6 후 PAYG
     (``api_key``) 는 Source literal 에서 제거. ``claude-cli`` = Claude Code
-    Max OAuth (default), ``openai-codex`` = ChatGPT Plus OAuth, ``auto`` =
+    Max OAuth (default), ``openai-codex`` = ChatGPT subscription OAuth, ``auto`` =
     manifest cascade (subscription-first, ``fallback_to_payg`` 가 True 여야
     PAYG 까지 fallback). argv translator 가 non-``api_key`` source 를
     ``--use-oauth`` 로 매핑 (모든 source 가 이제 non-api_key 라 항상 fire)."""

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -79,7 +79,7 @@ def _call_budget_llm(prompt: str) -> str | None:
     extraction as a soft hint and proceeds without it.
 
     TODO (follow-up PR): add a ``_call_codex_oauth`` path so a ChatGPT
-    Plus subscription quota can drive the extraction (matches the
+    subscription quota can drive the extraction (matches the
     PR #1133 OAuth bridge for Petri's judge/auditor). The Codex
     ``/v1/responses`` streaming-only request shape lives in
     ``plugins/petri_audit/codex_provider.py`` and would need to be

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -13,11 +13,20 @@ Completions wire shape (``tool_calls`` on assistant + ``role: tool`` with
 (``function_call`` / ``function_call_output`` typed items). Pre-A2 the
 adapter passed Anthropic content lists through verbatim → OpenAI/Codex
 SDK rejected with 400. Codex MCP review 2026-05-23 BLOCKER 2.
+
+PR-DRIFT-CUT (2026-05-24) — adds shared spec helpers (model-family
+detection + tools-array cap) for the OpenAI / Codex / GLM adapter
+family so spec quirks (max_completion_tokens, 128 tool cap, reasoning
+sampling-param ban) are honoured uniformly. Triggered by the post-v0.99.52
+smoke that hit both ``Unsupported parameter: 'max_tokens'`` and
+``array_above_max_length`` 400 in a single gpt-5.5 turn.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from core.llm.adapters.base import (
@@ -27,6 +36,170 @@ from core.llm.adapters.base import (
     ToolSpec,
     UsageSummary,
 )
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cross-adapter spec constants — verified 2026-05-24 against public docs
+# ---------------------------------------------------------------------------
+# OpenAI Chat Completions + Codex Responses both reject ``tools`` arrays
+# longer than 128 entries with 400 ``array_above_max_length``. The cap
+# is empirical (gpt-5.5 + gpt-5-mini both hit 129 → 400 in production
+# evidence). GLM endpoints (z.ai) are OpenAI-compatible and have not
+# published a cap, but we apply the same defensive limit to keep
+# behaviour predictable across the OpenAI-family adapter set.
+OPENAI_TOOLS_MAX = 128
+
+
+# ---------------------------------------------------------------------------
+# Explicit per-model spec registry — replaces the brittle prefix-match
+# (``startswith("gpt-5")``) approach. Grounded 2026-05-24 against:
+#   * https://developers.openai.com/api/docs/models
+#   * https://developers.openai.com/codex/models
+#   * https://developers.openai.com/api/docs/guides/reasoning
+# Add a new entry whenever GEODE wires a new OpenAI / Codex model — the
+# default (``_OPENAI_LEGACY_DEFAULT``) emits a WARNING on first use so
+# silent drift is impossible.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OpenAIModelSpec:
+    """Per-model API quirks for the OpenAI Chat Completions + Codex Responses surface."""
+
+    model_id: str
+    uses_max_completion_tokens: bool
+    """True → API expects ``max_completion_tokens`` (GPT-5.x + o-series).
+    False → legacy ``max_tokens`` (gpt-4.x and earlier)."""
+
+    accepts_temperature: bool
+    """False → API rejects ``temperature`` (reasoning models with active reasoning).
+    True → caller may pass ``temperature`` freely."""
+
+    reasoning_effort_values: tuple[str, ...] | None
+    """Valid values for ``reasoning_effort`` / ``reasoning.effort``.
+    ``None`` → parameter not supported by this model."""
+
+    context_window: int
+    """Total context window (input + output) in tokens — for guard logging only."""
+
+
+# Registry — keep alphabetically sorted within each family for stable diffs.
+_OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
+    # ── GPT-5 family (reasoning, max_completion_tokens, temperature blocked) ──
+    "gpt-5.3-codex": OpenAIModelSpec(
+        model_id="gpt-5.3-codex",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        context_window=200_000,
+    ),
+    "gpt-5.4": OpenAIModelSpec(
+        model_id="gpt-5.4",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        context_window=1_050_000,
+    ),
+    "gpt-5.4-mini": OpenAIModelSpec(
+        model_id="gpt-5.4-mini",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        context_window=1_050_000,
+    ),
+    "gpt-5.5": OpenAIModelSpec(
+        model_id="gpt-5.5",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        context_window=1_050_000,
+    ),
+    # ── o-series (always-on reasoning, no temperature, no "none" effort) ──
+    "o3": OpenAIModelSpec(
+        model_id="o3",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        context_window=200_000,
+    ),
+    "o4-mini": OpenAIModelSpec(
+        model_id="o4-mini",
+        uses_max_completion_tokens=True,
+        accepts_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        context_window=200_000,
+    ),
+}
+
+
+_OPENAI_LEGACY_DEFAULT = OpenAIModelSpec(
+    # Used when a model id isn't in the registry — assumes legacy gpt-4.x
+    # semantics (``max_tokens`` + ``temperature`` allowed). Warned on first
+    # use per (model_id, process) so adding a new model can't silently drift.
+    model_id="<unknown>",
+    uses_max_completion_tokens=False,
+    accepts_temperature=True,
+    reasoning_effort_values=None,
+    context_window=128_000,
+)
+
+# Process-scoped dedup so the warning fires once per unknown model_id,
+# not on every LLM call.
+_UNKNOWN_MODEL_WARNED: set[str] = set()
+
+
+def get_openai_model_spec(model_id: str) -> OpenAIModelSpec:
+    """Look up the explicit spec for an OpenAI / Codex model.
+
+    Unknown models fall back to :data:`_OPENAI_LEGACY_DEFAULT` with a
+    one-shot WARNING per ``model_id`` — the warning is the operator's
+    cue to add a registry entry. The fallback assumes gpt-4.x semantics
+    because that surface is the older, more permissive one and least
+    likely to break a brand-new model that the registry doesn't know.
+    """
+    spec = _OPENAI_MODELS.get(model_id)
+    if spec is not None:
+        return spec
+    if model_id not in _UNKNOWN_MODEL_WARNED:
+        _UNKNOWN_MODEL_WARNED.add(model_id)
+        log.warning(
+            "OpenAI model %r not in _OPENAI_MODELS registry — falling back "
+            "to legacy gpt-4.x defaults (max_tokens + temperature). Add a "
+            "spec entry to core/llm/adapters/_openai_common.py for "
+            "deterministic behaviour.",
+            model_id,
+        )
+    return _OPENAI_LEGACY_DEFAULT
+
+
+def cap_tools(
+    tools: list[dict[str, Any]], *, model: str, adapter_name: str
+) -> list[dict[str, Any]]:
+    """Truncate ``tools`` to :data:`OPENAI_TOOLS_MAX` with a logged warning.
+
+    Defensive guard at the adapter edge — the registry layer should
+    already deliver ≤128 tools, but a slow MCP-aggregation regression
+    or a per-session MCP burst can still push the array over. Hitting
+    this path means the operator should prune MCP servers in
+    ``~/.geode/config.toml [mcp.servers.*]`` or
+    ``.claude/mcp_servers.json``.
+    """
+    if len(tools) <= OPENAI_TOOLS_MAX:
+        return tools
+    log.warning(
+        "%s: tools array length %d > %d cap for model=%s — truncating to "
+        "first %d. Operator action: prune MCP servers in "
+        "``~/.geode/config.toml [mcp.servers.*]`` or "
+        "``.claude/mcp_servers.json``.",
+        adapter_name,
+        len(tools),
+        OPENAI_TOOLS_MAX,
+        model,
+        OPENAI_TOOLS_MAX,
+    )
+    return tools[:OPENAI_TOOLS_MAX]
+
 
 if TYPE_CHECKING:
     import openai

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -84,7 +84,7 @@ class CodexOAuthAdapter:
         :meth:`core.llm.providers.codex.CodexAgenticAdapter.agentic_call`
         — Codex backend has 4 mandatory differences vs. PAYG Responses API:
 
-        - ``max_output_tokens`` is forbidden (server-managed under the Plus
+        - ``max_output_tokens`` is forbidden (server-managed under the subscription
           quota; sending it returns 400 ``Unsupported parameter``).
         - ``store = False`` is required.
         - ``instructions`` field carries the system prompt (Responses API's
@@ -219,11 +219,13 @@ def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
       :func:`build_codex_input` which re-encodes Anthropic content blocks
       into Codex typed items (``function_call`` / ``function_call_output``)
     - ``store=False`` is mandatory
-    - ``max_output_tokens`` is FORBIDDEN — Plus subscription manages it
+    - ``max_output_tokens`` is FORBIDDEN — Subscription manages it
       server-side, sending the field returns 400
     - Tools use the FLAT shape (``translate_tool_for_codex``)
-    - gpt-5.x family omits ``temperature`` and adds ``reasoning`` +
-      ``include: ["reasoning.encrypted_content"]``
+    - Reasoning models (per
+      :func:`core.llm.adapters._openai_common.get_openai_model_spec`)
+      omit ``temperature`` and add ``reasoning`` + ``include:
+      ["reasoning.encrypted_content"]``
     - A2 (v0.99.44): previous-turn reasoning items replay inline via
       :func:`build_codex_input` — each assistant :class:`Message` carries
       its own ``codex_reasoning_items`` (populated by the bridge from the
@@ -232,7 +234,13 @@ def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
       correct ordinal position. The legacy whole-input prepend approach
       lost per-turn association for multi-assistant histories — Codex
       MCP A2 BLOCKER 3.
+    - PR-DRIFT-CUT (2026-05-24): replaced ``req.model.startswith("gpt-5")``
+      heuristic with explicit registry lookup so o3 / o4-mini / new
+      reasoning models go through the same branch automatically.
     """
+    from core.llm.adapters._openai_common import cap_tools, get_openai_model_spec
+
+    spec = get_openai_model_spec(req.model)
     resp_input = build_codex_input(req)
     kwargs: dict[str, Any] = {
         "model": req.model,
@@ -241,14 +249,16 @@ def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
         "store": False,
     }
     if req.tools:
-        kwargs["tools"] = [translate_tool_for_codex(t) for t in req.tools]
+        translated = [translate_tool_for_codex(t) for t in req.tools]
+        kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name="codex-oauth")
         kwargs["tool_choice"] = _translate_codex_tool_choice(req.tool_choice)
         kwargs["parallel_tool_calls"] = True
-    if req.model.startswith("gpt-5"):
-        # gpt-5.x family — encrypted reasoning passthrough; temperature omitted.
+    if spec.reasoning_effort_values is not None:
+        # Reasoning-model branch — encrypted reasoning passthrough +
+        # reasoning effort. Temperature is dropped per spec.
         kwargs["include"] = ["reasoning.encrypted_content"]
         kwargs["reasoning"] = {"effort": req.effort, "summary": "auto"}
-    elif req.temperature is not None:
+    elif req.temperature is not None and spec.accepts_temperature:
         kwargs["temperature"] = req.temperature
     return kwargs
 

--- a/core/llm/adapters/glm_coding_plan.py
+++ b/core/llm/adapters/glm_coding_plan.py
@@ -83,9 +83,11 @@ class GlmCodingPlanAdapter:
         if req.temperature is not None:
             kwargs["temperature"] = req.temperature
         if req.tools:
-            kwargs["tools"] = [translate_tool(t) for t in req.tools]
+            from core.llm.adapters._openai_common import cap_tools
             from core.llm.tool_choice import normalize
 
+            translated = [translate_tool(t) for t in req.tools]
+            kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name="glm-coding-plan")
             tc = normalize("glm", req.tool_choice)
             if tc is not None:
                 kwargs["tool_choice"] = tc

--- a/core/llm/adapters/glm_payg.py
+++ b/core/llm/adapters/glm_payg.py
@@ -81,7 +81,10 @@ class GlmPaygAdapter:
         if req.temperature is not None:
             kwargs["temperature"] = req.temperature
         if req.tools:
-            kwargs["tools"] = [translate_tool(t) for t in req.tools]
+            from core.llm.adapters._openai_common import cap_tools
+
+            translated = [translate_tool(t) for t in req.tools]
+            kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name="glm-payg")
             tc = _translate_tool_choice(req.tool_choice)
             if tc is not None:
                 kwargs["tool_choice"] = tc

--- a/core/llm/adapters/openai_payg.py
+++ b/core/llm/adapters/openai_payg.py
@@ -21,6 +21,8 @@ from typing import Any
 from core.llm.adapters._openai_common import (
     build_async_openai_client,
     build_messages,
+    cap_tools,
+    get_openai_model_spec,
     translate_chat_response,
     translate_tool,
 )
@@ -64,22 +66,50 @@ class OpenAIPaygAdapter:
         self._client = build_async_openai_client(settings.openai_api_key)
         return self._client
 
-    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
-        client = self._get_client()
+    def _build_kwargs(self, req: AdapterCallRequest, *, stream: bool) -> dict[str, Any]:
+        """Compose Chat Completions kwargs honouring per-model spec quirks.
+
+        PR-DRIFT-CUT (2026-05-24) consults
+        :func:`core.llm.adapters._openai_common.get_openai_model_spec`
+        for the per-model API surface (rather than the previous
+        ``startswith("gpt-5")`` heuristic):
+
+          * ``spec.uses_max_completion_tokens`` chooses between
+            ``max_completion_tokens`` (GPT-5.x + o-series) and the
+            legacy ``max_tokens`` key.
+          * ``spec.accepts_temperature`` is False for reasoning models,
+            so ``temperature`` is omitted entirely.
+          * ``tools`` array hard-caps at 128 entries via shared
+            :func:`cap_tools` with an operator-actionable log.
+
+        Unknown ``req.model`` falls back to legacy gpt-4.x defaults
+        with a one-shot WARNING so silent drift on new models is
+        impossible.
+        """
+        spec = get_openai_model_spec(req.model)
+        token_key = "max_completion_tokens" if spec.uses_max_completion_tokens else "max_tokens"
         kwargs: dict[str, Any] = {
             "model": req.model,
             "messages": build_messages(req),
-            "max_tokens": req.max_tokens,
+            token_key: req.max_tokens,
         }
-        if req.temperature is not None:
+        if stream:
+            kwargs["stream"] = True
+        if req.temperature is not None and spec.accepts_temperature:
             kwargs["temperature"] = req.temperature
         if req.tools:
-            kwargs["tools"] = [translate_tool(t) for t in req.tools]
+            translated = [translate_tool(t) for t in req.tools]
+            kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=self.name)
             tc = _translate_tool_choice(req.tool_choice)
             if tc is not None:
                 kwargs["tool_choice"] = tc
         if req.stop_sequences:
             kwargs["stop"] = list(req.stop_sequences)
+        return kwargs
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        client = self._get_client()
+        kwargs = self._build_kwargs(req, stream=False)
         try:
             response = await client.chat.completions.create(**kwargs)
         except Exception as exc:
@@ -94,14 +124,7 @@ class OpenAIPaygAdapter:
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
-        kwargs: dict[str, Any] = {
-            "model": req.model,
-            "messages": build_messages(req),
-            "max_tokens": req.max_tokens,
-            "stream": True,
-        }
-        if req.temperature is not None:
-            kwargs["temperature"] = req.temperature
+        kwargs = self._build_kwargs(req, stream=True)
         async for chunk in await client.chat.completions.create(**kwargs):
             choice = chunk.choices[0] if chunk.choices else None
             if choice is None:

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -77,7 +77,7 @@ class AgenticResponse:
     with the same attribute names (.type, .text, .name, .input, .id).
 
     ``codex_reasoning_items`` (v0.55.0): sidecar list of opaque
-    Reasoning items extracted from a Codex Plus stream. Each entry is
+    Reasoning items extracted from a Codex subscription stream. Each entry is
     a dict with ``{type:"reasoning", encrypted_content, summary?, id?}``
     fit for re-injection into the next-turn ``input`` array. Present
     only on responses from ``CodexAgenticAdapter``; ``None`` for every
@@ -114,7 +114,7 @@ def inject_reasoning_replay(
     lookup — mirrors Hermes ``codex_responses_adapter.py:228-246``.
 
     Both lists must preserve order (one Anthropic message → ≥1 entries
-    in oai_messages). Used by Codex Plus and PAYG OpenAI Responses
+    in oai_messages). Used by Codex subscription and PAYG OpenAI Responses
     adapters; without this, gpt-5.x loses reasoning state every turn
     when ``store=False`` (no server-side item resolution).
     """
@@ -284,7 +284,7 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
     - ``web_search_call`` items → skipped (server-side, transparent)
 
     v0.53.3 — usage is always extracted (even when ``output`` is empty)
-    so cost/token telemetry survives the Codex Plus
+    so cost/token telemetry survives the Codex subscription
     ``response.completed``-with-empty-output edge case. The CodexAgenticAdapter
     pre-populates ``response.output`` from accumulated
     ``response.output_item.done`` events before calling this normaliser
@@ -294,7 +294,7 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
     has_function_calls = False
     # v0.57.0 R6 — sidecar accumulator for the "live thinking..." UI surface.
     reasoning_summaries: list[str] = []
-    # v0.55.0 — sidecar accumulator for Codex Plus encrypted reasoning.
+    # v0.55.0 — sidecar accumulator for Codex subscription encrypted reasoning.
     # Hermes pattern (codex_responses_adapter.py:720-738): capture every
     # ``reasoning`` item the server emits so the loop can echo it back
     # in the next-turn ``input`` array. Without this, multi-turn gpt-5.x
@@ -389,7 +389,7 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
     if not blocks and (usage.output_tokens or 0) > (usage.thinking_tokens or 0):
         # The model produced visible output tokens but the normaliser
         # extracted no blocks. This is anomalous — most likely the
-        # Codex Plus accumulator missed an item type, or a future
+        # Codex subscription accumulator missed an item type, or a future
         # message sub-type. Surface as a single warning rather than
         # silently dropping a paid response.
         log.warning(

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -6,6 +6,7 @@ so that no consumer needs to import provider SDKs directly.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -283,8 +284,7 @@ def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
     if isinstance(exc, anthropic.InternalServerError):
         return _ERROR_CLASSIFICATION["server"]
     if isinstance(exc, anthropic.BadRequestError):
-        msg = str(exc).lower()
-        if "token" in msg or "context" in msg or "prompt exceeds" in msg or "max length" in msg:
+        if _looks_like_context_overflow(exc):
             return _ERROR_CLASSIFICATION["context_overflow"]
         return _ERROR_CLASSIFICATION["bad_request"]
 
@@ -382,6 +382,63 @@ def extract_billing_message(exc: Exception) -> str:
     return str(msg) or str(exc)
 
 
+def summarize_error_detail(raw: str | Exception) -> str:
+    """Strip raw SDK exception JSON down to the underlying ``error.message``.
+
+    PR-DRIFT-CUT (2026-05-24) — the bad_request branch in
+    :class:`AgenticLoop` used to emit the raw exception ``str()`` as
+    the assistant transcript line, which looked like
+    ``"Error code: 400 - {'error': {'message': "Unsupported parameter:
+    'max_tokens' ...", 'type': 'invalid_request_error', ...}}"``. That
+    is operator-grade noise — the user just needs the underlying
+    sentence. We try, in order:
+
+      1. Parse a real ``Exception`` and pull ``body['error']['message']``.
+      2. Regex-match a ``"message": "<msg>"`` field in the raw string.
+      3. Strip a leading ``Error code: NNN - `` prefix.
+
+    If none match we return the input untouched so we never *lose*
+    information — only filter when we can prove a clean extraction.
+    """
+    if isinstance(raw, Exception):
+        body = _extract_error_body(raw) or {}
+        err_obj = body.get("error")
+        if isinstance(err_obj, dict):
+            msg = err_obj.get("message")
+            if isinstance(msg, str) and msg:
+                return msg.strip()
+        msg = body.get("message")
+        if isinstance(msg, str) and msg:
+            return msg.strip()
+        raw = str(raw)
+
+    text = str(raw)
+
+    # Try to pull the inner ``'message': "<value>"`` or
+    # ``"message": '<value>'`` from a stringified dict body. The OpenAI
+    # SDK emits Python-dict repr where the value uses whichever quote
+    # the inner content does NOT use (e.g. value contains 'max_tokens'
+    # → outer quotes are ``"``), so we need to match both styles and
+    # tolerate escaped occurrences of the outer quote.
+    inner = re.search(
+        r"['\"]message['\"]\s*:\s*"
+        r"(?:\"((?:[^\"\\]|\\.)*)\"|'((?:[^'\\]|\\.)*)')",
+        text,
+    )
+    if inner:
+        captured = inner.group(1) if inner.group(1) is not None else inner.group(2)
+        if captured:
+            return captured.strip()
+    # Strip the leading "Error code: NNN - " preamble if present and the
+    # remainder is short enough to be a sentence (not the full JSON).
+    preamble = re.match(r"^Error code:\s*\d+\s*-\s*(.+)$", text, re.DOTALL)
+    if preamble:
+        remainder = preamble.group(1).strip()
+        if len(remainder) <= 240 and remainder.startswith(("{", "[")) is False:
+            return remainder
+    return text
+
+
 def build_model_action_message(
     *,
     error_type: str,
@@ -460,8 +517,77 @@ def _classify_openai_error(exc: Exception) -> tuple[str, str, str] | None:
     if isinstance(exc, openai.InternalServerError):
         return _ERROR_CLASSIFICATION["server"]
     if isinstance(exc, openai.BadRequestError):
-        msg = str(exc).lower()
-        if "token" in msg or "context" in msg or "prompt exceeds" in msg or "max length" in msg:
+        if _looks_like_context_overflow(exc):
             return _ERROR_CLASSIFICATION["context_overflow"]
         return _ERROR_CLASSIFICATION["bad_request"]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Context-overflow detection — strict, code-first, regex-anchored
+# ---------------------------------------------------------------------------
+# PR-DRIFT-CUT (2026-05-24) — the previous heuristic was a substring
+# match (``"token" in msg``) that misclassified *every* 400 mentioning
+# ``max_tokens``, including the gpt-5.5 "Unsupported parameter:
+# 'max_tokens'" error. That false-positive triggered the context-recovery
+# path, which dropped messages and surfaced "Context window exhausted"
+# to the user despite the real cause being a parameter-name mismatch.
+#
+# New strategy:
+#   1. Prefer the structured ``error.code`` field (provider-specific
+#      machine-readable name — OpenAI ``context_length_exceeded``,
+#      Anthropic ``prompt_too_long``, etc.).
+#   2. Fall back to word-anchored phrase matching on the message body
+#      with patterns that only match true overflow language.
+#
+# Adding a new provider: extend ``_CONTEXT_OVERFLOW_CODES`` /
+# ``_CONTEXT_OVERFLOW_PHRASES`` rather than relaxing the heuristic.
+
+_CONTEXT_OVERFLOW_CODES: frozenset[str] = frozenset(
+    {
+        "context_length_exceeded",  # OpenAI
+        "prompt_too_long",  # Anthropic
+        "context_window_exceeded",  # GLM / future
+    }
+)
+
+# Word-anchored phrases — every entry must describe context overflow
+# unambiguously. ``max_tokens`` parameter errors must NOT match.
+_CONTEXT_OVERFLOW_RE = re.compile(
+    r"\b("
+    r"context\s+length\s+exceeded|"
+    r"context\s+window\s+exceeded|"
+    r"prompt\s+is\s+too\s+long|"
+    r"prompt\s+exceeds\s+the\s+(?:maximum\s+)?context|"
+    r"exceeds\s+the\s+maximum\s+context\s+length|"
+    r"input\s+is\s+too\s+long|"
+    r"too\s+many\s+input\s+tokens|"
+    r"too\s+many\s+tokens"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_context_overflow(exc: Exception) -> bool:
+    """Return True when the 400 is a true context-overflow signal.
+
+    Prefers the structured ``error.code`` field; falls back to a tight
+    regex on the message. NEVER matches ``max_tokens`` /
+    ``Unsupported parameter`` / generic "tokens" mentions.
+    """
+    body = _extract_error_body(exc) or {}
+    err_obj = body.get("error") if isinstance(body.get("error"), dict) else None
+    code = ""
+    if err_obj is not None:
+        code = str(err_obj.get("code") or err_obj.get("type") or "").lower()
+    if not code:
+        code = str(body.get("code") or body.get("type") or "").lower()
+    if code in _CONTEXT_OVERFLOW_CODES:
+        return True
+
+    detail = ""
+    if err_obj is not None:
+        detail = str(err_obj.get("message") or "")
+    if not detail:
+        detail = str(body.get("message") or "") or str(exc)
+    return bool(_CONTEXT_OVERFLOW_RE.search(detail))

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -573,14 +573,21 @@ _CONTEXT_OVERFLOW_CODES: frozenset[str] = frozenset(
 )
 
 # Word-anchored phrases — every entry must describe context overflow
-# unambiguously. ``max_tokens`` parameter errors must NOT match.
+# unambiguously. ``max_tokens`` parameter errors (Unsupported parameter,
+# Unknown parameter, etc.) must NOT match. Patterns kept narrow:
+# they describe length-of-input language, not parameter-name language.
 _CONTEXT_OVERFLOW_RE = re.compile(
     r"\b("
     r"context\s+length\s+exceeded|"
     r"context\s+window\s+exceeded|"
+    r"maximum\s+context\s+length|"
     r"prompt\s+is\s+too\s+long|"
-    r"prompt\s+exceeds\s+the\s+(?:maximum\s+)?context|"
-    r"exceeds\s+the\s+maximum\s+context\s+length|"
+    # "prompt exceeds the model's context window of 200000 tokens" —
+    # tolerate up to 3 natural-language words between "exceeds" and
+    # "context" so possessives ("the model's") + adjectives ("the
+    # maximum") don't break the match.
+    r"prompt\s+exceeds(?:\s+\S+){0,3}\s+context|"
+    r"exceeds\s+the\s+(?:maximum\s+)?context|"
     r"input\s+is\s+too\s+long|"
     r"too\s+many\s+input\s+tokens|"
     r"too\s+many\s+tokens"

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -159,8 +159,28 @@ def _get_provider_client(provider: str) -> Any:
 
 
 def _get_fallback_chain(provider: str) -> list[str]:
-    result: list[str] = _get_provider_config(provider, "fallback_chain")
-    return result
+    """**DEPRECATED — returns empty list (PR-DRIFT-CUT, 2026-05-24).**
+
+    Pre-PR: looked up a configured fallback chain per provider so that
+    when the primary model returned a retryable error the dispatcher
+    would silently try the next model in the chain (and even cross
+    providers in the case of GLM → OpenAI). In production that meant
+    a single 400 on Anthropic could cascade to a z.ai call that
+    succeeded but surfaced the *Anthropic* error to the user — see
+    the v0.99.52 smoke (gpt-5.5 ``Unsupported parameter`` → context
+    overflow misclassification → z.ai 200 OK → UI showed "Context
+    window exhausted"). The chain was the *amplifier*; cutting it at
+    the source isolates failures to their actual provider.
+
+    The function signature is preserved so callers don't fork on the
+    rollout. Operators wanting an alternative model must invoke
+    ``/model <id>`` explicitly — there is no silent auto-fallback.
+    The legacy chain constants in :mod:`core.config`
+    (``ANTHROPIC_FALLBACK_CHAIN`` etc.) are still imported by the
+    dispatch table above to keep test fixtures + introspection
+    working, but their content is no longer consulted at call time.
+    """
+    return []
 
 
 def _get_provider_retryable_errors(provider: str) -> tuple[type[Exception], ...]:

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -1,7 +1,7 @@
-"""OpenAI Codex provider — Plus quota via chatgpt.com/backend-api/codex.
+"""OpenAI Codex provider — subscription quota via chatgpt.com/backend-api/codex.
 
 Uses Codex OAuth token (from ~/.codex/auth.json) to call OpenAI models
-through ChatGPT's backend API, consuming Plus subscription quota instead
+through ChatGPT's backend API, consuming subscription quota instead
 of API billing.
 
 Requires:
@@ -181,19 +181,24 @@ from core.llm.providers.openai import (  # noqa: E402
 from core.llm.router import call_with_failover  # noqa: E402
 
 
-# v0.52.7 — gpt-5.x family supports reasoning + omits temperature on Codex
-# backend. Pattern from Hermes ``_fixed_temperature_for_model`` (which returns
-# OMIT for these models) + Codex Rust ``Reasoning`` field on ResponsesApiRequest.
-# All current Codex-routed models (gpt-5.5, gpt-5.4, gpt-5.4-mini,
-# gpt-5.3-codex) are gpt-5.x — we gate by prefix so future spec additions
-# (gpt-5.6, gpt-5.x-codex-spark, etc.) inherit the same handling.
+# PR-DRIFT-CUT (2026-05-24) — replaced the v0.52.7 ``startswith("gpt-5")``
+# prefix heuristic with the explicit per-model registry in
+# :mod:`core.llm.adapters._openai_common`. A reasoning model is one whose
+# spec exposes a ``reasoning_effort_values`` tuple — that flag is the
+# single source of truth for "accepts ``reasoning`` + omits ``temperature``".
+# Adding a new Codex model only requires registering its spec; no string
+# matching needs to chase the catalog. Future ``gpt-5.x-codex-spark``,
+# ``gpt-5.6``, ``o5`` etc. inherit the right behaviour the moment they
+# appear in the registry.
 def _is_codex_reasoning_model(model: str) -> bool:
     """Return True for Codex models that accept ``reasoning`` + omit temperature."""
-    return model.startswith("gpt-5")
+    from core.llm.adapters._openai_common import get_openai_model_spec
+
+    return get_openai_model_spec(model).reasoning_effort_values is not None
 
 
 class CodexAgenticAdapter(OpenAIAgenticAdapter):
-    """OpenAI Codex adapter — Plus quota via Responses API streaming.
+    """OpenAI Codex adapter — subscription quota via Responses API streaming.
 
     Uses chatgpt.com/backend-api/codex with Codex OAuth token.
     """
@@ -204,7 +209,12 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
     @property
     def fallback_chain(self) -> list[str]:
-        return list(CODEX_FALLBACK_CHAIN)
+        """**DEPRECATED — returns ``[]`` (PR-DRIFT-CUT, 2026-05-24).**
+
+        See :func:`core.llm.provider_dispatch._get_fallback_chain` for
+        rationale.
+        """
+        return []
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
         token = _resolve_codex_token()
@@ -233,13 +243,13 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
         # v0.53.3 — use the Responses-API converter (was previously the
         # Chat-Completions converter ``_convert_messages_to_openai``,
         # which produced ``{role:"assistant", content:None,
-        # tool_calls:[...]}`` shapes that Codex Plus rejects with
+        # tool_calls:[...]}`` shapes that Codex subscription rejects with
         # ``input[i].content must be array or string, got null``). The
         # Responses API expects per-item-type wire shapes:
         # function_call (no content field), function_call_output
         # (output not content), message (content always string/array,
         # never null). OpenAI PAYG already used this converter
-        # (``openai.py:496``); Codex Plus inherits the same behaviour
+        # (``openai.py:496``); Codex subscription inherits the same behaviour
         # now. Spec-grounded against openai-python TypedDicts
         # ResponseFunctionToolCallParam / FunctionCallOutput /
         # ResponseOutputMessageParam.
@@ -313,7 +323,7 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
         async def _do_call(m: str) -> Any:
             # v0.52.6 hotfix — chatgpt.com/backend-api/codex/responses
             # rejects ``max_output_tokens`` with 400 ("Unsupported
-            # parameter"). The Plus subscription manages output limits
+            # parameter"). The subscription manages output limits
             # server-side; client cap is forbidden. PAYG
             # ``OpenAIAgenticAdapter`` still sends it for api.openai.com.
             kwargs: dict[str, Any] = {
@@ -325,7 +335,7 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
             # v0.52.7 — function-calling parity with Hermes / Codex Rust.
             # Pre-fix ``tools`` was dropped silently → Codex agentic loop
             # had no way to invoke any tool, breaking the entire native
-            # tool dispatch path on Plus subscriptions.
+            # tool dispatch path on subscriptions.
             if oai_tools:
                 kwargs["tools"] = oai_tools
                 kwargs["tool_choice"] = tc_val or "auto"
@@ -353,7 +363,7 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
                             accumulated_items.append(item)
                 final = await stream.get_final_response()
                 # Always overwrite — never trust SDK's reconstructed output
-                # for Codex Plus (it's structurally empty per the backend's
+                # for Codex subscription (it's structurally empty per the backend's
                 # SSE contract).
                 if accumulated_items:
                     final.output = accumulated_items
@@ -368,7 +378,7 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
             # renders the quota_exhausted IPC panel. Pre-fix the generic
             # Exception catch swallowed BillingError into self.last_error
             # and returned None, breaking the v0.53.0 fail-fast governance
-            # for Codex Plus quota exhaustion.
+            # for Codex subscription quota exhaustion.
             from core.llm.errors import BillingError
 
             if isinstance(exc, BillingError):

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -247,7 +247,15 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
     @property
     def fallback_chain(self) -> list[str]:
-        return list(GLM_FALLBACK_CHAIN)
+        """**DEPRECATED — returns ``[]`` (PR-DRIFT-CUT, 2026-05-24).**
+
+        See :func:`core.llm.provider_dispatch._get_fallback_chain` for
+        rationale. ``GLM_FALLBACK_CHAIN`` is intentionally still imported
+        at module scope so tests + introspection that examine the
+        constant directly keep working — the value is just no longer
+        consulted by the runtime failover loop.
+        """
+        return []
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
         return _resolve_glm_endpoint()
@@ -298,7 +306,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
             # because openai-python's ``ChatCompletion.create`` doesn't know
             # about it). Default ``clear_thinking=False`` — keep prior-turn
             # ``reasoning_content`` in context across rounds (matches the
-            # multi-turn-reasoning-preservation goal of R1 on Codex Plus).
+            # multi-turn-reasoning-preservation goal of R1 on Codex subscription).
             # Per-failover-model gate: drop the field on pre-GLM-4.5
             # models so the request is accepted.
             local_extra: dict[str, Any] = {}

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -513,7 +513,12 @@ class OpenAIAgenticAdapter:
 
     @property
     def fallback_chain(self) -> list[str]:
-        return list(OPENAI_FALLBACK_CHAIN)
+        """**DEPRECATED — returns ``[]`` (PR-DRIFT-CUT, 2026-05-24).**
+
+        See :func:`core.llm.provider_dispatch._get_fallback_chain` for
+        rationale.
+        """
+        return []
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
         """Return (api_key, base_url) for this provider. Override in subclasses."""
@@ -602,7 +607,7 @@ class OpenAIAgenticAdapter:
 
         # Convert messages to Responses API input format, then inject any
         # prior-turn encrypted reasoning blobs so gpt-5.x can resume
-        # state across turns (R3-mini parity with Codex Plus).
+        # state across turns (R3-mini parity with Codex subscription).
         from core.llm.agentic_response import inject_reasoning_replay
 
         oai_messages = _convert_messages_to_responses(system, messages)
@@ -618,7 +623,7 @@ class OpenAIAgenticAdapter:
                 "max_output_tokens": max_tokens,
                 "temperature": temperature,
                 # v0.61.0 — explicit ``store=False`` for parity with the
-                # Codex Plus path (``codex.py:331``). We feed conversations
+                # Codex subscription path (``codex.py:331``). We feed conversations
                 # via the ``input`` array + encrypted-content replay rather
                 # than ``previous_response_id``, so server-side storage is
                 # unused; opting out avoids unnecessary OpenAI-side
@@ -636,7 +641,7 @@ class OpenAIAgenticAdapter:
             # ``store=False`` so the server returns the opaque
             # continuation blob; ``summary="auto"`` opts the response into
             # reasoning summaries so the R6 surfacing path can render
-            # "live thinking..." for PAYG users (Codex Plus already had this).
+            # "live thinking..." for PAYG users (Codex subscription already had this).
             _EFFORT_MAP = {"low": "low", "medium": "medium", "high": "high", "max": "high"}
             if _is_payg_reasoning_model(m):
                 oai_effort = _EFFORT_MAP.get(effort, "medium")

--- a/core/llm/router/calls/_route.py
+++ b/core/llm/router/calls/_route.py
@@ -1,7 +1,7 @@
 """Provider resolution — Plan-aware routing for LLM call dispatch.
 
 Wraps ``resolve_routing(model)`` so the LLM call dispatch sees the
-actually-routed provider (e.g. ``openai-codex`` when a Plus OAuth Plan is
+actually-routed provider (e.g. ``openai-codex`` when a subscription OAuth Plan is
 registered) instead of the static ``_resolve_provider`` mapping.
 """
 

--- a/core/llm/strategies/plans.py
+++ b/core/llm/strategies/plans.py
@@ -29,7 +29,7 @@ class PlanKind(Enum):
     """How the user obtained this credential."""
 
     PAYG = "payg"  # pay-as-you-go API key (default for env-var seeded keys)
-    SUBSCRIPTION = "subscription"  # flat-fee plan with quota (GLM Coding, ChatGPT Plus)
+    SUBSCRIPTION = "subscription"  # flat-fee plan with quota (GLM Coding, ChatGPT subscription)
     OAUTH_BORROWED = "oauth_borrowed"  # token sourced from an external CLI (Codex CLI)
     CLOUD_PROVIDER = "cloud_provider"  # AWS Bedrock / GCP Vertex etc.
 
@@ -79,7 +79,7 @@ class Plan:
     base_url: str  # endpoint (may override ProviderSpec.default_base_url)
     auth_type: str = "bearer"
     quota: Quota | None = None
-    subscription_tier: str | None = None  # "Lite", "Pro", "Max", "ChatGPT Plus"
+    subscription_tier: str | None = None  # "Lite", "Pro", "Max", "ChatGPT subscription"
     upgrade_url: str | None = None  # surfaced in error hints when quota hits
 
 

--- a/core/orchestration/codex_cli_lane.py
+++ b/core/orchestration/codex_cli_lane.py
@@ -8,7 +8,7 @@ admission control + dashboard mirror in ``build_default_lanes``.
 Why a separate lane (not just ``global`` or the Claude lane)
 ============================================================
 
-Codex CLI's ``codex exec`` reaches the operator's ChatGPT-Plus OAuth
+Codex CLI's ``codex exec`` reaches the operator's ChatGPT subscription OAuth
 bucket (different from Anthropic's). Combining it with the
 ``claude-cli-subagent`` lane would cap the two providers against a
 single semaphore, blocking Codex spawns when Claude is busy and
@@ -21,7 +21,7 @@ The cap matches the Claude side for now
 1. Codex CLI's per-account burst limiter isn't publicly documented;
    the conservative public-doc-grounded cap leaves headroom for a
    host ``codex`` session.
-2. ChatGPT-Plus + Codex CLI behaviour under fan-out lacks the
+2. ChatGPT subscription + Codex CLI behaviour under fan-out lacks the
    paperclip-style empirical study Claude has. Until measurements
    land, "small + tunable" beats "high + untested".
 
@@ -73,7 +73,7 @@ CODEX_CLI_LANE_MAX_ENV = "GEODE_CODEX_CLI_LANE_MAX"
 """Operator override for :data:`DEFAULT_CODEX_CLI_LANE_MAX`."""
 
 DEFAULT_CODEX_CLI_LANE_MAX = 2
-"""Conservative cap until ChatGPT-Plus / Codex CLI burst-limit
+"""Conservative cap until ChatGPT subscription / Codex CLI burst-limit
 behaviour is measured. Same value as the Claude side; the per-
 provider knob lets operators tune independently as data accumulates."""
 

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -114,7 +114,7 @@ class SharedServices:
     # User saw "Already using GPT-5.5" in the prompt header but every
     # LLM call still routed to `claude-opus-4-7` — silently using a
     # different provider (paid Anthropic API instead of OAuth-borrowed
-    # Codex Plus). `create_session()` now reads `settings.model` directly
+    # Codex subscription). `create_session()` now reads `settings.model` directly
     # so each session reflects the latest user intent.
     _cost_budget: float = 0.0
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -249,7 +249,7 @@
   },
   {
     "name": "manage_login",
-    "description": "Unified credentials/plans command — Plans + API keys + OAuth + routing in one tool. Use whenever the user says login/logout, sets up a subscription (GLM Coding Lite/Pro/Max, ChatGPT Plus, Claude Pro), changes credentials, asks about quota, switches active plan, or pastes an API key with intent. Mirrors the /login slash command (see `core.cli.commands.cmd_login`).",
+    "description": "Unified credentials/plans command — Plans + API keys + OAuth + routing in one tool. Use whenever the user says login/logout, sets up a subscription (GLM Coding Lite/Pro/Max, ChatGPT Plus/Pro/Business/Enterprise, Claude Pro/Max ×5/Max ×20/Team), changes credentials, asks about quota, switches active plan, or pastes an API key with intent. Mirrors the /login slash command (see `core.cli.commands.cmd_login`).",
     "category": "model",
     "cost_tier": "cheap",
     "input_schema": {

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -232,7 +232,7 @@ def build_default_lanes() -> LaneQueue:
     )
     # PR-LQ-Phase3 (2026-05-22) — Codex CLI parity. Sibling lane to
     # ``claude-cli-subagent``; separate semaphore because the two
-    # provider buckets (Anthropic vs ChatGPT-Plus OAuth) are
+    # provider buckets (Anthropic vs ChatGPT subscription OAuth) are
     # independent. Operator tunes via ``GEODE_CODEX_CLI_LANE_MAX``.
     from core.orchestration.codex_cli_lane import (
         CODEX_CLI_LANE_NAME,

--- a/core/wiring/startup.py
+++ b/core/wiring/startup.py
@@ -113,8 +113,9 @@ def _has_any_llm_key() -> bool:
 def detect_subscription_oauth() -> str | None:
     """Detect a usable subscription-OAuth credential before any wizard runs.
 
-    Currently supports Codex CLI OAuth (ChatGPT Plus / Pro / Business / Edu /
-    Enterprise). Anthropic OAuth is intentionally excluded — Anthropic's
+    Currently supports Codex CLI OAuth (ChatGPT subscription — Plus /
+    Pro / Business / Edu / Enterprise). Anthropic OAuth is intentionally
+    excluded — Anthropic's
     terms of service (effective 2026-01-09) prohibit third-party tools from
     reusing the Claude Code OAuth token; ``core/lifecycle/container.py:271``
     documents the policy decision.

--- a/plugins/petri_audit/__init__.py
+++ b/plugins/petri_audit/__init__.py
@@ -53,7 +53,7 @@ except ImportError:
 
 # PR #6 (2026-05-14) — register the ``openai-codex`` ModelAPI alongside
 # ``geode``. ``OpenAICodexAPI`` routes ``openai-codex/<model>`` ids
-# through the ChatGPT Plus OAuth path so judge / auditor calls consume
+# through the ChatGPT subscription OAuth path so judge / auditor calls consume
 # the user's subscription quota instead of per-token billing. Same
 # try/except guard so the default ``uv sync`` (no [audit] extra) is
 # unaffected.

--- a/plugins/petri_audit/adapters/openai_codex_oauth.py
+++ b/plugins/petri_audit/adapters/openai_codex_oauth.py
@@ -1,4 +1,4 @@
-"""OpenAI Codex OAuth (ChatGPT Plus quota) adapter — manifest-bound facade.
+"""OpenAI Codex OAuth (ChatGPT subscription quota) adapter — manifest-bound facade.
 
 CSA-3 (2026-05-22) — flipped to register the paperclip-style
 :mod:`plugins.petri_audit.codex_cli_provider` (``codex-cli``

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -268,7 +268,7 @@ def audit(
         None,
         "--use-oauth/--no-oauth",
         help="Route gpt-5.x judge / auditor calls through the Codex OAuth "
-        "path (ChatGPT Plus subscription quota) instead of per-token "
+        "path (ChatGPT subscription quota) instead of per-token "
         "OpenAI PAYG billing. Default: auto-detect based on Codex token "
         "presence (~/.codex/auth.json or GEODE openai-codex profile). "
         "Use --no-oauth to force per-token billing even with a token. "

--- a/plugins/petri_audit/codex_cli_provider.py
+++ b/plugins/petri_audit/codex_cli_provider.py
@@ -501,7 +501,7 @@ def register() -> None:
             prompt = serialise_messages_to_prompt(input)
             # PR-LQ-Phase3 (2026-05-22) — share the
             # codex-cli-subagent lane with the self-improving-loop
-            # mutator path so the host ChatGPT-Plus OAuth bucket
+            # mutator path so the host ChatGPT subscription OAuth bucket
             # sees at most ``DEFAULT_CODEX_CLI_LANE_MAX`` (=2)
             # concurrent ``codex exec`` subprocesses. Parity with the
             # Claude-side wiring in ``ClaudeCliAPI.generate``.

--- a/plugins/petri_audit/codex_provider.py
+++ b/plugins/petri_audit/codex_provider.py
@@ -1,4 +1,4 @@
-"""inspect_ai ModelAPI for OpenAI Codex (ChatGPT Plus OAuth subscription).
+"""inspect_ai ModelAPI for OpenAI Codex (ChatGPT subscription).
 
 # OAuth 제약 + 검증 일정 (2026-05-14)
 #
@@ -16,7 +16,7 @@
 Bridges ``inspect_ai`` (and therefore inspect-petri's judge / auditor)
 into the Codex OAuth path that already lives in
 ``core/llm/providers/codex.py`` so judge calls consume the user's
-ChatGPT Plus subscription quota instead of per-token billing.
+ChatGPT subscription quota instead of per-token billing.
 
 Registered as ``@modelapi(name="openai-codex")`` from
 ``plugins/petri_audit/__init__.py`` (under the same try/except guard
@@ -35,11 +35,11 @@ grounded in ``docs/research/codex-oauth-request-spec.md``):
 - ``client.responses.create(**)`` (non-streaming) → ``responses.stream``
   required by chatgpt.com/backend-api/codex.
 - ``max_output_tokens`` parameter → 400 ``Unsupported parameter`` on
-  the Plus backend. Must be stripped.
+  the subscription backend. Must be stripped.
 - System prompt in ``input`` list as ``role:developer`` → Codex backend
   expects ``instructions=<system>`` field. Hermes / Codex Rust both
   shift system out of input.
-- ``response.completed`` event from the Plus backend omits the
+- ``response.completed`` event from the subscription backend omits the
   ``output`` field, so ``stream.get_final_response().output == []``
   even when output items were emitted. Must accumulate
   ``response.output_item.done`` events (codex.py:331-344 pattern).
@@ -161,9 +161,9 @@ def register() -> None:
           ``OPENAI_API_KEY`` env probe is short-circuited because we
           pre-populate ``kwargs["api_key"]``.
         - ``responses_api`` is forced ``True`` — Chat Completions is
-          unsupported on the Plus backend.
+          unsupported on the subscription backend.
         - ``responses_store`` is forced ``False`` — server-side state
-          is rejected by the Plus backend.
+          is rejected by the subscription backend.
         - ``generate()`` is overridden to use streaming, strip
           ``max_output_tokens``, move system into ``instructions=``,
           and apply the codex-rs output-item accumulator workaround.
@@ -182,7 +182,7 @@ def register() -> None:
             token = kwargs.get("api_key") or _resolve_codex_token()
             if not token:
                 raise environment_prerequisite_error(
-                    "OpenAI Codex (ChatGPT Plus)",
+                    "OpenAI Codex (ChatGPT subscription)",
                     [
                         "~/.codex/auth.json (Codex CLI login)",
                         "openai-codex profile in GEODE ProfileStore",
@@ -232,7 +232,7 @@ def register() -> None:
 
             Stock ``OpenAIAPI.count_tokens`` hits
             ``client.responses.input_tokens.count`` when ``responses_api=True``,
-            but the ChatGPT Plus backend returns
+            but the ChatGPT subscription backend returns
             ``PermissionDeniedError`` on that endpoint. tiktoken handles
             local counting for gpt-5.x and avoids the round-trip, which
             also keeps subscription quota free for actual generations.
@@ -351,7 +351,7 @@ def register() -> None:
                 extra_headers={"X-Inspect-Request-Id": request_id} | (config.extra_headers or {}),
                 **params,
             )
-            # ChatGPT Plus backend's /responses endpoint rejects requests
+            # ChatGPT subscription backend's /responses endpoint rejects requests
             # missing the ``instructions`` field with
             # ``BadRequestError: 'Instructions are required'``. Stock OpenAI
             # API treats it as optional, but the Codex backend is strict.

--- a/plugins/petri_audit/models.py
+++ b/plugins/petri_audit/models.py
@@ -130,7 +130,7 @@ def to_inspect_model(geode_id: str, *, use_oauth: bool | None = None) -> str:
     **PR #6 (2026-05-14) — OAuth routing**: ``gpt-5.*`` ids (``gpt-5.5``,
     ``gpt-5.4``, ``gpt-5.4-mini``, ``gpt-5.3-codex``) re-route to
     ``openai-codex/<model>`` so judge / auditor calls consume ChatGPT
-    Plus quota instead of per-token billing. ``use_oauth`` controls
+    subscription quota instead of per-token billing. ``use_oauth`` controls
     the auto-detect:
 
     - ``None`` (default) → auto-detect: re-route when a Codex OAuth

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -83,7 +83,7 @@ default = "auto"
 allowed = ["claude-cli", "api_key", "auto"]
 
 [petri.source.openai]
-# Same priority model as anthropic — OAuth (Codex / ChatGPT Plus quota) first.
+# Same priority model as anthropic — OAuth (Codex / ChatGPT subscription quota) first.
 default = "auto"
 allowed = ["openai-codex", "api_key", "auto"]
 

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -405,9 +405,9 @@ def estimate_cost_usd(
 
     **PR #6 (2026-05-14) — OAuth zeroing**: when ``judge_oauth`` /
     ``auditor_oauth`` is True (caller already classified the role as
-    Codex Plus OAuth-routed via ``is_oauth_routed``), the per-token
+    Codex subscription OAuth-routed via ``is_oauth_routed``), the per-token
     contribution for that role is set to zero. Subscription quota is
-    not billed per token; the only cost is the user's monthly Plus
+    not billed per token; the only cost is the user's monthly subscription
     fee, which is out of band for this estimator.
     """
 

--- a/plugins/seed_generation/picker.py
+++ b/plugins/seed_generation/picker.py
@@ -28,7 +28,7 @@ ToS notice
 ==========
 
 Subscription-backed OAuth paths (``claude-cli``, ``openai-codex``) drive
-LLM calls through the user's Claude.ai / ChatGPT Plus quota. Anthropic
+LLM calls through the user's Claude.ai / ChatGPT subscription quota. Anthropic
 and OpenAI's Terms of Service permit individual programmatic use but
 discourage automation at scale, so the picker surfaces a one-time
 warning when any role resolves to a subscription path. The notice is
@@ -599,7 +599,7 @@ def print_tos_notice(
         "\n"
         "─── seed-generation ToS notice ─────────────────────────────────────\n"
         f"Subscription-backed auth path(s) in use: {paths_in_use}\n"
-        "These paths charge the run against your Claude.ai / ChatGPT Plus\n"
+        "These paths charge the run against your Claude.ai / ChatGPT subscription\n"
         "quota. The vendors' Terms of Service permit individual programmatic\n"
         "use but discourage automation at scale; review the linked policies\n"
         "before running unattended.\n"

--- a/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
+++ b/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
@@ -62,9 +62,31 @@ def test_codex_kwargs_gpt5_omits_temperature_adds_reasoning() -> None:
     assert kwargs["include"] == ["reasoning.encrypted_content"]
 
 
-def test_codex_kwargs_non_gpt5_keeps_temperature() -> None:
-    """Non-gpt-5 models (e.g. o3) keep the temperature path."""
+def test_codex_kwargs_o_series_also_omits_temperature() -> None:
+    """PR-DRIFT-CUT (2026-05-24) — registry-driven reasoning detection.
+
+    Pre-PR the codex branch keyed on ``startswith("gpt-5")``, so o3 /
+    o4-mini fell into the "keep temperature" path. The registry now
+    treats every model with a ``reasoning_effort_values`` tuple as a
+    reasoning model — o3 and o4-mini included — so they correctly
+    omit ``temperature`` and add the ``reasoning`` block. Verified
+    2026-05-24 against OpenAI reasoning-models guide.
+    """
     kwargs = _build_codex_call_kwargs(_req(model="o3", temperature=0.3))
+    assert "temperature" not in kwargs
+    assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
+
+
+def test_codex_kwargs_legacy_model_keeps_temperature() -> None:
+    """Models NOT in the registry fall back to legacy gpt-4.x defaults.
+
+    Those defaults accept temperature, so the legacy branch is still
+    exercised — we just no longer reach it via prefix-heuristic. An
+    unknown model id (e.g. ``gpt-4o`` until it's registered) keeps
+    the temperature path.
+    """
+    kwargs = _build_codex_call_kwargs(_req(model="gpt-4o-legacy", temperature=0.3))
     assert kwargs["temperature"] == 0.3
     assert "reasoning" not in kwargs
 

--- a/tests/test_drift_fallback_cut.py
+++ b/tests/test_drift_fallback_cut.py
@@ -1,0 +1,231 @@
+"""Tests for PR-DRIFT-CUT (2026-05-24).
+
+Covers the five surfaces hardened in the v0.99.52 post-merge smoke
+incident:
+
+  1. OpenAI per-model spec registry replaces the ``startswith`` prefix
+     check (and warns on unknown models).
+  2. ``cap_tools`` truncates the 128-cap overflow with an actionable log.
+  3. ``summarize_error_detail`` strips raw SDK exception JSON down to
+     the underlying ``error.message``.
+  4. ``_looks_like_context_overflow`` is strict — never matches a
+     ``max_tokens`` parameter error.
+  5. Drift sync + provider fallback chains are dead no-ops.
+
+These tests pin the contracts the PR introduces so a future cleanup
+cannot silently revive the deprecated paths.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. OpenAI per-model spec registry
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_get_openai_model_spec_known_gpt5_family() -> None:
+    """GPT-5.x models route to the reasoning branch (max_completion_tokens, no temperature)."""
+    from core.llm.adapters._openai_common import get_openai_model_spec
+
+    for model_id in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"):
+        spec = get_openai_model_spec(model_id)
+        assert spec.uses_max_completion_tokens is True, model_id
+        assert spec.accepts_temperature is False, model_id
+        assert spec.reasoning_effort_values is not None, model_id
+        assert "none" in spec.reasoning_effort_values, model_id
+
+
+def test_get_openai_model_spec_o_series() -> None:
+    """o3 / o4-mini are reasoning models (no 'none' effort — always reasoning)."""
+    from core.llm.adapters._openai_common import get_openai_model_spec
+
+    for model_id in ("o3", "o4-mini"):
+        spec = get_openai_model_spec(model_id)
+        assert spec.uses_max_completion_tokens is True, model_id
+        assert spec.accepts_temperature is False, model_id
+        assert spec.reasoning_effort_values is not None, model_id
+        assert "none" not in spec.reasoning_effort_values, model_id
+
+
+def test_get_openai_model_spec_unknown_model_warns_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown model id → legacy gpt-4.x fallback + one-shot WARNING."""
+    from core.llm.adapters import _openai_common
+
+    # Clear the dedup set so the test sees a fresh warning.
+    _openai_common._UNKNOWN_MODEL_WARNED.discard("gpt-future-9.9")
+
+    caplog.set_level(logging.WARNING, logger="core.llm.adapters._openai_common")
+    spec = _openai_common.get_openai_model_spec("gpt-future-9.9")
+
+    assert spec.uses_max_completion_tokens is False  # legacy default
+    assert spec.accepts_temperature is True
+    assert any(
+        "gpt-future-9.9" in rec.message and "not in" in rec.message for rec in caplog.records
+    )
+
+    # Second call must not emit a duplicate warning.
+    caplog.clear()
+    _openai_common.get_openai_model_spec("gpt-future-9.9")
+    assert all("gpt-future-9.9" not in rec.message for rec in caplog.records)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. cap_tools — 128 cap enforcement
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_cap_tools_passthrough_under_limit() -> None:
+    from core.llm.adapters._openai_common import OPENAI_TOOLS_MAX, cap_tools
+
+    tools = [{"name": f"t{i}"} for i in range(OPENAI_TOOLS_MAX)]
+    result = cap_tools(tools, model="gpt-5.5", adapter_name="openai-payg")
+    assert result is tools  # untouched when at the cap
+
+
+def test_cap_tools_truncates_over_limit(caplog: pytest.LogCaptureFixture) -> None:
+    from core.llm.adapters._openai_common import OPENAI_TOOLS_MAX, cap_tools
+
+    tools = [{"name": f"t{i}"} for i in range(OPENAI_TOOLS_MAX + 48)]
+    caplog.set_level(logging.WARNING, logger="core.llm.adapters._openai_common")
+    result = cap_tools(tools, model="gpt-5.5", adapter_name="openai-payg")
+
+    assert len(result) == OPENAI_TOOLS_MAX
+    assert result[0]["name"] == "t0"
+    assert result[-1]["name"] == f"t{OPENAI_TOOLS_MAX - 1}"
+    assert any(
+        "tools array length" in rec.message and "gpt-5.5" in rec.message for rec in caplog.records
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 3. summarize_error_detail
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_summarize_error_detail_extracts_message_field() -> None:
+    from core.llm.errors import summarize_error_detail
+
+    raw = (
+        "Error code: 400 - {'error': {'message': "
+        "\"Unsupported parameter: 'max_tokens' is not supported with this model. "
+        "Use 'max_completion_tokens' instead.\", "
+        "'type': 'invalid_request_error', 'code': 'unsupported_parameter'}}"
+    )
+    cleaned = summarize_error_detail(raw)
+
+    assert cleaned.startswith("Unsupported parameter")
+    assert "max_completion_tokens" in cleaned
+    assert "Error code:" not in cleaned
+    assert "{" not in cleaned
+
+
+def test_summarize_error_detail_handles_exception_with_body() -> None:
+    from core.llm.errors import summarize_error_detail
+
+    exc: Any = Exception("legacy stringy")
+    exc.body = {"error": {"message": "Prompt is too long: 1234567 tokens."}}
+    assert summarize_error_detail(exc) == "Prompt is too long: 1234567 tokens."
+
+
+def test_summarize_error_detail_passthrough_when_unstructured() -> None:
+    """No extraction pattern matches → return input untouched (never drop info)."""
+    from core.llm.errors import summarize_error_detail
+
+    raw = "Just a plain string with no JSON inside"
+    assert summarize_error_detail(raw) == raw
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. _looks_like_context_overflow — strict matching
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _fake_exc(message: str, code: str = "") -> Exception:
+    exc: Any = Exception("Error code: 400 - <body>")
+    exc.body = (
+        {"error": {"message": message, "code": code}} if code else {"error": {"message": message}}
+    )
+    return exc
+
+
+def test_context_overflow_matches_structured_code() -> None:
+    from core.llm.errors import _looks_like_context_overflow
+
+    assert _looks_like_context_overflow(_fake_exc("anything", code="context_length_exceeded"))
+    assert _looks_like_context_overflow(_fake_exc("anything", code="prompt_too_long"))
+
+
+def test_context_overflow_does_not_match_max_tokens_parameter_error() -> None:
+    """Regression for the v0.99.52 smoke: 'max_tokens' must not trigger overflow."""
+    from core.llm.errors import _looks_like_context_overflow
+
+    msg = (
+        "Unsupported parameter: 'max_tokens' is not supported with this model. "
+        "Use 'max_completion_tokens' instead."
+    )
+    exc = _fake_exc(msg, code="unsupported_parameter")
+    assert _looks_like_context_overflow(exc) is False
+
+
+def test_context_overflow_matches_word_anchored_phrases() -> None:
+    from core.llm.errors import _looks_like_context_overflow
+
+    for msg in (
+        "Your prompt is too long, please shorten it.",
+        "context length exceeded: 350000 tokens.",
+        "The input is too long for the context window.",
+        "Too many tokens in this request",
+    ):
+        assert _looks_like_context_overflow(_fake_exc(msg)), msg
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Drift sync + fallback chains are no-ops
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_settings_model_target_always_none() -> None:
+    """Per PR-DRIFT-CUT, the drift target is unconditionally absent."""
+    from core.agent.loop._model_switching import _settings_model_target
+
+    fake_loop = SimpleNamespace(model="gpt-5.5", _disable_settings_drift=False)
+    assert _settings_model_target(fake_loop) is None
+
+
+def test_sync_model_from_settings_async_returns_false() -> None:
+    """Ditto for the per-turn async wrapper."""
+    import asyncio
+
+    from core.agent.loop._model_switching import sync_model_from_settings_async
+
+    fake_loop = SimpleNamespace(model="gpt-5.5")
+    assert asyncio.run(sync_model_from_settings_async(fake_loop)) is False
+
+
+def test_get_fallback_chain_returns_empty_for_every_provider() -> None:
+    """Cross-provider + same-provider fallback alike is dead."""
+    from core.llm.provider_dispatch import _get_fallback_chain
+
+    for provider in ("anthropic", "openai", "glm", "openai-codex"):
+        assert _get_fallback_chain(provider) == []
+
+
+def test_provider_fallback_chain_property_is_empty() -> None:
+    """Per-provider ``fallback_chain`` property is also deprecated to []."""
+    from core.llm.providers.codex import CodexAgenticAdapter
+    from core.llm.providers.glm import GlmAgenticAdapter
+    from core.llm.providers.openai import OpenAIAgenticAdapter
+
+    for cls in (OpenAIAgenticAdapter, GlmAgenticAdapter, CodexAgenticAdapter):
+        # ``fallback_chain`` is a property — read it off a bare instance
+        # without driving full provider init.
+        instance = cls.__new__(cls)  # type: ignore[call-arg]
+        assert instance.fallback_chain == []

--- a/tests/test_model_drift_health.py
+++ b/tests/test_model_drift_health.py
@@ -1,21 +1,23 @@
-"""Bug class B3 — model drift sync must check target health.
+"""Bug class B3 — model drift sync was the silent-revert load-bearer.
 
-The v0.52.1 incident: User completed `/login openai` (Codex Plus
-registered). Same session immediately started a new prompt. Settings
-store still pointed at the old `glm-4.7-flash`. Loop started with
-`glm-5.1`, detected drift, **silently overwrote loop's choice with
-`glm-4.7-flash`** even though GLM had no quota left. Result: 5×4 retry
-storm on a model the user did not pick and which had no available
-profile.
+Historical context (kept for the post-mortem trail): the v0.52.1
+incident saw a stale ``settings.model`` overwrite a freshly registered
+``loop.model`` because the drift sync ran on every turn and trusted
+``settings.model`` over the operator's most-recent choice. The original
+fix here was a *health-check guard* (consult ``ProfileRotator.resolve``
+before allowing the drift to proceed).
 
-Invariant: ``_sync_model_from_settings_async()`` must consult
-``ProfileRotator.resolve(target_provider)`` and **refuse** the drift
-when the rotator returns None (no eligible profile for the target).
-The loop's currently-chosen model is preserved instead.
+PR-DRIFT-CUT (2026-05-24) cut the entire drift surface — the root
+cause was that drift sync existed at all in a daemon process whose
+``settings`` snapshot can never be authoritative. These tests now pin
+the no-op contract: ``_sync_model_from_settings_async()`` always
+returns ``False`` and never invokes ``update_model_async``.
 
-Pattern source: OpenClaw ``evaluate_eligibility`` + ``_LAST_VERDICTS``
-cached health view (referenced in `core/auth/rotation.py`,
-`core/auth/profiles.py:176`).
+We retain the test file (rather than delete it) because the
+regressions it prevents are still real — they will surface the day
+anyone tries to revive auto-revert under the old name. The new tests
+that pin the *positive* contract (drift sync is dead) live in
+``tests/test_drift_fallback_cut.py``.
 """
 
 from __future__ import annotations
@@ -33,23 +35,22 @@ from core.agent.loop import _model_switching
 
 
 def test_sync_calls_health_check_before_update() -> None:
-    """Source-level: the drift branch must call ``_drift_target_is_healthy``
-    before ``self.update_model`` so an unhealthy drift target cannot
-    silently overwrite the loop's choice."""
+    """PR-DRIFT-CUT (2026-05-24) — drift sync entry point is a no-op.
+
+    Pre-PR this test asserted that ``_settings_model_target`` consulted
+    ``_drift_target_is_healthy`` *before* invoking ``update_model_async``.
+    The drift surface is now cut entirely, so the test pins the
+    stronger invariant: the function source must NOT call
+    ``update_model_async`` at all (it must be a permanent no-op so a
+    future revival has to use a new entry-point name).
+    """
     src = inspect.getsource(_model_switching._settings_model_target) + inspect.getsource(
         _model_switching.sync_model_from_settings_async
     )
-    health_pos = src.find("_drift_target_is_healthy")
-    update_pos = src.find("update_model_async")
-    assert health_pos >= 0, (
-        "_sync_model_from_settings must call _drift_target_is_healthy. "
-        "Without the check the v0.51-incident regression returns: stale "
-        "settings.model overwrites loop.model when target is unhealthy."
-    )
-    assert update_pos >= 0
-    assert health_pos < update_pos, (
-        "Health check must come BEFORE update_model — otherwise we swap "
-        "the adapter and only then discover there's no profile to use."
+    assert "update_model_async" not in src, (
+        "PR-DRIFT-CUT contract: ``sync_model_from_settings_async`` must "
+        "NEVER invoke ``update_model_async``. Reviving auto-revert under "
+        "this name re-introduces the v0.99.52 incident."
     )
 
 
@@ -138,8 +139,15 @@ def test_drift_refused_when_rotator_returns_none(monkeypatch) -> None:
     stub.update_model_async.assert_not_called()
 
 
-def test_drift_accepted_when_rotator_returns_profile(monkeypatch) -> None:
-    """Same setup but rotator returns a valid profile → drift proceeds."""
+def test_drift_is_noop_even_when_rotator_returns_profile(monkeypatch) -> None:
+    """PR-DRIFT-CUT (2026-05-24) — even a healthy rotator + settings
+    divergence must NOT trigger an auto-swap.
+
+    Pre-PR this asserted that a valid profile combined with
+    ``settings.model`` divergence drove ``update_model_async``. With
+    drift sync removed, the rotator state is irrelevant — the loop
+    waits for an explicit ``/model`` from the operator.
+    """
     stub = _make_loop_stub("glm-5.1")
 
     fake_rotator = MagicMock()
@@ -152,14 +160,14 @@ def test_drift_accepted_when_rotator_returns_profile(monkeypatch) -> None:
     with patch("core.config.settings", fake_settings):
         changed = asyncio.run(stub._sync_model_from_settings_async())
 
-    assert changed is True
-    # PR-MIC (2026-05-23) — drift sync now passes ``reason="drift_sync"``.
-    stub.update_model_async.assert_awaited_once_with("glm-4.7-flash", reason="drift_sync")
+    assert changed is False
+    stub.update_model_async.assert_not_awaited()
 
 
-def test_drift_accepted_when_rotator_not_initialised(monkeypatch) -> None:
-    """Early bootstrap: rotator singleton is None. Drift must NOT be blocked
-    (would prevent legitimate model switches before bootstrap completes).
+def test_drift_is_noop_when_rotator_not_initialised(monkeypatch) -> None:
+    """Early-bootstrap state was previously the lone exception that let
+    drift sync proceed even without a rotator. Post PR-DRIFT-CUT there
+    are no exceptions — drift never proceeds.
     """
     stub = _make_loop_stub("glm-5.1")
 
@@ -170,8 +178,8 @@ def test_drift_accepted_when_rotator_not_initialised(monkeypatch) -> None:
     with patch("core.config.settings", fake_settings):
         changed = asyncio.run(stub._sync_model_from_settings_async())
 
-    assert changed is True
-    stub.update_model_async.assert_awaited_once()
+    assert changed is False
+    stub.update_model_async.assert_not_awaited()
 
 
 def test_drift_no_op_when_models_match(monkeypatch) -> None:

--- a/tests/test_model_split.py
+++ b/tests/test_model_split.py
@@ -462,9 +462,16 @@ def test_verify_turn_async_off_mode_returns_pass(
 
 
 def test_drift_target_uses_act_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The model-drift sync targets ``settings.act_model`` (not
-    ``settings.model``) so an Opus-primary + Sonnet-act split doesn't
-    revert mid-session."""
+    """PR-DRIFT-CUT (2026-05-24) — drift target is unconditionally None.
+
+    Pre-PR this returned ``settings.act_model`` (or ``settings.model``)
+    so the per-turn drift sync would revert ``loop.model`` to the
+    settings value. The auto-revert silently overrode operator
+    ``/model`` selections and was cut at the source. The test now
+    pins the no-op contract — the function must NEVER return a
+    drift target, regardless of how settings diverge from
+    ``loop.model``.
+    """
     from core.agent.loop._model_switching import _settings_model_target
 
     fake_settings = SimpleNamespace(model="claude-opus-4-7", act_model="claude-sonnet-4-6")
@@ -476,14 +483,13 @@ def test_drift_target_uses_act_model(monkeypatch: pytest.MonkeyPatch) -> None:
         _drift_target_is_healthy=lambda _m: True,
     )
     target = _settings_model_target(loop_stub)
-    assert target == "claude-sonnet-4-6"  # act_model wins over model
+    assert target is None  # PR-DRIFT-CUT — auto-revert disabled
 
 
-def test_drift_target_falls_back_to_primary_model(
+def test_drift_target_is_none_regardless_of_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Empty ``act_model`` → drift target is ``settings.model`` (pre-A6
-    behaviour preserved)."""
+    """Companion to the above — empty ``act_model`` also gets no target."""
     from core.agent.loop._model_switching import _settings_model_target
 
     fake_settings = SimpleNamespace(model="claude-opus-4-7", act_model="")
@@ -495,7 +501,7 @@ def test_drift_target_falls_back_to_primary_model(
         _drift_target_is_healthy=lambda _m: True,
     )
     target = _settings_model_target(loop_stub)
-    assert target == "claude-opus-4-7"
+    assert target is None
 
 
 def test_drift_target_no_drift_when_already_matched(

--- a/tests/test_model_switch_guard.py
+++ b/tests/test_model_switch_guard.py
@@ -204,8 +204,18 @@ class TestUpdateModelIntegration:
             asyncio.run(loop.update_model_async("glm-5", "zhipuai"))
         # No crash
 
-    def test_sync_model_from_settings_detects_drift(self):
-        """_sync_model_from_settings picks up settings.model change."""
+    def test_sync_model_from_settings_no_longer_detects_drift(self):
+        """PR-DRIFT-CUT (2026-05-24) — drift sync is a permanent no-op.
+
+        Pre-PR this asserted that updating ``settings.model`` made
+        ``_sync_model_from_settings_async`` swap ``loop.model``. That
+        auto-revert behaviour silently overrode operator ``/model``
+        selections (the CLI process updates settings on disk; the
+        daemon's in-memory copy stays stale; the next round's drift
+        sync "synced" the loop back to the stale value). Drift is
+        cut at the source — ``loop.model`` must persist regardless
+        of how ``settings.model`` changes.
+        """
         ctx = ConversationContext()
         loop = _make_loop(ctx, model="claude-opus-4-6")
         assert loop.model == "claude-opus-4-6"
@@ -217,7 +227,7 @@ class TestUpdateModelIntegration:
             settings.model = "glm-5"
             with patch("core.ui.agentic_ui.update_session_model"):
                 asyncio.run(loop._sync_model_from_settings_async())
-            assert loop.model == "glm-5"
+            assert loop.model == "claude-opus-4-6"  # PR-DRIFT-CUT: no auto-swap
         finally:
             settings.model = old
 

--- a/tests/test_provider_switching.py
+++ b/tests/test_provider_switching.py
@@ -443,14 +443,17 @@ def test_update_model_swaps_adapter_on_provider_change(
     assert stub._tool_processor._model == "claude-opus-4-7"
 
 
-def test_drift_sync_emits_drift_sync_reason(isolated_auth, monkeypatch: pytest.MonkeyPatch) -> None:
-    """PR-MIC (2026-05-23) — ``sync_model_from_settings_async`` must
-    label the switch as ``reason="drift_sync"``. Pre-fix, the helper
-    omitted the kwarg so ``update_model_async``'s default
-    ``"user_switch"`` reached the MODEL_SWITCHED hook + UI, making
-    automatic settings drift look like an operator action.
-    Reproduces the 2026-05-23 production incident
-    (``gpt-5.5 → claude-opus-4-6 (user_switch)`` REPL header).
+def test_drift_sync_is_a_no_op_after_drift_cut(
+    isolated_auth, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-DRIFT-CUT (2026-05-24) — ``sync_model_from_settings_async``
+    no longer rewrites ``loop.model``. Pre-PR the helper compared
+    ``loop.model`` against ``settings.model`` and called
+    ``update_model_async`` to swap back, which silently reverted the
+    operator's most-recent ``/model`` choice (the CLI process writes
+    settings to disk while the daemon's in-memory copy stays stale).
+    The function is now a permanent no-op — operators must invoke
+    ``/model`` themselves.
     """
     from unittest.mock import AsyncMock, MagicMock
 
@@ -466,16 +469,12 @@ def test_drift_sync_emits_drift_sync_reason(isolated_auth, monkeypatch: pytest.M
     original_model = settings.model
     object.__setattr__(settings, "model", "claude-opus-4-6")
     try:
-        asyncio.run(_ms.sync_model_from_settings_async(stub))
+        result = asyncio.run(_ms.sync_model_from_settings_async(stub))
     finally:
         object.__setattr__(settings, "model", original_model)
 
-    stub.update_model_async.assert_awaited_once()
-    _args, kwargs = stub.update_model_async.await_args
-    assert kwargs.get("reason") == "drift_sync", (
-        "drift sync path must surface a distinct reason — UI mis-labels "
-        "as 'user_switch' otherwise (regression of 2026-05-23 incident)."
-    )
+    assert result is False, "drift sync must be a permanent no-op"
+    stub.update_model_async.assert_not_awaited()
 
 
 def test_update_model_marks_prompt_dirty_so_escalation_rebuilds(


### PR DESCRIPTION
## Summary

- **Drift sync + provider fallback chains 영구 제거** — 사용자의 ``/model`` 선택이 절대 자동 원복되지 않고, 한 provider의 실패가 다른 provider로 silent cascade되지 않음.
- **OpenAI/Codex/GLM 어댑터의 per-model spec를 explicit registry로 grounding** — ``startswith("gpt-5")`` prefix 휴리스틱 제거. ``_OPENAI_MODELS``가 모델별 ``max_completion_tokens`` / ``temperature`` / ``reasoning_effort`` / ``tools cap``의 단일 소스.
- **Raw SDK 에러가 사용자 transcript에 leak하지 않음** — ``summarize_error_detail``이 ``"Error code: 400 - {...}"``를 underlying ``error.message``로 사전 정리.

## Why

v0.99.52 머지 직후 smoke에서 *한 turn에 5개 결함이 cascade*:

| # | 결함 | 결과 |
|---|------|------|
| R1 | 176 tools > gpt-5.5 128 cap | 400 ``array_above_max_length`` |
| R2 | drift sync가 ``/model gpt-5.5`` 첫 turn에 ``claude-opus-4-7``로 원복 | 사용자 의도 무시 |
| R3 | adapter 선택이 OAuth 무시 (openai-payg로 라우팅) | 0 quota 사용 |
| R4 | openai_payg가 gpt-5.x에 ``max_tokens`` 전송 | 400 ``Unsupported parameter`` |
| R5 | error classifier가 R4를 ``context_overflow``로 오분류 | 잘못된 recovery |

cascade가 결국 z.ai 200 OK를 받았지만 UI는 "Context window exhausted"를 노출. 본 PR은 R1+R2+R4+R5와 raw 메시지 leak를 일괄 해소. R3 (adapter source flip)은 follow-up.

## Changes

| File | Change |
|------|--------|
| ``core/llm/adapters/_openai_common.py`` | ``OPENAI_TOOLS_MAX`` / ``OpenAIModelSpec`` / ``_OPENAI_MODELS`` registry / ``get_openai_model_spec`` / ``cap_tools`` 신규 |
| ``core/llm/adapters/openai_payg.py`` | ``_build_kwargs``가 registry로 ``max_completion_tokens`` / ``temperature`` 분기 + ``cap_tools`` 적용 |
| ``core/llm/adapters/codex_oauth.py`` | ``startswith("gpt-5")`` → registry-based; ``cap_tools`` 적용 |
| ``core/llm/adapters/glm_payg.py`` / ``glm_coding_plan.py`` | ``cap_tools`` 적용 (defensive 128) |
| ``core/llm/providers/codex.py`` | ``_is_codex_reasoning_model``이 registry 기반 |
| ``core/llm/providers/{openai,codex,glm}.py`` | ``fallback_chain`` property → ``[]`` (deprecated) |
| ``core/llm/provider_dispatch.py`` | ``_get_fallback_chain`` → ``[]`` (deprecated) |
| ``core/llm/errors.py`` | ``_looks_like_context_overflow`` 신규 (strict code+regex), ``summarize_error_detail`` 신규 |
| ``core/agent/loop/_model_switching.py`` | ``_settings_model_target`` / ``sync_model_from_settings_async`` → no-op (deprecated) |
| ``core/agent/loop/agent_loop.py`` | bad_request branch가 ``_build_model_action_result`` 경유 (raw f-string 제거); ``_build_model_action_result``가 ``summarize_error_detail`` 사용 |
| ``core/cli/onboarding.py`` / ``core/cli/commands/login.py`` | Subscription 메뉴에 ChatGPT Plus/Pro/Business/Enterprise + Claude Pro/Max ×5/Max ×20/Team 명시 |
| 25+ files | "ChatGPT Plus" / "Plus quota" / "Plus subscription" → "ChatGPT subscription" / "subscription quota" / "subscription" |
| ``tests/test_drift_fallback_cut.py`` | 신규 15 케이스 (registry + cap + classifier + sanitiser + no-op contracts) |
| ``tests/test_model_drift_health.py`` etc | 기존 drift 테스트 4건 → no-op contract assertion으로 재작성 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| F1 max_completion_tokens swap | Implemented | gpt-5.x + o-series registry-driven |
| F2 tools 128 cap | Implemented | openai_payg + codex_oauth + glm_payg + glm_coding_plan |
| F3 classifier word-boundary | Implemented | code-first + tight regex |
| F4 GLM/codex_oauth tools cap | Implemented | same shared helper |
| F5 temperature/reasoning_effort spec | Implemented | per-model registry |
| R2 drift sync | Removed (deprecated no-op) | function kept for grep traceability |
| R3 fallback chain | Removed (deprecated → ``[]``) | dispatch + per-provider both |
| Raw msg sanitiser | Implemented | ``summarize_error_detail`` |
| Plus → Subscription | Implemented | 30+ spots |
| R3 (adapter source flip) | Deferred | needs separate PR; ``loop._source`` 책임 분리 |

## Verification

- [x] ``ruff check`` clean (변경 파일 17개)
- [x] ``ruff format --check`` clean (post-format)
- [x] ``mypy`` clean (변경 파일 12개)
- [x] ``lint-imports`` 4/4 contracts kept
- [x] ``pytest`` 1428 passed / 0 failed (sweep: adapter|model|drift|fallback|classify|openai|codex|glm|agentic|context_overflow)
- [x] 기존 drift 테스트 4건 → 새 no-op contract로 재작성 + 회귀 트레일 유지
- [ ] CLI smoke (post-merge: ``/model gpt-5.5`` + ``/login openai`` + 단일 turn — 별 세션에서 실측)

## Reference

- Trigger: v0.99.52 post-merge smoke (2026-05-24)
- Grounding sources (full URL list in CHANGELOG):
  - OpenAI gpt-5.5 docs · LiteLLM #13381 · claude-code-router #686 · OpenAI reasoning guide · Anthropic Messages spec · Z.AI GLM-4.6 · OpenAI Codex auth