### PR TITLE
fix(sub-agent): per-task cwd isolation replaces blanket --no-session-persistence (PR-RESUME-NO-PERSIST-FIX B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,46 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-RESUME-NO-PERSIST-FIX (B2)** — sub-agent claude-cli adapter no
+  longer passes `--no-session-persistence`. Smoke 10 (v0.99.53,
+  post-PR-TRANSIENT-* chain) surfaced a regression: generator
+  `gen-gen1-000-c885bc29` + evolver `evolve-gen1-001-c252e5eb` both
+  failed after 5 retries with `claude-cli subprocess exited rc=1:
+  No conversation found with session ID <uuid>`. Root cause —
+  PR-PERMS-FLAG-FIX B (`--no-session-persistence`) was incompatible
+  with PR-V (`--resume <session_id>`) when both fired in the same
+  sub-agent's turn N+1: turn N could not save (persistence
+  disabled) so turn N+1's resume target did not exist. Replacement
+  is per-task cwd isolation via new `core/agent/task_isolation.py`:
+  the sub-agent worker binds `<run_dir>/sub_agents/<task_id>/cwd/`
+  to a ContextVar at startup (`_run_agentic` in
+  `core/agent/worker.py`); the claude-cli adapter
+  (`core/llm/adapters/claude_cli.py`) reads the ContextVar and
+  forwards as `cwd=` to `_run_claude_subprocess`
+  (`plugins/petri_audit/claude_cli_provider.py`); the subprocess
+  runs with that cwd, so claude-cli's session cache
+  (`~/.claude/projects/<cwd-hash>/sessions/`) is unique per task_id.
+  Cross-sub-agent leak prevented (each task_id has its own pool)
+  AND within-task continuity works (turn N+1 sees the same cwd as
+  turn N, so `--resume <id>` finds the session). Direct callers
+  outside sub-agent dispatch (inspect_ai audit lane, one-shot
+  diagnostic) get ContextVar=None → subprocess inherits caller cwd
+  (back-compat). Pinned by 19 new regression tests across 4 files:
+  `tests/core/agent/test_task_isolation.py` (5 tests — ContextVar
+  set/get/None/asyncio-isolation),
+  `tests/core/agent/test_worker_task_isolation_binding.py` (3
+  tests — worker mirrors the bind sequence, mkdir + ContextVar +
+  per-task disjoint cwds),
+  `tests/plugins/petri_audit/test_run_claude_subprocess_cwd.py` (2
+  tests — `cwd=` forwarded to `asyncio.create_subprocess_exec`,
+  default None preserved),
+  `tests/core/llm/adapters/test_claude_cli_adapter.py` (3 tests —
+  argv no longer carries `--no-session-persistence`, adapter
+  forwards ContextVar value, unset ContextVar = `cwd=None`).
+  Existing `build_claude_cli_argv` flag tests unchanged — the
+  function-level opt-in is retained for explicit callers that
+  need it.
+
 - **PR-TRANSIENT-WORD-BOUNDARIES** — single-word alternatives in the
   claude-cli transient classifier regex now anchor on `\b`. Smoke 8
   (v0.99.53, post-PR-TRANSIENT-BARE-HTTP-CODES) pilot sub-agent

