### PR TITLE
PR-TIMECAP — unify claude-cli + sub-agent gates to 30-min time-cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-TIMECAP** — unify claude-cli + seed-generation sub-agent
+  wall-clock gates to a **30-minute time-cap**, dropping the residual
+  turn-cap on the claude-cli adapter path. GEODE's policy is
+  "no turn-cap, run on time-cap"; the v0.99.52 → v0.99.53 smoke
+  surfaced two leaks of that policy:
+  - `core/llm/adapters/claude_cli.py:_call_llm` was passing
+    `max_turns=1` to `build_claude_cli_argv` — an inspect_ai
+    contract leak (that path owns its own iteration loop and expects
+    `generate()` to return after a single turn). AgenticLoop's adapter
+    call does the opposite: claude-cli must run its internal tool-loop
+    until it produces a terminal `stop_reason`. The previous cap
+    produced `error_max_turns` on the first tool call of every
+    seed-generation generator (Glob → Read → Write sequences need
+    multiple internal turns within a single adapter call). Now passes
+    `max_turns=100` — high enough that the 30-minute time-cap always
+    trips first, effectively turning the flag into a safety ceiling.
+  - `core/llm/adapters/claude_cli.py:_run_claude_subprocess` bumped
+    `timeout_s` from 600s to 1800s (10min → 30min).
+  - `plugins/seed_generation/_registry_builder.py` bumped
+    `SubAgentManager.timeout_s` from 600s to 1800s to match.
+  - All three caps now trip together at the 1800s boundary rather
+    than producing a window where the parent gives up before the
+    subprocess does (or vice versa).
+
 ## [0.99.53] - 2026-05-24
 
 > Drift / fallback / model-spec / settings-sync bundle. PR-DRIFT-CUT

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -95,14 +95,33 @@ class ClaudeCliAdapter:
         argv = build_claude_cli_argv(
             binary=binary,
             model_name=req.model,
-            max_turns=1,
+            # GEODE policy: no turn-cap, run on time-cap. claude-cli's
+            # ``--max-turns`` flag still requires a positive integer, so
+            # set it high enough that the 30-minute time-cap on
+            # ``_run_claude_subprocess`` (matched to the
+            # ``SubAgentManager.timeout_s=1800.0`` ceiling) always
+            # trips first. 100 turns × claude-cli's typical 5-10s per
+            # turn ≫ 1800s — the option becomes a safety ceiling, not
+            # the operational limit. The previous ``max_turns=1`` was
+            # an inspect_ai contract leak (that path owns its own
+            # iteration loop); AgenticLoop's adapter call does the
+            # opposite, letting claude-cli run its internal tool-loop
+            # until it produces a terminal ``stop_reason``.
+            max_turns=100,
             resume_session_id=req.resume_session_id or None,
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"
         try:
             async with acquire_claude_cli_lane_async(lane_key):
-                stdout, stderr, rc = await _run_claude_subprocess(argv, stdin_text, timeout_s=600.0)
+                # GEODE policy: 30-minute time-cap. Matches the
+                # ``SubAgentManager.timeout_s=1800.0`` ceiling so the
+                # subprocess and the parent-process wall-clock gates
+                # trip together rather than producing a 1200s window
+                # where the parent gives up before the subprocess does.
+                stdout, stderr, rc = await _run_claude_subprocess(
+                    argv, stdin_text, timeout_s=1800.0
+                )
         except ClaudeCliInvocationError as exc:
             self._last_error = exc
             raise

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -85,15 +85,19 @@ def build_subagent_manager() -> Any:
         agent_registry=agent_registry,
         hooks=hooks,
         max_depth=settings.max_subagent_depth,
-        # SubAgentManager default ``timeout_s=120.0`` clips opus-class
-        # generations at the ``claude-binary-spawn + OAuth + first-token``
-        # latency boundary (v0.99.52 smoke regression). Seed-generation
-        # routinely routes critic / proximity on opus-4.7 via
-        # ``claude-cli`` subprocess, so we bump the gate to 600s — well
-        # above the observed p95 cold-start path but still tight enough
-        # to surface a hung subprocess. Cheap-fast pilot calls finish
-        # in << 120s either way, so the looser cap is benign there.
-        timeout_s=600.0,
+        # GEODE policy: 30-minute time-cap (no turn-cap). Matches the
+        # ``claude-cli`` adapter's ``_run_claude_subprocess`` ceiling
+        # so the parent and child wall-clock gates trip together
+        # rather than producing a window where the parent gives up
+        # before the subprocess does. The pre-fix default
+        # ``timeout_s=120.0`` clipped opus-class generations at the
+        # ``claude-binary-spawn + OAuth + first-token`` latency
+        # boundary (v0.99.52 smoke regression). 1800s accommodates
+        # multi-tool-round seed-generation agents (Glob → Read → Write
+        # sequences within a single adapter call). Cheap-fast pilot
+        # calls finish in << 120s either way, so the looser cap is
+        # benign there.
+        timeout_s=1800.0,
     )
 
 


