### PR TITLE
feat(self-improving-loop): A.5 meta-judge module (PR-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-13 A.5 meta-judge module** — `core/self_improving_loop/meta_judge.py`
+  invokes a meta-judge LLM on the most-recent N attribution rows (via
+  PR-12 `read_recent_attributions`) and returns `MetaJudgeResult` with a
+  `drift_score` on `[0.0, 1.0]` + `drift_summary` text + `evaluated_count`
+  + `llm_raw` (capped 2000 chars). Pure function `build_meta_judge_prompt`
+  serialises records to JSONL; `parse_meta_judge_response` accepts strict
+  JSON, fence-wrapped JSON, or regex key-value fallback for low-capability
+  models, and returns `(0.0, "")` on total failure so callers can detect
+  "no signal". `invoke_meta_judge(n, llm_call, path)` accepts a dependency-
+  injected LLM callable (default = mutator dispatch) and returns `None`
+  when no attribution rows exist (fresh repo / pre-PR-5). Frontier
+  reference: Meta-Rewarding (Meta 2024-07 arXiv 2407.19594).
 - **PR-12 C.2 mutations_reader module** — `core/self_improving_loop/mutations_reader.py`
   adds a read-only iterator + type-safe filter for `mutations.jsonl`
   (`iter_mutations(path, kinds, limit)`, `read_recent_attributions(n, path)`,

--- a/core/self_improving_loop/meta_judge.py
+++ b/core/self_improving_loop/meta_judge.py
@@ -1,0 +1,231 @@
+"""A.5 (2026-05-25) — meta-judge retrospective drift detection (PR-13).
+
+Plan: ``docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md`` §C5.
+
+Frontier: **Meta-Rewarding** (Meta 2024-07 arXiv 2407.19594) — meta-judge LLM
+이 base judge 의 출력을 retrospective 평가해서 judge drift / saturation 감지.
+
+GEODE 채택: ``mutations.jsonl`` 의 최근 N attribution row 를 prompt 로 직렬화
+→ meta-judge LLM 에 "Across these N attributions, did the base judge's
+calibration shift?" → ``drift_score`` [0,1] + ``drift_summary`` text 반환.
+
+본 module 은 inference-time observability — mutator weight 학습 없음. cron /
+manual invocation 으로 정기 호출, drift_score > threshold 시 operator alert.
+
+Caller pattern (CLI / cron)::
+
+    from core.self_improving_loop.meta_judge import invoke_meta_judge
+    result = invoke_meta_judge(n=10)
+    if result is None:
+        # attribution row 부재 (fresh repo / pre-PR-5)
+        return
+    if result.drift_score > 0.6:
+        log.warning("meta-judge: drift_score=%.2f — %s", result.drift_score, result.drift_summary)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.self_improving_loop.attribution import AttributionRecord
+from core.self_improving_loop.mutations_reader import read_recent_attributions
+
+log = logging.getLogger(__name__)
+
+
+# JSON Schema-shaped LLM response. Plain-text fallback parser also accepts
+# loose "drift_score: 0.42" key-value lines (low-capability model graceful).
+META_JUDGE_RESPONSE_SCHEMA: str = """{
+  "drift_score": <float in [0.0, 1.0]>,
+  "drift_summary": "<one sentence summary of judge drift or calibration shift>"
+}"""
+
+
+_DEFAULT_SYSTEM_PROMPT: str = (
+    "You are a meta-judge — your job is to assess whether the base judge's "
+    "calibration drifted across a recent batch of attribution rows from a "
+    "self-improving loop. Score the drift on [0.0, 1.0] where 0.0 means "
+    "perfect calibration consistency (every attribution_score is well-justified "
+    "by its observed_dim values) and 1.0 means catastrophic drift (scores no "
+    "longer track underlying dim signals).\n\n"
+    "Output ONLY a single JSON object matching the schema given by the user. "
+    "No prose, no explanation outside the JSON."
+)
+
+
+class MetaJudgeResult(BaseModel):
+    """Structured outcome of a single meta-judge invocation.
+
+    ``drift_score`` clipped to [0, 1] by parser. ``evaluated_count`` records
+    how many attribution rows the LLM actually saw — caller can use this to
+    judge whether the score is statistically meaningful (e.g. < 3 → ignore).
+    ``llm_raw`` retained for debugging when the parser had to fall back.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: float
+    drift_score: float = Field(ge=0.0, le=1.0)
+    drift_summary: str
+    evaluated_count: int = Field(ge=0)
+    llm_raw: str = ""
+
+
+def build_meta_judge_prompt(records: list[AttributionRecord]) -> tuple[str, str]:
+    """Return ``(system_prompt, user_prompt)`` for the meta-judge LLM call.
+
+    Pure function — exposed for direct unit testing without an LLM call.
+    Empty records → ValueError (caller should skip invocation entirely
+    rather than build an empty prompt).
+    """
+    if not records:
+        raise ValueError("meta-judge: cannot build prompt for empty records")
+    serialised_rows: list[str] = []
+    for r in records:
+        serialised_rows.append(
+            json.dumps(
+                {
+                    "mutation_id": r.mutation_id,
+                    "observed_dim": r.observed_dim,
+                    "ci95": r.ci95,
+                    "significant": r.significant,
+                    "attribution_score": round(r.attribution_score, 4),
+                    "fitness_delta": (
+                        round(r.fitness_delta, 4) if r.fitness_delta is not None else None
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        )
+    body = "\n".join(serialised_rows)
+    user_prompt = (
+        f"The following {len(records)} attribution rows are from the most recent "
+        f"audits of the self-improving loop. Each row records what the base "
+        f"judge measured (``observed_dim``), the per-dim confidence interval "
+        f"(``ci95``), whether the dim moved significantly (``significant``), "
+        f"and a scalar ``attribution_score``.\n\n"
+        f"Attribution rows (JSONL, one per line):\n{body}\n\n"
+        f"Assess whether the base judge's calibration drifted across this "
+        f"batch. Respond using the schema:\n{META_JUDGE_RESPONSE_SCHEMA}\n"
+    )
+    return _DEFAULT_SYSTEM_PROMPT, user_prompt
+
+
+_DRIFT_SCORE_RE = re.compile(r'"?drift_score"?\s*[:=]\s*([0-9]*\.?[0-9]+)', re.IGNORECASE)
+_DRIFT_SUMMARY_RE = re.compile(r'"?drift_summary"?\s*[:=]\s*"([^"]+)"', re.IGNORECASE)
+
+
+def _clamp_score(raw: float) -> float:
+    return max(0.0, min(1.0, raw))
+
+
+def parse_meta_judge_response(text: str) -> tuple[float, str]:
+    """Extract ``(drift_score, drift_summary)`` from LLM raw text.
+
+    Strategy:
+
+    1. Strip code-fence wrappers (``` or ```json), look for a JSON object,
+       try ``json.loads`` first — strict-schema path.
+    2. Fall back to regex extraction (``drift_score: 0.4`` key-value style)
+       so a low-capability model that ignores the JSON instruction still
+       yields a usable signal.
+    3. On total failure → ``(0.0, "")`` so caller can detect "no signal"
+       via empty summary.
+
+    Score clamped to ``[0.0, 1.0]`` (defensive against out-of-range output).
+    Summary truncated to 500 chars (defense against prompt-leak abuse).
+    """
+    cleaned = text.strip()
+    # Strip markdown code fence if present.
+    fence_match = re.search(r"```(?:json)?\s*(.*?)```", cleaned, re.DOTALL)
+    if fence_match:
+        cleaned = fence_match.group(1).strip()
+
+    try:
+        obj = json.loads(cleaned)
+        if isinstance(obj, dict):
+            score_raw = obj.get("drift_score", 0.0)
+            summary_raw = obj.get("drift_summary", "")
+            if isinstance(score_raw, int | float):
+                return _clamp_score(float(score_raw)), str(summary_raw)[:500]
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    score_match = _DRIFT_SCORE_RE.search(cleaned)
+    summary_match = _DRIFT_SUMMARY_RE.search(cleaned)
+    if score_match:
+        try:
+            score = _clamp_score(float(score_match.group(1)))
+            summary = summary_match.group(1)[:500] if summary_match else ""
+            return score, summary
+        except (ValueError, IndexError):
+            pass
+
+    return 0.0, ""
+
+
+LlmCallable = Callable[[str, str], str]
+
+
+def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
+    """Lazy delegate to the mutator's default LLM call.
+
+    Keeps the meta-judge module importable in test contexts without the
+    anthropic SDK preloaded. Production caller may inject any callable
+    with the same shape.
+    """
+    from core.self_improving_loop.runner import _default_llm_call as _runner_call
+
+    return _runner_call(system_prompt, user_prompt)
+
+
+def invoke_meta_judge(
+    n: int = 10,
+    *,
+    llm_call: LlmCallable | None = None,
+    path: Path | None = None,
+) -> MetaJudgeResult | None:
+    """Read N recent attribution rows + invoke meta-judge LLM → result.
+
+    Returns ``None`` when no attribution rows are available (fresh repo or
+    pre-PR-5 baseline) — caller should treat this as "no signal" and skip
+    alerting. Otherwise returns ``MetaJudgeResult`` with clamped score +
+    truncated summary + raw LLM text for audit.
+
+    ``llm_call`` defaults to the runner's mutator dispatch; tests inject a
+    stub callable to keep this module independent of the LLM SDK.
+    """
+    if n <= 0:
+        raise ValueError(f"n must be >= 1, got {n}")
+    records = read_recent_attributions(n, path)
+    if not records:
+        log.info("meta-judge: no attribution rows; skipping invocation")
+        return None
+    system_prompt, user_prompt = build_meta_judge_prompt(records)
+    call = llm_call if llm_call is not None else _default_llm_call
+    raw = call(system_prompt, user_prompt)
+    drift_score, drift_summary = parse_meta_judge_response(raw)
+    return MetaJudgeResult(
+        ts=time.time(),
+        drift_score=drift_score,
+        drift_summary=drift_summary,
+        evaluated_count=len(records),
+        llm_raw=raw[:2000],  # cap so the result row stays compact in logs
+    )
+
+
+__all__ = [
+    "META_JUDGE_RESPONSE_SCHEMA",
+    "LlmCallable",
+    "MetaJudgeResult",
+    "build_meta_judge_prompt",
+    "invoke_meta_judge",
+    "parse_meta_judge_response",
+]

--- a/tests/core/self_improving_loop/test_meta_judge.py
+++ b/tests/core/self_improving_loop/test_meta_judge.py
@@ -1,0 +1,255 @@
+"""A.5 (2026-05-25) — meta-judge invocation invariants (PR-13).
+
+Scope:
+- build_meta_judge_prompt: empty records → ValueError, N records → 2-tuple,
+  serialised JSONL per row, no PII leaks
+- parse_meta_judge_response: strict JSON / fence-wrapped JSON / regex fallback
+  / total-failure → (0.0, "") / clamp [0, 1] / truncate 500
+- invoke_meta_judge: empty file → None / mock llm_call DI / score in
+  expected range / evaluated_count == records read
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.meta_judge import (
+    MetaJudgeResult,
+    build_meta_judge_prompt,
+    invoke_meta_judge,
+    parse_meta_judge_response,
+)
+
+
+def _attribution_row(mid: str, score: float = 0.3) -> dict:
+    return {
+        "ts": time.time(),
+        "kind": "attribution",
+        "mutation_id": mid,
+        "observed_dim": {"safety": 0.1},
+        "ci95": {"safety": 0.05},
+        "significant": {"safety": True},
+        "attribution_score": score,
+        "missing_baseline": False,
+        "fitness_delta": 0.02,
+    }
+
+
+def _write_attribution_jsonl(path: Path, n: int) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for i in range(n):
+            fh.write(json.dumps(_attribution_row(f"m{i}", 0.1 * (i + 1))) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# 1. build_meta_judge_prompt — empty + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_empty_records_raises() -> None:
+    with pytest.raises(ValueError, match="empty records"):
+        build_meta_judge_prompt([])
+
+
+def test_build_prompt_includes_count_in_user_prompt(tmp_path: Path) -> None:
+    """User prompt should mention the actual record count."""
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 3)
+    from core.self_improving_loop.mutations_reader import read_recent_attributions
+
+    records = read_recent_attributions(3, log)
+    _system, user_prompt = build_meta_judge_prompt(records)
+    assert "3 attribution rows" in user_prompt
+
+
+def test_build_prompt_serialises_each_record_as_jsonl(tmp_path: Path) -> None:
+    """Each record should appear as one JSONL line in the user prompt body."""
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 2)
+    from core.self_improving_loop.mutations_reader import read_recent_attributions
+
+    records = read_recent_attributions(2, log)
+    _system, user_prompt = build_meta_judge_prompt(records)
+    # Each record's mutation_id should appear; JSON shape preserved
+    assert "m0" in user_prompt
+    assert "m1" in user_prompt
+    assert "observed_dim" in user_prompt
+
+
+def test_build_prompt_system_demands_json_only() -> None:
+    """System prompt should constrain output to JSON (no prose)."""
+    records = [
+        type(
+            "R",
+            (),
+            {
+                "mutation_id": "x",
+                "observed_dim": {},
+                "ci95": {},
+                "significant": {},
+                "attribution_score": 0.0,
+                "fitness_delta": None,
+            },
+        )()
+    ]
+    system_prompt, _user = build_meta_judge_prompt(records)
+    assert "JSON" in system_prompt
+    assert "ONLY" in system_prompt or "only" in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# 2. parse_meta_judge_response — strict JSON path
+# ---------------------------------------------------------------------------
+
+
+def test_parse_strict_json() -> None:
+    raw = '{"drift_score": 0.42, "drift_summary": "scores drifted upward"}'
+    score, summary = parse_meta_judge_response(raw)
+    assert score == pytest.approx(0.42)
+    assert summary == "scores drifted upward"
+
+
+def test_parse_fence_wrapped_json() -> None:
+    raw = '```json\n{"drift_score": 0.7, "drift_summary": "high"}\n```'
+    score, summary = parse_meta_judge_response(raw)
+    assert score == pytest.approx(0.7)
+    assert summary == "high"
+
+
+def test_parse_fence_wrapped_no_lang_marker() -> None:
+    raw = '```\n{"drift_score": 0.3, "drift_summary": "ok"}\n```'
+    score, summary = parse_meta_judge_response(raw)
+    assert score == pytest.approx(0.3)
+    assert summary == "ok"
+
+
+def test_parse_clamps_out_of_range_score() -> None:
+    """drift_score > 1 or < 0 → clamped to [0, 1]."""
+    score_high, _ = parse_meta_judge_response('{"drift_score": 1.5, "drift_summary": "x"}')
+    assert score_high == 1.0
+    score_low, _ = parse_meta_judge_response('{"drift_score": -0.4, "drift_summary": "x"}')
+    assert score_low == 0.0
+
+
+def test_parse_truncates_summary_to_500() -> None:
+    long_summary = "x" * 1000
+    raw = json.dumps({"drift_score": 0.1, "drift_summary": long_summary})
+    _score, summary = parse_meta_judge_response(raw)
+    assert len(summary) == 500
+
+
+# ---------------------------------------------------------------------------
+# 3. parse_meta_judge_response — regex fallback + failure
+# ---------------------------------------------------------------------------
+
+
+def test_parse_regex_fallback_key_value_style() -> None:
+    """Low-capability model that doesn't return JSON → regex extracts."""
+    raw = 'Based on the attributions, drift_score: 0.55, drift_summary: "moderate".'
+    score, summary = parse_meta_judge_response(raw)
+    assert score == pytest.approx(0.55)
+    assert summary == "moderate"
+
+
+def test_parse_total_failure_returns_zero_and_empty() -> None:
+    """Completely unparseable output → (0.0, "") so caller can detect."""
+    score, summary = parse_meta_judge_response("This is not a meta-judge response at all.")
+    assert score == 0.0
+    assert summary == ""
+
+
+def test_parse_non_numeric_score_falls_through() -> None:
+    raw = '{"drift_score": "high", "drift_summary": "x"}'
+    score, summary = parse_meta_judge_response(raw)
+    # JSON loads succeeds but score is not numeric → regex fallback tries,
+    # finds nothing matching the numeric pattern → returns (0.0, "")
+    assert score == 0.0
+    # summary may be "x" via regex even when JSON path rejected score
+    assert summary in {"", "x"}
+
+
+# ---------------------------------------------------------------------------
+# 4. invoke_meta_judge — DI + skip + result shape
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_returns_none_when_no_attributions(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    # File 부재 → reader 가 빈 list → invoke 가 None
+    result = invoke_meta_judge(5, llm_call=lambda _s, _u: "", path=log)
+    assert result is None
+
+
+def test_invoke_calls_llm_with_built_prompts(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 2)
+    captured: dict[str, str] = {}
+
+    def fake_llm(system_prompt: str, user_prompt: str) -> str:
+        captured["system"] = system_prompt
+        captured["user"] = user_prompt
+        return '{"drift_score": 0.25, "drift_summary": "low"}'
+
+    result = invoke_meta_judge(2, llm_call=fake_llm, path=log)
+    assert result is not None
+    assert isinstance(result, MetaJudgeResult)
+    assert result.drift_score == pytest.approx(0.25)
+    assert result.drift_summary == "low"
+    assert result.evaluated_count == 2
+    assert "2 attribution rows" in captured["user"]
+    assert "meta-judge" in captured["system"]
+
+
+def test_invoke_clamps_score_via_parser(tmp_path: Path) -> None:
+    """End-to-end clamp via parse_meta_judge_response."""
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 1)
+    result = invoke_meta_judge(
+        1, llm_call=lambda _s, _u: '{"drift_score": 2.0, "drift_summary": "x"}', path=log
+    )
+    assert result is not None
+    assert result.drift_score == 1.0
+
+
+def test_invoke_records_raw_llm_text(tmp_path: Path) -> None:
+    """llm_raw should be retained for audit (truncated to 2000)."""
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 1)
+    raw_text = '{"drift_score": 0.5, "drift_summary": "x"}'
+    result = invoke_meta_judge(1, llm_call=lambda _s, _u: raw_text, path=log)
+    assert result is not None
+    assert result.llm_raw == raw_text
+
+
+def test_invoke_truncates_huge_raw(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 1)
+    huge = "x" * 5000
+    result = invoke_meta_judge(1, llm_call=lambda _s, _u: huge, path=log)
+    assert result is not None
+    assert len(result.llm_raw) == 2000
+
+
+def test_invoke_negative_n_raises(tmp_path: Path) -> None:
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 1)
+    with pytest.raises(ValueError, match=r"n must be >= 1"):
+        invoke_meta_judge(0, llm_call=lambda _s, _u: "", path=log)
+
+
+def test_invoke_total_parse_failure_yields_zero_score(tmp_path: Path) -> None:
+    """LLM returns garbage → MetaJudgeResult with drift_score=0.0 + empty summary.
+
+    Caller can detect "no signal" via empty summary (vs LLM saying score=0.0
+    means truly low drift). Score alone is ambiguous; pair with summary
+    emptiness check.
+    """
+    log = tmp_path / "mutations.jsonl"
+    _write_attribution_jsonl(log, 1)
+    result = invoke_meta_judge(1, llm_call=lambda _s, _u: "this is garbage output", path=log)
+    assert result is not None
+    assert result.drift_score == 0.0
+    assert result.drift_summary == ""

--- a/tests/core/self_improving_loop/test_meta_judge.py
+++ b/tests/core/self_improving_loop/test_meta_judge.py
@@ -162,13 +162,29 @@ def test_parse_total_failure_returns_zero_and_empty() -> None:
 
 
 def test_parse_non_numeric_score_falls_through() -> None:
+    """JSON loads succeeds but ``drift_score`` is non-numeric → regex
+    fallback tries to find numeric pattern → fails → returns (0.0, "").
+
+    Codex MCP WARN #3 tighten — earlier wording allowed `summary == "x"`
+    via regex even when JSON path rejected score; actual behaviour is
+    score_match=None → entire return is (0.0, ""). Pin the exact tuple.
+    """
     raw = '{"drift_score": "high", "drift_summary": "x"}'
     score, summary = parse_meta_judge_response(raw)
-    # JSON loads succeeds but score is not numeric → regex fallback tries,
-    # finds nothing matching the numeric pattern → returns (0.0, "")
     assert score == 0.0
-    # summary may be "x" via regex even when JSON path rejected score
-    assert summary in {"", "x"}
+    assert summary == ""
+
+
+def test_parse_negative_score_in_json_clamped_not_regex_fallback() -> None:
+    """Codex MCP WARN #4 — regex 가 negative number 매칭 안 함 (-? 미포함).
+    JSON 경로에서 negative 는 ``_clamp_score`` 가 0.0 으로 clamp. 본 test 가
+    JSON 경로 lower-bound clamp 의 정확한 동작 pin — regex fallback 로
+    falling through 하지 않음을 보장.
+    """
+    raw = '{"drift_score": -0.4, "drift_summary": "neg"}'
+    score, summary = parse_meta_judge_response(raw)
+    assert score == 0.0  # clamped from -0.4
+    assert summary == "neg"  # summary 보존 — regex 로 fall through 하지 않음
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `core/self_improving_loop/meta_judge.py` — invokes meta-judge LLM on N recent attribution rows (via PR-12 reader) → `MetaJudgeResult` with drift_score [0,1] + drift_summary.
- DI llm_call (test-friendly) + tolerant JSON parser (strict / fence / regex / total-failure).
- Plan §C5 (`docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md`) — Meta-Rewarding pattern.

## Why
PR-9 P3-revised wired the SPCT principle to ApplyRecord but never invoked the meta-judge that frontier (Meta-Rewarding) uses to detect judge drift. PR-12 C.2 mutations_reader now provides the read path; A.5 closes the loop by adding the inference-time invocation.

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/meta_judge.py`` | 신규 — MetaJudgeResult + build_meta_judge_prompt + parse_meta_judge_response + invoke_meta_judge + LlmCallable type alias |
| ``tests/core/self_improving_loop/test_meta_judge.py`` | 신규 — 19 invariants (prompt empty / count / serialisation / strict JSON / fence / clamp / truncate / regex fallback / total failure / DI / mocked call / negative n) |
| ``CHANGELOG.md`` | Unreleased PR-13 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| read_recent_attributions integration | Implemented | invoke_meta_judge 가 PR-12 reader 호출 |
| LLM call DI for tests | Implemented | llm_call: LlmCallable | None=None |
| empty-records graceful | Implemented | None 반환 (fresh repo / pre-PR-5) |
| 4 parser fallback strategies | Implemented | strict / fence / regex / (0.0, "") |
| score clamp + summary truncate | Implemented | [0,1] + 500 chars defense |
| CLI/cron entry | Deferred — caller side, separate PR (plan §C5 mentions "cron job 또는 manual") |

## Verification
- [x] ruff check + format clean (core / tests / plugins / autoresearch)
- [x] mypy clean (441 source files)
- [x] tests/core/self_improving_loop/test_meta_judge.py: 19/19 pass
- [x] tests/core/self_improving_loop/ regress: 177/177 pass aggregated (157 + 19 new)
- [x] No live test execution

## Reference
- Plan: ``docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md`` §C5
- Frontier: Meta-Rewarding (Meta 2024-07 arXiv 2407.19594)
- Prereq: PR-12 C.2 mutations_reader (#1659)