### PR TITLE
PR-PERMS-FLAG-FIX — actual bypass flag + cwd-cache isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,38 @@ functional change.
     Existing PR-SKIP-PERMS argv tests updated to the new flag
     literal.
 
+### Added
+- **PR-PERMS-FLAG-FIX (JSON-forcing bundle)** — `AdapterCallRequest`
+  gains a `response_schema: dict | None = None` field that threads
+  JSON Schema structured-output forcing through both subprocess
+  adapter paths:
+  - **claude-cli** (`plugins/petri_audit/claude_cli_provider.py`):
+    new `json_schema: dict | None = None` param on
+    `build_claude_cli_argv()` appends `--json-schema <inline-json>`
+    when set. Mirrors Anthropic SDK
+    `messages.parse(output_format=PydanticModel)` →
+    `JSONOutputFormatParam(schema=..., type="json_schema")`.
+  - **codex-cli** (`core/llm/adapters/codex_cli.py`): when
+    `req.response_schema` is set, the adapter materialises the
+    schema into a tempfile and appends `--output-schema <FILE>`
+    (codex-cli takes a file path, claude-cli takes inline — both
+    surface map to the same provider-side structured-output API
+    that the OpenAI SDK exposes as
+    `chat.completions.parse(response_format=PydanticModel)`).
+    Tempfile cleanup via try/finally so a subprocess crash doesn't
+    leak `/tmp` artefacts.
+  - Default `None` preserves back-compat (callers that don't need
+    structured output get free-form text responses).
+  - Eliminates the "LLM returns natural language + code block
+    instead of pure JSON" failure that clipped proximity / critic /
+    pilot / meta_reviewer in the v0.99.53 smoke 5. Wire-through from
+    seed-generation orchestrator → role-specific schema is a
+    follow-up PR (this PR lands the infrastructure).
+  - Pinned by 3 new argv unit tests for claude-cli:
+    `test_argv_json_schema_default_none_omits_flag`,
+    `test_argv_json_schema_dict_appends_serialized_inline`,
+    `test_argv_json_schema_composes_with_all_other_flags`.
+
 - **PR-PRT-STATUS** — claude-cli transient classifier no longer
   false-matches the informational `rate_limit_event` payload as a
   rejection signal. Pre-fix the regex's first alternative was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,37 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-PERMS-FLAG-FIX** — two coupled fixes for the v0.99.53
+  sub-agent isolation surface (caught by smoke 5 / Codex MCP review):
+  - **A: actual permission bypass flag.** `build_claude_cli_argv()`
+    previously emitted `--allow-dangerously-skip-permissions` which
+    is `claude --help`'s meta ENABLE flag, NOT the actual bypass.
+    The v0.99.53 smoke surfaced this when 1st sub-agent passed
+    (Bash tools went through a lighter check) and 2nd hit Write
+    denial on the same path. Now emits `--dangerously-skip-permissions`
+    (no `--allow-` prefix) which is the documented bypass flag.
+  - **B: claude-cli session cache isolation.** `build_claude_cli_argv()`
+    gains a `disable_session_persistence: bool = False` knob that
+    appends `--no-session-persistence`. claude-cli's own
+    `~/.claude/projects/<cwd-hash>/sessions/` cache is keyed on
+    *cwd*, not on GEODE's per-agent `task_id`, so successive smoke
+    runs in the same cwd silently shared cached conversation
+    context — surfaced in smoke 5's proximity sub-agent response
+    ("the excerpt mentions a scenario from a different smoke").
+    AgenticLoop adapter opts in via True since the sub-agent
+    dispatch model is "one task_id, one spawn" — there is no
+    cross-turn resume to optimize at that layer. PR-V's
+    `--resume <id>` path stays intact for callers that explicitly
+    thread a `resume_session_id` (none do at sub-agent dispatch
+    today; preserved for future explicit-id callers).
+  - Pinned by 4 new argv unit tests:
+    `test_argv_skip_permissions_uses_real_bypass_flag_not_meta`,
+    `test_argv_disable_session_persistence_default_false`,
+    `test_argv_disable_session_persistence_true_appends_flag`,
+    `test_argv_session_persistence_composes_with_skip_permissions`.
+    Existing PR-SKIP-PERMS argv tests updated to the new flag
+    literal.
+
 - **PR-PRT-STATUS** — claude-cli transient classifier no longer
   false-matches the informational `rate_limit_event` payload as a
   rejection signal. Pre-fix the regex's first alternative was

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -124,6 +124,23 @@ class AdapterCallRequest:
     # this saves 5-10K tokens per heartbeat. Empty = fresh session
     # (pre-PR-V behaviour). Non-claude-cli adapters ignore this field.
     resume_session_id: str = ""
