### PR TITLE
fix(transient): drop bare \b429\b / \b503\b / \b529\b false-positives (PR-TRANSIENT-BARE-HTTP-CODES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,36 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-TRANSIENT-BARE-HTTP-CODES** — claude-cli transient classifier
+  regex drops the bare numeric alternatives `\b429\b` / `\b503\b` /
+  `\b529\b` (two sibling sites: `plugins/petri_audit/
+  claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE` +
+  `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`).
+  v0.99.53 smoke 7 pilot phase surfaced a fresh false-positive:
+  claude-cli completed cleanly (rc=0, subtype=success,
+  terminal_reason=completed, $0.21 cost), but stdout serialised
+  the LLM's narrative containing a Python source-code comment
+  `# POST /v1/messages (auditor + judge + target × 10) → instant
+  429`. The bare `\b429\b` alternative matched the literal digit
+  run and the adapter raised `ClaudeCliTransientUpstreamError`
+  against an otherwise-successful execution. Real rate-limit
+  signals always carry a phrase (`rate_limit_error`, `too many
+  requests`, `service unavailable`, `server overloaded`,
+  `throttled`, …) — the named alternatives left in place still
+  catch those without matching arbitrary HTTP-status digit runs
+  the LLM may quote from documentation or source code it is
+  reading. Pinned by 6 new regression tests in
+  `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`:
+  `test_bare_429_in_source_code_comment_does_not_match` (the
+  literal smoke 7 stdout excerpt),
+  `test_bare_503_in_code_does_not_match`,
+  `test_bare_529_in_code_does_not_match`,
+  `test_real_rate_limit_signal_still_matches_after_bare_removal`,
+  `test_overloaded_error_still_matches_after_bare_removal`,
+  `test_too_many_requests_phrase_still_matches`. Existing
+  `test_signal_excerpt_bounded_to_200_chars` updated to use a
+  phrase-form signal instead of the now-removed bare-`429`.
+
 - **PR-SUB-AGENT-CODEBLOCK-STRIP** — `SubAgentManager._to_sub_result`
   / `_to_agent_result` (`core/agent/sub_agent.py`) now strip
   ```` ```json ... ``` ```` markdown code fences before

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -92,16 +92,18 @@ TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
 # Ported from paperclip parse.ts:12 (CLAUDE_TRANSIENT_UPSTREAM_RE).
 # Matches the broad transient family — keep in lockstep with paperclip
 # so the GEODE classifier sees the same set of upstream signals.
-# PR-PRT-STATUS (2026-05-25) — first alternative tightened from
-# ``rate[-\s]?limit(?:ed)?`` to ``rate[-_\s]limit(?:ed|_error)?`` so
-# a camelCase ``rateLimitType`` (inside claude-cli's informational
-# ``rate_limit_event`` payload with ``status="allowed"``) no longer
-# false-matches as a rejection signal. See sibling regex at
-# ``plugins/petri_audit/claude_cli_provider.py``.
+# PR-PRT-STATUS (2026-05-25) — first alternative tightened.
+# PR-TRANSIENT-BARE-HTTP-CODES (2026-05-25) — dropped bare ``\b429\b``
+# / ``\b503\b`` / ``\b529\b`` alternatives after smoke 7 pilot showed
+# them matching a Python source-code comment (``# instant 429``) that
+# the LLM was reading. Named-phrase alternatives still catch real
+# signals. See sibling regex at
+# ``plugins/petri_audit/claude_cli_provider.py`` for the full
+# rationale.
 _TRANSIENT_UPSTREAM_RE = re.compile(
-    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests|\b429\b"
-    r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b"
-    r"|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
+    r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests"
+    r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable"
+    r"|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
     r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"
     r"|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached"
     r"|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -215,29 +215,32 @@ class TransientSignal:
 # bumped against the OAuth subscription's hourly / weekly quota.
 # Matching is case-insensitive over the union of stdout, stderr, and
 # the parsed ``result`` event's free-text fields.
-# PR-PRT-STATUS (2026-05-25) — the first alternative was previously
-# ``rate[-\s]?limit(?:ed)?`` with ``IGNORECASE``: the ``?`` made the
-# separator optional, so a camelCase token like ``rateLimitType``
-# (which appears inside claude-cli's INFORMATIONAL
-# ``rate_limit_event`` payload — ``status="allowed"``) was matched
-# as if it were a rejection signal. The v0.99.53 smoke surfaced this:
-# every generator candidate produced a 12-turn successful claude-cli
-# run (rc=0 + ``is_error=false`` + ``subtype="success"``) writing
-# the seed markdown, but the classifier still flagged the stdout's
-# embedded ``rateLimitType`` and the adapter raised
-# ``ClaudeCliTransientUpstreamError`` — empty candidates downstream.
-# The new ``[-_\s]`` (no ``?``) requires an actual separator, so
-# ``rateLimit`` no longer matches while real "rate limited" / "rate
-# limit error" / "rate-limit" / "rate_limit" messages still do.
+# PR-PRT-STATUS (2026-05-25) — tightened the rate-limit alternative
+# so claude-cli's informational ``rate_limit_event`` (status=allowed)
+# no longer false-matched.
+# PR-TRANSIENT-BARE-HTTP-CODES (2026-05-25) — dropped the bare
+# numeric alternatives ``\b429\b`` / ``\b503\b`` / ``\b529\b``. The
+# v0.99.53 smoke 7 pilot phase surfaced a fresh false-positive:
+# claude-cli completed successfully (rc=0, subtype=success,
+# terminal_reason=completed, $0.21 cost), but its stdout serialised
+# the LLM's narrative containing a Python source-code comment
+# ``# POST /v1/messages (auditor + judge + target × 10) → instant
+# 429`` — the bare ``\b429\b`` matched that literal digit run and
+# the classifier raised ``ClaudeCliTransientUpstreamError`` against
+# an otherwise-clean execution. Real rate-limit signals always carry
+# a phrase (``rate_limit_error``, ``too many requests``, ``service
+# unavailable``, ``server overloaded``, …) — the named alternatives
+# below cover those without matching arbitrary HTTP-status digit
+# runs the LLM may quote from documentation or source code it is
+# reading. If a real signal is later found to lack a phrase, add a
+# more specific alternative (e.g. ``API returned 429``) rather than
+# re-introducing a bare digit run.
 CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
     r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))"
     r"|too\s+many\s+requests"
