### PR TITLE
release: v0.99.54 — smoke-green-loop sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,35 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-CLEANUP-WORKER-REQUEST-RUN-DIR** — delete dead
+  `WorkerRequest.run_dir` field + wire B2 per-task cwd binding to
+  the live SoT (`core.observability.run_dir.get_active_run_dir`).
+  PR-RESUME-NO-PERSIST-FIX's first cut read `request.run_dir` which
+  is **never populated** by any producer (verified via grep —
+  PR-Q chose env-var transport via `GEODE_RUN_DIR` instead). Smoke
+  11 confirmed the wiring gap: no `cwd/` subdir was ever created
+  under `sub_agents/<task_id>/`, so claude-cli subprocess ran in
+  the worktree root and the per-task cache-pool isolation was a
+  no-op. Migration:
+  - `core/agent/worker.py` `_run_agentic` now imports
+    `get_active_run_dir()` (re-bound by `worker.main()` from the
+    `GEODE_RUN_DIR` env var on entry) and uses the returned `Path`
+    to compute `<run_dir>/sub_agents/<task_id>/cwd/`. The dead
+    field `WorkerRequest.run_dir: str = ""` + its
+    `from_dict("run_dir", "")` echo are removed. Field's docstring
+    that suggested it was the SoT is replaced with a comment
+    pointing the next reader to `RUN_DIR_ENV` /
+    `get_active_run_dir`.
+  - 8 new regression tests across 2 files:
+    `tests/core/agent/test_worker_task_isolation_binding.py`
+    rewritten to mirror the corrected bind sequence (5 tests —
+    happy path, idempotent, disjoint pools, noop without run_dir,
+    noop without task_id);
+    `tests/core/agent/test_worker_request_no_run_dir_field.py`
+    (new — 3 anti-relapse tests pinning that the dataclass field
+    is gone, `from_dict` silently drops legacy `run_dir` payloads,
+    `to_dict` no longer encodes it).
+
 - **PR-RESUME-NO-PERSIST-FIX (B2)** — sub-agent claude-cli adapter no
   longer passes `--no-session-persistence`. Smoke 10 (v0.99.53,
   post-PR-TRANSIENT-* chain) surfaced a regression: generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.54] - 2026-05-25
+
 ### Fixed
 - **PR-CLEANUP-WORKER-REQUEST-RUN-DIR** — delete dead
   `WorkerRequest.run_dir` field + wire B2 per-task cwd binding to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.53
+- **Version**: 0.99.54
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.53 — Long-running Autonomous Execution Harness
+# GEODE v0.99.54 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.53**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.54**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.53 — Long-running Autonomous Execution Harness
+# GEODE v0.99.54 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.53**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.54**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -87,17 +87,18 @@ class WorkerRequest:
     # (PR-MAINPATH-67 deleted the legacy ``resolve_agentic_adapter``
     # fallback route — all dispatch now goes through Path-B).
     source: str = ""
-    # PR-Q (2026-05-24) — run-dir-as-anchor consolidation. When the
-    # parent orchestrator runs inside a per-cycle directory (e.g.
-    # seed-generation's ``state/seed-generation/<run_id>/``) it sets
-    # this so the worker's result.json + stderr.log + per-agent
-    # dialogue.jsonl all land *inside* the run dir instead of the
-    # global ``~/.geode/workers/`` + ``~/.geode/transcripts/`` pools.
-    # Empty string = legacy behaviour (global pools), so callers that
-    # don't run inside a cycle dir (gateway, REPL, ad-hoc CLI) are
-    # unaffected. Each writer reads this and walks
-    # ``<run_dir>/sub_agents/<task_id>/`` for its specific output.
-    run_dir: str = ""
+    # PR-Q (2026-05-24) chose to carry the orchestrator's active run_dir
+    # across the parent → worker boundary via the ``GEODE_RUN_DIR``
+    # environment variable (see
+    # ``core.observability.run_dir.RUN_DIR_ENV`` +
+    # ``IsolatedRunner._aexecute_subprocess``). The worker's
+    # ``main()`` re-binds the ContextVar from that env on entry, so
+    # every observability writer reads the live value via
+    # ``get_active_run_dir()``. The earlier ``run_dir: str = ""``
+    # field on this dataclass was orphaned dead code — no producer
+    # ever populated it, only ``from_dict`` echoed its missing-default
+    # — and a dual-SoT trap for the next reader (see
+    # PR-CLEANUP-WORKER-REQUEST-RUN-DIR, 2026-05-25). Removed.
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -130,7 +131,6 @@ class WorkerRequest:
             parent_session_key=data.get("parent_session_key", ""),
             parent_session_id=data.get("parent_session_id", ""),
             source=data.get("source", ""),
