### PR TITLE
fix(docs-site): seed run link → state.json instead of dir (PR-SEEDS-PER-RUN-LINK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ functional change.
   caller-side logged fitness (Codex MCP review fix; previously
   half-wired: caller multiplied, promote compared raw).
 
+### Fixed
+- **PR-SEEDS-PER-RUN-LINK** — seed listing `[raw 번들 ↗]` link
+  per row pointed at the run's directory (`/petri-bundle/seeds/
+  <run_id>/`). GitHub Pages does not serve directory listings,
+  so it returned HTTP 404 on click. The link now targets the
+  run's served `state.json` instead (`/petri-bundle/seeds/
+  <run_id>/state.json`). Prose mentions on the same page (KO +
+  EN) were updated to point at the concrete files
+  (`state.json` / `survivors.json`) instead of "per-run 디렉토리"
+  / "per-run directory" since the directory itself is not
+  reachable.
+
 ## [0.99.56] - 2026-05-25
 
 Patch release shipping PR-DETAIL-LINK-FIX so the seeds listing → detail click flow on the live Pages site stops returning 404. Single-PR rotation to fix a user-visible regression from v0.99.55.

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -177,8 +177,11 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
       <summary className="cursor-pointer px-4 py-3 hover:bg-white/[0.03] select-none">
         <code className="text-[#A573E8]">{run.run_id}</code>
         <span className="ml-3 text-white/50 text-sm">{headerKo}</span>
+        {/* GitHub Pages does not serve directory listings, so we link a
+            concrete served file (state.json) inside the per-run directory
+            instead of `<run_id>/`. PR-SEEDS-PER-RUN-LINK (2026-05-25). */}
         <a
-          href={`${RAW_BUNDLE_URL}${run.run_id}/`}
+          href={`${RAW_BUNDLE_URL}${run.run_id}/state.json`}
           className="ml-3 text-white/40 text-xs hover:text-[#A573E8]"
         >
           [{rawLinkLabel} ↗]
@@ -359,8 +362,9 @@ export default function Page() {
               을 읽어 dashboard 로 렌더링합니다.
             </p>
             <p>
-              raw 파일을 직접 보려면 <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> 의 정적 viewer 또는 per-run
-              디렉토리를 사용. inspect_ai <code>.eval</code> 아카이브 viewer 는 <a href="/petri-bundle/">/geode/petri-bundle/</a> 에 별도.
+              raw 파일을 직접 보려면 <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> 의 정적 viewer 또는
+              per-run <code>state.json</code> / <code>survivors.json</code> 파일 (디렉토리 listing 은 Pages 에서 제공 X).
+              inspect_ai <code>.eval</code> 아카이브 viewer 는 <a href="/petri-bundle/">/geode/petri-bundle/</a> 에 별도.
             </p>
 
             <h2>전체 Run</h2>
@@ -391,8 +395,9 @@ export default function Page() {
               at build time and renders them as a dashboard.
             </p>
             <p>
-              For raw files use the static viewer at <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> or browse the
-              per-run directory. The inspect_ai <code>.eval</code> archive viewer lives separately at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
+              For raw files use the static viewer at <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> or open
+              per-run <code>state.json</code> / <code>survivors.json</code> directly (Pages does not serve directory listings).
+              The inspect_ai <code>.eval</code> archive viewer lives separately at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
             </p>
 
             <h2>All runs</h2>


### PR DESCRIPTION
## Summary
- The per-row `[raw bundle ↗]` link on /docs/petri/seeds pointed at `/petri-bundle/seeds/<run>/` (a directory). GitHub Pages does not serve directory listings → HTTP 404 on click.
- Link now targets `<run>/state.json` which is served (HTTP 200).
- Prose mentions of "per-run 디렉토리" / "per-run directory" (KO + EN) updated to name concrete served files (state.json, survivors.json).

## Verification
- [x] Live confirmed: `<run>/` → 404, `<run>/state.json` → 200
- [x] `npx next build` clean
- [x] `tsc --noEmit` clean
- [x] `check_docs_links.py` static audit passes
- [ ] CI green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)