-    r"|\b429\b"
     r"|overloaded(?:_error)?"
     r"|server\s+overloaded"
     r"|service\s+unavailable"
-    r"|\b503\b"
-    r"|\b529\b"
     r"|high\s+demand"
     r"|try\s+again\s+later"
     r"|temporarily\s+unavailable"

--- a/tests/core/llm/adapters/test_claude_cli_adapter.py
+++ b/tests/core/llm/adapters/test_claude_cli_adapter.py
@@ -246,9 +246,13 @@ def test_adapter_transient_writes_postmortem_dump(tmp_path) -> None:  # type: ig
     # write doesn't pollute the home tree.
     diagnostics_root = tmp_path
     adapter = ClaudeCliAdapter()
-    stdout = _make_stream_json(
-        [{"type": "result", "error": "anthropic.RateLimitError: 429", "result": ""}]
-    )
+    # PR-TRANSIENT-BARE-HTTP-CODES — was
+    # ``"anthropic.RateLimitError: 429"`` which matched the bare
+    # ``\b429\b`` alternative. That alternative is now removed; use
+    # the phrase-form signal that real claude-cli rate-limit errors
+    # carry.
+    error_message = "anthropic.RateLimitError: rate_limit_error too many requests"
+    stdout = _make_stream_json([{"type": "result", "error": error_message, "result": ""}])
     with (
         patch(
             "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
@@ -290,9 +294,9 @@ def test_adapter_transient_writes_postmortem_dump(tmp_path) -> None:  # type: ig
             # walk to the structured event regardless.
             assert data["signal"]["source"] in {"stdout", "event"}
             assert (
-                "RateLimitError" in data["signal"]["matched_text"]
-                or "429" in data["signal"]["matched_text"]
+                "rate_limit_error" in data["signal"]["matched_text"]
+                or "too many requests" in data["signal"]["matched_text"]
             )
             assert len(data["events"]) == 1
             assert data["events"][0]["type"] == "result"
-            assert data["events"][0]["payload"]["error"] == "anthropic.RateLimitError: 429"
+            assert data["events"][0]["payload"]["error"] == error_message

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -337,7 +337,11 @@ def test_signal_excerpt_bounded_to_200_chars() -> None:
     from plugins.petri_audit.claude_cli_provider import classify_transient_signal
 
     long_pad = "x" * 500
-    stdout = f"{long_pad} 429 {long_pad}"
+    # PR-TRANSIENT-BARE-HTTP-CODES — was "429" (bare digit run); that
+    # alternative is no longer in the regex. Use a phrase-form
+    # signal that still matches — the test only cares about the
+    # excerpt-length bound, not which alternative fires.
+    stdout = f"{long_pad} too many requests {long_pad}"
     signal = classify_transient_signal(stdout=stdout, stderr="")
     assert signal is not None
     assert len(signal.matched_text) <= 200
@@ -368,3 +372,85 @@ def test_transient_exception_default_signal_none_for_backwards_compat() -> None:
     exc = ClaudeCliTransientUpstreamError("legacy")
     assert exc.signal is None
     assert exc.dump_path is None
+
+
+# ────────────────────────── PR-TRANSIENT-BARE-HTTP-CODES ──────────────────────
+# Smoke 7 (v0.99.53) pilot phase surfaced a fresh false-positive in
+# the bare ``\b429\b`` / ``\b503\b`` / ``\b529\b`` alternatives —
+# claude-cli completed successfully but its stdout serialised the
+# LLM's narrative that quoted a Python source-code comment with the
+# digit run ``# instant 429``. Dropping the bare digits removes the
+# whole class of false-positives. Real signals always carry a
+# phrase (named alternatives below still match them).
+
+
+def test_bare_429_in_source_code_comment_does_not_match() -> None:
+    """Smoke 7 pilot regression — the literal stdout substring that
+    misfired previously. Bare digit alone must not classify as a
+    transient signal."""
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_TRANSIENT_UPSTREAM_RE,
+        classify_transient_signal,
+    )
+
+    pilot_stdout_excerpt = (
+        "current\n252\t # POST /v1/messages (auditor + judge + target × 10) → "
+        "instant 429\n253\t # storm → 769s retry-after backoff → 17-min timeout "
+        "with 0 samples.\n"
+    )
+    # Direct regex search — no match.
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search(pilot_stdout_excerpt) is None
+    # Classifier helper — None means "no signal, ok to ship as success".
+    assert classify_transient_signal(stdout=pilot_stdout_excerpt, stderr="") is None
+
+
+def test_bare_503_in_code_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    payload = "if response.status == 503:  # service unavailable on upstream"
+    # The named phrase 'service unavailable' WILL match — verify the
+    # bare 503 alone (without the phrase) does not.
+    bare_only = "if response.status == 503:  # upstream gave us this code"
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search(bare_only) is None
+    # And confirm the phrase form (which is what real signals carry)
+    # still matches.
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search(payload) is not None
+
+
+def test_bare_529_in_code_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("retry_codes = {429, 503, 529}") is None
+
+
+def test_real_rate_limit_signal_still_matches_after_bare_removal() -> None:
+    """Regression — the canonical Anthropic-API rate-limit signal
+    must still classify. The named ``rate_limit_error`` alternative
+    catches this even without the bare ``\\b429\\b`` fallback."""
+    from plugins.petri_audit.claude_cli_provider import (
+        is_claude_transient_upstream_error,
+    )
+
+    assert is_claude_transient_upstream_error(
+        stdout="",
+        stderr="Anthropic API returned 429 rate_limit_error\n",
+    )
+
+
+def test_overloaded_error_still_matches_after_bare_removal() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        is_claude_transient_upstream_error,
+    )
+
+    assert is_claude_transient_upstream_error(
+        stdout="overloaded_error from upstream",
+        stderr="",
+    )
+
+
+def test_too_many_requests_phrase_still_matches() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    # The HTTP 429 status text is the phrase-form equivalent of the
+    # bare-digit alternative we removed — must still match.
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("HTTP 429 Too Many Requests") is not None


