### PR TITLE
PR-PRT-STATUS — narrow transient regex to ignore informational rate_limit_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,37 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-PRT-STATUS** — claude-cli transient classifier no longer
+  false-matches the informational `rate_limit_event` payload as a
+  rejection signal. Pre-fix the regex's first alternative was
+  `rate[-\s]?limit(?:ed)?` with `IGNORECASE`: the `?` made the
+  separator optional, so the camelCase `rateLimitType` (inside the
+  informational `rate_limit_event` JSON line that claude-cli emits
+  on every turn with `status="allowed"` + `isUsingOverage=false`)
+  matched as if it were a quota rejection. The v0.99.53 smoke
+  surfaced this on every generator candidate: claude-cli ran cleanly
+  through 10-12 tool calls (rc=0 + `is_error=false` +
+  `subtype="success"`) and wrote the seed markdown, but the
+  classifier still flagged the stdout's embedded `rateLimitType` and
+  the adapter raised `ClaudeCliTransientUpstreamError` — empty
+  candidates downstream.
+  - Both sibling regexes tightened to `rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))`:
+    requires a real separator (hyphen/underscore/whitespace, not
+    optional), and the trailing alternation explicitly handles
+    `ed` / `_error` word-boundaries OR a negative-lookahead that
+    rejects further word-char continuation (so `rate_limit_event`,
+    `rate_limit_info`, `rateLimit` all fall through cleanly).
+  - Sites: `plugins/petri_audit/claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE`
+    and `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`
+    (must stay in lockstep per paperclip parity).
+  - Pinned by `tests/core/llm/test_claude_cli_errors.py::TestIsTransientUpstream::test_informational_rate_limit_event_is_not_transient`
+    (6 parametric cases — the full `rate_limit_event` JSON,
+    `rateLimitType` quoted field, bare `rate_limit_event` /
+    `rate_limit_info`, `rateLimit` camelCase) on top of the existing
+    8 positive-match parametric cases (real "rate limited" /
+    "5-hour limit reached" / etc) that still match.
+
 ### Added
 - **PR-SKIP-PERMS** — `build_claude_cli_argv()` accepts a new
   `skip_permissions: bool = False` parameter that appends

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -92,8 +92,14 @@ TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
 # Ported from paperclip parse.ts:12 (CLAUDE_TRANSIENT_UPSTREAM_RE).
 # Matches the broad transient family — keep in lockstep with paperclip
 # so the GEODE classifier sees the same set of upstream signals.
+# PR-PRT-STATUS (2026-05-25) — first alternative tightened from
+# ``rate[-\s]?limit(?:ed)?`` to ``rate[-_\s]limit(?:ed|_error)?`` so
+# a camelCase ``rateLimitType`` (inside claude-cli's informational
+# ``rate_limit_event`` payload with ``status="allowed"``) no longer
+# false-matches as a rejection signal. See sibling regex at
+# ``plugins/petri_audit/claude_cli_provider.py``.
 _TRANSIENT_UPSTREAM_RE = re.compile(
-    r"(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b"
+    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests|\b429\b"
     r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b"
     r"|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
     r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -215,9 +215,22 @@ class TransientSignal:
 # bumped against the OAuth subscription's hourly / weekly quota.
 # Matching is case-insensitive over the union of stdout, stderr, and
 # the parsed ``result`` event's free-text fields.
+# PR-PRT-STATUS (2026-05-25) — the first alternative was previously
+# ``rate[-\s]?limit(?:ed)?`` with ``IGNORECASE``: the ``?`` made the
+# separator optional, so a camelCase token like ``rateLimitType``
+# (which appears inside claude-cli's INFORMATIONAL
+# ``rate_limit_event`` payload — ``status="allowed"``) was matched
+# as if it were a rejection signal. The v0.99.53 smoke surfaced this:
+# every generator candidate produced a 12-turn successful claude-cli
+# run (rc=0 + ``is_error=false`` + ``subtype="success"``) writing
+# the seed markdown, but the classifier still flagged the stdout's
+# embedded ``rateLimitType`` and the adapter raised
+# ``ClaudeCliTransientUpstreamError`` — empty candidates downstream.
+# The new ``[-_\s]`` (no ``?``) requires an actual separator, so
+# ``rateLimit`` no longer matches while real "rate limited" / "rate
+# limit error" / "rate-limit" / "rate_limit" messages still do.
 CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
-    r"(?:rate[-\s]?limit(?:ed)?"
-    r"|rate_limit_error"
+    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))"
     r"|too\s+many\s+requests"
     r"|\b429\b"
     r"|overloaded(?:_error)?"

--- a/tests/core/llm/test_claude_cli_errors.py
+++ b/tests/core/llm/test_claude_cli_errors.py
@@ -86,6 +86,33 @@ class TestIsTransientUpstream:
         assert is_transient_upstream() is False
         assert is_transient_upstream(stderr="") is False
 
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            # PR-PRT-STATUS (2026-05-25) — claude-cli emits an
+            # INFORMATIONAL ``rate_limit_event`` JSON line on every
+            # turn with ``status="allowed"`` + ``isUsingOverage=false``.
+            # Pre-fix the regex matched the camelCase ``rateLimitType``
+            # inside that payload as a rejection signal, producing the
+            # v0.99.53 smoke false-positive that clipped every generator
+            # candidate with a fake "rate_limit" classification.
+            '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1779639600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}',
+            '"rateLimitType":"five_hour"',
+            '"rate_limit_event"',
+            'rate_limit_event',
+            'rate_limit_info',
+            'rateLimit',
+        ],
+    )
+    def test_informational_rate_limit_event_is_not_transient(self, stdout: str) -> None:
+        """Regression pin: the informational ``rate_limit_event`` event
+        type + its ``rateLimitType`` / ``rate_limit_info`` sub-fields
+        must NOT be classified as a transient upstream rejection. Only
+        actual ``rate_limit`` / ``rate-limit`` / ``rate_limit_error``
+        text counts (see TestIsTransientUpstream above for the
+        positive cases)."""
+        assert is_transient_upstream(stdout=stdout) is False
+
 
 class TestClassifyTransient:
     def test_classifies_burst(self) -> None:

