### PR TITLE
promote PR-TRANSIENT-WORD-BOUNDARIES to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,34 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-TRANSIENT-WORD-BOUNDARIES** — single-word alternatives in the
+  claude-cli transient classifier regex now anchor on `\b`. Smoke 8
+  (v0.99.53, post-PR-TRANSIENT-BARE-HTTP-CODES) pilot sub-agent
+  surfaced `throttl(?:ed|ing)` matching `THROTTLED` inside the Python
+  constant `CODEX_CLI_LANE_THROTTLED_MSG` (from `core/orchestration/
+  codex_cli_lane.py`) that the LLM was quoting in a stack-trace
+  fragment. Identifier-internal hits previously slipped the regex
+  because the alternatives had no trailing `\b`. Four alternatives
+  tightened in both sibling sites (`plugins/petri_audit/
+  claude_cli_provider.py:CLAUDE_TRANSIENT_UPSTREAM_RE` +
+  `core/llm/claude_cli_errors.py:_TRANSIENT_UPSTREAM_RE`):
+  `throttl(?:ed|ing)` → `throttl(?:ed|ing)\b`,
+  `overloaded(?:_error)?` → `overloaded(?:_error)?\b`,
+  `throttlingexception` → `throttlingexception\b`,
+  `servicequotaexceededexception` → `servicequotaexceededexception\b`.
+  Real signals like `request was throttled` / `ThrottlingException` /
+  `overloaded_error` (with adjacent whitespace, quote, newline, or
+  punctuation) still match — only identifier-internal matches
+  (e.g. `THROTTLED_MSG`, `OVERLOADED_ERROR_MSG`) are excluded.
+  Pinned by 6 new regression tests in
+  `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`:
+  `test_throttled_inside_identifier_does_not_match` (literal smoke 8
+  stack-trace excerpt), `test_throttled_real_phrase_still_matches`,
+  `test_overloaded_inside_identifier_does_not_match`,
+  `test_overloaded_error_real_phrase_still_matches`,
+  `test_throttling_exception_inside_identifier_does_not_match`,
+  `test_throttling_exception_real_phrase_still_matches`.
+
 - **PR-TRANSIENT-BARE-HTTP-CODES** — claude-cli transient classifier
   regex drops the bare numeric alternatives `\b429\b` / `\b503\b` /
   `\b529\b` (two sibling sites: `plugins/petri_audit/

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -100,11 +100,15 @@ TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
 # signals. See sibling regex at
 # ``plugins/petri_audit/claude_cli_provider.py`` for the full
 # rationale.
+# PR-TRANSIENT-WORD-BOUNDARIES (2026-05-25) — single-word
+# alternatives anchor on ``\b``. See sibling regex at
+# ``plugins/petri_audit/claude_cli_provider.py`` for the full
+# smoke 8 pilot evidence.
 _TRANSIENT_UPSTREAM_RE = re.compile(
     r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))|too\s+many\s+requests"
-    r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable"
+    r"|overloaded(?:_error)?\b|server\s+overloaded|service\s+unavailable"
     r"|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
-    r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"
+    r"|throttl(?:ed|ing)\b|throttlingexception\b|servicequotaexceededexception\b"
     r"|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached"
     r"|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"
     r"|usage\s+limit\s+reached|usage\s+cap\s+reached)",

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -235,18 +235,30 @@ class TransientSignal:
 # reading. If a real signal is later found to lack a phrase, add a
 # more specific alternative (e.g. ``API returned 429``) rather than
 # re-introducing a bare digit run.
+# PR-TRANSIENT-WORD-BOUNDARIES (2026-05-25) — single-word alternatives
+# now anchor on ``\b`` so they don't match inside identifiers like
+# ``CODEX_CLI_LANE_THROTTLED_MSG`` (a constant in
+# ``core/orchestration/codex_cli_lane.py``). v0.99.53 smoke 8 pilot
+# sub-agent surfaced this: the LLM was reading or quoting a Python
+# stack-trace fragment containing that constant name, and
+# ``throttl(?:ed|ing)`` matched ``THROTTLED`` inside it (case-
+# insensitive). Real signals like "request was throttled" /
+# "Throttling exception thrown" still match because the next char
+# is space / punctuation. ``overloaded(?:_error)?`` /
+# ``throttlingexception`` / ``servicequotaexceededexception`` get
+# the same ``\b`` treatment for parallel safety.
 CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
     r"(?:rate[-_\s]limit(?:ed\b|_error\b|(?![_a-zA-Z]))"
     r"|too\s+many\s+requests"
-    r"|overloaded(?:_error)?"
+    r"|overloaded(?:_error)?\b"
     r"|server\s+overloaded"
     r"|service\s+unavailable"
     r"|high\s+demand"
     r"|try\s+again\s+later"
     r"|temporarily\s+unavailable"
-    r"|throttl(?:ed|ing)"
-    r"|throttlingexception"
-    r"|servicequotaexceededexception"
+    r"|throttl(?:ed|ing)\b"
+    r"|throttlingexception\b"
+    r"|servicequotaexceededexception\b"
     r"|out\s+of\s+extra\s+usage"
     r"|extra\s+usage\b"
     r"|claude\s+usage\s+limit\s+reached"

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -454,3 +454,58 @@ def test_too_many_requests_phrase_still_matches() -> None:
     # The HTTP 429 status text is the phrase-form equivalent of the
     # bare-digit alternative we removed — must still match.
     assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("HTTP 429 Too Many Requests") is not None
+
+
+# ────────────────────────── PR-TRANSIENT-WORD-BOUNDARIES ──────────────────────
+# Smoke 8 (v0.99.53, post-PR-TRANSIENT-BARE-HTTP-CODES) pilot
+# sub-agent surfaced single-word alternatives matching inside
+# identifiers (e.g. ``CODEX_CLI_LANE_THROTTLED_MSG`` — a Python
+# constant the LLM was quoting from a stack-trace fragment).
+# Anchoring on ``\b`` keeps real phrases matching while excluding
+# identifier-internal hits.
+
+
+def test_throttled_inside_identifier_does_not_match() -> None:
+    """Smoke 8 pilot regression — the literal stack-trace fragment
+    that misfired previously."""
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    stack_trace = (
+        "│ ❱ 171 │ │ raise TimeoutError(CODEX_CLI_LANE_THROTTLED_MSG) │\n"
+        "│ 172 │ lane = get_codex_cli_lane()"
+    )
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search(stack_trace) is None
+
+
+def test_throttled_real_phrase_still_matches() -> None:
+    """Real signal — phrase form with whitespace boundary."""
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("request was throttled") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("Throttling exception thrown") is not None
+
+
+def test_overloaded_inside_identifier_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("OVERLOADED_ERROR_MSG = '...'") is None
+
+
+def test_overloaded_error_real_phrase_still_matches() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("upstream returned overloaded_error\n") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("status: overloaded") is not None
+
+
+def test_throttling_exception_inside_identifier_does_not_match() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("THROTTLINGEXCEPTION_DEFAULT_MSG") is None
+
+
+def test_throttling_exception_real_phrase_still_matches() -> None:
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search("ThrottlingException ") is not None
+    assert CLAUDE_TRANSIENT_UPSTREAM_RE.search('"errorCode": "ThrottlingException"') is not None


### PR DESCRIPTION
## Summary
- Promotes PR-TRANSIENT-WORD-BOUNDARIES (#1618) to main: anchor 4 single-word alternatives in the claude-cli transient classifier regex on `\b` so identifier-internal hits (e.g. `THROTTLED` inside `CODEX_CLI_LANE_THROTTLED_MSG`) no longer false-match. Smoke 8 pilot evidence.

## Verification
- [x] PR #1618 7/7 CI checks green
- [x] 6 new regression tests in `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`