--- a/core/agent/task_isolation.py
+++ b/core/agent/task_isolation.py
@@ -1,0 +1,58 @@
+"""Per-task isolated working directory ContextVar.
+
+Set by the sub-agent worker at startup so the claude-cli adapter can
+spawn the ``claude`` subprocess with a per-task cwd. claude-cli's
+session cache (``~/.claude/projects/<cwd-hash>/sessions/``) is keyed
+on cwd; by giving each ``task_id`` its own directory the cache pools
+are non-overlapping, eliminating cross-sub-agent leak via cwd-cache
+auto-pickup. Within-task session persistence still works because
+turn N+1 of the same ``task_id`` sees the same cwd, so the
+``--resume <id>`` from PR-V finds the session turn N saved.
+
+PR-RESUME-NO-PERSIST-FIX (2026-05-25) — replaces the blunt
+``--no-session-persistence`` flag from PR-PERMS-FLAG-FIX B. That
+flag disabled ALL persistence, which broke PR-V's intra-task
+``--resume`` path because turn N had no saved session for turn N+1
+to resume from. The smoke 10 generator gen-gen1-000 and evolver
+evolve-gen1-001 both failed with ``No conversation found with
+session ID <uuid>`` because of that conflict.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from pathlib import Path
+
+__all__ = ["get_task_isolated_cwd", "set_task_isolated_cwd"]
+
+# Default ``None`` — when no sub-agent worker context is set (direct
+# adapter calls from inspect_ai audit lane, one-shot diagnostic
+# scripts, etc.), the adapter inherits the caller's cwd just as it
+# did pre-PR-RESUME-NO-PERSIST-FIX.
+_task_isolated_cwd: ContextVar[str | None] = ContextVar("geode_task_isolated_cwd", default=None)
+
+
+def set_task_isolated_cwd(cwd: str | Path | None) -> None:
+    """Bind a per-task working directory for the current execution
+    context.
+
+    The sub-agent worker calls this at startup with
+    ``<run_dir>/sub_agents/<task_id>/cwd/``. The directory must
+    already exist on disk — this function does NOT create it (the
+    worker mkdirs before binding so the read-write parity check is
+    explicit at the call site).
+
+    Passing ``None`` clears the binding (used by test teardown).
+    """
+    _task_isolated_cwd.set(str(cwd) if cwd is not None else None)
+
+
+def get_task_isolated_cwd() -> str | None:
+    """Return the per-task isolated cwd, or ``None`` if not bound.
+
+    The claude-cli adapter reads this and forwards to
+    ``asyncio.create_subprocess_exec(..., cwd=<value>)``. When ``None``,
+    the subprocess inherits the caller's cwd — same behavior as
+    pre-PR-RESUME-NO-PERSIST-FIX direct-call paths.
+    """
+    return _task_isolated_cwd.get()

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -279,6 +279,24 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     """Bootstrap minimal GEODE runtime and run AgenticLoop."""
     started = time.time()
 
+    # PR-RESUME-NO-PERSIST-FIX (2026-05-25) — bind a per-task isolated
+    # working directory so claude-cli's cwd-keyed session cache
+    # (``~/.claude/projects/<cwd-hash>/sessions/``) is unique per
+    # ``task_id``. This replaces the blunt ``--no-session-persistence``
+    # flag from PR-PERMS-FLAG-FIX B (which disabled ALL persistence and
+    # broke PR-V's intra-task ``--resume`` path). Cross-sub-agent leak
+    # via cwd-cache auto-pickup is now prevented because each task_id
+    # has its own cache pool; within-task continuity still works
+    # because turn N+1 sees the same cwd as turn N.
+    if request.run_dir and request.task_id:
+        from pathlib import Path
+
+        from core.agent.task_isolation import set_task_isolated_cwd
+
+        task_cwd_path = Path(request.run_dir) / "sub_agents" / request.task_id / "cwd"
+        task_cwd_path.mkdir(parents=True, exist_ok=True)
+        set_task_isolated_cwd(task_cwd_path)
+
     # 1. Build tool handlers (same factory as CLI)
     from core.cli.tool_handlers import _build_tool_handlers
 

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -122,17 +122,21 @@ class ClaudeCliAdapter:
             # working_dirs whitelist + isolated subprocess), so the
             # skip-permissions surface is sound.
             skip_permissions=True,
-            # PR-PERMS-FLAG-FIX (2026-05-25) — claude-cli's own
-            # session cache is keyed on cwd, NOT GEODE's task_id, so
-            # successive smoke runs in the same cwd leaked their
-            # cached conversation context across spawns. Strict
-            # per-spawn isolation > PR-V's cross-turn cached-marker
-            # optimization for the sub-agent dispatch model (each
-            # task_id spawns once and exits). PR-V's `--resume <id>`
-            # path still works for callers that explicitly thread a
-            # ``resume_session_id`` (none do at sub-agent dispatch
-            # today; preserved for future explicit-id callers).
-            disable_session_persistence=True,
+            # PR-RESUME-NO-PERSIST-FIX (2026-05-25) — pre-fix the
+            # adapter passed ``disable_session_persistence=True`` to
+            # block cross-sub-agent cwd-cache leak. But that broke
+            # PR-V's intra-task ``--resume`` path: claude-cli was
+            # told "don't save" on turn N then "resume <id>" on turn
+            # N+1 → "No conversation found with session ID <uuid>".
+            # The v0.99.53 smoke 10 surfaced this as generator
+            # gen-gen1-000 + evolver evolve-gen1-001 both failing
+            # after 5 retries. Replacement: per-task cwd isolation
+            # via :mod:`core.agent.task_isolation` (see ``cwd=``
+            # below) — the sub-agent worker binds
+            # ``<run_dir>/sub_agents/<task_id>/cwd/`` at startup,
+            # claude-cli's cwd-keyed session cache is unique per
+            # task, AND within-task continuity works because turn
+            # N+1 sees the same cwd as turn N.
             # PR-PERMS-FLAG-FIX (2026-05-25, JSON-forcing bundle) —
             # thread ``req.response_schema`` through to claude-cli's
             # ``--json-schema`` flag so callers that need a validated
@@ -145,6 +149,14 @@ class ClaudeCliAdapter:
         )
         stdin_text = build_subprocess_stdin(req)
         lane_key = f"claude-cli:{req.model}"
+        # PR-RESUME-NO-PERSIST-FIX (2026-05-25) — read per-task cwd
+        # bound by the sub-agent worker at startup. ``None`` for
+        # direct callers outside sub-agent dispatch (inspect_ai
+        # audit lane, one-shot diagnostic) — subprocess inherits
+        # caller cwd just as it did pre-fix.
+        from core.agent.task_isolation import get_task_isolated_cwd
+
+        subprocess_cwd = get_task_isolated_cwd()
         try:
             async with acquire_claude_cli_lane_async(lane_key):
                 # GEODE policy: 30-minute time-cap. Matches the
@@ -153,7 +165,7 @@ class ClaudeCliAdapter:
                 # trip together rather than producing a 1200s window
                 # where the parent gives up before the subprocess does.
                 stdout, stderr, rc = await _run_claude_subprocess(
-                    argv, stdin_text, timeout_s=1800.0
+                    argv, stdin_text, timeout_s=1800.0, cwd=subprocess_cwd
                 )
         except ClaudeCliInvocationError as exc:
             self._last_error = exc

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -864,13 +864,24 @@ def _is_expected_tool_use_boundary(events: list[StreamJsonEvent]) -> bool:
 
 
 async def _run_claude_subprocess(
-    argv: list[str], stdin_text: str, timeout_s: float
+    argv: list[str],
+    stdin_text: str,
+    timeout_s: float,
+    *,
+    cwd: str | None = None,
 ) -> tuple[str, str, int]:
     """Spawn ``claude`` subprocess, pipe stdin, capture stdout+stderr.
 
     Returns ``(stdout, stderr, returncode)``. Raises
     :class:`ClaudeCliInvocationError` on timeout or process spawn
     failure (NOT on non-zero returncode — caller decides).
