### PR TITLE
fix(seed-gen): evolver Jaccard threshold 0.70→0.90 + actual-score log (PR-EVOLVER-JACCARD-OBS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,29 @@ functional change.
   extended with a literature column without schema churn.
 
 ### Fixed
+- **PR-EVOLVER-JACCARD-OBS** — Evolver anti-convergence guard
+  observability + threshold tune. The CSP-6 Jaccard guard now logs
+  the actual measured score and the offending comparison target
+  (`parent:<id>` or `sibling:<evolved_id>`) when it coerces a
+  verdict to `evolution_skipped`, replacing the previous log line
+  that only reported the static threshold. The threshold itself was
+  raised 0.70 → 0.90 to match the prompt's single-section ±20%
+  rewrite contract (`plugins/seed_generation/agents/evolver.md`) —
+  under that constraint, two compliant evolutions naturally share
+  80-90% of their 5-grams. The original 0.70 mirrored
+  co-scientist's pool-deduplication threshold (where the evolver
+  was free to rewrite the entire body). Smoke 14 (archive
+  `.audit/smoke-archives/smoke-14-1779674544/`) iter-2 evolver
+  measured 5-gram Jaccard **0.8437** between parent
+  `gen1-002-e2b9f471` and its single-bullet rewrite ("all other
+  bullets preserved verbatim" per the LLM's own notes); the 0.70
+  threshold falsely rejected it as a near-duplicate, surfacing as
+  `verdict_not_ok` phase failure. The internal API renamed from
+  `_is_near_duplicate(parsed, ..., ...) -> bool` to
+  `_check_near_duplicate(...) -> tuple[bool, float, str]`. Tests:
+  8 in `tests/plugins/seed_generation/test_evolver_anti_convergence
+  .py` including a smoke-14 replay that pins the empirical anchor
+  (Jaccard ≈ 0.85 admitted at 0.90, rejected at 0.70).
 - **PR-JSON-WIRE** — per-role JSON Schema wire-through. New
   `plugins/seed_generation/json_schemas.py` declares 7 schemas
   (PROXIMITY / CRITIQUE / PILOT / VOTE / EVOLVE / META_REVIEW /

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -72,13 +72,27 @@ _VALID_VERDICTS = frozenset({"ok", "evolution_skipped", "failed"})
 # seed body whose 5-gram Jaccard against any sibling evolved (or
 # pre-existing) candidate exceeds this is treated as "too close" —
 # the verdict gets coerced to ``evolution_skipped`` so the parent
-# candidate stays. 0.70 mirrors the original co-scientist
-# ``DUPLICATE_SIMILARITY_THRESHOLD`` (``open-coscientist/nodes/
-# evolve.py:14``). Proximity uses a stricter 0.40 because it's
-# deduping against the entire pool; this guard fires AFTER the
-# Evolver writes the file, so it tolerates more overlap and only
-# flips on near-duplicates.
-ANTI_CONVERGENCE_JACCARD_THRESHOLD = 0.70
+# candidate stays.
+#
+# Raised 0.70 → 0.90 in PR-EVOLVER-JACCARD-OBS (2026-05-25). The
+# original 0.70 mirrored co-scientist's ``DUPLICATE_SIMILARITY_
+# THRESHOLD`` (``open-coscientist/nodes/evolve.py:14``), but
+# co-scientist's evolver was free to rewrite the entire body.
+# ``plugins/seed_generation/agents/evolver.md`` instead mandates
+# *single-section* rewrite with ±20% body-token budget — under that
+# contract, two compliant evolutions naturally share 80-90% of their
+# 5-grams. Smoke 14 (archive ``.audit/smoke-archives/
+# smoke-14-1779674544/``) iter-2 evolver returned ``verdict: "ok"``
+# for parent ``gen1-002-e2b9f471``; the evolved body's 5-gram Jaccard
+# against the parent measured **0.8437** (single bullet rewrite,
+# "all other bullets preserved verbatim" per the LLM's own
+# ``notes``), and the 0.70 threshold falsely coerced it to
+# ``evolution_skipped`` → ``verdict_not_ok`` phase failure. Raising
+# to 0.90 admits compliant section-rewrites while still catching the
+# "barely changed" failure mode (Jaccard > 0.95). Proximity keeps
+# its stricter 0.40 because it's deduping against the entire pool;
+# this guard fires AFTER the Evolver writes the file.
+ANTI_CONVERGENCE_JACCARD_THRESHOLD = 0.90
 
 
 class Evolver(BaseSeedAgent):
@@ -188,12 +202,21 @@ class Evolver(BaseSeedAgent):
             # The Evolver's verdict is best-effort LLM intent; this
             # guard is a deterministic safety net for the case where
             # the model thinks it diversified but actually didn't.
-            if self._is_near_duplicate(parsed, evolved_rows, candidates_by_id):
+            is_dup, score, against = self._check_near_duplicate(
+                parsed, evolved_rows, candidates_by_id
+            )
+            if is_dup:
+                # PR-EVOLVER-JACCARD-OBS (2026-05-25) — log the actual
+                # Jaccard score + the offending comparison target
+                # ("parent" or "sibling:<id>") so future threshold
+                # tuning has empirical data, not just the static cutoff.
                 log.info(
                     "seed-generation evolver: parent=%s evolved body too close "
-                    "to sibling (Jaccard ≥ %.2f) — coercing verdict to "
-                    "evolution_skipped.",
+                    "to %s (Jaccard %.4f ≥ threshold %.2f) — coercing verdict "
+                    "to evolution_skipped.",
                     task.args["parent_id"],
+                    against,
+                    score,
                     ANTI_CONVERGENCE_JACCARD_THRESHOLD,
                 )
                 continue
@@ -366,26 +389,42 @@ class Evolver(BaseSeedAgent):
             "notes": parsed.get("notes", ""),
         }
 
-    def _is_near_duplicate(
+    def _check_near_duplicate(
         self,
         parsed: dict[str, Any],
         already_admitted: list[dict[str, Any]],
         candidates_by_id: dict[str, dict[str, Any]],
-    ) -> bool:
-        """Return True iff the evolved body is too close to a sibling.
+    ) -> tuple[bool, float, str]:
+        """Compare the evolved body to siblings + parent; return verdict
+        + the offending Jaccard score + a label for the comparison
+        target so the caller can log empirical data (not just the
+        static threshold).
 
-        CSP-6 (2026-05-22) — reads the evolved file body and compares
+        CSP-6 (2026-05-22) reads the evolved file body and compares
         its 5-gram Jaccard against:
 
         1. Every already-admitted evolved row (the sibling spawns this
-           run already accepted).
+           run already accepted) — ``against = "sibling:<evolved_id>"``.
         2. The parent candidate's body (to catch the "evolution returned
-           almost the same text" failure mode the LLM verdict can miss).
+           almost the same text" failure mode the LLM verdict can miss)
+           — ``against = "parent:<parent_id>"``.
 
-        Returns True as soon as ANY comparison exceeds
-        :data:`ANTI_CONVERGENCE_JACCARD_THRESHOLD`. Returns False when
-        the evolved file is unreadable (defensive — failing closed
-        on every IO blip would mask legitimate evolutions).
+        Returns ``(True, score, against)`` as soon as ANY comparison
+        exceeds :data:`ANTI_CONVERGENCE_JACCARD_THRESHOLD`. Returns
+        ``(False, max_score_seen, against_or_"")`` when no comparison
+        crosses the threshold — ``max_score_seen`` is the highest
+        Jaccard observed across all comparisons (or 0.0 when no
+        comparison ran), so even non-dup admissions surface their
+        closest-neighbor score in logs if a caller wants to record it.
+
+        Returns ``(False, 0.0, "")`` when the evolved file is
+        unreadable (defensive — failing closed on every IO blip
+        would mask legitimate evolutions, per CSP-6 docstring).
+
+        PR-EVOLVER-JACCARD-OBS (2026-05-25) — refactored from the
+        boolean ``_is_near_duplicate`` so callers can log the actual
+        score + comparison target. Threshold raised 0.70 → 0.90 to
+        match the prompt's single-section ±20% rewrite contract.
         """
         from pathlib import Path
 
@@ -394,7 +433,7 @@ class Evolver(BaseSeedAgent):
         evolved_path = parsed.get("evolved_path")
         parent_id = parsed.get("parent_id")
         if not evolved_path:
-            return False
+            return (False, 0.0, "")
         try:
             evolved_body = Path(str(evolved_path)).read_text(encoding="utf-8")
         except OSError as exc:
@@ -404,8 +443,10 @@ class Evolver(BaseSeedAgent):
                 evolved_path,
                 exc,
             )
-            return False
+            return (False, 0.0, "")
         evolved_shingles = shingles(evolved_body)
+        max_score = 0.0
+        max_against = ""
         # Sibling check.
         for row in already_admitted:
             other_path = row.get("path")
@@ -416,8 +457,12 @@ class Evolver(BaseSeedAgent):
             except OSError:
                 continue
             score = jaccard_similarity(evolved_shingles, shingles(other_body))
+            label = f"sibling:{row.get('id', '<unknown>')}"
+            if score > max_score:
+                max_score = score
+                max_against = label
             if score >= ANTI_CONVERGENCE_JACCARD_THRESHOLD:
-                return True
+                return (True, score, label)
         # Parent-vs-evolved check — catches the "barely changed" LLM
         # output the verdict didn't flag.
         if parent_id:
@@ -431,6 +476,10 @@ class Evolver(BaseSeedAgent):
                         parent_body = ""
                     if parent_body:
                         score = jaccard_similarity(evolved_shingles, shingles(parent_body))
+                        label = f"parent:{parent_id}"
+                        if score > max_score:
+                            max_score = score
+                            max_against = label
                         if score >= ANTI_CONVERGENCE_JACCARD_THRESHOLD:
-                            return True
-        return False
+                            return (True, score, label)
+        return (False, max_score, max_against)

--- a/tests/plugins/seed_generation/test_evolver_anti_convergence.py
+++ b/tests/plugins/seed_generation/test_evolver_anti_convergence.py
@@ -103,9 +103,7 @@ class TestCheckNearDuplicate:
         assert is_dup is False, f"score={score:.4f} should admit at 0.90"
         assert 0.70 <= score < 0.90, f"score={score:.4f} should sit in the 0.70-0.90 band"
 
-    def test_unreadable_evolved_returns_admitting(
-        self, tmp_path: Path, evolver: Evolver
-    ) -> None:
+    def test_unreadable_evolved_returns_admitting(self, tmp_path: Path, evolver: Evolver) -> None:
         """IO failure on the evolved path → admit (fail open, defensive
         per CSP-6 docstring; failing closed on every blip would mask
         legitimate evolutions)."""

--- a/tests/plugins/seed_generation/test_evolver_anti_convergence.py
+++ b/tests/plugins/seed_generation/test_evolver_anti_convergence.py
@@ -26,26 +26,31 @@ def _write(tmp_path: Path, name: str, body: str) -> str:
     return str(path)
 
 
-class TestIsNearDuplicate:
+class TestCheckNearDuplicate:
     def test_distinct_body_admitted(self, tmp_path: Path, evolver: Evolver) -> None:
         evolved = _write(tmp_path, "ev.md", "completely unique scenario about tool error parsing")
         sibling = _write(
             tmp_path, "sib.md", "totally different paragraph mentioning escalation only"
         )
         parsed = {"evolved_path": evolved, "parent_id": None}
-        already = [{"path": sibling}]
-        assert evolver._is_near_duplicate(parsed, already, {}) is False
+        already = [{"id": "e0", "path": sibling}]
+        is_dup, score, _against = evolver._check_near_duplicate(parsed, already, {})
+        assert is_dup is False
+        assert 0.0 <= score < ANTI_CONVERGENCE_JACCARD_THRESHOLD
 
     def test_near_duplicate_sibling_flagged(self, tmp_path: Path, evolver: Evolver) -> None:
-        # Both bodies share the same long 5-gram prefix → Jaccard ≥ 0.7.
+        # Identical bodies → Jaccard 1.0 ≥ 0.90.
         shared = (
             "the model misuses tool error to escalate without reflection in repeated tries today"
         )
         a = _write(tmp_path, "a.md", shared)
-        b = _write(tmp_path, "b.md", shared + " minor difference")
+        b = _write(tmp_path, "b.md", shared)
         parsed = {"evolved_path": a, "parent_id": None}
-        already = [{"path": b}]
-        assert evolver._is_near_duplicate(parsed, already, {}) is True
+        already = [{"id": "e0", "path": b}]
+        is_dup, score, against = evolver._check_near_duplicate(parsed, already, {})
+        assert is_dup is True
+        assert score >= ANTI_CONVERGENCE_JACCARD_THRESHOLD
+        assert against == "sibling:e0"
 
     def test_near_duplicate_parent_flagged(self, tmp_path: Path, evolver: Evolver) -> None:
         # Evolver verdict claimed "ok" but the body is the same as parent.
@@ -56,22 +61,73 @@ class TestIsNearDuplicate:
         evolved_path = _write(tmp_path, "evolved.md", shared)
         parsed = {"evolved_path": evolved_path, "parent_id": "parent_id_xyz"}
         candidates_by_id = {"parent_id_xyz": {"path": parent_path}}
-        assert evolver._is_near_duplicate(parsed, [], candidates_by_id) is True
+        is_dup, score, against = evolver._check_near_duplicate(parsed, [], candidates_by_id)
+        assert is_dup is True
+        assert score >= ANTI_CONVERGENCE_JACCARD_THRESHOLD
+        assert against == "parent:parent_id_xyz"
 
-    def test_unreadable_evolved_returns_false(self, tmp_path: Path, evolver: Evolver) -> None:
+    def test_smoke14_replay_admitted_after_threshold_bump(
+        self, tmp_path: Path, evolver: Evolver
+    ) -> None:
+        """Replay smoke 14 iter-2 evolver shape: a single-bullet rewrite
+        of a ~3000-char parent yields Jaccard ≈ 0.84, which the
+        original 0.70 threshold falsely rejected but 0.90 admits.
+
+        This pins PR-EVOLVER-JACCARD-OBS's empirical claim. The
+        archive at ``.audit/smoke-archives/smoke-14-1779674544/``
+        documents the actual measurement (0.8437). Here we use a
+        compact body but the same characteristic: ~85% of the
+        5-grams overlap.
+        """
+        # 50 unique words shared between parent + evolved; the evolved
+        # replaces 5 of them with synonyms → ~85% 5-gram overlap.
+        base = (
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet "
+            "kilo lima mike november oscar papa quebec romeo sierra tango "
+            "uniform victor whiskey xray yankee zulu one two three four "
+            "five six seven eight nine ten eleven twelve thirteen fourteen "
+            "fifteen sixteen seventeen eighteen nineteen twenty alpha bravo charlie"
+        )
+        diverged = base.replace(
+            "alpha bravo charlie delta echo",
+            "WORDA WORDB WORDC WORDD WORDE",
+        )
+        parent_path = _write(tmp_path, "parent.md", base)
+        evolved_path = _write(tmp_path, "evolved.md", diverged)
+        parsed = {"evolved_path": evolved_path, "parent_id": "p"}
+        candidates_by_id = {"p": {"path": parent_path}}
+        is_dup, score, _against = evolver._check_near_duplicate(parsed, [], candidates_by_id)
+        # Compliant single-section rewrite — admitted by 0.90 threshold,
+        # rejected by old 0.70. Score documented here so a future
+        # threshold tweak surfaces the empirical anchor.
+        assert is_dup is False, f"score={score:.4f} should admit at 0.90"
+        assert 0.70 <= score < 0.90, f"score={score:.4f} should sit in the 0.70-0.90 band"
+
+    def test_unreadable_evolved_returns_admitting(
+        self, tmp_path: Path, evolver: Evolver
+    ) -> None:
         """IO failure on the evolved path → admit (fail open, defensive
         per CSP-6 docstring; failing closed on every blip would mask
         legitimate evolutions)."""
         parsed = {"evolved_path": str(tmp_path / "does_not_exist.md"), "parent_id": None}
-        assert evolver._is_near_duplicate(parsed, [], {}) is False
+        is_dup, score, against = evolver._check_near_duplicate(parsed, [], {})
+        assert is_dup is False
+        assert score == 0.0
+        assert against == ""
 
-    def test_missing_evolved_path_returns_false(self, evolver: Evolver) -> None:
+    def test_missing_evolved_path_returns_admitting(self, evolver: Evolver) -> None:
         parsed = {"evolved_path": "", "parent_id": None}
-        assert evolver._is_near_duplicate(parsed, [], {}) is False
+        is_dup, score, against = evolver._check_near_duplicate(parsed, [], {})
+        assert is_dup is False
+        assert score == 0.0
+        assert against == ""
 
     def test_threshold_value(self) -> None:
-        # Pin the threshold so accidental changes show up in review.
-        assert ANTI_CONVERGENCE_JACCARD_THRESHOLD == 0.70
+        # PR-EVOLVER-JACCARD-OBS raised the threshold 0.70 → 0.90;
+        # pinned here so future drift surfaces in review with the
+        # rationale (single-section ±20% prompt mathematically requires
+        # the looser bound). Smoke 14 iter-2 measurement: 0.8437.
+        assert ANTI_CONVERGENCE_JACCARD_THRESHOLD == 0.90
 
 
 class TestEvolverExecuteAdmissionFlow:
@@ -87,7 +143,7 @@ class TestEvolverExecuteAdmissionFlow:
             "the model misuses tool error to escalate without reflection in repeated tries today"
         )
         a_path = _write(tmp_path, "a.md", shared)
-        b_path = _write(tmp_path, "b.md", shared + " trivial diff")
+        b_path = _write(tmp_path, "b.md", shared)  # identical → Jaccard 1.0, certain dup hit
 
         # Stub manager: emits 2 ok-verdict results, both passing the
         # parse contract; the second one is the near-duplicate.


### PR DESCRIPTION
## Summary
- Replace `_is_near_duplicate(...) -> bool` with `_check_near_duplicate(...) -> tuple[bool, float, str]` so the caller can log the actual measured Jaccard + the offending comparison target (`parent:<id>` / `sibling:<id>`).
- Raise `ANTI_CONVERGENCE_JACCARD_THRESHOLD` 0.70 → 0.90 to match the prompt's single-section ±20% body-budget contract.

## Why
Smoke 14 iter-2 evolver (archive `.audit/smoke-archives/smoke-14-1779674544/`) returned `verdict: "ok"` for parent `gen1-002-e2b9f471` but the CSP-6 guard coerced it to `evolution_skipped`, surfacing as a `verdict_not_ok` phase failure:

```
phase_failed evolver — all 1 evolution sub-agents either failed
  or returned verdict != 'ok'; first error: verdict_not_ok
```

Recomputed measurement from the archive:
```python
parent  = '.audit/.../candidates_evolved/gen1-002-e2b9f471.md'  # 2884 chars
evolved = '.audit/.../sub_agents/.../candidates_evolved/0eeb1437-....md'  # 2929 chars
jaccard_similarity(shingles(parent), shingles(evolved)) == 0.8437
```

LLM's own `notes`: *"Removed GEODE tool_result_handling policy reference; replaced with stuck_in_loops-aligned bullet. All other bullets preserved verbatim."* — a compliant single-section rewrite of the body.

The 0.70 threshold was copied from co-scientist `DUPLICATE_SIMILARITY_THRESHOLD`, but co-scientist's evolver was free to rewrite the entire body. Our `evolver.md` mandates single-section rewrite with ±20% token budget — under that constraint, two compliant evolutions naturally share 80-90% of their 5-grams. The threshold needed to be relaxed to admit them; 0.90 still catches the "barely changed" failure mode (Jaccard > 0.95).

Old log was also unhelpful for empirical tuning — it reported only the static threshold, not the actual score or which comparison fired.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/agents/evolver.py` | Threshold 0.70 → 0.90; `_is_near_duplicate` renamed to `_check_near_duplicate` returning `(is_dup, score, against)`; aexecute log includes actual score + label |
| `tests/plugins/seed_generation/test_evolver_anti_convergence.py` | Update existing 6 tests to new API; add `test_smoke14_replay_admitted_after_threshold_bump` pinning the empirical anchor (Jaccard ≈ 0.85 admitted at 0.90, would reject at 0.70) |
| `CHANGELOG.md` | Entry under `[Unreleased] → Fixed` |

## Verification
- [x] `uv run pytest tests/plugins/seed_generation/test_evolver_anti_convergence.py` — 8/8 pass
- [x] `uv run pytest tests/plugins/seed_generation/` — 463 passed, 3 skipped
- [x] `uv run ruff check core/ tests/ plugins/` — 0 errors
- [x] `uv run mypy plugins/seed_generation/agents/evolver.py` — 0 errors
- [ ] CI 5/5 green (pending)
- [ ] Smoke 15 (Loop 1) — verifies evolver admits compliant single-section rewrites end-to-end (post-merge)

## Reference
- Smoke 14 archive: `.audit/smoke-archives/smoke-14-1779674544/`
- CSP-6 original threshold rationale: `plugins/seed_generation/agents/evolver.py` (the rewritten doc-comment retains the co-scientist citation but documents why it no longer applies).
- Prompt contract: `plugins/seed_generation/agents/evolver.md` lines 16-46 ("Rewrite ONLY that section" + "Total token budget within ±20% of original").

🤖 Generated with [Claude Code](https://claude.com/claude-code)