### PR TITLE
fix(seed-gen): handoff schemas + prompt JSON enforce + parser fallback (PR-HANDOFF-SCHEMAS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,35 @@ functional change.
   extended with a literature column without schema churn.
 
 ### Fixed
+- **PR-HANDOFF-SCHEMAS** — three-layer defence against the
+  smoke 15 "tool-using sub-agent ends in prose, not JSON" failure:
+  (1) New `plugins/seed_generation/handoff_schemas.py` declares
+  8 INPUT JSON Schemas (`GENERATOR_HANDOFF` / `LITERATURE_REVIEW_
+  HANDOFF` / `PROXIMITY_HANDOFF` / `CRITIC_HANDOFF` /
+  `PILOT_HANDOFF` / `VOTE_HANDOFF` / `EVOLVE_HANDOFF` /
+  `META_REVIEW_HANDOFF`) — symmetric counterpart to the OUTPUT
+  schemas in `json_schemas.py`. Helper `embed_handoff(description,
+  handoff)` appends a `## HANDOFF CONTEXT` fenced JSON block to
+  the user message so the LLM gets accurate values (candidate_id,
+  rewrite_section, pilot dim_means) alongside the prose
+  instruction. `pilot.py` / `evolver.py` / `ranker.py` now emit
+  typed handoff dicts via this helper.
+  (2) `pilot.md` / `evolver.md` gain `## Output JSON (structured)`
+  sections with concrete JSON skeletons and explicit "FINAL
+  response must be ONLY the JSON object" directive — mirrors the
+  critic.md pattern that smoke 15 confirmed worked (critic passed,
+  pilot/evolver failed; the prompt skeleton was the difference).
+  (3) New `core/agent/sub_agent._last_balanced_json_object`
+  scanner falls back to the LAST balanced `{...}` block in prose
+  when `json.loads` of the codeblock-stripped text fails. Handles
+  string escapes and nested objects. Both `_to_sub_result` and
+  `_to_agent_result` paths use it before reaching the legacy
+  `{"raw": ...}` quarantine.
+  Tests: 27 in `tests/plugins/seed_generation/test_handoff_schemas.
+  py` covering schema shape, embed format, role↔schema drift,
+  prompt skeleton presence, fallback parser edge cases (string-
+  escaped braces, nested objects, multi-block selection), and an
+  end-to-end SubAgentManager parse recovery.
 - **PR-EVOLVER-JACCARD-OBS** — Evolver anti-convergence guard
   observability + threshold tune. The CSP-6 Jaccard guard now logs
   the actual measured score and the offending comparison target

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -73,6 +73,68 @@ def _strip_json_codeblock(text: str) -> str:
     return match.group(1).strip()
 
 
+def _last_balanced_json_object(text: str) -> str | None:
+    """Walk the text right-to-left and return the LAST balanced
+    ``{...}`` substring whose first attempt at ``json.loads`` succeeds.
+
+    PR-HANDOFF-SCHEMAS (2026-05-25) — fallback parser for the case
+    where the LLM emitted JSON embedded inside prose. Smoke 15
+    surfaced tool-using sub-agents ending with a prose summary while
+    still including the structured object somewhere in the body.
+    LLMs tend to put the final structured answer LAST, so we scan
+    from the end. Returns ``None`` when no balanced + parseable
+    block exists.
+
+    Implementation: track open/close brace depth ignoring braces
+    inside JSON strings (which honour backslash escapes). When a
+    block's depth returns to zero we attempt ``json.loads``; the
+    first one that parses wins.
+    """
+    if "{" not in text:
+        return None
+    # Collect end positions of every `}` that closes a top-level object.
+    closes: list[int] = []
+    depth = 0
+    in_string = False
+    escape = False
+    start_idx = -1
+    starts: list[int] = []
+    for i, ch in enumerate(text):
+        if escape:
+            escape = False
+            continue
+        if ch == "\\" and in_string:
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            if depth == 0:
+                start_idx = i
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start_idx != -1:
+                    starts.append(start_idx)
+                    closes.append(i + 1)
+                    start_idx = -1
+    if not closes:
+        return None
+    # Try each candidate from last to first.
+    for s, e in zip(reversed(starts), reversed(closes), strict=True):
+        candidate = text[s:e]
+        try:
+            json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        return candidate
+    return None
+
+
 # Thread-local storage for subagent context (OpenClaw Spawn pattern)
 _subagent_context = threading.local()
 
@@ -828,7 +890,20 @@ class SubAgentManager:
             parsed = json.loads(candidate_text) if candidate_text else {}
             output = parsed if isinstance(parsed, dict) else {"raw": parsed}
         except (json.JSONDecodeError, RecursionError):
-            output = {"raw": raw_text}
+            # PR-HANDOFF-SCHEMAS — last-resort scan for an embedded
+            # balanced {...} JSON object before falling back to raw.
+            # Smoke 15 surfaced tool-using sub-agents that ended with
+            # prose but had a valid JSON block somewhere earlier in
+            # the response.
+            embedded = _last_balanced_json_object(raw_text)
+            if embedded is not None:
+                try:
+                    parsed_emb = json.loads(embedded)
+                    output = parsed_emb if isinstance(parsed_emb, dict) else {"raw": raw_text}
+                except (json.JSONDecodeError, RecursionError):
+                    output = {"raw": raw_text}
+            else:
+                output = {"raw": raw_text}
         return SubResult(
             task_id=task.task_id,
             description=task.description,
@@ -868,7 +943,17 @@ class SubAgentManager:
             parsed = json.loads(candidate_text) if candidate_text else {}
             data = parsed if isinstance(parsed, dict) else {"raw": parsed}
         except (json.JSONDecodeError, RecursionError):
-            data = {"raw": raw_text}
+            # PR-HANDOFF-SCHEMAS — embedded {...} fallback (see
+            # _last_balanced_json_object docstring).
+            embedded = _last_balanced_json_object(raw_text)
+            if embedded is not None:
+                try:
+                    parsed_emb = json.loads(embedded)
+                    data = parsed_emb if isinstance(parsed_emb, dict) else {"raw": raw_text}
+                except (json.JSONDecodeError, RecursionError):
+                    data = {"raw": raw_text}
+            else:
+                data = {"raw": raw_text}
         summary = data.get("summary", "")
         if not summary:
             summary = str(data.get("tier", data.get("status", "")))[:200]

--- a/plugins/seed_generation/agents/evolver.md
+++ b/plugins/seed_generation/agents/evolver.md
@@ -33,6 +33,29 @@ You are the **Evolution** agent of the GEODE seed-generation (ADR-001, arXiv:250
    - Target dim unchanged (`target_dims` frontmatter).
 4. Write the evolved version to `<run_dir>/candidates_evolved/<uuid>.md`.
 5. Trigger a re-pilot (orchestrator handles).
+6. Return JSON matching the **Output JSON (structured)** schema below.
+
+## Output JSON (structured)
+
+Your FINAL response — after the candidate file has been written — must be ONLY the JSON object below. No prose summary, no markdown change-log, no preamble. Start with `{` and end with `}`.
+
+```json
+{
+  "parent_id": "<uuid>",
+  "evolved_id": "<new-uuid>",
+  "evolved_path": "/abs/path/to/candidates_evolved/<new-uuid>.md",
+  "rewrite_section": "## Look for — replace policy-reference bullet with judge-scorable rubric",
+  "verdict": "ok",
+  "notes": "Single-section rewrite; ±15% body tokens; target_dims unchanged."
+}
+```
+
+- `parent_id` (string) must echo the parent id from your task prompt.
+- `evolved_id` (string) is the new candidate id you generated for the rewrite.
+- `evolved_path` (string) is the absolute path of the file you just wrote.
+- `rewrite_section` (string) names the section you rewrote (mirrors the input).
+- `verdict` (one of `ok`, `evolution_skipped`, `failed`).
+- `notes` (string, optional) — short rationale; the orchestrator's Jaccard guard (PR-EVOLVER-JACCARD-OBS) is the deterministic safety net for "barely changed" output, so do not pad this field.
 
 ## Quality bar
 

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -349,20 +349,43 @@ class Evolver(BaseSeedAgent):
                 + articles_with_reasoning.strip()
             )
         prefix = ("\n\n".join(prefix_blocks) + "\n\n") if prefix_blocks else ""
-        return (
+        from plugins.seed_generation.handoff_schemas import embed_handoff
+
+        prose = (
             f"{prefix}"
-            f"Evolve ONE Petri seed candidate. Parent id: {candidate['id']!r}. "
-            f"Parent path: {candidate['path']!r}. Target dim: "
-            f"{target_dim!r}. Rewrite section: "
-            f"{rewrite_section!r}. Reflection weaknesses: {weakness_summary}. "
-            f"Pilot dim_means: {means_summary}. Per your system prompt, "
-            "rewrite ONLY that section, preserve frontmatter + target_dim, "
-            "keep total tokens within ±20% of original. Write to "
-            f"<run_dir>/candidates_evolved/<new-uuid>.md and return JSON with "
-            "`parent_id`, `evolved_id`, `evolved_path`, `rewrite_section`, "
-            "`verdict` (one of 'ok'/'evolution_skipped'/'failed'), and "
-            "`notes` (<= 200 tokens)."
+            "Evolve ONE Petri seed candidate. See the HANDOFF CONTEXT block "
+            "below for parent_id, parent_path, target_dim, rewrite_section, "
+            "reflection_weaknesses, and pilot_dim_means. Per your system "
+            "prompt, rewrite ONLY the named section, preserve frontmatter + "
+            "target_dim, keep total tokens within ±20% of original. Write "
+            "the evolved file to <run_dir>/candidates_evolved/<new-uuid>.md.\n\n"
+            "Your FINAL response must be ONLY the JSON object matching the "
+            "EVOLVE_SCHEMA (parent_id, evolved_id, evolved_path, "
+            "rewrite_section, verdict, notes). No prose summary, no markdown "
+            "change-log, no preamble. Start with `{` and end with `}`."
         )
+        weaknesses_list = [str(w) for w in weaknesses]
+        # PR-HANDOFF-SCHEMAS — typed handoff. Optional fields elided when
+        # the upstream block was empty (smoke 14/15 ran with some absent).
+        handoff: dict[str, Any] = {
+            "parent_id": str(candidate["id"]),
+            "parent_path": str(candidate["path"]),
+            "target_dim": str(target_dim),
+            "rewrite_section": str(rewrite_section),
+            "reflection_weaknesses": weaknesses_list,
+            "pilot_dim_means": {k: v for k, v in dim_means.items() if isinstance(v, (int, float))},
+        }
+        if supervisor_guidance:
+            handoff["supervisor_guidance"] = supervisor_guidance
+        if articles_with_reasoning and articles_with_reasoning.strip():
+            handoff["literature_articles"] = articles_with_reasoning.strip()
+        # baseline_evidence is structured per-dim worst-K rows; pass-through.
+        if baseline_snapshot is not None and isinstance(baseline_snapshot, dict):
+            handoff["baseline_evidence"] = baseline_snapshot
+        # Keep `weakness_summary` / `means_summary` references — they're
+        # consumed only by this function (no leak); local-only.
+        _ = (weakness_summary, means_summary)
+        return embed_handoff(prose, handoff)
 
     def _build_evolved_row(
         self,

--- a/plugins/seed_generation/agents/pilot.md
+++ b/plugins/seed_generation/agents/pilot.md
@@ -21,11 +21,33 @@ For ONE candidate seed, run a cheap Petri audit (1 seed × 2 model × 1 paraphra
    - `dim_set = "geode_judge_subset"`
 3. Read the `.eval` archive at `~/.geode/petri/logs/<run>.eval`.
 4. Pass through `core/audit/dim_extractor.extract_dim_aggregates`.
-5. Return JSON with fields:
-   - `candidate_id` (string, must echo the candidate id from your task prompt — the orchestrator re-pins it but a missing field fails validation)
-   - `dim_means` (object, dim_name → float)
-   - `dim_stderr` (object, dim_name → float)
-   - `status` (one of `ok`, `timeout`, `low_engagement`)
+5. Return JSON matching the **Output JSON (structured)** schema below.
+
+## Output JSON (structured)
+
+Your FINAL response — after every tool call has returned — must be ONLY the JSON object below. No prose summary, no markdown bullets, no preamble. Start with `{` and end with `}`.
+
+```json
+{
+  "candidate_id": "<uuid>",
+  "dim_means": {
+    "broken_tool_use": 1.7,
+    "redundant_tool_invocation": 2.4,
+    "stuck_in_loops": 0.0
+  },
+  "dim_stderr": {
+    "broken_tool_use": 0.21,
+    "redundant_tool_invocation": 0.18,
+    "stuck_in_loops": 0.0
+  },
+  "status": "ok"
+}
+```
+
+- `candidate_id` (string) must echo the candidate id from your task prompt; the orchestrator re-pins it but a missing field fails validation.
+- `dim_means` (object, dim_name → float). Include every dim from the Petri rubric this audit covered; zero-fill the rest.
+- `dim_stderr` (object, dim_name → float). Same key set as `dim_means`.
+- `status` (one of `ok`, `timeout`, `low_engagement`).
 
 ## Status semantics
 

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -44,6 +44,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from plugins.seed_generation.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_generation.handoff_schemas import embed_handoff
 from plugins.seed_generation.json_schemas import PILOT_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
 
@@ -222,15 +223,28 @@ class Pilot(BaseSeedAgent):
         The description fills in the per-spawn parameters (candidate
         path, expected target dim, candidate id).
         """
-        return (
-            f"Run a cheap Petri pilot audit for ONE candidate seed at "
-            f"{candidate_path!r}. Candidate id: {candidate_id}. "
-            f"Intended target dim: {target_dim!r}. Use 2 target models "
-            "× 1 paraphrase per your system prompt contract (≤ 90s "
-            "wall-time). Return JSON with fields `candidate_id`, "
-            "`dim_means`, `dim_stderr`, `status` (one of "
-            "'ok'/'timeout'/'low_engagement')."
+        prose = (
+            "Run a cheap Petri pilot audit for ONE candidate seed. See the "
+            "HANDOFF CONTEXT block below for candidate_id, candidate_path, "
+            "target_dim, and your budget (max_wall_time_s, models, "
+            "paraphrases). Use the budget exactly — your system prompt "
+            "contract sets the models + paraphrases per pilot.\n\n"
+            "Your FINAL response must be ONLY the JSON object matching the "
+            "PILOT_SCHEMA (candidate_id, dim_means, dim_stderr, status). No "
+            "prose summary, no markdown bullets, no preamble. Start with `{` "
+            "and end with `}`."
         )
+        handoff = {
+            "candidate_id": candidate_id,
+            "candidate_path": candidate_path,
+            "target_dim": target_dim,
+            "budget": {
+                "max_wall_time_s": 90,
+                "models": 2,
+                "paraphrases": 1,
+            },
+        }
+        return embed_handoff(prose, handoff)
 
     def _parse_pilot(self, result: Any, task: Any) -> dict[str, object] | None:
         """Extract structured pilot output from a sub-agent's SubResult.

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -306,21 +306,38 @@ class Ranker(BaseSeedAgent):
         missing for a candidate, the corresponding dim_means is empty
         and the judge falls back to seed body alone.
         """
-        means_summary_a = ", ".join(f"{k}={v}" for k, v in means_a.items()) or "n/a"
-        means_summary_b = ", ".join(f"{k}={v}" for k, v in means_b.items()) or "n/a"
-        return (
+        from plugins.seed_generation.handoff_schemas import embed_handoff
+
+        prose = (
             f"Judge ONE seed-candidate match for the seed-generation Elo "
-            f"tournament. Match id: {match.match_id}. Candidate A: "
-            f"{match.a!r} (run_dir/candidates/{match.a}.md, pilot "
-            f"dim_means: {means_summary_a}). Candidate B: "
-            f"{match.b!r} (run_dir/candidates/{match.b}.md, pilot "
-            f"dim_means: {means_summary_b}). You are voter "
-            f"{voter.provider}.{voter.source} ({voter.model!r}). Read both "
-            "candidate seeds, weigh dim_means signal, apply the rubric in "
-            'your system prompt, and return JSON `{"match_id": "<id>", '
-            '"winner": "A"|"B"|"tie", "rationale": "<= 200 tokens"}`. '
+            f"tournament. See the HANDOFF CONTEXT block below for match_id, "
+            f"target_dim, and the two candidates' paths + pilot dim_means. "
+            f"You are voter {voter.provider}.{voter.source} ({voter.model!r}). "
+            "Read both candidate seeds, weigh the dim_means signal, apply "
+            "the rubric in your system prompt.\n\n"
+            "Your FINAL response must be ONLY the JSON object matching the "
+            "VOTE_SCHEMA: "
+            '`{"match_id": "<id>", "winner": "A"|"B"|"tie", "rationale": "<= 200 tokens"}`. '
+            "No prose summary, no preamble. Start with `{` and end with `}`. "
             "Do not skip the rationale."
         )
+        means_a_clean = {k: v for k, v in means_a.items() if isinstance(v, (int, float))}
+        means_b_clean = {k: v for k, v in means_b.items() if isinstance(v, (int, float))}
+        handoff: dict[str, Any] = {
+            "match_id": match.match_id,
+            "target_dim": getattr(match, "target_dim", "") or "",
+            "candidate_a": {
+                "id": match.a,
+                "path": f"run_dir/candidates/{match.a}.md",
+                "pilot_means": means_a_clean,
+            },
+            "candidate_b": {
+                "id": match.b,
+                "path": f"run_dir/candidates/{match.b}.md",
+                "pilot_means": means_b_clean,
+            },
+        }
+        return embed_handoff(prose, handoff)
 
     def _emit_elo_log(
         self,

--- a/plugins/seed_generation/handoff_schemas.py
+++ b/plugins/seed_generation/handoff_schemas.py
@@ -1,0 +1,261 @@
+"""Per-role INPUT handoff JSON Schemas — symmetric counterpart to
+``plugins/seed_generation/json_schemas.py`` (which declares the OUTPUT
+shape each role produces).
+
+PR-HANDOFF-SCHEMAS (2026-05-25) — when each role's ``_build_tasks``
+runs, it composes a typed dict matching the matching ``*_HANDOFF``
+schema below, then serializes it as a ``## HANDOFF CONTEXT``
+JSON block appended to the LLM user message. The sub-agent reads
+the prose for instruction and the JSON for accurate values
+(``candidate_id``, dim_means, rewrite_section, etc.).
+
+Drift between this file and the actual handoff dict shape is a
+real bug: if the role's ``_build_description`` adds a new field
+without updating the schema, the structured handoff loses its
+type contract. Tests in
+``tests/plugins/seed_generation/test_handoff_schemas.py`` enforce
+the lockstep.
+
+Design notes
+============
+
+- ``target_dim`` is a single ``str`` everywhere (the run's intended
+  dim; ``PipelineState.target_dim: str`` is the SoT). Multi-dim
+  attribution lives in seed frontmatter's ``target_dims: list[str]``
+  and in critic OUTPUT's ``target_dims_actual: array of string``.
+- Optional fields (baseline_evidence / supervisor_guidance /
+  literature_articles / priors) are NOT in ``required`` — smoke 14
+  and smoke 15 ran with some of these absent.
+- ``additionalProperties`` is left default (true) so future
+  optional fields can be added without breaking back-compat.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+
+def _additive(properties: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    """Wrap a properties dict + required list into a complete JSON Schema.
+
+    Mirror of ``plugins.seed_generation.json_schemas._additive`` —
+    duplicated here to keep the two files mutually independent so
+    one can be deleted without breaking the other.
+    """
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    }
+
+
+GENERATOR_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "target_dim": {"type": "string"},
+        "gen_tag": {"type": "string"},
+        "candidate_id": {"type": "string"},
+        "output_path": {"type": "string"},
+        "existing_pool": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "path": {"type": "string"},
+                },
+                "required": ["id", "path"],
+            },
+        },
+        "supervisor_guidance": {"type": "object"},
+        "articles_with_reasoning": {"type": "string"},
+        "baseline_evidence": {"type": "object"},
+    },
+    required=["target_dim", "gen_tag", "candidate_id", "output_path"],
+)
+"""Generator — writes a candidate `.md` file. No OUTPUT schema
+(generator returns a file path, not JSON)."""
+
+
+LITERATURE_REVIEW_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "target_dim": {"type": "string"},
+        "max_papers": {"type": "integer"},
+        "queries_per_run": {"type": "integer"},
+        "supervisor_guidance": {"type": "object"},
+    },
+    required=["target_dim", "max_papers", "queries_per_run"],
+)
+"""LiteratureReview — Phase A of the 4-phase literature pipeline."""
+
+
+PROXIMITY_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "run_id": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "candidates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "path": {"type": "string"},
+                    "target_dim": {"type": "string"},
+                    "body_preview": {"type": "string"},
+                },
+                "required": ["id", "path", "target_dim"],
+            },
+        },
+    },
+    required=["run_id", "target_dim", "candidates"],
+)
+"""Proximity — single-shot clustering across all candidates."""
+
+
+CRITIC_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "candidate_id": {"type": "string"},
+        "candidate_path": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "baseline_evidence": {"type": "object"},
+        "priors": {"type": "object"},
+        "supervisor_guidance": {"type": "object"},
+        "literature_articles": {"type": "string"},
+    },
+    required=["candidate_id", "candidate_path", "target_dim"],
+)
+"""Critic — per-candidate critique. Optional fields carry
+baseline / priors / guidance / literature context when present."""
+
+
+PILOT_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "candidate_id": {"type": "string"},
+        "candidate_path": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "budget": {
+            "type": "object",
+            "properties": {
+                "max_wall_time_s": {"type": "number"},
+                "models": {"type": "integer"},
+                "paraphrases": {"type": "integer"},
+            },
+            "required": ["max_wall_time_s", "models", "paraphrases"],
+        },
+    },
+    required=["candidate_id", "candidate_path", "target_dim", "budget"],
+)
+"""Pilot — Petri inner-loop audit per candidate. Budget block
+explicit so the LLM knows the wall-time + model count + paraphrase
+count it must respect."""
+
+
+VOTE_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "match_id": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "candidate_a": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "path": {"type": "string"},
+                "pilot_means": {
+                    "type": "object",
+                    "additionalProperties": {"type": "number"},
+                },
+            },
+            "required": ["id", "path"],
+        },
+        "candidate_b": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "path": {"type": "string"},
+                "pilot_means": {
+                    "type": "object",
+                    "additionalProperties": {"type": "number"},
+                },
+            },
+            "required": ["id", "path"],
+        },
+    },
+    required=["match_id", "target_dim", "candidate_a", "candidate_b"],
+)
+"""Ranker voter — per-match A/B vote with pilot dim_means
+attached so the judge sees the per-dim signal alongside seed
+paths."""
+
+
+EVOLVE_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "parent_id": {"type": "string"},
+        "parent_path": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "rewrite_section": {"type": "string"},
+        "reflection_weaknesses": {"type": "array", "items": {"type": "string"}},
+        "pilot_dim_means": {
+            "type": "object",
+            "additionalProperties": {"type": "number"},
+        },
+        "baseline_evidence": {"type": "object"},
+        "supervisor_guidance": {"type": "object"},
+        "literature_articles": {"type": "string"},
+    },
+    required=["parent_id", "parent_path", "target_dim", "rewrite_section"],
+)
+"""Evolver — rewrites ONE section of a survivor candidate.
+Pulls Critic's ``rewrite_section`` + ``weaknesses`` and Pilot's
+``dim_means`` so the LLM knows which dim regressed."""
+
+
+META_REVIEW_HANDOFF: Final[dict[str, Any]] = _additive(
+    properties={
+        "run_id": {"type": "string"},
+        "target_dim": {"type": "string"},
+        "counts": {
+            "type": "object",
+            "properties": {
+                "candidates": {"type": "integer"},
+                "reflections": {"type": "integer"},
+                "pilot_rows": {"type": "integer"},
+                "survivors": {"type": "integer"},
+                "evolved": {"type": "integer"},
+            },
+            "required": ["candidates", "reflections", "pilot_rows", "survivors", "evolved"],
+        },
+        "elo_distribution": {"type": "object"},
+        "candidate_ids": {"type": "array", "items": {"type": "string"}},
+    },
+    required=["run_id", "target_dim", "counts", "candidate_ids"],
+)
+"""Meta-reviewer — full-run aggregate. Counts (not raw rows) per
+the AgentDef contract: ``Meta-reviewer caps output at one paragraph
++ a few aggregate dicts.``"""
+
+
+def embed_handoff(description: str, handoff: dict[str, Any]) -> str:
+    """Append a ``## HANDOFF CONTEXT`` JSON block to the LLM user message.
+
+    The sub-agent reads the prose for instruction and the JSON for
+    accurate values (candidate_id / dim_means / rewrite_section etc.).
+    The block uses a labeled fenced code block so the LLM cannot
+    mistake the handoff for its expected JSON output. claude-cli
+    `--json-schema` enforcement applies to the response, not the
+    prompt — embedding JSON in the prompt is safe.
+    """
+    import json
+
+    body = json.dumps(handoff, indent=2, ensure_ascii=False, default=str)
+    return f"{description}\n\n## HANDOFF CONTEXT\n```json\n{body}\n```\n"
+
+
+__all__ = [
+    "CRITIC_HANDOFF",
+    "EVOLVE_HANDOFF",
+    "GENERATOR_HANDOFF",
+    "LITERATURE_REVIEW_HANDOFF",
+    "META_REVIEW_HANDOFF",
+    "PILOT_HANDOFF",
+    "PROXIMITY_HANDOFF",
+    "VOTE_HANDOFF",
+    "embed_handoff",
+]

