### PR TITLE
feat(self-improving-loop): attribution wiring gap fill (W1-W4) + RFC amend

### DIFF
--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2246,6 +2246,63 @@ def main() -> int:
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 
+    # W2 (2026-05-25 attribution wiring) — closed loop completion.
+    # runner.py 의 ``_run_autoresearch_subprocess`` 가 propose-apply-audit
+    # 한 cycle 동안 env 3개로 propagate 한다:
+    #   - GEODE_SIL_AUDIT_RUN_ID  (this cycle 의 audit run id, mutations.jsonl 의
+    #     apply row 와 같은 값)
+    #   - GEODE_SIL_MUTATION_ID   (apply row 의 mutation_id; attribution row 의
+    #     foreign key)
+    #   - GEODE_SIL_EXPECTED_DIM  (mutator LLM 의 commitment, JSON dict)
+    # 셋 모두 set 됐을 때만 attribution row append (manual --promote /
+    # standalone audit 보존). dry-run 도 skip — synthetic dim_means 는
+    # attribution 신호가 무의미.
+    _sil_mutation_id = os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+    _sil_audit_run_id = os.environ.get("GEODE_SIL_AUDIT_RUN_ID", "").strip()
+    _sil_expected_raw = os.environ.get("GEODE_SIL_EXPECTED_DIM", "")
+    if not args.dry_run and _sil_mutation_id and _sil_audit_run_id:
+        try:
+            from core.self_improving_loop.attribution import write_attribution
+            from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+            try:
+                _sil_expected_dim = json.loads(_sil_expected_raw) if _sil_expected_raw else {}
+                if not isinstance(_sil_expected_dim, dict):
+                    _sil_expected_dim = {}
+            except json.JSONDecodeError:
+                _sil_expected_dim = {}
+            _sil_baseline_before = (
+                BaselineSnapshot(
+                    dim_means=dict(baseline_means),
+                    dim_stderr=dict(baseline_stderr or {}),
+                )
+                if baseline_means
+                else None
+            )
+            _sil_baseline_after = BaselineSnapshot(
+                dim_means=dict(dim_means),
+                dim_stderr=dict(dim_stderr or {}),
+            )
+            _sil_fitness_before = (
+                sum(baseline_means.values()) / len(baseline_means) if baseline_means else None
+            )
+            write_attribution(
+                mutation_id=_sil_mutation_id,
+                expected_dim=_sil_expected_dim,
+                baseline_before=_sil_baseline_before,
+                baseline_after=_sil_baseline_after,
+                fitness_before=_sil_fitness_before,
+                fitness_after=float(fitness),
+                audit_run_id=_sil_audit_run_id,
+            )
+        except Exception:  # pragma: no cover — defensive
+            log.warning(
+                "self-improving-loop attribution write failed for mutation %s audit_run %s",
+                _sil_mutation_id,
+                _sil_audit_run_id,
+                exc_info=True,
+            )
+
     # P1a — append to the shared cross-loop session registry.
     _append_session_index(
         session_id=session_id,

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -40,10 +40,39 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel, ConfigDict, Field
+
 if TYPE_CHECKING:
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
 from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
+
+
+class AttributionRecord(BaseModel):
+    """Pydantic schema for ``mutations.jsonl`` attribution row (W4, 2026-05-25).
+
+    Schema 정의는 ``compute_attribution()`` payload 와 1:1 매치.
+    ``extra="allow"`` 로 legacy row 호환 + PR-E confidence_stability /
+    PR-SIL-5THEME C4 fitness ledger / W3 audit_run_id 모두 optional.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    ts: float
+    kind: str = Field(default="attribution", pattern=r"^attribution$")
+    mutation_id: str
+    observed_dim: dict[str, float] = Field(default_factory=dict)
+    ci95: dict[str, float] = Field(default_factory=dict)
+    significant: dict[str, bool] = Field(default_factory=dict)
+    attribution_score: float = 0.0
+    missing_baseline: bool = True
+    confidence_trajectory: list[float] = Field(default_factory=list)
+    confidence_stability: float | None = None
+    fitness_before: float | None = None
+    fitness_after: float | None = None
+    fitness_delta: float | None = None
+    audit_run_id: str | None = None
+
 
 log = logging.getLogger(__name__)
 
@@ -177,6 +206,7 @@ def compute_attribution(
     confidence_trajectory: list[float] | None = None,
     fitness_before: float | None = None,
     fitness_after: float | None = None,
+    audit_run_id: str = "",
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -211,6 +241,12 @@ def compute_attribution(
         "confidence_trajectory": trajectory,
         "confidence_stability": stability,
     }
+    # W3 (2026-05-25 attribution wiring) — cross-ref to the Petri eval
+    # archive measured for this mutation. Empty string when the caller
+    # didn't propagate the audit_run_id (e.g. legacy callsite); column
+    # omitted so legacy readers stay graceful.
+    if audit_run_id:
+        payload["audit_run_id"] = audit_run_id
     # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 fitness Δ.
     # ``baseline_before.fitness`` / ``baseline_after.fitness`` 는 dataclass 에
     # 없으므로 caller 가 명시 fitness_before / fitness_after 전달. 둘 다
@@ -247,8 +283,10 @@ def append_attribution_log(
     """
     target = log_path if log_path is not None else MUTATION_AUDIT_LOG_PATH
     target.parent.mkdir(parents=True, exist_ok=True)
+    # W4 (2026-05-25) — Pydantic schema validation. drift fail-fast.
+    validated = AttributionRecord.model_validate(payload).model_dump(exclude_none=True)
     with target.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        fh.write(json.dumps(validated, ensure_ascii=False, sort_keys=True))
         fh.write("\n")
     return target
 
@@ -263,6 +301,7 @@ def write_attribution(
     log_path: Path | None = None,
     fitness_before: float | None = None,
     fitness_after: float | None = None,
+    audit_run_id: str = "",
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
 
@@ -288,12 +327,14 @@ def write_attribution(
         confidence_trajectory=confidence_trajectory,
         fitness_before=fitness_before,
         fitness_after=fitness_after,
+        audit_run_id=audit_run_id,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload
 
 
 __all__ = [
+    "AttributionRecord",
     "append_attribution_log",
     "compute_attribution",
     "confidence_trajectory_from_episodes",

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import os
 import subprocess
 import time
 import uuid
@@ -47,6 +48,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
 from core.paths import (
@@ -57,6 +60,7 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "MUTATION_AUDIT_LOG_PATH",
+    "ApplyRecord",
     "Mutation",
     "Proposal",
     "RunnerContext",
@@ -70,6 +74,36 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
+
+
+class ApplyRecord(BaseModel):
+    """Pydantic schema for ``mutations.jsonl`` apply row (W4, 2026-05-25).
+
+    Schema 정의는 ``Mutation.to_audit_row()`` 의 출력 dict 와 1:1 매치.
+    writer side validation 으로 schema drift 를 fail-fast 로 잡는다 —
+    legacy dict row 도 ``extra="allow"`` 로 호환 (cost_* 등의 optional
+    field 는 None 으로 떨어짐). reader 마이그레이션은 W4b 후속 PR.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    ts: float
+    kind: str = Field(default="applied", pattern=r"^applied$")
+    mutation_id: str
+    target_kind: str
+    target_section: str
+    previous_value: str
+    new_value: str
+    rationale: str = ""
+    target_dim: str = ""
+    expected_dim: dict[str, float] = Field(default_factory=dict)
+    rollback_condition: str = ""
+    baseline_fitness: float | None = None
+    cost_input_tokens: int | None = None
+    cost_output_tokens: int | None = None
+    cost_elapsed_seconds: float | None = None
+    cost_model: str | None = None
+    audit_run_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -130,12 +164,21 @@ class Mutation:
         previous_value: str,
         timestamp: float | None = None,
         baseline_fitness: float | None = None,
+        audit_run_id: str = "",
     ) -> dict[str, Any]:
         """Render the mutation as one audit-log row.
 
         PR-SIL-5THEME C4 (2026-05-23) — cost 4-field 추가. 모두 0 / "" 일
         때만 row 에 컬럼 자체 미생성 → legacy reader 가 새 컬럼 부재 시
         graceful (key 가 없으면 0 / "" 가정).
+
+        W3 (2026-05-25 attribution wiring) — ``audit_run_id`` parameter
+        추가. cross-ref key to the Petri eval archive measured for this
+        mutation. Empty string when the apply happens outside an audit
+        lane (manual --promote, replay); column omitted so legacy reader
+        무영향. ``Mutation`` 자체는 frozen dataclass 라 LLM 응답 구조
+        immutable 유지; audit_run_id 는 runner-side context 로 to_audit_row
+        호출 시점에 inject 한다.
         """
         row: dict[str, Any] = {
             "ts": timestamp if timestamp is not None else time.time(),
@@ -151,6 +194,8 @@ class Mutation:
             "rollback_condition": self.rollback_condition,
             "baseline_fitness": baseline_fitness,
         }
+        if audit_run_id:
+            row["audit_run_id"] = audit_run_id
         # PR-SIL-5THEME C4 — cost 컬럼은 non-zero 일 때만 emit. 0 값
         # (legacy 또는 mock LLM 호출) 은 column 자체 생략 — JSONL 의
         # noise 절감 + legacy reader 무영향.
@@ -734,6 +779,18 @@ def parse_mutation(raw: str) -> Mutation:
             # genuine numeric, not a coerced bool).
             if isinstance(k, str) and isinstance(v, int | float) and not isinstance(v, bool):
                 expected_dim[k] = float(v)
+    if not expected_dim:
+        # W1 (2026-05-25 attribution wiring) — expected_dim 가 비어 있으면
+        # 후속 ``compute_attribution`` 이 attribution_score 0.0 으로만 평가
+        # 되어 mutation 효과 측정이 무의미해진다. LLM 이 prompt 의 명시 요청
+        # (``Mutation Contract`` §expected_dim) 을 빠뜨렸다는 신호이므로
+        # WARNING 으로 surface 한다 — fail-closed 가 아니라 loop 가 계속
+        # 돌면서 다음 mutation 에 영향 주지 않도록 graceful.
+        log.warning(
+            "self-improving-loop: mutation %r has empty expected_dim — "
+            "attribution score will be 0.0 (LLM omitted dim commitments)",
+            payload.get("target_section", "(unknown)"),
+        )
     rollback_raw = payload.get("rollback_condition", "")
     rollback_condition = rollback_raw.strip() if isinstance(rollback_raw, str) else ""
     # PR-6 C-5 — target_kind dispatches to the policy SoT file. Default
@@ -831,17 +888,31 @@ def append_audit_log(
     previous_value: str,
     baseline_fitness: float | None = None,
     log_path: Path | None = None,
+    audit_run_id: str = "",
 ) -> Path:
     """Append one mutation row to the git-tracked audit jsonl.
 
     Returns the path of the audit log so the caller can ``git add``
     it. Best-effort — directory is created if missing.
+
+    W3 (2026-05-25 attribution wiring) — ``audit_run_id`` forwarded to
+    ``Mutation.to_audit_row`` so the apply row carries the cross-ref
+    key to the matching attribution row.
     """
     target = log_path if log_path is not None else MUTATION_AUDIT_LOG_PATH
     target.parent.mkdir(parents=True, exist_ok=True)
-    row = mutation.to_audit_row(previous_value=previous_value, baseline_fitness=baseline_fitness)
+    row = mutation.to_audit_row(
+        previous_value=previous_value,
+        baseline_fitness=baseline_fitness,
+        audit_run_id=audit_run_id,
+    )
+    # W4 (2026-05-25) — Pydantic schema validation. drift 가 발생하면
+    # ValidationError 가 fail-fast 로 raise → 잘못된 row 가 git-tracked
+    # ledger 에 들어가지 않음. backward-compat 은 ApplyRecord 의
+    # ``extra="allow"`` + optional cost/audit_run_id field 로 유지.
+    validated = ApplyRecord.model_validate(row).model_dump(exclude_none=True)
     with target.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+        fh.write(json.dumps(validated, ensure_ascii=False) + "\n")
     return target
 
 
@@ -897,6 +968,9 @@ def _run_autoresearch_subprocess(
     *,
     repo_root: Path,
     dry_run: bool,
+    audit_run_id: str = "",
+    mutation_id: str = "",
+    expected_dim: dict[str, float] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Spawn ``autoresearch/train.py`` for the post-mutation audit.
 
@@ -904,13 +978,26 @@ def _run_autoresearch_subprocess(
     operators flip to ``dry_run=False`` for a real budget-spending
     audit. The subprocess is non-fatal — failures log + return so the
     runner can record the mutation row even when the audit aborts.
+
+    W2/W3 (2026-05-25 attribution wiring) — when ``audit_run_id`` /
+    ``mutation_id`` / ``expected_dim`` 모두 non-empty 면 env 로
+    propagate. train.py 의 _persist_baseline 직후 hook 이 env 받고
+    ``write_attribution`` 호출 → mutations.jsonl 에 attribution row
+    append. env 누락 시 hook 가 graceful skip (legacy --promote /
+    manual run 보존).
     """
     argv = ["uv", "run", "python", "autoresearch/train.py"]
     if dry_run:
         argv.append("--dry-run")
+    env = os.environ.copy()
+    if audit_run_id and mutation_id:
+        env["GEODE_SIL_AUDIT_RUN_ID"] = audit_run_id
+        env["GEODE_SIL_MUTATION_ID"] = mutation_id
+        env["GEODE_SIL_EXPECTED_DIM"] = json.dumps(expected_dim or {}, ensure_ascii=False)
     return subprocess.run(  # noqa: S603  # nosec B603 — argv built from constants
         argv,
         cwd=str(repo_root),
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -1035,7 +1122,14 @@ class SelfImprovingLoopRunner:
         lands, the SoT is rolled back to
         ``proposal.original_sections`` and the original exception
         propagates so the caller can retry.
+
+        W3 (2026-05-25 attribution wiring) — audit_run_id 를 propose-
+        apply-audit 단일 cycle 안에서 mint. mutations.jsonl 의 apply
+        row 와 attribution row 가 audit_run_id 로 join 가능. mint 는
+        rerun_enabled 일 때만 (rerun_disabled 면 audit 가 안 일어나
+        attribution row 도 없으니 audit_run_id 무의미).
         """
+        audit_run_id = uuid.uuid4().hex[:12] if self.rerun_enabled else ""
         _new_sections, previous_value = apply_mutation(
             proposal.mutation, current_sections=proposal.target_sections
         )
@@ -1044,6 +1138,7 @@ class SelfImprovingLoopRunner:
                 proposal.mutation,
                 previous_value=previous_value,
                 log_path=self.audit_log_path,
+                audit_run_id=audit_run_id,
             )
         except OSError as exc:
             self._rollback_sot(proposal.original_sections, mutation=proposal.mutation, exc=exc)
@@ -1052,7 +1147,11 @@ class SelfImprovingLoopRunner:
             _git_commit_audit_log(log_path, mutation=proposal.mutation)
         if self.rerun_enabled:
             repo_root = log_path.resolve().parents[1]
-            self._invoke_autoresearch(repo_root)
+            self._invoke_autoresearch(
+                repo_root,
+                audit_run_id=audit_run_id,
+                mutation=proposal.mutation,
+            )
         self._append_self_improving_loop_index(proposal.mutation, previous_value)
         return proposal.mutation
 
@@ -1119,10 +1218,28 @@ class SelfImprovingLoopRunner:
                 mutation.target_section,
             )
 
-    def _invoke_autoresearch(self, repo_root: Path) -> None:
-        """Wrap the autoresearch subprocess so tests can override."""
+    def _invoke_autoresearch(
+        self,
+        repo_root: Path,
+        *,
+        audit_run_id: str = "",
+        mutation: Mutation | None = None,
+    ) -> None:
+        """Wrap the autoresearch subprocess so tests can override.
+
+        W2/W3 (2026-05-25 attribution wiring) — propagate audit_run_id +
+        mutation_id + expected_dim to the subprocess env so the
+        attribution row written after the audit carries the same
+        cross-ref keys as the apply row.
+        """
         try:
-            _run_autoresearch_subprocess(repo_root=repo_root, dry_run=self.rerun_dry_run)
+            _run_autoresearch_subprocess(
+                repo_root=repo_root,
+                dry_run=self.rerun_dry_run,
+                audit_run_id=audit_run_id,
+                mutation_id=mutation.mutation_id if mutation is not None else "",
+                expected_dim=mutation.expected_dim if mutation is not None else None,
+            )
         except Exception:  # pragma: no cover — defensive
             log.warning("self-improving-loop autoresearch re-run failed", exc_info=True)
 

--- a/docs/plans/2026-05-25-attribution-wiring-gap-fill.md
+++ b/docs/plans/2026-05-25-attribution-wiring-gap-fill.md
@@ -1,0 +1,234 @@
+# 2026-05-25 — Attribution Wiring Gap Fill (Cognitive-Loop Uplift PR-5 후속)
+
+> Status: **Draft** (사용자 검토 대기)
+> Framing: **wiring gap fill** — cognitive-loop-uplift sprint 의 dead-framework debt 중 attribution.py 만 처리
+> 관련 메모리: [[project-autoresearch-separation-architecture]], [[project-autoresearch-state-injection-pipeline]], [[project-autoresearch-fragmentation-audit]], [[reference-mutation-surface-frontier-2026-05-25]], [[feedback-post-implementation-verification]]
+> 정정 대상: PR #1626 RFC (`docs/plans/2026-05-25-lineage-attribution-schema.md`)
+
+## 1. Background
+
+Cognitive-loop-uplift sprint (`docs/plans/2026-05-21-cognitive-loop-uplift.md`) 의 PR-1~PR-6 모두 main merge 완료 (2026-05-20):
+- PR-1 G-A~G-E (mutator manifest) — LIVE
+- PR-2 C-1+C-6 (CognitiveState + 6 HookEvent telemetry) — LIVE
+- PR-3 C-2 (reflection node) — LIVE
+- PR-4 C-3 (episodic memory) — LIVE
+- PR-5 C-4 (causal attribution) — **framework only, production caller 0**
+- PR-6 C-5 (5-kind policy dispatcher) — LIVE 하나 `expected_dim` 생성 부재로 closed loop 미완성
+
+`self_improving_loop/` 17 모듈 분류:
+
+| 분류 | 모듈 수 | 비고 |
+|---|---|---|
+| LIVE | 11 | runner / policies / in_context_wiring / 외 8 |
+| WIRED-COLD | 1 | auto_trigger (config flag off default) |
+| FRAMEWORK-ONLY | **5** | attribution + DPO 4종 (pack/publisher/redaction/stats) |
+
+즉 wiring debt 는 attribution 만의 isolated 문제가 아니라 systemic — sprint 가 framework 깔고 wiring 을 후속에 미루는 패턴이 반복됨. 본 plan 은 그 중 attribution 만 다룬다.
+
+## 2. Frame — "wiring gap fill"
+
+| 위치 | dead-framework | 본 plan scope? |
+|---|---|---|
+| (A) `attribution.py` (PR-5 C-4) | caller 0, `compute_attribution` 호출 없음 | ✅ 본 plan |
+| (B) DPO M4 파이프라인 (`dpo_pack/publisher/redaction/stats`) | CLI endpoint 부재로 unreachable | ❌ 별 sprint |
+| (C) `auto_trigger.py` cold wiring | config flag off default | ❌ operator decision |
+
+본 plan 은 (A) 만 처리. (B)/(C) 는 GAP 자체는 인지하나 별 sprint.
+
+## 3. Goal
+
+**PR-5 attribution 의 closed loop 완성**:
+
+1. mutation 적용 시 `expected_dim` 명시 생성 (현재 LLM 이 빠뜨릴 수 있음)
+2. audit 종료 후 `compute_attribution` 호출 → mutations.jsonl 에 `kind="attribution"` row 실제 append
+3. mutation row ↔ attribution row 의 within-ledger cross-ref (`audit_run_id` correlation id) 추가. **Petri eval archive path 와의 명시 link 는 본 PR scope 밖** — 후속 PR 에서 `eval_archive` field 추가
+4. (선택) apply + attribution row 의 Pydantic schema freeze
+
+결과로 mutation → expected_dim → audit → observed_dim → attribution_score → (후속 PR 의) policy 선택 인과사슬 완성. PR-6 의 5-kind policy dispatcher 가 이 신호 기반으로 mutation 채택률을 학습할 수 있게 됨.
+
+## 4. Out of Scope
+
+- PR #1626 RFC 의 디렉토리 grouping / UUIDv7 / 4 파일 schema / day prefix — **over-engineering 으로 폐기** (§7 RFC amend 에서 명시적 drop)
+- DPO M4 wiring (dpo_pack/publisher/redaction/stats)
+- auto_trigger 활성화
+- F1 cross-run SoT 3중첩 통합 ([[project-autoresearch-fragmentation-audit]])
+- F3 mutator 가 자기 mutations.jsonl history 를 context 로 받기 (단, attribution wiring 후 자연 가능 — 후속)
+- frontier 디렉토리 grouping 패턴의 실제 채택 ([[reference-mutation-surface-frontier-2026-05-25]] 의 (multi-dim × lineage) 분면은 RFC 정정 후 single-ledger 패턴으로 재해석)
+
+## 5. 4 Wiring 작업 정의
+
+| # | Wiring | 위치 | LOC | 검증 테스트 |
+|---|---|---|---|---|
+| **W1** | mutation prompt 가 `expected_dim` 명시 요청 + parse | `core/self_improving_loop/runner.py` 의 mutator system prompt + `parse_mutation()` (line 743 부근) | ~30 | `test_mutation_prompt_requests_expected_dim`, `test_apply_row_includes_expected_dim` |
+| **W2** | `compute_attribution` caller (post-audit hook) | `autoresearch/train.py:_persist_baseline()` 직후 (T4 timing) | ~50 | `test_post_audit_writes_attribution_row`, `test_attribution_row_has_observed_dim` |
+| **W3** | `audit_run_id` field 추가 (mutation + attribution row) | `runner.py:Mutation.to_audit_row()` + `attribution.py:write_attribution()` + 호출자 chain | ~30 | `test_mutation_row_includes_audit_run_id`, `test_audit_run_id_cross_ref_works` |
+| **W4** | Pydantic schema freeze | `attribution.py:AttributionRecord` + `runner.py:ApplyRecord` 별 Pydantic | ~80 | `test_apply_record_roundtrip`, `test_attribution_record_roundtrip` |
+
+총 ~270 LOC + 8 테스트 (2026-05-25 운영자 결정 — 4 wiring 완전 묶음).
+
+### W1 상세
+
+현재 `parse_mutation()` (`runner.py:743`) 는 LLM response 에서 `expected_dim` 을 optional 로 추출 — LLM 이 빠뜨리면 빈 dict. mutation prompt 자체가 `expected_dim` 을 명시 요청하지 않음 (mutator 가 "어떤 파일의 어떤 부분 바꿔" 만 묻고, "그래서 어떤 dim 이 어떻게 움직일 거라고 기대해?" 는 안 물음).
+
+수정:
+- mutator system prompt 에 `expected_dim` 명시 요청 추가 ("for each dim you expect to move, output {dim: signed_delta_in_[-1,1]}")
+- `parse_mutation()` 에서 `expected_dim` 비어 있으면 WARNING log (validation 강화)
+
+### W2 상세
+
+`autoresearch/train.py` 의 audit 종료 시점 (`_persist_baseline()` 직후) 에:
+```python
+from core.self_improving_loop.attribution import compute_attribution, append_attribution_log
+payload = compute_attribution(
+    mutation_id=current_mutation_id,
+    expected_dim=current_mutation_expected_dim,
+    baseline_before=baseline_snapshot_before,
+    baseline_after=baseline_snapshot_after,
+    fitness_before=fitness_before,
+    fitness_after=fitness_after,
+)
+append_attribution_log(payload, log_path=MUTATION_AUDIT_LOG_PATH)
+```
+
+`current_mutation_id` + `current_mutation_expected_dim` 은 audit subprocess 의 진입 context 에서 받음 (env 또는 stdin) — 또는 가장 최근 `kind="applied"` row 를 mutations.jsonl 에서 tail 로 읽기.
+
+후자가 단순 (외부 의존 없음, JSONL tail 로 충분).
+
+### W3 상세
+
+apply row + attribution row 에 `audit_run_id` 추가 — runner 가 propose-apply-audit 한 cycle 안에서 mint 하는 **correlation id** (`uuid.uuid4().hex[:12]`). 본 PR 의 audit_run_id 는 Petri eval archive 의 path/hash 와 link 되지 않음 — 단지 within-ledger 의 (apply, attribution) row pair 를 join 하는 second key.
+
+`Mutation.to_audit_row(audit_run_id=...)` parameter 로 전달 (Mutation 자체는 frozen). attribution row 도 같은 audit_run_id carry. mutations.jsonl 단일 ledger 안에서 mutation_id (primary) + audit_run_id (secondary) 두 키로 row pair 식별.
+
+Petri eval archive path 와의 명시 link (`eval_archive` field) 는 후속 PR — `train.py:_resolve_eval_archive_path()` 의 결과를 attribution row 의 새 field 로 추가하면 됨 (~10 LOC).
+
+### W4 상세
+
+기존 dict-based row → Pydantic `ApplyRecord` + `AttributionRecord` 모델로 freeze. validation 강화 + IDE autocomplete + JSON schema export. 마이그레이션: 기존 reader 코드 (`outer_bundle.py`, `cli/commands/self_improving.py`) 의 dict 접근을 `.model_dump()` 호환 layer 로 wrap (backward-compat 보존). writer 는 `model.model_dump_json()` 으로 직렬화.
+
+## 6. PR 분할 옵션
+
+### α-1: PR-2.1 (RFC amend) + PR-3 (wiring)
+
+- PR-2.1: RFC #1626 amend (~50 LOC RFC 변경) → develop
+- PR-3: 4 wiring 구현 (~190 LOC + 6 테스트)
+- 2 PR sequential, PR-3 는 PR-2.1 merge 후 시작
+
+장점: RFC amend 와 wiring 의 의도가 명확히 분리 (문서 PR vs 코드 PR), 각 PR scope 작음
+단점: 2 PR 분리 비용, PR-3 worktree 가 RFC amend 반영을 위해 rebase 필요
+
+### α-2: PR-3 단일 PR (RFC amend + wiring 통합)
+
+- 단일 PR: RFC amend + 4 wiring 구현 (~240 LOC + 6 테스트 + RFC 1장)
+
+장점: RFC amend 의 동기 (wiring 으로 정정) 가 같은 PR 안에서 명백, sprint 1 회로 끝
+단점: PR scope 크고 review 부담 ↑
+
+**추천: α-2** — RFC amend 의 의도가 wiring 자체이므로 한 패키지로 묶는 게 자연스러움. RFC amend 만 따로 PR 으로 분리하면 reviewer 가 "왜 이렇게 amend 하나" 를 wiring 의 motivation 없이 판단해야 함.
+
+## 7. RFC amend 내용 (PR #1626 의 정정)
+
+기존 RFC `docs/plans/2026-05-25-lineage-attribution-schema.md` 의 amend 사항:
+
+| § | 기존 | amend |
+|---|---|---|
+| §0 | (Status: Final) | "Status: **Amended 2026-05-25** — 디렉토리 grouping 폐기, single-ledger 패턴으로 정정. 정정 사유: PR-5 C-4 attribution.py 의 dead-framework 발견" 추가 |
+| §4 Frontier | (multi-dim × lineage) 분면 채택 | "GEODE 의 기존 single-ledger 패턴 (`mutations.jsonl` 의 `kind` discriminator) 이 이미 (lineage × multi-dim) 두 측면을 단일 ledger 로 통합. frontier 의 디렉토리 grouping 패턴 (AlphaEvolve evolutionary DB) 은 GEODE 의 single-ledger 와 정합 안 됨 — 패턴 적용 거부" |
+| §5 디렉토리 구조 | `runs/<YYYY-MM-DD>/<UUIDv7>/{apply,pre_state,post_state}.json + trace.eval` | **폐기**. `mutations.jsonl` single-ledger 유지, `audit_run_id` field 추가로 Petri trace link 만 명시 |
+| §6 4 파일 schema | apply / pre_state / post_state / trace.eval | **폐기**. 기존 `Mutation.to_audit_row()` (16 fields) + `compute_attribution()` (13 fields) row schema 유지. `audit_run_id` field 만 추가. (선택) Pydantic freeze 는 W4 |
+| §7 Writer/Reader | runs.py 신규 모듈 | **폐기**. 기존 `runner.py:append_audit_log` + `attribution.py:append_attribution_log` writer 유지. reader 는 mutations.jsonl tail / mutation_id join |
+| §8 운영자 결정 5 항목 | UUIDv7 / symlink / day prefix / drift / siblings | **drop**: UUIDv7 (단순 hex[12] 유지), symlink (audit_run_id 로 대체), day prefix (해당없음), siblings (해당없음). **유지**: drift invariant (apply ↔ attribution 의 mutation_id 동등성 + expected_dim ↔ observed_dim 정합) |
+| §11 Acceptance Criteria | 디렉토리 / Pydantic / UUIDv7 / symlink invariant | 4 wiring 의 6 invariant 테스트로 재정의 (W1-W4) |
+| §13 Reference | AlphaEvolve / AI Scientist v2 / DGM / Voyager | frontier 그라운딩 정정 — single-ledger 패턴은 GEODE 만의 것 (openclaw/hermes/autoresearch 검증 0건). DGM/AlphaEvolve 는 lineage 측만 부차 reference |
+
+새 §0 "정정 history" 추가 — 2026-05-25 정정 사유 + 이전 결정의 어느 부분 무효 명시 ([[feedback-changelog-implementation-parity]] 정합).
+
+## 8. Acceptance Criteria
+
+### Implementation
+- [ ] W1: mutation prompt 에 `expected_dim` 요청이 명시됨, mutation row 의 `expected_dim` 이 non-empty 로 append
+- [ ] W2: audit 종료 후 `compute_attribution` 호출 + attribution row append
+- [ ] W3: mutation row + attribution row 모두 `audit_run_id` field 가짐, mutation_id + audit_run_id 두 키로 row pair 식별 가능 (Petri eval archive link 는 후속 PR)
+- [ ] W4: Pydantic ApplyRecord / AttributionRecord schema roundtrip 통과 + backward-compat dict reader wrap
+
+### Invariant tests (6)
+- [ ] `test_mutation_prompt_requests_expected_dim`
+- [ ] `test_apply_row_includes_expected_dim_after_parse`
+- [ ] `test_post_audit_writes_attribution_row`
+- [ ] `test_mutation_id_join_apply_to_attribution`
+- [ ] `test_audit_run_id_cross_ref_with_petri_eval`
+- [ ] `test_backward_compat_dict_row_reader_unchanged`
+
+### Quality gates
+- [ ] `uv run ruff check core/ tests/ plugins/`
+- [ ] `uv run ruff format --check core/ tests/ plugins/`
+- [ ] `uv run mypy core/ plugins/`
+- [ ] `uv run pytest tests/core/self_improving_loop/ tests/test_attribution_belief.py tests/test_causal_attribution.py -q`
+- [ ] `uv run lint-imports`
+- [ ] CLI smoke: `uv run geode version`
+
+### Codex MCP verification
+- [ ] Diff cross-LLM 검증 — 4 wiring 의 production caller chain 완성, dead code 없음
+- [ ] Closed loop 검증 — mutation → expected_dim → audit → observed_dim → attribution_score 인과사슬
+- [ ] RFC amend 정정 사항이 diff 와 1:1 매치 ([[feedback-changelog-implementation-parity]])
+- [ ] Out-of-scope leak 없음 (DPO M4 framework 등 isolated 변경이 없도록 scope confine)
+
+## 9. Codex MCP 검증 단계
+
+[[feedback-codex-mcp-verification]] 따라 PR push 직전 Codex MCP (`mcp__codex__codex`) 호출:
+
+```
+prompt:
+  GEODE self-improving-loop 의 attribution wiring gap fill PR-3 diff 를 검증해줘.
+  4 wiring (W1-W4) 의 production caller chain 이 끊김 없이 연결되는지 + closed loop
+  (mutation → expected_dim → audit → observed_dim → attribution_score) 가 완성되는지 +
+  RFC #1626 amend 사항이 diff 의 변경과 정합하는지 cross-check.
+
+  특히 다음 anti-deception 패턴 확인:
+  - mutation_id 가 attribution row 에 실제 propagate 되는가 (silent disconnect?)
+  - compute_attribution 호출 시 baseline_before/after 가 stale 가능성 (T4 race)
+  - expected_dim parse 가 fail 시 fallback behavior 가 quota 낭비를 방지하는가
+  - DPO M4 framework 같은 isolated 변경이 포함됐는가 (scope leak)
+```
+
+sandbox=read-only, approval-policy=never.
+
+## 10. Sprint 추정
+
+| 단계 | 시간 | LOC |
+|---|---|---|
+| Plan 검토 + 승인 (현재) | — | — |
+| Worktree 할당 | 1 min | — |
+| RFC amend draft | 15 min | RFC ±50 |
+| W1 mutation prompt + parse | 20 min | ~30 |
+| W2 compute_attribution caller | 30 min | ~50 |
+| W3 audit_run_id field | 20 min | ~30 |
+| W4 Pydantic freeze | 40 min | ~80 |
+| 8 invariant 테스트 작성 | 50 min | ~200 (테스트) |
+| Local quality gates | 5 min | — |
+| Codex MCP 검증 | 15 min | — |
+| PR 생성 + CI watch + merge | 15 min | — |
+| **Total** | **~3시간** | **~340** |
+
+## 11. 후속 작업 (본 PR scope 밖, Codex MCP 검증 #5/#6 잔존 항목 포함)
+
+- **F1 cross-run SoT 3중첩 통합** (별 sprint) — [[project-autoresearch-fragmentation-audit]] F1
+- **F3 mutator history reader wiring** — mutations.jsonl tail + mutation_id join 으로 mutator context 풍부화 (~20 LOC)
+- **G2 rollback_condition enforcement** — attribution row 의 observed_dim 과 apply row 의 rollback_condition 비교, fitness 저하 시 자동 revert
+- **audit_run_id ↔ Petri eval_archive 명시 link** (Codex MCP 검증 #5 잔존) — attribution row 에 `eval_archive` field 추가 (`train.py:_resolve_eval_archive_path()` 결과 forward, ~10 LOC)
+- **baseline_before T3 snapshot 캡처** (Codex MCP 검증 #6 잔존) — train.py 가 T4 시점 baseline.json 을 read 하므로 T3↔T4 사이 다른 mutation 이 baseline 을 promote 했으면 stale 위험. `core/llm/audit_lane.py` 의 OL-P2 audit_lane=1 가 host 단위 mitigate (host 당 동시 audit 1개), multi-host scenario 는 별 incident. T3 snapshot 을 env 또는 임시 파일로 propagate 하면 race 자체 제거 (~30 LOC)
+- **self-improving runner concurrent run 방지** (Codex MCP 검증 #6 잔존) — file lock (`fcntl.LOCK_EX` on mutations.jsonl) 또는 host-level pid file 로 두 runner 동시 실행 차단
+- **MCTS sibling exploration** — frontier 패턴 #3 (AFLOW/SELA/BFTS), siblings field 활성화
+
+## 12. Reference
+
+- 2026-05-21 plan: `docs/plans/2026-05-21-cognitive-loop-uplift.md` (PR-1~PR-6 cognitive uplift sprint)
+- 2026-05-25 RFC: `docs/plans/2026-05-25-lineage-attribution-schema.md` (PR #1626 — 본 plan 으로 amend)
+- Memory:
+  - [[project-autoresearch-separation-architecture]] — 5 kind mutation surface 의 분리 구조
+  - [[project-autoresearch-state-injection-pipeline]] — env propagation + 12-kind STRICT 모드
+  - [[project-autoresearch-fragmentation-audit]] — F1/F2/F3 파편화 신호 (본 wiring 으로 F3 enabler)
+  - [[reference-mutation-surface-frontier-2026-05-25]] — frontier 16건 (정정 후 single-ledger 가 GEODE 만의 패턴)
+  - [[feedback-post-implementation-verification]] — 본 plan 작성 자체가 이 feedback 의 3번째 사례 (PR-1 ENV-PROPAGATION drop + 이번 attribution.py + DPO M4 framework 발견)
+  - [[feedback-codex-mcp-verification]] — §9 Codex MCP 검증 단계
+  - [[feedback-changelog-implementation-parity]] — §7 RFC amend 의 정정 history + §8 Codex verification 포함 사유

--- a/docs/plans/2026-05-25-lineage-attribution-schema.md
+++ b/docs/plans/2026-05-25-lineage-attribution-schema.md
@@ -1,9 +1,36 @@
 # 2026-05-25 — Lineage + Attribution Schema (RFC)
 
-> Status: **Final** (2026-05-25 운영자 5 항목 일괄 채택)
-> Scope: PR-3 LINEAGE+ATTRIBUTION 통합 구현의 사전 schema 확정
+> Status: **Amended 2026-05-25** — 디렉토리 grouping / UUIDv7 / 4 파일 schema 모두 폐기, single-ledger 패턴으로 정정
+> Scope: PR-3 ATTRIBUTION WIRING 사전 schema 확정 (이전 "LINEAGE+ATTRIBUTION 통합" → "wiring gap fill" 로 재정의)
 > Sprint: PR-2 SCHEMA-DESIGN
-> 관련 메모리: [[project-autoresearch-separation-architecture]], [[project-autoresearch-state-injection-pipeline]], [[project-autoresearch-fragmentation-audit]], [[reference-mutation-surface-frontier-2026-05-25]]
+> 관련 메모리: [[project-autoresearch-separation-architecture]], [[project-autoresearch-state-injection-pipeline]], [[project-autoresearch-fragmentation-audit]], [[reference-mutation-surface-frontier-2026-05-25]], [[feedback-post-implementation-verification]]
+> Follow-up plan: [2026-05-25 Attribution Wiring Gap Fill](./2026-05-25-attribution-wiring-gap-fill.md)
+
+## 0. 정정 history (2026-05-25 amend)
+
+본 RFC 의 초기 결정 (디렉토리 grouping + UUIDv7 + 4 파일 schema + day prefix) 은 PR-3 worktree 의 GAP audit 단계에서 다음 사실을 발견하여 **전면 정정**:
+
+| 발견 | 영향 |
+|---|---|
+| `core/self_improving_loop/attribution.py` (PR-5 C-4, 2026-05-21) 가 이미 `compute_attribution()` 으로 multi-dim attribution payload (`observed_dim`, `ci95`, `significant`, `attribution_score`, `confidence_stability`) 생산하며 결과를 mutations.jsonl 의 `kind="attribution"` row 로 append 하는 single-ledger 패턴 채택 | 본 RFC 의 `post_state.json` 별 파일 + 디렉토리 grouping schema 와 충돌 |
+| `core/self_improving_loop/runner.py:822, 842` 가 이미 `previous_value` 를 mutations.jsonl 의 apply row 에 저장 | 본 RFC 의 `pre_state.json` 의 lineage 측 부분 무효 |
+| `compute_attribution` 의 production caller 0 (tests/ 만) — PR-5 framework only, PR-6 wiring 이 빠짐 | 본 RFC 가 사실상 그 wiring gap 을 채우는 작업이었음 — 새 schema 가 아니라 기존 schema 의 caller 추가가 정답 |
+| openclaw / hermes / autoresearch 어느 곳에서도 디렉토리 grouping 패턴 검증 0건 — single-ledger + `kind` discriminator 가 GEODE 만의 패턴 | §4 frontier 그라운딩의 (multi-dim × lineage) 분면 채택 근거 약화 |
+
+[[feedback-post-implementation-verification]] 위반 사례 — RFC 작성 전에 `grep -rn "attribution" core/self_improving_loop/` 한 번이면 발견했을 것. 후속 plan ([Attribution Wiring Gap Fill](./2026-05-25-attribution-wiring-gap-fill.md)) 으로 정정된 4 wiring 진행.
+
+**유효한 결정** (amend 후 유지):
+- (선택) Pydantic schema freeze (W4)
+- drift invariant (apply ↔ attribution 의 mutation_id 동등성)
+- `audit_run_id` field 추가 (mutation row ↔ Petri eval cross-ref)
+
+**무효 결정** (amend 후 폐기):
+- 디렉토리 grouping (`runs/<YYYY-MM-DD>/<UUIDv7>/`)
+- UUIDv7 (단순 hex[12] 유지)
+- day prefix
+- 4 파일 schema (apply/pre_state/post_state/trace.eval)
+- `siblings: []` 필드 예약
+- relative symlink for trace.eval (`audit_run_id` field 로 대체)
 
 ## 1. 배경
 
@@ -29,6 +56,8 @@ frontier 패턴 중 GEODE 가 점유할 분면은 **(multi-dim × lineage)** —
 
 ## 4. Frontier 그라운딩
 
+> **[AMENDED 2026-05-25]** — GEODE 의 기존 single-ledger 패턴 (mutations.jsonl 의 `kind` discriminator) 이 이미 (lineage × multi-dim) 두 측면을 단일 ledger 로 통합. frontier 의 디렉토리 grouping 패턴 (AlphaEvolve evolutionary DB) 은 GEODE 와 정합 안 됨 — 패턴 적용 거부. openclaw/hermes/autoresearch 검증에서도 디렉토리 grouping 사례 0건. 이하 4분면 표는 historical reference (이론적 분류, 채택 안 함).
+
 frontier 16건은 **2 직교 차원** 으로 분류 가능:
 - **Lineage** (storage): mutation trace 를 append-only archive 로 보존하는가
 - **Multi-dim** (semantic): mutation 의 효과를 N≥2 차원으로 측정하는가
@@ -52,6 +81,8 @@ frontier 16건은 **2 직교 차원** 으로 분류 가능:
 
 ## 5. 디렉토리 구조
 
+> **[AMENDED 2026-05-25]** — 본 § 의 디렉토리 grouping schema 는 폐기. mutations.jsonl single-ledger 패턴 유지 + `audit_run_id` field 만 추가. 정정된 schema 는 [follow-up plan §5/§7](./2026-05-25-attribution-wiring-gap-fill.md) 참조. 이하 내용은 historical record.
+
 ```
 autoresearch/state/
 ├── mutations.jsonl                          # 기존 index ledger (유지, drift invariant 로 동기)
@@ -67,6 +98,8 @@ autoresearch/state/
 `<YYYY-MM-DD>` 예: `2026-05-25/`. 일별 prefix 로 디렉토리당 항목 수 안전 확보 (월 1000 mutation 시 일 ~33 < 50). `pre_state` / `post_state` 명명은 두 파일이 multi-dim mutation lineage 의 (before/after) 양면임을 명시화 — frontier 의 (multi-dim × lineage) 분면 채택과 정합.
 
 ## 6. 파일별 Schema
+
+> **[AMENDED 2026-05-25]** — 4 파일 schema (`apply.json`/`pre_state.json`/`post_state.json`/`trace.eval`) 모두 폐기. 기존 `Mutation.to_audit_row()` (16 fields, runner.py:127-164) + `compute_attribution()` (13 fields, attribution.py:171-235) 의 row schema 그대로 유지. `audit_run_id` field 만 추가. (선택) Pydantic schema freeze (W4) 는 [follow-up plan §5/W4](./2026-05-25-attribution-wiring-gap-fill.md) 참조. 이하 내용은 historical record.
 
 ### 6.1 `apply.json`
 
@@ -146,6 +179,8 @@ audit subprocess 가 종료 시 `docs/petri-bundle/logs/<audit_id>.eval` 를 가
 
 ## 7. Writer / Reader 책임
 
+> **[AMENDED 2026-05-25]** — 신규 `core/self_improving_loop/runs.py` 모듈 + 4 writer hook 모두 폐기. 기존 writer 유지: `runner.py:append_audit_log()` (apply row, T3) + `attribution.py:append_attribution_log()` (attribution row, T4). 정정된 wiring 위치는 [follow-up plan §5 W1-W4](./2026-05-25-attribution-wiring-gap-fill.md) 참조. 이하 내용은 historical record.
+
 ### Writer
 
 | 파일 | Writer 함수 | 위치 | 시점 |
@@ -183,6 +218,8 @@ def load_post_state_for_mutation(mutation_id: str) -> PostStateRecord | None: ..
 
 ## 8. 운영자 결정 사항 (2026-05-25 일괄 채택)
 
+> **[AMENDED 2026-05-25]** — Q1 UUIDv7 / Q2 symlink / Q3 day prefix / Q5 siblings 모두 폐기 (해당 항목 자체 부재). Q4 drift invariant 만 유효 (apply ↔ attribution mutation_id 동등성 + expected_dim ↔ observed_dim 정합). 추가 결정 사항: `audit_run_id` field, Pydantic schema freeze. 이하 표는 historical record.
+
 | # | 항목 | 채택 | 근거 |
 |---|---|---|---|
 | Q1 | mutation_id 형식 | **UUIDv7** (RFC 9562) | time-sortable, `runs/2026-05-25/<uuidv7>/` 디렉토리 시간순 정렬, mutator history reader 효율. 기존 mutations.jsonl UUID4 row 는 backward-compat 유지, 신규 mutation 부터 UUIDv7 |
@@ -205,6 +242,8 @@ def load_post_state_for_mutation(mutation_id: str) -> PostStateRecord | None: ..
 ⚠️ PR-3 구현 전 `git check-ignore autoresearch/state/runs/2026-05-25/test-id/apply.json` 으로 실제 ignore 정책 확인 + 회귀 invariant 테스트 ([[project-petri-p1-handoff]] PR-G5b 의 silent-ignored writer 사례 회피).
 
 ## 11. PR-3 Acceptance Criteria
+
+> **[AMENDED 2026-05-25]** — 본 § 의 acceptance criteria 폐기. 정정된 acceptance 는 [follow-up plan §8](./2026-05-25-attribution-wiring-gap-fill.md) 의 4 wiring (W1-W4) + 8 invariant tests. 이하 내용은 historical record.
 
 - [ ] 디렉토리 구조 §5 와 정확히 매치 (`runs/<YYYY-MM-DD>/<UUIDv7>/`)
 - [ ] 4 파일 schema §6 와 정확히 매치 (Pydantic model 로 freeze: `ApplyRecord`, `PreStateRecord`, `PostStateRecord`)

--- a/tests/core/self_improving_loop/test_attribution_wiring.py
+++ b/tests/core/self_improving_loop/test_attribution_wiring.py
@@ -1,0 +1,379 @@
+"""Tests for the 2026-05-25 attribution wiring (W1-W4).
+
+Covers the closed loop completion from
+``docs/plans/2026-05-25-attribution-wiring-gap-fill.md`` §5:
+
+* **W1** — ``expected_dim`` is requested by the mutator prompt and
+  warned-on-empty by ``parse_mutation``.
+* **W2** — the ``compute_attribution`` caller hook in
+  ``autoresearch/train.py`` fires when ``GEODE_SIL_*`` env triplet is
+  set, and skips otherwise (legacy --promote preserved).
+* **W3** — ``audit_run_id`` propagates from ``apply_proposal`` through
+  ``Mutation.to_audit_row`` and the autoresearch subprocess env.
+* **W4** — ``ApplyRecord`` / ``AttributionRecord`` Pydantic schemas
+  freeze the mutations.jsonl row shape; ``extra="allow"`` keeps legacy
+  dict rows readable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.attribution import (
+    AttributionRecord,
+    append_attribution_log,
+)
+from core.self_improving_loop.runner import (
+    _MUTATION_CONTRACT_SUFFIX,
+    ApplyRecord,
+    Mutation,
+    _run_autoresearch_subprocess,
+    append_audit_log,
+    parse_mutation,
+)
+from pydantic import ValidationError
+
+# ---------------------------------------------------------------------------
+# W1 — mutator prompt + parse_mutation
+# ---------------------------------------------------------------------------
+
+
+class TestW1ExpectedDimPromptAndParse:
+    def test_mutation_contract_suffix_requests_expected_dim(self) -> None:
+        """The mutator prompt must explicitly request ``expected_dim`` so
+        PR-5 attribution can compute observed vs expected delta.
+
+        Regression guard for the closed-loop wiring — without this the
+        LLM has no reason to populate ``expected_dim`` and attribution
+        scores degrade to 0.0 silently.
+        """
+        assert '"expected_dim"' in _MUTATION_CONTRACT_SUFFIX
+        assert "expected delta" in _MUTATION_CONTRACT_SUFFIX
+        assert (
+            "PR-5 attribution" in _MUTATION_CONTRACT_SUFFIX
+            or "attribution" in _MUTATION_CONTRACT_SUFFIX
+        )
+
+    def test_parse_mutation_warns_on_empty_expected_dim(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """W1: missing ``expected_dim`` is a silent dead-loop signal —
+        ``parse_mutation`` must surface it via WARNING log so operators
+        can spot mutators that drop the commitment."""
+        raw = json.dumps(
+            {
+                "target_section": "thinking_visibility",
+                "new_value": "Surface your reasoning.",
+                "rationale": "operator request",
+                # expected_dim intentionally omitted
+            }
+        )
+        with caplog.at_level(logging.WARNING, logger="core.self_improving_loop.runner"):
+            mutation = parse_mutation(raw)
+        assert mutation.expected_dim == {}
+        assert any("empty expected_dim" in record.getMessage() for record in caplog.records)
+
+    def test_parse_mutation_no_warning_when_expected_dim_populated(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """W1 negative case — populated ``expected_dim`` must NOT warn."""
+        raw = json.dumps(
+            {
+                "target_section": "thinking_visibility",
+                "new_value": "Surface your reasoning.",
+                "rationale": "operator request",
+                "expected_dim": {"helpfulness": 0.1},
+            }
+        )
+        with caplog.at_level(logging.WARNING, logger="core.self_improving_loop.runner"):
+            mutation = parse_mutation(raw)
+        assert mutation.expected_dim == {"helpfulness": 0.1}
+        assert not any("empty expected_dim" in record.getMessage() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# W2 — subprocess env propagation
+# ---------------------------------------------------------------------------
+
+
+class TestW2SubprocessEnvPropagation:
+    def test_run_autoresearch_subprocess_sets_sil_env_when_triplet_supplied(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """W2: when ``audit_run_id`` + ``mutation_id`` are supplied,
+        env triplet must propagate to subprocess. Captures the env dict
+        passed to subprocess.run via monkeypatch instead of actually
+        spawning."""
+        captured: dict[str, str] = {}
+
+        def fake_run(argv: list[str], *args: object, **kwargs: object) -> object:
+            env = kwargs.get("env") or {}
+            captured.update({k: v for k, v in env.items() if k.startswith("GEODE_SIL_")})
+
+            class _Fake:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Fake()
+
+        monkeypatch.setattr(
+            "core.self_improving_loop.runner.subprocess.run",
+            fake_run,
+        )
+        _run_autoresearch_subprocess(
+            repo_root=tmp_path,
+            dry_run=True,
+            audit_run_id="audit-abc123",
+            mutation_id="mut-xyz789",
+            expected_dim={"safety": 0.3, "helpfulness": -0.05},
+        )
+        assert captured["GEODE_SIL_AUDIT_RUN_ID"] == "audit-abc123"
+        assert captured["GEODE_SIL_MUTATION_ID"] == "mut-xyz789"
+        # JSON encoded — parse and compare for stability against key order
+        parsed = json.loads(captured["GEODE_SIL_EXPECTED_DIM"])
+        assert parsed == {"safety": 0.3, "helpfulness": -0.05}
+
+    def test_run_autoresearch_subprocess_skips_env_when_triplet_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """W2 negative — legacy --promote / standalone audit (no
+        attribution context) must NOT inject the env triplet."""
+        captured: dict[str, str] = {}
+
+        def fake_run(argv: list[str], *args: object, **kwargs: object) -> object:
+            env = kwargs.get("env") or {}
+            captured.update({k: v for k, v in env.items() if k.startswith("GEODE_SIL_")})
+
+            class _Fake:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Fake()
+
+        monkeypatch.setattr(
+            "core.self_improving_loop.runner.subprocess.run",
+            fake_run,
+        )
+        _run_autoresearch_subprocess(repo_root=tmp_path, dry_run=True)
+        assert "GEODE_SIL_AUDIT_RUN_ID" not in captured
+        assert "GEODE_SIL_MUTATION_ID" not in captured
+        assert "GEODE_SIL_EXPECTED_DIM" not in captured
+
+
+# ---------------------------------------------------------------------------
+# W3 — audit_run_id field on apply row
+# ---------------------------------------------------------------------------
+
+
+class TestW3AuditRunIdField:
+    def test_apply_row_includes_audit_run_id_when_supplied(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """W3: ``append_audit_log(audit_run_id="...")`` writes a row
+        with ``audit_run_id`` populated. Within-ledger correlation id
+        (NOT a Petri eval archive path — that link is a follow-up PR;
+        see plan §11)."""
+        log_path = tmp_path / "mutations.jsonl"
+        mutation = Mutation(
+            target_section="role",
+            new_value="You are GEODE.",
+            rationale="test",
+            expected_dim={"safety": 0.1},
+        )
+        append_audit_log(
+            mutation,
+            previous_value="",
+            log_path=log_path,
+            audit_run_id="audit-test-run-id",
+        )
+        rows = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+        assert len(rows) == 1
+        assert rows[0]["audit_run_id"] == "audit-test-run-id"
+        assert rows[0]["mutation_id"] == mutation.mutation_id
+        assert rows[0]["expected_dim"] == {"safety": 0.1}
+
+    def test_apply_row_omits_audit_run_id_when_blank(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """W3 backward compat — legacy --promote / manual run produces
+        no audit_run_id column. Legacy reader stays graceful."""
+        log_path = tmp_path / "mutations.jsonl"
+        mutation = Mutation(
+            target_section="role",
+            new_value="You are GEODE.",
+            rationale="test",
+        )
+        append_audit_log(mutation, previous_value="", log_path=log_path)
+        row = json.loads(log_path.read_text().splitlines()[0])
+        assert "audit_run_id" not in row
+
+
+# ---------------------------------------------------------------------------
+# W4 — Pydantic schema freeze
+# ---------------------------------------------------------------------------
+
+
+class TestW4PydanticSchemaFreeze:
+    def test_apply_record_roundtrip(self) -> None:
+        """W4: ApplyRecord schema accepts a complete apply row and
+        survives roundtrip without information loss."""
+        row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "mut-abc",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "old",
+            "new_value": "new",
+            "rationale": "test",
+            "target_dim": "helpfulness",
+            "expected_dim": {"helpfulness": 0.2},
+            "rollback_condition": "any dim drops > 0.5",
+            "baseline_fitness": 0.42,
+            "audit_run_id": "audit-xyz",
+        }
+        record = ApplyRecord.model_validate(row)
+        dumped = record.model_dump(exclude_none=True)
+        # All supplied fields round-trip
+        for key, value in row.items():
+            assert dumped[key] == value
+
+    def test_attribution_record_roundtrip(self) -> None:
+        """W4: AttributionRecord schema accepts a complete attribution
+        row including W3 ``audit_run_id`` + PR-E confidence trajectory."""
+        payload = {
+            "ts": 1716638500.0,
+            "kind": "attribution",
+            "mutation_id": "mut-abc",
+            "observed_dim": {"helpfulness": 0.15},
+            "ci95": {"helpfulness": 0.08},
+            "significant": {"helpfulness": True},
+            "attribution_score": 0.15,
+            "missing_baseline": False,
+            "confidence_trajectory": [0.7, 0.8, 0.75],
+            "confidence_stability": 0.95,
+            "fitness_before": 0.40,
+            "fitness_after": 0.42,
+            "fitness_delta": 0.02,
+            "audit_run_id": "audit-xyz",
+        }
+        record = AttributionRecord.model_validate(payload)
+        dumped = record.model_dump(exclude_none=True)
+        for key, value in payload.items():
+            assert dumped[key] == value
+
+    def test_apply_record_rejects_wrong_kind(self) -> None:
+        """W4: schema enforces ``kind="applied"`` literal — drift fails
+        fast at the writer boundary so a stray ``attribution`` row
+        cannot leak into the apply lane."""
+        bad = {
+            "ts": 1716638400.0,
+            "kind": "attribution",  # wrong kind
+            "mutation_id": "mut-abc",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+        }
+        with pytest.raises(ValidationError):
+            ApplyRecord.model_validate(bad)
+
+    def test_legacy_dict_row_with_extra_fields_passes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """W4 backward compat — legacy mutations.jsonl rows may carry
+        keys this PR doesn't model (e.g. a future field). ``extra="allow"``
+        keeps validation green so historical rows stay readable."""
+        future_field_row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "mut-legacy",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+            "rationale": "",
+            "future_feature_flag": "experimental",  # unknown
+        }
+        record = ApplyRecord.model_validate(future_field_row)
+        assert record.mutation_id == "mut-legacy"
+
+    def test_append_attribution_log_validates_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """W4: append_attribution_log runs the Pydantic validator before
+        write so invalid payloads never reach disk."""
+        log_path = tmp_path / "mutations.jsonl"
+        bad_payload = {
+            "ts": "not-a-float",  # invalid type
+            "kind": "attribution",
+            "mutation_id": "mut-x",
+        }
+        with pytest.raises(ValidationError):
+            append_attribution_log(bad_payload, log_path=log_path)
+        assert not log_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Cross-ref invariant — mutation_id join
+# ---------------------------------------------------------------------------
+
+
+class TestMutationIdJoin:
+    def test_apply_and_attribution_share_mutation_id(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The whole point of the wiring: apply row + attribution row
+        in the same mutations.jsonl can be joined by ``mutation_id``."""
+        log_path = tmp_path / "mutations.jsonl"
+        mutation = Mutation(
+            target_section="role",
+            new_value="You are GEODE.",
+            rationale="test",
+            expected_dim={"safety": 0.1},
+        )
+        append_audit_log(
+            mutation,
+            previous_value="",
+            log_path=log_path,
+            audit_run_id="audit-join-test",
+        )
+        # Attribution side — payload mimics what compute_attribution
+        # would produce when called from train.py's W2 hook.
+        attribution_payload = {
+            "ts": 1716638500.0,
+            "kind": "attribution",
+            "mutation_id": mutation.mutation_id,  # same id
+            "observed_dim": {"safety": 0.05},
+            "ci95": {"safety": 0.02},
+            "significant": {"safety": True},
+            "attribution_score": 0.05,
+            "missing_baseline": False,
+            "confidence_trajectory": [],
+            "confidence_stability": None,
+            "audit_run_id": "audit-join-test",
+        }
+        append_attribution_log(attribution_payload, log_path=log_path)
+
+        rows = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+        assert len(rows) == 2
+        apply_row = next(r for r in rows if r["kind"] == "applied")
+        attribution_row = next(r for r in rows if r["kind"] == "attribution")
+        assert apply_row["mutation_id"] == attribution_row["mutation_id"]
+        assert apply_row["audit_run_id"] == attribution_row["audit_run_id"]

--- a/tests/test_causal_attribution.py
+++ b/tests/test_causal_attribution.py
@@ -300,7 +300,14 @@ def test_compute_attribution_missing_after_returns_empty_shape() -> None:
 
 def test_append_attribution_log_writes_one_row(tmp_path: Path) -> None:
     log_path = tmp_path / "mutations.jsonl"
-    payload = {"mutation_id": "m-1", "kind": "attribution", "observed_dim": {"safety": 0.3}}
+    # W4 (2026-05-25) — Pydantic AttributionRecord requires ``ts``;
+    # legacy minimal-payload pattern updated to include the timestamp.
+    payload = {
+        "ts": 1716638400.0,
+        "mutation_id": "m-1",
+        "kind": "attribution",
+        "observed_dim": {"safety": 0.3},
+    }
     out = append_attribution_log(payload, log_path=log_path)
     assert out == log_path
     rows = log_path.read_text(encoding="utf-8").strip().splitlines()
@@ -313,7 +320,10 @@ def test_append_attribution_log_writes_one_row(tmp_path: Path) -> None:
 def test_append_attribution_log_appends_to_existing_file(tmp_path: Path) -> None:
     log_path = tmp_path / "mutations.jsonl"
     log_path.write_text('{"existing":true}\n', encoding="utf-8")
-    append_attribution_log({"mutation_id": "m-1", "kind": "attribution"}, log_path=log_path)
+    append_attribution_log(
+        {"ts": 1716638400.0, "mutation_id": "m-1", "kind": "attribution"},
+        log_path=log_path,
+    )
     rows = log_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(rows) == 2
     assert json.loads(rows[0]) == {"existing": True}


### PR DESCRIPTION
## Summary
- Cognitive-loop-uplift sprint (2026-05-21) 의 PR-5 C-4 attribution.py framework-only 상태 (production caller 0) 를 4 wiring (W1-W4) 로 closed loop 완성
- RFC #1626 amend — 디렉토리 grouping / UUIDv7 / 4 파일 schema 모두 폐기, single-ledger 패턴 유지
- Codex MCP cross-LLM 검증 통과 (4 PASS, 2 WARN 잔존 항목 후속 PR 로 명시 분리)

## Why
2026-05-21 cognitive-loop-uplift sprint 의 6 PR (PR-1~PR-6) 이 모두 main merge 됐지만 PR-5 의 `compute_attribution()` production caller 가 0 (tests/ 만) — framework 만 깔리고 wiring 은 PR-6 으로 미뤘는데 PR-6 가 5-kind dispatcher 만 wire 하고 attribution 은 빠뜨림. self_improving_loop/ 17 모듈 중 5개 (attribution + DPO M4 4종) 가 같은 FRAMEWORK-ONLY 패턴 — wiring debt 가 systemic.

본 PR 가 그 중 attribution 만 처리. mutation → expected_dim → audit → observed_dim → attribution_score 인과사슬 완성 → PR-6 의 5-kind policy dispatcher 가 이 신호 기반으로 mutation 채택률을 학습할 수 있게 됨.

기존 PR-2 RFC (#1626) 는 디렉토리 grouping / UUIDv7 / 4 파일 schema 를 제안했으나, GAP audit 단계에서 attribution.py 의 single-ledger 패턴 + previous_value 가 이미 mutations.jsonl 에 저장 발견 → RFC 폐기 + single-ledger 유지로 정정. [[feedback-post-implementation-verification]] 3번째 사례.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | +129 — ApplyRecord Pydantic + audit_run_id mint + env propagation + expected_dim WARNING |
| `core/self_improving_loop/attribution.py` | +43 — AttributionRecord Pydantic + audit_run_id propagation |
| `autoresearch/train.py` | +57 — _persist_baseline 직후 GEODE_SIL_* env 받고 write_attribution 호출 |
| `tests/core/self_improving_loop/test_attribution_wiring.py` | 신규 +379 — 13 invariant tests (W1-W4 + mutation_id join) |
| `tests/test_causal_attribution.py` | +14 — legacy minimal-payload tests 의 ts field 보강 (Pydantic strict 정합) |
| `docs/plans/2026-05-25-attribution-wiring-gap-fill.md` | 신규 +234 — plan 문서 |
| `docs/plans/2026-05-25-lineage-attribution-schema.md` | +45 — RFC #1626 amend (§0 정정 history + §4/§5/§6/§7/§8/§11 amend) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| W1 expected_dim prompt + parse | Partially → Wired | Prompt + parse 는 PR-5 에 이미 있음, WARNING log 만 신규 (5 LOC) |
| W2 compute_attribution caller | Not Implemented → Wired | train.py:_persist_baseline 직후 hook 추가 |
| W3 audit_run_id field | Not Implemented → Wired | within-ledger correlation id (Petri eval link 는 후속) |
| W4 Pydantic schema freeze | Not Implemented → Wired | ApplyRecord + AttributionRecord, writer side validation |
| Petri eval_archive link | Dropped to followup | Codex MCP 검증 #5 — plan §11 후속 |
| Baseline T3 snapshot | Dropped to followup | Codex MCP 검증 #6 — OL-P2 audit_lane=1 가 host 단위 mitigate |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean (19 source files)
- [x] pytest impacted areas — **228 passed** (tests/core/self_improving_loop/ + tests/test_attribution_belief.py + tests/test_causal_attribution.py + tests/test_autoresearch_train.py + tests/test_self_improving_*)
- [x] lint-imports — 4 contracts kept
- [x] Codex MCP cross-LLM verification (threadId 019e5cf0-6f55-7c42-84bc-7db59f3513bb): 4 PASS, 2 WARN (잔존 항목 plan §11 후속으로 명시 분리)

## Reference
- Plan: `docs/plans/2026-05-25-attribution-wiring-gap-fill.md` (본 PR 산출물)
- RFC amend: `docs/plans/2026-05-25-lineage-attribution-schema.md` (PR #1626 amend, single-ledger 패턴 유지)
- Cognitive-loop-uplift sprint: `docs/plans/2026-05-21-cognitive-loop-uplift.md` (PR-1~PR-6 origin)
- Memory: project-autoresearch-separation-architecture, project-autoresearch-state-injection-pipeline, project-autoresearch-fragmentation-audit, reference-mutation-surface-frontier-2026-05-25, feedback-post-implementation-verification, feedback-codex-mcp-verification, feedback-changelog-implementation-parity