### PR TITLE
fix(transient): anchor \b on single-word alternatives (PR-TRANSIENT-WORD-BOUNDARIES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,34 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-TRANSIENT-WORD-BOUNDARIES** — single-word alternatives in the
+  claude-cli transient classifier regex now anchor on `\b`. Smoke 8
+  (v0.99.53, post-PR-TRANSIENT-BARE-HTTP-CODES) pilot sub-agent
+  surfaced `throttl(?:ed|ing)` matching `THROTTLED` inside the Python
+  constant `CODEX_CLI_LANE_THROTTLED_MSG` (from `core/orchestration/
+  codex_cli_lane.py`) that the LLM was quoting in a stack-trace
+  fragment. Identifier-internal hits previously slipped the regex
+  because the alternatives had no trailing `\b`. Four alternatives
+  tightened in both sibling sites (`plugins/petri_audit/
+  claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE` +
+  `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`):
+  `throttl(?:ed|ing)` → `throttl(?:ed|ing)\b`,
+  `overloaded(?:_error)?` → `overloaded(?:_error)?\b`,
+  `throttlingexception` → `throttlingexception\b`,
+  `servicequotaexceededexception` → `servicequotaexceededexception\b`.
+  Real signals like `request was throttled` / `ThrottlingException` /
+  `overloaded_error` (with adjacent whitespace, quote, newline, or
+  punctuation) still match — only identifier-internal matches
+  (e.g. `THROTTLED_MSG`, `OVERLOADED_ERROR_MSG`) are excluded.
+  Pinned by 6 new regression tests in
+  `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`:
+  `test_throttled_inside_identifier_does_not_match` (literal smoke 8
+  stack-trace excerpt), `test_throttled_real_phrase_still_matches`,
+  `test_overloaded_inside_identifier_does_not_match`,
+  `test_overloaded_error_real_phrase_still_matches`,
+  `test_throttling_exception_inside_identifier_does_not_match`,
+  `test_throttling_exception_real_phrase_still_matches`.
+
 - **PR-TRANSIENT-BARE-HTTP-CODES** — claude-cli transient classifier
   regex drops the bare numeric alternatives `\b429\b` / `\b503\b` /
   `\b529\b` (two sibling sites: `plugins/petri_audit/

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -100,11 +100,15 @@ TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
 # signals. See sibling regex at
 # ``plugins/petri_audit/claude_cli_provider.py`` for the full
 # rationale.
+# PR-TRANSIENT-WORD-BOUNDARIES (2026-05-25) — single-word
+# alternatives anchor on ``\b``. See sibling regex at
+# ``plugins/petri_audit/claude_cli_provider.py`` for the full
+# smoke 8 pilot evidence.
 _TRANSIENT_UPSTREAM_RE = re.compile(
     r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests"
-    r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable"
+    r"|overloaded(?:_error)?\b|server\s+overloaded|service\s+unavailable"
     r"|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
-    r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"
+    r"|throttl(?:ed|ing)\b|throttlingexception\b|servicequotaexceededexception\b"
     r"|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached"
     r"|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"
     r"|usage\s+limit\s+reached|usage\s+cap\s+reached)",

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -235,18 +235,30 @@ class TransientSignal:
 # reading. If a real signal is later found to lack a phrase, add a
 # more specific alternative (e.g. ``API returned 429``) rather than
 # re-introducing a bare digit run.
+# PR-TRANSIENT-WORD-BOUNDARIES (2026-05-25) — single-word alternatives
+# now anchor on ``\b`` so they don't match inside identifiers like
+# ``CODEX_CLI_LANE_THROTTLED_MSG`` (a constant in
+# ``core/orchestration/codex_cli_lane.py``). v0.99.53 smoke 8 pilot
+# sub-agent surfaced this: the LLM was reading or quoting a Python
+# stack-trace fragment containing that constant name, and
+# ``throttl(?:ed|ing)`` matched ``THROTTLED`` inside it (case-
+# insensitive). Real signals like "request was throttled" /
+# "Throttling exception thrown" still match because the next char
+# is space / punctuation. ``overloaded(?:_error)?`` /
+# ``throttlingexception`` / ``servicequotaexceededexception`` get
+# the same ``\b`` treatment for parallel safety.
 CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
     r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))"
     r"|too\s+many\s+requests"
-    r"|overloaded(?:_error)?"
+    r"|overloaded(?:_error)?\b"
     r"|server\s+overloaded"
     r"|service\s+unavailable"
     r"|high\s+demand"
     r"|try\s+again\s+later"
     r"|temporarily\s+unavailable"
-    r"|throttl(?:ed|ing)"
-    r"|throttlingexception"
-    r"|servicequotaexceededexception"
+    r"|throttl(?:ed|ing)\b"
+    r"|throttlingexception\b"
+    r"|servicequotaexceededexception\b"
     r"|out\s+of\s+extra\s+usage"
     r"|extra\s+usage\b"
     r"|claude\s+usage\s+limit\s+reached"

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -454,3 +454,58 @@ def test_too_many_requests_phrase_still_matches() -> None:
     # The HTTP 429 status text is the phrase-form equivalent of the
     # bare-digit alternative we removed — must still match.
     assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("HTTP 429 Too Many Requests") is not None
+
+
+# ────────────────────────── PR-TRANSIENT-WORD-BOUNDARIES ──────────────────────
+# Smoke 8 (v0.99.53, post-PR-TRANSIENT-BARE-HTTP-CODES) pilot
+# sub-agent surfaced single-word alternatives matching inside
+# identifiers (e.g. ``CODEX_CLI_LANE_THROTTLED_MSG`` — a Python
+# constant the LLM was quoting from a stack-trace fragment).
+# Anchoring on ``\b`` keeps real phrases matching while excluding
+# identifier-internal hits.
+
+
+def test_throttled_inside_identifier_does_not_match() -> None:
+    """Smoke 8 pilot regression — the literal stack-trace fragment
+    that misfired previously."""
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    stack_trace = (
+        "│ ❱ 171 │ │ raise TimeoutError(CODEX_CLI_LANE_THROTTLED_MSG) │\n"
+        "│ 172 │ lane = get_codex_cli_lane()"
+    )
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search(stack_trace) is None
+
+
+def test_throttled_real_phrase_still_matches() -> None:
+    """Real signal — phrase form with whitespace boundary."""
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("request was throttled") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("Throttling exception thrown") is not None
+
+
+def test_overloaded_inside_identifier_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("OVERLOADED_ERROR_MSG = '...'") is None
+
+
+def test_overloaded_error_real_phrase_still_matches() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("upstream returned overloaded_error\n") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("status: overloaded") is not None
+
+
+def test_throttling_exception_inside_identifier_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("THROTTLINGEXCEPTION_DEFAULT_MSG") is None
+
+
+def test_throttling_exception_real_phrase_still_matches() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("ThrottlingException ") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search('"errorCode": "ThrottlingException"') is not None


### PR DESCRIPTION
## Summary

Anchor single-word alternatives in the claude-cli transient-upstream classifier regex on `\b` so they don't match inside identifiers like `CODEX_CLI_LANE_THROTTLED_MSG`. Smoke 8 pilot sub-agent surfaced `throttl(?:ed|ing)` matching `THROTTLED` inside that Python constant when the LLM was quoting a stack-trace fragment.

- Four alternatives tightened: `throttl(?:ed|ing)\b`, `overloaded(?:_error)?\b`, `throttlingexception\b`, `servicequotaexceededexception\b`.
- Two sibling sites: `plugins/petri_audit/claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE` + `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`.
- 6 regression tests cover both directions (identifier-internal must NOT match, real phrase MUST still match).

## Why

Smoke 8 (v0.99.53, post-PR-SUB-AGENT-CODEBLOCK-STRIP + PR-TRANSIENT-BARE-HTTP-CODES landed on main) made huge progress: ZERO `phase_failed` events, all 8 phases reached, pipeline_finished, survivors=2 ≥ candidates_requested=2.

But 1 of 2 pilot sub-agents still failed at the sub-agent level. Pilot's diagnostic dump matched signal:

```
matched='codex_lane_acquisition): │\n│ ❱ 171 │ │ raise TimeoutError(CODEX_CLI_LANE_THROTTLED_MSG) │\n│ 172 │ lane = get_codex_cli_lane()'
```

The LLM was reading or quoting a Python stack-trace fragment containing the constant name `CODEX_CLI_LANE_THROTTLED_MSG`. The classifier regex's `throttl(?:ed|ing)` alternative (with `re.IGNORECASE`) matched `THROTTLED` literally — pre-fix the alternative had no `\b` trailing anchor, so `THROTTLED_MSG` matched as if it were the real phrase "throttled".

Same class of false-positive PR-TRANSIENT-BARE-HTTP-CODES addressed for bare digit runs; this PR addresses it for single-word alternatives that can appear as identifier substrings. Real signals like:
- `request was throttled`
- `Throttling exception thrown`
- `upstream returned overloaded_error\n`
- `"errorCode": "ThrottlingException"`

…all have whitespace/quote/newline/punctuation adjacent and still match with `\b`.

The remaining sub-agent failure in smoke 8 (`vote-m000-*`) is a REAL Codex 5-hour OAuth bucket throttle (operational state, not a code defect) — out of scope for this PR.

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` | `throttl(?:ed|ing)` → `throttl(?:ed|ing)\b`; `overloaded(?:_error)?` → `overloaded(?:_error)?\b`; `throttlingexception` → `throttlingexception\b`; `servicequotaexceededexception` → `servicequotaexceededexception\b`. Comment block updated with PR-TRANSIENT-WORD-BOUNDARIES rationale (smoke 8 evidence). |
| `core/llm/claude_cli_errors.py` | Identical changes to keep paperclip-parity sibling regex in lockstep. |
| `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py` | 6 new tests: `test_throttled_inside_identifier_does_not_match` (literal smoke 8 stack-trace excerpt), `test_throttled_real_phrase_still_matches`, `test_overloaded_inside_identifier_does_not_match`, `test_overloaded_error_real_phrase_still_matches`, `test_throttling_exception_inside_identifier_does_not_match`, `test_throttling_exception_real_phrase_still_matches`. |
| `CHANGELOG.md` | Unreleased entry under Fixed, above PR-TRANSIENT-BARE-HTTP-CODES. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `throttl(?:ed|ing)\b` anchored | Implemented | both sibling sites |
| `overloaded(?:_error)?\b` anchored | Implemented | both sibling sites |
| `throttlingexception\b` anchored | Implemented | both sibling sites |
| `servicequotaexceededexception\b` anchored | Implemented | both sibling sites |
| Identifier-internal hits excluded | Verified | 3 negative tests |
| Real-phrase signals still match | Verified | 3 positive tests |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 885 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 432 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] Focused: `pytest tests/plugins/petri_audit/test_claude_cli_transient_classifier.py tests/plugins/petri_audit/test_claude_cli_provider.py tests/core/llm/test_claude_cli_errors.py tests/core/llm/adapters/test_claude_cli_adapter.py` — 90 passed (was 78) + 1 skipped
- [ ] Full pytest suite — running

## Reference

- Smoke 8 pilot dump: `~/.geode/diagnostics/claude-cli-transient/...claude-haiku-4-5.json` — matched signal contained the literal stack-trace fragment with `CODEX_CLI_LANE_THROTTLED_MSG`.
- Sister PR chain on v0.99.53:
  PR-DEFECT-AB → PR-COMM-2/3/3b/3c/3d/4 → PR-TIMECAP → PR-SKIP-PERMS → PR-PRT-STATUS → PR-PERMS-FLAG-FIX (#1610) → PR-JSON-CODEBLOCK-STRIP (#1612) → PR-SUB-AGENT-CODEBLOCK-STRIP (#1614) → PR-TRANSIENT-BARE-HTTP-CODES (#1616) → **PR-TRANSIENT-WORD-BOUNDARIES**
