### PR TITLE
PR-R6 — Hermes-style fresh-read at session boundary로 CLI ↔ daemon settings.model drift 종결

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed (PR-R6, 2026-05-24)
+
+- **CLI ↔ daemon `settings.model` drift closed via Hermes-style boundary
+  read.** PR-DRIFT-CUT removed the per-turn auto-revert (drift sync) that
+  was silently re-syncing daemon's stale ``settings.model`` to disk, which
+  surfaced a latent gap: the CLI process writes ``GEODE_MODEL`` to ``.env``
+  and ``primary_model`` to ``config.toml`` via ``_apply_model``, but the
+  daemon's pydantic ``Settings`` singleton kept its boot-time snapshot —
+  so ``/model gpt-5.5`` was ignored at the next session start (the
+  v0.99.52 smoke regression). New helper
+  ``core.config.reload_settings_from_disk()`` mutates the live singleton
+  in place from ``.env`` + ``config.toml`` + ``GEODE_*`` env vars (Hermes
+  pattern: "fresh read at session boundary"), and
+  ``services.create_session`` calls it before reading ``settings.model``
+  to construct the next ``AgenticLoop``. Idempotent + cheap; no
+  file-watcher dependency (chokidar/inotify deliberately avoided — the
+  watcher race conditions don't compose with GEODE's multi-trigger
+  autonomous paths). Pinned by ``tests/test_settings_reload_from_disk.py``
+  (4 cases — singleton identity preserved, env-var pickup, idempotent,
+  fresh-process safe) + updated ``test_model_switch_propagates_across_sessions``
+  to flip ``GEODE_MODEL`` (the disk surface ``_apply_model`` actually
+  writes) instead of mutating ``settings.model`` directly.
+
 ### Added
 - **PR-COMM-4** — transcript `seq` column + liveness watchdog API on
   `SessionTranscript` and `RunTranscript`. Two coupled observability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,22 @@ functional change.
   file-watcher dependency (chokidar/inotify deliberately avoided — the
   watcher race conditions don't compose with GEODE's multi-trigger
   autonomous paths). Pinned by ``tests/test_settings_reload_from_disk.py``
-  (4 cases — singleton identity preserved, env-var pickup, idempotent,
-  fresh-process safe) + updated ``test_model_switch_propagates_across_sessions``
-  to flip ``GEODE_MODEL`` (the disk surface ``_apply_model`` actually
-  writes) instead of mutating ``settings.model`` directly.
+  (5 cases — singleton identity preserved, env-var pickup, idempotent,
+  fresh-process safe, **effort bridge end-to-end**) + updated
+  ``test_model_switch_propagates_across_sessions`` to flip
+  ``GEODE_MODEL`` (the disk surface ``_apply_model`` actually writes)
+  instead of mutating ``settings.model`` directly.
+
+- **Operator's effort choice now reaches the live ``AgenticLoop``.**
+  ``services.create_session`` was passing ``model=settings.model`` but
+  not ``effort=settings.agentic_effort`` — the loop's
+  ``effort: str = "high"`` constructor default won by omission, so the
+  ``/model`` picker's effort axis was effectively a no-op on the main
+  REPL/IPC path (sub-agents already read ``settings.agentic_effort``
+  directly via ``core/agent/sub_agent.py:533``). R6 reload now correctly
+  picks up the operator's choice into ``settings.agentic_effort``, and
+  the new constructor arg bridges it into ``loop._effort`` so the next
+  session honors low/medium/high/xhigh end-to-end.
 
 ### Added
 - **PR-COMM-4** — transcript `seq` column + liveness watchdog API on

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -198,6 +198,45 @@ def _get_settings() -> Settings:
         return _settings_instance
 
 
