### PR TITLE
develop → main: PR-12 C.2 mutations_reader backmerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-12 C.2 mutations_reader module** — `core/self_improving_loop/mutations_reader.py`
+  adds a read-only iterator + type-safe filter for `mutations.jsonl`
+  (`iter_mutations(path, kinds, limit)`, `read_recent_attributions(n, path)`,
+  `read_recent_applies(n, path, include_siblings)`). A `kind` discriminator
+  routes apply rows (`applied` / `applied_sibling`) to `ApplyRecord` and
+  attribution rows to `AttributionRecord`. Malformed JSON / non-dict /
+  schema-invalid / unknown-kind rows skip with `log.warning` so a single
+  corrupted row does not abort the reader. File absent → empty iterator
+  (fresh-repo graceful). Prerequisite for A.5 P3.2 meta-judge invocation
+  (PR-13) and F3 fragmentation signal (mutator self-history access).
+
 ## [0.99.57] - 2026-05-25
 
 Patch release bundling PR-11 anchor-confidence multiplier wiring + PR-SEEDS-PER-RUN-LINK (Pages directory-listing 404 fix on the seed listing).

--- a/core/self_improving_loop/mutations_reader.py
+++ b/core/self_improving_loop/mutations_reader.py
@@ -1,0 +1,172 @@
+"""C.2 (2026-05-25) — mutations.jsonl reader (history access for mutator + meta-judge).
+
+``mutations.jsonl`` 은 self-improving loop 의 single-ledger SoT — apply row
+(``kind="applied"`` / ``"applied_sibling"``) + attribution row
+(``kind="attribution"``) 가 한 file 에 row-append. 본 module 이전엔 writer
+(``runner.append_mutation`` / ``attribution.write_attribution``) 만 있고
+reader 부재 — F3 신호 (mutator 가 자기 history 를 못 봄 → repetitive mutation
+위험) + meta-judge (A.5, PR-13) 의 prereq.
+
+본 module 은 **read-only iterator + type-safe filter**:
+
+- :func:`iter_mutations` — kind filter + limit 지원, malformed row graceful skip
+- :func:`read_recent_attributions` — N 최근 attribution row 만
+- :func:`read_recent_applies` — N 최근 apply row 만 (sibling 포함/제외)
+
+Pydantic 검증으로 schema drift fail-fast. ``extra="allow"`` 라 legacy /
+future-added field 도 호환.
+
+Path: ``core/paths.MUTATION_AUDIT_LOG_PATH`` 기본. caller 가 다른 path 지정
+가능 (test fixture / 다른 worktree audit log).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from core.paths import MUTATION_AUDIT_LOG_PATH
+from core.self_improving_loop.attribution import AttributionRecord
+from core.self_improving_loop.runner import ApplyRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+log = logging.getLogger(__name__)
+
+
+_KINDS_APPLY: frozenset[str] = frozenset({"applied", "applied_sibling"})
+_KINDS_ATTRIBUTION: frozenset[str] = frozenset({"attribution"})
+
+
+def _parse_row(raw: str) -> ApplyRecord | AttributionRecord | None:
+    """Parse one JSONL line. Returns ``None`` on malformed / unknown kind.
+
+    Discriminator: top-level ``kind`` field. ``applied`` / ``applied_sibling``
+    → ApplyRecord, ``attribution`` → AttributionRecord. 다른 kind 는 future-
+    proof skip (log.debug 만).
+    """
+    raw_strip = raw.strip()
+    if not raw_strip:
+        return None
+    try:
+        payload = _json.loads(raw_strip)
+    except _json.JSONDecodeError as exc:
+        log.warning("mutations_reader: malformed JSON line skipped (%s)", exc)
+        return None
+    if not isinstance(payload, dict):
+        log.warning("mutations_reader: non-dict row skipped (type=%s)", type(payload).__name__)
+        return None
+    kind = payload.get("kind", "applied")
+    try:
+        if kind in _KINDS_APPLY:
+            return ApplyRecord.model_validate(payload)
+        if kind in _KINDS_ATTRIBUTION:
+            return AttributionRecord.model_validate(payload)
+    except ValidationError as exc:
+        log.warning(
+            "mutations_reader: schema-invalid row skipped (kind=%s mutation_id=%s err=%s)",
+            kind,
+            payload.get("mutation_id", "?"),
+            exc.errors()[0]["msg"] if exc.errors() else "<unknown>",
+        )
+        return None
+    log.debug("mutations_reader: unknown kind=%r skipped", kind)
+    return None
+
+
+def iter_mutations(
+    path: Path | None = None,
+    *,
+    kinds: Iterable[str] | None = None,
+    limit: int | None = None,
+) -> Iterator[ApplyRecord | AttributionRecord]:
+    """Yield validated rows from ``mutations.jsonl`` (file or empty if absent).
+
+    Parameters
+    ----------
+    path
+        JSONL file. Default = ``MUTATION_AUDIT_LOG_PATH``.
+    kinds
+        Iterable of kind strings to keep (``"applied"`` / ``"applied_sibling"``
+        / ``"attribution"``). ``None`` = all kinds.
+    limit
+        Max rows to yield (post-filter). ``None`` = unlimited.
+
+    File 부재 → 빈 iterator (caller 가 attribution.jsonl 없는 fresh repo
+    에서 graceful 동작). Malformed / schema-invalid row 는 warning + skip
+    (이미 운영 중인 long-running loop 에서 1 row 손상이 reader 전체를
+    abort 시키면 안 됨).
+    """
+    target = path if path is not None else MUTATION_AUDIT_LOG_PATH
+    if not target.exists():
+        return
+    kind_filter: frozenset[str] | None = frozenset(kinds) if kinds is not None else None
+    emitted = 0
+    with target.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            record = _parse_row(line)
+            if record is None:
+                continue
+            if kind_filter is not None and record.kind not in kind_filter:
+                continue
+            yield record
+            emitted += 1
+            if limit is not None and emitted >= limit:
+                return
+
+
+def read_recent_attributions(
+    n: int = 10,
+    path: Path | None = None,
+) -> list[AttributionRecord]:
+    """Return the most-recent N attribution rows (newest last in file order).
+
+    JSONL 은 append-only 이므로 file 의 마지막 N 행이 최근 N 회 attribution.
+    Pre-PR-5 file 에는 attribution row 자체가 없을 수 있음 → 빈 list 반환
+    (graceful, meta-judge caller 가 빈 list 시 skip).
+    """
+    if n <= 0:
+        raise ValueError(f"n must be >= 1, got {n}")
+    rows = [
+        r for r in iter_mutations(path, kinds={"attribution"}) if isinstance(r, AttributionRecord)
+    ]
+    return rows[-n:]
+
+
+def read_recent_applies(
+    n: int = 10,
+    path: Path | None = None,
+    *,
+    include_siblings: bool = False,
+) -> list[ApplyRecord]:
+    """Return the most-recent N apply rows.
+
+    Parameters
+    ----------
+    n
+        Number of recent rows to return.
+    include_siblings
+        ``False`` (default) → ``kind="applied"`` only (top-1 채택). ``True``
+        → ``applied_sibling`` (group 의 non-best, in-memory only) 포함 — group
+        statistic 재구성 / repetitive-mutation 검사용.
+    """
+    if n <= 0:
+        raise ValueError(f"n must be >= 1, got {n}")
+    kinds = {"applied", "applied_sibling"} if include_siblings else {"applied"}
+    rows = [r for r in iter_mutations(path, kinds=kinds) if isinstance(r, ApplyRecord)]
+    return rows[-n:]
+
+
+__all__ = [
+    "ApplyRecord",
+    "AttributionRecord",
+    "iter_mutations",
+    "read_recent_applies",
+    "read_recent_attributions",
+]

--- a/tests/core/self_improving_loop/test_mutations_reader.py
+++ b/tests/core/self_improving_loop/test_mutations_reader.py
@@ -1,0 +1,337 @@
+"""C.2 (2026-05-25) — mutations.jsonl reader invariants (PR-12).
+
+Scope: iter_mutations / read_recent_attributions / read_recent_applies 의
+- discriminator (kind → ApplyRecord / AttributionRecord)
+- kind filter + limit
+- malformed row graceful skip
+- file 부재 → 빈 iterator
+- include_siblings 옵션
+- N 최근 ordering (file append-order = chronological)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.attribution import AttributionRecord
+from core.self_improving_loop.mutations_reader import (
+    iter_mutations,
+    read_recent_applies,
+    read_recent_attributions,
+)
+from core.self_improving_loop.runner import ApplyRecord
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    """Helper — append rows as JSONL."""
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _apply_row(
+    mutation_id: str,
+    *,
+    kind: str = "applied",
+    ts: float | None = None,
+    group_id: str | None = None,
+) -> dict:
+    return {
+        "ts": ts if ts is not None else time.time(),
+        "kind": kind,
+        "mutation_id": mutation_id,
+        "target_kind": "prompt",
+        "target_section": "role",
+        "previous_value": "x",
+        "new_value": "y",
+        **({"group_id": group_id} if group_id else {}),
+    }
+
+
+def _attribution_row(
+    mutation_id: str,
+    *,
+    ts: float | None = None,
+    group_id: str | None = None,
+) -> dict:
+    return {
+        "ts": ts if ts is not None else time.time(),
+        "kind": "attribution",
+        "mutation_id": mutation_id,
+        "observed_dim": {"safety": 0.1},
+        "ci95": {"safety": 0.05},
+        "significant": {"safety": True},
+        "attribution_score": 0.3,
+        "missing_baseline": False,
+        **({"group_id": group_id} if group_id else {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. File absent → empty iterator
+# ---------------------------------------------------------------------------
+
+
+def test_iter_mutations_file_absent_returns_empty(tmp_path: Path) -> None:
+    """File 자체 부재 → 빈 iterator (fresh repo / 처음 audit 직전)."""
+    missing = tmp_path / "mutations.jsonl"
+    assert list(iter_mutations(missing)) == []
+
+
+def test_read_recent_attributions_file_absent_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "mutations.jsonl"
+    assert read_recent_attributions(5, missing) == []
+
+
+def test_read_recent_applies_file_absent_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "mutations.jsonl"
+    assert read_recent_applies(5, missing) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Discriminator (kind → record type)
+# ---------------------------------------------------------------------------
+
+
+def test_discriminator_routes_applied_to_apply_record(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_apply_row("m1")])
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+    assert isinstance(rows[0], ApplyRecord)
+    assert rows[0].mutation_id == "m1"
+
+
+def test_discriminator_routes_applied_sibling_to_apply_record(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_apply_row("m1", kind="applied_sibling", group_id="g1")])
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+    assert isinstance(rows[0], ApplyRecord)
+    assert rows[0].kind == "applied_sibling"
+
+
+def test_discriminator_routes_attribution_to_attribution_record(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_attribution_row("m1")])
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+    assert isinstance(rows[0], AttributionRecord)
+    assert rows[0].mutation_id == "m1"
+    assert rows[0].kind == "attribution"
+
+
+# ---------------------------------------------------------------------------
+# 3. Kind filter
+# ---------------------------------------------------------------------------
+
+
+def test_kind_filter_attribution_only(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1"),
+            _attribution_row("m1"),
+            _apply_row("m2", kind="applied_sibling"),
+            _attribution_row("m2"),
+        ],
+    )
+    rows = list(iter_mutations(log, kinds={"attribution"}))
+    assert len(rows) == 2
+    assert all(isinstance(r, AttributionRecord) for r in rows)
+
+
+def test_kind_filter_applied_only_excludes_sibling(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1", kind="applied"),
+            _apply_row("m2", kind="applied_sibling"),
+            _apply_row("m3", kind="applied"),
+        ],
+    )
+    rows = list(iter_mutations(log, kinds={"applied"}))
+    assert [r.mutation_id for r in rows] == ["m1", "m3"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Limit
+# ---------------------------------------------------------------------------
+
+
+def test_limit_caps_iteration(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_apply_row(f"m{i}") for i in range(10)])
+    rows = list(iter_mutations(log, limit=3))
+    assert len(rows) == 3
+    assert [r.mutation_id for r in rows] == ["m0", "m1", "m2"]
+
+
+def test_limit_post_filter(tmp_path: Path) -> None:
+    """limit 는 kind filter 후 카운트 (filter 후 N row 까지만)."""
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1"),
+            _attribution_row("m1"),
+            _apply_row("m2"),
+            _attribution_row("m2"),
+            _apply_row("m3"),
+        ],
+    )
+    rows = list(iter_mutations(log, kinds={"applied"}, limit=2))
+    assert [r.mutation_id for r in rows] == ["m1", "m2"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Malformed row graceful skip
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_skipped(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    log = tmp_path / "mutations.jsonl"
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(_apply_row("m1")) + "\n")
+        fh.write("not valid json {\n")
+        fh.write(json.dumps(_apply_row("m2")) + "\n")
+    rows = list(iter_mutations(log))
+    assert [r.mutation_id for r in rows] == ["m1", "m2"]
+
+
+def test_blank_line_skipped(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(_apply_row("m1")) + "\n")
+        fh.write("\n")
+        fh.write("   \n")
+        fh.write(json.dumps(_apply_row("m2")) + "\n")
+    rows = list(iter_mutations(log))
+    assert [r.mutation_id for r in rows] == ["m1", "m2"]
+
+
+def test_non_dict_row_skipped(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps([1, 2, 3]) + "\n")  # array, not dict
+        fh.write(json.dumps(_apply_row("m1")) + "\n")
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+    assert rows[0].mutation_id == "m1"
+
+
+def test_schema_invalid_row_skipped(tmp_path: Path) -> None:
+    """Missing required field (mutation_id) → ValidationError → skip."""
+    log = tmp_path / "mutations.jsonl"
+    bad_row = {"ts": time.time(), "kind": "applied", "target_kind": "prompt"}
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(bad_row) + "\n")
+        fh.write(json.dumps(_apply_row("m1")) + "\n")
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+    assert rows[0].mutation_id == "m1"
+
+
+def test_unknown_kind_skipped(tmp_path: Path) -> None:
+    """Future-added kind → silent skip (forward compat)."""
+    log = tmp_path / "mutations.jsonl"
+    weird = {"ts": time.time(), "kind": "future_kind_v9", "mutation_id": "m1"}
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(weird) + "\n")
+        fh.write(json.dumps(_apply_row("m1")) + "\n")
+    rows = list(iter_mutations(log))
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Recent ordering (file append-order = chronological)
+# ---------------------------------------------------------------------------
+
+
+def test_read_recent_attributions_returns_last_n(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    rows_to_write = [_attribution_row(f"m{i}", ts=float(i)) for i in range(10)]
+    _write_jsonl(log, rows_to_write)
+    recent = read_recent_attributions(3, log)
+    assert [r.mutation_id for r in recent] == ["m7", "m8", "m9"]
+
+
+def test_read_recent_applies_skips_attribution_rows(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1"),
+            _attribution_row("m1"),
+            _apply_row("m2"),
+            _attribution_row("m2"),
+        ],
+    )
+    recent = read_recent_applies(10, log)
+    assert [r.mutation_id for r in recent] == ["m1", "m2"]
+    assert all(isinstance(r, ApplyRecord) for r in recent)
+
+
+def test_read_recent_applies_include_siblings(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1", kind="applied"),
+            _apply_row("m2", kind="applied_sibling", group_id="g1"),
+            _apply_row("m3", kind="applied_sibling", group_id="g1"),
+            _apply_row("m4", kind="applied"),
+        ],
+    )
+    without = read_recent_applies(10, log, include_siblings=False)
+    assert [r.mutation_id for r in without] == ["m1", "m4"]
+    with_sib = read_recent_applies(10, log, include_siblings=True)
+    assert [r.mutation_id for r in with_sib] == ["m1", "m2", "m3", "m4"]
+
+
+def test_read_recent_applies_slice_through_sibling_group_chronological(
+    tmp_path: Path,
+) -> None:
+    """Codex MCP review WARN — N slice 가 sibling group 가운데서 자를 때
+    chronological order 보존 + partial group 명시 (caller 가 group_id 로
+    재구성 책임). 본 test 가 그 invariant pin."""
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(
+        log,
+        [
+            _apply_row("m1", kind="applied"),
+            _apply_row("m2", kind="applied_sibling", group_id="g1"),
+            _apply_row("m3", kind="applied_sibling", group_id="g1"),
+            _apply_row("m4", kind="applied", group_id="g1"),  # group g1 의 top-1
+            _apply_row("m5", kind="applied_sibling", group_id="g2"),
+            _apply_row("m6", kind="applied", group_id="g2"),
+        ],
+    )
+    # N=3 → 마지막 3 row (m4 / m5 / m6) — group g1 의 sibling m2/m3 잘려나감
+    sliced = read_recent_applies(3, log, include_siblings=True)
+    assert [r.mutation_id for r in sliced] == ["m4", "m5", "m6"]
+    # group_id 만으로 caller 가 partial group 인지 확인 가능 (m5 의 g2 는
+    # m6 와 같은 group 의 sibling, full group 보존)
+    g1_in_slice = [r for r in sliced if r.group_id == "g1"]
+    g2_in_slice = [r for r in sliced if r.group_id == "g2"]
+    assert len(g1_in_slice) == 1  # partial — sibling m2/m3 missing
+    assert len(g2_in_slice) == 2  # full — sibling m5 + apply m6
+
+
+def test_read_recent_attributions_negative_n_raises(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_attribution_row("m1")])
+    with pytest.raises(ValueError, match=r"n must be >= 1"):
+        read_recent_attributions(0, log)
+
+
+def test_read_recent_applies_negative_n_raises(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_jsonl(log, [_apply_row("m1")])
+    with pytest.raises(ValueError, match=r"n must be >= 1"):
+        read_recent_applies(-3, log)

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.55"
+version = "0.99.57"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bring PR-12 C.2 (#1659) into main — `core/self_improving_loop/mutations_reader.py` + 21 invariants.
- 1 commit ahead, 4 files / +522 lines.

## Verification
- [x] CI 8/8 green on the squash commit `5d6be12b` before develop merge
- [x] Codex MCP review (thread 019e5e40) 1 WARN (slice-through-sibling) addressed in same PR with pinning test
- [x] Tests: 21/21 reader invariants + 157/157 SIL aggregate
- [x] Local develop ↔ main content diff verified (gitflow merge-commit asymmetry only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)