### PR TITLE
promote PR-JSON-CODEBLOCK-STRIP to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-JSON-CODEBLOCK-STRIP** — `parse_structured_output()` (shared
+  parser used by Critic / Pilot / Ranker / Evolver / Meta-review)
+  now strips ```` ```json ... ``` ```` markdown code fences before
+  `json.loads()`. The v0.99.53 smoke 6 surfaced critic / proximity /
+  meta_reviewer phases failing on otherwise-valid JSON because the
+  LLM (claude-cli with `--json-schema` not yet wired through the
+  orchestrator) wrapped its response in a markdown code block. The
+  pre-fix path called `json.loads(raw_output["text"])` directly,
+  which rejects the wrapper with `JSONDecodeError`, so the result
+  was dropped and the phase aborted with "malformed payload".
+  New `_strip_json_codeblock()` helper at the top of `base.py`
+  uses a `re.DOTALL` regex to unwrap `` ```json `` / `` ```JSON `` /
+  bare `` ``` `` fences (optional language tag + optional newline
+  variants), returning the inner body. Plain (un-fenced) JSON
+  passes through unchanged. Pinned by 6 new regression tests in
+  `tests/plugins/seed_generation/test_base.py`:
+  `test_parse_text_json_codeblock_fence_with_lang_tag`,
+  `test_parse_text_json_codeblock_fence_no_lang_tag`,
+  `test_parse_text_json_codeblock_fence_with_leading_prose`,
+  `test_parse_text_json_codeblock_fence_uppercase_lang_tag`,
+  `test_parse_text_json_codeblock_inline_no_newline`,
+  `test_parse_text_plain_json_still_works_after_fence_helper`.
+
 - **PR-PERMS-FLAG-FIX** — two coupled fixes for the v0.99.53
   sub-agent isolation surface (caught by smoke 5 / Codex MCP review):
   - **A: actual permission bypass flag.** `build_claude_cli_argv()`

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import abc
 import json
 import logging
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -53,6 +54,30 @@ from typing import Any, Literal
 log = logging.getLogger(__name__)
 
 __all__ = ["BaseSeedAgent", "SeedAgentResult", "parse_structured_output"]
+
+
+# Matches a fenced code block containing JSON. The optional language tag
+# (`json` / `JSON`) and surrounding whitespace/newlines are stripped; the
+# captured group is the inner JSON body. Smoke 6 surfaced critic /
+# proximity / meta_reviewer responses wrapped in ```json``` fences that
+# json.loads() rejects — this helper unwraps them before parsing.
+_JSON_CODEBLOCK_RE = re.compile(
+    r"```(?:json|JSON)?\s*\n?(.*?)\n?\s*```",
+    re.DOTALL,
+)
+
+
+def _strip_json_codeblock(text: str) -> str:
+    """Strip a leading/trailing ```json``` fence from an LLM response.
+
+    Returns the inner body if a fenced block is found, otherwise the
+    original string unchanged. The body itself is whitespace-stripped so
+    json.loads() sees `{...}` without leading/trailing newlines.
+    """
+    match = _JSON_CODEBLOCK_RE.search(text)
+    if match is None:
+        return text
+    return match.group(1).strip()
 
 
 def parse_structured_output(
@@ -96,8 +121,9 @@ def parse_structured_output(
     if has_required or (not required_fields and not has_text):
         parsed = dict(raw_output)
     elif has_text:
+        candidate_text = _strip_json_codeblock(raw_output["text"])
         try:
-            candidate = json.loads(raw_output["text"])
+            candidate = json.loads(candidate_text)
         except json.JSONDecodeError:
             return None
         if isinstance(candidate, dict):

--- a/tests/plugins/seed_generation/test_base.py
+++ b/tests/plugins/seed_generation/test_base.py
@@ -95,3 +95,64 @@ def test_parse_empty_required_fields_accepts_any_dict() -> None:
         required_fields=(),
     )
     assert out == {"anything": "goes"}
+
+
+def test_parse_text_json_codeblock_fence_with_lang_tag() -> None:
+    """Smoke 6 regression — critic/proximity LLM wrapped JSON in
+    ```json ... ``` fence; the parser must strip the fence before
+    json.loads()."""
+    out = parse_structured_output(
+        {"text": '```json\n{"a": 1, "b": 2}\n```'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_text_json_codeblock_fence_no_lang_tag() -> None:
+    """Bare ``` fence (no language tag) must also unwrap."""
+    out = parse_structured_output(
+        {"text": '```\n{"a": 1}\n```'},
+        required_fields=("a",),
+    )
+    assert out == {"a": 1}
+
+
+def test_parse_text_json_codeblock_fence_with_leading_prose() -> None:
+    """LLM may prepend prose before the fence — the regex skips to the
+    block and unwraps it."""
+    payload = (
+        'Sure, here is the analysis:\n\n```json\n{"candidate_id": "gen1-000", "score": 7}\n```'
+    )
+    out = parse_structured_output(
+        {"text": payload},
+        required_fields=("candidate_id", "score"),
+    )
+    assert out == {"candidate_id": "gen1-000", "score": 7}
+
+
+def test_parse_text_json_codeblock_fence_uppercase_lang_tag() -> None:
+    out = parse_structured_output(
+        {"text": '```JSON\n{"x": 99}\n```'},
+        required_fields=("x",),
+    )
+    assert out == {"x": 99}
+
+
+def test_parse_text_json_codeblock_inline_no_newline() -> None:
+    """Some LLMs collapse the fence to a single line — still unwrap."""
+    out = parse_structured_output(
+        {"text": '```json {"a": 1, "b": 2} ```'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_text_plain_json_still_works_after_fence_helper() -> None:
+    """Regression — plain (un-fenced) JSON must still parse correctly
+    when the helper is active. No fence in input → helper returns the
+    string unchanged."""
+    out = parse_structured_output(
+        {"text": '{"a": 1, "b": 2}'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary
- Promotes PR-JSON-CODEBLOCK-STRIP (#1612) to main: `parse_structured_output()` now strips ```json``` markdown code fences before json.loads(), unblocking critic / proximity / meta_reviewer phases in seed-generation smoke 6.

## Verification
- [x] PR #1612 7/7 CI checks green (Lint, Type, Test, Security, install ubuntu/macos, Detect changes)
- [x] 6 new regression tests in `tests/plugins/seed_generation/test_base.py` (15 total)