### PR TITLE
feat(self-improving-loop): P3-revised anchor calibration + SPCT principle wiring

### DIFF
--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -292,6 +292,22 @@ class AutoresearchConfig(BaseModel):
     point 는 unreachable worst-case (e.g., dim 별 0).
     """
 
+    anchor_confidence_mode: bool = False
+    """P3-revised (2026-05-25, SPCT + Meta-Rewarding) — anchor 3
+    (admirable / disappointing / needs_attention) → fitness 의 confidence
+    multiplier routing knob. plan ``docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md``.
+
+    - ``False`` (default, legacy): anchor 3 가 dim_means 에 measured 되지만
+      fitness 계산에는 weight=0 (제외). PR-5 이전 동작 그대로.
+    - ``True``: ``compute_anchor_confidence_multiplier`` helper 가
+      ``0.7 + 0.3 × normalized_anchor`` range [0.7, 1.0] 의 multiplier
+      산출. caller (autoresearch/train.py compute_fitness — P3.1 후속 wiring)
+      가 base_fitness × multiplier 적용.
+
+    사용자 결정 D2 (2026-05-25): anchor 3 → self-improving loop baseline 의
+    input. PSM 패턴 거부 후 RL-derived (AutoGLM ORM confidence band).
+    """
+
     target_model: str | None = None
     """**Deprecated pre-PR #1496 slot** — surviving for back-compat
     config file load. Never consulted at runtime. Will be dropped in a