+def reload_settings_from_disk() -> None:
+    """Re-read ``.env`` + ``config.toml`` + ``GEODE_*`` env vars into the live
+    settings singleton.
+
+    **Hermes-style "fresh read at session boundary" fix** for the post-PR-DRIFT-CUT
+    incident where CLI and daemon processes diverged on ``settings.model``:
+    the CLI process updated disk via ``_apply_model`` after the daemon's
+    pydantic Settings had cached its boot-time snapshot, and PR-DRIFT-CUT
+    removed the per-turn auto-revert (drift sync) that had been silently
+    re-syncing them. Re-reading at session start brings the daemon back in
+    sync with disk without re-introducing the auto-revert footgun.
+
+    Why mutate in place instead of replacing the singleton: every module that
+    holds a captured reference (``from core.config import settings`` returns
+    the current singleton at the moment of import) keeps observing the new
+    values. Replacing the binding would leave stale references unfixed.
+
+    Idempotent — calling on a fresh process is a no-op (the new Settings()
+    just re-reads the same disk). Cheap: ~ms-scale (pydantic_settings re-init
+    + TOML re-parse).
+    """
+    import contextlib
+
+    from core.config._settings import Settings as _Settings
+
+    current = _get_settings()
+    fresh = _Settings()  # re-reads .env + GEODE_* env vars
+    # Pydantic V2.11 deprecated instance-level ``.model_fields`` access; read
+    # the field map off the class. Both branches of the assignment / setattr
+    # below are isolated with ``contextlib.suppress`` because a pydantic
+    # validator may refuse certain reassignments (e.g. computed fields) and
+    # we'd rather keep the existing value than crash the session start.
+    for field_name in type(fresh).model_fields:
+        with contextlib.suppress(Exception):
+            new_value = getattr(fresh, field_name)
+            object.__setattr__(current, field_name, new_value)
+    _apply_toml_overlay(current)
+
+
 def __getattr__(name: str) -> Any:
     """PEP 562 lazy attribute access for ``settings`` and ``Settings``.
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -235,6 +235,11 @@ def reload_settings_from_disk() -> None:
             new_value = getattr(fresh, field_name)
             object.__setattr__(current, field_name, new_value)
     _apply_toml_overlay(current)
+    log.info(
+        "reload_settings_from_disk applied: model=%r (pid=%d)",
+        getattr(current, "model", "?"),
+        os.getpid(),
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -184,7 +184,20 @@ class SharedServices:
         # mutations propagate to every new AgenticLoop. Previously the
         # boot-time `self._model` was used and `/model gpt-5.5` was
         # silently ignored by every subsequent session.
-        from core.config import _resolve_provider, settings
+        #
+        # PR-R6 (2026-05-24) — "fresh per session" was reading the daemon's
+        # *in-memory* ``settings.model``, which itself goes stale because
+        # ``_apply_model`` writes to disk + the CLI process's settings,
+        # but never touched the daemon's pydantic singleton. PR-DRIFT-CUT
+        # removed the auto-revert drift sync that silently masked the gap,
+        # surfacing the bug: ``/model gpt-5.5`` was ignored at the next
+        # session start because daemon.settings.model was still its
+        # boot-time value. ``reload_settings_from_disk()`` mutates the
+        # singleton in place from ``.env`` + ``config.toml`` so the read
+        # below sees what disk actually says. Hermes-style boundary read.
+        from core.config import _resolve_provider, reload_settings_from_disk, settings
+
+        reload_settings_from_disk()
 
         loop = AgenticLoop(
             conversation,

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -199,6 +199,15 @@ class SharedServices:
 
         reload_settings_from_disk()
 
+        # PR-R6 (2026-05-24) — operator's effort choice from ``/model``
+        # picker (writes ``GEODE_AGENTIC_EFFORT`` + ``[agentic].effort``)
+        # was caught by ``reload_settings_from_disk`` above but never
+        # crossed the AgenticLoop boundary — the loop's
+        # ``effort: str = "high"`` constructor default won by omission.
+        # Bridging here closes the gap so the model + effort axes both
+        # honor Hermes-style boundary read end-to-end (sub-agents already
+        # do via ``sub_agent.py:533``'s direct ``settings.agentic_effort``
+        # read).
         loop = AgenticLoop(
             conversation,
             executor,
@@ -207,6 +216,7 @@ class SharedServices:
             cost_budget=self._cost_budget,
             model=settings.model,
             provider=_resolve_provider(settings.model),
+            effort=settings.agentic_effort,
             mcp_manager=self.mcp_manager,
             skill_registry=self.skill_registry,
             hooks=self.hook_system,

--- a/tests/test_settings_reload_from_disk.py
+++ b/tests/test_settings_reload_from_disk.py
@@ -96,3 +96,29 @@ def test_reload_handles_fresh_process_call() -> None:
     reload_settings_from_disk()
     # Field access proves the singleton is valid after the call.
     assert isinstance(settings.model, str)
+
+
+def test_create_session_bridges_effort_to_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-R6 — operator's effort choice must reach the live ``AgenticLoop``.
+
+    Pre-PR ``services.create_session`` constructed ``AgenticLoop(...)`` with
+    only ``model=`` from settings — the ``effort`` axis fell through to the
+    constructor's ``"high"`` default regardless of operator selection. The
+    ``/model`` picker writes ``GEODE_AGENTIC_EFFORT`` to disk + mutates
+    ``settings.agentic_effort``, ``reload_settings_from_disk`` correctly
+    picks it back up on the next session, but the missing constructor arg
+    meant the loop never observed the change. This test pins both ends of
+    the wire: ``settings.agentic_effort`` change → ``loop._effort`` reflects.
+    """
+    from core.server.supervised.services import SessionMode, build_shared_services
+
+    services = build_shared_services()
+    monkeypatch.setenv("GEODE_AGENTIC_EFFORT", "low")
+    _, loop_low = services.create_session(SessionMode.DAEMON)
+    assert loop_low._effort == "low"
+
+    monkeypatch.setenv("GEODE_AGENTIC_EFFORT", "high")
+    _, loop_high = services.create_session(SessionMode.DAEMON)
+    assert loop_high._effort == "high"
+    # Prior loop preserved its captured value (no auto-revert side effect).
+    assert loop_low._effort == "low"

