### PR TITLE
feat(self-improving-loop): A.7 propose_swarm + apply_swarm_proposals wiring (PR-14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,15 +55,20 @@ functional change.
   `swarm_id`, forwards `swarm_id` + `sub_agent_index` to each
   sub-agent's `apply_group_proposals`, and returns the last-committed
   sub-agent's mutation (MVP last-wins). `Mutation.to_audit_row` +
-  `append_audit_log` + `apply_group_proposals` all accept `swarm_id` +
-  `sub_agent_index` (default `""` / `None` → row column omitted, legacy
-  unchanged). `run_once` dispatches to swarm mode when
-  `AutoresearchConfig.sub_agent_count >= 2`. Swarm-level fitness
-  aggregation via `aggregate_swarm_fitness` deferred to a follow-up
-  that pairs PR-12 `mutations_reader` with the helper — current MVP
-  surfaces swarm metadata in mutations.jsonl rows for cross-sub-agent
-  grep analysis (no runtime aggregation). Frontier: Kimi K2.6 PARL
-  inference-time variant.
+  `append_audit_log` + `apply_group_proposals` + `apply_proposal` all
+  accept `swarm_id` + `sub_agent_index` (default `""` / `None` → row
+  column omitted, legacy unchanged). `run_once` dispatches to swarm
+  mode when `AutoresearchConfig.sub_agent_count >= 2`. Swarm-level
+  fitness aggregation via `aggregate_swarm_fitness` deferred to a
+  follow-up that pairs PR-12 `mutations_reader` with the helper —
+  current MVP surfaces swarm metadata in mutations.jsonl rows for
+  cross-sub-agent grep analysis (no runtime aggregation). Codex MCP
+  review caught a half-wire (Conditional Read Parity) at the
+  `apply_group_proposals(n=1)` singleton shortcut → `apply_proposal`
+  path where swarm metadata was being dropped on the most common MVP
+  config (`sub_agent_count>=2, group_size=1`); fixed by extending
+  `apply_proposal` with the same kwargs and forwarding from the
+  shortcut. Frontier: Kimi K2.6 PARL inference-time variant.
 - **PR-13 A.5 meta-judge module** — `core/self_improving_loop/meta_judge.py`
   invokes a meta-judge LLM on the most-recent N attribution rows (via
   PR-12 `read_recent_attributions`) and returns `MetaJudgeResult` with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-14 A.7 propose_swarm + apply_swarm_proposals wiring** —
+  `SelfImprovingLoopRunner` gains `propose_swarm(m, n)` (returns
+  `list[list[Proposal]]` — M sub-agents × N siblings, sequential) and
+  `apply_swarm_proposals(swarm_proposals)` which mints a single
+  `swarm_id`, forwards `swarm_id` + `sub_agent_index` to each
+  sub-agent's `apply_group_proposals`, and returns the last-committed
+  sub-agent's mutation (MVP last-wins). `Mutation.to_audit_row` +
+  `append_audit_log` + `apply_group_proposals` all accept `swarm_id` +
+  `sub_agent_index` (default `""` / `None` → row column omitted, legacy
+  unchanged). `run_once` dispatches to swarm mode when
+  `AutoresearchConfig.sub_agent_count >= 2`. Swarm-level fitness
+  aggregation via `aggregate_swarm_fitness` deferred to a follow-up
+  that pairs PR-12 `mutations_reader` with the helper — current MVP
+  surfaces swarm metadata in mutations.jsonl rows for cross-sub-agent
+  grep analysis (no runtime aggregation). Frontier: Kimi K2.6 PARL
+  inference-time variant.
 - **PR-13 A.5 meta-judge module** — `core/self_improving_loop/meta_judge.py`
   invokes a meta-judge LLM on the most-recent N attribution rows (via
   PR-12 `read_recent_attributions`) and returns `MetaJudgeResult` with a

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1476,7 +1476,11 @@ class SelfImprovingLoopRunner:
         에 의존하므로 audit 가 실제로 fire 되어야 함.
         """
         if len(proposals) == 1:
-            return self.apply_proposal(proposals[0])
+            return self.apply_proposal(
+                proposals[0],
+                swarm_id=swarm_id,
+                sub_agent_index=sub_agent_index,
+            )
         if not self.rerun_enabled:
             raise RuntimeError(
                 "P1-revised group sampling requires rerun_enabled=True "
@@ -1746,7 +1750,13 @@ class SelfImprovingLoopRunner:
         )
         return valid_mutations[-1]
 
-    def apply_proposal(self, proposal: Proposal) -> Mutation:
+    def apply_proposal(
+        self,
+        proposal: Proposal,
+        *,
+        swarm_id: str = "",
+        sub_agent_index: int | None = None,
+    ) -> Mutation:
         """Apply a previously-proposed mutation — write SoT, audit
         log, (optional) git commit, (optional) autoresearch rerun.
 
@@ -1766,6 +1776,14 @@ class SelfImprovingLoopRunner:
         row 와 attribution row 가 audit_run_id 로 join 가능. mint 는
         rerun_enabled 일 때만 (rerun_disabled 면 audit 가 안 일어나
         attribution row 도 없으니 audit_run_id 무의미).
+
+        P4 (PR-14, 2026-05-25) — ``swarm_id`` + ``sub_agent_index`` 인자
+        추가. 일반 caller 는 default ("" / None) 로 legacy 동작 보존.
+        ``apply_swarm_proposals`` → ``apply_group_proposals(n=1 group)`` →
+        ``apply_proposal`` singleton shortcut path 에서 swarm metadata
+        가 누락되지 않도록 forward (Codex MCP review #1662 catch — MVP
+        path ``sub_agent_count>=2, group_size=1`` 에서 swarm row 가
+        silent half-wire 되는 patch).
         """
         audit_run_id = _mint_audit_run_id() if self.rerun_enabled else ""
         _new_sections, previous_value = apply_mutation(
@@ -1777,6 +1795,8 @@ class SelfImprovingLoopRunner:
                 previous_value=previous_value,
                 log_path=self.audit_log_path,
                 audit_run_id=audit_run_id,
+                swarm_id=swarm_id,
+                sub_agent_index=sub_agent_index,
             )
         except OSError as exc:
             self._rollback_sot(proposal.original_sections, mutation=proposal.mutation, exc=exc)

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -197,6 +197,8 @@ class Mutation:
         kind: str = "applied",
         group_id: str = "",
         group_advantage: float | None = None,
+        swarm_id: str = "",
+        sub_agent_index: int | None = None,
     ) -> dict[str, Any]:
         """Render the mutation as one audit-log row.
 
@@ -234,6 +236,13 @@ class Mutation:
             row["group_id"] = group_id
         if group_advantage is not None:
             row["group_advantage"] = round(float(group_advantage), 6)
+        # P4 (2026-05-25, PR-14 wiring) — multi-level swarm grouping.
+        # ``sub_agent_index=0`` 이 valid (첫 sub-agent) 이므로 None 으로
+        # 구분 — legacy non-swarm mode 는 None.
+        if swarm_id:
+            row["swarm_id"] = swarm_id
+        if sub_agent_index is not None:
+            row["sub_agent_index"] = int(sub_agent_index)
         # PR-SIL-5THEME C4 — cost 컬럼은 non-zero 일 때만 emit. 0 값
         # (legacy 또는 mock LLM 호출) 은 column 자체 생략 — JSONL 의
         # noise 절감 + legacy reader 무영향.
@@ -1077,6 +1086,8 @@ def append_audit_log(
     kind: str = "applied",
     group_id: str = "",
     group_advantage: float | None = None,
+    swarm_id: str = "",
+    sub_agent_index: int | None = None,
 ) -> Path:
     """Append one mutation row to the git-tracked audit jsonl.
 
@@ -1101,6 +1112,8 @@ def append_audit_log(
         kind=kind,
         group_id=group_id,
         group_advantage=group_advantage,
+        swarm_id=swarm_id,
+        sub_agent_index=sub_agent_index,
     )
     # W4 (2026-05-25) — Pydantic schema validation. drift 가 발생하면
     # ValidationError 가 fail-fast 로 raise → 잘못된 row 가 git-tracked
@@ -1418,7 +1431,13 @@ class SelfImprovingLoopRunner:
                 proposals.append(future.result())
         return proposals
 
-    def apply_group_proposals(self, proposals: list[Proposal]) -> Mutation | None:
+    def apply_group_proposals(
+        self,
+        proposals: list[Proposal],
+        *,
+        swarm_id: str = "",
+        sub_agent_index: int | None = None,
+    ) -> Mutation | None:
         """P1-revised (2026-05-25) — apply N sibling proposals → audit →
         variance filter → advantage normalization → top-1 commit.
 
@@ -1586,6 +1605,8 @@ class SelfImprovingLoopRunner:
                     kind="applied",
                     group_id=group_id,
                     group_advantage=advantages[best_idx],
+                    swarm_id=swarm_id,
+                    sub_agent_index=sub_agent_index,
                 )
             except OSError as exc:
                 self._rollback_sot(
@@ -1610,6 +1631,8 @@ class SelfImprovingLoopRunner:
                     kind="applied_sibling",
                     group_id=group_id,
                     group_advantage=advantages[i],
+                    swarm_id=swarm_id,
+                    sub_agent_index=sub_agent_index,
                 )
 
             if self.commit_enabled:
