### PR TITLE
release: v0.99.55 — PR-EVOLVER-JACCARD-OBS + PETRI-BUNDLE-LANDING + HANDOFF-SCHEMAS bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [v0.99.55] - 2026-05-25
+
+Bundles 3 PRs: PR-EVOLVER-JACCARD-OBS, PR-PETRI-BUNDLE-LANDING, PR-HANDOFF-SCHEMAS. Smoke-15-driven defence against tool-using sub-agents emitting prose instead of JSON, plus Petri bundle bridge UI and Jaccard threshold tune.
+
 ### Added
 - **PR-PETRI-BUNDLE-LANDING** — bridge UI/UX for the three Petri bundle
   surfaces (`/petri-bundle/`, `/petri-bundle/seeds/`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ functional change.
 
 ## [Unreleased]
 
-## [v0.99.55] - 2026-05-25
+## [0.99.55] - 2026-05-25
 
 Bundles 3 PRs: PR-EVOLVER-JACCARD-OBS, PR-PETRI-BUNDLE-LANDING, PR-HANDOFF-SCHEMAS. Smoke-15-driven defence against tool-using sub-agents emitting prose instead of JSON, plus Petri bundle bridge UI and Jaccard threshold tune.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.54
+- **Version**: 0.99.55
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.54 — Long-running Autonomous Execution Harness
+# GEODE v0.99.55 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.54**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.55**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.54 — Long-running Autonomous Execution Harness
+# GEODE v0.99.55 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.54**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.55**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.54"
+version = "0.99.55"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Version bump 0.99.54 → 0.99.55 across 5 SoT locations.
- Bundles 3 merged PRs (#1638 / #1642 / #1646) addressing smoke 15 failures and Petri bundle UX.

## Verification
- [x] `grep -n "0\.99\.55"` across pyproject.toml / CLAUDE.md / README.md / README.ko.md / CHANGELOG.md — all 5 match
- [ ] CI 5/5 green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)