+    # PR-PERMS-FLAG-FIX (2026-05-25) — JSON-schema forcing parity
+    # across both Anthropic + OpenAI structured-output APIs:
+    # * Anthropic SDK ``messages.parse(output_format=PydanticModel)`` →
+    #   ``JSONOutputFormatParam(schema=..., type="json_schema")``.
+    # * OpenAI SDK ``chat.completions.parse(response_format=PydanticModel)`` →
+    #   ``json_schema`` with ``strict=true``.
+    # * claude-cli (``--print``) flag ``--json-schema <schema>`` (inline string).
+    # * codex-cli (``exec``) flag ``--output-schema <FILE>`` (path-based).
+    #
+    # Set this dict (a JSON Schema object) when the caller expects a
+    # validated JSON shape — eliminates the "LLM returns natural
+    # language + code block instead of pure JSON" failure that
+    # clipped proximity / critic / pilot / meta_reviewer in the
+    # v0.99.53 smoke. Adapters that don't support structured outputs
+    # ignore this field and fall back to prompt-engineered JSON
+    # discipline.
+    response_schema: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -133,6 +133,15 @@ class ClaudeCliAdapter:
             # ``resume_session_id`` (none do at sub-agent dispatch
             # today; preserved for future explicit-id callers).
             disable_session_persistence=True,
+            # PR-PERMS-FLAG-FIX (2026-05-25, JSON-forcing bundle) —
+            # thread ``req.response_schema`` through to claude-cli's
+            # ``--json-schema`` flag so callers that need a validated
+            # JSON shape (seed-generation proximity / critic / pilot /
+            # meta_reviewer, autoresearch judges, etc.) get structured
+            # output instead of natural-language wrappers. None = no
+            # forcing (back-compat: relies on prompt-engineered JSON
+            # discipline).
+            json_schema=req.response_schema,
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -122,6 +122,17 @@ class ClaudeCliAdapter:
             # working_dirs whitelist + isolated subprocess), so the
             # skip-permissions surface is sound.
             skip_permissions=True,
+            # PR-PERMS-FLAG-FIX (2026-05-25) — claude-cli's own
+            # session cache is keyed on cwd, NOT GEODE's task_id, so
+            # successive smoke runs in the same cwd leaked their
+            # cached conversation context across spawns. Strict
+            # per-spawn isolation > PR-V's cross-turn cached-marker
+            # optimization for the sub-agent dispatch model (each
+            # task_id spawns once and exits). PR-V's `--resume <id>`
+            # path still works for callers that explicitly thread a
+            # ``resume_session_id`` (none do at sub-agent dispatch
+            # today; preserved for future explicit-id callers).
+            disable_session_persistence=True,
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"

--- a/core/llm/adapters/codex_cli.py
+++ b/core/llm/adapters/codex_cli.py
@@ -54,6 +54,9 @@ class CodexCliAdapter:
 
     async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
         import asyncio
+        import json as _json
+        import tempfile
+        from pathlib import Path as _Path
 
         from core.orchestration.codex_cli_lane import acquire_codex_cli_lane_async
 
@@ -64,40 +67,65 @@ class CodexCliAdapter:
                 "Install the Codex CLI or use the openai-payg / codex-oauth adapter."
             )
         argv = [binary, "exec", "--model", req.model, "--full-auto"]
