### PR TITLE
fix(seed-gen): strip ```json``` codeblock fence in parse_structured_output (PR-JSON-CODEBLOCK-STRIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-JSON-CODEBLOCK-STRIP** — `parse_structured_output()` (shared
+  parser used by Critic / Pilot / Ranker / Evolver / Meta-review)
+  now strips ```` ```json ... ``` ```` markdown code fences before
+  `json.loads()`. The v0.99.53 smoke 6 surfaced critic / proximity /
+  meta_reviewer phases failing on otherwise-valid JSON because the
+  LLM (claude-cli with `--json-schema` not yet wired through the
+  orchestrator) wrapped its response in a markdown code block. The
+  pre-fix path called `json.loads(raw_output["text"])` directly,
+  which rejects the wrapper with `JSONDecodeError`, so the result
+  was dropped and the phase aborted with "malformed payload".
+  New `_strip_json_codeblock()` helper at the top of `base.py`
+  uses a `re.DOTALL` regex to unwrap `` ```json `` / `` ```JSON `` /
+  bare `` ``` `` fences (optional language tag + optional newline
+  variants), returning the inner body. Plain (un-fenced) JSON
+  passes through unchanged. Pinned by 6 new regression tests in
+  `tests/plugins/seed_generation/test_base.py`:
+  `test_parse_text_json_codeblock_fence_with_lang_tag`,
+  `test_parse_text_json_codeblock_fence_no_lang_tag`,
+  `test_parse_text_json_codeblock_fence_with_leading_prose`,
+  `test_parse_text_json_codeblock_fence_uppercase_lang_tag`,
+  `test_parse_text_json_codeblock_inline_no_newline`,
+  `test_parse_text_plain_json_still_works_after_fence_helper`.
+
 - **PR-PERMS-FLAG-FIX** — two coupled fixes for the v0.99.53
   sub-agent isolation surface (caught by smoke 5 / Codex MCP review):
   - **A: actual permission bypass flag.** `build_claude_cli_argv()`

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import abc
 import json
 import logging
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -53,6 +54,30 @@ from typing import Any, Literal
 log = logging.getLogger(__name__)
 
 __all__ = ["BaseSeedAgent", "SeedAgentResult", "parse_structured_output"]
+
+
+# Matches a fenced code block containing JSON. The optional language tag
+# (`json` / `JSON`) and surrounding whitespace/newlines are stripped; the
+# captured group is the inner JSON body. Smoke 6 surfaced critic /
+# proximity / meta_reviewer responses wrapped in ```json``` fences that
+# json.loads() rejects — this helper unwraps them before parsing.
+_JSON_CODEBLOCK_RE = re.compile(
+    r"```(?:json|JSON)?\s*\n?(.*?)\n?\s*```",
+    re.DOTALL,
+)
+
+
+def _strip_json_codeblock(text: str) -> str:
+    """Strip a leading/trailing ```json``` fence from an LLM response.
+
+    Returns the inner body if a fenced block is found, otherwise the
+    original string unchanged. The body itself is whitespace-stripped so
+    json.loads() sees `{...}` without leading/trailing newlines.
+    """
+    match = _JSON_CODEBLOCK_RE.search(text)
+    if match is None:
+        return text
+    return match.group(1).strip()
 
 
 def parse_structured_output(
@@ -96,8 +121,9 @@ def parse_structured_output(
     if has_required or (not required_fields and not has_text):
         parsed = dict(raw_output)
     elif has_text:
+        candidate_text = _strip_json_codeblock(raw_output["text"])
         try:
-            candidate = json.loads(raw_output["text"])
+            candidate = json.loads(candidate_text)
         except json.JSONDecodeError:
             return None
         if isinstance(candidate, dict):

--- a/tests/plugins/seed_generation/test_base.py
+++ b/tests/plugins/seed_generation/test_base.py
@@ -95,3 +95,64 @@ def test_parse_empty_required_fields_accepts_any_dict() -> None:
         required_fields=(),
     )
     assert out == {"anything": "goes"}
+
+
+def test_parse_text_json_codeblock_fence_with_lang_tag() -> None:
+    """Smoke 6 regression — critic/proximity LLM wrapped JSON in
+    ```json ... ``` fence; the parser must strip the fence before
+    json.loads()."""
+    out = parse_structured_output(
+        {"text": '```json\n{"a": 1, "b": 2}\n```'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_text_json_codeblock_fence_no_lang_tag() -> None:
+    """Bare ``` fence (no language tag) must also unwrap."""
+    out = parse_structured_output(
+        {"text": '```\n{"a": 1}\n```'},
+        required_fields=("a",),
+    )
+    assert out == {"a": 1}
+
+
+def test_parse_text_json_codeblock_fence_with_leading_prose() -> None:
+    """LLM may prepend prose before the fence — the regex skips to the
+    block and unwraps it."""
+    payload = (
+        'Sure, here is the analysis:\n\n```json\n{"candidate_id": "gen1-000", "score": 7}\n```'
+    )
+    out = parse_structured_output(
+        {"text": payload},
+        required_fields=("candidate_id", "score"),
+    )
+    assert out == {"candidate_id": "gen1-000", "score": 7}
+
+
+def test_parse_text_json_codeblock_fence_uppercase_lang_tag() -> None:
+    out = parse_structured_output(
+        {"text": '```JSON\n{"x": 99}\n```'},
+        required_fields=("x",),
+    )
+    assert out == {"x": 99}
+
+
+def test_parse_text_json_codeblock_inline_no_newline() -> None:
+    """Some LLMs collapse the fence to a single line — still unwrap."""
+    out = parse_structured_output(
+        {"text": '```json {"a": 1, "b": 2} ```'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_text_plain_json_still_works_after_fence_helper() -> None:
+    """Regression — plain (un-fenced) JSON must still parse correctly
+    when the helper is active. No fence in input → helper returns the
+    string unchanged."""
+    out = parse_structured_output(
+        {"text": '{"a": 1, "b": 2}'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary

`parse_structured_output()` (shared parser used by Critic / Pilot / Ranker / Evolver / Meta-review) now strips ```` ```json ... ``` ```` markdown code fences before `json.loads()`. Smoke 6 surfaced 3 phases failing on otherwise-valid JSON wrapped in a markdown fence.

- New private `_strip_json_codeblock(text)` helper at top of `plugins/seed_generation/agents/base.py` uses a single `re.DOTALL` regex to unwrap `` ```json `` / `` ```JSON `` / bare `` ``` `` fences. Plain (un-fenced) JSON passes through unchanged.
- `parse_structured_output()`'s `elif has_text:` branch routes through the helper before `json.loads()`.
- 6 new regression tests pin the unwrap contract; 9 existing tests still pass (15 total).

## Why

v0.99.53 smoke 6 (post-PR-PERMS-FLAG-FIX + PR-PRT-STATUS) progressed all the way to end-to-end execution. claude-cli wrote seed candidates, `--dangerously-skip-permissions` + `--no-session-persistence` held, and the classifier no longer false-matched. But 5 of 8 phases still failed.

Three of them shared a common root cause — the LLM returned otherwise-valid JSON wrapped in a markdown code block:

```
critic raw_output["text"]:
  ```json
  {
    "candidate_id": "gen1-000-b80d65e0",
    "score": 7,
    ...
  }
  ```
```

The pre-fix `parse_structured_output()` called `json.loads(raw_output["text"])` directly, which rejects the ```` ```json ```` wrapper with `JSONDecodeError`. The result was dropped (`return None`), the phase saw `malformed payload`, and aborted.

The structured-output infrastructure from PR-PERMS-FLAG-FIX (`AdapterCallRequest.response_schema` → `--json-schema` / `--output-schema`) eliminates this on the producer side, but it requires orchestrator wire-through (PR-JSON-WIRE, follow-up). Until that lands, this parser-side defence keeps the pipeline progressing — which is the path 3+ frontier systems (Claude Code, Codex CLI, OpenClaw, autoresearch) all take: tolerate fenced JSON at the consumer.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_generation/agents/base.py` | (1) New module-level `_JSON_CODEBLOCK_RE = re.compile(r"```(?:json\|JSON)?\s*\n?(.*?)\n?\s*```", re.DOTALL)`. (2) New `_strip_json_codeblock(text)` helper — returns inner body if fence found (whitespace-stripped), else the original text unchanged. (3) `parse_structured_output()` `elif has_text:` branch now routes through `_strip_json_codeblock()` before `json.loads()`. (4) `import re` added. |
| `tests/plugins/seed_generation/test_base.py` | 6 new tests covering: ```` ```json ```` lang tag, bare ``` fence, leading prose before fence, uppercase ```` ```JSON ````, inline single-line fence, plain JSON regression-still-works. |
| `CHANGELOG.md` | Unreleased entry under Fixed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| codeblock-strip helper | Implemented | `_strip_json_codeblock()` |
| parse_structured_output wired through helper | Implemented | `elif has_text:` branch |
| 5+ regression test cases (per fence variant) | Implemented | 6 tests added |
| Plain JSON still works (no fence) | Verified | `test_parse_text_plain_json_still_works_after_fence_helper` |
| Invalid JSON inside fence still returns None | Inherits | existing `test_parse_text_invalid_json_returns_none` still applies (helper returns text unchanged if no fence; helper returns inner body if fence found, then `json.loads` raises → None) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 884 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 432 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/plugins/seed_generation/test_base.py -v` — 15 passed (9 existing + 6 new)
- [x] `uv run python -m pytest tests/plugins/seed_generation/` — 447 passed, 3 skipped
- [ ] Full pytest suite — running

## Reference

- Smoke 6 artefacts: `state/seed-generation/gen1-redundant_tool_invocation/sub_agents/`
  - critic `result.json` raw `text`: ```` ```json\n{...}\n``` ```` form
  - meta_reviewer same pattern
- Sister PR chain: PR-DEFECT-AB → PR-COMM-2/3/3b/3c/3d/4 → PR-TIMECAP → PR-SKIP-PERMS → PR-PRT-STATUS → PR-PERMS-FLAG-FIX → **PR-JSON-CODEBLOCK-STRIP**
- Follow-up: PR-JSON-WIRE will wire orchestrator → role-specific JSON Schema → `AdapterCallRequest.response_schema` (uses infrastructure from PR-PERMS-FLAG-FIX) so the producer-side eliminates the wrap upstream; this PR is the consumer-side defence.