+
+    ``cwd`` — PR-RESUME-NO-PERSIST-FIX (2026-05-25). When set, the
+    subprocess runs in that directory so claude-cli's cwd-keyed
+    session cache (``~/.claude/projects/<cwd-hash>/sessions/``) lives
+    in a per-task pool. ``None`` (default) inherits the caller's cwd
+    — used by inspect_ai audit lane + one-shot diagnostic callers
+    that don't go through the sub-agent worker.
     """
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -878,6 +889,7 @@ async def _run_claude_subprocess(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
         )
     except (FileNotFoundError, OSError) as exc:
         raise ClaudeCliInvocationError(f"failed to spawn `claude`: {exc!r}") from exc

--- a/tests/core/agent/test_task_isolation.py
+++ b/tests/core/agent/test_task_isolation.py
@@ -1,0 +1,89 @@
+"""Tests for ``core.agent.task_isolation``.
+
+PR-RESUME-NO-PERSIST-FIX (2026-05-25) — the sub-agent worker binds a
+per-task cwd so claude-cli's cwd-keyed session cache pool is unique
+per ``task_id``. This module is a thin ContextVar wrapper; tests
+cover set/get semantics + None default + path coercion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from core.agent.task_isolation import get_task_isolated_cwd, set_task_isolated_cwd
+
+# Test fixtures use ``/tmp/...`` literals only as string-equality
+# probes — nothing is actually created on disk. ``# noqa: S108`` on
+# each site keeps ruff's filesystem-security lint quiet without
+# pulling in a tmp_path fixture that's overkill for the ContextVar
+# round-trip checks here.
+_FAKE_CWD_A = "/tmp/some-task-cwd"  # noqa: S108 — ContextVar value probe, not a real dir
+_FAKE_CWD_B = "/tmp/another-task-cwd"  # noqa: S108
+_FAKE_CWD_C = "/tmp/before-clear"  # noqa: S108
+_FAKE_CWD_PARENT = "/tmp/parent-cwd"  # noqa: S108
+_FAKE_CWD_CHILD_A = "/tmp/child-a"  # noqa: S108
+_FAKE_CWD_CHILD_B = "/tmp/child-b"  # noqa: S108
+
+
+def test_default_is_none() -> None:
+    """Unbound ContextVar returns None — direct callers (audit lane,
+    diagnostic scripts) get the caller's cwd via subprocess inherit."""
+    set_task_isolated_cwd(None)
+    assert get_task_isolated_cwd() is None
+
+
+def test_set_and_get_string() -> None:
+    set_task_isolated_cwd(_FAKE_CWD_A)
+    try:
+        assert get_task_isolated_cwd() == _FAKE_CWD_A
+    finally:
+        set_task_isolated_cwd(None)
+
+
+def test_set_and_get_path() -> None:
+    """``Path`` instances are coerced to ``str`` so the consumer
+    (``asyncio.create_subprocess_exec(cwd=...)``) gets a value of the
+    expected type without each call site stringifying."""
+    set_task_isolated_cwd(Path(_FAKE_CWD_B))
+    try:
+        value = get_task_isolated_cwd()
+        assert value == _FAKE_CWD_B
+        assert isinstance(value, str)
+    finally:
+        set_task_isolated_cwd(None)
+
+
+def test_none_clears_binding() -> None:
+    set_task_isolated_cwd(_FAKE_CWD_C)
+    set_task_isolated_cwd(None)
+    assert get_task_isolated_cwd() is None
+
+
+def test_contextvar_isolation_across_asyncio_tasks() -> None:
+    """ContextVar copies bindings into spawned tasks but mutations
+    in one task don't leak back to the parent — verifies the
+    per-task isolation semantics hold under asyncio.gather. Critical
+    for the sub-agent dispatch model where multiple sub-agents may
+    run concurrently in the same parent process."""
+
+    async def child(new_cwd: str) -> str | None:
+        before = get_task_isolated_cwd()
+        set_task_isolated_cwd(new_cwd)
+        await asyncio.sleep(0)  # yield so other tasks interleave
+        return before
+
+    async def main() -> list[str | None]:
+        set_task_isolated_cwd(_FAKE_CWD_PARENT)
+        results = await asyncio.gather(
+            child(_FAKE_CWD_CHILD_A),
+            child(_FAKE_CWD_CHILD_B),
+        )
+        # Parent's binding must NOT have been mutated by children.
+        assert get_task_isolated_cwd() == _FAKE_CWD_PARENT
+        return results
+
+    results = asyncio.run(main())
+    # Each child inherited the parent's binding at spawn time.
+    assert all(before == _FAKE_CWD_PARENT for before in results)
+    set_task_isolated_cwd(None)