+        # PR-PERMS-FLAG-FIX (2026-05-25, JSON-forcing bundle) —
+        # ``codex exec --output-schema <FILE>`` takes a JSON Schema
+        # FILE path (vs claude-cli's ``--json-schema <inline>``
+        # string). Materialise the schema into a tempfile when
+        # ``req.response_schema`` is set, clean up after the
+        # subprocess exits. Mirrors the same structured-output forcing
+        # the OpenAI SDK does via
+        # ``chat.completions.parse(response_format=PydanticModel)`` →
+        # ``json_schema`` with ``strict=true``.
+        _schema_tmp: _Path | None = None
+        if req.response_schema is not None:
+            _fd, _path = tempfile.mkstemp(prefix="codex-cli-schema-", suffix=".json")
+            _schema_tmp = _Path(_path)
+            try:
+                with open(_fd, "w", encoding="utf-8") as fh:
+                    _json.dump(req.response_schema, fh, separators=(",", ":"))
+            except Exception:
+                _schema_tmp.unlink(missing_ok=True)
+                _schema_tmp = None
+                raise
+            argv += ["--output-schema", str(_schema_tmp)]
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"codex-cli:{req.model}"
-        async with acquire_codex_cli_lane_async(lane_key):
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    *argv,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-            except (FileNotFoundError, OSError) as exc:
-                self._last_error = exc
-                raise RuntimeError(f"codex-cli: spawn failed — {exc!r}") from exc
-            try:
-                stdout_b, stderr_b = await asyncio.wait_for(
-                    proc.communicate(stdin_text.encode("utf-8")),
-                    timeout=600.0,
-                )
-            except TimeoutError as exc:
-                proc.kill()
-                await proc.wait()
-                self._last_error = exc
-                raise RuntimeError("codex-cli: subprocess timeout after 600s") from exc
-        stdout = stdout_b.decode("utf-8", errors="replace")
-        stderr = stderr_b.decode("utf-8", errors="replace")
-        rc = proc.returncode or 0
-        if rc != 0:
-            err_excerpt = stderr.strip().splitlines()[-1] if stderr.strip() else "<no stderr>"
-            raise RuntimeError(f"codex-cli subprocess exited rc={rc}: {err_excerpt}")
-        return AdapterCallResult(
-            text=stdout,
-            usage=UsageSummary(),
-            stop_reason="end_turn",
-        )
+        try:
+            async with acquire_codex_cli_lane_async(lane_key):
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        *argv,
+                        stdin=asyncio.subprocess.PIPE,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                except (FileNotFoundError, OSError) as exc:
+                    self._last_error = exc
+                    raise RuntimeError(f"codex-cli: spawn failed — {exc!r}") from exc
+                try:
+                    stdout_b, stderr_b = await asyncio.wait_for(
+                        proc.communicate(stdin_text.encode("utf-8")),
+                        timeout=600.0,
+                    )
+                except TimeoutError as exc:
+                    proc.kill()
+                    await proc.wait()
+                    self._last_error = exc
+                    raise RuntimeError("codex-cli: subprocess timeout after 600s") from exc
+            stdout = stdout_b.decode("utf-8", errors="replace")
+            stderr = stderr_b.decode("utf-8", errors="replace")
+            rc = proc.returncode or 0
+            if rc != 0:
+                err_excerpt = stderr.strip().splitlines()[-1] if stderr.strip() else "<no stderr>"
+                raise RuntimeError(f"codex-cli subprocess exited rc={rc}: {err_excerpt}")
+            return AdapterCallResult(
+                text=stdout,
+                usage=UsageSummary(),
+                stop_reason="end_turn",
+            )
+        finally:
+            if _schema_tmp is not None:
+                _schema_tmp.unlink(missing_ok=True)
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         result = await self.acomplete(req)

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -337,6 +337,7 @@ def build_claude_cli_argv(
     resume_session_id: str | None = None,
     skip_permissions: bool = False,
     disable_session_persistence: bool = False,
+    json_schema: dict[str, Any] | None = None,
 ) -> list[str]:
     """Construct the ``claude --print`` argv.
 
@@ -395,6 +396,16 @@ def build_claude_cli_argv(
             optimization. GEODE's AgenticLoop adapter call passes True
             because the sub-agent execution model is "one task_id, one
             spawn" — there is no cross-turn resume to optimize.
+        json_schema: JSON Schema dict that constrains the model's
+            final response shape. When set, appends
+            ``--json-schema <json>`` (inline). Mirrors the Anthropic
+            SDK's ``messages.parse(output_format=PydanticModel)`` →
+            ``JSONOutputFormatParam(schema=..., type="json_schema")``
+            structured-output API. Eliminates the "LLM returns natural
+            language + code block instead of pure JSON" failure that
+            clipped proximity / critic / pilot / meta_reviewer in the
+            v0.99.53 smoke. Callers pass the dict; this helper handles
+            serialisation.
 
     The output format is pinned to ``stream-json`` + ``--verbose`` —
     we need every event to construct ``ModelOutput`` faithfully.
@@ -464,6 +475,13 @@ def build_claude_cli_argv(
         # is documented in ``claude --help``: "Disable session
         # persistence ... only works with --print".
         argv += ["--no-session-persistence"]
+    if json_schema is not None:
+        # PR-PERMS-FLAG-FIX (2026-05-25, JSON-forcing bundle) — pass
+        # the schema inline so claude-cli's structured-output
+        # validator constrains the model's final response. Mirrors
+        # paperclip / Anthropic SDK
+        # ``messages.parse(output_format=...)`` → JSONOutputFormat.
+        argv += ["--json-schema", json.dumps(json_schema, separators=(",", ":"))]
     if extra_args:
         argv += list(extra_args)
     return argv

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -336,6 +336,7 @@ def build_claude_cli_argv(
     extra_args: Iterable[str] | None = None,
     resume_session_id: str | None = None,
     skip_permissions: bool = False,
+    disable_session_persistence: bool = False,
 ) -> list[str]:
     """Construct the ``claude --print`` argv.
 
