### PR TITLE
promote PR-SUB-AGENT-CODEBLOCK-STRIP to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,33 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-SUB-AGENT-CODEBLOCK-STRIP** — `SubAgentManager._to_sub_result`
+  / `_to_agent_result` (`core/agent/sub_agent.py`) now strip
+  ```` ```json ... ``` ```` markdown code fences before
+  `json.loads(isolation.output)`. Smoke 7 (v0.99.53, post
+  PR-JSON-CODEBLOCK-STRIP) surfaced proximity + critic phases
+  still failing — the consumer-side strip in
+  `parse_structured_output()` doesn't help when the producer
+  (sub_agent) wraps the fenced text into `{"raw": <wrapped-text>}`
+  before the consumer sees it. Proximity's consumer (which
+  expects either required fields or a `text` key) cannot recover
+  from `{"raw": ...}`; critic's consumer also has no path to
+  unwrap inside a `raw` envelope. Applying the strip at the
+  producer layer eliminates the `{"raw": ...}` fallback for
+  fenced JSON, so downstream agents see a proper dict.
+  New module-level `_JSON_CODEBLOCK_RE` + `_strip_json_codeblock()`
+  helper (sister regex to the one in
+  `plugins/seed_generation/agents/base.py` from
+  PR-JSON-CODEBLOCK-STRIP). Plain (un-fenced) JSON passes through
+  unchanged; non-JSON text still falls back to `{"raw": <text>}`
+  (preserving the original raw envelope behaviour). Pinned by 9
+  new regression tests in
+  `tests/core/agent/test_subagent_json_codeblock_strip.py`:
+  fence with `json` tag, fence with prose preamble, plain JSON
+  regression, non-JSON raw fallback, empty output, bare ``` fence,
+  `_to_agent_result` fence unwrap, `_to_agent_result` plain JSON,
+  `_to_agent_result` raw fallback.
+
 - **PR-JSON-CODEBLOCK-STRIP** — `parse_structured_output()` (shared
   parser used by Critic / Pilot / Ranker / Evolver / Meta-review)
   now strips ```` ```json ... ``` ```` markdown code fences before

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -38,6 +39,39 @@ if TYPE_CHECKING:
     from core.skills.agents import AgentRegistry
 
 log = logging.getLogger(__name__)
+
+
+# Matches a fenced code block (optional `json` / `JSON` lang tag, optional
+# surrounding newlines). Smoke 7 surfaced both proximity and critic
+# failing because the LLM (claude-cli without --json-schema wired
+# through) returned otherwise-valid JSON wrapped in a ```json``` fence
+# plus narrative prose. The pre-fix `json.loads(isolation.output)`
+# rejected the wrapper and the SubAgentManager fell back to
+# `{"raw": <wrapped-text>}` — which downstream consumers cannot
+# interpret. Sister regex lives in
+# `plugins/seed_generation/agents/base.py` (consumer-side defence
+# from PR-JSON-CODEBLOCK-STRIP); this producer-side strip eliminates
+# the {"raw": ...} fallback so all sub-agent consumers see a proper
+# dict.
+_JSON_CODEBLOCK_RE = re.compile(
+    r"```(?:json|JSON)?\s*\n?(.*?)\n?\s*```",
+    re.DOTALL,
+)
+
+
+def _strip_json_codeblock(text: str) -> str:
+    """Unwrap a leading/trailing ```json``` fence around an LLM response.
+
+    Returns the inner body if a fenced block is found (whitespace
+    stripped), otherwise the original text unchanged. Plain (un-fenced)
+    output passes through. The regex uses `re.search`, so prose
+    preceding the fence is discarded.
+    """
+    match = _JSON_CODEBLOCK_RE.search(text)
+    if match is None:
+        return text
+    return match.group(1).strip()
+
 
 # Thread-local storage for subagent context (OpenClaw Spawn pattern)
 _subagent_context = threading.local()
@@ -773,11 +807,13 @@ class SubAgentManager:
                 duration_ms=isolation.duration_ms,
             )
         output: dict[str, Any]
+        raw_text = isolation.output or ""
+        candidate_text = _strip_json_codeblock(raw_text) if raw_text else raw_text
         try:
-            parsed = json.loads(isolation.output) if isolation.output else {}
+            parsed = json.loads(candidate_text) if candidate_text else {}
             output = parsed if isinstance(parsed, dict) else {"raw": parsed}
         except (json.JSONDecodeError, RecursionError):
-            output = {"raw": isolation.output}
+            output = {"raw": raw_text}
         return SubResult(
             task_id=task.task_id,
             description=task.description,
@@ -811,11 +847,13 @@ class SubAgentManager:
                 duration_ms=isolation.duration_ms,
             )
         data: dict[str, Any]
+        raw_text = isolation.output or ""
+        candidate_text = _strip_json_codeblock(raw_text) if raw_text else raw_text
         try:
-            parsed = json.loads(isolation.output) if isolation.output else {}
+            parsed = json.loads(candidate_text) if candidate_text else {}
             data = parsed if isinstance(parsed, dict) else {"raw": parsed}
         except (json.JSONDecodeError, RecursionError):
-            data = {"raw": isolation.output}
+            data = {"raw": raw_text}
         summary = data.get("summary", "")
         if not summary:
             summary = str(data.get("tier", data.get("status", "")))[:200]

--- a/tests/core/agent/test_subagent_json_codeblock_strip.py
+++ b/tests/core/agent/test_subagent_json_codeblock_strip.py
@@ -1,0 +1,146 @@
+"""Regression tests for sub_agent's producer-side ```json``` codeblock strip.
+
+Smoke 7 (v0.99.53, post-PR-JSON-CODEBLOCK-STRIP) surfaced both
+proximity and critic still failing because the LLM wrapped its
+otherwise-valid JSON in a ```json``` markdown fence. The pre-fix
+`SubAgentManager._to_sub_result` / `_to_agent_result` called
+`json.loads(isolation.output)` directly, which raises JSONDecodeError
+on the fence and falls back to `{"raw": <wrapped-text>}` —
+downstream parsers (proximity uses a non-`text`-key consumer) can't
+recover from that shape.
+
+The fix applies `_strip_json_codeblock()` *before* `json.loads()` at
+both convert sites, so a fenced JSON body parses to a proper dict
+and propagates as `SubResult.output` / `SubAgentResult.data`.
+"""
+
+from __future__ import annotations
+
+from core.agent.sub_agent import SubAgentManager, SubTask
+from core.orchestration.isolated_execution import IsolatedRunner, IsolationResult
+
+
+def _make_manager() -> SubAgentManager:
+    return SubAgentManager(runner=IsolatedRunner())
+
+
+def _make_task(task_id: str = "t1", task_type: str = "analyze") -> SubTask:
+    return SubTask(task_id=task_id, description="desc", task_type=task_type)
+
+
+def _make_isolation(output: str) -> IsolationResult:
+    return IsolationResult(session_id="s1", success=True, output=output)
+
+
+def test_to_sub_result_unwraps_json_codeblock_fence() -> None:
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation('```json\n{"similarity_clusters": [], "k": 1}\n```')
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.success is True
+    assert result.output == {"similarity_clusters": [], "k": 1}
+    # No "raw" fallback when the fence unwraps to valid JSON.
+    assert "raw" not in result.output
+
+
+def test_to_sub_result_unwraps_fence_with_leading_prose() -> None:
+    """Smoke 7 proximity case — LLM narrates its tool-call attempts
+    before emitting the structured payload."""
+    manager = _make_manager()
+    task = _make_task()
+    text = (
+        "New IDs — searching for these files on disk. "
+        "The excerpts are detailed enough to assess similarity.\n\n"
+        '```json\n{"similarity_clusters": [{"cluster_id": "c0"}]}\n```'
+    )
+    isolation = _make_isolation(text)
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.success is True
+    assert result.output == {"similarity_clusters": [{"cluster_id": "c0"}]}
+
+
+def test_to_sub_result_plain_json_still_works() -> None:
+    """Regression — un-fenced JSON must still parse correctly."""
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation('{"a": 1, "b": 2}')
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.output == {"a": 1, "b": 2}
+
+
+def test_to_sub_result_non_json_text_falls_back_to_raw() -> None:
+    """Regression — text that contains no JSON and no fence still
+    falls into the `{"raw": <text>}` wrapper (unchanged behaviour)."""
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation("just plain prose, no JSON here")
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.output == {"raw": "just plain prose, no JSON here"}
+
+
+def test_to_sub_result_empty_output_yields_empty_dict() -> None:
+    """Empty isolation.output yields an empty dict — no fence-strip
+    side effect on this path."""
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation("")
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.output == {}
+
+
+def test_to_sub_result_bare_fence_no_lang_tag() -> None:
+    """Some LLMs omit the `json` lang tag — bare ``` fence must
+    also unwrap."""
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation('```\n{"x": 42}\n```')
+
+    result = manager._to_sub_result(task, isolation)
+
+    assert result.output == {"x": 42}
+
+
+def test_to_agent_result_unwraps_json_codeblock_fence() -> None:
+    """Parallel fix at `_to_agent_result` — same regex applied so the
+    SubAgentResult.data carries the parsed dict instead of the
+    `{"raw": ...}` fallback."""
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation('```json\n{"summary": "done", "tier": "gold"}\n```')
+
+    agent_result = manager._to_agent_result(task, isolation)
+
+    assert agent_result.status == "ok"
+    assert agent_result.data == {"summary": "done", "tier": "gold"}
+    assert agent_result.summary == "done"
+
+
+def test_to_agent_result_plain_json_still_works() -> None:
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation('{"summary": "ok", "x": 1}')
+
+    agent_result = manager._to_agent_result(task, isolation)
+
+    assert agent_result.data == {"summary": "ok", "x": 1}
+    assert agent_result.summary == "ok"
+
+
+def test_to_agent_result_non_json_text_falls_back_to_raw() -> None:
+    manager = _make_manager()
+    task = _make_task()
+    isolation = _make_isolation("free-form natural language response")
+
+    agent_result = manager._to_agent_result(task, isolation)
+
+    assert agent_result.data == {"raw": "free-form natural language response"}


### PR DESCRIPTION
## Summary
- Promotes PR-SUB-AGENT-CODEBLOCK-STRIP (#1614) to main: `SubAgentManager._to_sub_result` / `_to_agent_result` now strip ```json``` markdown code fences before `json.loads(isolation.output)` at the producer layer, eliminating the `{"raw": <wrapped-text>}` envelope that blocks downstream consumers. Smoke 7 surfaced proximity / critic / evolver / meta_reviewer all failing on this; this fix unblocks 4 of the 5 failing phases.

## Verification
- [x] PR #1614 7/7 CI checks green
- [x] 9 new regression tests in `tests/core/agent/test_subagent_json_codeblock_strip.py`