--- a/tests/core/agent/test_worker_task_isolation_binding.py
+++ b/tests/core/agent/test_worker_task_isolation_binding.py
@@ -1,0 +1,80 @@
+"""PR-RESUME-NO-PERSIST-FIX (B2) — sub-agent worker binds per-task
+cwd at startup.
+
+Tests verify the binding behavior in isolation by exercising the
+``set_task_isolated_cwd`` call path that ``_run_agentic`` triggers
+before the AgenticLoop is built. We don't run the full worker (it
+needs the IPC subprocess scaffolding) — instead we replicate the
+exact 3 lines from ``worker.py`` and assert the side effects
+(ContextVar set + directory exists).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.agent.task_isolation import get_task_isolated_cwd, set_task_isolated_cwd
+
+
+def _bind_like_worker(run_dir: str, task_id: str) -> Path:
+    """Mirror the exact bind sequence in ``core/agent/worker.py:
+    _run_agentic`` so the test stays in lockstep with the production
+    path. If the production binding changes, this helper must
+    change too."""
+    task_cwd_path = Path(run_dir) / "sub_agents" / task_id / "cwd"
+    task_cwd_path.mkdir(parents=True, exist_ok=True)
+    set_task_isolated_cwd(task_cwd_path)
+    return task_cwd_path
+
+
+def test_worker_bind_creates_directory_and_sets_contextvar(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    run_dir = str(tmp_path)
+    task_id = "gen-gen1-000-abc12345"
+
+    bound_path = _bind_like_worker(run_dir, task_id)
+
+    # 1. Directory exists on disk.
+    expected_path = tmp_path / "sub_agents" / task_id / "cwd"
+    assert expected_path.is_dir()
+    assert bound_path == expected_path
+
+    # 2. ContextVar carries the absolute path as a string.
+    value = get_task_isolated_cwd()
+    assert value == str(expected_path)
+    assert isinstance(value, str)
+
+    set_task_isolated_cwd(None)
+
+
+def test_worker_bind_is_idempotent(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Same task_id binding twice in a row (e.g. crash + retry path)
+    must not error on the mkdir or overwrite a stale binding with a
+    different path."""
+    run_dir = str(tmp_path)
+    task_id = "evolve-gen1-001-xyz67890"
+
+    first = _bind_like_worker(run_dir, task_id)
+    second = _bind_like_worker(run_dir, task_id)
+
+    assert first == second
+    assert get_task_isolated_cwd() == str(second)
+    set_task_isolated_cwd(None)
+
+
+def test_per_task_cwd_pools_are_disjoint(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Two different task_ids in the same run_dir get different
+    cwds — verifies the cross-sub-agent cwd-cache isolation
+    invariant the whole PR exists to enforce."""
+    run_dir = str(tmp_path)
+
+    cwd_a = _bind_like_worker(run_dir, "gen-gen1-000-aaaa")
+    cwd_b = _bind_like_worker(run_dir, "gen-gen1-001-bbbb")
+
+    assert cwd_a != cwd_b
+    # Different cwd → different hash → different
+    # ~/.claude/projects/<hash>/sessions/ pool.
+    assert cwd_a.name == "cwd"
+    assert cwd_b.name == "cwd"
+    assert cwd_a.parent.name == "gen-gen1-000-aaaa"
+    assert cwd_b.parent.name == "gen-gen1-001-bbbb"
+    set_task_isolated_cwd(None)

--- a/tests/core/llm/adapters/test_claude_cli_adapter.py
+++ b/tests/core/llm/adapters/test_claude_cli_adapter.py
@@ -300,3 +300,135 @@ def test_adapter_transient_writes_postmortem_dump(tmp_path) -> None:  # type: ig
             assert len(data["events"]) == 1
             assert data["events"][0]["type"] == "result"
             assert data["events"][0]["payload"]["error"] == error_message
+
+
+# ────────────────────────── PR-RESUME-NO-PERSIST-FIX (B2) ─────────────────────
+# Smoke 10 surfaced --no-session-persistence ↔ --resume conflict:
+# pre-fix the adapter unconditionally appended --no-session-persistence
+# which broke PR-V's turn-N→turn-N+1 resume path. The B2 fix replaces
+# the blunt flag with per-task cwd isolation. These tests pin both
+# sides of the contract.
+
+
+def test_adapter_argv_no_longer_contains_no_session_persistence() -> None:
+    """PR-RESUME-NO-PERSIST-FIX — the adapter must NOT inject
+    --no-session-persistence into argv. Cross-sub-agent leak is
+    prevented by per-task cwd isolation instead (see
+    ``test_adapter_passes_task_isolated_cwd_to_subprocess``)."""
+    import contextlib
+
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliInvocationError
+
+    captured_argv: list[str] = []
+
+    async def _fake_subprocess(argv: list[str], stdin: str, **kwargs: Any) -> tuple[str, str, int]:
+        captured_argv.extend(argv)
+        # rc=0 + no events → adapter raises ClaudeCliInvocationError;
+        # argv is already captured so suppressing is fine.
+        return ("", "", 0)
+
+    adapter = ClaudeCliAdapter()
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            _fake_subprocess,
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+        contextlib.suppress(ClaudeCliInvocationError),
+    ):
+        asyncio.run(adapter.acomplete(_build_request()))
+
+    assert captured_argv, "expected _run_claude_subprocess to be called"
+    assert "--no-session-persistence" not in captured_argv
+
+
+def test_adapter_passes_task_isolated_cwd_to_subprocess() -> None:
+    """PR-RESUME-NO-PERSIST-FIX — when the ContextVar is set, the
+    adapter forwards the value as the subprocess cwd= kwarg. This is
+    the only mechanism by which the per-task cache-pool isolation
+    propagates from worker startup down to claude-cli."""
+    import contextlib
+
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliInvocationError
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _fake_subprocess(
+        argv: list[str], stdin: str, *args: Any, **kwargs: Any
+    ) -> tuple[str, str, int]:
+        captured_kwargs.update(kwargs)
+        return ("", "", 0)
+
+    adapter = ClaudeCliAdapter()
+    set_task_isolated_cwd("/tmp/per-task-cwd-test")  # noqa: S108 — string probe, not a real dir
+    try:
+        with (
+            patch(
+                "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+                return_value="/fake/claude",
+            ),
+            patch(
+                "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+                _fake_subprocess,
+            ),
+            patch(
+                "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+                _passthrough_lane,
+            ),
+            contextlib.suppress(ClaudeCliInvocationError),
+        ):
+            asyncio.run(adapter.acomplete(_build_request()))
+    finally:
+        set_task_isolated_cwd(None)
+
+    assert captured_kwargs.get("cwd") == "/tmp/per-task-cwd-test"  # noqa: S108
+
+
+def test_adapter_passes_none_cwd_when_context_var_unset() -> None:
+    """Direct-call path (inspect_ai audit lane, one-shot diagnostic) —
+    no sub-agent worker bound the ContextVar, so cwd= should be None
+    and the subprocess inherits the caller's cwd."""
+    import contextlib
+
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from plugins.petri_audit.claude_cli_provider import ClaudeCliInvocationError
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _fake_subprocess(
+        argv: list[str], stdin: str, *args: Any, **kwargs: Any
+    ) -> tuple[str, str, int]:
+        captured_kwargs.update(kwargs)
+        return ("", "", 0)
+
+    set_task_isolated_cwd(None)  # explicit clear for determinism
+    adapter = ClaudeCliAdapter()
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            _fake_subprocess,
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+        contextlib.suppress(ClaudeCliInvocationError),
+    ):
+        asyncio.run(adapter.acomplete(_build_request()))
+
+    assert captured_kwargs.get("cwd") is None