-            run_dir=data.get("run_dir", ""),
         )
 
 
@@ -288,12 +288,24 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     # via cwd-cache auto-pickup is now prevented because each task_id
     # has its own cache pool; within-task continuity still works
     # because turn N+1 sees the same cwd as turn N.
-    if request.run_dir and request.task_id:
-        from pathlib import Path
+    #
+    # PR-CLEANUP-WORKER-REQUEST-RUN-DIR (2026-05-25) — the first cut
+    # of this binding read ``request.run_dir`` (a dead field on
+    # ``WorkerRequest`` that no producer ever populated), so the
+    # guard never fired and the mkdir never ran. Smoke 11 confirmed
+    # the wiring gap (no ``cwd/`` subdir in ``sub_agents/<task_id>/``).
+    # The live SoT for an orchestrator-bound run_dir at the worker
+    # side is :func:`core.observability.run_dir.get_active_run_dir`
+    # — ``worker.main()`` already re-binds the ContextVar from the
+    # ``GEODE_RUN_DIR`` env var on entry, so by the time
+    # ``_run_agentic`` runs the value is available.
+    from core.observability.run_dir import get_active_run_dir
 
+    active_run_dir = get_active_run_dir()
+    if active_run_dir is not None and request.task_id:
         from core.agent.task_isolation import set_task_isolated_cwd
 