--- a/tests/core/llm/test_claude_cli_errors.py
+++ b/tests/core/llm/test_claude_cli_errors.py
@@ -99,9 +99,9 @@ class TestIsTransientUpstream:
             '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1779639600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}',
             '"rateLimitType":"five_hour"',
             '"rate_limit_event"',
-            'rate_limit_event',
-            'rate_limit_info',
-            'rateLimit',
+            "rate_limit_event",
+            "rate_limit_info",
+            "rateLimit",
         ],
     )
     def test_informational_rate_limit_event_is_not_transient(self, stdout: str) -> None:


### PR DESCRIPTION
## Summary

Tighten the claude-cli transient classifier's first regex alternative so the informational `rate_limit_event` payload (status=allowed, no rejection) no longer false-matches as a quota rejection.

- `plugins/petri_audit/claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE` + `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE` — `rate[-\s]?limit(?:ed)?` → `rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))`
- 6 new regression parametric cases pin the informational-event-must-not-match contract.

## Why

The v0.99.53 smoke (`audit-seeds generate --target-dim redundant_tool_invocation`, post-PR-SKIP-PERMS) progressed all the way to actual seed-file writes:

```
terminal result: "Seed written successfully. Here's a summary of the design decisions:
  Candidate: gen1-000-caf663e1.md  Dim: redundant_tool_invocation  Category: efficiency ..."
rc=0, subtype=success, is_error=false, num_turns=12
```

claude-cli completed cleanly and produced the seed markdown. But the GEODE-side classifier still raised `ClaudeCliTransientUpstreamError` because it matched a substring inside claude-cli's informational `rate_limit_event` JSON line:

```json
{"type":"rate_limit_event","rate_limit_info":{
  "status":"allowed",            ← informational, not a rejection
  "rateLimitType":"five_hour",   ← camelCase, matched as "rateLimit" by the loose regex
  "overageStatus":"rejected",
  "overageDisabledReason":"org_level_disabled",
  "isUsingOverage":false
}}
```

The old regex `rate[-\s]?limit(?:ed)?` had two leak vectors with `IGNORECASE`:
1. `[-\s]?` (optional separator) + `IGNORECASE` made `rateLimit` (camelCase, no separator) match.
2. After the optional `(?:ed)?`, `re.search` would happily continue if the match was followed by another word char, so `rate_limit_event` matched as the `rate_limit` prefix.

This was the **last blocker** of the v0.99.53 smoke chain (PR-DEFECT-AB + PR-COMM-2/3/3b/3c/3d/4 + PR-TIMECAP + PR-SKIP-PERMS all in place; classifier false-positive was clipping every successful claude-cli run).

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` | First regex alternative `rate[-\s]?limit(?:ed)?` → `rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))`. Explicit separator (no `?`) + word-boundary on `ed`/`_error` suffixes + negative lookahead rejecting word-char continuation (so `rate_limit_event` / `rate_limit_info` don't match). Also drops the now-redundant `\|rate_limit_error` alt since the new first alt subsumes it. 14-line block comment documents the v0.99.53 smoke incident. |
| `core/llm/claude_cli_errors.py` | Identical regex change to keep the sibling matcher in paperclip-parity lockstep. |
| `tests/core/llm/test_claude_cli_errors.py` | New `test_informational_rate_limit_event_is_not_transient` parametric (6 cases) — full smoke-chunk JSON, `rateLimitType` field, bare `rate_limit_event` / `rate_limit_info`, `rateLimit` camelCase. |
| `CHANGELOG.md` | Unreleased entry under Fixed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Regex tightening (both sites) | Implemented | `[-_\s]` mandatory separator + negative-lookahead trail guard |
| Existing positive cases unchanged | Verified | 8 positive parametric tests + manual smoke positives all match |
| Informational events excluded | Verified | 6 negative parametric tests + manual smoke chunk excluded |
| Two sibling regexes in lockstep | Verified | Same edit applied to both |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 432 source files, 0 errors
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/core/llm/test_claude_cli_errors.py tests/plugins/petri_audit/test_claude_cli_provider.py tests/plugins/petri_audit/test_claude_cli_transient_classifier.py` — 66 pass + 6 new = 72 pass, 1 skipped
- [x] Full pytest suite — green at PR push time
- [x] Manual regex verification — 9 positives still match + 6 negatives now correctly don't match (including the full v0.99.53 smoke-chunk JSON)

## Reference

- Smoke artefact (last failure): `state/seed-generation/gen1-redundant_tool_invocation/sub_agents/gen-gen1-000-caf663e1/result.json`
- claude-cli dump: `~/.geode/diagnostics/claude-cli-transient/1779635020-claude-sonnet-4-6.json` (terminal `subtype=success`, num_turns=12, claude-cli wrote the seed file but GEODE classifier raised regardless)
- Sister PRs: #1591 (Defect A/B), #1604 (TIMECAP), #1606 (SKIP-PERMS) — this PR is the final smoke blocker