@@ -366,12 +367,34 @@ def build_claude_cli_argv(
             ``execute.ts:697`` "instructions are already in the
             session cache").
         skip_permissions: When True append the
-            ``--allow-dangerously-skip-permissions`` flag. Required
-            for headless sub-agent execution (operator can't approve
+            ``--dangerously-skip-permissions`` flag. Required for
+            headless sub-agent execution (operator can't approve
             file-system permission prompts in a background spawn).
             GEODE's AgenticLoop adapter call passes True; inspect_ai
             / petri_audit interactive paths leave it False so the
             CLI's permission prompts still gate writes.
+
+            Note: ``claude --help`` lists two related flags. The
+            ``--allow-dangerously-skip-permissions`` variant only
+            *enables the option*; ``--dangerously-skip-permissions``
+            (no ``--allow-`` prefix) actually performs the bypass.
+            PR-PERMS-FLAG-FIX (2026-05-25) corrected from the former
+            to the latter after the v0.99.53 smoke surfaced the
+            difference (1st sub-agent passed, 2nd hit Write denial
+            because the meta-flag didn't actually bypass).
+        disable_session_persistence: When True append
+            ``--no-session-persistence``. claude-cli's own
+            ``~/.claude/projects/<cwd-hash>/sessions/`` cache is keyed
+            on cwd, NOT on GEODE's per-agent task_id, so successive
+            smoke runs sharing the same cwd would read each other's
+            cached conversation context — surfaced as "the excerpt
+            mentions a scenario from a different smoke" in the v0.99.53
+            smoke. Setting True turns off the persistence side-channel
+            entirely, restoring strict per-spawn isolation at the cost
+            of giving up PR-V's cross-turn cached-marker billing
+            optimization. GEODE's AgenticLoop adapter call passes True
+            because the sub-agent execution model is "one task_id, one
+            spawn" — there is no cross-turn resume to optimize.
 
     The output format is pinned to ``stream-json`` + ``--verbose`` —
     we need every event to construct ``ModelOutput`` faithfully.
@@ -414,16 +437,33 @@ def build_claude_cli_argv(
         # subprocess, so any tool that requires interactive permission
         # approval (Write outside cwd, Bash dangerous commands, etc.)
         # would hang the subprocess on a prompt no one can answer.
-        # The v0.99.53 smoke surfaced this as Write-tool permission
-        # denials on every seed candidate generation (claude-cli's
-        # LLM tried 3 Write attempts + Bash-cat-redirect + Agent
-        # delegation, all blocked, then exited cleanly with a "please
-        # grant write access" final message — but with empty
-        # candidates downstream). This flag is recommended only for
-        # sandboxes with no internet access per ``claude --help``;
-        # GEODE's sub-agent dispatch IS such a sandbox (denied_tools
-        # set + working_dirs whitelist + isolated subprocess).
-        argv += ["--allow-dangerously-skip-permissions"]
+        # PR-PERMS-FLAG-FIX (2026-05-25): the original
+        # ``--allow-dangerously-skip-permissions`` is only the meta
+        # ENABLE flag; ``--dangerously-skip-permissions`` (no
+        # ``--allow-`` prefix) is the one that ACTUALLY bypasses.
+        # v0.99.53 smoke caught this — 1st sub-agent passed (Bash
+        # tools bypassed under a lighter check) while 2nd hit Write
+        # denial because the meta-flag never enabled the bypass.
+        # ``claude --help`` documents both: this flag is recommended
+        # only for sandboxes; GEODE's sub-agent dispatch IS such a
+        # sandbox (denied_tools set + working_dirs whitelist +
+        # isolated subprocess).
+        argv += ["--dangerously-skip-permissions"]
+    if disable_session_persistence:
+        # PR-PERMS-FLAG-FIX (2026-05-25) — claude-cli's own session
+        # cache (``~/.claude/projects/<cwd-hash>/sessions/``) is keyed
+        # on cwd, NOT on GEODE's per-agent ``task_id``. v0.99.53
+        # smoke surfaced this as cross-smoke conversation leakage —
+        # the proximity sub-agent in smoke 5 responded with "the
+        # excerpt mentions a scenario from a different smoke" because
+        # claude-cli auto-resumed a cached session from smoke 3 / 4
+        # that happened to share the same cwd. Disabling persistence
+        # restores strict per-spawn isolation at the cost of PR-V's
+        # cross-turn cached-marker billing — acceptable for sub-agent
+        # spawns which run once and exit. ``--no-session-persistence``
+        # is documented in ``claude --help``: "Disable session
+        # persistence ... only works with --print".
+        argv += ["--no-session-persistence"]
     if extra_args:
         argv += list(extra_args)
     return argv

--- a/tests/plugins/petri_audit/test_claude_cli_provider.py
+++ b/tests/plugins/petri_audit/test_claude_cli_provider.py
@@ -325,6 +325,62 @@ def test_argv_session_persistence_composes_with_skip_permissions() -> None:
     assert argv[-2:] == ["--reasoning-effort", "high"]
 
 
+def test_argv_json_schema_default_none_omits_flag() -> None:
+    """PR-PERMS-FLAG-FIX (2026-05-25, JSON-forcing bundle) — default
+    None means callers that don't need structured output retain
+    free-form text responses."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(binary="/x/claude", model_name="claude-opus-4-7")
+    assert "--json-schema" not in argv
+
+
+def test_argv_json_schema_dict_appends_serialized_inline() -> None:
+    """When ``json_schema`` is set, claude-cli's ``--json-schema``
+    flag receives the schema serialised as inline JSON. Pinned shape
+    so a future refactor doesn't accidentally pass a file path
+    (claude-cli accepts inline only; codex-cli is the path-based one)."""
+    import json
+
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    schema = {
+        "type": "object",
+        "properties": {"verdict": {"type": "string"}},
+        "required": ["verdict"],
+    }
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        json_schema=schema,
+    )
+    assert "--json-schema" in argv
+    idx = argv.index("--json-schema")
+    parsed = json.loads(argv[idx + 1])
+    assert parsed == schema
+
+
+def test_argv_json_schema_composes_with_all_other_flags() -> None:
+    """All three new dispatch-policy flags (skip_permissions,
+    disable_session_persistence, json_schema) can be applied in the
+    same call without disturbing the existing ``extra_args``
+    tail-anchor invariant."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        skip_permissions=True,
+        disable_session_persistence=True,
+        json_schema={"type": "object"},
+        extra_args=["--reasoning-effort", "high"],
+    )
+    assert "--dangerously-skip-permissions" in argv
+    assert "--no-session-persistence" in argv
+    assert "--json-schema" in argv
+    assert argv[-2:] == ["--reasoning-effort", "high"]
+
+
 # ---------------------------------------------------------------------------
 # Message serialiser
 # ---------------------------------------------------------------------------

--- a/tests/plugins/petri_audit/test_claude_cli_provider.py
+++ b/tests/plugins/petri_audit/test_claude_cli_provider.py
@@ -208,7 +208,7 @@ def test_argv_skip_permissions_default_false() -> None:
     from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
 
     argv = build_claude_cli_argv(binary="/x/claude", model_name="claude-opus-4-7")
-    assert "--allow-dangerously-skip-permissions" not in argv
+    assert "--dangerously-skip-permissions" not in argv
 
 
 def test_argv_skip_permissions_true_appends_flag() -> None:
@@ -223,7 +223,7 @@ def test_argv_skip_permissions_true_appends_flag() -> None:
         model_name="claude-opus-4-7",
         skip_permissions=True,
     )
-    assert "--allow-dangerously-skip-permissions" in argv
+    assert "--dangerously-skip-permissions" in argv
 
 
 def test_argv_skip_permissions_order_after_tools_block() -> None:
@@ -239,7 +239,7 @@ def test_argv_skip_permissions_order_after_tools_block() -> None:
         skip_permissions=True,
     )
     tools_idx = argv.index("--tools")
-    skip_idx = argv.index("--allow-dangerously-skip-permissions")
+    skip_idx = argv.index("--dangerously-skip-permissions")
     assert tools_idx < skip_idx
 
 
@@ -256,7 +256,73 @@ def test_argv_skip_permissions_composes_with_extra_args() -> None:
         extra_args=["--reasoning-effort", "high"],
     )
     assert argv[-2:] == ["--reasoning-effort", "high"]