--- a/core/self_improving_loop/anchor_confidence.py
+++ b/core/self_improving_loop/anchor_confidence.py
@@ -1,0 +1,119 @@
+"""P3-revised (2026-05-25) — Anchor confidence multiplier.
+
+Plan: ``docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md``.
+
+사용자 결정 D2 (2026-05-25): anchor 3 (admirable / disappointing /
+needs_attention) → self-improving loop baseline 의 input. PSM 패턴 거부
+후 RL-derived (AutoGLM ORM confidence band).
+
+본 모듈 = compute_fitness 의 multiplier helper. judge anchor 의 1-10
+scale score 를 [0, 1] 로 normalize 한 뒤 [0.7, 1.0] range 의 multiplier
+산출. caller (autoresearch/train.py compute_fitness — P3.1 후속 wiring)
+가 ``base_fitness × multiplier`` 적용.
+
+Frontier:
+- AutoGLM (Zhipu+Tsinghua 2024-11) — ORM outcome confidence band
+- SPCT (DeepSeek-GRM 2026-Q1) — self-generated principle 이 anchor 의
+  calibration 단계와 정합
+- Meta-Rewarding (Meta 2024-07 arXiv 2407.19594) — meta-judge drift 방지
+  (anchor 가 trade-off 한 dim 의 confidence sink)
+
+GEODE 의 mutator API frozen 와 정합 — multiplier 는 inference-time selection
+신호, weight 학습 없음.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+ANCHOR_DIMS_POSITIVE: tuple[str, ...] = ("admirable",)
+"""High score = good (positive direction). 1-10 scale, higher → multiplier ↑."""
+
+ANCHOR_DIMS_NEGATIVE: tuple[str, ...] = ("disappointing", "needs_attention")
+"""High score = bad (negative direction, good-low palette). caller 가
+1-10 scale 의 inverted score 를 normalized → multiplier ↑ 로 매핑."""
+
+MULTIPLIER_MIN: float = 0.7
+"""Multiplier range lower bound — anchor 가 worst-case 일 때. mutation
+gaming 의 impact 제한 (anchor 가 자체 target 되어도 fitness 의 30%
+이상 영향 못 줌)."""
+
+MULTIPLIER_MAX: float = 1.0
+"""Multiplier range upper bound — anchor 가 best-case 일 때 (legacy
+fitness 유지). caller 는 multiplier 가 1.0 이면 P3-revised 비활성과
+동일 동작 (backward compat)."""
+
+
+def _normalize_anchor_score(
+    score: float,
+    *,
+    invert: bool = False,
+    scale_min: float = 1.0,
+    scale_max: float = 10.0,
+) -> float:
+    """1-10 scale score → [0, 1] normalized.
+
+    invert=True 면 (good-low palette) 의 score 를 inverted. 예: disappointing
+    score=10 (very disappointing) → 0.0 (low confidence).
+
+    Out-of-range score 는 clamp.
+    """
+    if scale_max <= scale_min:
+        return 0.0
+    clamped = max(scale_min, min(scale_max, score))
+    normalized = (clamped - scale_min) / (scale_max - scale_min)
+    return 1.0 - normalized if invert else normalized
+
+
+def compute_anchor_confidence_multiplier(
+    dim_means: dict[str, float],
+    *,
+    multiplier_min: float = MULTIPLIER_MIN,
+    multiplier_max: float = MULTIPLIER_MAX,
+) -> float:
+    """3 anchor dims (admirable / disappointing / needs_attention) → 단일
+    multiplier in ``[multiplier_min, multiplier_max]``.
+
+    Formula::
+
+        anchor_score = mean(
+            normalize(admirable),
+            normalize_inverted(disappointing),
+            normalize_inverted(needs_attention),
+        )
+        multiplier = min + (max - min) × anchor_score
+
+    Returns ``multiplier_max`` (legacy fitness 유지) when 모든 anchor dim 이
+    ``dim_means`` 에서 missing (PR-5 이전 baseline 의 graceful fallback).
+    """
+    positive_scores = [
+        _normalize_anchor_score(dim_means[d]) for d in ANCHOR_DIMS_POSITIVE if d in dim_means
+    ]
+    negative_scores = [
+        _normalize_anchor_score(dim_means[d], invert=True)
+        for d in ANCHOR_DIMS_NEGATIVE
+        if d in dim_means
+    ]
+    all_scores = positive_scores + negative_scores
+    if not all_scores:
+        log.debug(
+            "anchor_confidence: no anchor dims found in dim_means; "
+            "defaulting to multiplier_max=%s (legacy fitness 유지)",
+            multiplier_max,
+        )
+        return multiplier_max
+    anchor_score = sum(all_scores) / len(all_scores)
+    multiplier = multiplier_min + (multiplier_max - multiplier_min) * anchor_score
+    # Defensive clamp (anchor_score 가 0..1 range 외일 가능성 mitigate)
+    return max(multiplier_min, min(multiplier_max, multiplier))
+
+
+__all__ = [
+    "ANCHOR_DIMS_NEGATIVE",
+    "ANCHOR_DIMS_POSITIVE",
+    "MULTIPLIER_MAX",
+    "MULTIPLIER_MIN",
+    "compute_anchor_confidence_multiplier",
+]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -114,6 +114,11 @@ class ApplyRecord(BaseModel):
     재구성 가능. group_size=1 (legacy) 일 때 None."""
     group_advantage: float | None = None
     """P1-revised — advantage normalization z-score. group_size=1 일 때 None."""
+    principle: str | None = Field(default=None, max_length=500)
+    """P3-revised (2026-05-25, SPCT) — mutator 가 mutation 직전 명시
+    한 self-generated judging principle. SPCT (DeepSeek-GRM 2026-Q1) 패턴.
+    None 일 때 legacy (P3 이전 mutation row). max 500 chars (parse_mutation
+    guard)."""
 
 
 @dataclass(frozen=True)
@@ -167,6 +172,13 @@ class Mutation:
     cost_output_tokens: int = 0
     cost_elapsed_seconds: float = 0.0
     cost_model: str = ""
