### PR TITLE
refactor(self-improving-loop): PR-5 Codex MCP cleanup — F3+F4+F5 dedup

### DIFF
--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -244,6 +244,24 @@ def load_policy(kind: str) -> dict[str, str]:
     return {k: str(v) for k, v in payload.items() if isinstance(k, str)}
 
 
+def _serialize_policy_payload(kind: str, sections: dict[str, str]) -> str:
+    """Codex MCP review F4 (Dedup) — ``write_policy`` 와 ``write_sibling_in_memory``
+    가 동일한 serialization (``_NESTED_KINDS`` flatten + JSON sort_keys) 을
+    중복 구현하던 것을 helper 로 추출. 두 caller 가 same payload format 보장.
+    """
+    serializable: dict[str, object]
+    if kind in _NESTED_KINDS:
+        serializable = dict(_unflatten_nested(sections, kind=kind))
+    else:
+        serializable = {k: v for k, v in sections.items() if isinstance(k, str)}
+    return json.dumps(
+        serializable,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+
+
 def write_sibling_in_memory(kind: str, sections: dict[str, str]) -> Path:
     """Write policy sections to a TEMPORARY file (not the SoT path).
 
@@ -269,17 +287,7 @@ def write_sibling_in_memory(kind: str, sections: dict[str, str]) -> Path:
         raise ValueError(f"unknown target_kind {kind!r}, expected one of {TARGET_KINDS!r}")
     import tempfile
 
-    serializable: dict[str, object]
-    if kind in _NESTED_KINDS:
-        serializable = dict(_unflatten_nested(sections, kind=kind))
-    else:
-        serializable = {k: v for k, v in sections.items() if isinstance(k, str)}
-    payload = json.dumps(
-        serializable,
-        ensure_ascii=False,
-        indent=2,
-        sort_keys=True,
-    )
+    payload = _serialize_policy_payload(kind, sections)
     fd, temp_path_str = tempfile.mkstemp(
         suffix=f"-{kind}-sibling.json",
         prefix="geode-sibling-",
@@ -315,20 +323,9 @@ def write_policy(kind: str, sections: dict[str, str]) -> Path:
     path = policy_path(kind)
     _maybe_migrate_legacy_sot(kind, path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    serializable: dict[str, object]
-    if kind in _NESTED_KINDS:
-        # ``_unflatten_nested`` returns ``dict[str, dict[str, object]]`` —
-        # widen to ``dict[str, object]`` so the type matches the legacy
-        # ``dict[str, str]`` branch under a common annotation.
-        serializable = dict(_unflatten_nested(sections, kind=kind))
-    else:
-        serializable = {k: v for k, v in sections.items() if isinstance(k, str)}
-    payload = json.dumps(
-        serializable,
-        ensure_ascii=False,
-        indent=2,
-        sort_keys=True,
-    )
+    # Codex MCP review F4 (Dedup) — _serialize_policy_payload 가
+    # write_sibling_in_memory 와 같은 serialization 보장.
+    payload = _serialize_policy_payload(kind, sections)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(payload + "\n", encoding="utf-8")
     tmp.replace(path)

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1115,6 +1115,14 @@ def _git_commit_audit_log(
     return True
 
 
+def _mint_audit_run_id() -> str:
+    """Codex MCP review F5 (Dedup) — apply_proposal / apply_group_proposals
+    의 audit_run_id 생성 식을 single source 로 통일. UUID4 의 hex prefix[:12]
+    (W3 PR-3 의 within-ledger correlation key format).
+    """
+    return uuid.uuid4().hex[:12]
+
+
 _SIBLING_SOT_ENV_MAP: dict[str, str] = {
     "prompt": "GEODE_WRAPPER_OVERRIDE",
     "tool_policy": "GEODE_TOOL_POLICY_OVERRIDE",
@@ -1342,16 +1350,17 @@ class SelfImprovingLoopRunner:
 
         # Codex MCP review (slop) — ThreadPoolExecutor 는 ContextVar 를 자동
         # 전파하지 않는다. session metrics / cost ledger ContextVar 가 thread
-        # 안에서 unset → parent session aggregate 와 분리될 위험. copy_context()
-        # 로 명시 전파.
-        parent_ctx = contextvars.copy_context()
+        # 안에서 unset → parent session aggregate 와 분리될 위험. 각 submit
+        # 마다 ``copy_context()`` 로 main thread 의 ctx snapshot 을 fresh copy
+        # 해 thread 안에서 run — 같은 Context 객체를 여러 thread 에서 enter
+        # 할 수 없는 제약 (RuntimeError "already entered") 회피.
 
-        def _propose_in_ctx() -> Proposal:
-            return parent_ctx.run(self.propose)
+        def _propose_with_fresh_ctx() -> Proposal:
+            return contextvars.copy_context().run(self.propose)
 
         proposals: list[Proposal] = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=n) as executor:
-            futures = [executor.submit(_propose_in_ctx) for _ in range(n)]
+            futures = [executor.submit(_propose_with_fresh_ctx) for _ in range(n)]
             for future in concurrent.futures.as_completed(futures):
                 proposals.append(future.result())
         return proposals
@@ -1435,7 +1444,7 @@ class SelfImprovingLoopRunner:
                 f"또는 GEODE_TEMPERATURE_SELF_IMPROVING_MUTATION env 를 >= 0.1 로 set."
             )
 
-        group_id = uuid.uuid4().hex[:12]
+        group_id = _mint_audit_run_id()
         log.info(
             "self-improving-loop: group %s — N=%d sibling propose+audit start",
             group_id,
@@ -1456,7 +1465,7 @@ class SelfImprovingLoopRunner:
                 sibling_sot_paths.append(sibling_sot_path)
                 sibling_previous_values.append(previous_value)
 
-                audit_run_id = uuid.uuid4().hex[:12]
+                audit_run_id = _mint_audit_run_id()
                 audit_run_ids.append(audit_run_id)
 
                 repo_root = (self.audit_log_path or MUTATION_AUDIT_LOG_PATH).resolve().parents[1]
@@ -1586,7 +1595,7 @@ class SelfImprovingLoopRunner:
         rerun_enabled 일 때만 (rerun_disabled 면 audit 가 안 일어나
         attribution row 도 없으니 audit_run_id 무의미).
         """
-        audit_run_id = uuid.uuid4().hex[:12] if self.rerun_enabled else ""
+        audit_run_id = _mint_audit_run_id() if self.rerun_enabled else ""
         _new_sections, previous_value = apply_mutation(
             proposal.mutation, current_sections=proposal.target_sections
         )

--- a/tests/core/self_improving_loop/test_env_naming_invariant.py
+++ b/tests/core/self_improving_loop/test_env_naming_invariant.py
@@ -1,0 +1,79 @@
+"""F3 (Codex MCP review Dedup) — env naming invariant between runner.py
+_SIBLING_SOT_ENV_MAP and autoresearch/train.py W3 env literal block.
+
+Two SOT sources for sibling SoT path propagation env vars:
+- ``core/self_improving_loop/runner.py:_SIBLING_SOT_ENV_MAP`` (5 kinds —
+  Mutation.target_kind)
+- ``autoresearch/train.py:809-873`` literal env assignment block (12
+  kinds — all GLOBAL_*_PATH)
+
+The 5-kind subset MUST be identical between the two SOTs — drift means
+sibling audit subprocess receives a different env name than what GEODE
+runtime's strict-mode reader expects → silent disconnection ([[feedback-
+changelog-implementation-parity]]).
+
+This test pins the 5-kind subset by reading the literal env block from
+train.py and grepping for each Mutation.target_kind's expected env name.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from core.self_improving_loop.policies import TARGET_KINDS
+from core.self_improving_loop.runner import _SIBLING_SOT_ENV_MAP
+
+
+def _read_train_py_source() -> str:
+    """Read autoresearch/train.py source text."""
+    here = Path(__file__).resolve()
+    # tests/core/self_improving_loop/ → ../../../autoresearch/train.py
+    repo_root = here.parents[3]
+    train_py = repo_root / "autoresearch" / "train.py"
+    return train_py.read_text(encoding="utf-8")
+
+
+def test_sibling_env_map_covers_all_target_kinds() -> None:
+    """F3.1: _SIBLING_SOT_ENV_MAP 가 TARGET_KINDS 의 모든 kind 를 cover."""
+    missing = set(TARGET_KINDS) - set(_SIBLING_SOT_ENV_MAP)
+    assert not missing, (
+        f"_SIBLING_SOT_ENV_MAP missing kinds: {missing}. "
+        f"sibling sampling 안 됨 — TARGET_KINDS 와 동기 필수."
+    )
+
+
+def test_sibling_env_names_match_train_py() -> None:
+    """F3.2: runner.py 의 _SIBLING_SOT_ENV_MAP 의 env 명명이 train.py 의
+    W3 env literal block 과 정확히 일치 — drift 시 sibling audit 가
+    잘못된 env 로 launched → silent SoT-not-loaded.
+    """
+    train_src = _read_train_py_source()
+    for kind, env_name in _SIBLING_SOT_ENV_MAP.items():
+        # train.py 가 env[<env_name>] = ... 로 set 하는지 (literal 검색)
+        # 또는 env literal "GEODE_<KIND>_OVERRIDE" 가 등장하는지
+        pattern = re.compile(rf'env\[\s*["\']({re.escape(env_name)})["\']\s*\]')
+        assert pattern.search(train_src), (
+            f"train.py 가 env[{env_name!r}] 을 set 안 함. runner.py 의 "
+            f"_SIBLING_SOT_ENV_MAP[{kind!r}]={env_name!r} 와 drift. "
+            f"sibling audit 가 SoT 못 받음."
+        )
+
+
+def test_geode_override_naming_pattern() -> None:
+    """F3.3: env 명명이 ``GEODE_<KIND>_OVERRIDE`` pattern 따름 — naming
+    convention 일관성."""
+    pattern = re.compile(r"^GEODE_[A-Z_]+_OVERRIDE$")
+    for kind, env_name in _SIBLING_SOT_ENV_MAP.items():
+        assert pattern.match(env_name), (
+            f"_SIBLING_SOT_ENV_MAP[{kind!r}]={env_name!r} does not match "
+            f"GEODE_<KIND>_OVERRIDE pattern"
+        )
+
+
+def test_sibling_env_value_unique() -> None:
+    """F3.4: env 명명이 unique (한 env 가 여러 kind 에 묶이지 않음)."""
+    env_values = list(_SIBLING_SOT_ENV_MAP.values())
+    assert len(env_values) == len(set(env_values)), (
+        f"_SIBLING_SOT_ENV_MAP has duplicate env names: {env_values}"
+    )


### PR DESCRIPTION
## Summary
- PR-5 #1641 Codex MCP review 의 미적용 Dedup 항목 3개 (F3 env invariant, F4 serialize helper, F5 audit_run_id helper) + ContextVar propagation bug fix
- ~120 LOC small cleanup

## Why
PR-5 Codex MCP review (threadId 019e5dc9) 의 GAP=3 / Dedup=5 / Slop=6 중 critical 4 fix 는 PR-5 안에서 적용, 나머지 Dedup 항목을 별 cleanup PR 로 처리 (plan `docs/plans/2026-05-25-pr5-residual-fix-deferred.md` 의 routing).

또한 PR-5 의 `propose_group(n)` 의 ContextVar 사용이 잘못됐어 — `parent_ctx.run` 가 동일 context 를 여러 thread 에서 동시 enter 못 함. test_n2_invokes_propose_twice 가 본 PR 로 fix.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/policies.py` | `_serialize_policy_payload(kind, sections)` helper 추출 + `write_policy` + `write_sibling_in_memory` 가 모두 사용 |
| `core/self_improving_loop/runner.py` | `_mint_audit_run_id()` helper + 3 call site 변경 / ContextVar fresh copy fix (`contextvars.copy_context().run` per submit) |
| `tests/core/self_improving_loop/test_env_naming_invariant.py` | 신규 4 invariant test (env naming drift 방지) |

## GAP Audit
| Item | Status |
|------|--------|
| F3 env invariant | Implemented (4 tests, shared constants extraction 은 12-kind scope 와 충돌로 test-based drift 방지) |
| F4 serialize helper | Implemented (write_policy + write_sibling_in_memory dedup) |
| F5 audit_run_id helper | Implemented (3 call site 통일) |
| ContextVar propagation bug | Fixed (PR-5 의 test_n2 fail → pass) |
| F1 GAP HIGH (test coverage 8 통합) | Deferred to P2 sprint |
| F2 GAP MEDIUM (orphan attribution row) | Deferred to P2 ledger redesign |
| F6 Slop LOW (sentinel string 분산) | Deferred (import cycle 위험) |
| F7 Slop LOW (unlink try/except) | 유지 (defensive log) |

## Verification
- [x] ruff check + format: 통과 (378 files)
- [x] mypy: 통과 (18 source)
- [x] pytest: **230 passed** (test_env_naming_invariant.py 4 신규 + 기존 test_baseline_rl_grounding.py 의 test_n2 fix 포함)

## Reference
- 선행: PR-5 #1641 baseline RL grounding (merged f993e0bb)
- 선행: PR #1643 P2-P5 plans + residual fix routing (merged 1f422528)
- Plan: `docs/plans/2026-05-25-pr5-residual-fix-deferred.md`
- Codex MCP threadId: `019e5dc9-ad11-7f20-b997-8039188b6c2c`