### PR TITLE
release: v0.99.57 — pass-through (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.57] - 2026-05-25
+
+Patch release bundling PR-11 anchor-confidence multiplier wiring + PR-SEEDS-PER-RUN-LINK (Pages directory-listing 404 fix on the seed listing).
+
 ### Added
 - **PR-11 P3.1 anchor confidence multiplier wiring** — `autoresearch/train.py
   compute_fitness` now accepts `anchor_means` + `anchor_confidence_mode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ functional change.
   caller-side logged fitness (Codex MCP review fix; previously
   half-wired: caller multiplied, promote compared raw).
 
+### Fixed
+- **PR-SEEDS-PER-RUN-LINK** — seed listing `[raw 번들 ↗]` link
+  per row pointed at the run's directory (`/petri-bundle/seeds/
+  <run_id>/`). GitHub Pages does not serve directory listings,
+  so it returned HTTP 404 on click. The link now targets the
+  run's served `state.json` instead (`/petri-bundle/seeds/
+  <run_id>/state.json`). Prose mentions on the same page (KO +
+  EN) were updated to point at the concrete files
+  (`state.json` / `survivors.json`) instead of "per-run 디렉토리"
+  / "per-run directory" since the directory itself is not
+  reachable.
+
 ## [0.99.56] - 2026-05-25
 
 Patch release shipping PR-DETAIL-LINK-FIX so the seeds listing → detail click flow on the live Pages site stops returning 404. Single-PR rotation to fix a user-visible regression from v0.99.55.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.56
+- **Version**: 0.99.57
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.56 — Long-running Autonomous Execution Harness
+# GEODE v0.99.57 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.56**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.57**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.56 — Long-running Autonomous Execution Harness
+# GEODE v0.99.57 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.56**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.57**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.56"
+version = "0.99.57"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -177,8 +177,11 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
       <summary className="cursor-pointer px-4 py-3 hover:bg-white/[0.03] select-none">
         <code className="text-[#A573E8]">{run.run_id}</code>
         <span className="ml-3 text-white/50 text-sm">{headerKo}</span>
+        {/* GitHub Pages does not serve directory listings, so we link a
+            concrete served file (state.json) inside the per-run directory
+            instead of `<run_id>/`. PR-SEEDS-PER-RUN-LINK (2026-05-25). */}
         <a
-          href={`${RAW_BUNDLE_URL}${run.run_id}/`}
+          href={`${RAW_BUNDLE_URL}${run.run_id}/state.json`}
           className="ml-3 text-white/40 text-xs hover:text-[#A573E8]"
         >
           [{rawLinkLabel} ↗]
@@ -359,8 +362,9 @@ export default function Page() {
               을 읽어 dashboard 로 렌더링합니다.
             </p>
             <p>
-              raw 파일을 직접 보려면 <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> 의 정적 viewer 또는 per-run
-              디렉토리를 사용. inspect_ai <code>.eval</code> 아카이브 viewer 는 <a href="/petri-bundle/">/geode/petri-bundle/</a> 에 별도.
+              raw 파일을 직접 보려면 <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> 의 정적 viewer 또는
+              per-run <code>state.json</code> / <code>survivors.json</code> 파일 (디렉토리 listing 은 Pages 에서 제공 X).
+              inspect_ai <code>.eval</code> 아카이브 viewer 는 <a href="/petri-bundle/">/geode/petri-bundle/</a> 에 별도.
             </p>
 
             <h2>전체 Run</h2>
@@ -391,8 +395,9 @@ export default function Page() {
               at build time and renders them as a dashboard.
             </p>
             <p>
-              For raw files use the static viewer at <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> or browse the
-              per-run directory. The inspect_ai <code>.eval</code> archive viewer lives separately at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
+              For raw files use the static viewer at <a href={RAW_BUNDLE_URL}><code>{RAW_BUNDLE_URL}</code></a> or open
+              per-run <code>state.json</code> / <code>survivors.json</code> directly (Pages does not serve directory listings).
+              The inspect_ai <code>.eval</code> archive viewer lives separately at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
             </p>
 
             <h2>All runs</h2>


### PR DESCRIPTION
## Summary
- Develop → main pass-through for v0.99.57 stamp + PR-11 + PR-SEEDS-PER-RUN-LINK.

## Verification
- Release PR #1657 merged green to develop.
- Pages will deploy the seed listing per-run link fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)