### PR TITLE
release: v0.99.53 — PR-DRIFT-CUT + PR-R6 bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.53] - 2026-05-24
+
+> Drift / fallback / model-spec / settings-sync bundle. PR-DRIFT-CUT
+> (#1598) cut the per-turn auto-revert that silently reverted operator
+> ``/model`` selections + the cross-provider fallback chains that
+> cascaded a single 400 into z.ai 200, and grounded OpenAI / Codex /
+> GLM adapter quirks (``max_completion_tokens`` / temperature /
+> 128-tool cap) in an explicit per-model registry. PR-R6 (#1599)
+> closed the CLI ↔ daemon ``settings.model`` drift with a
+> Hermes-style ``reload_settings_from_disk()`` boundary read at
+> ``services.create_session`` + bridged ``settings.agentic_effort``
+> into the ``AgenticLoop`` constructor so the operator's picker
+> choice propagates end-to-end. 2 PRs, 6+ regression categories
+> closed.
+
 ### Fixed (PR-R6, 2026-05-24)
 
 - **CLI ↔ daemon `settings.model` drift closed via Hermes-style boundary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.52
+- **Version**: 0.99.53
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.52 — Long-running Autonomous Execution Harness
+# GEODE v0.99.53 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.52**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.53**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.52 — Long-running Autonomous Execution Harness
+# GEODE v0.99.53 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.52**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.53**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.52"
+version = "0.99.53"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.52"
+version = "0.99.53"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.53 — drift / fallback / model-spec / settings-sync 묶음. 5-location version stamp + CHANGELOG promotion.

## Verification
- [x] ruff check clean (core + tests + plugins)
- [x] ruff format --check clean
- [x] CHANGELOG `[Unreleased]` → `[0.99.53] - 2026-05-24` 헤더 변환 완료
- [x] 5 locations: pyproject.toml:3 / CLAUDE.md:11 / README.md:25 / README.ko.md:21,338 모두 0.99.53

## 포함 PR
- **#1598 PR-DRIFT-CUT** — drift sync + provider fallback chains 영구 제거, OpenAI/Codex/GLM 어댑터 spec registry, raw SDK error sanitiser, Plus→Subscription rename
- **#1599 PR-R6** — Hermes-style `reload_settings_from_disk()` + effort axis bridge