### PR TITLE
feat(self-improving-loop): P4 swarm scaffolding — Kimi K2.6 PARL inference-time

### DIFF
--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -292,6 +292,25 @@ class AutoresearchConfig(BaseModel):
     point 는 unreachable worst-case (e.g., dim 별 0).
     """
 
+    sub_agent_count: Annotated[int, Field(ge=1, le=5)] = 1
+    """P4 (2026-05-25, Kimi K2.6 PARL inference-time 변형) — swarm-level
+    sub-agent 개수. plan ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md``.
+
+    - ``1`` (default, legacy): single mutation chain. P1-revised group
+      sampling (group_size) 만 활성.
+    - ``3``: MVP — 3 sub-agent 가 각자 다른 agent_contract policy slice
+      로 mutation chain 진행. swarm-mean baseline.
+    - ``5``: full — Kimi K2.6 PARL 의 inference-time 축소판.
+
+    audit cost = sub_agent_count × group_size × per-cycle cost. config
+    cap = 5 로 unconstrained cost explosion 방지.
+    """
+
+    swarm_aggregation: Literal["mean", "median", "max"] = "mean"
+    """P4 — sub-agent fitness aggregation strategy. ``mean`` 이 PARL 의
+    swarm-mean 패턴 (Kimi K2.6 추정). ``median`` 은 outlier-resilient,
+    ``max`` 는 best-of-M exploration."""
+
     anchor_confidence_mode: bool = False
     """P3-revised (2026-05-25, SPCT + Meta-Rewarding) — anchor 3
     (admirable / disappointing / needs_attention) → fitness 의 confidence

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -119,6 +119,13 @@ class ApplyRecord(BaseModel):
     한 self-generated judging principle. SPCT (DeepSeek-GRM 2026-Q1) 패턴.
     None 일 때 legacy (P3 이전 mutation row). max 500 chars (parse_mutation
     guard)."""
+    swarm_id: str | None = None
+    """P4 (2026-05-25, Kimi K2.6 PARL inference-time) — swarm-level grouping
+    key. multi-level: swarm_id (level 2) + group_id (level 1). 1=disabled
+    legacy."""
+    sub_agent_index: int | None = None
+    """P4 — sub-agent index (0..sub_agent_count-1) in the swarm.
+    contribution decomposition 시 식별 key."""
 
 
 @dataclass(frozen=True)

--- a/core/self_improving_loop/swarm_scaffolding.py
+++ b/core/self_improving_loop/swarm_scaffolding.py
@@ -1,0 +1,92 @@
+"""P4 (2026-05-25) — Swarm-level baseline scaffolding (Kimi K2.6 영감).
+
+Plan: ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md``.
+
+Frontier source:
+- Kimi K2.6 (Moonshot 2026-04-20) — PARL (Parallel-Agent RL), 100→300
+  sub-agent + 1500→4000 coordinated step. credit assignment 식은 미공개.
+
+GEODE 적용 — Kimi K2.6 의 *post-trained* decomposition policy 는 mutator
+frozen 와 충돌. **inference-time 변형**:
+- M sub-agent 가 각자 mutation chain (다른 agent_contract policy slice)
+- swarm-level fitness aggregation (mean / max config)
+- multi-level grouping: swarm_id (level 2) + group_id (level 1)
+
+본 모듈 = **selection-only scaffolding** (P1-revised, P2 와 같은 정합):
+- training-time policy update 없음 (mutator API frozen)
+- post-trained PARL 의 정확한 식 미공개로, 본 MVP 는 aggregation +
+  multi-level grouping helper 만. 실제 propose_swarm + apply_swarm
+  wiring 은 P4.1 후속.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Literal
+
+log = logging.getLogger(__name__)
+
+SwarmAggregation = Literal["mean", "median", "max"]
+"""Swarm-level fitness aggregation strategy. plan §3 D1.
+
+- ``mean``: M sub-agent 의 fitness 평균. PARL 의 swarm-mean 패턴 (Kimi
+  K2.6 추정).
+- ``median``: outlier-resilient. 단일 sub-agent failure 시 swarm 안정.
+- ``max``: best-of-M. exploration 강조.
+"""
+
+
+def aggregate_swarm_fitness(
+    fitness_values: list[float],
+    *,
+    method: SwarmAggregation = "mean",
+) -> float:
+    """M sub-agent 의 fitness scalar → 1 swarm-level fitness.
+
+    Plan §5 D3 — apply_swarm_proposals 의 fitness aggregation step.
+    aggregation strategy 는 config knob (``AutoresearchConfig.swarm_aggregation``).
+
+    Empty list → 0.0 (graceful fallback, swarm 폐기 시그널).
+    """
+    if not fitness_values:
+        return 0.0
+    if method == "mean":
+        return sum(fitness_values) / len(fitness_values)
+    if method == "median":
+        return statistics.median(fitness_values)
+    if method == "max":
+        return max(fitness_values)
+    raise ValueError(f"unknown swarm_aggregation method: {method!r}")
+
+
+def decompose_sub_agent_contribution(
+    swarm_fitness: float,
+    sub_agent_fitness_values: list[float],
+    *,
+    method: SwarmAggregation = "mean",
+) -> list[float]:
+    """Sub-agent 별 swarm fitness 기여도 (per-agent contribution).
+
+    Plan §3 sub-agent contribution decomposition. PARL 의 credit assignment
+    식이 미공개라 본 MVP 는 단순 deviation:
+
+    - ``mean``: contribution_i = fitness_i - swarm_mean
+    - ``median``: contribution_i = fitness_i - swarm_median
+    - ``max``: contribution_i = 1.0 if argmax else 0.0
+
+    Returns list parallel to ``sub_agent_fitness_values`` — same indexing.
+    """
+    if not sub_agent_fitness_values:
+        return []
+    if method == "max":
+        max_val = max(sub_agent_fitness_values)
+        return [1.0 if v == max_val else 0.0 for v in sub_agent_fitness_values]
+    return [v - swarm_fitness for v in sub_agent_fitness_values]
+
+
+__all__ = [
+    "SwarmAggregation",
+    "aggregate_swarm_fitness",
+    "decompose_sub_agent_contribution",
+]

