### PR TITLE
feat(site): docs/petri/seeds page renders seed-generation runs (Next.js + DocsShell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,37 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-SEEDS-PETRI-NEXTJS-PAGE** — new Next.js docs page
+  `site/src/app/docs/petri/seeds/page.tsx` renders the self-improving
+  loop's seed-generation runs as a first-class GEODE docs surface,
+  unified with the other `docs/petri/*` pages (overview / scenarios /
+  run / judge-dimensions / bundle). Replaces the prior raw-HTML
+  `docs/petri-bundle/seeds/index.html` as the primary discovery
+  surface; the raw HTML stays as a fallback for direct bundle access.
+
+  Implementation:
+  - Server Component reads `docs/petri-bundle/seeds/listing.json` and
+    each run's `state.json` / `survivors.json` / `meta_review.json` at
+    build time via `node:fs`. Pages workflow already triggers on both
+    `site/**` and `docs/petri-bundle/**`, so every new published run
+    rebuilds the page.
+  - `DocsShell` + `Bi` (bilingual ko/en) wrappers match the existing
+    petri docs pattern (`bundle/page.tsx`). Dark theme, `#A573E8`
+    amethyst accent, no emoji, no card grids per `feedback-no-box-
+    ui-no-emoji` and `site/DESIGN.md`.
+  - Runs table (run_id / gen_tag / target_dim / status / draft surv
+    / evolved / iters / cost USD) with anchor links into expandable
+    per-run `<details>`: survivors (id + elo + pilot status +
+    candidate file link + evolved children), cost rollup, meta-review
+    session_summary, next-gen priors (target_dim + weight +
+    rationale), evolution yield, Elo distribution. Each run's header
+    also carries a `[raw bundle ↗]` link back to
+    `/petri-bundle/seeds/<run_id>/` for direct file access.
+  - Status derived from listing: `survivors_count == 0` fail,
+    `evolved_count < survivors_count` partial, else ok.
+  - Sitemap entry registered in `site/src/lib/geode-docs/sitemap.ts`
+    under the verification section, sibling to `petri/bundle`.
+
 - **PR-SEEDS-BUNDLE-VIEWER** — `docs/petri-bundle/seeds/index.html` ships
   a self-contained viewer for the self-improving-loop seed-generation
   runs published into the petri-bundle. Previously

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -1,0 +1,411 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Seed Generation Runs · GEODE Docs" };
+
+// At build time, process.cwd() is the site/ directory.
+// Seeds live one level up under docs/petri-bundle/seeds/ in the repo root.
+const REPO_ROOT = path.join(process.cwd(), "..");
+const SEEDS_DIR = path.join(REPO_ROOT, "docs", "petri-bundle", "seeds");
+const RAW_BUNDLE_URL = "/petri-bundle/seeds/";
+
+type ListingRun = {
+  run_id: string;
+  gen_tag: string;
+  target_dim: string;
+  candidates_drafted: number;
+  survivors_count: number;
+  evolved_count: number;
+  iterations: number;
+  max_iterations: number;
+  usd_spent: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  has_meta_review: boolean;
+  has_supervisor_guidance: boolean;
+  literature_snapshots_count: number;
+  debate_transcripts_count: number;
+  url: string;
+};
+
+type Listing = { kind?: string; count?: number; runs?: ListingRun[] };
+
+type RunDetail = {
+  run: ListingRun;
+  state: Record<string, unknown> | null;
+  survivors: Record<string, unknown> | null;
+  meta: Record<string, unknown> | null;
+};
+
+function loadRuns(): RunDetail[] {
+  const listingPath = path.join(SEEDS_DIR, "listing.json");
+  if (!fs.existsSync(listingPath)) return [];
+  let listing: Listing;
+  try {
+    listing = JSON.parse(fs.readFileSync(listingPath, "utf-8")) as Listing;
+  } catch {
+    return [];
+  }
+  const runs = listing.runs ?? [];
+  return runs.map((run) => {
+    const runDir = path.join(SEEDS_DIR, run.run_id);
+    const read = (filename: string): Record<string, unknown> | null => {
+      const p = path.join(runDir, filename);
+      if (!fs.existsSync(p)) return null;
+      try {
+        return JSON.parse(fs.readFileSync(p, "utf-8")) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    };
+    return {
+      run,
+      state: read("state.json"),
+      survivors: read("survivors.json"),
+      meta: read("meta_review.json"),
+    };
+  });
+}
+
+function statusOf(run: ListingRun): "ok" | "partial" | "fail" {
+  if (run.candidates_drafted === 0 || run.survivors_count === 0) return "fail";
+  if (run.evolved_count < run.survivors_count) return "partial";
+  return "ok";
+}
+
+function fmtUSD(n: number | undefined | null): string {
+  return `$${(n ?? 0).toFixed(2)}`;
+}
+
+function fmtInt(n: number | undefined | null): string {
+  return (n ?? 0).toLocaleString();
+}
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function asNumber(v: unknown): number {
+  return typeof v === "number" ? v : 0;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function asObject(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+const STATUS_LABEL_EN = { ok: "ok", partial: "partial", fail: "fail" } as const;
+const STATUS_LABEL_KO = { ok: "정상", partial: "부분", fail: "실패" } as const;
+
+function RunsTable({ runs, locale }: { runs: RunDetail[]; locale: "ko" | "en" }) {
+  const headers =
+    locale === "ko"
+      ? ["run_id", "gen_tag", "target_dim", "상태", "draft → surv", "evolved", "iters", "비용 USD"]
+      : ["run_id", "gen_tag", "target_dim", "status", "draft → surv", "evolved", "iters", "cost USD"];
+  const STATUS_LABEL = locale === "ko" ? STATUS_LABEL_KO : STATUS_LABEL_EN;
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          {headers.map((h) => (
+            <th key={h}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map(({ run }) => {
+          const status = statusOf(run);
+          return (
+            <tr key={run.run_id}>
+              <td>
+                <a href={`#run-${run.run_id}`}>
+                  <code>{run.run_id}</code>
+                </a>
+              </td>
+              <td><code>{run.gen_tag}</code></td>
+              <td><code>{run.target_dim}</code></td>
+              <td>{STATUS_LABEL[status]}</td>
+              <td>{run.candidates_drafted} → {run.survivors_count}</td>
+              <td>{run.evolved_count}</td>
+              <td>{run.iterations}</td>
+              <td>{fmtUSD(run.usd_spent)}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | "en" }) {
+  const { run, state, survivors, meta } = detail;
+  const stateObj = state ?? {};
+  const survivorsList = asArray(asObject(survivors).survivors);
+  const evolvedList = asArray(asObject(stateObj).evolved_candidates);
+  const evolvedByParent = new Map<string, string[]>();
+  for (const ev of evolvedList) {
+    const evObj = asObject(ev);
+    const parent = asString(evObj.parent_id);
+    const id = asString(evObj.id);
+    if (!parent || !id) continue;
+    if (!evolvedByParent.has(parent)) evolvedByParent.set(parent, []);
+    evolvedByParent.get(parent)!.push(id);
+  }
+
+  const metaObj = asObject(meta ?? asObject(stateObj).meta_review);
+  const sessionSummary = asString(metaObj.session_summary);
+  const nextGenPriors = asArray(metaObj.next_gen_priors);
+  const evolutionYield = asObject(metaObj.evolution_yield);
+  const eloDist = asObject(metaObj.elo_distribution);
+
+  const heading = locale === "ko" ? "생존 후보" : "Survivors";
+  const costHeading = locale === "ko" ? "비용 집계" : "Cost rollup";
+  const summaryHeading = locale === "ko" ? "메타 리뷰 요약" : "Meta-review summary";
+  const priorsHeading = locale === "ko" ? "다음 세대 prior" : "Next-gen priors";
+  const yieldHeading = locale === "ko" ? "진화 산출" : "Evolution yield";
+  const eloHeading = locale === "ko" ? "Elo 분포" : "Elo distribution";
+  const rawLinkLabel = locale === "ko" ? "raw 번들" : "raw bundle";
+  const headerKo = `${run.gen_tag} · target_dim=${run.target_dim}`;
+
+  return (
+    <details id={`run-${run.run_id}`} className="my-4 border border-white/10 rounded-md">
+      <summary className="cursor-pointer px-4 py-3 hover:bg-white/[0.03] select-none">
+        <code className="text-[#A573E8]">{run.run_id}</code>
+        <span className="ml-3 text-white/50 text-sm">{headerKo}</span>
+        <a
+          href={`${RAW_BUNDLE_URL}${run.run_id}/`}
+          className="ml-3 text-white/40 text-xs hover:text-[#A573E8]"
+        >
+          [{rawLinkLabel} ↗]
+        </a>
+      </summary>
+      <div className="px-4 py-3 border-t border-white/10">
+        {survivorsList.length > 0 && (
+          <>
+            <h3>{heading}</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>candidate_id</th>
+                  <th>elo</th>
+                  <th>pilot</th>
+                  <th>{locale === "ko" ? "후보 파일" : "candidate file"}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {survivorsList.map((s) => {
+                  const sObj = asObject(s);
+                  const sid = asString(sObj.id);
+                  const elo = asNumber(sObj.elo_rating);
+                  const pilotObj = asObject(sObj.pilot);
+                  const pilotStatus = asString(pilotObj.status) || ".";
+                  const candidatePath = asString(sObj.path);
+                  const filename = candidatePath.split("/").pop() ?? "";
+                  const fileHref = filename
+                    ? `${RAW_BUNDLE_URL}${run.run_id}/candidates/${filename}`
+                    : undefined;
+                  const evolved = evolvedByParent.get(sid) ?? [];
+                  return (
+                    <tr key={sid}>
+                      <td><code>{sid}</code></td>
+                      <td>{Math.round(elo)}</td>
+                      <td>{pilotStatus}</td>
+                      <td>
+                        {fileHref ? (
+                          <a href={fileHref}><code>{filename}</code></a>
+                        ) : (
+                          <code>{filename || "."}</code>
+                        )}
+                        {evolved.length > 0 && (
+                          <span className="ml-2 text-white/40 text-xs">
+                            → {evolved.map((e) => <code key={e} className="mr-1">{e}</code>)}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </>
+        )}
+
+        <h3>{costHeading}</h3>
+        <table>
+          <tbody>
+            <tr><th>total USD</th><td>{fmtUSD(asNumber(stateObj.usd_spent))}</td></tr>
+            <tr><th>prompt_tokens</th><td>{fmtInt(asNumber(stateObj.prompt_tokens))}</td></tr>
+            <tr><th>completion_tokens</th><td>{fmtInt(asNumber(stateObj.completion_tokens))}</td></tr>
+            <tr>
+              <th>{locale === "ko" ? "iter / max" : "iters / max"}</th>
+              <td>{asNumber(stateObj.current_iteration)} / {asNumber(stateObj.max_iterations)}</td>
+            </tr>
+            <tr>
+              <th>literature_snapshots</th>
+              <td>{Object.keys(asObject(stateObj.literature_snapshots)).length}</td>
+            </tr>
+            <tr>
+              <th>debate_transcripts</th>
+              <td>{Object.keys(asObject(stateObj.debate_transcripts)).length}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        {sessionSummary && (
+          <>
+            <h3>{summaryHeading}</h3>
+            <p>{sessionSummary}</p>
+          </>
+        )}
+
+        {nextGenPriors.length > 0 && (
+          <>
+            <h3>{priorsHeading}</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>target_dim</th>
+                  <th>weight</th>
+                  <th>{locale === "ko" ? "근거" : "rationale"}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {nextGenPriors.map((p, idx) => {
+                  const pObj = asObject(p);
+                  return (
+                    <tr key={`${asString(pObj.target_dim)}-${idx}`}>
+                      <td><code>{asString(pObj.target_dim)}</code></td>
+                      <td>{asNumber(pObj.weight).toFixed(2)}</td>
+                      <td>{asString(pObj.rationale)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </>
+        )}
+
+        {Object.keys(evolutionYield).length > 0 && (
+          <>
+            <h3>{yieldHeading}</h3>
+            <table>
+              <tbody>
+                <tr>
+                  <th>{locale === "ko" ? "시도" : "attempted"}</th>
+                  <td>{fmtInt(asNumber(evolutionYield.attempted))}</td>
+                </tr>
+                <tr>
+                  <th>{locale === "ko" ? "성공" : "successful"}</th>
+                  <td>{fmtInt(asNumber(evolutionYield.successful))}</td>
+                </tr>
+              </tbody>
+            </table>
+          </>
+        )}
+
+        {Object.keys(eloDist).length > 0 && (
+          <>
+            <h3>{eloHeading}</h3>
+            <table>
+              <tbody>
+                <tr><th>min</th><td>{fmtInt(asNumber(eloDist.min))}</td></tr>
+                <tr><th>p50</th><td>{fmtInt(asNumber(eloDist.p50))}</td></tr>
+                <tr><th>p95</th><td>{fmtInt(asNumber(eloDist.p95))}</td></tr>
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+    </details>
+  );
+}
+
+export default function Page() {
+  const runs = loadRuns();
+  const totalRuns = runs.length;
+  const totalCandidates = runs.reduce((a, r) => a + r.run.candidates_drafted, 0);
+  const totalSurvivors = runs.reduce((a, r) => a + r.run.survivors_count, 0);
+  const totalCost = runs.reduce((a, r) => a + r.run.usd_spent, 0);
+
+  return (
+    <DocsShell
+      slug="petri/seeds"
+      title="Seed Generation Runs"
+      titleKo="Seed 생성 Run"
+      summary={`${totalRuns} runs · ${totalCandidates} candidates drafted · ${totalSurvivors} survived · ${fmtUSD(totalCost)} total spend.`}
+      summaryKo={`${totalRuns}개 run · ${totalCandidates}개 후보 생성 · ${totalSurvivors}개 생존 · ${fmtUSD(totalCost)} 총 비용.`}
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              <strong>Reference:</strong> self-improving loop 의 seed-generation 파이프라인이 매 generation 마다 산출한 결과를
+              <code>docs/petri-bundle/seeds/</code> 에 git-tracked snapshot 으로 publish 합니다. 본 페이지는 build time 에
+              <code>listing.json</code> + per-run <code>state.json</code> / <code>survivors.json</code> / <code>meta_review.json</code>
+              을 읽어 dashboard 로 렌더링합니다.
+            </p>
+            <p>
+              raw 파일을 직접 보려면 <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> 의 정적 viewer 또는 per-run
+              디렉토리를 사용. inspect_ai <code>.eval</code> 아카이브 viewer 는 <a href="/petri-bundle/">/geode/petri-bundle/</a> 에 별도.
+            </p>
+
+            <h2>전체 Run</h2>
+            <RunsTable runs={runs} locale="ko" />
+
+            <h2>Run 별 상세</h2>
+            <p>각 row 를 펼치면 survivors / 비용 / meta-review / next-gen prior / Elo 분포가 표시됩니다.</p>
+            {runs.length === 0 ? (
+              <p><em>아직 published 된 run 이 없습니다. <code>docs/petri-bundle/seeds/listing.json</code> 을 확인하세요.</em></p>
+            ) : (
+              runs.map((r) => <RunDetailBlock key={r.run.run_id} detail={r} locale="ko" />)
+            )}
+
+            <h2>SoT 와 파이프라인</h2>
+            <ul>
+              <li>seed-generation 소스: <code>plugins/seed_generation/orchestrator.py</code> (8-phase: supervisor → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer)</li>
+              <li>bundle 동기화: <code>plugins/seed_generation/bundle_sync.py</code> 가 run 종료 시 결과를 <code>docs/petri-bundle/seeds/&lt;run_id&gt;/</code> 로 mirror</li>
+              <li>관련 plan: <a href="/geode/docs/capabilities/seed-pipeline">Seed Pipeline</a> · <a href="/geode/docs/petri/scenarios">Petri Scenarios</a></li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <p>
+              <strong>Reference:</strong> the self-improving loop&apos;s seed-generation pipeline publishes per-generation results
+              as git-tracked snapshots under <code>docs/petri-bundle/seeds/</code>. This page reads
+              <code>listing.json</code> + per-run <code>state.json</code> / <code>survivors.json</code> / <code>meta_review.json</code>
+              at build time and renders them as a dashboard.
+            </p>
+            <p>
+              For raw files use the static viewer at <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> or browse the
+              per-run directory. The inspect_ai <code>.eval</code> archive viewer lives separately at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
+            </p>
+
+            <h2>All runs</h2>
+            <RunsTable runs={runs} locale="en" />
+
+            <h2>Per-run detail</h2>
+            <p>Expand each row for survivors / cost / meta-review / next-gen priors / Elo distribution.</p>
+            {runs.length === 0 ? (
+              <p><em>No published runs yet. Check <code>docs/petri-bundle/seeds/listing.json</code>.</em></p>
+            ) : (
+              runs.map((r) => <RunDetailBlock key={r.run.run_id} detail={r} locale="en" />)
+            )}
+
+            <h2>Source &amp; pipeline</h2>
+            <ul>
+              <li>seed-generation source: <code>plugins/seed_generation/orchestrator.py</code> (8-phase: supervisor → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer)</li>
+              <li>bundle sync: <code>plugins/seed_generation/bundle_sync.py</code> mirrors completed runs into <code>docs/petri-bundle/seeds/&lt;run_id&gt;/</code></li>
+              <li>related: <a href="/geode/docs/capabilities/seed-pipeline">Seed Pipeline</a> · <a href="/geode/docs/petri/scenarios">Petri Scenarios</a></li>
+            </ul>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -127,6 +127,7 @@ export const DOCS_SITEMAP: DocSection[] = [
       { slug: "petri/run", title: "Petri Run", titleKo: "Petri 실행", summary: "geode audit (primary) or inspect eval (raw). Choose model roles, dim set, seeds, and turn budget.", summaryKo: "geode audit (1차 명령) 또는 inspect eval (raw). 모델 역할, dim set, seeds, turn 예산 선택.", quadrant: "how-to" },
       { slug: "petri/judge-dimensions", title: "Petri Judge Dimensions", titleKo: "Petri Judge 차원", summary: "What each dimension scores. How to read the heatmap. Default geode_5axes (22 dims) vs inspect_petri full default (38).", summaryKo: "각 차원이 무엇을 평가하는지. heatmap 읽는 법. 기본 geode_5axes (22 dim) vs inspect_petri default (38).", quadrant: "reference" },
       { slug: "petri/bundle", title: "Petri Bundle Viewer", titleKo: "Petri Bundle 뷰어", summary: "Live inspect_ai transcript viewer for the latest GEODE audit run.", summaryKo: "최신 GEODE 감사 run의 라이브 inspect_ai 트랜스크립트 뷰어.", quadrant: "reference", externalUrl: "/petri-bundle/" },
+      { slug: "petri/seeds", title: "Petri Seed Generation Runs", titleKo: "Petri Seed 생성 Run", summary: "Per-generation seed-generation dashboard. Runs table plus per-run survivors, cost, meta-review, next-gen priors. Build-time render of docs/petri-bundle/seeds/.", summaryKo: "self-improving loop seed-generation per-generation 대시보드. run 테이블 + 생존 후보 / 비용 / 메타리뷰 / 다음세대 prior. docs/petri-bundle/seeds/ 의 build-time 렌더.", quadrant: "reference" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- `site/src/app/docs/petri/seeds/page.tsx` — Next.js docs 페이지로 self-improving loop 의 seed-generation 결과를 첫 클래스 surface 로 노출
- 기존 docs/petri/* (overview / scenarios / run / judge-dimensions / bundle) 5 페이지와 톤·구조 통일 (DocsShell + Bi + Tailwind dark + #A573E8 amethyst)
- Server Component 가 build time 에 `docs/petri-bundle/seeds/listing.json` + per-run `state.json` / `survivors.json` / `meta_review.json` 을 `node:fs` 로 로드, 정적 렌더링

## Why
- 직전 PR #1632 (`docs/petri-bundle/seeds/index.html`) 는 404 만 해소한 raw-data dump. 운영자 피드백: "그냥 raw 데이터야. petri 디자인 명세에 맞게 만들어둔 목업들이 있을텐데"
- 사이트 디자인 시스템 (`site/DESIGN.md`: 단일 dark substrate + amethyst/citrine 2-accent + no emoji + no card grids) 과 mismatch
- 사이트의 다른 docs/petri/* 5 페이지 는 모두 DocsShell + Bi 패턴 + Tailwind dark 인데 seeds 만 light theme bare HTML 이었음
- 운영자 directive: "목업+플랜+seed gen 데이터 기반으로 petri-bundle과 묶이는 방향으로 제작 및 배포할거야. 스택은 Next.js로 잡고 petri-bundle 페이지와 통일시켜"

## Changes
| File | Change |
|------|--------|
| `site/src/app/docs/petri/seeds/page.tsx` | NEW (411 LOC) — Server Component, runs 테이블 + per-run drill-down, bilingual ko/en |
| `site/src/lib/geode-docs/sitemap.ts` | `petri/seeds` 항목 1줄 추가 (sibling to `petri/bundle`) |
| `CHANGELOG.md` | `[Unreleased]` Added 섹션에 PR-SEEDS-PETRI-NEXTJS-PAGE 엔트리 |

## Design

| 결정 | 근거 |
|------|------|
| Next.js page (Server Component) vs 정적 HTML | `site/` 디자인 시스템 통일 + DocsShell sidebar nav + Bi 이중언어 자동 적용. inspect_ai SPA 와 별도 surface 로 coexist |
| Build-time `fs.readFileSync` (Server Component) | `output: "export"` 정적 export 환경 — server component 가 build time 에 한 번 실행. pages.yml 이 `site/**` + `docs/petri-bundle/**` 양쪽 트리거 → 새 run 발행 시 자동 rebuild |
| Raw HTML 잔존 vs 삭제 | PR #1632 의 `/petri-bundle/seeds/index.html` 는 direct bundle access fallback 으로 보존. 사용자가 raw 데이터 / candidate `.md` 파일을 URL 로 직접 접근하는 워크플로 유지 |
| status 파생 (listing 내 없음) | `survivors_count == 0` → fail, `evolved_count < survivors_count` → partial, else ok. schema 변경 없이 listing 의미 만으로 분류 |
| `dim_means` heatmap / phase progress 생략 | `state.json` 에 phase-by-phase 타이밍 부재 + dim heatmap 은 chart lib 추가 필요 — schema 가 깊어지면 follow-up. 현 surface 는 메타데이터·survivors·meta-review 까지 |
| 모든 em-dash (`—`) 제거 | `site/CLAUDE.md` 의 "대시 사용 자제. 마침표 (.)나 쉼표 (,) 로 대체" 규정 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Next.js + DocsShell 패턴 적용 | Implemented | `bundle/page.tsx` 시그너처와 동일 |
| build-time JSON load | Implemented | `node:fs` Server Component pattern, `process.cwd()` = `site/` |
| 사이트맵 등록 | Implemented | `petri/bundle` 직후, `quadrant: "reference"` |
| 이중언어 (ko/en) | Implemented | Bi 컴포넌트 + 테이블 헤더 locale 분기 |
| raw HTML 와 coexist | Implemented | `[raw bundle ↗]` 링크 per-run, primary surface 는 Next.js |
| schema gap (phase progress, dim heatmap) | Deferred | 향후 state.json schema 확장 후 |
| Em-dash 제거 | Implemented | grep 0 hit, `·` middle dot 만 사용 |

## Verification
- [x] `npx next build` clean, `/docs/petri/seeds` 가 73 static pages 중 하나로 emit
- [x] Local preview (`python3 -m http.server --directory out`) — 페이지 200 OK, `gen1-redundant_tool_invocation` × 25 / `target_dim` × 11 / `next-gen` × 6 등 실 데이터 그라운딩 확인
- [x] grep `—` / `–` in `page.tsx` → 0 hit (site/CLAUDE.md 규정)
- [ ] Post-merge CI: site/** path 의 lint + build + render-lint
- [ ] Post-merge Pages deploy: `https://mangowhoiscloud.github.io/geode/docs/petri/seeds` 200 + 데이터 정상 렌더링

## Reference
- 목업 source: `/tmp/geode-literature-mockup/seeds.html` (v2 post-Slop)
- 사이트 디자인 명세: `site/DESIGN.md` (amethyst/citrine 2-accent, dark substrate, no emoji)
- 자매 페이지 패턴: `site/src/app/docs/petri/bundle/page.tsx`
- 이전 PR: #1632 (raw HTML 404 fix, develop → main 머지 완료)