-        task_cwd_path = Path(request.run_dir) / "sub_agents" / request.task_id / "cwd"
+        task_cwd_path = active_run_dir / "sub_agents" / request.task_id / "cwd"
         task_cwd_path.mkdir(parents=True, exist_ok=True)
         set_task_isolated_cwd(task_cwd_path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.53"
+version = "0.99.54"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/agent/test_task_isolation.py
+++ b/tests/core/agent/test_task_isolation.py
@@ -14,10 +14,10 @@ from pathlib import Path
 from core.agent.task_isolation import get_task_isolated_cwd, set_task_isolated_cwd
 
 # Test fixtures use ``/tmp/...`` literals only as string-equality
-# probes — nothing is actually created on disk. ``# noqa: S108`` on
-# each site keeps ruff's filesystem-security lint quiet without
-# pulling in a tmp_path fixture that's overkill for the ContextVar
-# round-trip checks here.
+# probes — nothing is actually created on disk. The per-line
+# ``noqa`` suppression below keeps ruff's filesystem-security lint
+# (S108) quiet without pulling in a tmp_path fixture that's overkill
+# for the ContextVar round-trip checks here.
 _FAKE_CWD_A = "/tmp/some-task-cwd"  # noqa: S108 — ContextVar value probe, not a real dir
 _FAKE_CWD_B = "/tmp/another-task-cwd"  # noqa: S108
 _FAKE_CWD_C = "/tmp/before-clear"  # noqa: S108

--- a/tests/core/agent/test_worker_request_no_run_dir_field.py
+++ b/tests/core/agent/test_worker_request_no_run_dir_field.py
@@ -1,0 +1,57 @@
+"""PR-CLEANUP-WORKER-REQUEST-RUN-DIR (2026-05-25) — anti-relapse pin.
+
+``WorkerRequest.run_dir`` was a dead dataclass field — declared with
+a docstring suggesting it carried the parent orchestrator's active
+run_dir across the IPC boundary, but no producer ever populated it
+(PR-Q chose env-var transport instead). The field's docstring caused
+PR-RESUME-NO-PERSIST-FIX's first cut to mis-wire the per-task cwd
+binding against the dead source, so the smoke 11 ``cwd/`` subdirs
+were never created. Test pins:
+
+1. The field is GONE from the dataclass schema.
+2. ``to_dict``/``from_dict`` round-trip does NOT echo any ``run_dir``
+   key (back-compat callers passing it on the wire silently drop it,
+   no crash).
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from core.agent.worker import WorkerRequest
+
+
+def test_worker_request_does_not_carry_run_dir_field() -> None:
+    field_names = {f.name for f in fields(WorkerRequest)}
+    assert "run_dir" not in field_names, (
+        f"WorkerRequest.run_dir must stay removed (was dead code that "
+        f"misled PR-RESUME-NO-PERSIST-FIX). Live SoT is "
+        f"core.observability.run_dir.get_active_run_dir(). "
+        f"Current fields: {sorted(field_names)}"
+    )
+
+
+def test_from_dict_silently_drops_legacy_run_dir_key() -> None:
+    """Wire-level back-compat — if a parent on an older release
+    still emits ``run_dir`` in the WorkerRequest payload, the
+    worker must accept the dict without crashing. The field is
+    dropped (no longer a constructor kwarg) and from_dict does
+    not pass it through."""
+    payload = {
+        "task_id": "gen-gen1-000-legacy",
+        "task_type": "analyze",
+        "description": "legacy producer still sends run_dir",
+        "run_dir": "/Users/mango/workspace/geode/state/seed-generation/some-run",
+    }
+    request = WorkerRequest.from_dict(payload)
+
+    assert request.task_id == "gen-gen1-000-legacy"
+    # ``hasattr`` is False because the dataclass no longer declares
+    # ``run_dir`` at all (not just defaults-to-empty).
+    assert not hasattr(request, "run_dir")
+
+
+def test_to_dict_does_not_include_run_dir_key() -> None:
+    request = WorkerRequest(task_id="gen-gen1-000-encode")
+    encoded = request.to_dict()
+    assert "run_dir" not in encoded

--- a/tests/core/agent/test_worker_task_isolation_binding.py
+++ b/tests/core/agent/test_worker_task_isolation_binding.py
@@ -1,12 +1,17 @@
-"""PR-RESUME-NO-PERSIST-FIX (B2) — sub-agent worker binds per-task
-cwd at startup.
+"""PR-RESUME-NO-PERSIST-FIX (B2) + PR-CLEANUP-WORKER-REQUEST-RUN-DIR —
+sub-agent worker binds per-task cwd at startup by reading the live
+run_dir SoT (``core.observability.run_dir.get_active_run_dir``),
+NOT the dead ``WorkerRequest.run_dir`` field.
 
-Tests verify the binding behavior in isolation by exercising the
-``set_task_isolated_cwd`` call path that ``_run_agentic`` triggers
-before the AgenticLoop is built. We don't run the full worker (it
-needs the IPC subprocess scaffolding) — instead we replicate the
-exact 3 lines from ``worker.py`` and assert the side effects
-(ContextVar set + directory exists).
+Tests mirror the exact bind sequence ``_run_agentic`` uses so the
+suite stays in lockstep with the production path. Coverage:
+
+* ContextVar-bound run_dir → per-task cwd materialised + ContextVar set.
+* Different task_ids → disjoint cwd pools (cross-sub-agent isolation
+  invariant the whole PR exists to enforce).
+* Idempotent re-bind (crash + retry).
+* Unbound ContextVar (no orchestrator) → no per-task cwd created,
+  no ContextVar set (legacy callers unaffected).
 """
 
 from __future__ import annotations
@@ -14,67 +19,105 @@ from __future__ import annotations
 from pathlib import Path
 
 from core.agent.task_isolation import get_task_isolated_cwd, set_task_isolated_cwd
+from core.observability.run_dir import get_active_run_dir, set_active_run_dir
 
 
-def _bind_like_worker(run_dir: str, task_id: str) -> Path:
-    """Mirror the exact bind sequence in ``core/agent/worker.py:
-    _run_agentic`` so the test stays in lockstep with the production
-    path. If the production binding changes, this helper must
-    change too."""
-    task_cwd_path = Path(run_dir) / "sub_agents" / task_id / "cwd"
+def _bind_like_worker(task_id: str) -> Path | None:
+    """Mirror the bind sequence in ``core/agent/worker.py:_run_agentic``.
+
+    Reads ``get_active_run_dir()`` (the live SoT — populated by
+    ``worker.main()`` from the ``GEODE_RUN_DIR`` env var on entry).
+    Returns the bound cwd path, or ``None`` when no orchestrator
+    has set a run_dir (the legacy direct-call surface).
+    """
+    active_run_dir = get_active_run_dir()
+    if active_run_dir is None or not task_id:
+        return None
+    task_cwd_path = active_run_dir / "sub_agents" / task_id / "cwd"
     task_cwd_path.mkdir(parents=True, exist_ok=True)
     set_task_isolated_cwd(task_cwd_path)
     return task_cwd_path
 
 
 def test_worker_bind_creates_directory_and_sets_contextvar(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    run_dir = str(tmp_path)
-    task_id = "gen-gen1-000-abc12345"
+    """Happy path — orchestrator set ``_active_run_dir``, worker
+    binding materialises the cwd + sets the per-task ContextVar."""
+    set_active_run_dir(tmp_path)
+    try:
+        task_id = "gen-gen1-000-abc12345"
+        bound_path = _bind_like_worker(task_id)
 
-    bound_path = _bind_like_worker(run_dir, task_id)
+        expected_path = tmp_path / "sub_agents" / task_id / "cwd"
+        assert bound_path == expected_path
+        assert expected_path.is_dir()
 
-    # 1. Directory exists on disk.
-    expected_path = tmp_path / "sub_agents" / task_id / "cwd"
-    assert expected_path.is_dir()
-    assert bound_path == expected_path
-
-    # 2. ContextVar carries the absolute path as a string.
-    value = get_task_isolated_cwd()
-    assert value == str(expected_path)
-    assert isinstance(value, str)
-
-    set_task_isolated_cwd(None)
+        value = get_task_isolated_cwd()
+        assert value == str(expected_path)
+        assert isinstance(value, str)
+    finally:
+        set_task_isolated_cwd(None)
+        set_active_run_dir(None)
 
 
 def test_worker_bind_is_idempotent(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    """Same task_id binding twice in a row (e.g. crash + retry path)
-    must not error on the mkdir or overwrite a stale binding with a
+    """Same task_id binding twice (e.g. crash + retry path) must
+    not error on the mkdir or overwrite a stale binding with a
     different path."""
-    run_dir = str(tmp_path)
-    task_id = "evolve-gen1-001-xyz67890"
+    set_active_run_dir(tmp_path)
+    try:
+        task_id = "evolve-gen1-001-xyz67890"
+        first = _bind_like_worker(task_id)
+        second = _bind_like_worker(task_id)
 
-    first = _bind_like_worker(run_dir, task_id)
-    second = _bind_like_worker(run_dir, task_id)
-
-    assert first == second
-    assert get_task_isolated_cwd() == str(second)
-    set_task_isolated_cwd(None)
+        assert first == second
+        assert get_task_isolated_cwd() == str(second)
+    finally:
+        set_task_isolated_cwd(None)
+        set_active_run_dir(None)
 
 
 def test_per_task_cwd_pools_are_disjoint(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """Two different task_ids in the same run_dir get different
-    cwds — verifies the cross-sub-agent cwd-cache isolation
-    invariant the whole PR exists to enforce."""
-    run_dir = str(tmp_path)
+    cwds — cross-sub-agent cwd-cache isolation invariant."""
+    set_active_run_dir(tmp_path)
+    try:
+        cwd_a = _bind_like_worker("gen-gen1-000-aaaa")
+        cwd_b = _bind_like_worker("gen-gen1-001-bbbb")
+        assert cwd_a is not None and cwd_b is not None
 
-    cwd_a = _bind_like_worker(run_dir, "gen-gen1-000-aaaa")
-    cwd_b = _bind_like_worker(run_dir, "gen-gen1-001-bbbb")
+        assert cwd_a != cwd_b
+        # Different cwd → different hash → different
+        # ~/.claude/projects/<hash>/sessions/ pool.
+        assert cwd_a.name == "cwd"
+        assert cwd_b.name == "cwd"
+        assert cwd_a.parent.name == "gen-gen1-000-aaaa"
+        assert cwd_b.parent.name == "gen-gen1-001-bbbb"
+    finally:
+        set_task_isolated_cwd(None)
+        set_active_run_dir(None)
 
-    assert cwd_a != cwd_b
-    # Different cwd → different hash → different
-    # ~/.claude/projects/<hash>/sessions/ pool.
-    assert cwd_a.name == "cwd"
-    assert cwd_b.name == "cwd"
-    assert cwd_a.parent.name == "gen-gen1-000-aaaa"
-    assert cwd_b.parent.name == "gen-gen1-001-bbbb"
+
+def test_worker_bind_noop_when_no_active_run_dir() -> None:
+    """Direct-call surface (gateway, REPL, ad-hoc CLI, tests) —
+    no orchestrator has bound a run_dir, so the worker skips the
+    per-task cwd setup and the ContextVar stays at its default
+    ``None``. This preserves the legacy behaviour callers outside
+    seed-generation depend on."""
+    set_active_run_dir(None)  # explicit clear
     set_task_isolated_cwd(None)
+    bound = _bind_like_worker("gen-gen1-000-no-orchestrator")
+    assert bound is None
+    assert get_task_isolated_cwd() is None
+
+
+def test_worker_bind_noop_when_task_id_empty(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Symmetric guard — run_dir is bound but the request carries
+    an empty task_id (unexpected, but the binding must not raise)."""
+    set_active_run_dir(tmp_path)
+    set_task_isolated_cwd(None)
+    try:
+        bound = _bind_like_worker("")
+        assert bound is None
+        assert get_task_isolated_cwd() is None
+    finally:
+        set_active_run_dir(None)


### PR DESCRIPTION
## Summary
- v0.99.54 release — 7 PR chain that drove seed-generation smoke to all-green (#1610, #1612, #1614, #1616, #1618, #1620, #1622)
- Version bump 0.99.53 → 0.99.54 across 5 locations
- CHANGELOG [0.99.54] - 2026-05-25 stamped

## Verification
- [x] PR #1623 (release → develop) 8/8 CI checks green
- [x] Smoke 11 archive — pipeline_finished, 0 phase_failed, 2 survivors