### PR TITLE
promote PR-SKIP-PERMS to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-SKIP-PERMS** — `build_claude_cli_argv()` accepts a new
+  `skip_permissions: bool = False` parameter that appends
+  `--allow-dangerously-skip-permissions` to the claude-cli argv when
+  True. GEODE's AgenticLoop adapter (`core/llm/adapters/claude_cli.py`)
+  passes True so headless sub-agent subprocesses don't hang on
+  interactive permission prompts (Write outside cwd, Bash dangerous
+  commands, etc.).
+  - **Smoke-blocking issue** (v0.99.53 smoke after PR-TIMECAP): every
+    seed-generation generator candidate tried Write → got permission
+    denied → tried Bash-cat-redirect → denied → tried Agent
+    delegation → denied → exited cleanly with a "please grant write
+    access" final message → pipeline saw empty candidates → aborted.
+    claude-cli rc=0 + is_error=false the whole way (no claude-cli
+    bug, just an interactive-prompt-in-headless-subprocess mismatch).
+  - **Default off** so inspect_ai / petri_audit interactive paths
+    keep their permission prompts; AgenticLoop adapter explicitly
+    opts in. The CLI flag is `--allow-dangerously-skip-permissions`
+    (recommended only for sandboxes per `claude --help`) — GEODE's
+    sub-agent dispatch IS such a sandbox (denied_tools set +
+    working_dirs whitelist + isolated subprocess).
+  - Pinned by `tests/plugins/petri_audit/test_claude_cli_provider.py`
+    (4 cases — default-off, explicit-on, ordering vs `--tools`,
+    composes-with-extra_args).
+
 ### Changed
 - **PR-TIMECAP** — unify claude-cli + seed-generation sub-agent
   wall-clock gates to a **30-minute time-cap**, dropping the residual

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -109,6 +109,19 @@ class ClaudeCliAdapter:
             # until it produces a terminal ``stop_reason``.
             max_turns=100,
             resume_session_id=req.resume_session_id or None,
+            # PR-SKIP-PERMS (2026-05-24) — operator directive: GEODE's
+            # AgenticLoop spawns claude-cli as a headless subprocess.
+            # Permission prompts (Write outside cwd, Bash dangerous
+            # commands, etc.) would hang the subprocess on an
+            # interactive prompt that no one can answer. The v0.99.53
+            # smoke surfaced this as Write-tool denials on every seed
+            # candidate generation — claude-cli exited cleanly with a
+            # "please grant write access" final message but the
+            # downstream pipeline saw empty candidates. Sub-agents
+            # already run inside the GEODE sandbox (denied_tools set +
+            # working_dirs whitelist + isolated subprocess), so the
+            # skip-permissions surface is sound.
+            skip_permissions=True,
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -322,6 +322,7 @@ def build_claude_cli_argv(
     disable_builtin_tools: bool = False,
     extra_args: Iterable[str] | None = None,
     resume_session_id: str | None = None,
+    skip_permissions: bool = False,
 ) -> list[str]:
     """Construct the ``claude --print`` argv.
 
@@ -351,6 +352,13 @@ def build_claude_cli_argv(
             claude-cli pulls the cached one (paperclip
             ``execute.ts:697`` "instructions are already in the
             session cache").
+        skip_permissions: When True append the
+            ``--allow-dangerously-skip-permissions`` flag. Required
+            for headless sub-agent execution (operator can't approve
+            file-system permission prompts in a background spawn).
+            GEODE's AgenticLoop adapter call passes True; inspect_ai
+            / petri_audit interactive paths leave it False so the
+            CLI's permission prompts still gate writes.
 
     The output format is pinned to ``stream-json`` + ``--verbose`` —
     we need every event to construct ``ModelOutput`` faithfully.
@@ -387,6 +395,22 @@ def build_claude_cli_argv(
         # over mcp__bridge__send_message). ``--tools ""`` disables
         # the built-in set so only MCP tools remain.
         argv += ["--tools", ""]
+    if skip_permissions:
+        # PR-SKIP-PERMS (2026-05-24) — operator directive: GEODE's
+        # AgenticLoop adapter spawns claude-cli as a headless
+        # subprocess, so any tool that requires interactive permission
+        # approval (Write outside cwd, Bash dangerous commands, etc.)
+        # would hang the subprocess on a prompt no one can answer.
+        # The v0.99.53 smoke surfaced this as Write-tool permission
+        # denials on every seed candidate generation (claude-cli's
+        # LLM tried 3 Write attempts + Bash-cat-redirect + Agent
+        # delegation, all blocked, then exited cleanly with a "please
+        # grant write access" final message — but with empty
+        # candidates downstream). This flag is recommended only for
+        # sandboxes with no internet access per ``claude --help``;
+        # GEODE's sub-agent dispatch IS such a sandbox (denied_tools
+        # set + working_dirs whitelist + isolated subprocess).
+        argv += ["--allow-dangerously-skip-permissions"]
     if extra_args:
         argv += list(extra_args)
     return argv

--- a/tests/plugins/petri_audit/test_claude_cli_provider.py
+++ b/tests/plugins/petri_audit/test_claude_cli_provider.py
@@ -201,6 +201,64 @@ def test_argv_extra_args_appended() -> None:
     assert argv[-2:] == ["--reasoning-effort", "high"]
 
 
+def test_argv_skip_permissions_default_false() -> None:
+    """PR-SKIP-PERMS (2026-05-24) — default-off so legacy
+    inspect_ai / petri_audit interactive paths keep their permission
+    prompts. AgenticLoop adapter explicitly opts in via True."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(binary="/x/claude", model_name="claude-opus-4-7")
+    assert "--allow-dangerously-skip-permissions" not in argv
+
+
+def test_argv_skip_permissions_true_appends_flag() -> None:
+    """PR-SKIP-PERMS — explicit True appends the flag so headless
+    sub-agent subprocesses don't hang on interactive permission
+    prompts (v0.99.53 smoke regression: Write tool denials clipped
+    every generator candidate)."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        skip_permissions=True,
+    )
+    assert "--allow-dangerously-skip-permissions" in argv
+
+
+def test_argv_skip_permissions_order_after_tools_block() -> None:
+    """The flag lands AFTER the optional ``--tools "" `` block (set
+    by ``disable_builtin_tools=True``) so the argv shape stays
+    deterministic for the CSA-2 MCP bridge path."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        disable_builtin_tools=True,
+        skip_permissions=True,
+    )
+    tools_idx = argv.index("--tools")
+    skip_idx = argv.index("--allow-dangerously-skip-permissions")
+    assert tools_idx < skip_idx
+
+
+def test_argv_skip_permissions_composes_with_extra_args() -> None:
+    """``extra_args`` still appends LAST so operator overrides /
+    test injection points stay at the tail of the argv even when
+    skip_permissions is on."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        skip_permissions=True,
+        extra_args=["--reasoning-effort", "high"],
+    )
+    assert argv[-2:] == ["--reasoning-effort", "high"]
+    assert "--allow-dangerously-skip-permissions" in argv[:-2]
+
+
 # ---------------------------------------------------------------------------
 # Message serialiser
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Promote PR-SKIP-PERMS (#1606) from develop to main — claude-cli adapter unifies on `--allow-dangerously-skip-permissions` for headless sub-agent subprocesses.

## Verification

- [x] feature → develop merged (#1606, 8/8 green)
- [x] No CHANGELOG bump (gitflow non-release path)