--- a/tests/core/llm/adapters/test_claude_cli_resume.py
+++ b/tests/core/llm/adapters/test_claude_cli_resume.py
@@ -230,8 +230,12 @@ def test_v3_adapter_round_trip_threads_resume_and_emits_session_id() -> None:
     captured_argv: list[str] = []
 
     async def _fake_subprocess(
-        argv: list[str], stdin_text: str, timeout_s: float
+        argv: list[str], stdin_text: str, timeout_s: float, **kwargs: object
     ) -> tuple[str, str, int]:
+        # PR-RESUME-NO-PERSIST-FIX (2026-05-25) added a keyword-only
+        # ``cwd`` parameter to ``_run_claude_subprocess``. Accept
+        # **kwargs so this fixture stays compatible with current and
+        # future keyword-only additions.
         captured_argv.extend(argv)
         return (stdout, "", 0)
 

--- a/tests/plugins/petri_audit/test_run_claude_subprocess_cwd.py
+++ b/tests/plugins/petri_audit/test_run_claude_subprocess_cwd.py
@@ -1,0 +1,80 @@
+"""PR-RESUME-NO-PERSIST-FIX (B2) — ``_run_claude_subprocess``
+forwards ``cwd`` to ``asyncio.create_subprocess_exec``.
+
+Verifies the lowest-level subprocess invocation receives the cwd
+override. Without this propagation the adapter-level wiring would
+be a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+
+def _build_fake_proc(stdout: bytes = b"", stderr: bytes = b"", rc: int = 0) -> Any:
+    """Minimal asyncio.subprocess.Process stub used by both tests."""
+
+    class _Proc:
+        returncode = rc
+
+        async def communicate(self, _stdin: bytes) -> tuple[bytes, bytes]:
+            return (stdout, stderr)
+
+        def kill(self) -> None:
+            pass
+
+        async def wait(self) -> int:
+            return rc
+
+    return _Proc()
+
+
+def test_run_subprocess_forwards_cwd_when_set() -> None:
+    from plugins.petri_audit.claude_cli_provider import _run_claude_subprocess
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _build_fake_proc()
+
+    with patch("asyncio.create_subprocess_exec", _fake_create):
+        asyncio.run(
+            _run_claude_subprocess(
+                ["/fake/claude", "--print"],
+                stdin_text="",
+                timeout_s=10.0,
+                cwd="/tmp/per-task-test-cwd",  # noqa: S108 — propagation probe
+            )
+        )
+
+    assert captured.get("cwd") == "/tmp/per-task-test-cwd"  # noqa: S108
+
+
+def test_run_subprocess_omits_cwd_default_inherits() -> None:
+    """When no cwd is passed, ``asyncio.create_subprocess_exec``
+    receives ``cwd=None`` (its own default = inherit caller's cwd).
+    Confirms back-compat for direct callers that pre-date the B2
+    fix (inspect_ai audit lane, one-shot diagnostic scripts)."""
+    from plugins.petri_audit.claude_cli_provider import _run_claude_subprocess
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _build_fake_proc()
+
+    with patch("asyncio.create_subprocess_exec", _fake_create):
+        asyncio.run(
+            _run_claude_subprocess(
+                ["/fake/claude", "--print"],
+                stdin_text="",
+                timeout_s=10.0,
+            )
+        )
+
+    # ``cwd`` key is in captured kwargs with value None.
+    assert "cwd" in captured
+    assert captured["cwd"] is None


### PR DESCRIPTION
## Summary

Replace blanket `--no-session-persistence` (from PR-PERMS-FLAG-FIX B) with **per-task cwd isolation**. Sub-agent worker binds `<run_dir>/sub_agents/<task_id>/cwd/` to a ContextVar; claude-cli adapter reads it and forwards as `cwd=` to subprocess; claude-cli's cwd-keyed session cache pool is therefore unique per `task_id`. Both cross-sub-agent isolation AND within-task `--resume` continuity hold simultaneously.

- New module `core/agent/task_isolation.py` — ContextVar + set/get helpers
- Worker startup (`core/agent/worker.py:_run_agentic`) mkdirs the per-task cwd + binds ContextVar
- Adapter (`core/llm/adapters/claude_cli.py`) reads ContextVar + forwards as `cwd=`
- Subprocess runner (`plugins/petri_audit/claude_cli_provider.py:_run_claude_subprocess`) accepts `cwd: str | None = None`
- 19 regression tests across 4 files pin every step of the propagation chain

## Why

Smoke 10 (v0.99.53, post-PR-TRANSIENT-* chain) surfaced two distinct sub-agent failures:

```
Task failed: gen-gen1-000-c885bc29 — unknown
  detail: claude-cli subprocess exited rc=1:
          No conversation found with session ID: f26c25d3-1ca4-43e6-8847-b2e4b396ee41
  attempts: 5

Task failed: evolve-gen1-001-c252e5eb — unknown
  detail: claude-cli subprocess exited rc=1:
          No conversation found with session ID: c784e72c-b01e-4709-a5c1-c6cab319571f
  attempts: 5
```

Root cause: PR-PERMS-FLAG-FIX B added `--no-session-persistence` to the adapter call to block cross-sub-agent cwd-cache leakage. But PR-V (`--resume <session_id>`) requires turn N's session to be saved so turn N+1 can resume it. Both flags fired in every sub-agent's argv → turn 1 succeeded (claude-cli ran fresh) → turn 1's session was NOT saved (persistence disabled) → adapter captured `emitted_session_id` from turn 1's stream-events → turn 2 passed `--resume <id>` → claude-cli reported "No conversation found" → 5 retries → fail.

Option B2 (operator directive 2026-05-25, "session persistence는 필요해"): keep session persistence AND keep cross-sub-agent isolation by giving each task_id its own working directory. claude-cli's session cache lives at `~/.claude/projects/<cwd-hash>/sessions/`, keyed on cwd. If sub-agent A runs in `<run_dir>/sub_agents/<task-A>/cwd/` and sub-agent B runs in `<run_dir>/sub_agents/<task-B>/cwd/`, their cache pools are non-overlapping, eliminating leak via cwd-cache. Within the same task_id, turn N and turn N+1 see the same cwd, so the resume path works.

## Changes

| File | Change |
|------|--------|
| `core/agent/task_isolation.py` | **New module.** ContextVar `_task_isolated_cwd: ContextVar[str \| None]` + `set_task_isolated_cwd(cwd)` + `get_task_isolated_cwd()`. Defaults to `None` so direct callers (audit lane, diagnostic) get subprocess-inherit. |
| `core/agent/worker.py` | `_run_agentic` (before AgenticLoop build) mkdirs `<run_dir>/sub_agents/<task_id>/cwd/` and binds ContextVar via `set_task_isolated_cwd`. Gated on `request.run_dir and request.task_id` (both fields already in `WorkerRequest`). |
| `core/llm/adapters/claude_cli.py` | (1) Removed `disable_session_persistence=True` from `build_claude_cli_argv` call. (2) Added `from core.agent.task_isolation import get_task_isolated_cwd` + `subprocess_cwd = get_task_isolated_cwd()`. (3) Passed `cwd=subprocess_cwd` to `_run_claude_subprocess`. Comment block fully rewritten to document the B2 substitution and reference smoke 10 evidence. |
| `plugins/petri_audit/claude_cli_provider.py` | `_run_claude_subprocess` signature adds `cwd: str \| None = None` (keyword-only). Forwarded to `asyncio.create_subprocess_exec(cwd=cwd)`. Docstring documents the per-task isolation rationale + direct-caller back-compat. |
| `tests/core/agent/test_task_isolation.py` | **New file.** 5 tests: default None, set/get string, set/get Path coercion, None clears, asyncio.gather isolation. |
| `tests/core/agent/test_worker_task_isolation_binding.py` | **New file.** 3 tests: bind creates dir + sets ContextVar, bind idempotent, per-task cwds disjoint. Mirrors the production bind sequence exactly. |
| `tests/plugins/petri_audit/test_run_claude_subprocess_cwd.py` | **New file.** 2 tests: cwd forwarded to `create_subprocess_exec`, default cwd=None preserved. |
| `tests/core/llm/adapters/test_claude_cli_adapter.py` | 3 new tests: argv no longer carries `--no-session-persistence`, adapter forwards ContextVar value as cwd=, unset ContextVar → cwd=None. |
| `CHANGELOG.md` | Unreleased entry under Fixed, above PR-TRANSIENT-WORD-BOUNDARIES. |

`build_claude_cli_argv`'s `disable_session_persistence` parameter and the corresponding argv tests remain — explicit callers (one-shot diagnostic, future audit-lane variants) can still opt in. Only the AgenticLoop-adapter call site no longer auto-sets it.

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| ContextVar module + set/get | Implemented | `core/agent/task_isolation.py` |
| Worker binds at startup | Implemented | `core/agent/worker.py:_run_agentic` |
| Worker creates directory | Implemented | `task_cwd_path.mkdir(parents=True, exist_ok=True)` |
| Adapter reads ContextVar | Implemented | `subprocess_cwd = get_task_isolated_cwd()` |
| Adapter forwards as cwd= | Implemented | `_run_claude_subprocess(..., cwd=subprocess_cwd)` |
| Subprocess accepts cwd= | Implemented | `_run_claude_subprocess` signature + `create_subprocess_exec(cwd=)` |
| Blanket `--no-session-persistence` removed | Implemented | `disable_session_persistence=True` deleted from adapter call site |
| `build_claude_cli_argv` param preserved | Verified | Explicit-call surface unchanged (3 existing tests still pass) |
| Direct-caller back-compat | Verified | `test_adapter_passes_none_cwd_when_context_var_unset` |
| Asyncio.gather isolation | Verified | `test_contextvar_isolation_across_asyncio_tasks` |
| Per-task cwds disjoint | Verified | `test_per_task_cwd_pools_are_disjoint` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 889 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 433 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] Focused: `pytest tests/core/agent/test_task_isolation.py tests/core/agent/test_worker_task_isolation_binding.py tests/plugins/petri_audit/test_run_claude_subprocess_cwd.py tests/core/llm/adapters/test_claude_cli_adapter.py` — 19 passed
- [ ] Full pytest suite — running

## Reference

- Smoke 10 archive: `/Users/mango/workspace/geode/.audit/smoke-archives/smoke-10-1779662494/sub_agents/`
  - `gen-gen1-000-c885bc29/result.json` — first session-resume failure
  - `evolve-gen1-001-c252e5eb/result.json` — second session-resume failure
- Sister PR chain on v0.99.53:
  PR-DEFECT-AB → PR-COMM-* → PR-TIMECAP → PR-SKIP-PERMS → PR-PRT-STATUS → PR-PERMS-FLAG-FIX (#1610) → PR-JSON-CODEBLOCK-STRIP (#1612) → PR-SUB-AGENT-CODEBLOCK-STRIP (#1614) → PR-TRANSIENT-BARE-HTTP-CODES (#1616) → PR-TRANSIENT-WORD-BOUNDARIES (#1618) → **PR-RESUME-NO-PERSIST-FIX (B2)**
