### PR TITLE
promote PR-PRT-STATUS to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,37 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-PRT-STATUS** — claude-cli transient classifier no longer
+  false-matches the informational `rate_limit_event` payload as a
+  rejection signal. Pre-fix the regex's first alternative was
+  `rate[-\s]?limit(?:ed)?` with `IGNORECASE`: the `?` made the
+  separator optional, so the camelCase `rateLimitType` (inside the
+  informational `rate_limit_event` JSON line that claude-cli emits
+  on every turn with `status="allowed"` + `isUsingOverage=false`)
+  matched as if it were a quota rejection. The v0.99.53 smoke
+  surfaced this on every generator candidate: claude-cli ran cleanly
+  through 10-12 tool calls (rc=0 + `is_error=false` +
+  `subtype="success"`) and wrote the seed markdown, but the
+  classifier still flagged the stdout's embedded `rateLimitType` and
+  the adapter raised `ClaudeCliTransientUpstreamError` — empty
+  candidates downstream.
+  - Both sibling regexes tightened to `rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))`:
+    requires a real separator (hyphen/underscore/whitespace, not
+    optional), and the trailing alternation explicitly handles
+    `ed` / `_error` word-boundaries OR a negative-lookahead that
+    rejects further word-char continuation (so `rate_limit_event`,
+    `rate_limit_info`, `rateLimit` all fall through cleanly).
+  - Sites: `plugins/petri_audit/claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE`
+    and `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`
+    (must stay in lockstep per paperclip parity).
+  - Pinned by `tests/core/llm/test_claude_cli_errors.py::TestIsTransientUpstream::test_informational_rate_limit_event_is_not_transient`
+    (6 parametric cases — the full `rate_limit_event` JSON,
+    `rateLimitType` quoted field, bare `rate_limit_event` /
+    `rate_limit_info`, `rateLimit` camelCase) on top of the existing
+    8 positive-match parametric cases (real "rate limited" /
+    "5-hour limit reached" / etc) that still match.
+
 ### Added
 - **PR-SKIP-PERMS** — `build_claude_cli_argv()` accepts a new
   `skip_permissions: bool = False` parameter that appends

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -92,8 +92,14 @@ TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
 # Ported from paperclip parse.ts:12 (CLAUDE_TRANSIENT_UPSTREAM_RE).
 # Matches the broad transient family — keep in lockstep with paperclip
 # so the GEODE classifier sees the same set of upstream signals.
+# PR-PRT-STATUS (2026-05-25) — first alternative tightened from
+# ``rate[-\s]?limit(?:ed)?`` to ``rate[-_\s]limit(?:ed|_error)?`` so
+# a camelCase ``rateLimitType`` (inside claude-cli's informational
+# ``rate_limit_event`` payload with ``status="allowed"``) no longer
+# false-matches as a rejection signal. See sibling regex at
+# ``plugins/petri_audit/claude_cli_provider.py``.
 _TRANSIENT_UPSTREAM_RE = re.compile(
-    r"(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b"
+    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests|\b429\b"
     r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b"
     r"|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
     r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -215,9 +215,22 @@ class TransientSignal:
 # bumped against the OAuth subscription's hourly / weekly quota.
 # Matching is case-insensitive over the union of stdout, stderr, and
 # the parsed ``result`` event's free-text fields.
+# PR-PRT-STATUS (2026-05-25) — the first alternative was previously
+# ``rate[-\s]?limit(?:ed)?`` with ``IGNORECASE``: the ``?`` made the
+# separator optional, so a camelCase token like ``rateLimitType``
+# (which appears inside claude-cli's INFORMATIONAL
+# ``rate_limit_event`` payload — ``status="allowed"``) was matched
+# as if it were a rejection signal. The v0.99.53 smoke surfaced this:
+# every generator candidate produced a 12-turn successful claude-cli
+# run (rc=0 + ``is_error=false`` + ``subtype="success"``) writing
+# the seed markdown, but the classifier still flagged the stdout's
+# embedded ``rateLimitType`` and the adapter raised
+# ``ClaudeCliTransientUpstreamError`` — empty candidates downstream.
+# The new ``[-_\s]`` (no ``?``) requires an actual separator, so
+# ``rateLimit`` no longer matches while real "rate limited" / "rate
+# limit error" / "rate-limit" / "rate_limit" messages still do.
 CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
-    r"(?:rate[-\s]?limit(?:ed)?"
-    r"|rate_limit_error"
+    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))"
     r"|too\s+many\s+requests"
     r"|\b429\b"
     r"|overloaded(?:_error)?"

--- a/tests/core/llm/test_claude_cli_errors.py
+++ b/tests/core/llm/test_claude_cli_errors.py
@@ -86,6 +86,33 @@ class TestIsTransientUpstream:
         assert is_transient_upstream() is False
         assert is_transient_upstream(stderr="") is False
 
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            # PR-PRT-STATUS (2026-05-25) — claude-cli emits an
+            # INFORMATIONAL ``rate_limit_event`` JSON line on every
+            # turn with ``status="allowed"`` + ``isUsingOverage=false``.
+            # Pre-fix the regex matched the camelCase ``rateLimitType``
+            # inside that payload as a rejection signal, producing the
+            # v0.99.53 smoke false-positive that clipped every generator
+            # candidate with a fake "rate_limit" classification.
+            '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1779639600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}',
+            '"rateLimitType":"five_hour"',
+            '"rate_limit_event"',
+            'rate_limit_event',
+            'rate_limit_info',
+            'rateLimit',
+        ],
+    )
+    def test_informational_rate_limit_event_is_not_transient(self, stdout: str) -> None:
+        """Regression pin: the informational ``rate_limit_event`` event
+        type + its ``rateLimitType`` / ``rate_limit_info`` sub-fields
+        must NOT be classified as a transient upstream rejection. Only
+        actual ``rate_limit`` / ``rate-limit`` / ``rate_limit_error``
+        text counts (see TestIsTransientUpstream above for the
+        positive cases)."""
+        assert is_transient_upstream(stdout=stdout) is False
+
 
 class TestClassifyTransient:
     def test_classifies_burst(self) -> None:

--- a/tests/core/llm/test_claude_cli_errors.py
+++ b/tests/core/llm/test_claude_cli_errors.py
@@ -99,9 +99,9 @@ class TestIsTransientUpstream:
             '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1779639600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}',
             '"rateLimitType":"five_hour"',
             '"rate_limit_event"',
-            'rate_limit_event',
-            'rate_limit_info',
-            'rateLimit',
+            "rate_limit_event",
+            "rate_limit_info",
+            "rateLimit",
         ],
     )
     def test_informational_rate_limit_event_is_not_transient(self, stdout: str) -> None:


### PR DESCRIPTION
## Summary

Promote PR-PRT-STATUS (#1608) — claude-cli transient classifier narrowed to ignore informational `rate_limit_event` payloads.

## Verification

- [x] feature → develop merged (#1608, 8/8 green)
- [x] No CHANGELOG bump (gitflow non-release path)