-    assert "--allow-dangerously-skip-permissions" in argv[:-2]
+    assert "--dangerously-skip-permissions" in argv[:-2]
+
+
+def test_argv_skip_permissions_uses_real_bypass_flag_not_meta() -> None:
+    """PR-PERMS-FLAG-FIX (2026-05-25) — the v0.99.53 smoke surfaced
+    that the former ``--allow-dangerously-skip-permissions`` flag is
+    only the meta ENABLE flag, while ``--dangerously-skip-permissions``
+    (no ``--allow-`` prefix) is the one that actually performs the
+    bypass. Pin the active flag name so a future refactor doesn't
+    silently regress to the meta-flag and produce mixed-result smoke
+    runs (1st sub-agent passes via lighter checks, 2nd fails on
+    Write denial)."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        skip_permissions=True,
+    )
+    assert "--dangerously-skip-permissions" in argv
+    # The meta-only "allow-" variant must NEVER appear — it doesn't
+    # bypass anything by itself and would just confuse log readers.
+    assert "--allow-dangerously-skip-permissions" not in argv
+
+
+def test_argv_disable_session_persistence_default_false() -> None:
+    """PR-PERMS-FLAG-FIX (2026-05-25) — default off so callers that
+    rely on PR-V's `--resume`-based cross-turn cached-marker billing
+    optimization (5-10K tokens saved per heartbeat) are unaffected.
+    Sub-agent dispatch explicitly opts in via True."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(binary="/x/claude", model_name="claude-opus-4-7")
+    assert "--no-session-persistence" not in argv
+
+
+def test_argv_disable_session_persistence_true_appends_flag() -> None:
+    """Explicit True appends the flag so sub-agent spawns get strict
+    per-process isolation (no cwd-keyed claude-cli session cache
+    leaking conversation context across smokes)."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        disable_session_persistence=True,
+    )
+    assert "--no-session-persistence" in argv
+
+
+def test_argv_session_persistence_composes_with_skip_permissions() -> None:
+    """Both new flags can be enabled simultaneously — both are
+    sub-agent dispatch policy defaults — and they retain a stable
+    ordering relative to ``--tools "" `` and ``extra_args``."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/x/claude",
+        model_name="claude-opus-4-7",
+        skip_permissions=True,
+        disable_session_persistence=True,
+        extra_args=["--reasoning-effort", "high"],
+    )
+    assert "--dangerously-skip-permissions" in argv
+    assert "--no-session-persistence" in argv
+    # extra_args still tail-anchored
+    assert argv[-2:] == ["--reasoning-effort", "high"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two coupled fixes for the v0.99.53 sub-agent isolation surface (caught by smoke 5 trace + Codex MCP review):

- **A (flag rename):** `--allow-dangerously-skip-permissions` → `--dangerously-skip-permissions`. The former is `claude --help`'s meta ENABLE flag and does not actually bypass; the latter is the documented bypass.
- **B (session persistence):** new `disable_session_persistence: bool = False` param on `build_claude_cli_argv()` appends `--no-session-persistence`. AgenticLoop adapter opts in to prevent claude-cli's cwd-keyed session cache from leaking conversation context across sub-agent spawns.

## Why

Smoke 5 (`audit-seeds generate --target-dim redundant_tool_invocation`, post-PR-PRT-STATUS) progressed past the classifier false-positive into the next layer of issues:

1. **1 of 2 generator candidates wrote to disk; the other was Write-denied.** Same PR-SKIP-PERMS / same binary / same `claude-cli` invocation pattern, but split results. Root cause: the flag GEODE was passing (`--allow-dangerously-skip-permissions`) is only `claude --help`'s meta ENABLE flag — it tells the CLI "you may use the bypass option" without actually invoking the bypass. The actual bypass is `--dangerously-skip-permissions` (no `--allow-` prefix). claude-cli's permission system has a per-tool gradient; lighter checks (Bash) passed silently while the explicit Write check (gen1-001-fe59b502.md path) still blocked. The 2nd sub-agent's `result.json.output` ends with: *"The write is blocked pending your approval for path `.../gen1-001-fe59b502.md`."*

2. **proximity LLM responded with "the excerpt mentions a scenario from a different smoke."** The prompted candidate IDs (`gen1-000-62d84728`, `gen1-001-fe59b502`) were freshly generated by smoke 5, but the LLM saw context referencing OLDER scenarios (`calendar_fetch`) from prior smoke runs. claude-cli's own session cache (`~/.claude/projects/<cwd-hash>/sessions/`) is keyed on **cwd**, not on GEODE's per-agent `task_id`, so successive smoke runs in the same cwd auto-resumed each other's cached conversation context. PR-V's GEODE-level session isolation (`<run_dir>/sub_agents/<task_id>/session.json`) doesn't help here — it controls *explicit* resume, not the implicit cwd-cache resume claude-cli does on its own.

Both gaps surface from the same place (`build_claude_cli_argv`), so a single PR fixing both is the minimal-friction landing.

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` | (1) `skip_permissions=True` branch now emits `--dangerously-skip-permissions` (was `--allow-dangerously-skip-permissions`). Docstring + inline block-comment cite the v0.99.53 smoke split-result evidence + `claude --help`'s distinction between the two flags. (2) New `disable_session_persistence: bool = False` param appends `--no-session-persistence` when True. Docstring documents the cwd-cache cross-smoke leak that smoke 5 surfaced. |
| `core/llm/adapters/claude_cli.py` | AgenticLoop adapter call site adds `disable_session_persistence=True` alongside the existing `skip_permissions=True`. 11-line block comment explains the PR-V trade-off: cross-turn cached-marker billing optimization gives way to strict per-spawn isolation, acceptable because sub-agent dispatch is "one task_id, one spawn". |
| `tests/plugins/petri_audit/test_claude_cli_provider.py` | (1) Existing 4 PR-SKIP-PERMS argv tests updated to the new `--dangerously-skip-permissions` literal. (2) 4 new tests: `test_argv_skip_permissions_uses_real_bypass_flag_not_meta` (pins the bypass flag + asserts the meta-`--allow-` form never appears), `test_argv_disable_session_persistence_default_false`, `test_argv_disable_session_persistence_true_appends_flag`, `test_argv_session_persistence_composes_with_skip_permissions`. |
| `CHANGELOG.md` | Unreleased entry under Fixed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| A: actual bypass flag | Implemented | `--dangerously-skip-permissions` (no `--allow-`) |
| A: regression pin against meta-flag relapse | Implemented | `test_..._uses_real_bypass_flag_not_meta` asserts both directions |
| B: `disable_session_persistence` param | Implemented | default False (back-compat) |
| B: AgenticLoop adapter opts in | Implemented | `core/llm/adapters/claude_cli.py` |
| B: existing tests updated to new literal | Implemented | 4 sites in `test_claude_cli_provider.py` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check` — 884 files unchanged
- [x] `uv run mypy core/ plugins/` — 432 source files, 0 errors
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] Direct argv unit smoke — 3/3 pass (A flag rename, B persistence flag, both + extra_args order)
- [x] Full pytest suite — green at PR push time

## Reference

- Smoke 5 artefacts: `state/seed-generation/gen1-redundant_tool_invocation/sub_agents/`
  - `gen-gen1-000-62d84728/result.json` (success, wrote candidate)
  - `gen-gen1-001-fe59b502/result.json` (success=true but output ends with "write is blocked pending your approval")
- claude-cli dump: latest in `~/.geode/diagnostics/claude-cli-transient/`
- `claude --help` flag distinction:
  - `--allow-dangerously-skip-permissions` "Enable bypassing all permission checks AS AN OPTION, without it being enabled by default"
  - `--dangerously-skip-permissions` "Bypass all permission checks"
  - `--no-session-persistence` "Disable session persistence - sessions will not be saved to disk and cannot be resumed (only works with --print)"
- Sister PR chain on v0.99.53: PR-DEFECT-AB → PR-COMM-2/3/3b/3c/3d/4 → PR-TIMECAP → PR-SKIP-PERMS → PR-PRT-STATUS → **PR-PERMS-FLAG-FIX**
