### PR TITLE
feat(self-improving-loop): C.4 credit_assignment module (PR-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,19 +51,22 @@ functional change.
 - **PR-16 C.4 credit_assignment module** —
   `core/self_improving_loop/credit_assignment.py` adds two pure
   functions for selection-layer observability:
-  `compute_credit_assignment(mutation, group_advantage)` partitions a
-  single mutation's `group_advantage` across its `expected_dim` keys
-  by magnitude-weighted share (`credit[d] = group_advantage *
-  |expected_dim[d]| / sum(|expected_dim|)`), and
+  `compute_credit_assignment(mutation, group_advantage)` applies a
+  **heuristic magnitude-weighted partition** of a single mutation's
+  `group_advantage` across its `expected_dim` keys (`credit[d] =
+  group_advantage * |expected_dim[d]| / sum(|expected_dim|)`), and
   `aggregate_credit_history(records)` sums these contributions across
   an iterable of `ApplyRecord` rows (e.g. PR-12
   `read_recent_applies` output) for a per-dim cumulative credit
   ranking. Records with `group_advantage=None` (legacy single-mutation
   mode) or empty `expected_dim` are skipped silently. Sign convention:
   credit magnitude tracks `group_advantage` sign; intent direction
-  stays encoded in the original `expected_dim` sign. Frontier:
-  Quality-Diversity behavior-characterization mapping + DAPO/GRPO
-  advantage decomposition.
+  stays encoded in the original `expected_dim` sign. Caller (CLI /
+  operator dashboard surfacing the rank) is deferred to a follow-up
+  PR. Frontier: Quality-Diversity behavior-characterization mapping
+  (Mouret & Clune 2015); DAPO/GRPO justify the scalar
+  `group_advantage`, but the per-dim partition itself is a local
+  heuristic — not a direct DAPO/GRPO formula.
 
 ## [0.99.58] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-16 C.4 credit_assignment module** —
+  `core/self_improving_loop/credit_assignment.py` adds two pure
+  functions for selection-layer observability:
+  `compute_credit_assignment(mutation, group_advantage)` partitions a
+  single mutation's `group_advantage` across its `expected_dim` keys
+  by magnitude-weighted share (`credit[d] = group_advantage *
+  |expected_dim[d]| / sum(|expected_dim|)`), and
+  `aggregate_credit_history(records)` sums these contributions across
+  an iterable of `ApplyRecord` rows (e.g. PR-12
+  `read_recent_applies` output) for a per-dim cumulative credit
+  ranking. Records with `group_advantage=None` (legacy single-mutation
+  mode) or empty `expected_dim` are skipped silently. Sign convention:
+  credit magnitude tracks `group_advantage` sign; intent direction
+  stays encoded in the original `expected_dim` sign. Frontier:
+  Quality-Diversity behavior-characterization mapping + DAPO/GRPO
+  advantage decomposition.
+
 ## [0.99.58] - 2026-05-25
 
 Bundles PR-SG-SELECTION-ALIGN + PR-12/13/14 from develop (mutations_reader + meta_judge + propose_swarm wiring). seed-gen now surfaces the same selection-layer signals (anchor 3 / scenario_realism / tier model / Pareto front / target_dims_attribution) that autoresearch fitness reads.

--- a/core/self_improving_loop/credit_assignment.py
+++ b/core/self_improving_loop/credit_assignment.py
@@ -1,0 +1,99 @@
+"""C.4 (2026-05-25) — credit assignment 사전 매핑 (PR-16).
+
+PR-5 의 ``attribution.py`` 가 사후 (post-audit) ``observed_dim - expected_dim``
+delta 를 계산하지만, group sampling 시 **사전적으로** "이 mutation 의
+group_advantage 가 어느 dim 에 attributable 한가?" 는 추적 불가.
+
+본 module 의 두 함수:
+
+- :func:`compute_credit_assignment` — single ``Mutation`` + ``group_advantage``
+  scalar 를 받아 ``expected_dim`` magnitude-weighted partition 으로 dim 별
+  signed credit 분배.
+- :func:`aggregate_credit_history` — mutations.jsonl 의 ``ApplyRecord`` list
+  (PR-12 ``read_recent_applies`` 결과) 를 받아 history 전체의 dim 별
+  cumulative credit aggregate.
+
+이는 **selection-layer observability** — weight 학습 X, mutator API frozen
+유지. 후속 caller (CLI 또는 operator dashboard) 가 결과를 visualise.
+
+Frontier reference: Quality-Diversity (Mouret & Clune 2015) 의
+behavior-characterization mapping + DAPO/GRPO 의 advantage decomposition.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.self_improving_loop.runner import ApplyRecord, Mutation
+
+
+def compute_credit_assignment(
+    mutation: Mutation,
+    group_advantage: float | None,
+) -> dict[str, float]:
+    """Partition ``group_advantage`` across ``mutation.expected_dim`` keys
+    by magnitude-weighted share.
+
+    Formula::
+
+        total_abs = sum(|expected_dim[d]| for d in dims)
+        credit[d] = group_advantage * (|expected_dim[d]| / total_abs)
+
+    The credit is unsigned in magnitude (positive advantage → positive
+    credit per dim) since the operator's *intent* on a dim is encoded
+    in the ``expected_dim`` sign, not the partition. A caller that
+    needs the *direction* multiplied by intent uses
+    ``credit[d] * sign(expected_dim[d])``.
+
+    Returns empty dict when:
+    - ``group_advantage is None`` (legacy non-group mode)
+    - ``mutation.expected_dim`` is empty (mutator didn't commit dims)
+    - ``sum(|expected_dim|)`` is 0 (degenerate)
+    """
+    if group_advantage is None:
+        return {}
+    if not mutation.expected_dim:
+        return {}
+    total_abs = sum(abs(float(v)) for v in mutation.expected_dim.values())
+    if total_abs == 0.0:
+        return {}
+    return {
+        dim: group_advantage * (abs(float(weight)) / total_abs)
+        for dim, weight in mutation.expected_dim.items()
+    }
+
+
+def aggregate_credit_history(
+    records: Iterable[ApplyRecord],
+) -> dict[str, float]:
+    """Aggregate signed credit across an iterable of ``ApplyRecord`` rows.
+
+    Each record contributes its mutation's per-dim credit (computed from
+    its ``expected_dim`` + ``group_advantage``). Records with no
+    ``group_advantage`` or empty ``expected_dim`` are skipped silently.
+
+    Returns ``{dim_name: cumulative_credit}`` — operator dashboard can
+    rank dims by total credit to see which dims the mutator has been
+    investing in.
+    """
+    out: dict[str, float] = defaultdict(float)
+    for record in records:
+        advantage = getattr(record, "group_advantage", None)
+        expected = getattr(record, "expected_dim", None)
+        if advantage is None or not expected:
+            continue
+        total_abs = sum(abs(float(v)) for v in expected.values())
+        if total_abs == 0.0:
+            continue
+        for dim, weight in expected.items():
+            out[dim] += float(advantage) * (abs(float(weight)) / total_abs)
+    return dict(out)
+
+
+__all__ = [
+    "aggregate_credit_history",
+    "compute_credit_assignment",
+]

--- a/tests/core/self_improving_loop/test_credit_assignment.py
+++ b/tests/core/self_improving_loop/test_credit_assignment.py
@@ -1,0 +1,182 @@
+"""C.4 (2026-05-25) — credit_assignment invariants (PR-16).
+
+Scope:
+- compute_credit_assignment: group_advantage None / empty expected_dim /
+  zero-magnitude expected_dim → empty dict (graceful)
+- happy path: magnitude-weighted partition sum = group_advantage
+- single dim → all credit goes there
+- aggregate_credit_history: empty / cumulative / skip rows without advantage
+- expected_dim sign convention — credit is unsigned, caller multiplies by
+  sign(expected_dim[d]) if directional intent needed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from core.self_improving_loop.credit_assignment import (
+    aggregate_credit_history,
+    compute_credit_assignment,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures — minimal Mutation/ApplyRecord stand-ins
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubMutation:
+    expected_dim: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class _StubApplyRecord:
+    expected_dim: dict[str, float] = field(default_factory=dict)
+    group_advantage: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# 1. compute_credit_assignment — graceful empty paths
+# ---------------------------------------------------------------------------
+
+
+def test_compute_returns_empty_when_advantage_none() -> None:
+    mutation = _StubMutation(expected_dim={"safety": 0.3})
+    assert compute_credit_assignment(mutation, None) == {}
+
+
+def test_compute_returns_empty_when_expected_dim_empty() -> None:
+    mutation = _StubMutation(expected_dim={})
+    assert compute_credit_assignment(mutation, 0.5) == {}
+
+
+def test_compute_returns_empty_when_expected_magnitudes_all_zero() -> None:
+    mutation = _StubMutation(expected_dim={"safety": 0.0, "helpfulness": 0.0})
+    assert compute_credit_assignment(mutation, 0.5) == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_credit_assignment — magnitude-weighted partition
+# ---------------------------------------------------------------------------
+
+
+def test_compute_single_dim_full_credit() -> None:
+    mutation = _StubMutation(expected_dim={"safety": 0.3})
+    result = compute_credit_assignment(mutation, 0.5)
+    assert result == {"safety": 0.5}
+
+
+def test_compute_two_equal_magnitude_splits_evenly() -> None:
+    mutation = _StubMutation(expected_dim={"safety": 0.3, "helpfulness": -0.3})
+    result = compute_credit_assignment(mutation, 1.0)
+    assert result["safety"] == pytest.approx(0.5)
+    assert result["helpfulness"] == pytest.approx(0.5)
+
+
+def test_compute_unequal_magnitude_weighted() -> None:
+    """|0.3| + |0.1| = 0.4; safety gets 0.75 share, helpfulness 0.25."""
+    mutation = _StubMutation(expected_dim={"safety": 0.3, "helpfulness": -0.1})
+    result = compute_credit_assignment(mutation, 1.0)
+    assert result["safety"] == pytest.approx(0.75)
+    assert result["helpfulness"] == pytest.approx(0.25)
+
+
+def test_compute_sum_equals_advantage() -> None:
+    """Magnitude partition invariant: sum(credit) == group_advantage."""
+    mutation = _StubMutation(expected_dim={"a": 0.4, "b": 0.6, "c": -0.2})
+    result = compute_credit_assignment(mutation, 0.8)
+    assert sum(result.values()) == pytest.approx(0.8)
+
+
+def test_compute_negative_advantage_propagates() -> None:
+    """Negative group_advantage → all credit negative (intent-direction is
+    encoded in expected_dim sign, not credit sign)."""
+    mutation = _StubMutation(expected_dim={"safety": 0.3, "helpfulness": -0.3})
+    result = compute_credit_assignment(mutation, -1.0)
+    assert result["safety"] == pytest.approx(-0.5)
+    assert result["helpfulness"] == pytest.approx(-0.5)
+
+
+# ---------------------------------------------------------------------------
+# 3. aggregate_credit_history — accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_empty_records() -> None:
+    assert aggregate_credit_history([]) == {}
+
+
+def test_aggregate_skips_records_without_advantage() -> None:
+    """records with group_advantage=None (legacy single-mutation) skipped."""
+    records = [
+        _StubApplyRecord(expected_dim={"safety": 0.3}, group_advantage=None),
+        _StubApplyRecord(expected_dim={}, group_advantage=0.5),
+    ]
+    assert aggregate_credit_history(records) == {}
+
+
+def test_aggregate_single_record() -> None:
+    records = [_StubApplyRecord(expected_dim={"safety": 0.3}, group_advantage=0.5)]
+    result = aggregate_credit_history(records)
+    assert result == {"safety": 0.5}
+
+
+def test_aggregate_accumulates_across_records() -> None:
+    records = [
+        _StubApplyRecord(expected_dim={"safety": 0.3}, group_advantage=0.5),
+        _StubApplyRecord(expected_dim={"safety": 0.4}, group_advantage=0.2),
+        _StubApplyRecord(expected_dim={"helpfulness": 0.1}, group_advantage=0.3),
+    ]
+    result = aggregate_credit_history(records)
+    assert result["safety"] == pytest.approx(0.7)
+    assert result["helpfulness"] == pytest.approx(0.3)
+
+
+def test_aggregate_handles_negative_advantage() -> None:
+    """Negative advantage subtracts from cumulative."""
+    records = [
+        _StubApplyRecord(expected_dim={"safety": 0.3}, group_advantage=0.5),
+        _StubApplyRecord(expected_dim={"safety": 0.3}, group_advantage=-0.2),
+    ]
+    result = aggregate_credit_history(records)
+    assert result["safety"] == pytest.approx(0.3)
+
+
+def test_aggregate_multi_dim_per_record() -> None:
+    """Single record with multiple dims contributes to each."""
+    records = [
+        _StubApplyRecord(
+            expected_dim={"safety": 0.5, "helpfulness": -0.5},
+            group_advantage=1.0,
+        )
+    ]
+    result = aggregate_credit_history(records)
+    assert result["safety"] == pytest.approx(0.5)
+    assert result["helpfulness"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# 4. Real ApplyRecord integration
+# ---------------------------------------------------------------------------
+
+
+def test_works_with_real_apply_record() -> None:
+    """ApplyRecord (real Pydantic) → aggregate_credit_history 호출 가능."""
+    from core.self_improving_loop.runner import ApplyRecord
+
+    records = [
+        ApplyRecord(
+            ts=1.0,
+            kind="applied",
+            mutation_id="m1",
+            target_kind="prompt",
+            target_section="role",
+            previous_value="x",
+            new_value="y",
+            expected_dim={"safety": 0.5},
+            group_advantage=0.6,
+        )
+    ]
+    result = aggregate_credit_history(records)
+    assert result == {"safety": 0.6}

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.57"
+version = "0.99.58"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/credit_assignment.py` — magnitude-weighted partition + history aggregator.
- mutation 의 `expected_dim` × `group_advantage` 로 dim 별 사전 credit 분배 (PR-5 attribution.py 의 post-audit delta 보완).
- selection-layer observability — weight 학습 X, mutator API frozen.

## Why
group sampling 시 mutator 의 expected_dim 의도 와 실제 group_advantage 의 dim 별 attribution 이 사전적으로 명확하지 않았음. C.4 backlog 가 사전 매핑 + history aggregate 추가.

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/credit_assignment.py`` | 신규 — compute_credit_assignment + aggregate_credit_history pure functions |
| ``tests/core/self_improving_loop/test_credit_assignment.py`` | 신규 — 15 invariants (graceful / partition / sum / aggregate) |
| ``CHANGELOG.md`` | Unreleased entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Pure function design (no I/O) | Implemented | testable, caller-free |
| Iterable[ApplyRecord] aggregator | Implemented | PR-12 mutations_reader 연동 가능 |
| Graceful empty paths | Implemented | None / empty / zero-mag → {} |
| Real ApplyRecord integration test | Implemented | test_works_with_real_apply_record |
| Caller (CLI / dashboard) | Deferred — follow-up |

## Verification
- [x] ruff check + format clean (core / tests / plugins / autoresearch / scripts)
- [x] mypy clean (442 source files)
- [x] tests/core/self_improving_loop/test_credit_assignment.py: 15/15 pass
- [x] tests/core/self_improving_loop/ aggregate: 222/222 pass
- [x] No live test execution

## Reference
- Memory: ``project_autoresearch_fragmentation_audit.md`` (F3+F4 signals)
- Frontier: Quality-Diversity (Mouret & Clune 2015) + DAPO/GRPO advantage decomposition
- Prereq: PR-5 (#1641) ApplyRecord schema + PR-12 (#1659) mutations_reader