### PR TITLE
promote v0.99.53 timecap unification to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-TIMECAP** — unify claude-cli + seed-generation sub-agent
+  wall-clock gates to a **30-minute time-cap**, dropping the residual
+  turn-cap on the claude-cli adapter path. GEODE's policy is
+  "no turn-cap, run on time-cap"; the v0.99.52 → v0.99.53 smoke
+  surfaced two leaks of that policy:
+  - `core/llm/adapters/claude_cli.py:_call_llm` was passing
+    `max_turns=1` to `build_claude_cli_argv` — an inspect_ai
+    contract leak (that path owns its own iteration loop and expects
+    `generate()` to return after a single turn). AgenticLoop's adapter
+    call does the opposite: claude-cli must run its internal tool-loop
+    until it produces a terminal `stop_reason`. The previous cap
+    produced `error_max_turns` on the first tool call of every
+    seed-generation generator (Glob → Read → Write sequences need
+    multiple internal turns within a single adapter call). Now passes
+    `max_turns=100` — high enough that the 30-minute time-cap always
+    trips first, effectively turning the flag into a safety ceiling.
+  - `core/llm/adapters/claude_cli.py:_run_claude_subprocess` bumped
+    `timeout_s` from 600s to 1800s (10min → 30min).
+  - `plugins/seed_generation/_registry_builder.py` bumped
+    `SubAgentManager.timeout_s` from 600s to 1800s to match.
+  - All three caps now trip together at the 1800s boundary rather
+    than producing a window where the parent gives up before the
+    subprocess does (or vice versa).
+
 ## [0.99.53] - 2026-05-24
 
 > Drift / fallback / model-spec / settings-sync bundle. PR-DRIFT-CUT

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -95,14 +95,33 @@ class ClaudeCliAdapter:
         argv = build_claude_cli_argv(
             binary=binary,
             model_name=req.model,
-            max_turns=1,
+            # GEODE policy: no turn-cap, run on time-cap. claude-cli's
+            # ``--max-turns`` flag still requires a positive integer, so
+            # set it high enough that the 30-minute time-cap on
+            # ``_run_claude_subprocess`` (matched to the
+            # ``SubAgentManager.timeout_s=1800.0`` ceiling) always
+            # trips first. 100 turns × claude-cli's typical 5-10s per
+            # turn ≫ 1800s — the option becomes a safety ceiling, not
+            # the operational limit. The previous ``max_turns=1`` was
+            # an inspect_ai contract leak (that path owns its own
+            # iteration loop); AgenticLoop's adapter call does the
+            # opposite, letting claude-cli run its internal tool-loop
+            # until it produces a terminal ``stop_reason``.
+            max_turns=100,
             resume_session_id=req.resume_session_id or None,
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"
         try:
             async with acquire_claude_cli_lane_async(lane_key):
-                stdout, stderr, rc = await _run_claude_subprocess(argv, stdin_text, timeout_s=600.0)
+                # GEODE policy: 30-minute time-cap. Matches the
+                # ``SubAgentManager.timeout_s=1800.0`` ceiling so the
+                # subprocess and the parent-process wall-clock gates
+                # trip together rather than producing a 1200s window
+                # where the parent gives up before the subprocess does.
+                stdout, stderr, rc = await _run_claude_subprocess(
+                    argv, stdin_text, timeout_s=1800.0
+                )
         except ClaudeCliInvocationError as exc:
             self._last_error = exc
             raise

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -85,15 +85,19 @@ def build_subagent_manager() -> Any:
         agent_registry=agent_registry,
         hooks=hooks,
         max_depth=settings.max_subagent_depth,
-        # SubAgentManager default ``timeout_s=120.0`` clips opus-class
-        # generations at the ``claude-binary-spawn + OAuth + first-token``
-        # latency boundary (v0.99.52 smoke regression). Seed-generation
-        # routinely routes critic / proximity on opus-4.7 via
-        # ``claude-cli`` subprocess, so we bump the gate to 600s — well
-        # above the observed p95 cold-start path but still tight enough
-        # to surface a hung subprocess. Cheap-fast pilot calls finish
-        # in << 120s either way, so the looser cap is benign there.
-        timeout_s=600.0,
+        # GEODE policy: 30-minute time-cap (no turn-cap). Matches the
+        # ``claude-cli`` adapter's ``_run_claude_subprocess`` ceiling
+        # so the parent and child wall-clock gates trip together
+        # rather than producing a window where the parent gives up
+        # before the subprocess does. The pre-fix default
+        # ``timeout_s=120.0`` clipped opus-class generations at the
+        # ``claude-binary-spawn + OAuth + first-token`` latency
+        # boundary (v0.99.52 smoke regression). 1800s accommodates
+        # multi-tool-round seed-generation agents (Glob → Read → Write
+        # sequences within a single adapter call). Cheap-fast pilot
+        # calls finish in << 120s either way, so the looser cap is
+        # benign there.
+        timeout_s=1800.0,
     )
 
 


### PR DESCRIPTION
## Summary

Promote PR-TIMECAP (#1604) from develop to main — 30-minute time-cap unification across claude-cli adapter + SubAgentManager.

## Verification

- [x] feature → develop merged (#1604, 8/8 green)
- [x] No CHANGELOG bump (gitflow non-release path)