--- a/tests/plugins/seed_generation/test_evolver.py
+++ b/tests/plugins/seed_generation/test_evolver.py
@@ -335,8 +335,9 @@ def test_evolver_injects_baseline_evidence_into_description(monkeypatch: Any) ->
     for task in manager.received_tasks:
         assert "Recent audit evidence" in task.description
         assert "seed-evolver" in task.description
-        # Original pilot signals still present.
-        assert "Pilot dim_means" in task.description
+        # PR-HANDOFF-SCHEMAS (2026-05-25) — pilot signals now live inside
+        # the `## HANDOFF CONTEXT` JSON block as `pilot_dim_means`.
+        assert "pilot_dim_means" in task.description
 
 
 def test_evolver_no_evidence_block_without_snapshot() -> None:

--- a/tests/plugins/seed_generation/test_handoff_schemas.py
+++ b/tests/plugins/seed_generation/test_handoff_schemas.py
@@ -1,0 +1,323 @@
+"""PR-HANDOFF-SCHEMAS (2026-05-25) — handoff schema + embed + prompt
+skeleton + sub_agent.py fallback parser tests.
+
+Why these tests exist
+=====================
+
+Smoke 15 (archive ``.audit/smoke-archives/smoke-15-1779677713/``)
+established the pilot + evolver failure mode: tool-using sub-agents
+end with prose summaries when the only JSON-forcing signal is
+``--json-schema`` (a soft hint, not enforced). This PR adds three
+layers of defence and these tests pin each:
+
+1. **Typed handoff** — every role's user message carries a
+   ``## HANDOFF CONTEXT`` JSON block matching the role's
+   ``*_HANDOFF`` schema in ``handoff_schemas.py``.
+2. **Prompt skeleton** — pilot.md / evolver.md / ranker.md prose
+   instructs "FINAL response must be ONLY the JSON object".
+3. **Fallback parser** — ``sub_agent._last_balanced_json_object``
+   recovers a JSON block embedded inside prose responses.
+
+Drift between schema and the actual handoff dict the role emits
+is a real bug. The drift test enumerates the required fields of
+each HANDOFF schema and asserts they appear in the corresponding
+role's serialized handoff dict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.handoff_schemas import (
+    CRITIC_HANDOFF,
+    EVOLVE_HANDOFF,
+    GENERATOR_HANDOFF,
+    LITERATURE_REVIEW_HANDOFF,
+    META_REVIEW_HANDOFF,
+    PILOT_HANDOFF,
+    PROXIMITY_HANDOFF,
+    VOTE_HANDOFF,
+    embed_handoff,
+)
+
+ROLE_PROMPTS = Path(__file__).parents[3] / "plugins" / "seed_generation" / "agents"
+
+
+# ─────────────────────────── Schema shape pinning ─────────────────────────────
+
+
+class TestSchemaShape:
+    """Each handoff schema must be a valid additive JSON Schema dict."""
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            CRITIC_HANDOFF,
+            EVOLVE_HANDOFF,
+            GENERATOR_HANDOFF,
+            LITERATURE_REVIEW_HANDOFF,
+            META_REVIEW_HANDOFF,
+            PILOT_HANDOFF,
+            PROXIMITY_HANDOFF,
+            VOTE_HANDOFF,
+        ],
+    )
+    def test_top_level_shape(self, schema: dict) -> None:
+        assert schema["type"] == "object"
+        assert isinstance(schema["properties"], dict)
+        assert isinstance(schema["required"], list)
+        assert schema["required"], "required list must be non-empty"
+        # every required key must appear in properties
+        missing = [k for k in schema["required"] if k not in schema["properties"]]
+        assert not missing, f"required keys missing from properties: {missing}"
+
+
+# ─────────────────────────── embed_handoff format ─────────────────────────────
+
+
+class TestEmbedHandoff:
+    def test_prose_preserved_above_block(self) -> None:
+        out = embed_handoff("Do X.", {"a": 1})
+        assert out.startswith("Do X.")
+
+    def test_block_uses_json_fence(self) -> None:
+        out = embed_handoff("prose", {"a": 1})
+        assert "## HANDOFF CONTEXT" in out
+        assert "```json" in out
+        assert out.rstrip().endswith("```")
+
+    def test_block_round_trips(self) -> None:
+        payload = {"candidate_id": "abc", "target_dim": "redundant_tool_invocation"}
+        out = embed_handoff("p", payload)
+        # Extract the fenced block body and json.loads it.
+        marker = "```json\n"
+        start = out.index(marker) + len(marker)
+        end = out.rindex("```")
+        body = out[start:end].strip()
+        assert json.loads(body) == payload
+
+    def test_non_string_values_serialise_via_default_str(self) -> None:
+        class _Obj:
+            def __str__(self) -> str:
+                return "obj-repr"
+
+        out = embed_handoff("p", {"obj": _Obj()})
+        # default=str makes the obj serialisable.
+        assert "obj-repr" in out
+
+
+# ─────────────────────────── Schema ↔ role drift ──────────────────────────────
+
+
+class TestRoleHandoffDrift:
+    """Each role's ``_build_description`` must produce a HANDOFF
+    CONTEXT block matching the required keys of its schema."""
+
+    def _extract_handoff(self, description: str) -> dict:
+        marker = "```json\n"
+        start = description.index(marker) + len(marker)
+        end = description.rindex("```")
+        return json.loads(description[start:end].strip())
+
+    def test_pilot_handoff_matches_schema(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from plugins.seed_generation.agents.pilot import Pilot
+
+        agent = Pilot(MagicMock())
+        desc = agent._build_description(
+            candidate_id="gen1-000-deadbeef",
+            candidate_path="/tmp/seed.md",  # noqa: S108
+            target_dim="redundant_tool_invocation",
+        )
+        handoff = self._extract_handoff(desc)
+        for key in PILOT_HANDOFF["required"]:
+            assert key in handoff, f"pilot handoff missing required key: {key}"
+        assert handoff["candidate_id"] == "gen1-000-deadbeef"
+        assert handoff["budget"]["models"] == 2
+
+    def test_evolver_handoff_matches_schema(self) -> None:
+        from unittest.mock import MagicMock
+
+        from plugins.seed_generation.agents.evolver import Evolver
+
+        agent = Evolver(MagicMock())
+        desc = agent._build_description(
+            candidate={
+                "id": "gen1-001-cafebabe",
+                "path": "/tmp/parent.md",  # noqa: S108
+                "target_dim": "stuck_in_loops",
+            },
+            rewrite_section="## Look for — rewrite policy bullet",
+            weaknesses=["judge cannot score this dim"],
+            dim_means={"stuck_in_loops": 1.5},
+            baseline_snapshot=None,
+            supervisor_guidance=None,
+            articles_with_reasoning="",
+        )
+        handoff = self._extract_handoff(desc)
+        for key in EVOLVE_HANDOFF["required"]:
+            assert key in handoff, f"evolver handoff missing required key: {key}"
+        assert handoff["parent_id"] == "gen1-001-cafebabe"
+        assert handoff["reflection_weaknesses"] == ["judge cannot score this dim"]
+
+    def test_ranker_voter_handoff_matches_schema(self) -> None:
+        from unittest.mock import MagicMock
+
+        from plugins.seed_generation.agents.ranker import Ranker
+        from plugins.seed_generation.tournament import MatchPlan
+
+        ranker = Ranker.__new__(Ranker)
+        match = MatchPlan(match_id="m-0", a="cand-a", b="cand-b")
+        voter = MagicMock()
+        voter.provider = "anthropic"
+        voter.source = "claude-cli"
+        voter.model = "claude-opus-4-7"
+        desc = Ranker._build_description(
+            ranker,
+            match=match,
+            voter=voter,
+            means_a={"redundant_tool_invocation": 1.2},
+            means_b={"redundant_tool_invocation": 0.9},
+        )
+        handoff = self._extract_handoff(desc)
+        for key in VOTE_HANDOFF["required"]:
+            assert key in handoff, f"voter handoff missing required key: {key}"
+        assert handoff["candidate_a"]["id"] == "cand-a"
+        assert handoff["candidate_b"]["pilot_means"]["redundant_tool_invocation"] == 0.9
+
+
+# ─────────────────────────── Prompt-md JSON skeleton ──────────────────────────
+
+
+class TestPromptOutputSection:
+    """pilot.md / evolver.md / ranker.md must contain a strong
+    'FINAL response only JSON' directive plus a concrete skeleton.
+
+    Smoke 15 evidence: critic.md (which has this section) passed;
+    pilot.md / evolver.md (which lacked it) emitted prose summaries.
+    """
+
+    @pytest.mark.parametrize(
+        ("md_name", "must_contain"),
+        [
+            ("pilot.md", ["## Output JSON (structured)", "dim_means", "dim_stderr", '"status"']),
+            (
+                "evolver.md",
+                ["## Output JSON (structured)", '"verdict"', "evolved_path", "parent_id"],
+            ),
+        ],
+    )
+    def test_prompt_includes_output_skeleton(self, md_name: str, must_contain: list[str]) -> None:
+        body = (ROLE_PROMPTS / md_name).read_text(encoding="utf-8")
+        for token in must_contain:
+            assert token in body, f"{md_name} missing required token: {token}"
+
+    @pytest.mark.parametrize("md_name", ["pilot.md", "evolver.md"])
+    def test_prompt_demands_pure_json_final(self, md_name: str) -> None:
+        body = (ROLE_PROMPTS / md_name).read_text(encoding="utf-8")
+        # Strong JSON-only directive (allows minor wording variation).
+        body_lc = body.lower()
+        assert "final response" in body_lc or "final output" in body_lc
+        assert "only the json" in body_lc or "only json" in body_lc
+
+
+# ─────────────────────────── Fallback parser ──────────────────────────────────
+
+
+class TestLastBalancedJsonObject:
+    def test_returns_object_at_end_of_prose(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        text = 'I did the work. Result: {"a": 1, "b": 2}'
+        assert _last_balanced_json_object(text) == '{"a": 1, "b": 2}'
+
+    def test_picks_last_when_multiple(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        text = 'Intermediate {"step": 1}. Final {"answer": 42}.'
+        assert _last_balanced_json_object(text) == '{"answer": 42}'
+
+    def test_returns_none_when_no_braces(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        assert _last_balanced_json_object("plain prose with no json") is None
+
+    def test_ignores_braces_inside_strings(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        text = 'final {"msg": "has } embedded", "ok": true}'
+        out = _last_balanced_json_object(text)
+        assert out is not None
+        assert json.loads(out) == {"msg": "has } embedded", "ok": True}
+
+    def test_handles_escaped_quotes_in_strings(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        text = r'{"text": "she said \"hi\"", "n": 1}'
+        out = _last_balanced_json_object(text)
+        assert out is not None
+        assert json.loads(out) == {"text": 'she said "hi"', "n": 1}
+
+    def test_nested_objects_balance_correctly(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        text = 'prose {"outer": {"inner": {"deep": 1}}, "k": "v"} more prose'
+        out = _last_balanced_json_object(text)
+        assert out is not None
+        parsed = json.loads(out)
+        assert parsed["outer"]["inner"]["deep"] == 1
+
+    def test_skips_unparseable_blocks(self) -> None:
+        from core.agent.sub_agent import _last_balanced_json_object
+
+        # First block (later in text — scanned first) is malformed; second
+        # block is valid; the function falls back to the valid one.
+        text = '{"good": 1} ... and now broken {bad,}'
+        out = _last_balanced_json_object(text)
+        # The right-to-left scan tries `{bad,}` first (fails),
+        # then `{"good": 1}` (succeeds).
+        assert out is not None
+        assert json.loads(out) == {"good": 1}
+
+
+class TestSubAgentParseFallback:
+    """End-to-end: a SubAgentManager parsing an isolation output that's
+    PROSE + embedded JSON recovers the JSON via the fallback parser.
+
+    Smoke 15 grounding: pilot emitted prose with audit JSON embedded
+    inside; the previous parser fell back to `{"raw": ...}` and the
+    orchestrator marked the candidate `malformed_pilot`.
+    """
+
+    def test_parse_returns_dict_when_prose_wraps_json(self) -> None:
+        from unittest.mock import MagicMock
+
+        from core.agent.sub_agent import SubAgentManager, SubTask
+        from core.orchestration.isolated_execution import IsolatedRunner, IsolationResult
+
+        runner = MagicMock(spec=IsolatedRunner)
+        mgr = SubAgentManager(runner=runner)
+        task = SubTask(task_id="t1", description="d", task_type="seed-pilot")
+        prose_output = (
+            "I'll run the audit. "
+            "Now I see the results. "
+            '{"candidate_id": "abc", "dim_means": {"x": 1}, '
+            '"dim_stderr": {"x": 0}, "status": "ok"}'
+        )
+        isolation = IsolationResult(
+            session_id="s",
+            success=True,
+            output=prose_output,
+            error=None,
+            duration_ms=10.0,
+        )
+        result = mgr._to_sub_result(task, isolation)  # type: ignore[attr-defined]
+        assert result.success is True
+        assert isinstance(result.output, dict)
+        # Fallback path must NOT return `{"raw": ...}`.
+        assert "raw" not in result.output
+        assert result.output["candidate_id"] == "abc"
+        assert result.output["status"] == "ok"


### PR DESCRIPTION
## Summary
- 8 INPUT handoff JSON Schemas (typed counterpart to `json_schemas.py` OUTPUT side) + `embed_handoff` helper appending `## HANDOFF CONTEXT` JSON block to LLM user_message.
- pilot.md / evolver.md gain `## Output JSON (structured)` skeleton sections with "FINAL response must be ONLY the JSON object" directive.
- `core/agent/sub_agent._last_balanced_json_object` fallback parser recovers JSON embedded in prose responses.

## Why
Smoke 15 (`.audit/smoke-archives/smoke-15-1779677713/`) had pilot + evolver failing with `malformed_pilot` / `malformed_evolve` even though PR-JSON-WIRE plumbed `--json-schema` through every layer:

```
phase_failed pilot — first error: malformed_pilot:
  result.output={'raw': "I'll run the Petri pilot audit..."}
phase_failed evolver — first error: malformed_evolve:
  result.output={'raw': "Reading the parent seed candidate..."}
```

Root cause grounded by reading `sub_agents/*/result.json`: tool-using sub-agents emit prose summaries at the end. `--json-schema` is a soft system-prompt hint, not Anthropic API enforcement, and the LLM ignored it. Per-role observability listed in the issue:

| Role | `## Output JSON` section in .md | smoke 15 |
|---|---|---|
| critic | ✓ (concrete skeleton) | pass |
| meta_reviewer | ✓ (no tools used) | pass |
| pilot | ✗ | **fail** |
| evolver | ✗ | **fail** |
| ranker (voter) | ✗ | n/a (n=1 → skipped) |

The prompt skeleton was the differentiator. Adding handoff JSON gives the LLM accurate values alongside prose, and the parser fallback recovers when the LLM still wraps JSON in prose despite stronger instructions.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/handoff_schemas.py` | NEW — 8 INPUT schemas + `embed_handoff` |
| `plugins/seed_generation/agents/pilot.md` | NEW `## Output JSON (structured)` section + skeleton |
| `plugins/seed_generation/agents/evolver.md` | NEW `## Output JSON (structured)` section + skeleton |
| `plugins/seed_generation/agents/pilot.py` | `_build_description` emits `PILOT_HANDOFF` via `embed_handoff`; FINAL-response directive in prose |
| `plugins/seed_generation/agents/evolver.py` | Same — `EVOLVE_HANDOFF` typed dict (parent_id / rewrite_section / reflection_weaknesses / pilot_dim_means + optional baseline / supervisor / literature). |
| `plugins/seed_generation/agents/ranker.py` | Same — `VOTE_HANDOFF` for voter sub-agent |
| `core/agent/sub_agent.py` | `_last_balanced_json_object` scanner. `_to_sub_result` + `_to_agent_result` use it before `{"raw": ...}` quarantine. |
| `tests/plugins/seed_generation/test_handoff_schemas.py` | NEW — 27 tests (schema shape ×8, embed format ×4, role↔schema drift ×3, prompt skeleton ×4, fallback parser ×7, end-to-end ×1) |
| `tests/plugins/seed_generation/test_evolver.py` | UPDATE — assert `pilot_dim_means` (JSON handoff field) instead of legacy `"Pilot dim_means"` prose marker |
| `CHANGELOG.md` | Entry under `[Unreleased] → Fixed` |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Schemas for all 8 roles | Implemented | Symmetric with `json_schemas.py` OUTPUT side. |
| Critical 3 roles wired (pilot / evolver / ranker) | Implemented | Used `embed_handoff` in `_build_description`. |
| Remaining 5 roles (generator / literature_review / proximity / critic / meta_reviewer) wiring | Deferred | These passed smoke 15. Future PR can migrate them additively without breaking. |
| Prompt skeleton on failing roles | Implemented | pilot.md + evolver.md (smoke 15 failure roles). ranker.md left untouched — voter has no .md system prompt file. |
| Fallback parser handles both parse paths | Implemented | `_to_sub_result` + `_to_agent_result`. |

## Verification
- [x] `uv run pytest tests/plugins/seed_generation/test_handoff_schemas.py` — 27/27 pass
- [x] `uv run pytest tests/plugins/seed_generation/ tests/core/agent/` — 552 passed, 3 skipped
- [x] `uv run ruff check core/ tests/ plugins/` + `ruff format --check` — clean
- [x] `uv run mypy plugins/seed_generation/ core/agent/sub_agent.py` — 0 errors
- [x] `uv run lint-imports` — 4 contracts kept
- [ ] CI 5/5 green (pending)
- [ ] Smoke 16 (Loop 1, n=1) end-to-end — verifies pilot + evolver emit valid JSON (post-merge)

## Reference
- Smoke 15 archive: `.audit/smoke-archives/smoke-15-1779677713/`
- Earlier per-role observability listed in conversation (critic.md pattern as positive control)
- json_schemas.py — OUTPUT side counterpart preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)