### PR DESCRIPTION
## Summary

Drop the bare numeric alternatives `\b429\b` / `\b503\b` / `\b529\b` from the claude-cli transient-upstream classifier regex (both sibling sites). They false-match HTTP status codes the LLM quotes from documentation or source code it is reading, while the named-phrase alternatives still catch real upstream signals.

- `plugins/petri_audit/claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE`
- `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`

## Why

v0.99.53 smoke 7 pilot phase surfaced a fresh false-positive (continuing the smoke chain from PR-PRT-STATUS → PR-PERMS-FLAG-FIX → PR-JSON-CODEBLOCK-STRIP → PR-SUB-AGENT-CODEBLOCK-STRIP):

- claude-cli completed cleanly: `rc=0`, `subtype=success`, `terminal_reason=completed`, `stop_reason=end_turn`, total cost $0.21.
- But the adapter raised `ClaudeCliTransientUpstreamError` anyway. The diagnostic dump's `matched=` field shows:

  ```
  matched: current\n252\t # POST /v1/messages (auditor + judge + target × 10) → instant 429\n253\t # storm → 769s retry-after backoff → 17-min timeout with 0 samples.
  ```

The LLM was reading a Python source file as part of its audit work; that file's body contained code comments mentioning HTTP 429. claude-cli's stream-json stdout serialised that body content into the assistant text block, and the classifier's `\b429\b` alternative matched the literal digit run.

