### PR TITLE
fix(codex-oauth): postmortem dump for empty output_text (PR-CODEX-OAUTH-EMPTY-TEXT-DUMP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-CODEX-OAUTH-EMPTY-TEXT-DUMP** — codex_oauth adapter writes a
+  postmortem dump to `~/.geode/diagnostics/codex-oauth-empty-text/
+  <ts>-<model>.json` when the upstream returns `output_text=""`.
+  Smoke 11/12/13 vote-m000-openai.openai-codex consistently failed
+  in this shape (10s elapsed, ~$0.04 billed, zero
+  assistant_message events, `termination_reason="natural"`) — the
+  worker treated empty text as failure with no diagnostic surface.
+  Dump captures (usage / reasoning_items raw + count /
+  reasoning_summaries / stop_reason) and the adapter logs the dump
+  path on the warning line alongside the worker-level failure.
+  Mirrors `claude_cli._dump_transient_postmortem` shape so
+  `~/.geode/diagnostics/` houses both diagnostic categories under
+  one tar-up. Pinned by 5 regression tests in
+  `tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py`.
+
 - **PR-SESSION-RESUME-PARAMS** — paperclip-aligned cwd-paired
   resume-context tracking. Smoke 12 (v0.99.54) surfaced a
   stale-session bug after the PR-CLEANUP per-task cwd isolation

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -120,7 +120,32 @@ class CodexOAuthAdapter:
             self._last_error = exc
             log.warning("codex-oauth: responses.stream failed model=%s err=%s", req.model, exc)
             raise
-        return translate_codex_response(final, accumulated_items=accumulated)
+        result = translate_codex_response(final, accumulated_items=accumulated)
+        # PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — Codex sometimes
+        # returns ``output_text=""`` while emitting reasoning-only items
+        # (gpt-5.x reasoning mode skipping the visible-answer block).
+        # The downstream worker treats empty text as failure
+        # (``worker.py:_persist_outcome: success = bool(text)``), and
+        # the user only sees ``summary="termination_reason=natural"``
+        # with no clue why. Smoke 11/12/13 vote-m000-openai.openai-codex
+        # all failed in this pattern (10s elapsed, $0.04 billed, zero
+        # assistant_message events). Dump a postmortem so the operator
+        # can recover the (usage / reasoning_items / reasoning_summaries
+        # / stop_reason) without re-running the cycle, and log the dump
+        # path on the warning line that surfaces alongside the
+        # worker-level failure.
+        if not result.text:
+            dump_path = _dump_empty_text_postmortem(model=req.model, result=result)
+            log.warning(
+                "codex-oauth: empty output_text model=%s "
+                "reasoning_items=%d reasoning_summaries=%d stop_reason=%s dump=%s",
+                req.model,
+                len(result.reasoning_items),
+                len(result.reasoning_summaries),
+                result.stop_reason,
+                dump_path or "<dump failed>",
+            )
+        return result
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
@@ -278,6 +303,66 @@ def _translate_codex_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, An
 
     normalised = normalize("openai", tc)
     return normalised if normalised is not None else "auto"
+
+
+def _dump_empty_text_postmortem(
+    *,
+    model: str,
+    result: AdapterCallResult,
+) -> str | None:
+    """Persist a JSON post-mortem for every codex-oauth empty-text
+    response so operators can diagnose without re-running the cycle.
+    Returns the dump path (str) on success, ``None`` on any I/O error
+    (best-effort — diagnostic, not correctness-critical). Mirrors
+    ``claude_cli._dump_transient_postmortem`` shape so the same
+    operator's ``diagnostics tar-up`` workflow catches both.
+
+    PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — Codex gpt-5.x
+    sometimes returns reasoning items with no visible-answer text;
+    the worker treats that as failure with no actionable surface.
+    The dump records the four diagnostic dimensions:
+
+    (1) ``usage`` — input/output token counts the upstream billed
+    (2) ``reasoning_items`` — typed encrypted_content blobs (raw)
+    (3) ``reasoning_summaries`` — the model's plain-text chain of thought
+    (4) ``stop_reason`` — Codex backend's terminal status
+
+    Future ratchet: if a category of empty-text responses turns out
+    to be recoverable (e.g. ``reasoning_summaries`` carries the
+    actual answer in a parseable shape), add a text fallback inside
+    ``acomplete`` keyed on the dump's payload shape.
+    """
+    import json
+    import time
+
+    from core.paths import GLOBAL_DIAGNOSTICS_DIR
+
+    try:
+        postmortem_dir = GLOBAL_DIAGNOSTICS_DIR / "codex-oauth-empty-text"
+        postmortem_dir.mkdir(parents=True, exist_ok=True)
+        hit_ts = int(time.time())
+        postmortem_path = postmortem_dir / f"{hit_ts}-{model}.json"
+        payload: dict[str, Any] = {
+            "ts": hit_ts,
+            "model": model,
+            "stop_reason": result.stop_reason,
+            "usage": {
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+            },
+            "reasoning_items_count": len(result.reasoning_items),
+            "reasoning_summaries_count": len(result.reasoning_summaries),
+            "reasoning_items": list(result.reasoning_items),
+            "reasoning_summaries": list(result.reasoning_summaries),
+        }
+        postmortem_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        return str(postmortem_path)
+    except OSError as exc:
+        log.debug("codex-oauth: postmortem dump write failed: %s", exc)
+        return None
 
 
 __all__ = ["CodexOAuthAdapter"]

--- a/tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py
+++ b/tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py
@@ -1,0 +1,128 @@
+"""PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — regression pins for
+the empty-output_text postmortem dump.
+
+Smoke 11/12/13 vote-m000-openai.openai-codex consistently failed
+with ``output_text=""``, ``termination_reason="natural"``, 10s
+elapsed, $0.04 billed. The codex_oauth adapter now writes a
+diagnostic dump so the operator can see what the model actually
+emitted (reasoning_items / reasoning_summaries / usage / stop_reason)
+without re-running the cycle.
+
+Mirrors ``claude_cli._dump_transient_postmortem`` shape so
+``~/.geode/diagnostics/`` houses both, and any operator
+``diagnostics tar-up`` workflow catches them with one path filter.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from core.llm.adapters.base import (
+    AdapterCallResult,
+    UsageSummary,
+)
+from core.llm.adapters.codex_oauth import _dump_empty_text_postmortem
+
+
+def _build_result(
+    *,
+    text: str = "",
+    reasoning_items: tuple[dict, ...] = (),
+    reasoning_summaries: tuple[str, ...] = (),
+    stop_reason: str = "completed",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> AdapterCallResult:
+    return AdapterCallResult(
+        text=text,
+        usage=UsageSummary(input_tokens=input_tokens, output_tokens=output_tokens),
+        stop_reason=stop_reason,
+        tool_uses=(),
+        raw_response=None,
+        reasoning_items=reasoning_items,
+        reasoning_summaries=reasoning_summaries,
+    )
+
+
+def test_dump_writes_postmortem_file(tmp_path: Path) -> None:
+    """Happy path — empty text + 1 reasoning summary → dump created
+    with all 4 diagnostic dimensions."""
+    result = _build_result(
+        reasoning_items=({"type": "reasoning", "encrypted_content": "abc"},),
+        reasoning_summaries=("The user wants me to compare two seeds.",),
+    )
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=result)
+
+    assert dump_path is not None
+    p = Path(dump_path)
+    assert p.is_file()
+    assert p.parent.name == "codex-oauth-empty-text"
+    assert p.name.endswith("-gpt-5.5.json")
+    payload = json.loads(p.read_text(encoding="utf-8"))
+    assert payload["model"] == "gpt-5.5"
+    assert payload["stop_reason"] == "completed"
+    assert payload["usage"]["input_tokens"] == 100
+    assert payload["usage"]["output_tokens"] == 50
+    assert payload["reasoning_items_count"] == 1
+    assert payload["reasoning_summaries_count"] == 1
+    assert payload["reasoning_summaries"] == [
+        "The user wants me to compare two seeds.",
+    ]
+    assert payload["reasoning_items"][0]["encrypted_content"] == "abc"
+
+
+def test_dump_creates_parent_dir(tmp_path: Path) -> None:
+    """First-ever dump must create the
+    ``~/.geode/diagnostics/codex-oauth-empty-text/`` directory."""
+    target = tmp_path / "fresh-diagnostics"
+    assert not target.exists()
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", target):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.4-mini", result=result)
+    assert dump_path is not None
+    assert (target / "codex-oauth-empty-text").is_dir()
+
+
+def test_dump_handles_empty_reasoning_gracefully(tmp_path: Path) -> None:
+    """No reasoning_items / no reasoning_summaries — dump still
+    writes (just with empty arrays). Operator sees this as a "the
+    model returned nothing at all" signal vs the more common
+    "reasoning-only" signal."""
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=result)
+    assert dump_path is not None
+    payload = json.loads(Path(dump_path).read_text(encoding="utf-8"))
+    assert payload["reasoning_items_count"] == 0
+    assert payload["reasoning_summaries_count"] == 0
+    assert payload["reasoning_items"] == []
+    assert payload["reasoning_summaries"] == []
+
+
+def test_dump_returns_none_on_disk_error(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Disk full / permission denied — return ``None`` so the caller
+    logs ``<dump failed>`` and continues. Postmortem is best-effort,
+    not correctness-critical."""
+    # Point GLOBAL_DIAGNOSTICS_DIR at a non-writable path (a regular
+    # file masquerading as a directory).
+    blocker = tmp_path / "blocker-file"
+    blocker.write_text("not a directory", encoding="utf-8")
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", blocker):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=_build_result())
+    assert dump_path is None
+
+
+def test_dump_filename_format(tmp_path: Path) -> None:
+    """``<ts>-<model>.json`` so ``ls -t`` sorts chronologically and
+    model groups alphabetically — same convention as claude_cli."""
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.4-mini", result=result)
+    assert dump_path is not None
+    name = Path(dump_path).name
+    ts_part, _, model_part = name.partition("-")
+    assert ts_part.isdigit()
+    assert model_part == "gpt-5.4-mini.json"


### PR DESCRIPTION
## Summary
codex_oauth adapter writes a JSON post-mortem to \`~/.geode/diagnostics/codex-oauth-empty-text/<ts>-<model>.json\` when the upstream returns \`output_text=""\`. Adapter also logs the dump path alongside the warning that surfaces with the worker-level failure.

## Why
Smoke 11/12/13 vote-m000-openai.openai-codex all failed in the same shape: 10s elapsed, ~\$0.04 billed, zero assistant_message events, \`termination_reason=natural\`. The worker treats empty text as failure (\`worker.py:466 success = bool(text)\`) and operators see only \`Sub-agent failed: termination_reason=natural\` — no diagnostic surface to distinguish reasoning-only response vs blocked vs genuine silence without re-running the cycle (which burns more quota).

## Changes
| File | Change |
|------|--------|
| \`core/llm/adapters/codex_oauth.py\` | After \`translate_codex_response\`, when \`result.text == ""\` call new \`_dump_empty_text_postmortem(model, result)\` + log warning with dump path. Helper captures (ts, model, stop_reason, usage, reasoning_items raw + count, reasoning_summaries) into the dump. Mirrors \`claude_cli._dump_transient_postmortem\` filename + location conventions. |
| \`tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py\` | New — 5 tests: happy-path 4-dimension capture, parent-dir creation, empty-reasoning graceful, disk-error graceful (returns None), filename format. |
| \`CHANGELOG.md\` | Unreleased entry under Fixed. |

## Verification
- [x] \`uv run ruff check\` — All checks passed
- [x] \`uv run ruff format --check\` — 892 files unchanged
- [x] \`uv run mypy core/ plugins/\` — Success, 433 source files
- [x] \`uv run lint-imports\` — 4 contracts kept
- [x] Focused: \`pytest tests/core/llm/adapters/\` — 136 passed

## Reference
- Smoke 13 archive: \`/Users/mango/workspace/geode/.audit/smoke-archives/smoke-13-*/sub_agents/vote-m000-openai.openai-codex/\`
- Sister diagnostic pattern: \`core/llm/adapters/claude_cli.py:_dump_transient_postmortem\` (PR-T, 2026-05-25)