### PR TITLE
promote seeds bundle viewer + codex-oauth fixes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-SEEDS-BUNDLE-VIEWER** — `docs/petri-bundle/seeds/index.html` ships
+  a self-contained viewer for the self-improving-loop seed-generation
+  runs published into the petri-bundle. Previously
+  `https://mangowhoiscloud.github.io/geode/petri-bundle/seeds/` returned
+  404 (GitHub Pages disallows directory browsing); only direct file URLs
+  like `/seeds/listing.json` or
+  `/seeds/<run_id>/state.json` worked. The new index fetches
+  `listing.json` at load, renders a dense run table (run_id / gen_tag /
+  target_dim / status / draft→survivors / evolved / iters / cost USD),
+  and lazily drills down per run into `state.json` + `survivors.json` +
+  `meta_review.json` — survivors with elo + candidate `.md` link, cost
+  rollup, meta-review session_summary, next-gen priors, evolution yield,
+  Elo distribution. Status is derived from the listing
+  (`survivors_count == 0` → fail, `evolved_count < survivors_count` →
+  partial, else ok). The viewer is a single static HTML file (no
+  build step, no Next.js dep) so it ships alongside the inspect-petri
+  eval-log viewer at `/petri-bundle/` and the pages.yml workflow that
+  already triggers on `docs/petri-bundle/**` deploys it without any new
+  CI wiring. Mockup source: `/tmp/geode-literature-mockup/seeds.html`
+  (v2 post-Slop-feedback dense-table design); adapted to the live
+  schema (no phase progress yet — that field doesn't exist in
+  `state.json`; no candidate titles yet — would require `.md`
+  frontmatter fetch). Once
+  [`docs/plans/2026-05-23-seed-gen-loop3-bundle-serving.md`](../docs/plans/2026-05-23-seed-gen-loop3-bundle-serving.md)
+  Phase 2 ships its `LiteratureReview` agent the same viewer can be
+  extended with a literature column without schema churn.
+
 ### Fixed
 - **PR-ENV-WHITELIST-CODEX-BYPASS** — add
   `GEODE_CODEX_OAUTH_POLL_DISABLED` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-CODEX-OAUTH-EMPTY-TEXT-DUMP** — codex_oauth adapter writes a
+  postmortem dump to `~/.geode/diagnostics/codex-oauth-empty-text/
+  <ts>-<model>.json` when the upstream returns `output_text=""`.
+  Smoke 11/12/13 vote-m000-openai.openai-codex consistently failed
+  in this shape (10s elapsed, ~$0.04 billed, zero
+  assistant_message events, `termination_reason="natural"`) — the
+  worker treated empty text as failure with no diagnostic surface.
+  Dump captures (usage / reasoning_items raw + count /
+  reasoning_summaries / stop_reason) and the adapter logs the dump
+  path on the warning line alongside the worker-level failure.
+  Mirrors `claude_cli._dump_transient_postmortem` shape so
+  `~/.geode/diagnostics/` houses both diagnostic categories under
+  one tar-up. Pinned by 5 regression tests in
+  `tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py`.
+
 - **PR-ENV-WHITELIST-CODEX-BYPASS** — add
   `GEODE_CODEX_OAUTH_POLL_DISABLED` to
   `IsolatedRunner._SUBPROCESS_ENV_WHITELIST`. Smoke 13 vote-m000-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-ENV-WHITELIST-CODEX-BYPASS** — add
+  `GEODE_CODEX_OAUTH_POLL_DISABLED` to
+  `IsolatedRunner._SUBPROCESS_ENV_WHITELIST`. Smoke 13 vote-m000-*
+  failed with `codex-cli-subagent lane blocked — Codex 5-hour OAuth
+  bucket >= throttle threshold (see GEODE_CODEX_OAUTH_POLL_DISABLED
+  to bypass)` even though the operator had set the env on the parent
+  `geode serve` process. Root cause: the whitelist did not include
+  the bypass env, so the `safe_env` built in
+  `_aexecute_subprocess` dropped it before spawning the worker.
+  The worker subprocess then ran
+  `should_block_codex_lane_acquisition()` with an unset env, the
+  throttle gate fired, and 5 retries failed against the actual
+  ChatGPT Plus subscription bucket that had headroom. Pinned by 4
+  regression tests in `tests/test_subprocess_env_whitelist.py`:
+  bypass env present, operator-knob set preserved, credential envs
+  preserved, dangerous-env exclusion guard.
+
 - **PR-SESSION-RESUME-PARAMS** — paperclip-aligned cwd-paired
   resume-context tracking. Smoke 12 (v0.99.54) surfaced a
   stale-session bug after the PR-CLEANUP per-task cwd isolation

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -120,7 +120,32 @@ class CodexOAuthAdapter:
             self._last_error = exc
             log.warning("codex-oauth: responses.stream failed model=%s err=%s", req.model, exc)
             raise