@@ -1626,6 +1649,102 @@ class SelfImprovingLoopRunner:
                         "self-improving-loop: sibling temp file cleanup failed for %s",
                         sibling_path,
                     )
+
+    def propose_swarm(self, m: int, n: int) -> list[list[Proposal]]:
+        """P4 (PR-14, 2026-05-25) — multi-level swarm propose.
+
+        M sub-agent × N sibling = M groups of N proposals. Each sub-agent
+        runs an independent :meth:`propose_group` call. Sub-agent slice
+        differentiation (per-sub-agent agent_contract policy) is deferred
+        to A.8 follow-up — this PR keeps the same prompt across all
+        sub-agents and lets stochasticity (temperature >= 0.1) provide
+        the inter-agent diversity. Kimi K2.6 의 inference-time PARL 패턴.
+
+        Sequential (not parallel) for cost predictability — propose_group
+        already parallelises N sibling LLM calls inside one sub-agent, so
+        running M sub-agents sequentially keeps the parallelism bounded
+        at N (no M×N thread pool explosion).
+        """
+        if m < 1:
+            raise ValueError(f"propose_swarm: m must be >= 1, got {m}")
+        if n < 1:
+            raise ValueError(f"propose_swarm: n must be >= 1, got {n}")
+        swarm_groups: list[list[Proposal]] = []
+        for sub_agent_index in range(m):
+            log.info(
+                "self-improving-loop: swarm sub-agent %d/%d — propose_group(n=%d)",
+                sub_agent_index + 1,
+                m,
+                n,
+            )
+            swarm_groups.append(self.propose_group(n))
+        return swarm_groups
+
+    def apply_swarm_proposals(self, swarm_proposals: list[list[Proposal]]) -> Mutation | None:
+        """P4 (PR-14, 2026-05-25) — apply M sub-agent groups → return
+        last-committed sub-agent's chosen mutation (MVP last-wins).
+
+        Steps:
+
+        1. Mint single ``swarm_id`` for the cycle (shared by all sub-
+           agents' apply / sibling rows in mutations.jsonl).
+        2. For each sub-agent group → :meth:`apply_group_proposals` with
+           ``swarm_id`` + ``sub_agent_index`` forwarded. Each sub-agent
+           returns the group's best Mutation (or None on variance-filter
+           skip).
+        3. Returns the last sub-agent's mutation (last-wins commit on
+           canonical SoT). When all sub-agents skipped via variance
+           filter → returns ``None`` (full-swarm cycle skip).
+
+        MVP scope (deliberate) — swarm-level fitness aggregation via
+        :func:`aggregate_swarm_fitness` is *not* applied here because
+        ``Mutation`` doesn't carry post-audit fitness back through
+        ``apply_group_proposals``; the helper exists in
+        ``core/self_improving_loop/swarm_scaffolding.py`` and is used
+        out-of-band by callers that read mutations.jsonl ApplyRecord
+        rows via PR-12 ``mutations_reader`` (each row carries
+        ``baseline_fitness`` + ``group_advantage``). A.8 follow-up will
+        wire sub-agent contract slices so the "last-wins" commit becomes
+        per-slice (no SoT collision), and a downstream wrapper will use
+        the reader + ``aggregate_swarm_fitness`` to produce an explicit
+        swarm-level fitness scalar. Until then, swarm mode's primary
+        value is the mutations.jsonl observability surface — operators
+        can grep ``swarm_id`` + ``sub_agent_index`` for cross-sub-agent
+        analysis even without runtime aggregation.
+        """
+        if not swarm_proposals:
+            raise ValueError("apply_swarm_proposals: empty swarm")
+        swarm_id = _mint_audit_run_id()
+        log.info(
+            "self-improving-loop: swarm %s — M=%d sub-agents (sequential)",
+            swarm_id,
+            len(swarm_proposals),
+        )
+
+        sub_agent_mutations: list[Mutation | None] = []
+        for sub_agent_index, group in enumerate(swarm_proposals):
+            chosen = self.apply_group_proposals(
+                group, swarm_id=swarm_id, sub_agent_index=sub_agent_index
+            )
+            sub_agent_mutations.append(chosen)
+
+        # Filter sub-agents that returned None (variance-filter skip).
+        valid_mutations = [m for m in sub_agent_mutations if m is not None]
+        if not valid_mutations:
+            log.info(
+                "self-improving-loop: swarm %s — all sub-agents skipped "
+                "(variance filter); no swarm commit",
+                swarm_id,
+            )
+            return None
+
+        log.info(
+            "self-improving-loop: swarm %s — %d/%d sub-agents committed",
+            swarm_id,
+            len(valid_mutations),
+            len(swarm_proposals),
+        )
+        return valid_mutations[-1]
 
     def apply_proposal(self, proposal: Proposal) -> Mutation:
         """Apply a previously-proposed mutation — write SoT, audit
@@ -1696,7 +1815,16 @@ class SelfImprovingLoopRunner:
         """
         from core.config.self_improving_loop import load_self_improving_loop_config
 