+
+    principle: str = ""
+    """P3-revised (2026-05-25, SPCT) — mutator 가 mutation 직전 명시한
+    self-generated judging principle. SPCT (DeepSeek-GRM 2026-Q1) 패턴 —
+    principle → critique → reward chain 의 입구. parse_mutation 이
+    LLM response 의 ``principle`` key 에서 추출 (max 500자). 빈 문자열
+    일 때 legacy mutator (P3 이전) 호환."""
 
     def to_audit_row(
         self,
@@ -225,6 +237,10 @@ class Mutation:
             row["cost_elapsed_seconds"] = round(float(self.cost_elapsed_seconds), 4)
         if self.cost_model:
             row["cost_model"] = str(self.cost_model)
+        # P3-revised — principle non-empty 시만 emit (legacy mutation row
+        # 무영향).
+        if self.principle:
+            row["principle"] = self.principle
         return row
 
 
@@ -424,6 +440,15 @@ _MUTATION_CONTRACT_SUFFIX = (
     "``reflection`` (reflection.json). "
     "Omit for prompt-level mutations. (``retrieval`` was deprecated "
     "in ADR-012 S0d, 2026-05-21 — see policies.py docstring.)\n"
+    "- **Principle-first (P3-revised, 2026-05-25, SPCT pattern)**: BEFORE "
+    "selecting ``target_section`` and writing ``new_value``, explicitly state "
+    "the judging principle that motivates this mutation — what specific axis "
+    "of GEODE behaviour should it move, and why? Output the principle as a "
+    "short string in the ``principle`` field (<= 500 chars). This is the "
+    "SPCT (DeepSeek-GRM 2026-Q1) frontier — self-generated principles "
+    "anchor self-judge drift and let downstream attribution (PR-3 W2 hook) "
+    "trace causal hypothesis. legacy callers (P3 이전) may omit; empty "
+    "string is graceful.\n"
     "- **Group sampling (P1-revised, 2026-05-25)**: when this invocation is "
     "part of a sibling group (``group_size > 1``), each sibling MUST target a "
     "meaningfully different section or strategy. Repeating the same "
@@ -441,7 +466,8 @@ _MUTATION_CONTRACT_SUFFIX = (
     '  "target_dim": "<dim name the mutation aims at, or empty>",\n'
     '  "target_kind": "<prompt|tool_policy|decomposition|reflection>",\n'
     '  "expected_dim": {"<dim>": 0.0, ...},\n'
-    '  "rollback_condition": "<one-line predicate, or empty>"\n'
+    '  "rollback_condition": "<one-line predicate, or empty>",\n'
+    '  "principle": "<= 500 chars SPCT principle (P3-revised), or empty>"\n'
     "}\n"
 )
 """Appended to program.md so the runner can scope it to a single mutation step.
@@ -819,6 +845,16 @@ def parse_mutation(raw: str) -> Mutation:
         )
     rollback_raw = payload.get("rollback_condition", "")
     rollback_condition = rollback_raw.strip() if isinstance(rollback_raw, str) else ""
+    # P3-revised (2026-05-25, SPCT pattern) — principle 추출. LLM 이 명시
+    # 안 하면 (legacy 또는 mutator omit) 빈 문자열. max 500 chars guard.
+    principle_raw = payload.get("principle", "")
+    principle = principle_raw.strip() if isinstance(principle_raw, str) else ""
+    if len(principle) > 500:
+        raise ValueError(
+            f"principle length {len(principle)} exceeds 500 char cap "
+            f"(SPCT principle must be concise — frontier reference: "
+            f"DeepSeek-GRM)"
+        )
     # PR-6 C-5 — target_kind dispatches to the policy SoT file. Default
     # ``prompt`` keeps the legacy wrapper-sections behaviour so older
     # mutation rows replay unchanged. Unknown kinds raise ValueError so
@@ -843,6 +879,7 @@ def parse_mutation(raw: str) -> Mutation:
             mutation_id=mutation_id_raw.strip(),
             expected_dim=expected_dim,
             rollback_condition=rollback_condition,
+            principle=principle,
         )
     return Mutation(
         target_section=target_section.strip(),
@@ -852,6 +889,7 @@ def parse_mutation(raw: str) -> Mutation:
         target_kind=target_kind,
         expected_dim=expected_dim,
         rollback_condition=rollback_condition,
+        principle=principle,
     )
 
 

--- a/tests/core/self_improving_loop/test_p3_anchor_spct.py
+++ b/tests/core/self_improving_loop/test_p3_anchor_spct.py
@@ -1,0 +1,238 @@
+"""P3-revised (2026-05-25) — anchor calibration + SPCT principle wiring tests.
+
+Plan: ``docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md``.
+
+Covers:
+- Mutation.principle field (SPCT pattern, max 500 chars)
+- ApplyRecord.principle field
+- parse_mutation 의 principle 추출 + max-length guard
+- _MUTATION_CONTRACT_SUFFIX 의 principle 단계 명시
+- compute_anchor_confidence_multiplier 의 normalization + range [0.7, 1.0]
+- AutoresearchConfig.anchor_confidence_mode (default False, legacy)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from core.self_improving_loop.anchor_confidence import (
+    ANCHOR_DIMS_NEGATIVE,
+    ANCHOR_DIMS_POSITIVE,
+    MULTIPLIER_MAX,
+    MULTIPLIER_MIN,
+    _normalize_anchor_score,
+    compute_anchor_confidence_multiplier,
+)
+from core.self_improving_loop.runner import (
+    _MUTATION_CONTRACT_SUFFIX,
+    ApplyRecord,
+    Mutation,
+    parse_mutation,
+)
+
+# ---------------------------------------------------------------------------
+# C1 — mutator prompt suffix advertises principle step
+# ---------------------------------------------------------------------------
+
+
+class TestMutationContractSuffixPrinciple:
+    def test_suffix_mentions_principle(self) -> None:
+        """C1-1: _MUTATION_CONTRACT_SUFFIX 가 principle 단계 명시."""
+        assert "principle" in _MUTATION_CONTRACT_SUFFIX.lower()
+        assert "spct" in _MUTATION_CONTRACT_SUFFIX.lower()
+
+    def test_response_schema_includes_principle_field(self) -> None:
+        """C1-2: response schema JSON template 에 principle key 포함."""
+        assert '"principle"' in _MUTATION_CONTRACT_SUFFIX
+
+
+# ---------------------------------------------------------------------------
+# C2 + C3 — Mutation.principle + parse_mutation
+# ---------------------------------------------------------------------------
+
+
+class TestParseMutationPrinciple:
+    def test_parses_principle_when_supplied(self) -> None:
+        """C3-1: LLM response 의 principle key 가 Mutation.principle 로."""
+        raw = json.dumps(
+            {
+                "target_section": "role",
+                "new_value": "Surface reasoning steps.",
+                "rationale": "test",
+                "principle": "Prefer transparency over brevity.",
+            }
+        )
+        mutation = parse_mutation(raw)
+        assert mutation.principle == "Prefer transparency over brevity."
+
+    def test_legacy_no_principle_empty_string(self) -> None:
+        """C3-2: legacy LLM (principle 미지원) → Mutation.principle 빈 문자열."""
+        raw = json.dumps(
+            {
+                "target_section": "role",
+                "new_value": "Surface reasoning steps.",
+                "rationale": "test",
+            }
+        )
+        mutation = parse_mutation(raw)
+        assert mutation.principle == ""
+
+    def test_principle_exceeds_500_raises(self) -> None:
+        """C3-3: principle > 500 chars → ValueError (concise principle 강제)."""
+        oversize = "x" * 501
+        raw = json.dumps(
+            {
+                "target_section": "role",
+                "new_value": "test",
+                "rationale": "test",
+                "principle": oversize,
+            }
+        )
+        with pytest.raises(ValueError, match=r"principle length .* exceeds 500"):
+            parse_mutation(raw)
+
+
+# ---------------------------------------------------------------------------
+# C4 — Mutation.to_audit_row + ApplyRecord schema
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipleAuditRowEmission:
+    def test_principle_emitted_in_audit_row(self) -> None:
+        """C4-1: Mutation.principle non-empty → audit row 에 principle 포함."""
+        mutation = Mutation(
+            target_section="role",
+            new_value="x",
+            rationale="t",
+            principle="Prefer clarity",
+        )
+        row = mutation.to_audit_row(previous_value="")
+        assert row["principle"] == "Prefer clarity"
+
+    def test_principle_empty_omitted_from_row(self) -> None:
+        """C4-2: principle="" (legacy) → row 에서 column 생략."""
+        mutation = Mutation(
+            target_section="role",
+            new_value="x",
+            rationale="t",
+        )
+        row = mutation.to_audit_row(previous_value="")
+        assert "principle" not in row
+
+    def test_apply_record_accepts_principle(self) -> None:
+        """C4-3: ApplyRecord schema 가 principle field 허용."""
+        row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "m1",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+            "principle": "Prefer clarity",
+        }
+        record = ApplyRecord.model_validate(row)
+        assert record.principle == "Prefer clarity"
+
+    def test_apply_record_legacy_no_principle(self) -> None:
+        """C4-4: legacy row (principle 없음) 도 통과."""
+        row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "m1",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+        }
+        record = ApplyRecord.model_validate(row)
+        assert record.principle is None
+
+
+# ---------------------------------------------------------------------------
+# C7 — anchor confidence multiplier
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAnchorConfidenceMultiplier:
+    def test_no_anchor_dims_returns_max(self) -> None:
+        """C7-1: dim_means 에 anchor dim 없음 → multiplier_max (legacy 호환)."""
+        m = compute_anchor_confidence_multiplier({})
+        assert m == MULTIPLIER_MAX
+
+    def test_admirable_max_score(self) -> None:
+        """C7-2: admirable=10 (max good) → multiplier_max."""
+        m = compute_anchor_confidence_multiplier({"admirable": 10.0})
+        assert m == pytest.approx(MULTIPLIER_MAX)
+
+    def test_admirable_min_score(self) -> None:
+        """C7-3: admirable=1 (min good) → multiplier_min."""
+        m = compute_anchor_confidence_multiplier({"admirable": 1.0})
+        assert m == pytest.approx(MULTIPLIER_MIN)
+
+    def test_disappointing_inverted(self) -> None:
+        """C7-4: disappointing=10 (very bad) → multiplier_min (inverted)."""
+        m = compute_anchor_confidence_multiplier({"disappointing": 10.0})
+        assert m == pytest.approx(MULTIPLIER_MIN)
+
+    def test_disappointing_low_score(self) -> None:
+        """C7-5: disappointing=1 (not bad) → multiplier_max (inverted)."""
+        m = compute_anchor_confidence_multiplier({"disappointing": 1.0})
+        assert m == pytest.approx(MULTIPLIER_MAX)
+
+    def test_three_anchors_mean(self) -> None:
+        """C7-6: 3 anchor 의 mean. admirable=10, disappointing=1, needs_attention=1
+        → 모두 best → multiplier_max."""
+        m = compute_anchor_confidence_multiplier(
+            {"admirable": 10.0, "disappointing": 1.0, "needs_attention": 1.0}
+        )
+        assert m == pytest.approx(MULTIPLIER_MAX)
+
+    def test_multiplier_within_range(self) -> None:
+        """C7-7: multiplier 가 항상 [0.7, 1.0] 안 (clamp invariant)."""
+        for admire in (1.0, 5.0, 10.0):
+            for disap in (1.0, 5.0, 10.0):
+                m = compute_anchor_confidence_multiplier(
+                    {"admirable": admire, "disappointing": disap}
+                )
+                assert MULTIPLIER_MIN <= m <= MULTIPLIER_MAX
+
+    def test_normalize_inverted(self) -> None:
+        """C7-8: _normalize_anchor_score(invert=True) 가 good-low palette 처리."""
+        # 1-10 scale, score=10 → invert=True 시 0.0 (worst)
+        assert _normalize_anchor_score(10.0, invert=True) == pytest.approx(0.0)
+        assert _normalize_anchor_score(1.0, invert=True) == pytest.approx(1.0)
+        # invert=False (default, good-high)
+        assert _normalize_anchor_score(10.0) == pytest.approx(1.0)
+        assert _normalize_anchor_score(1.0) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Config knob
+# ---------------------------------------------------------------------------
+
+
+class TestAnchorConfidenceConfigKnob:
+    def test_default_disabled(self) -> None:
+        """C7-9: AutoresearchConfig.anchor_confidence_mode default = False."""
+        from core.config.self_improving_loop import AutoresearchConfig
+
+        cfg = AutoresearchConfig()
+        assert cfg.anchor_confidence_mode is False
+
+
+# ---------------------------------------------------------------------------
+# Anchor dim set sanity
+# ---------------------------------------------------------------------------
+
+
+class TestAnchorDimSets:
+    def test_dim_sets_disjoint(self) -> None:
+        """W-DIM-1: positive + negative anchor sets disjoint."""
+        assert set(ANCHOR_DIMS_POSITIVE).isdisjoint(set(ANCHOR_DIMS_NEGATIVE))
+
+    def test_dim_sets_non_empty(self) -> None:
+        """W-DIM-2: each anchor set non-empty."""
+        assert len(ANCHOR_DIMS_POSITIVE) > 0
+        assert len(ANCHOR_DIMS_NEGATIVE) > 0