-        return translate_codex_response(final, accumulated_items=accumulated)
+        result = translate_codex_response(final, accumulated_items=accumulated)
+        # PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — Codex sometimes
+        # returns ``output_text=""`` while emitting reasoning-only items
+        # (gpt-5.x reasoning mode skipping the visible-answer block).
+        # The downstream worker treats empty text as failure
+        # (``worker.py:_persist_outcome: success = bool(text)``), and
+        # the user only sees ``summary="termination_reason=natural"``
+        # with no clue why. Smoke 11/12/13 vote-m000-openai.openai-codex
+        # all failed in this pattern (10s elapsed, $0.04 billed, zero
+        # assistant_message events). Dump a postmortem so the operator
+        # can recover the (usage / reasoning_items / reasoning_summaries
+        # / stop_reason) without re-running the cycle, and log the dump
+        # path on the warning line that surfaces alongside the
+        # worker-level failure.
+        if not result.text:
+            dump_path = _dump_empty_text_postmortem(model=req.model, result=result)
+            log.warning(
+                "codex-oauth: empty output_text model=%s "
+                "reasoning_items=%d reasoning_summaries=%d stop_reason=%s dump=%s",
+                req.model,
+                len(result.reasoning_items),
+                len(result.reasoning_summaries),
+                result.stop_reason,
+                dump_path or "<dump failed>",
+            )
+        return result
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
@@ -278,6 +303,66 @@ def _translate_codex_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, An
 
     normalised = normalize("openai", tc)
     return normalised if normalised is not None else "auto"
+
+
+def _dump_empty_text_postmortem(
+    *,
+    model: str,
+    result: AdapterCallResult,
+) -> str | None:
+    """Persist a JSON post-mortem for every codex-oauth empty-text
+    response so operators can diagnose without re-running the cycle.
+    Returns the dump path (str) on success, ``None`` on any I/O error
+    (best-effort — diagnostic, not correctness-critical). Mirrors
+    ``claude_cli._dump_transient_postmortem`` shape so the same
+    operator's ``diagnostics tar-up`` workflow catches both.
+
+    PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — Codex gpt-5.x
+    sometimes returns reasoning items with no visible-answer text;
+    the worker treats that as failure with no actionable surface.
+    The dump records the four diagnostic dimensions:
+
+    (1) ``usage`` — input/output token counts the upstream billed
+    (2) ``reasoning_items`` — typed encrypted_content blobs (raw)
+    (3) ``reasoning_summaries`` — the model's plain-text chain of thought
+    (4) ``stop_reason`` — Codex backend's terminal status
+
+    Future ratchet: if a category of empty-text responses turns out
+    to be recoverable (e.g. ``reasoning_summaries`` carries the
+    actual answer in a parseable shape), add a text fallback inside
+    ``acomplete`` keyed on the dump's payload shape.
+    """
+    import json
+    import time
+
+    from core.paths import GLOBAL_DIAGNOSTICS_DIR
+
+    try:
+        postmortem_dir = GLOBAL_DIAGNOSTICS_DIR / "codex-oauth-empty-text"
+        postmortem_dir.mkdir(parents=True, exist_ok=True)
+        hit_ts = int(time.time())
+        postmortem_path = postmortem_dir / f"{hit_ts}-{model}.json"
+        payload: dict[str, Any] = {
+            "ts": hit_ts,
+            "model": model,
+            "stop_reason": result.stop_reason,
+            "usage": {
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+            },
+            "reasoning_items_count": len(result.reasoning_items),
+            "reasoning_summaries_count": len(result.reasoning_summaries),
+            "reasoning_items": list(result.reasoning_items),
+            "reasoning_summaries": list(result.reasoning_summaries),
+        }
+        postmortem_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        return str(postmortem_path)
+    except OSError as exc:
+        log.debug("codex-oauth: postmortem dump write failed: %s", exc)
+        return None
 
 
 __all__ = ["CodexOAuthAdapter"]

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -95,6 +95,14 @@ class IsolatedRunner:
 
     # Subprocess env whitelist — only these vars are forwarded to child processes.
     # Prevents accidental leakage of secrets or shell-specific vars.
