### PR TITLE
fix(env-whitelist): forward GEODE_CODEX_OAUTH_POLL_DISABLED to worker (PR-ENV-WHITELIST-CODEX-BYPASS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-ENV-WHITELIST-CODEX-BYPASS** — add
+  `GEODE_CODEX_OAUTH_POLL_DISABLED` to
+  `IsolatedRunner._SUBPROCESS_ENV_WHITELIST`. Smoke 13 vote-m000-*
+  failed with `codex-cli-subagent lane blocked — Codex 5-hour OAuth
+  bucket >= throttle threshold (see GEODE_CODEX_OAUTH_POLL_DISABLED
+  to bypass)` even though the operator had set the env on the parent
+  `geode serve` process. Root cause: the whitelist did not include
+  the bypass env, so the `safe_env` built in
+  `_aexecute_subprocess` dropped it before spawning the worker.
+  The worker subprocess then ran
+  `should_block_codex_lane_acquisition()` with an unset env, the
+  throttle gate fired, and 5 retries failed against the actual
+  ChatGPT Plus subscription bucket that had headroom. Pinned by 4
+  regression tests in `tests/test_subprocess_env_whitelist.py`:
+  bypass env present, operator-knob set preserved, credential envs
+  preserved, dangerous-env exclusion guard.
+
 - **PR-SESSION-RESUME-PARAMS** — paperclip-aligned cwd-paired
   resume-context tracking. Smoke 12 (v0.99.54) surfaced a
   stale-session bug after the PR-CLEANUP per-task cwd isolation

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -95,6 +95,14 @@ class IsolatedRunner:
 
     # Subprocess env whitelist — only these vars are forwarded to child processes.
     # Prevents accidental leakage of secrets or shell-specific vars.
+    # PR-ENV-WHITELIST-CODEX-BYPASS (2026-05-25) — added
+    # ``GEODE_CODEX_OAUTH_POLL_DISABLED`` after smoke 13 surfaced the
+    # gap: operator set the env on the parent serve process to bypass
+    # GEODE's pre-emptive 5-hour Codex OAuth throttle gate, but the
+    # worker subprocess didn't inherit it, so
+    # ``should_block_codex_lane_acquisition`` re-fired its
+    # ``TimeoutError(CODEX_CLI_LANE_THROTTLED_MSG)`` for every codex
+    # voter even though the actual subscription bucket had headroom.
     _SUBPROCESS_ENV_WHITELIST: set[str] = {
         "PATH",
         "HOME",
@@ -109,6 +117,7 @@ class IsolatedRunner:
         "VIRTUAL_ENV",
         "GEODE_CONFIG_PATH",
         "GEODE_DATA_DIR",
+        "GEODE_CODEX_OAUTH_POLL_DISABLED",
     }
 
     def __init__(

--- a/tests/test_subprocess_env_whitelist.py
+++ b/tests/test_subprocess_env_whitelist.py
@@ -1,0 +1,67 @@
+"""PR-ENV-WHITELIST-CODEX-BYPASS (2026-05-25) — anti-relapse pins for
+the subprocess env-var forwarding whitelist.
+
+Smoke 13 vote-m000-* (codex voter route) failed with
+``codex-cli-subagent lane blocked — Codex 5-hour OAuth bucket >=
+throttle threshold (see GEODE_CODEX_OAUTH_POLL_DISABLED to bypass)``
+even though the operator had set the env on the parent ``geode
+serve`` process. Root cause: ``IsolatedRunner._SUBPROCESS_ENV_WHITELIST``
+did NOT include ``GEODE_CODEX_OAUTH_POLL_DISABLED``, so the
+``safe_env`` built for the child subprocess dropped it.
+
+These tests pin:
+1. The bypass env is in the whitelist (literal name presence).
+2. The set of other ``GEODE_*`` operator knobs already in the
+   whitelist is preserved (regression guard against accidental
+   removal).
+3. The whitelist remains conservative — common shell / secret vars
+   that should NOT leak (``OAUTH_TOKEN``, ``SSH_AUTH_SOCK``, …) are
+   absent.
+"""
+
+from __future__ import annotations
+
+from core.orchestration.isolated_execution import IsolatedRunner
+
+
+def test_codex_oauth_poll_disabled_is_whitelisted() -> None:
+    """The exact env name documented in
+    ``core/orchestration/codex_cli_lane.py:CODEX_CLI_LANE_THROTTLED_MSG``
+    must reach the worker subprocess for the bypass to take effect."""
+    assert "GEODE_CODEX_OAUTH_POLL_DISABLED" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+
+
+def test_geode_operator_knobs_preserved() -> None:
+    """Regression guard — these are documented operator knobs that
+    callers configure on the parent process and expect to reach the
+    worker. Removing any of them from the whitelist would silently
+    break their effect."""
+    required = {
+        "GEODE_CONFIG_PATH",
+        "GEODE_DATA_DIR",
+        "GEODE_CODEX_OAUTH_POLL_DISABLED",
+    }
+    missing = required - IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert not missing, f"required operator knobs missing from whitelist: {sorted(missing)}"
+
+
+def test_credential_envs_present() -> None:
+    """Provider API keys must continue to forward (used by PAYG
+    adapters that read ``os.environ`` directly)."""
+    assert "ANTHROPIC_API_KEY" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert "OPENAI_API_KEY" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+
+
+def test_dangerous_envs_excluded() -> None:
+    """Anti-leak guard — these are vars that frequently carry
+    secrets / host-specific state that the worker has no business
+    seeing. Keep the whitelist conservative."""
+    forbidden = {
+        "SSH_AUTH_SOCK",
+        "AWS_SECRET_ACCESS_KEY",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "OAUTH_TOKEN",
+    }
+    leaked = forbidden & IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert not leaked, f"sensitive envs must not enter the whitelist: {sorted(leaked)}"


### PR DESCRIPTION
## Summary
Add \`GEODE_CODEX_OAUTH_POLL_DISABLED\` to \`IsolatedRunner._SUBPROCESS_ENV_WHITELIST\` so the operator's bypass actually reaches the worker subprocess.

## Why
Smoke 13 (v0.99.54) vote-m000-* both failed with the documented bypass-hint message:
\`\`\`
codex-cli-subagent lane blocked — Codex 5-hour OAuth bucket >= throttle threshold
(see GEODE_CODEX_OAUTH_POLL_DISABLED to bypass).
\`\`\`
even though the operator launched serve with the env set. Tracing \`safe_env\` build in \`_aexecute_subprocess\` showed the env was being stripped: \`_SUBPROCESS_ENV_WHITELIST\` lacked the key, so the worker re-ran \`should_block_codex_lane_acquisition()\` with the env unset and the throttle gate fired against a subscription bucket that had headroom.

## Changes
| File | Change |
|------|--------|
| \`core/orchestration/isolated_execution.py\` | Add \`"GEODE_CODEX_OAUTH_POLL_DISABLED"\` to the whitelist set + comment block citing smoke 13 evidence. |
| \`tests/test_subprocess_env_whitelist.py\` | New — 4 tests: bypass env present, operator-knob set preserved, credential envs preserved, dangerous-env exclusion guard. |
| \`CHANGELOG.md\` | Unreleased entry under Fixed. |

## Verification
- [x] \`uv run ruff check core/ tests/ plugins/\` — All checks passed
- [x] \`uv run ruff format --check core/ tests/ plugins/\` — 892 files unchanged
- [x] \`uv run mypy core/ plugins/\` — 433 source files, 0 errors
- [x] Focused: \`pytest tests/test_subprocess_env_whitelist.py tests/test_isolated_execution.py\` — 43 passed