--- a/tests/core/self_improving_loop/test_p4_swarm.py
+++ b/tests/core/self_improving_loop/test_p4_swarm.py
@@ -1,0 +1,125 @@
+"""P4 (2026-05-25) — Swarm-level baseline scaffolding tests.
+
+Plan: ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md``.
+
+Covers:
+- SwarmConfig (sub_agent_count + swarm_aggregation)
+- aggregate_swarm_fitness (mean / median / max)
+- decompose_sub_agent_contribution
+- ApplyRecord.swarm_id + sub_agent_index field
+- backward compat (sub_agent_count=1 legacy)
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.runner import ApplyRecord
+from core.self_improving_loop.swarm_scaffolding import (
+    aggregate_swarm_fitness,
+    decompose_sub_agent_contribution,
+)
+
+
+class TestAggregateSwarmFitness:
+    def test_mean(self) -> None:
+        """D-AGG-1: method='mean' → arithmetic mean."""
+        assert aggregate_swarm_fitness([0.3, 0.5, 0.7], method="mean") == pytest.approx(0.5)
+
+    def test_median(self) -> None:
+        """D-AGG-2: method='median' → middle value (odd N)."""
+        assert aggregate_swarm_fitness([0.1, 0.5, 0.9], method="median") == 0.5
+
+    def test_max(self) -> None:
+        """D-AGG-3: method='max' → best-of-M."""
+        assert aggregate_swarm_fitness([0.1, 0.5, 0.9], method="max") == 0.9
+
+    def test_empty_returns_zero(self) -> None:
+        """D-AGG-4: empty list → 0.0 (graceful, swarm 폐기 시그널)."""
+        assert aggregate_swarm_fitness([], method="mean") == 0.0
+
+    def test_unknown_method_raises(self) -> None:
+        """D-AGG-5: invalid method → ValueError."""
+        with pytest.raises(ValueError, match="unknown swarm_aggregation method"):
+            aggregate_swarm_fitness([0.5], method="bogus")  # type: ignore[arg-type]
+
+
+class TestDecomposeSubAgentContribution:
+    def test_mean_method_deviation(self) -> None:
+        """D-DEC-1: method='mean' → fitness_i - swarm_mean."""
+        contributions = decompose_sub_agent_contribution(
+            swarm_fitness=0.5,
+            sub_agent_fitness_values=[0.3, 0.5, 0.7],
+            method="mean",
+        )
+        assert contributions == pytest.approx([-0.2, 0.0, 0.2])
+
+    def test_max_method_one_hot(self) -> None:
+        """D-DEC-2: method='max' → argmax index = 1.0, rest = 0.0."""
+        contributions = decompose_sub_agent_contribution(
+            swarm_fitness=0.9,
+            sub_agent_fitness_values=[0.3, 0.5, 0.9],
+            method="max",
+        )
+        assert contributions == [0.0, 0.0, 1.0]
+
+    def test_empty_returns_empty(self) -> None:
+        """D-DEC-3: empty sub-agent list → empty contributions."""
+        assert decompose_sub_agent_contribution(0.0, [], method="mean") == []
+
+
+class TestSwarmConfigKnob:
+    def test_sub_agent_count_default_one(self) -> None:
+        """D-CFG-1: AutoresearchConfig.sub_agent_count default = 1 (legacy)."""
+        from core.config.self_improving_loop import AutoresearchConfig
+
+        cfg = AutoresearchConfig()
+        assert cfg.sub_agent_count == 1
+
+    def test_swarm_aggregation_default_mean(self) -> None:
+        """D-CFG-2: swarm_aggregation default = 'mean'."""
+        from core.config.self_improving_loop import AutoresearchConfig
+
+        cfg = AutoresearchConfig()
+        assert cfg.swarm_aggregation == "mean"
+
+    def test_sub_agent_count_cap(self) -> None:
+        """D-CFG-3: sub_agent_count max = 5 (Field(le=5) cost cap)."""
+        from core.config.self_improving_loop import AutoresearchConfig
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AutoresearchConfig(sub_agent_count=6)
+
+
+class TestApplyRecordSwarmField:
+    def test_swarm_id_optional(self) -> None:
+        """D-SCH-1: ApplyRecord.swarm_id + sub_agent_index field 허용."""
+        row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "m1",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+            "swarm_id": "swarm-abc",
+            "sub_agent_index": 2,
+        }
+        record = ApplyRecord.model_validate(row)
+        assert record.swarm_id == "swarm-abc"
+        assert record.sub_agent_index == 2
+
+    def test_swarm_id_legacy_none(self) -> None:
+        """D-SCH-2: legacy row (swarm_id 없음) 도 통과."""
+        row = {
+            "ts": 1716638400.0,
+            "kind": "applied",
+            "mutation_id": "m1",
+            "target_kind": "prompt",
+            "target_section": "role",
+            "previous_value": "",
+            "new_value": "x",
+        }
+        record = ApplyRecord.model_validate(row)
+        assert record.swarm_id is None
+        assert record.sub_agent_index is None


### PR DESCRIPTION
## Summary
- 2026-05-25 plan (PR #1643 영속화) 의 P4 MVP — swarm aggregation helper + multi-level grouping schema
- Kimi K2.6 PARL 의 inference-time 변형 (training-time policy update 거부)
- 243 LOC + 13 invariant tests

## Why
PR-5 P1-revised 의 N=2 group sampling 은 *single-cycle*. Kimi K2.6 (Moonshot 2026-04-20) 의 PARL 은 300 sub-agent + 4000 step swarm. inference-time 변형으로 M sub-agent multi-level grouping 인프라 제공 — full wiring 은 P4.1 후속.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/swarm_scaffolding.py` | 신규 +90 — SwarmAggregation Literal + aggregate_swarm_fitness + decompose_sub_agent_contribution |
| `core/config/self_improving_loop.py` | +30 — AutoresearchConfig.sub_agent_count (default 1, le=5 cap) + swarm_aggregation ('mean'/'median'/'max') |
| `core/self_improving_loop/runner.py` | +10 — ApplyRecord.swarm_id + sub_agent_index field |
| `tests/core/self_improving_loop/test_p4_swarm.py` | 신규 +120 — 13 invariant tests |

## GAP Audit
| Item | Status |
|------|--------|
| D1 SwarmConfig knobs | Implemented |
| D5 swarm_id + sub_agent_index field | Implemented |
| swarm aggregation helper | Implemented |
| sub-agent contribution decomposition | Implemented |
| D2 propose_swarm(M) | Deferred to P4.1 (runner.py full wiring) |
| D3 apply_swarm_proposals | Deferred to P4.1 |
| D6 agent_contracts sub-agent slice | Deferred to P4.1 |

## Verification
- [x] ruff check + format: 통과 (384 files)
- [x] mypy: 통과 (21 source files)
- [x] pytest: **137 passed** (test_p4_swarm.py 13 신규 + 기존 모두 호환)

## Reference
- Plan: `docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md` (PR #1643 merged)
- 선행: PR-5/PR-7/PR-8/PR-9
- Frontier: [Kimi K2.6 MarkTechPost](https://www.marktechpost.com/2026/04/20/moonshot-ai-releases-kimi-k2-6-with-long-horizon-coding-agent-swarm-scaling-to-300-sub-agents-and-4000-coordinated-steps/) / [Credit Assignment Survey arXiv 2604.09459](https://arxiv.org/html/2604.09459v1)