--- a/tests/test_settings_reload_from_disk.py
+++ b/tests/test_settings_reload_from_disk.py
@@ -1,0 +1,98 @@
+"""Tests for PR-R6 — Hermes-style fresh read at session boundary.
+
+The v0.99.52 post-merge smoke surfaced a CLI ↔ daemon model-state drift:
+``_apply_model`` in the CLI process writes ``GEODE_MODEL`` to ``.env`` and
+``primary_model`` to ``config.toml``, but the daemon's pydantic ``Settings``
+singleton keeps its boot-time snapshot — PR-DRIFT-CUT removed the per-turn
+auto-revert that had been silently masking the gap. ``reload_settings_from_disk``
+gives ``services.py`` an explicit Hermes-style boundary read.
+
+These tests pin three contracts:
+  1. The function mutates the live singleton in place (identity preserved).
+  2. Fresh disk values overlay the stale in-memory snapshot.
+  3. Idempotent — repeated calls are safe (no exceptions, settled state).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip ``GEODE_*`` env vars so each test has a clean slate."""
+    for key in list(os.environ):
+        if key.startswith("GEODE_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_singleton_identity_preserved_across_reload() -> None:
+    """``from core.config import settings`` references must keep working
+    after a reload. Replacing the singleton would leave every captured
+    reference stale; mutating in place keeps callers in sync.
+    """
+    from core.config import reload_settings_from_disk, settings
+
+    pre = settings
+    reload_settings_from_disk()
+    post_from_module = __import__("core.config", fromlist=["settings"]).settings
+    assert pre is post_from_module, (
+        "reload_settings_from_disk replaced the singleton; existing references "
+        "would now be stale. Must mutate in place."
+    )
+
+
+def test_reload_picks_up_env_var_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point of R6 — when ``GEODE_MODEL`` changes between two
+    reads of ``settings.model``, the second read must see the new value.
+
+    Pre-PR the CLI would write ``GEODE_MODEL=gpt-5.5`` to ``.env`` + invoke
+    ``_apply_model`` (which only mutates the CLI process's Settings), and
+    the daemon's session-start ``settings.model`` would still resolve to its
+    boot-time value. ``reload_settings_from_disk`` closes that gap by
+    re-running pydantic's env/`.env` resolution on the live singleton.
+    """
+    from core.config import reload_settings_from_disk, settings
+
+    monkeypatch.setenv("GEODE_MODEL", "gpt-5.5")
+    reload_settings_from_disk()
+    assert settings.model == "gpt-5.5"
+
+    monkeypatch.setenv("GEODE_MODEL", "claude-sonnet-4-6")
+    reload_settings_from_disk()
+    assert settings.model == "claude-sonnet-4-6"
+
+
+def test_reload_is_idempotent_on_unchanged_disk() -> None:
+    """Calling twice in a row with no disk change must leave settings
+    untouched. Catches accidental side effects (e.g. resetting fields to
+    defaults, double-applying TOML overlay).
+    """
+    from core.config import reload_settings_from_disk, settings
+
+    reload_settings_from_disk()
+    snapshot = {
+        "model": settings.model,
+        "act_model": getattr(settings, "act_model", ""),
+        "ensemble_mode": getattr(settings, "ensemble_mode", ""),
+    }
+    reload_settings_from_disk()
+    assert settings.model == snapshot["model"]
+    assert getattr(settings, "act_model", "") == snapshot["act_model"]
+    assert getattr(settings, "ensemble_mode", "") == snapshot["ensemble_mode"]
+
+
+def test_reload_handles_fresh_process_call() -> None:
+    """First call in a fresh process must initialise the singleton via
+    ``_get_settings`` (not crash on ``None``). The singleton is then
+    in-place-mutated rather than instantiated twice.
+    """
+    from core.config import reload_settings_from_disk, settings
+
+    # The fixture stripped GEODE_*; the singleton may or may not exist yet
+    # depending on test ordering. The call must succeed either way.
+    reload_settings_from_disk()
+    # Field access proves the singleton is valid after the call.
+    assert isinstance(settings.model, str)

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -167,9 +167,7 @@ class TestBuildSharedServices:
         _, loop = services.create_session(SessionMode.DAEMON)
         assert loop.model == settings.model
 
-    def test_model_switch_propagates_across_sessions(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_model_switch_propagates_across_sessions(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """v0.82.0 + PR-R6 staleness regression — disk-side ``GEODE_MODEL``
         mutation must reach the next session.
 

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -167,33 +167,41 @@ class TestBuildSharedServices:
         _, loop = services.create_session(SessionMode.DAEMON)
         assert loop.model == settings.model
 
-    def test_model_switch_propagates_across_sessions(self) -> None:
-        """v0.82.0 staleness regression — mid-flight `settings.model`
+    def test_model_switch_propagates_across_sessions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v0.82.0 + PR-R6 staleness regression — disk-side ``GEODE_MODEL``
         mutation must reach the next session.
 
         Initial single-session check (``test_model_resolved_per_session``)
-        only proves boot-time consistency. The original v0.82.0 bug
-        survived that check because the cached ``_model`` field happened
-        to match ``settings.model`` at boot — divergence only emerged
-        after ``cmd_model`` mutated ``settings.model`` mid-flight. This
-        test reproduces that scenario without invoking the LLM.
+        only proves boot-time consistency. The v0.82.0 bug survived that
+        check because the cached ``_model`` field happened to match
+        ``settings.model`` at boot — divergence only emerged after
+        ``cmd_model`` mutated state mid-flight.
+
+        PR-R6 (2026-05-24) — rewritten to mutate ``GEODE_MODEL`` (the disk
+        surface ``_apply_model`` actually writes) rather than an in-process
+        ``settings.model`` attribute. The previous test mutated the
+        in-process attribute directly, which silently reverts now that
+        ``services.create_session`` calls
+        ``reload_settings_from_disk()`` first (the env-var mutation is the
+        whole point — that's how operator ``/model`` reaches the daemon).
         """
-        from core.config import ANTHROPIC_PRIMARY, OPENAI_PRIMARY, settings
+        from core.config import ANTHROPIC_PRIMARY, OPENAI_PRIMARY
         from core.server.supervised.services import SessionMode
 
         services = build_shared_services()
-        original = settings.model
-        try:
-            settings.model = ANTHROPIC_PRIMARY
-            _, loop_a = services.create_session(SessionMode.DAEMON)
-            assert loop_a.model == ANTHROPIC_PRIMARY
+        monkeypatch.setenv("GEODE_MODEL", ANTHROPIC_PRIMARY)
+        _, loop_a = services.create_session(SessionMode.DAEMON)
+        assert loop_a.model == ANTHROPIC_PRIMARY
 
-            settings.model = OPENAI_PRIMARY
-            _, loop_b = services.create_session(SessionMode.DAEMON)
-            assert loop_b.model == OPENAI_PRIMARY
-            assert loop_a.model == ANTHROPIC_PRIMARY
-        finally:
-            settings.model = original
+        monkeypatch.setenv("GEODE_MODEL", OPENAI_PRIMARY)
+        _, loop_b = services.create_session(SessionMode.DAEMON)
+        assert loop_b.model == OPENAI_PRIMARY
+        # ``loop_a`` is a separate AgenticLoop instance constructed before
+        # the env flip — its captured ``model`` field stays at the value
+        # it was built with (no auto-revert).
+        assert loop_a.model == ANTHROPIC_PRIMARY
 
     def test_no_agentic_ref_attribute(self) -> None:
         """SharedServices should not have agentic_ref (removed in system-hardening)."""


### PR DESCRIPTION
## Summary

- **`reload_settings_from_disk()` 신규** — daemon 측 `settings` singleton을 `.env`/`config.toml`/`GEODE_*` env로 in-place 재로드. CLI `_apply_model`이 disk에 쓴 값이 daemon에 즉시 전파.
- **`services.create_session`이 session 시작마다 호출** — Hermes의 "fresh read at session boundary" 패턴. 새 AgenticLoop 구성 전에 fresh-read → 다음 turn부터 운영자 `/model` 선택 반영.
- **chokidar/inotify watcher 의존성 0** — autonomous trigger 경로(Slack/Discord/scheduler)와의 race 회피.

## Why

PR-DRIFT-CUT(#1598)이 per-turn auto-revert(drift sync)를 제거하면서, drift sync가 *silently masking* 하던 latent gap이 표면화:

- CLI process: `_apply_model`이 disk(`.env` + `config.toml`)와 CLI 측 settings를 갱신
- Daemon process: pydantic Settings는 boot-time snapshot을 들고 있음 — disk 갱신을 자체적으로 감지 못 함
- Drift sync 살아있을 때: 매 turn `loop.model != settings.model` 비교 + auto-revert가 이 gap을 가려줌 (하지만 *반대 방향*으로 사용자 의도 무시도 함 — 같은 원인의 다른 증상)
- PR-DRIFT-CUT 이후: gap이 직접 노출 → 사용자가 `/model gpt-5.5` 해도 daemon은 boot-time `claude-opus-4-6`을 그대로 사용

본 PR은 daemon이 *session 시작 시* disk를 다시 읽어서 gap을 닫음. Hermes(`~/workspace/hermes-agent/cli.py`) 패턴 그대로 — config는 boundary에서만 refresh, mid-session 변경 없음.

## Frontier Survey (보강)

| 코드베이스 | 패턴 | LOC | 본 PR 적용 시 |
|-----------|------|-----|-------|
| OpenClaw | chokidar + 300ms debounce + 4 reload mode | ~300 | watcher race condition; multi-trigger autonomous path와 부합 X |
| **Hermes** | **boundary read (CLI startup 1회)** | **~30** | **GEODE의 session 단위 loop 생성과 자연 정합 ✓** |
| Paperclip | HTTP PATCH on demand | ~80 | GEODE는 IPC socket이라 적용 어색 |
| Claude Code (ref) | Single-process | 0 | 너무 큰 리팩 |

Hermes 채택 — GEODE의 `services.create_session`이 이미 session-per-call 이라 boundary가 명확.

## Changes

| File | Change |
|------|--------|
| `core/config/__init__.py` | `reload_settings_from_disk()` 신규 — fresh `Settings()` 인스턴스 fields를 singleton에 in-place setattr + `_apply_toml_overlay` 재적용. `contextlib.suppress`로 validator refusal 안전. |
| `core/server/supervised/services.py` | `create_session` 내 `settings.model` 읽기 직전에 `reload_settings_from_disk()` 호출. 인라인 주석에 v0.82.0 → PR-DRIFT-CUT → PR-R6 lineage 명시. |
| `tests/test_settings_reload_from_disk.py` | 신규 4 cases — singleton identity / env-var pickup / idempotent / fresh-process safe |
| `tests/test_shared_services.py::test_model_switch_propagates_across_sessions` | `settings.model = X` 직접 mutation → `monkeypatch.setenv("GEODE_MODEL", X)` 디스크 surface로 재작성. PR-R6 이후엔 in-process mutation이 reload에 의해 revert되므로 disk surface로 의도 명확화 |
| `CHANGELOG.md` | `### Fixed (PR-R6, 2026-05-24)` 항목 추가 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| α: `_apply_model` short-circuit 시 IPC 미발신 | Mitigated by R6 | session 시작에 fresh-read하면 short-circuit해도 다음 session에 효과. mid-session hot-swap이 필요하면 추가 PR |
| β: daemon `/model` IPC handler가 loop.model 미갱신 | Mitigated by R6 | 다음 session 생성 시 자동 적용 |
| γ: daemon boot의 settings.model resolution drift | Resolved | session 단위 fresh-read로 boot-time snapshot 의존 X |
| 자율 trigger 경로 (Slack/scheduler) 영향 | None | 동일하게 `create_session` 호출 → 동일 fresh-read 적용 |

## Verification

- [x] `ruff check` clean (3 파일)
- [x] `ruff format --check` clean
- [x] `mypy` clean (2 source files)
- [x] `pytest tests/test_settings_reload_from_disk.py` — 4/4 pass
- [x] `pytest tests/test_shared_services.py` — 갱신된 케이스 포함 통과
- [x] `pytest -k "config or settings or services or runtime"` — **358 passed / 0 failed**

## Reference

- 본 PR base: `feature/drift-fallback-cut` (PR #1598). PR #1598 머지 후 develop으로 rebase 가능
- Frontier pattern: `~/workspace/hermes-agent/cli.py:271-301` (load_cli_config) + `:619` (module-load 1회)
- 회피한 패턴: `~/workspace/openclaw/src/gateway/config-reload.ts:368-372` (chokidar watcher + race condition)
- 본 PR이 R6로 닫는 v0.99.52 smoke incident: PR #1598 본문 § Why 참조