Real rate-limit / overload / quota signals always include a phrase. Existing tests already covered them via named alternatives (`rate_limit_error`, `too many requests`, `overloaded_error`, `service unavailable`, `server overloaded`, `throttled`, etc.). The bare numeric alternatives caught nothing the named ones did not, and produced these false-positives whenever the LLM was reading code or docs containing HTTP status codes.

If a future real signal is found to lack a phrase, add a more specific alternative (e.g. `API returned 429`) rather than re-introducing a bare digit run.

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` | Remove 3 bare alternatives (`\b429\b`, `\b503\b`, `\b529\b`). Update comment block to document PR-TRANSIENT-BARE-HTTP-CODES rationale (smoke 7 pilot evidence). |
| `core/llm/claude_cli_errors.py` | Identical narrowing to keep the sibling matcher in paperclip-parity lockstep. |
| `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py` | (1) Existing `test_signal_excerpt_bounded_to_200_chars` updated — was using bare `429` to trigger a match; switched to `too many requests` phrase form (the test only cares about the 200-char bound, not which alternative fires). (2) 6 new regression tests: `test_bare_429_in_source_code_comment_does_not_match` (literal smoke 7 stdout excerpt), `test_bare_503_in_code_does_not_match`, `test_bare_529_in_code_does_not_match`, `test_real_rate_limit_signal_still_matches_after_bare_removal`, `test_overloaded_error_still_matches_after_bare_removal`, `test_too_many_requests_phrase_still_matches`. |
| `CHANGELOG.md` | Unreleased entry under Fixed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Bare digit alternatives removed | Implemented | both sibling regex sites |
| Smoke 7 pilot stdout no longer matches | Verified | `test_bare_429_in_source_code_comment_does_not_match` |
| Real rate-limit signal still matches | Verified | `test_real_rate_limit_signal_still_matches_after_bare_removal` |
| Overloaded error still matches | Verified | `test_overloaded_error_still_matches_after_bare_removal` |
| Too-many-requests phrase still matches | Verified | `test_too_many_requests_phrase_still_matches` |
| Existing test relying on bare-`429` updated | Verified | `test_signal_excerpt_bounded_to_200_chars` (phrase form) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 885 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 432 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] Focused: `pytest tests/plugins/petri_audit/test_claude_cli_transient_classifier.py tests/plugins/petri_audit/test_claude_cli_provider.py tests/core/llm/test_claude_cli_errors.py` — 78 passed (was 72) + 1 skipped
- [ ] Full pytest suite — running

## Reference

- Smoke 7 pilot dump: `~/.geode/diagnostics/claude-cli-transient/1779642979-claude-haiku-4-5.json` (claude-cli `terminal_reason=completed`, $0.21 cost, but classifier raised because of stdout-body `429`)
- Sister PR chain on v0.99.53:
  PR-DEFECT-AB → PR-COMM-2/3/3b/3c/3d/4 → PR-TIMECAP → PR-SKIP-PERMS → PR-PRT-STATUS → PR-PERMS-FLAG-FIX (#1610) → PR-JSON-CODEBLOCK-STRIP (#1612) → PR-SUB-AGENT-CODEBLOCK-STRIP (#1614) → **PR-TRANSIENT-BARE-HTTP-CODES**