-        group_size = load_self_improving_loop_config().autoresearch.group_size
+        cfg = load_self_improving_loop_config()
+        group_size = cfg.autoresearch.group_size
+        sub_agent_count = cfg.autoresearch.sub_agent_count
+        if sub_agent_count >= 2:
+            # P4 (PR-14, 2026-05-25) — multi-level swarm mode. Cost cap is
+            # ``sub_agent_count * group_size`` audits per cycle; operator
+            # is expected to keep ``group_size=1`` when ``sub_agent_count>=2``
+            # to bound cost to M audits, unless they explicitly want M×N.
+            swarm_proposals = self.propose_swarm(sub_agent_count, group_size)
+            return self.apply_swarm_proposals(swarm_proposals)
         if group_size <= 1:
             return self.apply_proposal(self.propose())
         proposals = self.propose_group(group_size)

--- a/tests/core/self_improving_loop/test_baseline_rl_grounding.py
+++ b/tests/core/self_improving_loop/test_baseline_rl_grounding.py
@@ -479,7 +479,13 @@ class TestApplyGroupProposals:
 
         called = {"apply_proposal_count": 0}
 
-        def fake_apply_proposal(self: Any, proposal: Proposal) -> Mutation:
+        def fake_apply_proposal(
+            self: Any,
+            proposal: Proposal,
+            *,
+            swarm_id: str = "",
+            sub_agent_index: int | None = None,
+        ) -> Mutation:
             called["apply_proposal_count"] += 1
             return proposal.mutation
 