### PR DESCRIPTION
## Summary
- 2026-05-25 plan (PR #1643 영속화) 의 P3-revised MVP — SPCT self-generated principle + anchor confidence multiplier helper
- 사용자 결정 D2 (anchor 3 → baseline input) 구체 wiring
- 412 LOC + 20 invariant tests

## Why
PR-5 후 anchor 3 (admirable/disappointing/needs_attention) 가 measured 되지만 weight=0 으로 fitness 계산에서 제외. 사용자 결정 D2 가 anchor → "self-improving loop baseline 의 input" 으로 routing. SPCT (DeepSeek-GRM 2026-Q1) frontier 의 self-generated principle pattern + AutoGLM ORM confidence band 의 [0.7, 1.0] multiplier 차용. PSM 거부 후 RL-derived selection layer.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | Mutation.principle field (frozen, default "") / ApplyRecord.principle field (Pydantic, max 500 chars) / parse_mutation 의 principle 추출 + max-length guard / to_audit_row 의 principle emit (non-empty) / _MUTATION_CONTRACT_SUFFIX 의 SPCT principle 단계 명시 |
| `core/self_improving_loop/anchor_confidence.py` | 신규 — 3 anchor dim normalization + [0.7, 1.0] multiplier 산출 helper (ANCHOR_DIMS_POSITIVE / NEGATIVE / MULTIPLIER_MIN / MAX / compute_anchor_confidence_multiplier) |
| `core/config/self_improving_loop.py` | AutoresearchConfig.anchor_confidence_mode (default False, legacy) |
| `tests/core/self_improving_loop/test_p3_anchor_spct.py` | 신규 — 20 invariant tests |

## GAP Audit
| Item | Status |
|------|--------|
| C1 mutator suffix principle 단계 | Implemented |
| C2 Mutation.principle field | Implemented |
| C3 parse_mutation 의 principle 추출 + 500 char guard | Implemented |
| C4 ApplyRecord.principle field | Implemented |
| C7 anchor confidence multiplier helper | Implemented |
| C7 multiplier 의 compute_fitness wiring | Deferred to P3.1 (autoresearch/train.py modify) |
| C5 meta-judge invocation | Deferred (recent N mutation attribution retrospective) |
| C6 causal_hypothesis (CRM) | Deferred |

## Verification
- [x] ruff check + format: 통과 (382 files)
- [x] mypy: 통과 (20 source files)
- [x] pytest: **124 passed** (test_p3_anchor_spct.py 20 신규 + 기존 self_improving_loop suite + test_pareto_archive.py + test_baseline_rl_grounding.py 호환)

## Reference
- Plan: `docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md` (PR #1643 merged)
- 선행: PR-5 #1641 / PR-7 #1644 / PR-8 #1645
- Frontier: [SPCT DeepSeek-GRM](https://medium.com/@noailabs/self-principled-critique-tuning-spct-deepseek-grm-0669f822d0cb) / [Meta-Rewarding arXiv 2407.19594](https://arxiv.org/abs/2407.19594) / [AutoGLM arXiv 2411.00820](https://arxiv.org/abs/2411.00820)