### PR TITLE
feat(petri-bundle): seeds/ viewer — fix 404 + render listing.json drill-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-SEEDS-BUNDLE-VIEWER** — `docs/petri-bundle/seeds/index.html` ships
+  a self-contained viewer for the self-improving-loop seed-generation
+  runs published into the petri-bundle. Previously
+  `https://mangowhoiscloud.github.io/geode/petri-bundle/seeds/` returned
+  404 (GitHub Pages disallows directory browsing); only direct file URLs
+  like `/seeds/listing.json` or
+  `/seeds/<run_id>/state.json` worked. The new index fetches
+  `listing.json` at load, renders a dense run table (run_id / gen_tag /
+  target_dim / status / draft→survivors / evolved / iters / cost USD),
+  and lazily drills down per run into `state.json` + `survivors.json` +
+  `meta_review.json` — survivors with elo + candidate `.md` link, cost
+  rollup, meta-review session_summary, next-gen priors, evolution yield,
+  Elo distribution. Status is derived from the listing
+  (`survivors_count == 0` → fail, `evolved_count < survivors_count` →
+  partial, else ok). The viewer is a single static HTML file (no
+  build step, no Next.js dep) so it ships alongside the inspect-petri
+  eval-log viewer at `/petri-bundle/` and the pages.yml workflow that
+  already triggers on `docs/petri-bundle/**` deploys it without any new
+  CI wiring. Mockup source: `/tmp/geode-literature-mockup/seeds.html`
+  (v2 post-Slop-feedback dense-table design); adapted to the live
+  schema (no phase progress yet — that field doesn't exist in
+  `state.json`; no candidate titles yet — would require `.md`
+  frontmatter fetch). Once
+  [`docs/plans/2026-05-23-seed-gen-loop3-bundle-serving.md`](../docs/plans/2026-05-23-seed-gen-loop3-bundle-serving.md)
+  Phase 2 ships its `LiteratureReview` agent the same viewer can be
+  extended with a literature column without schema churn.
+
 ### Fixed
 - **PR-ENV-WHITELIST-CODEX-BYPASS** — add
   `GEODE_CODEX_OAUTH_POLL_DISABLED` to

