### PR TITLE
fix(docs-site): drop trailing slash from seed detail links (PR-DETAIL-LINK-FIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-DETAIL-LINK-FIX** — seed detail links now match
+  `next.config.ts: trailingSlash: false`. Four hrefs in
+  `site/src/app/docs/petri/seeds/page.tsx` and
+  `site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx`
+  ended with `/`, which the static export does not serve (HTTP
+  404 on `https://mangowhoiscloud.github.io/geode/docs/petri/
+  seeds/<run>/<id>/`). Dropped trailing slashes; the parent /
+  evolved-children cross-links inside the detail page now use
+  `./<id>` (browser resolves to `/docs/petri/seeds/<run>/<id>`
+  because the current URL has no trailing slash).
+
 ## [0.99.55] - 2026-05-25
 
 Bundles 3 PRs: PR-EVOLVER-JACCARD-OBS, PR-PETRI-BUNDLE-LANDING, PR-HANDOFF-SCHEMAS. Smoke-15-driven defence against tool-using sub-agents emitting prose instead of JSON, plus Petri bundle bridge UI and Jaccard threshold tune.

--- a/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
+++ b/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
@@ -314,7 +314,7 @@ function SeedDetail(props: DetailProps) {
             <tr>
               <th>parent_id</th>
               <td>
-                <a href={`./${seed.parent_id}/`}><code>{seed.parent_id}</code></a>
+                <a href={`./${seed.parent_id}`}><code>{seed.parent_id}</code></a>
               </td>
             </tr>
           )}
@@ -323,7 +323,7 @@ function SeedDetail(props: DetailProps) {
               <th>{t("진화 자식", "evolved children")}</th>
               <td>
                 {seed.evolved_children.map((c) => (
-                  <a key={c} href={`./${c}/`} className="mr-2"><code>{c}</code></a>
+                  <a key={c} href={`./${c}`} className="mr-2"><code>{c}</code></a>
                 ))}
               </td>
             </tr>

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -210,7 +210,8 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                     ? `${RAW_BUNDLE_URL}${run.run_id}/candidates/${filename}`
                     : undefined;
                   const evolved = evolvedByParent.get(sid) ?? [];
-                  const detailHref = `/docs/petri/seeds/${run.run_id}/${sid}/`;
+                  // next.config.ts has `trailingSlash: false` so links must NOT end in `/`.
+                  const detailHref = `/docs/petri/seeds/${run.run_id}/${sid}`;
                   return (
                     <tr key={sid}>
                       <td>
@@ -227,7 +228,7 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                         {evolved.length > 0 && (
                           <span className="ml-2 text-white/40 text-xs">
                             → {evolved.map((e) => {
-                              const eHref = `/docs/petri/seeds/${run.run_id}/${e}/`;
+                              const eHref = `/docs/petri/seeds/${run.run_id}/${e}`;
                               return (
                                 <a key={e} href={eHref} className="mr-1"><code>{e}</code></a>
                               );


### PR DESCRIPTION
## Summary
- 4 hrefs in the seed detail surfaces ended with `/`; `next.config.ts: trailingSlash: false` does not serve those.
- Dropped trailing slashes. Cross-links inside detail page use `./<id>` (no slash).

## Why
Verified after PR-PETRI-BUNDLE-LANDING (#1642) deployed:
```
curl -I /docs/petri/seeds/gen1-redundant_tool_invocation/gen1-001-56634935/  → HTTP 404
curl -I /docs/petri/seeds/gen1-redundant_tool_invocation/gen1-001-56634935   → HTTP 200
```

Detail pages WORK at their static-export path (`<id>.html` / no-slash); the leak was in how seeds listing + detail page constructed in-site cross-links.

## Changes
| File | Change |
|------|--------|
| `site/src/app/docs/petri/seeds/page.tsx` | drop `/` from `detailHref` (l.213) and evolved-child `eHref` (l.230). Comment cites `trailingSlash: false`. |
| `site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx` | drop `/` from parent_id and evolved-children cross-links. Use `./<id>` (browser resolves to sibling under the current `<run>/`). |
| `CHANGELOG.md` | Entry under `[Unreleased] → Fixed`. |

## Verification
- [x] `npx next build` — clean
- [x] `tsc --noEmit` — clean
- [x] `grep -oE 'href="/docs/petri/seeds/[^"]*"' out/docs/petri/seeds.html` shows no trailing-slash hrefs
- [ ] CI 5/5 green (pending)
- [ ] Live URL HTTP 200 (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)