--- a/tests/core/self_improving_loop/test_propose_swarm.py
+++ b/tests/core/self_improving_loop/test_propose_swarm.py
@@ -273,6 +273,44 @@ def test_run_once_dispatches_to_swarm_when_sub_agent_count_ge_2(
     assert called["apply_swarm_proposals"] is True
 
 
+def test_swarm_n1_mvp_path_writes_swarm_metadata_to_mutations_jsonl(
+    tmp_path: Path,
+) -> None:
+    """Codex MCP review #1662 catch — MVP path ``sub_agent_count>=2,
+    group_size=1`` 에서 apply_group_proposals 가 singleton shortcut 으로
+    apply_proposal 호출 시 swarm_id + sub_agent_index 가 누락되면 안 됨.
+
+    Real audit-row 검증 — propose_swarm(3, 1) → apply_swarm_proposals →
+    3 sub-agent 별 apply_group_proposals(1 proposal) → apply_proposal
+    singleton path. mutations.jsonl 의 모든 row 가 동일 swarm_id +
+    distinct sub_agent_index (0, 1, 2) 보유해야.
+    """
+    import json as _json
+
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    runner.audit_log_path = tmp_path / "mutations.jsonl"
+
+    # propose_swarm(3, 1) → 3 groups of 1 proposal each
+    groups = [[_fake_proposal()], [_fake_proposal()], [_fake_proposal()]]
+    runner.propose_group = lambda n: groups.pop(0)  # type: ignore[method-assign]
+
+    result = runner.apply_swarm_proposals(runner.propose_swarm(3, 1))
+    assert result is not None
+
+    # Read mutations.jsonl — should have 3 apply rows
+    rows = [
+        _json.loads(line) for line in runner.audit_log_path.read_text().splitlines() if line
+    ]
+    assert len(rows) == 3
+    swarm_ids = {r.get("swarm_id") for r in rows}
+    assert len(swarm_ids) == 1  # all 3 share single swarm_id
+    assert next(iter(swarm_ids)) != ""  # non-empty
+    sub_agent_indices = {r.get("sub_agent_index") for r in rows}
+    assert sub_agent_indices == {0, 1, 2}  # distinct per sub-agent
+
+
 def test_run_once_skips_swarm_when_sub_agent_count_is_1() -> None:
     """sub_agent_count=1 (default) → legacy group_size 분기."""
     from core.self_improving_loop.runner import SelfImprovingLoopRunner

--- a/tests/core/self_improving_loop/test_propose_swarm.py
+++ b/tests/core/self_improving_loop/test_propose_swarm.py
@@ -1,0 +1,305 @@
+"""A.7 (2026-05-25) — propose_swarm + apply_swarm_proposals wiring invariants (PR-14).
+
+Scope: SelfImprovingLoopRunner.propose_swarm / apply_swarm_proposals 의
+- propose_swarm signature (m, n) + ValueError
+- list[list[Proposal]] shape — M sub-agents × N siblings
+- apply_swarm_proposals 의 swarm_id mint + sub_agent_index forwarding
+- ApplyRecord 의 swarm_id / sub_agent_index emit (mutations.jsonl)
+- swarm_id / sub_agent_index 는 to_audit_row 의 non-empty 시만 emit (legacy 무영향)
+- run_once 분기 — sub_agent_count >= 2 → swarm mode
+- empty swarm → ValueError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from core.self_improving_loop.runner import (
+    Mutation,
+    Proposal,
+    append_audit_log,
+)
+
+# ---------------------------------------------------------------------------
+# 1. to_audit_row + append_audit_log — swarm_id / sub_agent_index emit
+# ---------------------------------------------------------------------------
+
+
+def _make_mutation(target_section: str = "role", new_value: str = "y") -> Mutation:
+    return Mutation(
+        target_section=target_section,
+        new_value=new_value,
+        rationale="test",
+        mutation_id="m_x",
+    )
+
+
+def test_to_audit_row_emits_swarm_id_when_non_empty() -> None:
+    mutation = _make_mutation()
+    row = mutation.to_audit_row(previous_value="x", swarm_id="sw_abc")
+    assert row["swarm_id"] == "sw_abc"
+
+
+def test_to_audit_row_skips_swarm_id_when_empty() -> None:
+    """Legacy non-swarm mode → row 에 swarm_id column 미생성."""
+    mutation = _make_mutation()
+    row = mutation.to_audit_row(previous_value="x")
+    assert "swarm_id" not in row
+
+
+def test_to_audit_row_emits_sub_agent_index_when_non_none() -> None:
+    mutation = _make_mutation()
+    # sub_agent_index=0 도 valid 한 첫 sub-agent → row 에 emit
+    row = mutation.to_audit_row(previous_value="x", sub_agent_index=0)
+    assert row["sub_agent_index"] == 0
+
+
+def test_to_audit_row_emits_sub_agent_index_nonzero() -> None:
+    mutation = _make_mutation()
+    row = mutation.to_audit_row(previous_value="x", sub_agent_index=2)
+    assert row["sub_agent_index"] == 2
+
+
+def test_to_audit_row_skips_sub_agent_index_when_none() -> None:
+    mutation = _make_mutation()
+    row = mutation.to_audit_row(previous_value="x", sub_agent_index=None)
+    assert "sub_agent_index" not in row
+
+
+def test_append_audit_log_writes_swarm_fields(tmp_path: Path) -> None:
+    """End-to-end — append_audit_log writes Pydantic-validated row with
+    swarm_id + sub_agent_index when forwarded."""
+    import json as _json
+
+    log_path = tmp_path / "mutations.jsonl"
+    mutation = _make_mutation()
+    append_audit_log(
+        mutation,
+        previous_value="x",
+        log_path=log_path,
+        swarm_id="sw_42",
+        sub_agent_index=1,
+    )
+    with log_path.open() as fh:
+        row = _json.loads(fh.readline())
+    assert row["swarm_id"] == "sw_42"
+    assert row["sub_agent_index"] == 1
+
+
+def test_append_audit_log_omits_swarm_fields_for_legacy(tmp_path: Path) -> None:
+    """Backward compat — legacy callers (no swarm args) get no swarm columns."""
+    import json as _json
+
+    log_path = tmp_path / "mutations.jsonl"
+    mutation = _make_mutation()
+    append_audit_log(mutation, previous_value="x", log_path=log_path)
+    with log_path.open() as fh:
+        row = _json.loads(fh.readline())
+    assert "swarm_id" not in row
+    assert "sub_agent_index" not in row
+
+
+# ---------------------------------------------------------------------------
+# 2. propose_swarm signature + shape
+# ---------------------------------------------------------------------------
+
+
+def _make_runner_with_mock_propose(propose_groups: list[list[Proposal]]):
+    """Build a real runner but stub propose_group to return canned data
+    so we don't need an LLM. Use mock.patch on the instance method."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    iterator = iter(propose_groups)
+
+    def fake_propose_group(n: int) -> list[Proposal]:
+        return next(iterator)
+
+    runner.propose_group = fake_propose_group  # type: ignore[method-assign]
+    return runner
+
+
+def _fake_proposal() -> Proposal:
+    return Proposal(
+        mutation=_make_mutation(),
+        target_sections={"role": "x"},
+        original_sections={"role": "x"},
+    )
+
+
+def test_propose_swarm_zero_m_raises() -> None:
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    with pytest.raises(ValueError, match=r"m must be >= 1"):
+        runner.propose_swarm(0, 2)
+
+
+def test_propose_swarm_zero_n_raises() -> None:
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    with pytest.raises(ValueError, match=r"n must be >= 1"):
+        runner.propose_swarm(2, 0)
+
+
+def test_propose_swarm_returns_m_groups_of_n() -> None:
+    groups = [[_fake_proposal(), _fake_proposal()] for _ in range(3)]
+    runner = _make_runner_with_mock_propose(groups)
+    result = runner.propose_swarm(3, 2)
+    assert len(result) == 3  # M sub-agents
+    assert all(len(g) == 2 for g in result)  # each group has N siblings
+
+
+def test_propose_swarm_m_equals_1_returns_single_group() -> None:
+    groups = [[_fake_proposal()]]
+    runner = _make_runner_with_mock_propose(groups)
+    result = runner.propose_swarm(1, 1)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. apply_swarm_proposals — swarm_id + sub_agent_index forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_apply_swarm_proposals_empty_raises() -> None:
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    with pytest.raises(ValueError, match="empty swarm"):
+        runner.apply_swarm_proposals([])
+
+
+def test_apply_swarm_proposals_returns_last_committed() -> None:
+    """MVP last-wins — last sub-agent's mutation is returned."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    mutation_a = _make_mutation(new_value="a")
+    mutation_b = _make_mutation(new_value="b")
+
+    captured: list[tuple[str, int]] = []
+
+    def fake_apply_group(group, *, swarm_id, sub_agent_index):
+        captured.append((swarm_id, sub_agent_index))
+        return mutation_a if sub_agent_index == 0 else mutation_b
+
+    runner.apply_group_proposals = fake_apply_group  # type: ignore[method-assign]
+    result = runner.apply_swarm_proposals([[_fake_proposal()], [_fake_proposal()]])
+    assert result is mutation_b  # last committed
+    # swarm_id shared across sub-agents
+    assert captured[0][0] == captured[1][0]
+    assert captured[0][0] != ""
+    # sub_agent_index distinct 0, 1
+    assert {c[1] for c in captured} == {0, 1}
+
+
+def test_apply_swarm_proposals_all_skipped_returns_none() -> None:
+    """All sub-agents return None (variance filter) → swarm returns None."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    runner.apply_group_proposals = lambda group, **kw: None  # type: ignore[method-assign]
+    result = runner.apply_swarm_proposals(
+        [[_fake_proposal()], [_fake_proposal()], [_fake_proposal()]]
+    )
+    assert result is None
+
+
+def test_apply_swarm_proposals_partial_skip() -> None:
+    """Some sub-agents skip, some commit → return last valid commit."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    mutation_b = _make_mutation(new_value="b")
+
+    def fake_apply(group, *, swarm_id, sub_agent_index):
+        if sub_agent_index == 0:
+            return None
+        if sub_agent_index == 1:
+            return mutation_b
+        return None  # idx 2 skips again
+
+    runner.apply_group_proposals = fake_apply  # type: ignore[method-assign]
+    result = runner.apply_swarm_proposals(
+        [[_fake_proposal()], [_fake_proposal()], [_fake_proposal()]]
+    )
+    assert result is mutation_b
+
+
+# ---------------------------------------------------------------------------
+# 4. run_once dispatch — sub_agent_count >= 2 → swarm mode
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_dispatches_to_swarm_when_sub_agent_count_ge_2(
+    tmp_path: Path,
+) -> None:
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    runner.audit_log_path = tmp_path / "mutations.jsonl"
+
+    called = {"propose_swarm": False, "apply_swarm_proposals": False}
+
+    def fake_propose_swarm(m: int, n: int) -> list[list[Proposal]]:
+        called["propose_swarm"] = True
+        assert m == 3
+        assert n == 1
+        return [[_fake_proposal()]]
+
+    def fake_apply_swarm(swarm_proposals) -> Mutation:
+        called["apply_swarm_proposals"] = True
+        return _make_mutation()
+
+    runner.propose_swarm = fake_propose_swarm  # type: ignore[method-assign]
+    runner.apply_swarm_proposals = fake_apply_swarm  # type: ignore[method-assign]
+
+    fake_cfg = type("Cfg", (), {})()
+    fake_cfg.autoresearch = type(
+        "AR",
+        (),
+        {"group_size": 1, "sub_agent_count": 3, "swarm_aggregation": "mean"},
+    )()
+    with patch(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        return_value=fake_cfg,
+    ):
+        runner.run_once()
+    assert called["propose_swarm"] is True
+    assert called["apply_swarm_proposals"] is True
+
+
+def test_run_once_skips_swarm_when_sub_agent_count_is_1() -> None:
+    """sub_agent_count=1 (default) → legacy group_size 분기."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+
+    swarm_called = {"v": False}
+
+    def fake_swarm(*a, **kw):
+        swarm_called["v"] = True
+        return _make_mutation()
+
+    runner.propose_swarm = fake_swarm  # type: ignore[method-assign]
+    runner.apply_swarm_proposals = fake_swarm  # type: ignore[method-assign]
+    # group_size=1 legacy path — propose() / apply_proposal() stubbed
+    runner.propose = lambda: _fake_proposal()  # type: ignore[method-assign]
+    runner.apply_proposal = lambda p: _make_mutation()  # type: ignore[method-assign]
+
+    fake_cfg = type("Cfg", (), {})()
+    fake_cfg.autoresearch = type(
+        "AR",
+        (),
+        {"group_size": 1, "sub_agent_count": 1, "swarm_aggregation": "mean"},
+    )()
+    with patch(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        return_value=fake_cfg,
+    ):
+        runner.run_once()
+    assert swarm_called["v"] is False  # swarm 미진입

--- a/tests/core/self_improving_loop/test_propose_swarm.py
+++ b/tests/core/self_improving_loop/test_propose_swarm.py
@@ -280,14 +280,17 @@ def test_swarm_n1_mvp_path_writes_swarm_metadata_to_mutations_jsonl(
     group_size=1`` 에서 apply_group_proposals 가 singleton shortcut 으로
     apply_proposal 호출 시 swarm_id + sub_agent_index 가 누락되면 안 됨.
 
-    Real audit-row 검증 — propose_swarm(3, 1) → apply_swarm_proposals →
-    3 sub-agent 별 apply_group_proposals(1 proposal) → apply_proposal
-    singleton path. mutations.jsonl 의 모든 row 가 동일 swarm_id +
-    distinct sub_agent_index (0, 1, 2) 보유해야.
+    apply_proposal 의 SoT write 만 stub (canonical wrapper.json 을
+    안 건드리도록) — append_audit_log 자체는 real 호출해서 mutations.jsonl
+    의 swarm_id + sub_agent_index emit 을 end-to-end 검증.
     """
     import json as _json
 
-    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+    from core.self_improving_loop.runner import (
+        Proposal,
+        SelfImprovingLoopRunner,
+        append_audit_log,
+    )
 
     runner = SelfImprovingLoopRunner(rerun_enabled=False)
     runner.audit_log_path = tmp_path / "mutations.jsonl"
@@ -296,13 +299,32 @@ def test_swarm_n1_mvp_path_writes_swarm_metadata_to_mutations_jsonl(
     groups = [[_fake_proposal()], [_fake_proposal()], [_fake_proposal()]]
     runner.propose_group = lambda n: groups.pop(0)  # type: ignore[method-assign]
 
+    # Stub apply_proposal — write the apply row to OUR test log_path (not
+    # canonical SoT) so the test does not touch wrappers/policies. Forwards
+    # swarm_id + sub_agent_index just like the production singleton
+    # shortcut does after the Codex MCP fix.
+    def fake_apply_proposal(
+        proposal: Proposal,
+        *,
+        swarm_id: str = "",
+        sub_agent_index: int | None = None,
+    ):
+        append_audit_log(
+            proposal.mutation,
+            previous_value="x",
+            log_path=runner.audit_log_path,
+            swarm_id=swarm_id,
+            sub_agent_index=sub_agent_index,
+        )
+        return proposal.mutation
+
+    runner.apply_proposal = fake_apply_proposal  # type: ignore[method-assign]
+
     result = runner.apply_swarm_proposals(runner.propose_swarm(3, 1))
     assert result is not None
 
     # Read mutations.jsonl — should have 3 apply rows
-    rows = [
-        _json.loads(line) for line in runner.audit_log_path.read_text().splitlines() if line
-    ]
+    rows = [_json.loads(line) for line in runner.audit_log_path.read_text().splitlines() if line]
     assert len(rows) == 3
     swarm_ids = {r.get("swarm_id") for r in rows}
     assert len(swarm_ids) == 1  # all 3 share single swarm_id

--- a/tests/core/self_improving_loop/test_propose_swarm.py
+++ b/tests/core/self_improving_loop/test_propose_swarm.py
@@ -287,7 +287,6 @@ def test_swarm_n1_mvp_path_writes_swarm_metadata_to_mutations_jsonl(
     import json as _json
 
     from core.self_improving_loop.runner import (
-        Proposal,
         SelfImprovingLoopRunner,
         append_audit_log,
     )


### PR DESCRIPTION
## Summary
- New `SelfImprovingLoopRunner.propose_swarm(m, n)` + `apply_swarm_proposals` — multi-level swarm grouping with `swarm_id` + `sub_agent_index` propagation to mutations.jsonl.
- `Mutation.to_audit_row` + `append_audit_log` + `apply_group_proposals` accept `swarm_id` + `sub_agent_index` (default empty → row column omitted, legacy unchanged).
- `run_once` dispatches to swarm mode when `AutoresearchConfig.sub_agent_count >= 2`.

## Why
PR-10 (#1650) shipped `swarm_scaffolding.py` helper but `runner.py` never called the multi-level swarm path → dead scaffolding. Backlog A.7 closes that loop. Frontier reference: Kimi K2.6 PARL (Moonshot 2026-04-20) inference-time variant.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | Mutation.to_audit_row + append_audit_log + apply_group_proposals 의 swarm_id/sub_agent_index parameter 추가. propose_swarm + apply_swarm_proposals 신규. run_once 분기 확장. |
| `tests/core/self_improving_loop/test_propose_swarm.py` | 17 wiring invariants |
| `CHANGELOG.md` | Unreleased entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| swarm_id / sub_agent_index emit to mutations.jsonl | Implemented | to_audit_row + append_audit_log + apply_group_proposals 3 layer 모두 forward |
| propose_swarm(m, n) shape | Implemented | M × N list[list[Proposal]] |
| apply_swarm_proposals last-wins MVP | Implemented | last valid sub-agent's mutation returned |
| run_once dispatch | Implemented | sub_agent_count >= 2 → swarm mode |
| aggregate_swarm_fitness 실 wiring | Deferred — Mutation 이 post-audit fitness 를 carry back 안 함. follow-up sprint 가 PR-12 mutations_reader 로 baseline_fitness 를 read 후 helper 호출 |
| A.8 sub-agent contract slice 분리 | Deferred — 본 PR scope 외 |

## Verification
- [x] ruff check + format clean (core / tests / plugins / autoresearch)
- [x] mypy clean (441 source files)
- [x] tests/core/self_improving_loop/test_propose_swarm.py: 17/17 pass
- [x] tests/core/self_improving_loop/ regress: 195/195 pass aggregated (178 + 17 new, includes 1 fmt fix)
- [x] No live test execution

## Reference
- Frontier: Kimi K2.6 PARL (Moonshot 2026-04-20) inference-time 변형
- Plan: ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md``
- Prior: PR-10 (#1650) swarm_scaffolding helper