### PR DESCRIPTION
## Summary

Unify GEODE's claude-cli + seed-generation sub-agent wall-clock gates to a single **30-minute time-cap**, dropping the residual turn-cap on the claude-cli adapter path.

- `core/llm/adapters/claude_cli.py` — `max_turns=1` → `max_turns=100` (safety ceiling) + subprocess `timeout_s=600.0` → `1800.0`
- `plugins/seed_generation/_registry_builder.py` — `SubAgentManager.timeout_s=600.0` → `1800.0`

## Why

The v0.99.52 → v0.99.53 smoke (`audit-seeds generate --target-dim redundant_tool_invocation`) failed with both candidates' generator sub-agents exiting on `error_max_turns` at `num_turns=2`. Root-cause diagnosis surfaced two leaks of GEODE's "no turn-cap, run on time-cap" policy:

1. **claude-cli `--max-turns=1` hardcoded on the AgenticLoop path.** The original comment ("Defaults to 1 because inspect_ai expects `generate()` to return after one turn — it owns the iteration loop") describes the inspect_ai contract. AgenticLoop's adapter call has the OPPOSITE contract: claude-cli must run its internal tool-loop until it produces a terminal `stop_reason` (e.g. seed-generation generator needs Glob → Glob → Read → Write within a single adapter call). With `--max-turns=1`, claude-cli exited after the first `assistant`-message-with-tool-use event, before the `tool_result` came back — manifesting as `error_max_turns`.

2. **Mismatched subprocess timeouts.** claude-cli subprocess wall-clock was 600s, SubAgentManager parent gate was 600s (post-PR-PROMOTE), but the broader policy intent was 30 minutes for opus-class generations on Claude Code Max. The 600s value was a smoke-prep stepping stone; this PR commits the policy-aligned 1800s end-to-end.

The Codex MCP review notes also caught a secondary mis-diagnosis from the smoke trace: the PR-T transient classifier matched a `rate_limit_event` text with `"status":"allowed"` + `"isUsingOverage":false` — that event is **informational**, not a rejection. The actual claude-cli exit was `error_max_turns`. A follow-up PR (PR-PRT-STATUS) should narrow the classifier to only match rejected events; this PR fixes the underlying max-turns cause so the misclassification's downstream visibility drops.

## Changes

| File | Change |
|------|--------|
| `core/llm/adapters/claude_cli.py` | `max_turns=1` → `max_turns=100` (effective safety ceiling); `_run_claude_subprocess(... timeout_s=600.0)` → `timeout_s=1800.0`. Two block-comments document the 30-min time-cap policy at both call sites. |
| `plugins/seed_generation/_registry_builder.py` | `SubAgentManager(..., timeout_s=600.0)` → `timeout_s=1800.0`. Comment updated to reference the matching claude-cli subprocess ceiling so the parent/child gates trip together. |
| `CHANGELOG.md` | Unreleased entry under Changed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| claude-cli `--max-turns` effective ceiling | Implemented | 100 ≫ 1800s / 5-10s per turn |
| claude-cli subprocess `timeout_s` | Implemented | 1800.0s |
| SubAgentManager `timeout_s` | Implemented | 1800.0s (matches subprocess) |
| Existing `max_turns=1` test expectations | None — no test pins claude-cli adapter `--max-turns=1` | grep confirms |
| PR-T classifier false-positive fix | **Deferred (PR-PRT-STATUS)** | Filtered to `status="rejected"` events only |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — 884 files unchanged
- [x] `uv run mypy core/ plugins/` — 432 source files, 0 errors
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/core/llm/adapters/test_claude_cli_adapter.py tests/core/llm/adapters/test_claude_cli_resume.py tests/core/llm/test_claude_cli_errors.py tests/plugins/petri_audit/test_claude_cli_transient_classifier.py tests/plugins/petri_audit/test_claude_cli_provider.py tests/plugins/seed_generation/` — 526 pass, 4 skipped
- [x] Full pytest suite — green at PR push time

## Reference

- Smoke artefact: `/Users/mango/workspace/geode/state/seed-generation/gen1-redundant_tool_invocation/sub_agents/gen-gen1-000-2ea2afb8/` (error_max_turns at num_turns=2)
- claude-cli dump: `~/.geode/diagnostics/claude-cli-transient/1779631562-claude-sonnet-4-6.json`
- PR-PROMOTE #1602/#1603 — partial promotion (600s) that this PR completes (1800s)