--- a/docs/petri-bundle/seeds/index.html
+++ b/docs/petri-bundle/seeds/index.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>seeds/ — GEODE petri-bundle</title>
+<meta name="description" content="GEODE self-improving loop seed-generation runs — per-run candidates, survivors, evolved variants, and meta-review.">
+<style>
+  :root {
+    --bg: #fafaf9;
+    --fg: #1a1a1a;
+    --muted: #5a5a5a;
+    --accent: #2563eb;
+    --border: #d4d4d4;
+    --code-bg: #f0efed;
+    --green: #15803d;
+    --red: #b91c1c;
+    --amber: #b45309;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.5;
+    font-size: 14px;
+  }
+  .nav {
+    border-bottom: 1px solid var(--border);
+    padding: 10px 24px;
+    font-size: 13px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+  .nav a { color: var(--muted); text-decoration: none; margin-right: 16px; }
+  .nav a:hover { color: var(--accent); text-decoration: underline; }
+  .nav a.active { color: var(--fg); font-weight: 600; }
+  main { max-width: 1280px; margin: 0 auto; padding: 24px; }
+  h1 { font-size: 20px; margin: 0 0 4px 0; font-weight: 700; }
+  .subtitle { color: var(--muted); font-size: 12px; margin-bottom: 18px; font-family: ui-monospace, Menlo, monospace; }
+  h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; margin: 28px 0 8px; }
+  code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 12px; font-family: ui-monospace, Menlo, monospace; }
+  .counts-line { font-family: ui-monospace, Menlo, monospace; font-size: 13px; color: var(--muted); margin-bottom: 18px; }
+  .counts-line strong { color: var(--fg); font-weight: 600; }
+  .status-msg { font-family: ui-monospace, Menlo, monospace; font-size: 13px; color: var(--muted); padding: 12px 0; }
+  .status-msg.err { color: var(--red); }
+  table.runs {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 13px;
+  }
+  table.runs th {
+    text-align: left;
+    padding: 5px 10px 5px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  table.runs td {
+    padding: 6px 10px 6px 0;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  table.runs td.id a { color: var(--accent); text-decoration: none; }
+  table.runs td.id a:hover { text-decoration: underline; }
+  table.runs td.tag { color: var(--fg); font-weight: 600; }
+  table.runs td.dim { color: var(--accent); }
+  table.runs td.status.ok { color: var(--green); }
+  table.runs td.status.partial { color: var(--amber); }
+  table.runs td.status.fail { color: var(--red); }
+  table.runs td.num { text-align: right; color: var(--fg); }
+  table.runs td.cost { text-align: right; color: var(--muted); font-size: 12px; }
+  .run-detail { background: white; border: 1px solid var(--border); margin-top: 18px; padding: 16px 18px; }
+  .run-detail h3 { font-size: 14px; margin: 0 0 10px 0; font-family: ui-monospace, Menlo, monospace; }
+  .run-detail h3 .runid { color: var(--accent); }
+  .run-detail h3 .dim-tag { color: var(--muted); margin-left: 8px; font-size: 12px; font-weight: normal; }
+  .run-detail .err-msg { color: var(--red); font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+  table.phases, table.survivors, table.priors {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+  table.phases th, table.survivors th, table.priors th {
+    text-align: left;
+    padding: 4px 8px 4px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 10px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  table.phases td, table.survivors td, table.priors td {
+    padding: 5px 8px 5px 0;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  table.survivors td.cid a { color: var(--accent); text-decoration: none; }
+  table.survivors td.cid a:hover { text-decoration: underline; }
+  table.survivors td.elo { text-align: right; }
+  table.survivors td.evolved { color: var(--muted); font-size: 11px; }
+  table.survivors td.scenario { color: var(--fg); font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; }
+  table.priors td.dim { color: var(--accent); }
+  table.priors td.weight { text-align: right; }
+  table.priors td.rationale { font-family: ui-sans-serif, system-ui, sans-serif; color: var(--fg); font-size: 12px; }
+  .cost-grid { display: grid; grid-template-columns: 180px 1fr; gap: 4px 16px; font-family: ui-monospace, Menlo, monospace; font-size: 12px; margin: 0; }
+  .cost-grid dt { color: var(--muted); }
+  .cost-grid dd { margin: 0; }
+  .summary-prose { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; color: var(--fg); margin: 6px 0 0 0; max-width: 920px; }
+  .footnote { color: var(--muted); font-size: 11px; font-family: ui-monospace, Menlo, monospace; margin-top: 28px; padding-top: 10px; border-top: 1px solid var(--border); }
+  .footnote a { color: var(--accent); text-decoration: none; }
+  .footnote a:hover { text-decoration: underline; }
+  details.run-detail summary { cursor: pointer; list-style: none; }
+  details.run-detail summary::-webkit-details-marker { display: none; }
+  details.run-detail summary::before { content: "▸ "; color: var(--muted); font-family: ui-monospace, Menlo, monospace; }
+  details.run-detail[open] summary::before { content: "▾ "; }
+</style>
+</head>
+<body>
+
+<div class="nav">
+  <a href="../">/petri-bundle/</a>
+  <a href="../logs/">logs/</a>
+  <a href="./" class="active">seeds/</a>
+</div>
+
+<main>
+  <h1>seeds/</h1>
+  <p class="subtitle">docs/petri-bundle/seeds/listing.json + per-run state.json · self-improving loop seed-generation</p>
+
+  <div id="counts" class="counts-line">Loading <code>listing.json</code>…</div>
+
+  <h2>Runs</h2>
+  <div id="runs-area">
+    <div class="status-msg">Loading runs…</div>
+  </div>
+
+  <div class="footnote">
+    Source: <code>docs/petri-bundle/seeds/listing.json</code> (catalog index) + per-run <code>state.json</code> / <code>survivors.json</code> / <code>meta_review.json</code>.<br>
+    Runs are published by the seed-generation pipeline (<code>plugins/seed_generation/bundle_sync.py</code>). Click a run to expand its survivors, meta-review, and cost rollup.<br>
+    Per-run candidate <code>.md</code> files are directly addressable; sibling viewers — <a href="../">petri-bundle landing</a>, <a href="../logs/">inspect-petri eval logs</a>.
+  </div>
+</main>
+
+<script>
+"use strict";
+
+const STATUS_OF = (run) => {
+  if (run.candidates_drafted === 0) return "fail";
+  if (run.survivors_count === 0) return "fail";
+  if (run.evolved_count < run.survivors_count) return "partial";
+  return "ok";
+};
+
+const FMT_USD = (n) => `$${(n ?? 0).toFixed(2)}`;
+const FMT_INT = (n) => (n ?? 0).toLocaleString();
+const FMT_RATIO = (a, b) => `${a ?? 0} → ${b ?? 0}`;
+
+const escapeHtml = (s) => {
+  if (s == null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};
+
+async function fetchJson(url) {
+  const r = await fetch(url, { cache: "no-cache" });
+  if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
+  return r.json();
+}
+
+function renderRunsTable(listing) {
+  const runs = listing.runs ?? [];
+  const totalCandidates = runs.reduce((a, r) => a + (r.candidates_drafted ?? 0), 0);
+  const totalSurvivors = runs.reduce((a, r) => a + (r.survivors_count ?? 0), 0);
+  const totalCost = runs.reduce((a, r) => a + (r.usd_spent ?? 0), 0);
+
+  document.getElementById("counts").innerHTML = `
+    <strong>${runs.length}</strong> ${runs.length === 1 ? "run" : "runs"} ·
+    <strong>${totalCandidates}</strong> candidates drafted ·
+    <strong>${totalSurvivors}</strong> survived ·
+    <strong>${FMT_USD(totalCost)}</strong> total spend
+  `;
+
+  if (runs.length === 0) {
+    document.getElementById("runs-area").innerHTML =
+      `<div class="status-msg">listing.json has 0 runs.</div>`;
+    return;
+  }
+
+  const rowsHtml = runs.map(run => {
+    const status = STATUS_OF(run);
+    return `
+      <tr>
+        <td class="id"><a href="#run-${escapeHtml(run.run_id)}">${escapeHtml(run.run_id)}</a></td>
+        <td class="tag">${escapeHtml(run.gen_tag ?? "")}</td>
+        <td class="dim">${escapeHtml(run.target_dim ?? "")}</td>
+        <td class="status ${status}">${status}</td>
+        <td class="num">${FMT_RATIO(run.candidates_drafted, run.survivors_count)}</td>
+        <td class="num">${run.evolved_count ?? 0}</td>
+        <td class="num">${run.iterations ?? 0}</td>
+        <td class="cost">${FMT_USD(run.usd_spent)}</td>
+      </tr>
+    `;
+  }).join("");
+
+  const detailsHtml = runs.map(run => `
+    <details class="run-detail" id="run-${escapeHtml(run.run_id)}">
+      <summary>
+        <h3>
+          <span class="runid">${escapeHtml(run.run_id)}</span>
+          <span class="dim-tag">${escapeHtml(run.gen_tag ?? "")} · target_dim=${escapeHtml(run.target_dim ?? "")}</span>
+        </h3>
+      </summary>
+      <div data-run-body data-url="${escapeHtml(run.url ?? "")}" data-run-id="${escapeHtml(run.run_id)}">
+        <div class="status-msg">Loading details…</div>
+      </div>
+    </details>
+  `).join("");
+
+  document.getElementById("runs-area").innerHTML = `
+    <table class="runs">
+      <thead>
+        <tr>
+          <th>run_id</th>
+          <th>gen_tag</th>
+          <th>target_dim</th>
+          <th>status</th>
+          <th>draft → surv</th>
+          <th>evolved</th>
+          <th>iters</th>
+          <th>cost USD</th>
+        </tr>
+      </thead>
+      <tbody>${rowsHtml}</tbody>
+    </table>
+    ${detailsHtml}
+  `;
+
+  // Lazy-load run details on first open
+  document.querySelectorAll("details.run-detail").forEach(el => {
+    el.addEventListener("toggle", () => {
+      if (!el.open) return;
+      const body = el.querySelector("[data-run-body]");
+      if (body.dataset.loaded === "1") return;
+      body.dataset.loaded = "1";
+      loadRunDetail(body);
+    });
+  });
+
+  // Auto-open if URL hash points to a run
+  if (window.location.hash.startsWith("#run-")) {
+    const target = document.querySelector(window.location.hash);
+    if (target && target.tagName === "DETAILS") {
+      target.open = true;
+    }
+  }
+}
+
+async function loadRunDetail(body) {
+  const url = body.dataset.url;
+  const runId = body.dataset.runId;
+  if (!url) {
+    body.innerHTML = `<div class="err-msg">listing entry missing 'url' field for ${escapeHtml(runId)}</div>`;
+    return;
+  }
+  // ``url`` is a path relative to /seeds/ (per listing.json schema), e.g.
+  // ``seeds/gen1-redundant_tool_invocation/``. Strip the leading ``seeds/``
+  // because the viewer is already served from /seeds/.
+  const base = url.replace(/^seeds\//, "");
+  try {
+    const [state, survivors, meta] = await Promise.all([
+      fetchJson(`${base}state.json`).catch(() => null),
+      fetchJson(`${base}survivors.json`).catch(() => null),
+      fetchJson(`${base}meta_review.json`).catch(() => null),
+    ]);
+    body.innerHTML = renderRunBody({ runId, base, state, survivors, meta });
+  } catch (e) {
+    body.innerHTML = `<div class="err-msg">load failed: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function renderRunBody({ runId, base, state, survivors, meta }) {
+  const parts = [];
+
+  // Survivors
+  if (survivors && survivors.survivors && survivors.survivors.length > 0) {
+    parts.push(`<h2>Survivors</h2>`);
+    parts.push(`<table class="survivors"><thead><tr><th>candidate_id</th><th>elo</th><th>pilot_status</th><th>candidate file</th></tr></thead><tbody>`);
+    for (const s of survivors.survivors) {
+      const evolvedNote = (state?.evolved_candidates ?? [])
+        .filter(e => e.parent_id === s.id)
+        .map(e => `→ ${escapeHtml(e.id)}`)
+        .join(", ");
+      const pilotStatus = s.pilot?.status ?? "—";
+      const filename = (s.path ?? "").split("/").pop() ?? "";
+      const href = filename ? `${base}candidates/${filename}` : "#";
+      parts.push(`
+        <tr>
+          <td class="cid"><a href="${escapeHtml(href)}">${escapeHtml(s.id)}</a></td>
+          <td class="elo">${FMT_INT(Math.round(s.elo_rating ?? 0))}</td>
+          <td>${escapeHtml(pilotStatus)}</td>
+          <td class="evolved">${escapeHtml(filename)}${evolvedNote ? " · " + evolvedNote : ""}</td>
+        </tr>
+      `);
+    }
+    parts.push(`</tbody></table>`);
+  }
+
+  // Cost rollup
+  if (state) {
+    parts.push(`<h2>Cost rollup</h2>`);
+    parts.push(`<dl class="cost-grid">`);
+    parts.push(`<dt>total USD</dt><dd>${FMT_USD(state.usd_spent)}</dd>`);
+    parts.push(`<dt>prompt_tokens</dt><dd>${FMT_INT(state.prompt_tokens)}</dd>`);
+    parts.push(`<dt>completion_tokens</dt><dd>${FMT_INT(state.completion_tokens)}</dd>`);
+    if (state.max_iterations != null) {
+      parts.push(`<dt>iterations</dt><dd>${state.current_iteration ?? 0} / ${state.max_iterations}</dd>`);
+    }
+    if (state.literature_snapshots) {
+      const litCount = Object.keys(state.literature_snapshots).length;
+      parts.push(`<dt>literature_snapshots</dt><dd>${litCount}</dd>`);
+    }
+    if (state.debate_transcripts) {
+      const dbCount = Object.keys(state.debate_transcripts).length;
+      parts.push(`<dt>debate_transcripts</dt><dd>${dbCount}</dd>`);
+    }
+    parts.push(`</dl>`);
+  }
+
+  // Meta-review: session summary + next_gen_priors + coverage
+  const m = meta ?? state?.meta_review ?? null;
+  if (m) {
+    if (m.session_summary) {
+      parts.push(`<h2>Meta-review summary</h2>`);
+      parts.push(`<p class="summary-prose">${escapeHtml(m.session_summary)}</p>`);
+    }
+    if (m.next_gen_priors && m.next_gen_priors.length > 0) {
+      parts.push(`<h2>Next-gen priors</h2>`);
+      parts.push(`<table class="priors"><thead><tr><th>target_dim</th><th>weight</th><th>rationale</th></tr></thead><tbody>`);
+      for (const p of m.next_gen_priors) {
+        parts.push(`
+          <tr>
+            <td class="dim">${escapeHtml(p.target_dim ?? "")}</td>
+            <td class="weight">${(p.weight ?? 0).toFixed(2)}</td>
+            <td class="rationale">${escapeHtml(p.rationale ?? "")}</td>
+          </tr>
+        `);
+      }
+      parts.push(`</tbody></table>`);
+    }
+    if (m.evolution_yield) {
+      const ey = m.evolution_yield;
+      parts.push(`<h2>Evolution yield</h2>`);
+      parts.push(`<dl class="cost-grid">`);
+      parts.push(`<dt>attempted</dt><dd>${FMT_INT(ey.attempted)}</dd>`);
+      parts.push(`<dt>successful</dt><dd>${FMT_INT(ey.successful)}</dd>`);
+      parts.push(`</dl>`);
+    }
+    if (m.elo_distribution) {
+      const ed = m.elo_distribution;
+      parts.push(`<h2>Elo distribution</h2>`);
+      parts.push(`<dl class="cost-grid">`);
+      parts.push(`<dt>min</dt><dd>${FMT_INT(ed.min)}</dd>`);
+      parts.push(`<dt>p50</dt><dd>${FMT_INT(ed.p50)}</dd>`);
+      parts.push(`<dt>p95</dt><dd>${FMT_INT(ed.p95)}</dd>`);
+      parts.push(`</dl>`);
+    }
+  }
+
+  if (parts.length === 0) {
+    return `<div class="status-msg">No detail files (state.json / survivors.json / meta_review.json) were resolvable for ${escapeHtml(runId)}.</div>`;
+  }
+  return parts.join("\n");
+}
+
+(async function main() {
+  try {
+    const listing = await fetchJson("./listing.json");
+    if (listing.kind && listing.kind !== "seeds") {
+      throw new Error(`listing.json kind="${listing.kind}", expected "seeds"`);
+    }
+    renderRunsTable(listing);
+  } catch (e) {
+    document.getElementById("counts").innerHTML = "";
+    document.getElementById("runs-area").innerHTML =
+      `<div class="status-msg err">listing.json fetch failed: ${escapeHtml(e.message)}</div>`;
+  }
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `docs/petri-bundle/seeds/index.html` 단일 정적 파일로 self-improving-loop seed-generation 결과를 시각화 — 종전 `https://mangowhoiscloud.github.io/geode/petri-bundle/seeds/` 의 404 해소
- `listing.json` fetch → 런 테이블 (run_id / gen_tag / target_dim / status / draft→survivors / evolved / iters / cost USD) → `<details>` 토글 시 `state.json` + `survivors.json` + `meta_review.json` lazy load
- 빌드 스텝 / Next.js 의존성 없이 inspect-petri viewer (`/petri-bundle/`) 와 같은 자리에 배포 — `.github/workflows/pages.yml` 의 `docs/petri-bundle/**` 트리거가 자동 처리

## Why
- 운영자 HTTP HEAD 진단 (2026-05-25): `/petri-bundle/` 200, `/petri-bundle/seeds/listing.json` 200, `/petri-bundle/seeds/` **404** — GitHub Pages 가 디렉토리 browse 불허
- 사실상 모든 데이터 파일(`listing.json`, per-run `state.json` / `survivors.json` / `meta_review.json`, candidate `.md`)이 deploy 됐음에도 사람이 발견할 진입점이 없는 상태
- inspect-petri 의 eval-log viewer (`/petri-bundle/`) 는 `.eval` 아카이브용이라 seed-generation 산출물 (트랜스크립트 / 후보 / 메타리뷰 / 평가 로그)을 표현하지 않음 → 별도 surface 필요
- 본 PR 의 viewer 는 inspect-petri viewer 와 coexist — `/petri-bundle/` 랜딩 ↔ `/petri-bundle/logs/` (inspect-ai) ↔ `/petri-bundle/seeds/` (본 PR) 3-way nav

## Changes
| File | Change |
|------|--------|
| `docs/petri-bundle/seeds/index.html` | NEW — listing.json fetch + per-run drill-down (~400 LOC HTML + inline CSS + inline JS) |
| `CHANGELOG.md` | `[Unreleased]` Added 섹션에 PR-SEEDS-BUNDLE-VIEWER 항목 |

## Design

| 결정 | 근거 |
|------|------|
| **단일 정적 HTML, no build step** | inspect-petri 의 `/petri-bundle/index.html` 와 동일 패턴. Next.js 페이지로 만들면 `site/` 라우팅 + `out/` rebuild + `getStaticProps` 필요 — `docs/petri-bundle/**` 변경만으로 자체 deploy 가능한 단순 surface 유지 |
| **dense table + monospace** | v2 design (post-Slop feedback 2026-05-23, `[[feedback-no-box-ui-no-emoji]]`). Mockup 출처: `/tmp/geode-literature-mockup/seeds.html`. No emoji, no card boxes, system font for prose, monospace for IDs/numbers |
| **status 파생 (listing 에 없음)** | `survivors_count == 0` → fail, `evolved_count < survivors_count` → partial, else ok. listing schema 변경 0 |
| **phase progress 생략** | 현 `state.json` 에 phase-by-phase 타이밍 부재. Mockup 의 phase progress 섹션은 schema 확장 후 follow-up |
| **candidate title 생략** | `.md` frontmatter fetch 필요 — N 개 추가 HTTP request. Survivors 테이블은 candidate_id / elo / pilot_status / 파일명 만으로 충분 |
| **lazy-load on `<details>` toggle** | 1 run 만 있으면 효과 없지만 N>10 runs 시 초기 로드 N 배 fetch 방지 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 404 해소 | Implemented | `/seeds/` 가 이제 `index.html` 자동 서빙 |
| listing.json 렌더링 | Implemented | runs 테이블 + 합계 (`N runs · N candidates · N survived · $X total spend`) |
| per-run drill-down | Implemented | survivors / cost rollup / meta-review session_summary / next-gen priors / evolution yield / Elo distribution |
| phase progress | Dropped from scope | `state.json` 에 phase 타이밍 없음 — schema 확장 후 별 PR |
| candidate title 추출 | Dropped from scope | `.md` frontmatter fetch 비용 vs 가치 |
| literature column | Deferred | Phase 2 (seed-gen-loop3-bundle-serving) ship 후 컬럼 추가 |

## Verification
- [x] Local server smoke (`python3 -m http.server 8765` from `docs/petri-bundle/`) — `/seeds/` 200, `/seeds/listing.json` 200, `/seeds/gen1-redundant_tool_invocation/state.json` 200
- [x] Viewer 가 listing.json 의 1 run (`gen1-redundant_tool_invocation`) 정상 렌더링 — runs 테이블 + 자동 expand (#run-…) + survivors / meta-review 표시
- [x] HTML/JS validation — script error 0, fetch error 0
- [x] Static-only (Next.js 빌드 불필요) — Pages workflow `docs/petri-bundle/**` 트리거가 그대로 픽업
- [ ] Live Pages deploy 확인 — 머지 + Pages workflow run 후 `https://mangowhoiscloud.github.io/geode/petri-bundle/seeds/` 200 확인 예정

## Reference
- HTTP HEAD 진단 (운영자): 2026-05-25
- Mockup 원본: `/tmp/geode-literature-mockup/seeds.html` (v2 post-Slop)
- 데이터 schema: `docs/petri-bundle/seeds/listing.json`, `docs/petri-bundle/seeds/gen1-redundant_tool_invocation/state.json`
- inspect-petri viewer 와 coexist: `/petri-bundle/` 랜딩 + `/petri-bundle/logs/` (.eval) + `/petri-bundle/seeds/` (본 PR)
- Phase 2 follow-up: `docs/plans/2026-05-23-seed-gen-loop3-bundle-serving.md`