### PR TITLE
fix(session-resume): paperclip-aligned cwd-paired resume tracking (PR-SESSION-RESUME-PARAMS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,57 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-SESSION-RESUME-PARAMS** — paperclip-aligned cwd-paired
+  resume-context tracking. Smoke 12 (v0.99.54) surfaced a
+  stale-session bug after the PR-CLEANUP per-task cwd isolation
+  landed: claude-cli's session storage is cwd-keyed
+  (`~/.claude/projects/<cwd-slug>/<session_id>.jsonl`), so a UUID
+  stored in SQLite from cwd A produces `No conversation found with
+  session ID <uuid>` when `_load_prior_session_id` returns it for a
+  worker now running in cwd B. The proximity and meta_reviewer
+  phases both failed because their stored UUIDs (from a smoke 11
+  run that pre-dated B2 wiring) pointed into the workspace-root
+  cwd-pool while smoke 12 ran in per-task isolated cwds.
+  Fix mirrors paperclip's `claudeSessionCwdMatchesExecutionTarget`
+  (`packages/adapters/claude-local/src/server/execute.ts:592`):
+  a paired `cwd` field stored alongside the session_id, and a
+  read-time `path.resolve()` equality gate. On mismatch the loader
+  returns `""` to force a fresh session instead of the doomed
+  `--resume <stale_id>`. Schema migration uses a JSON blob column
+  so future paired fields (`prompt_bundle_key`, `adapter_type`,
+  `remote_id`, …) extend without further ALTERs (codex-cli /
+  payg / subscription adapters are covered by the same shape).
+  Changes:
+  - `core/memory/session_manager.py` — `agent_runtime_state` table
+    grows `session_resume_params TEXT NOT NULL DEFAULT '{}'`;
+    additive ALTER mirrors the PR-CL-BUDGET `sessions`-table
+    pattern for legacy DBs.
+  - `core/observability/agent_runtime_state.py` — dataclass field
+    `session_resume_params: dict[str, Any]`; writer accepts the
+    dict and JSON-serialises before storage with a COALESCE guard
+    that preserves prior params on partial upserts; reader parses
+    JSON with graceful degradation to `{}` on malformed content.
+  - `core/agent/loop/agent_loop.py` — new `_saved_cwd_matches_current`
+    helper (paperclip-mirror); `_load_prior_session_id` gates on
+    cwd equality before returning the stored id; `_persist_session_id`
+    captures `get_task_isolated_cwd()` into both SQLite + the
+    legacy session.json file fallback so the reader's symmetric
+    gate has the same SoT regardless of which path served the id.
+  - `core/wiring/bootstrap.py` — `_on_session_ended` hook handler
+    threads the per-task cwd into `record_agent_session_end` so
+    the canonical SESSION_ENDED write path is paired too.
+  - 19 new regression tests across `tests/test_session_resume_params.py`
+    pin every layer: 7 helper tests
+    (`_saved_cwd_matches_current` — empty / mismatch / resolve
+    normalisation), 4 SQLite round-trip tests (round-trip /
+    legacy empty / preserve-on-upsert / malformed JSON
+    graceful), 4 `_load_prior_session_id` integration tests
+    (match / mismatch / legacy-empty / direct-call), 2
+    `_persist_session_id` end-to-end tests (cwd written / cwd
+    omitted), 2 migration sanity tests (fresh-DB / ALTER on
+    legacy-DB).
+
 ## [0.99.54] - 2026-05-25
 
 ### Fixed

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -57,20 +57,58 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _saved_cwd_matches_current(stored_cwd: str, current_cwd: str) -> bool:
+    """Paperclip-aligned cwd-equality check
+    (``packages/adapters/claude-local/src/server/execute.ts:592`` ->
+    ``claudeSessionCwdMatchesExecutionTarget``).
+
+    Returns True when EITHER the stored side or the current side is
+    empty (legacy rows / direct-call callers without per-task cwd)
+    so the resume gate skips and the call falls through to the
+    existing happy path. When both are non-empty, compares via
+    ``Path(x).resolve()`` to normalise symlinks / ``..`` / trailing
+    slashes — string equality alone is insufficient when the worker
+    and the claude-cli call sites pass differently-shaped absolute
+    paths.
+    """
+    from pathlib import Path
+
+    if not stored_cwd or not current_cwd:
+        return True
+    try:
+        return Path(stored_cwd).resolve() == Path(current_cwd).resolve()
+    except (OSError, RuntimeError):
+        # Path resolution can raise on cycles / inaccessible mounts.
+        # Treat as mismatch to force a fresh session rather than a
+        # doomed resume.
+        return False
+
+
 def _load_prior_session_id(session_id: str) -> str:
     """Return the claude-cli session_id from the prior turn of this
-    sub-agent, or empty string when no prior session exists.
+    sub-agent, or empty string when no prior session exists OR the
+    saved session belongs to a different cwd-pool.
 
     PR-COMM-3c (2026-05-24) — SQLite primary, file fallback.
-    Reads ``agent_runtime_state.claude_cli_session_id`` first
-    (single source of truth introduced by PR-COMM-3 / PR-COMM-3b).
-    Falls back to the legacy
-    ``<run_dir>/sub_agents/<session_id>/session.json`` file from PR-V
-    so existing on-disk caches keep working through the 1-release
-    grace window (slated for removal in v0.99.54). Returns empty on
-    any I/O / parse error so the call falls back to a fresh session
-    rather than crashing.
+    PR-SESSION-RESUME-PARAMS (2026-05-25) — paperclip-aligned cwd
+    verification. Reading ``agent_runtime_state.claude_cli_session_id``
+    is not enough on its own: claude-cli's session storage is keyed
+    on cwd (``~/.claude/projects/<cwd-slug>/<session_id>.jsonl``), so
+    a stored UUID from a prior cwd produces ``"No conversation
+    found"`` against the current per-task cwd-pool (smoke 12
+    proximity + meta_reviewer evidence). Before returning the UUID
+    we verify ``session_resume_params.cwd == get_task_isolated_cwd()``;
+    on mismatch we return ``""`` to force a fresh session. Same
+    check applied to the legacy session.json file fallback.
+
+    Returns empty on any I/O / parse / mismatch so the call falls
+    back to a fresh session rather than crashing or resuming a
+    stale id.
     """
+    from core.agent.task_isolation import get_task_isolated_cwd
+
+    current_cwd = get_task_isolated_cwd() or ""
+
     # SQLite primary — read from the per-agent row landed by
     # PR-COMM-3b's record_agent_session_end hook handler.
     try:
@@ -78,7 +116,16 @@ def _load_prior_session_id(session_id: str) -> str:
 
         state = get_agent_runtime_state(session_id)
         if state is not None and state.claude_cli_session_id:
-            return state.claude_cli_session_id
+            stored_cwd = str(state.session_resume_params.get("cwd", ""))
+            if _saved_cwd_matches_current(stored_cwd, current_cwd):
+                return state.claude_cli_session_id
+            log.info(
+                "session %s saved for cwd=%r — skipping resume in cwd=%r",
+                state.claude_cli_session_id,
+                stored_cwd,
+                current_cwd,
+            )
+            return ""
     except Exception:
         log.debug(
             "agent_runtime_state read failed for %s — falling back to session.json",
@@ -101,7 +148,21 @@ def _load_prior_session_id(session_id: str) -> str:
 
         payload = json.loads(session_path.read_text(encoding="utf-8"))
         cached = payload.get("claude_cli_session_id", "")
-        return str(cached) if cached else ""
+        if not cached:
+            return ""
+        # PR-SESSION-RESUME-PARAMS — file fallback gets the same
+        # paired-cwd gate. Missing key (legacy file pre-fix) skips
+        # the gate and returns the id (back-compat).
+        stored_cwd_file = str(payload.get("cwd", ""))
+        if not _saved_cwd_matches_current(stored_cwd_file, current_cwd):
+            log.info(
+                "session %s (file) saved for cwd=%r — skipping resume in cwd=%r",
+                cached,
+                stored_cwd_file,
+                current_cwd,
+            )
+            return ""
+        return str(cached)
     except Exception:
         log.debug("session.json read failed for %s", session_id, exc_info=True)
         return ""
@@ -127,6 +188,18 @@ def _persist_session_id(session_id: str, emitted_session_id: str) -> None:
     if not emitted_session_id:
         return
 
+    # PR-SESSION-RESUME-PARAMS (2026-05-25) — capture the cwd the
+    # session was actually written from. claude-cli's session
+    # storage is cwd-keyed (``~/.claude/projects/<cwd-slug>/``), so
+    # the next reader MUST know which cwd this id is good for. Empty
+    # string when no per-task isolation is in scope (direct-call
+    # surface) — the reader's gate skips on empty stored_cwd
+    # (back-compat with pre-fix rows).
+    from core.agent.task_isolation import get_task_isolated_cwd
+
+    write_cwd = get_task_isolated_cwd() or ""
+    resume_params = {"cwd": write_cwd} if write_cwd else {}
+
     # SQLite primary write — directly upsert the resumable session_id
     # so the next turn's _load_prior_session_id sees it even if the
     # round's SESSION_ENDED hook hasn't fired yet (early termination,
@@ -137,6 +210,7 @@ def _persist_session_id(session_id: str, emitted_session_id: str) -> None:
         record_agent_session_end(
             agent_id=session_id,
             claude_cli_session_id=emitted_session_id,
+            session_resume_params=resume_params,
         )
     except Exception:
         log.debug(
@@ -162,6 +236,11 @@ def _persist_session_id(session_id: str, emitted_session_id: str) -> None:
             "claude_cli_session_id": emitted_session_id,
             "updated_at": time.time(),
         }
+        # PR-SESSION-RESUME-PARAMS — paired cwd in the file fallback
+        # as well so the reader's symmetric gate has the same SoT
+        # regardless of which path served the resume id.
+        if write_cwd:
+            payload["cwd"] = write_cwd
         session_path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2),
             encoding="utf-8",

--- a/core/memory/session_manager.py
+++ b/core/memory/session_manager.py
@@ -176,10 +176,26 @@ CREATE TABLE IF NOT EXISTS agent_runtime_state (
     total_cached_input_tokens INTEGER NOT NULL DEFAULT 0,
     total_cost_cents          INTEGER NOT NULL DEFAULT 0,
     last_error                TEXT NOT NULL DEFAULT '',
+    session_resume_params     TEXT NOT NULL DEFAULT '{}',
     created_at                REAL NOT NULL,
     updated_at                REAL NOT NULL
 )
 """
+
+# PR-SESSION-RESUME-PARAMS (2026-05-25) — additive ALTER for legacy DBs
+# that pre-date the column. Mirrors paperclip's ``sessionParams`` JSON
+# blob (``packages/adapters/claude-local/src/server/execute.ts:592``) —
+# a single TEXT column that carries every resume-context field
+# (currently ``cwd``; future ``prompt_bundle_key`` / ``adapter_type`` /
+# ``remote_id`` etc. can land in the same JSON without further ALTERs).
+# Read-time the JSON is parsed once and validated against the current
+# execution context (see
+# ``core/agent/loop/agent_loop.py:_load_prior_session_id``); a mismatch
+# forces a fresh session instead of a doomed ``--resume <id>`` against
+# a cwd-pool that does not hold that session file.
+_AGENT_RUNTIME_STATE_EXTRA_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("session_resume_params", "TEXT NOT NULL DEFAULT '{}'"),
+)
 
 _CREATE_AGENT_RUNTIME_KIND_INDEX_SQL = """\
 CREATE INDEX IF NOT EXISTS idx_agent_runtime_kind
@@ -451,6 +467,26 @@ class SessionManager:
         # runs) stay local. ``IF NOT EXISTS`` keeps the bootstrap
         # idempotent on legacy DBs.
         self._conn.execute(_CREATE_AGENT_RUNTIME_STATE_TABLE_SQL)
+        # PR-SESSION-RESUME-PARAMS (2026-05-25) — additive ALTER for legacy
+        # DBs whose ``agent_runtime_state`` was created before the
+        # ``session_resume_params`` column existed. Same pattern as the
+        # PR-CL-BUDGET / PR-CL-A3 ``sessions`` table migration above.
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            existing_agent_cols = {
+                str(r[1])
+                for r in self._conn.execute("PRAGMA table_info(agent_runtime_state)").fetchall()
+            }
+            for col_name, col_decl in _AGENT_RUNTIME_STATE_EXTRA_COLUMNS:
+                if col_name not in existing_agent_cols:
+                    # col_name + col_decl sourced from a module-level constant — not user input.
+                    self._conn.execute(
+                        f"ALTER TABLE agent_runtime_state ADD COLUMN {col_name} {col_decl}"
+                    )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
         self._conn.execute(_CREATE_AGENT_RUNTIME_KIND_INDEX_SQL)
         self._conn.execute(_CREATE_AGENT_RUNTIME_COMPONENT_INDEX_SQL)
         self._conn.execute(_CREATE_AGENT_RUNTIME_UPDATED_INDEX_SQL)

--- a/core/observability/agent_runtime_state.py
+++ b/core/observability/agent_runtime_state.py
@@ -58,6 +58,15 @@ class AgentRuntimeState:
     total_cached_input_tokens: int = 0
     total_cost_cents: int = 0
     last_error: str = ""
+    # PR-SESSION-RESUME-PARAMS (2026-05-25) — paperclip
+    # ``sessionParams`` JSON blob mirror. Carries the resume-context
+    # the next reader needs to verify before resuming the saved
+    # session: at minimum the ``cwd`` the session was written from.
+    # Future fields (``prompt_bundle_key``, ``adapter_type``,
+    # ``remote_id``, …) extend the same dict without further schema
+    # ALTERs. Empty dict on legacy rows preserves back-compat (the
+    # reader skips the verification gate when the dict is empty).
+    session_resume_params: dict[str, Any] = field(default_factory=dict)
     created_at: float = 0.0
     updated_at: float = 0.0
 
@@ -145,26 +154,44 @@ def record_agent_session_end(
     component: str = "agentic_loop",
     adapter_type: str = "",
     claude_cli_session_id: str = "",
+    session_resume_params: dict[str, Any] | None = None,
 ) -> None:
     """Upsert the ``agent_runtime_state`` row for a completed AgenticLoop.
 
     Fires on ``HookEvent.SESSION_ENDED`` from every AgenticLoop path
     (REPL / gateway / sub-agent). Preserves cumulative totals — the
-    UPSERT only writes identity + session_id columns; totals are
-    accumulated separately by :func:`accumulate_tokens_and_cost`.
+    UPSERT only writes identity + session_id + resume_params columns;
+    totals are accumulated separately by
+    :func:`accumulate_tokens_and_cost`.
+
+    ``session_resume_params`` — PR-SESSION-RESUME-PARAMS (2026-05-25)
+    paperclip-aligned JSON dict. When non-empty the caller MUST
+    populate at minimum ``{"cwd": <current cwd>}`` so the next
+    reader can verify the saved session belongs to the same
+    execution context. Empty / None preserves the legacy behaviour
+    (no gate at read-time). Serialised to JSON before storage; the
+    column type is TEXT.
     """
+    import json
+
     conn = _get_conn()
     if conn is None or not agent_id:
         return
     now = time.time()
+    params_blob = (
+        json.dumps(session_resume_params, separators=(",", ":"), ensure_ascii=False)
+        if session_resume_params
+        else ""
+    )
     try:
         with _LOCK:
             conn.execute(
                 """\
                 INSERT INTO agent_runtime_state
                     (agent_id, agent_kind, component, adapter_type,
-                     claude_cli_session_id, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                     claude_cli_session_id, session_resume_params,
+                     created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), '{}'), ?, ?)
                 ON CONFLICT(agent_id) DO UPDATE SET
                     agent_kind            = excluded.agent_kind,
                     component             = excluded.component,
@@ -174,6 +201,11 @@ def record_agent_session_end(
                             THEN excluded.claude_cli_session_id
                         ELSE agent_runtime_state.claude_cli_session_id
                     END,
+                    session_resume_params = CASE
+                        WHEN excluded.session_resume_params != '{}'
+                            THEN excluded.session_resume_params
+                        ELSE agent_runtime_state.session_resume_params
+                    END,
                     updated_at            = excluded.updated_at
                 """,
                 (
@@ -182,6 +214,7 @@ def record_agent_session_end(
                     component,
                     adapter_type,
                     claude_cli_session_id,
+                    params_blob,
                     now,
                     now,
                 ),
@@ -370,6 +403,8 @@ def mark_run_ended(run_id: str, status: str) -> None:
 
 def get_agent_runtime_state(agent_id: str) -> AgentRuntimeState | None:
     """Fetch one agent's cumulative state; None if no row exists."""
+    import json
+
     conn = _get_conn()
     if conn is None or not agent_id:
         return None
@@ -380,7 +415,8 @@ def get_agent_runtime_state(agent_id: str) -> AgentRuntimeState | None:
                    claude_cli_session_id, last_run_id, last_run_status,
                    total_input_tokens, total_output_tokens,
                    total_cached_input_tokens, total_cost_cents,
-                   last_error, created_at, updated_at
+                   last_error, session_resume_params,
+                   created_at, updated_at
             FROM agent_runtime_state WHERE agent_id = ?
             """,
             (agent_id,),
@@ -390,6 +426,22 @@ def get_agent_runtime_state(agent_id: str) -> AgentRuntimeState | None:
         return None
     if row is None:
         return None
+    # PR-SESSION-RESUME-PARAMS — JSON blob → dict. Malformed JSON
+    # (legacy '' or operator hand-edits) gracefully degrades to {}
+    # so the caller's resume gate just skips (treats as "no
+    # context recorded, no guard").
+    raw_params = str(row[12]) if row[12] is not None else ""
+    try:
+        parsed_params = json.loads(raw_params) if raw_params else {}
+        if not isinstance(parsed_params, dict):
+            parsed_params = {}
+    except json.JSONDecodeError:
+        log.debug(
+            "agent_runtime_state(%s).session_resume_params malformed: %r",
+            agent_id,
+            raw_params,
+        )
+        parsed_params = {}
     return AgentRuntimeState(
         agent_id=str(row[0]),
         agent_kind=str(row[1]),
@@ -403,8 +455,9 @@ def get_agent_runtime_state(agent_id: str) -> AgentRuntimeState | None:
         total_cached_input_tokens=int(row[9]),
         total_cost_cents=int(row[10]),
         last_error=str(row[11]),
-        created_at=float(row[12]),
-        updated_at=float(row[13]),
+        session_resume_params=parsed_params,
+        created_at=float(row[13]),
+        updated_at=float(row[14]),
     )
 
 

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -192,12 +192,25 @@ def build_hooks(
             agent_id = str(data.get("session_id") or data.get("agent_id") or "")
             if not agent_id:
                 return
+            # PR-SESSION-RESUME-PARAMS (2026-05-25) — capture the
+            # per-task cwd alongside the claude-cli session_id so
+            # the next reader can verify the saved session belongs
+            # to the current cwd-pool (paperclip
+            # ``execute.ts:592`` ``claudeSessionCwdMatchesExecutionTarget``).
+            # Empty when no per-task isolation is in scope (REPL /
+            # gateway) — the reader's gate skips on empty
+            # stored_cwd, preserving legacy behaviour.
+            from core.agent.task_isolation import get_task_isolated_cwd
+
+            task_cwd = get_task_isolated_cwd() or ""
+            resume_params: dict[str, Any] = {"cwd": task_cwd} if task_cwd else {}
             record_agent_session_end(
                 agent_id=agent_id,
                 agent_kind=str(data.get("agent_kind", "repl")),
                 component=str(data.get("component", "agentic_loop")),
                 adapter_type=str(data.get("adapter_type", "")),
                 claude_cli_session_id=str(data.get("claude_cli_session_id", "")),
+                session_resume_params=resume_params,
             )
 
         def _on_subagent_completed(_event: HookEvent, data: dict[str, Any]) -> None:

--- a/tests/test_session_resume_params.py
+++ b/tests/test_session_resume_params.py
@@ -1,0 +1,424 @@
+"""PR-SESSION-RESUME-PARAMS (2026-05-25) — paperclip-aligned cwd-paired
+resume-context tests.
+
+Smoke 12 (v0.99.54) surfaced a stale-session bug: claude-cli's
+session storage is cwd-keyed (``~/.claude/projects/<cwd-slug>/``),
+so a UUID stored in SQLite from cwd A produces "No conversation
+found" when ``_load_prior_session_id`` returns it for a worker
+running in cwd B. The fix mirrors paperclip's
+``claudeSessionCwdMatchesExecutionTarget`` from
+``packages/adapters/claude-local/src/server/execute.ts:592``: a
+paired ``cwd`` field stored alongside the session_id, and a
+read-time ``path.resolve()`` equality gate.
+
+This file tests:
+1. ``_saved_cwd_matches_current`` resolve-equality helper.
+2. ``record_agent_session_end`` round-trips
+   ``session_resume_params={"cwd": ...}``.
+3. ``get_agent_runtime_state`` returns the parsed dict.
+4. ``_load_prior_session_id`` returns "" on cwd mismatch (the
+   smoke 12 regression scenario) and the saved id on cwd match.
+5. Legacy rows with empty ``session_resume_params`` skip the gate
+   (back-compat — pre-fix DBs / direct-call surfaces).
+6. ``_persist_session_id`` writes the cwd into both SQLite and
+   the session.json file fallback when ``get_task_isolated_cwd()``
+   is bound.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# ────────────────────── _saved_cwd_matches_current ────────────────────────────
+
+
+def test_match_helper_returns_true_when_both_empty() -> None:
+    """Legacy direct-call surface — neither side has a cwd to compare."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    assert _saved_cwd_matches_current("", "") is True
+
+
+def test_match_helper_returns_true_when_stored_empty_legacy_row() -> None:
+    """Pre-fix SQLite rows have empty ``session_resume_params`` →
+    no cwd recorded → gate skips so resume goes through (back-compat)."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    assert _saved_cwd_matches_current("", "/Users/u/wkspc/sub_agents/x/cwd") is True
+
+
+def test_match_helper_returns_true_when_current_empty_direct_call() -> None:
+    """Direct-call surface (no per-task isolation) — current cwd is empty,
+    so the gate skips. This preserves the original PR-V behaviour."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    assert _saved_cwd_matches_current("/Users/u/wkspc/sub_agents/x/cwd", "") is True
+
+
+def test_match_helper_returns_true_on_equal_paths() -> None:
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    p = "/Users/u/wkspc/sub_agents/x/cwd"
+    assert _saved_cwd_matches_current(p, p) is True
+
+
+def test_match_helper_returns_false_on_different_paths(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The smoke 12 scenario — saved cwd != current cwd → fresh session."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    a = tmp_path / "sub_agents" / "proximity" / "cwd"
+    b = tmp_path / "sub_agents" / "critic" / "cwd"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    assert _saved_cwd_matches_current(str(a), str(b)) is False
+
+
+def test_match_helper_normalises_trailing_slash(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``path.resolve()`` strips trailing slashes; the gate must too."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    d = tmp_path / "real-cwd"
+    d.mkdir()
+    assert _saved_cwd_matches_current(f"{d}/", str(d)) is True
+
+
+def test_match_helper_normalises_dotdot(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``a/b/../c`` and ``a/c`` resolve to the same absolute path."""
+    from core.agent.loop.agent_loop import _saved_cwd_matches_current
+
+    base = tmp_path / "a" / "c"
+    base.mkdir(parents=True)
+    raw = f"{tmp_path}/a/b/../c"
+    assert _saved_cwd_matches_current(str(base), raw) is True
+
+
+# ────────────────────── SQLite round-trip ─────────────────────────────────────
+
+
+def _isolated_db(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Point the runtime-state singleton at a fresh tmp DB per test.
+
+    Mirrors ``tests/test_agent_runtime_state.py:tmp_db`` exactly:
+    bootstrap schema via ``SessionManager(db_path=...)``, monkeypatch
+    the canonical resolver, then reset the agent_runtime_state cached
+    connection so the next ``_get_conn()`` rebuilds against the tmp
+    path.
+    """
+    from core.memory.session_manager import SessionManager
+
+    from core.observability import agent_runtime_state as ars
+
+    db_path = tmp_path / "sessions.db"
+    SessionManager(db_path=db_path)
+    monkeypatch.setattr(
+        "core.memory.session_manager._get_default_db_path",
+        lambda: db_path,
+    )
+    ars._reset_for_tests(db_path=db_path)
+
+
+def test_record_agent_session_end_round_trips_resume_params(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    _isolated_db(monkeypatch, tmp_path)
+    from core.observability.agent_runtime_state import (
+        get_agent_runtime_state,
+        record_agent_session_end,
+    )
+
+    record_agent_session_end(
+        agent_id="proximity-gen1-test",
+        claude_cli_session_id="uuid-aaa",
+        session_resume_params={"cwd": "/Users/u/wkspc/sub_agents/proximity/cwd"},
+    )
+    state = get_agent_runtime_state("proximity-gen1-test")
+    assert state is not None
+    assert state.claude_cli_session_id == "uuid-aaa"
+    assert state.session_resume_params == {"cwd": "/Users/u/wkspc/sub_agents/proximity/cwd"}
+
+
+def test_record_agent_session_end_legacy_path_empty_params(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """When caller passes no resume_params (REPL / gateway) the stored
+    blob is empty (``{}``) and the reader's gate skips."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.observability.agent_runtime_state import (
+        get_agent_runtime_state,
+        record_agent_session_end,
+    )
+
+    record_agent_session_end(
+        agent_id="repl-session-x",
+        claude_cli_session_id="uuid-bbb",
+    )
+    state = get_agent_runtime_state("repl-session-x")
+    assert state is not None
+    assert state.session_resume_params == {}
+
+
+def test_record_agent_session_end_preserves_resume_params_across_upserts(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """First call sets cwd. Second call with empty resume_params (e.g.
+    a token-only update) must NOT wipe the previously stored cwd."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.observability.agent_runtime_state import (
+        get_agent_runtime_state,
+        record_agent_session_end,
+    )
+
+    record_agent_session_end(
+        agent_id="agent-preserve",
+        claude_cli_session_id="uuid-ccc",
+        session_resume_params={"cwd": "/tmp/cwd-1"},  # noqa: S108
+    )
+    # Second upsert without resume_params (mimics an unrelated update path).
+    record_agent_session_end(
+        agent_id="agent-preserve",
+        claude_cli_session_id="uuid-ccc",
+    )
+    state = get_agent_runtime_state("agent-preserve")
+    assert state is not None
+    assert state.session_resume_params == {"cwd": "/tmp/cwd-1"}  # noqa: S108
+
+
+def test_get_agent_runtime_state_graceful_on_malformed_json(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Operator hand-edits or legacy non-JSON content must NOT crash —
+    the reader degrades to ``{}`` so the gate skips."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.observability.agent_runtime_state import get_agent_runtime_state
+
+    from core.observability import agent_runtime_state as ars
+
+    conn = ars._get_conn()
+    assert conn is not None
+    import time as _t
+
+    now = _t.time()
+    conn.execute(
+        """INSERT INTO agent_runtime_state
+            (agent_id, claude_cli_session_id, session_resume_params,
+             created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)""",
+        ("agent-malformed", "uuid-ddd", "this-is-not-json", now, now),
+    )
+    conn.commit()
+    state = get_agent_runtime_state("agent-malformed")
+    assert state is not None
+    assert state.session_resume_params == {}  # graceful degrade
+    # ``claude_cli_session_id`` still loaded correctly.
+    assert state.claude_cli_session_id == "uuid-ddd"
+
+
+# ────────────────────── _load_prior_session_id integration ────────────────────
+
+
+def test_load_prior_session_id_returns_id_on_cwd_match(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _load_prior_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import record_agent_session_end
+
+    cwd = tmp_path / "match-cwd"
+    cwd.mkdir()
+    record_agent_session_end(
+        agent_id="agent-match",
+        claude_cli_session_id="uuid-eee",
+        session_resume_params={"cwd": str(cwd)},
+    )
+    set_task_isolated_cwd(cwd)
+    try:
+        assert _load_prior_session_id("agent-match") == "uuid-eee"
+    finally:
+        set_task_isolated_cwd(None)
+
+
+def test_load_prior_session_id_returns_empty_on_cwd_mismatch(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """Smoke 12 regression — saved cwd differs from current per-task cwd
+    → return "" so adapter starts a fresh session instead of resuming
+    against a pool that doesn't hold the session file."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _load_prior_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import record_agent_session_end
+
+    saved_cwd = tmp_path / "smoke-11-cwd"
+    current_cwd = tmp_path / "smoke-12-cwd"
+    saved_cwd.mkdir()
+    current_cwd.mkdir()
+    record_agent_session_end(
+        agent_id="proximity-stale",
+        claude_cli_session_id="uuid-fff",
+        session_resume_params={"cwd": str(saved_cwd)},
+    )
+    set_task_isolated_cwd(current_cwd)
+    try:
+        assert _load_prior_session_id("proximity-stale") == ""
+    finally:
+        set_task_isolated_cwd(None)
+
+
+def test_load_prior_session_id_returns_id_on_legacy_empty_params(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """Pre-PR-SESSION-RESUME-PARAMS rows have empty params → gate skips
+    → resume id returned (back-compat preserved)."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _load_prior_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import record_agent_session_end
+
+    record_agent_session_end(
+        agent_id="legacy-agent",
+        claude_cli_session_id="uuid-ggg",
+    )
+    set_task_isolated_cwd(tmp_path / "any-cwd")
+    (tmp_path / "any-cwd").mkdir()
+    try:
+        assert _load_prior_session_id("legacy-agent") == "uuid-ggg"
+    finally:
+        set_task_isolated_cwd(None)
+
+
+def test_load_prior_session_id_returns_id_on_direct_call_no_isolation(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """No per-task isolation bound (REPL / gateway / one-shot) → current
+    cwd is empty → gate skips → resume id returned."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _load_prior_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import record_agent_session_end
+
+    record_agent_session_end(
+        agent_id="repl-x",
+        claude_cli_session_id="uuid-hhh",
+        session_resume_params={"cwd": "/some/saved/cwd"},
+    )
+    set_task_isolated_cwd(None)
+    assert _load_prior_session_id("repl-x") == "uuid-hhh"
+
+
+# ────────────────────── _persist_session_id end-to-end ────────────────────────
+
+
+def test_persist_session_id_writes_cwd_to_sqlite_and_file(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """When ``get_task_isolated_cwd()`` returns a bound cwd, the writer
+    paths (SQLite primary + session.json fallback) BOTH carry the
+    paired cwd. Symmetric with the reader's gate."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _persist_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import get_agent_runtime_state
+    from core.observability.run_dir import set_active_run_dir
+
+    set_active_run_dir(tmp_path)
+    task_cwd = tmp_path / "sub_agents" / "evolver-test" / "cwd"
+    task_cwd.mkdir(parents=True)
+    set_task_isolated_cwd(task_cwd)
+    try:
+        _persist_session_id("evolver-test", "uuid-iii")
+    finally:
+        set_task_isolated_cwd(None)
+        set_active_run_dir(None)
+
+    # SQLite primary
+    state = get_agent_runtime_state("evolver-test")
+    assert state is not None
+    assert state.claude_cli_session_id == "uuid-iii"
+    assert state.session_resume_params.get("cwd") == str(task_cwd)
+
+    # session.json file fallback
+    session_json = tmp_path / "sub_agents" / "evolver-test" / "session.json"
+    assert session_json.exists()
+    payload = json.loads(session_json.read_text(encoding="utf-8"))
+    assert payload["claude_cli_session_id"] == "uuid-iii"
+    assert payload["cwd"] == str(task_cwd)
+
+
+def test_persist_session_id_omits_cwd_when_isolation_unset(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """No per-task isolation → ``cwd`` field omitted from both writers
+    (back-compat — legacy callers / REPL / gateway)."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.agent.loop.agent_loop import _persist_session_id
+    from core.agent.task_isolation import set_task_isolated_cwd
+    from core.observability.agent_runtime_state import get_agent_runtime_state
+    from core.observability.run_dir import set_active_run_dir
+
+    set_active_run_dir(tmp_path)
+    set_task_isolated_cwd(None)
+    _persist_session_id("repl-no-isolation", "uuid-jjj")
+    set_active_run_dir(None)
+
+    state = get_agent_runtime_state("repl-no-isolation")
+    assert state is not None
+    assert state.claude_cli_session_id == "uuid-jjj"
+    assert "cwd" not in state.session_resume_params
+
+    session_json = tmp_path / "sub_agents" / "repl-no-isolation" / "session.json"
+    if session_json.exists():
+        payload = json.loads(session_json.read_text(encoding="utf-8"))
+        assert "cwd" not in payload
+
+
+# ────────────────────── Migration sanity ──────────────────────────────────────
+
+
+def test_schema_carries_session_resume_params_column(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Fresh DB must include the new column from
+    ``_CREATE_AGENT_RUNTIME_STATE_TABLE_SQL``."""
+    _isolated_db(monkeypatch, tmp_path)
+    from core.observability import agent_runtime_state as ars
+
+    conn = ars._get_conn()
+    assert conn is not None
+    cols = {str(r[1]) for r in conn.execute("PRAGMA table_info(agent_runtime_state)").fetchall()}
+    assert "session_resume_params" in cols
+
+
+def test_alter_table_adds_column_to_legacy_db(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Simulate a legacy DB: create the table without the new column,
+    then re-open through SessionManager and verify the migration ALTER
+    fired."""
+    db_path = tmp_path / "legacy.db"
+    import sqlite3
+
+    legacy = sqlite3.connect(str(db_path))
+    legacy.execute(
+        """CREATE TABLE agent_runtime_state (
+            agent_id TEXT PRIMARY KEY,
+            agent_kind TEXT NOT NULL DEFAULT 'subagent',
+            component TEXT NOT NULL DEFAULT 'agentic_loop',
+            adapter_type TEXT NOT NULL DEFAULT '',
+            claude_cli_session_id TEXT NOT NULL DEFAULT '',
+            last_run_id TEXT NOT NULL DEFAULT '',
+            last_run_status TEXT NOT NULL DEFAULT '',
+            total_input_tokens INTEGER NOT NULL DEFAULT 0,
+            total_output_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_cents INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT NOT NULL DEFAULT '',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )"""
+    )
+    legacy.commit()
+    legacy.close()
+
+    # Re-open via SessionManager → migration runs.
+    from core.memory.session_manager import SessionManager
+
+    SessionManager(db_path)
+    check = sqlite3.connect(str(db_path))
+    cols = {str(r[1]) for r in check.execute("PRAGMA table_info(agent_runtime_state)").fetchall()}
+    check.close()
+    assert "session_resume_params" in cols
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.53"
+version = "0.99.54"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Paperclip-aligned cwd-paired resume-context tracking. claude-cli's session storage is cwd-keyed; storing a session_id alone is insufficient when the worker's cwd later changes (e.g. PR-CLEANUP's per-task isolation). New `session_resume_params` JSON column on `agent_runtime_state` stores `{cwd: <write-time cwd>}`; reader gates on `path.resolve()` equality before returning the saved id. Schema is JSON to absorb future fields (`prompt_bundle_key`, `adapter_type`, …) without further ALTERs.

- `core/memory/session_manager.py` — schema + additive ALTER migration
- `core/observability/agent_runtime_state.py` — dataclass + writer/reader JSON ser/des with COALESCE preserve-on-partial-upsert
- `core/agent/loop/agent_loop.py` — `_saved_cwd_matches_current` helper + gate in `_load_prior_session_id` + paired write in `_persist_session_id`
- `core/wiring/bootstrap.py` — SESSION_ENDED hook handler threads cwd
- 19 regression tests across helper / SQLite / loader / persister / migration

## Why

Smoke 12 (v0.99.54, post-PR-CLEANUP per-task cwd isolation) surfaced:

```
proximity-gen1-redundant_tool_invocation FAILED:
  claude-cli subprocess exited rc=1: No conversation found with
  session ID: 2cf7d472-3f03-48b6-b308-016ea9b05bb5  (5 attempts)

meta_reviewer FAILED (same shape)
```

Grounded forensics:

- The UUID `2cf7d472-...` lives in `~/.geode/projects/-Users-mango-workspace-geode/sessions/sessions.db` (`agent_runtime_state.claude_cli_session_id`), last updated 2026-05-25 08:26:46 — smoke 11's timeframe, when the worker was running in **workspace-root cwd** (PR-CLEANUP B2 wiring fix had not landed yet).
- The matching session file `~/.claude/projects/-Users-mango-workspace-geode/2cf7d472-....jsonl` exists in the **workspace-root** cwd-pool.
- Smoke 12 ran post-PR-CLEANUP — worker bound `<run_dir>/sub_agents/proximity-.../cwd/` as per-task cwd. claude-cli subprocess ran in THAT cwd. Its cwd-hashed pool is empty (no prior session there).
- `_load_prior_session_id` read SQLite, got the stale UUID from smoke 11, passed `--resume 2cf7d472-...` → claude-cli looked in its current cwd-pool → "No conversation found" → 5 retries → fail.

This is a 2-SoT mismatch: SQLite's `claude_cli_session_id` points into ONE cwd-pool while the current claude-cli subprocess runs in ANOTHER. Storing the session_id alone is insufficient; we need the cwd it was written for.

### Naming / extensibility decision

The first cut considered a `claude_cli_session_cwd` column. Operator pushed back: hash-as-filepath (which I mis-labelled the slug pattern as) is an anti-pattern; other agents use plain slugs; and an adapter-specific column doesn't extend to codex-cli / payg / subscription. Investigation of how other agents handle cwd-paired session resume:

| System | Session storage key | cwd handling |
|--------|--------------------|--------------|
| claude-cli | `~/.claude/projects/<cwd-slug>/<uuid>.jsonl` | Directory name = cwd-slug (`/` → `-`) |
| Codex CLI | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl` | cwd is **file metadata** (`session_meta.payload.cwd`), not a path component |
| **paperclip** (claude-cli wrapper) | `sessionId` + `cwd` paired plain-string fields on `sessionParams` | Read-time `path.resolve()` equality gate |
| Hermes | DB-backed session_id (no cwd-keyed pool) | n/a |

**Paperclip is the closest sister precedent** — same problem (wrapping claude-cli, multi-context execution), solved with a `sessionParams` JSON blob carrying multiple resume-context fields (sessionId, cwd, promptBundleKey, remoteExecution). This PR adopts the same shape so the same column extends across adapters and future paired fields land in the JSON without further schema changes.

## Changes

| File | Change |
|------|--------|
| `core/memory/session_manager.py` | Add `session_resume_params TEXT NOT NULL DEFAULT '{}'` to `_CREATE_AGENT_RUNTIME_STATE_TABLE_SQL` (fresh DBs). Add `_AGENT_RUNTIME_STATE_EXTRA_COLUMNS` tuple + ALTER TABLE migration (legacy DBs) — same shape as PR-CL-BUDGET's `_HANDOFF_COLUMNS` migration for the `sessions` table. |
| `core/observability/agent_runtime_state.py` | Dataclass field `session_resume_params: dict[str, Any] = field(default_factory=dict)`. Writer (`record_agent_session_end`) accepts the dict, JSON-serialises with `separators=(",", ":")`, COALESCE-protects against partial-upsert wipes (a later token-only update must NOT erase the prior `cwd`). Reader (`get_agent_runtime_state`) parses JSON with graceful degradation on malformed content. |
| `core/agent/loop/agent_loop.py` | New `_saved_cwd_matches_current(stored, current)` helper — paperclip-mirror, returns True on either-side-empty (back-compat skip) or `Path(x).resolve()` equality. `_load_prior_session_id` reads `state.session_resume_params.get("cwd")` and applies the gate before returning the id; legacy session.json file fallback gets the same gate. `_persist_session_id` captures `get_task_isolated_cwd()` into both SQLite and the file fallback. |
| `core/wiring/bootstrap.py` | `_on_session_ended` hook handler captures `get_task_isolated_cwd()` into `record_agent_session_end(session_resume_params={"cwd": ...})` — the canonical SESSION_ENDED write path. |
| `tests/test_session_resume_params.py` | **New.** 19 tests across 6 groups: helper (7 — empty / mismatch / resolve normalisation), SQLite round-trip (4 — round-trip / legacy / preserve-on-upsert / malformed-JSON-graceful), loader integration (4 — match / mismatch / legacy-empty / direct-call), persister end-to-end (2 — cwd-written / cwd-omitted), migration sanity (2 — fresh-DB / legacy-DB ALTER). |
| `CHANGELOG.md` | Unreleased entry under Fixed. |
| `uv.lock` | version stamp bump 0.99.53 → 0.99.54 (regenerated by uv sync). |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Schema column added | Implemented | both fresh + migration paths |
| Writer accepts paired params | Implemented | `record_agent_session_end(session_resume_params=...)` |
| Writer preserves prior params on partial upsert | Implemented | `COALESCE(NULLIF(?, ''), '{}')` + CASE-WHEN-`!='{}'` |
| Reader parses + populates dataclass | Implemented | graceful JSON.JSONDecodeError → `{}` |
| Loader gate on cwd equality | Implemented | both SQLite + file fallback symmetric |
| Persister writes paired cwd | Implemented | both SQLite + file fallback symmetric |
| Bootstrap SESSION_ENDED handler threads cwd | Implemented | canonical hook path |
| Back-compat (empty cwd skips gate) | Verified | 3 tests |
| Future extensibility (JSON blob) | Implemented | adapter-agnostic, additive fields land in same column |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 891 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 433 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] Focused: `pytest tests/test_session_resume_params.py tests/test_agent_runtime_state.py tests/test_agent_runtime_state_wiring.py` — 49 passed (30 existing + 19 new)
- [ ] Full pytest suite — running

## Reference

- Smoke 12 archive: `/Users/mango/workspace/geode/.audit/smoke-archives/smoke-12-*/sub_agents/proximity-.../` — stale-UUID evidence
- SQLite forensics: `~/.geode/projects/-Users-mango-workspace-geode/sessions/sessions.db` row + `~/.claude/projects/-Users-mango-workspace-geode/2cf7d472-....jsonl` file existence
- Paperclip pattern: `~/workspace/paperclip/packages/adapters/claude-local/src/server/execute.ts:592` (`claudeSessionCwdMatchesExecutionTarget` + `sessionParams` JSON blob)
- Sister PR chain on v0.99.54:
  PR-PERMS-FLAG-FIX (#1610) → PR-JSON-CODEBLOCK-STRIP (#1612) → PR-SUB-AGENT-CODEBLOCK-STRIP (#1614) → PR-TRANSIENT-BARE-HTTP-CODES (#1616) → PR-TRANSIENT-WORD-BOUNDARIES (#1618) → PR-RESUME-NO-PERSIST-FIX B2 (#1620) → PR-CLEANUP-WORKER-REQUEST-RUN-DIR (#1622) → **PR-SESSION-RESUME-PARAMS**