+    # PR-ENV-WHITELIST-CODEX-BYPASS (2026-05-25) — added
+    # ``GEODE_CODEX_OAUTH_POLL_DISABLED`` after smoke 13 surfaced the
+    # gap: operator set the env on the parent serve process to bypass
+    # GEODE's pre-emptive 5-hour Codex OAuth throttle gate, but the
+    # worker subprocess didn't inherit it, so
+    # ``should_block_codex_lane_acquisition`` re-fired its
+    # ``TimeoutError(CODEX_CLI_LANE_THROTTLED_MSG)`` for every codex
+    # voter even though the actual subscription bucket had headroom.
     _SUBPROCESS_ENV_WHITELIST: set[str] = {
         "PATH",
         "HOME",
@@ -109,6 +117,7 @@ class IsolatedRunner:
         "VIRTUAL_ENV",
         "GEODE_CONFIG_PATH",
         "GEODE_DATA_DIR",
+        "GEODE_CODEX_OAUTH_POLL_DISABLED",
     }
 
     def __init__(

--- a/docs/petri-bundle/seeds/index.html
+++ b/docs/petri-bundle/seeds/index.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>seeds/ — GEODE petri-bundle</title>
+<meta name="description" content="GEODE self-improving loop seed-generation runs — per-run candidates, survivors, evolved variants, and meta-review.">
+<style>
+  :root {
+    --bg: #fafaf9;
+    --fg: #1a1a1a;
+    --muted: #5a5a5a;
+    --accent: #2563eb;
+    --border: #d4d4d4;
+    --code-bg: #f0efed;
+    --green: #15803d;
+    --red: #b91c1c;
+    --amber: #b45309;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.5;
+    font-size: 14px;
+  }
+  .nav {
+    border-bottom: 1px solid var(--border);
+    padding: 10px 24px;
+    font-size: 13px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+  .nav a { color: var(--muted); text-decoration: none; margin-right: 16px; }
+  .nav a:hover { color: var(--accent); text-decoration: underline; }
+  .nav a.active { color: var(--fg); font-weight: 600; }
+  main { max-width: 1280px; margin: 0 auto; padding: 24px; }
+  h1 { font-size: 20px; margin: 0 0 4px 0; font-weight: 700; }
+  .subtitle { color: var(--muted); font-size: 12px; margin-bottom: 18px; font-family: ui-monospace, Menlo, monospace; }
+  h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; margin: 28px 0 8px; }
+  code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 12px; font-family: ui-monospace, Menlo, monospace; }
+  .counts-line { font-family: ui-monospace, Menlo, monospace; font-size: 13px; color: var(--muted); margin-bottom: 18px; }
+  .counts-line strong { color: var(--fg); font-weight: 600; }
+  .status-msg { font-family: ui-monospace, Menlo, monospace; font-size: 13px; color: var(--muted); padding: 12px 0; }
+  .status-msg.err { color: var(--red); }
+  table.runs {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 13px;
+  }
+  table.runs th {
+    text-align: left;
+    padding: 5px 10px 5px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  table.runs td {
+    padding: 6px 10px 6px 0;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  table.runs td.id a { color: var(--accent); text-decoration: none; }
+  table.runs td.id a:hover { text-decoration: underline; }
+  table.runs td.tag { color: var(--fg); font-weight: 600; }
+  table.runs td.dim { color: var(--accent); }
+  table.runs td.status.ok { color: var(--green); }
+  table.runs td.status.partial { color: var(--amber); }
+  table.runs td.status.fail { color: var(--red); }
+  table.runs td.num { text-align: right; color: var(--fg); }
+  table.runs td.cost { text-align: right; color: var(--muted); font-size: 12px; }
+  .run-detail { background: white; border: 1px solid var(--border); margin-top: 18px; padding: 16px 18px; }
+  .run-detail h3 { font-size: 14px; margin: 0 0 10px 0; font-family: ui-monospace, Menlo, monospace; }
+  .run-detail h3 .runid { color: var(--accent); }
+  .run-detail h3 .dim-tag { color: var(--muted); margin-left: 8px; font-size: 12px; font-weight: normal; }
+  .run-detail .err-msg { color: var(--red); font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+  table.phases, table.survivors, table.priors {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+  table.phases th, table.survivors th, table.priors th {
+    text-align: left;
+    padding: 4px 8px 4px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 10px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  table.phases td, table.survivors td, table.priors td {
+    padding: 5px 8px 5px 0;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  table.survivors td.cid a { color: var(--accent); text-decoration: none; }
+  table.survivors td.cid a:hover { text-decoration: underline; }
+  table.survivors td.elo { text-align: right; }
+  table.survivors td.evolved { color: var(--muted); font-size: 11px; }
+  table.survivors td.scenario { color: var(--fg); font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; }
+  table.priors td.dim { color: var(--accent); }
+  table.priors td.weight { text-align: right; }
+  table.priors td.rationale { font-family: ui-sans-serif, system-ui, sans-serif; color: var(--fg); font-size: 12px; }
+  .cost-grid { display: grid; grid-template-columns: 180px 1fr; gap: 4px 16px; font-family: ui-monospace, Menlo, monospace; font-size: 12px; margin: 0; }
+  .cost-grid dt { color: var(--muted); }
+  .cost-grid dd { margin: 0; }
+  .summary-prose { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; color: var(--fg); margin: 6px 0 0 0; max-width: 920px; }
+  .footnote { color: var(--muted); font-size: 11px; font-family: ui-monospace, Menlo, monospace; margin-top: 28px; padding-top: 10px; border-top: 1px solid var(--border); }
+  .footnote a { color: var(--accent); text-decoration: none; }
+  .footnote a:hover { text-decoration: underline; }
+  details.run-detail summary { cursor: pointer; list-style: none; }
+  details.run-detail summary::-webkit-details-marker { display: none; }
+  details.run-detail summary::before { content: "▸ "; color: var(--muted); font-family: ui-monospace, Menlo, monospace; }
+  details.run-detail[open] summary::before { content: "▾ "; }
+</style>
+</head>
+<body>
+
+<div class="nav">
+  <a href="../">/petri-bundle/</a>
+  <a href="../logs/">logs/</a>
+  <a href="./" class="active">seeds/</a>
+</div>
+
+<main>
+  <h1>seeds/</h1>
+  <p class="subtitle">docs/petri-bundle/seeds/listing.json + per-run state.json · self-improving loop seed-generation</p>
+
+  <div id="counts" class="counts-line">Loading <code>listing.json</code>…</div>
+
+  <h2>Runs</h2>
+  <div id="runs-area">
+    <div class="status-msg">Loading runs…</div>
+  </div>
+
+  <div class="footnote">
+    Source: <code>docs/petri-bundle/seeds/listing.json</code> (catalog index) + per-run <code>state.json</code> / <code>survivors.json</code> / <code>meta_review.json</code>.<br>
+    Runs are published by the seed-generation pipeline (<code>plugins/seed_generation/bundle_sync.py</code>). Click a run to expand its survivors, meta-review, and cost rollup.<br>
+    Per-run candidate <code>.md</code> files are directly addressable; sibling viewers — <a href="../">petri-bundle landing</a>, <a href="../logs/">inspect-petri eval logs</a>.
+  </div>
+</main>
+
+<script>
+"use strict";
+
+const STATUS_OF = (run) => {
+  if (run.candidates_drafted === 0) return "fail";
+  if (run.survivors_count === 0) return "fail";
+  if (run.evolved_count < run.survivors_count) return "partial";
+  return "ok";
+};
+
+const FMT_USD = (n) => `$${(n ?? 0).toFixed(2)}`;
+const FMT_INT = (n) => (n ?? 0).toLocaleString();
+const FMT_RATIO = (a, b) => `${a ?? 0} → ${b ?? 0}`;
+
+const escapeHtml = (s) => {
+  if (s == null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};
+
+async function fetchJson(url) {
+  const r = await fetch(url, { cache: "no-cache" });
+  if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
+  return r.json();
+}
+
+function renderRunsTable(listing) {
+  const runs = listing.runs ?? [];
+  const totalCandidates = runs.reduce((a, r) => a + (r.candidates_drafted ?? 0), 0);
+  const totalSurvivors = runs.reduce((a, r) => a + (r.survivors_count ?? 0), 0);
+  const totalCost = runs.reduce((a, r) => a + (r.usd_spent ?? 0), 0);
+
+  document.getElementById("counts").innerHTML = `
+    <strong>${runs.length}</strong> ${runs.length === 1 ? "run" : "runs"} ·
+    <strong>${totalCandidates}</strong> candidates drafted ·
+    <strong>${totalSurvivors}</strong> survived ·
+    <strong>${FMT_USD(totalCost)}</strong> total spend
+  `;
+
+  if (runs.length === 0) {
+    document.getElementById("runs-area").innerHTML =
+      `<div class="status-msg">listing.json has 0 runs.</div>`;
+    return;
+  }
+
+  const rowsHtml = runs.map(run => {
+    const status = STATUS_OF(run);
+    return `
+      <tr>
+        <td class="id"><a href="#run-${escapeHtml(run.run_id)}">${escapeHtml(run.run_id)}</a></td>
+        <td class="tag">${escapeHtml(run.gen_tag ?? "")}</td>
+        <td class="dim">${escapeHtml(run.target_dim ?? "")}</td>
+        <td class="status ${status}">${status}</td>
+        <td class="num">${FMT_RATIO(run.candidates_drafted, run.survivors_count)}</td>
+        <td class="num">${run.evolved_count ?? 0}</td>
+        <td class="num">${run.iterations ?? 0}</td>
+        <td class="cost">${FMT_USD(run.usd_spent)}</td>
+      </tr>
+    `;
+  }).join("");
+
+  const detailsHtml = runs.map(run => `
+    <details class="run-detail" id="run-${escapeHtml(run.run_id)}">
+      <summary>
+        <h3>
+          <span class="runid">${escapeHtml(run.run_id)}</span>
+          <span class="dim-tag">${escapeHtml(run.gen_tag ?? "")} · target_dim=${escapeHtml(run.target_dim ?? "")}</span>
+        </h3>
+      </summary>
+      <div data-run-body data-url="${escapeHtml(run.url ?? "")}" data-run-id="${escapeHtml(run.run_id)}">
+        <div class="status-msg">Loading details…</div>
+      </div>
+    </details>
+  `).join("");
+
+  document.getElementById("runs-area").innerHTML = `
+    <table class="runs">
+      <thead>
+        <tr>
+          <th>run_id</th>
+          <th>gen_tag</th>
+          <th>target_dim</th>
+          <th>status</th>
+          <th>draft → surv</th>
+          <th>evolved</th>
+          <th>iters</th>
+          <th>cost USD</th>
+        </tr>
+      </thead>
+      <tbody>${rowsHtml}</tbody>
+    </table>
+    ${detailsHtml}
+  `;
+
+  // Lazy-load run details on first open
+  document.querySelectorAll("details.run-detail").forEach(el => {
+    el.addEventListener("toggle", () => {
+      if (!el.open) return;
+      const body = el.querySelector("[data-run-body]");
+      if (body.dataset.loaded === "1") return;
+      body.dataset.loaded = "1";
+      loadRunDetail(body);
+    });
+  });
+
+  // Auto-open if URL hash points to a run
+  if (window.location.hash.startsWith("#run-")) {
+    const target = document.querySelector(window.location.hash);
+    if (target && target.tagName === "DETAILS") {
+      target.open = true;
+    }
+  }
+}
+
+async function loadRunDetail(body) {
+  const url = body.dataset.url;
+  const runId = body.dataset.runId;
+  if (!url) {
+    body.innerHTML = `<div class="err-msg">listing entry missing 'url' field for ${escapeHtml(runId)}</div>`;
+    return;
+  }
+  // ``url`` is a path relative to /seeds/ (per listing.json schema), e.g.
+  // ``seeds/gen1-redundant_tool_invocation/``. Strip the leading ``seeds/``
+  // because the viewer is already served from /seeds/.
+  const base = url.replace(/^seeds\//, "");
+  try {
+    const [state, survivors, meta] = await Promise.all([
+      fetchJson(`${base}state.json`).catch(() => null),
+      fetchJson(`${base}survivors.json`).catch(() => null),
+      fetchJson(`${base}meta_review.json`).catch(() => null),
+    ]);
+    body.innerHTML = renderRunBody({ runId, base, state, survivors, meta });
+  } catch (e) {
+    body.innerHTML = `<div class="err-msg">load failed: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function renderRunBody({ runId, base, state, survivors, meta }) {
+  const parts = [];
+
+  // Survivors
+  if (survivors && survivors.survivors && survivors.survivors.length > 0) {
+    parts.push(`<h2>Survivors</h2>`);
+    parts.push(`<table class="survivors"><thead><tr><th>candidate_id</th><th>elo</th><th>pilot_status</th><th>candidate file</th></tr></thead><tbody>`);
+    for (const s of survivors.survivors) {
+      const evolvedNote = (state?.evolved_candidates ?? [])
+        .filter(e => e.parent_id === s.id)
+        .map(e => `→ ${escapeHtml(e.id)}`)
+        .join(", ");
+      const pilotStatus = s.pilot?.status ?? "—";
+      const filename = (s.path ?? "").split("/").pop() ?? "";
+      const href = filename ? `${base}candidates/${filename}` : "#";
+      parts.push(`
+        <tr>
+          <td class="cid"><a href="${escapeHtml(href)}">${escapeHtml(s.id)}</a></td>
+          <td class="elo">${FMT_INT(Math.round(s.elo_rating ?? 0))}</td>
+          <td>${escapeHtml(pilotStatus)}</td>
+          <td class="evolved">${escapeHtml(filename)}${evolvedNote ? " · " + evolvedNote : ""}</td>
+        </tr>
+      `);
+    }
+    parts.push(`</tbody></table>`);
+  }
+
+  // Cost rollup
+  if (state) {
+    parts.push(`<h2>Cost rollup</h2>`);
+    parts.push(`<dl class="cost-grid">`);
+    parts.push(`<dt>total USD</dt><dd>${FMT_USD(state.usd_spent)}</dd>`);
+    parts.push(`<dt>prompt_tokens</dt><dd>${FMT_INT(state.prompt_tokens)}</dd>`);
+    parts.push(`<dt>completion_tokens</dt><dd>${FMT_INT(state.completion_tokens)}</dd>`);
+    if (state.max_iterations != null) {
+      parts.push(`<dt>iterations</dt><dd>${state.current_iteration ?? 0} / ${state.max_iterations}</dd>`);
+    }
+    if (state.literature_snapshots) {
+      const litCount = Object.keys(state.literature_snapshots).length;
+      parts.push(`<dt>literature_snapshots</dt><dd>${litCount}</dd>`);
+    }
+    if (state.debate_transcripts) {
+      const dbCount = Object.keys(state.debate_transcripts).length;
+      parts.push(`<dt>debate_transcripts</dt><dd>${dbCount}</dd>`);
+    }
+    parts.push(`</dl>`);
+  }
+
+  // Meta-review: session summary + next_gen_priors + coverage
+  const m = meta ?? state?.meta_review ?? null;
+  if (m) {
+    if (m.session_summary) {
+      parts.push(`<h2>Meta-review summary</h2>`);
+      parts.push(`<p class="summary-prose">${escapeHtml(m.session_summary)}</p>`);
+    }
+    if (m.next_gen_priors && m.next_gen_priors.length > 0) {
+      parts.push(`<h2>Next-gen priors</h2>`);
+      parts.push(`<table class="priors"><thead><tr><th>target_dim</th><th>weight</th><th>rationale</th></tr></thead><tbody>`);
+      for (const p of m.next_gen_priors) {
+        parts.push(`
+          <tr>
+            <td class="dim">${escapeHtml(p.target_dim ?? "")}</td>
+            <td class="weight">${(p.weight ?? 0).toFixed(2)}</td>
+            <td class="rationale">${escapeHtml(p.rationale ?? "")}</td>
+          </tr>
+        `);
+      }
+      parts.push(`</tbody></table>`);
+    }
+    if (m.evolution_yield) {
+      const ey = m.evolution_yield;
+      parts.push(`<h2>Evolution yield</h2>`);
+      parts.push(`<dl class="cost-grid">`);
+      parts.push(`<dt>attempted</dt><dd>${FMT_INT(ey.attempted)}</dd>`);
+      parts.push(`<dt>successful</dt><dd>${FMT_INT(ey.successful)}</dd>`);
+      parts.push(`</dl>`);
+    }
+    if (m.elo_distribution) {
+      const ed = m.elo_distribution;
+      parts.push(`<h2>Elo distribution</h2>`);
+      parts.push(`<dl class="cost-grid">`);
+      parts.push(`<dt>min</dt><dd>${FMT_INT(ed.min)}</dd>`);
+      parts.push(`<dt>p50</dt><dd>${FMT_INT(ed.p50)}</dd>`);
+      parts.push(`<dt>p95</dt><dd>${FMT_INT(ed.p95)}</dd>`);
+      parts.push(`</dl>`);
+    }
+  }
+
+  if (parts.length === 0) {
+    return `<div class="status-msg">No detail files (state.json / survivors.json / meta_review.json) were resolvable for ${escapeHtml(runId)}.</div>`;
+  }
+  return parts.join("\n");
+}
+
+(async function main() {
+  try {
+    const listing = await fetchJson("./listing.json");
+    if (listing.kind && listing.kind !== "seeds") {
+      throw new Error(`listing.json kind="${listing.kind}", expected "seeds"`);
+    }
+    renderRunsTable(listing);
+  } catch (e) {
+    document.getElementById("counts").innerHTML = "";
+    document.getElementById("runs-area").innerHTML =
+      `<div class="status-msg err">listing.json fetch failed: ${escapeHtml(e.message)}</div>`;
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py
+++ b/tests/core/llm/adapters/test_codex_oauth_empty_text_dump.py
@@ -1,0 +1,128 @@
+"""PR-CODEX-OAUTH-EMPTY-TEXT-DUMP (2026-05-25) — regression pins for
+the empty-output_text postmortem dump.
+
+Smoke 11/12/13 vote-m000-openai.openai-codex consistently failed
+with ``output_text=""``, ``termination_reason="natural"``, 10s
+elapsed, $0.04 billed. The codex_oauth adapter now writes a
+diagnostic dump so the operator can see what the model actually
+emitted (reasoning_items / reasoning_summaries / usage / stop_reason)
+without re-running the cycle.
+
+Mirrors ``claude_cli._dump_transient_postmortem`` shape so
+``~/.geode/diagnostics/`` houses both, and any operator
+``diagnostics tar-up`` workflow catches them with one path filter.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from core.llm.adapters.base import (
+    AdapterCallResult,
+    UsageSummary,
+)
+from core.llm.adapters.codex_oauth import _dump_empty_text_postmortem
+
+
+def _build_result(
+    *,
+    text: str = "",
+    reasoning_items: tuple[dict, ...] = (),
+    reasoning_summaries: tuple[str, ...] = (),
+    stop_reason: str = "completed",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> AdapterCallResult:
+    return AdapterCallResult(
+        text=text,
+        usage=UsageSummary(input_tokens=input_tokens, output_tokens=output_tokens),
+        stop_reason=stop_reason,
+        tool_uses=(),
+        raw_response=None,
+        reasoning_items=reasoning_items,
+        reasoning_summaries=reasoning_summaries,
+    )
+
+
+def test_dump_writes_postmortem_file(tmp_path: Path) -> None:
+    """Happy path — empty text + 1 reasoning summary → dump created
+    with all 4 diagnostic dimensions."""
+    result = _build_result(
+        reasoning_items=({"type": "reasoning", "encrypted_content": "abc"},),
+        reasoning_summaries=("The user wants me to compare two seeds.",),
+    )
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=result)
+
+    assert dump_path is not None
+    p = Path(dump_path)
+    assert p.is_file()
+    assert p.parent.name == "codex-oauth-empty-text"
+    assert p.name.endswith("-gpt-5.5.json")
+    payload = json.loads(p.read_text(encoding="utf-8"))
+    assert payload["model"] == "gpt-5.5"
+    assert payload["stop_reason"] == "completed"
+    assert payload["usage"]["input_tokens"] == 100
+    assert payload["usage"]["output_tokens"] == 50
+    assert payload["reasoning_items_count"] == 1
+    assert payload["reasoning_summaries_count"] == 1
+    assert payload["reasoning_summaries"] == [
+        "The user wants me to compare two seeds.",
+    ]
+    assert payload["reasoning_items"][0]["encrypted_content"] == "abc"
+
+
+def test_dump_creates_parent_dir(tmp_path: Path) -> None:
+    """First-ever dump must create the
+    ``~/.geode/diagnostics/codex-oauth-empty-text/`` directory."""
+    target = tmp_path / "fresh-diagnostics"
+    assert not target.exists()
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", target):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.4-mini", result=result)
+    assert dump_path is not None
+    assert (target / "codex-oauth-empty-text").is_dir()
+
+
+def test_dump_handles_empty_reasoning_gracefully(tmp_path: Path) -> None:
+    """No reasoning_items / no reasoning_summaries — dump still
+    writes (just with empty arrays). Operator sees this as a "the
+    model returned nothing at all" signal vs the more common
+    "reasoning-only" signal."""
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=result)
+    assert dump_path is not None
+    payload = json.loads(Path(dump_path).read_text(encoding="utf-8"))
+    assert payload["reasoning_items_count"] == 0
+    assert payload["reasoning_summaries_count"] == 0
+    assert payload["reasoning_items"] == []
+    assert payload["reasoning_summaries"] == []
+
+
+def test_dump_returns_none_on_disk_error(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Disk full / permission denied — return ``None`` so the caller
+    logs ``<dump failed>`` and continues. Postmortem is best-effort,
+    not correctness-critical."""
+    # Point GLOBAL_DIAGNOSTICS_DIR at a non-writable path (a regular
+    # file masquerading as a directory).
+    blocker = tmp_path / "blocker-file"
+    blocker.write_text("not a directory", encoding="utf-8")
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", blocker):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.5", result=_build_result())
+    assert dump_path is None
+
+
+def test_dump_filename_format(tmp_path: Path) -> None:
+    """``<ts>-<model>.json`` so ``ls -t`` sorts chronologically and
+    model groups alphabetically — same convention as claude_cli."""
+    result = _build_result()
+    with patch("core.paths.GLOBAL_DIAGNOSTICS_DIR", tmp_path):
+        dump_path = _dump_empty_text_postmortem(model="gpt-5.4-mini", result=result)
+    assert dump_path is not None
+    name = Path(dump_path).name
+    ts_part, _, model_part = name.partition("-")
+    assert ts_part.isdigit()
+    assert model_part == "gpt-5.4-mini.json"

--- a/tests/test_subprocess_env_whitelist.py
+++ b/tests/test_subprocess_env_whitelist.py
@@ -1,0 +1,67 @@
+"""PR-ENV-WHITELIST-CODEX-BYPASS (2026-05-25) — anti-relapse pins for
+the subprocess env-var forwarding whitelist.
+
+Smoke 13 vote-m000-* (codex voter route) failed with
+``codex-cli-subagent lane blocked — Codex 5-hour OAuth bucket >=
+throttle threshold (see GEODE_CODEX_OAUTH_POLL_DISABLED to bypass)``
+even though the operator had set the env on the parent ``geode
+serve`` process. Root cause: ``IsolatedRunner._SUBPROCESS_ENV_WHITELIST``
+did NOT include ``GEODE_CODEX_OAUTH_POLL_DISABLED``, so the
+``safe_env`` built for the child subprocess dropped it.
+
+These tests pin:
+1. The bypass env is in the whitelist (literal name presence).
+2. The set of other ``GEODE_*`` operator knobs already in the
+   whitelist is preserved (regression guard against accidental
+   removal).
+3. The whitelist remains conservative — common shell / secret vars
+   that should NOT leak (``OAUTH_TOKEN``, ``SSH_AUTH_SOCK``, …) are
+   absent.
+"""
+
+from __future__ import annotations
+
+from core.orchestration.isolated_execution import IsolatedRunner
+
+
+def test_codex_oauth_poll_disabled_is_whitelisted() -> None:
+    """The exact env name documented in
+    ``core/orchestration/codex_cli_lane.py:CODEX_CLI_LANE_THROTTLED_MSG``
+    must reach the worker subprocess for the bypass to take effect."""
+    assert "GEODE_CODEX_OAUTH_POLL_DISABLED" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+
+
+def test_geode_operator_knobs_preserved() -> None:
+    """Regression guard — these are documented operator knobs that
+    callers configure on the parent process and expect to reach the
+    worker. Removing any of them from the whitelist would silently
+    break their effect."""
+    required = {
+        "GEODE_CONFIG_PATH",
+        "GEODE_DATA_DIR",
+        "GEODE_CODEX_OAUTH_POLL_DISABLED",
+    }
+    missing = required - IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert not missing, f"required operator knobs missing from whitelist: {sorted(missing)}"
+
+
+def test_credential_envs_present() -> None:
+    """Provider API keys must continue to forward (used by PAYG
+    adapters that read ``os.environ`` directly)."""
+    assert "ANTHROPIC_API_KEY" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert "OPENAI_API_KEY" in IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+
+
+def test_dangerous_envs_excluded() -> None:
+    """Anti-leak guard — these are vars that frequently carry
+    secrets / host-specific state that the worker has no business
+    seeing. Keep the whitelist conservative."""
+    forbidden = {
+        "SSH_AUTH_SOCK",
+        "AWS_SECRET_ACCESS_KEY",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "OAUTH_TOKEN",
+    }
+    leaked = forbidden & IsolatedRunner._SUBPROCESS_ENV_WHITELIST
+    assert not leaked, f"sensitive envs must not enter the whitelist: {sorted(leaked)}"


### PR DESCRIPTION
## Summary
develop → main pass-through carrying 3 post-v0.99.54 PRs to trigger Pages deploy of the new `/petri-bundle/seeds/` viewer.

| PR | Title |
|----|-------|
| #1632 | feat(petri-bundle): seeds/ viewer — fix 404 + render listing.json drill-down |
| #1631 | fix(codex-oauth): postmortem dump when output_text is empty |
| #1629 | fix(env-whitelist): forward GEODE_CODEX_OAUTH_POLL_DISABLED to worker subprocess |

Primary trigger: PR #1632 — landing it on main fires `.github/workflows/pages.yml` (`docs/petri-bundle/**` path) → `/petri-bundle/seeds/` 200 + viewer renders. Currently 404 in production.

## Verification
- [x] All 3 PRs already passed CI on their feature → develop merges
- [x] develop currently mergeable into main (no conflicts, fast-forwardable via merge commit)
- [ ] Post-merge: Pages workflow run success + `https://mangowhoiscloud.github.io/geode/petri-bundle/seeds/` returns 200