### PR TITLE
feat(self-improving-loop): C.5 kind × dim cross-effect matrix (PR-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-17 C.5 kind × dim cross-effect matrix** —
+  `core/self_improving_loop/kind_dim_matrix.py` inner-joins apply rows
+  (PR-12 `read_recent_applies`) with attribution rows (PR-12
+  `read_recent_attributions`) on `mutation_id` and produces a 2-D
+  `{target_kind: {dim_name: cumulative_score}}` matrix
+  (`compute_kind_dim_matrix`). Each cell accumulates
+  `attribution_score × observed_dim[dim]` (signed). Orphan apply or
+  attribution rows are skipped silently. Companions:
+  `rank_dims_by_kind(kind)` / `rank_kinds_by_dim(dim)` sort by
+  absolute score with optional `limit`. Resolves F4 fragmentation
+  signal — operators can answer "which mutation kind has moved which
+  dim the most over history" without re-deriving from raw JSONL.
+  Pure functions (I/O-free); caller (CLI / dashboard) deferred to a
+  follow-up PR. Frontier: Quality-Diversity behavior-niche grid
+  (Mouret & Clune 2015) + DGM archive lineage causal trace.
 - **PR-16 C.4 credit_assignment module** —
   `core/self_improving_loop/credit_assignment.py` adds two pure
   functions for selection-layer observability:

--- a/core/self_improving_loop/kind_dim_matrix.py
+++ b/core/self_improving_loop/kind_dim_matrix.py
@@ -1,0 +1,112 @@
+"""C.5 (2026-05-25) — kind × dim cross-effect matrix (PR-17).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` 신호 4 — 한 cycle 에
+multi-kind mutation 가능성 + kind 간 interference confound. dim 단위
+attribution 으로는 (kind × dim) interaction 추적 불가.
+
+본 module = **5 kind × 24 dim matrix observability**:
+
+- :func:`compute_kind_dim_matrix(apply_records, attribution_records)` —
+  ApplyRecord 의 ``target_kind`` 와 AttributionRecord 의 ``observed_dim`` 을
+  ``mutation_id`` 로 inner-join 해서 2D dict (``{kind: {dim: cumulative_score}}``)
+  produce.
+- :func:`rank_dims_by_kind(matrix, kind)` — 한 kind 가 가장 영향 준 dim 들
+  내림차순.
+- :func:`rank_kinds_by_dim(matrix, dim)` — 한 dim 에 가장 영향 준 kind 들
+  내림차순.
+
+PR-12 ``read_recent_applies`` + PR-12 ``read_recent_attributions`` 결과를
+caller 가 inject — module 자체는 pure (I/O X). caller (CLI / dashboard) 가
+2D matrix 를 시각화.
+
+Frontier reference: Quality-Diversity 의 behavior-niche grid + DGM 의
+archive lineage causal trace.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.self_improving_loop.attribution import AttributionRecord
+    from core.self_improving_loop.runner import ApplyRecord
+
+
+def compute_kind_dim_matrix(
+    apply_records: Iterable[ApplyRecord],
+    attribution_records: Iterable[AttributionRecord],
+) -> dict[str, dict[str, float]]:
+    """Build a ``{target_kind: {dim_name: cumulative_attribution_score}}`` matrix.
+
+    Inner-join apply 와 attribution rows on ``mutation_id``. Each
+    (kind, dim) cell accumulates ``observed_dim[dim]`` from every
+    matched attribution row, scaled by ``attribution_score`` of that
+    row. The result lets operators answer "which kind of mutation has
+    moved which dim the most over history" — F4 fragmentation signal
+    resolver.
+
+    Apply rows whose ``mutation_id`` doesn't appear in any attribution
+    row are skipped (no signal). Attribution rows without a matching
+    apply row are skipped (orphan). Both iterables are consumed once.
+    """
+    apply_kind_by_id: dict[str, str] = {}
+    for ar in apply_records:
+        mid = getattr(ar, "mutation_id", "")
+        kind = getattr(ar, "target_kind", "")
+        if mid and kind:
+            apply_kind_by_id[mid] = kind
+
+    matrix: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for attr in attribution_records:
+        mid = getattr(attr, "mutation_id", "")
+        if not mid or mid not in apply_kind_by_id:
+            continue
+        kind = apply_kind_by_id[mid]
+        observed = getattr(attr, "observed_dim", None) or {}
+        score = float(getattr(attr, "attribution_score", 0.0))
+        for dim, value in observed.items():
+            # signed contribution — direction is preserved
+            matrix[kind][dim] += score * float(value)
+
+    return {kind: dict(dims) for kind, dims in matrix.items()}
+
+
+def rank_dims_by_kind(
+    matrix: dict[str, dict[str, float]],
+    kind: str,
+    *,
+    limit: int | None = None,
+) -> list[tuple[str, float]]:
+    """Return ``[(dim, score), ...]`` sorted by absolute score descending
+    for the given kind. Empty list when kind absent."""
+    dims = matrix.get(kind, {})
+    if not dims:
+        return []
+    ranked = sorted(dims.items(), key=lambda kv: abs(kv[1]), reverse=True)
+    if limit is not None:
+        return ranked[:limit]
+    return ranked
+
+
+def rank_kinds_by_dim(
+    matrix: dict[str, dict[str, float]],
+    dim: str,
+    *,
+    limit: int | None = None,
+) -> list[tuple[str, float]]:
+    """Return ``[(kind, score), ...]`` sorted by absolute score descending
+    for the given dim. Empty list when no kind has touched the dim."""
+    kinds_touching = [(kind, dims.get(dim, 0.0)) for kind, dims in matrix.items() if dim in dims]
+    ranked = sorted(kinds_touching, key=lambda kv: abs(kv[1]), reverse=True)
+    if limit is not None:
+        return ranked[:limit]
+    return ranked
+
+
+__all__ = [
+    "compute_kind_dim_matrix",
+    "rank_dims_by_kind",
+    "rank_kinds_by_dim",
+]

--- a/tests/core/self_improving_loop/test_kind_dim_matrix.py
+++ b/tests/core/self_improving_loop/test_kind_dim_matrix.py
@@ -1,0 +1,228 @@
+"""C.5 (2026-05-25) — kind × dim cross-effect matrix invariants (PR-17).
+
+Scope:
+- compute_kind_dim_matrix: empty / inner-join on mutation_id / signed contribution /
+  orphan attribution skip / orphan apply skip / single kind multi-dim accumulation
+- rank_dims_by_kind / rank_kinds_by_dim: absolute-magnitude sort / limit / missing key
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from core.self_improving_loop.kind_dim_matrix import (
+    compute_kind_dim_matrix,
+    rank_dims_by_kind,
+    rank_kinds_by_dim,
+)
+
+
+@dataclass
+class _StubApply:
+    mutation_id: str
+    target_kind: str
+
+
+@dataclass
+class _StubAttr:
+    mutation_id: str
+    observed_dim: dict[str, float] = field(default_factory=dict)
+    attribution_score: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# 1. compute_kind_dim_matrix — empty + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_empty_inputs() -> None:
+    assert compute_kind_dim_matrix([], []) == {}
+
+
+def test_matrix_only_applies_no_attribution() -> None:
+    """Apply rows without matching attribution → empty matrix."""
+    applies = [_StubApply("m1", "prompt"), _StubApply("m2", "tool_policy")]
+    assert compute_kind_dim_matrix(applies, []) == {}
+
+
+def test_matrix_only_attribution_no_apply() -> None:
+    """Orphan attribution → no kind to attach → skip."""
+    attrs = [_StubAttr("m1", {"safety": 0.5})]
+    assert compute_kind_dim_matrix([], attrs) == {}
+
+
+def test_matrix_inner_join_single_pair() -> None:
+    applies = [_StubApply("m1", "prompt")]
+    attrs = [_StubAttr("m1", {"safety": 0.5}, attribution_score=1.0)]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix == {"prompt": {"safety": 0.5}}
+
+
+def test_matrix_inner_join_two_kinds() -> None:
+    applies = [
+        _StubApply("m1", "prompt"),
+        _StubApply("m2", "tool_policy"),
+    ]
+    attrs = [
+        _StubAttr("m1", {"safety": 0.5}, attribution_score=1.0),
+        _StubAttr("m2", {"safety": 0.3}, attribution_score=1.0),
+    ]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(0.5)
+    assert matrix["tool_policy"]["safety"] == pytest.approx(0.3)
+
+
+def test_matrix_accumulates_same_kind_dim() -> None:
+    """Two apply+attr pairs on same kind+dim → sum."""
+    applies = [
+        _StubApply("m1", "prompt"),
+        _StubApply("m2", "prompt"),
+    ]
+    attrs = [
+        _StubAttr("m1", {"safety": 0.2}, attribution_score=1.0),
+        _StubAttr("m2", {"safety": 0.4}, attribution_score=1.0),
+    ]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(0.6)
+
+
+def test_matrix_signed_contribution() -> None:
+    """Negative observed_dim preserves sign."""
+    applies = [_StubApply("m1", "prompt")]
+    attrs = [_StubAttr("m1", {"safety": -0.3}, attribution_score=1.0)]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(-0.3)
+
+
+def test_matrix_scaled_by_attribution_score() -> None:
+    """attribution_score scales observed_dim contribution."""
+    applies = [_StubApply("m1", "prompt")]
+    attrs = [_StubAttr("m1", {"safety": 1.0}, attribution_score=0.5)]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(0.5)
+
+
+def test_matrix_orphan_attribution_skipped() -> None:
+    """Attribution row whose mutation_id has no apply row → skip."""
+    applies = [_StubApply("m1", "prompt")]
+    attrs = [
+        _StubAttr("m1", {"safety": 0.5}),
+        _StubAttr("orphan", {"safety": 0.9}),  # no apply
+    ]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(0.5)
+    assert "orphan" not in matrix.get("prompt", {})
+
+
+def test_matrix_multi_dim_one_attribution() -> None:
+    """Single attribution row with multiple dims contributes to each."""
+    applies = [_StubApply("m1", "prompt")]
+    attrs = [
+        _StubAttr(
+            "m1",
+            {"safety": 0.5, "helpfulness": -0.2},
+            attribution_score=1.0,
+        )
+    ]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix["prompt"]["safety"] == pytest.approx(0.5)
+    assert matrix["prompt"]["helpfulness"] == pytest.approx(-0.2)
+
+
+# ---------------------------------------------------------------------------
+# 2. rank_dims_by_kind
+# ---------------------------------------------------------------------------
+
+
+def test_rank_dims_returns_sorted_by_abs_descending() -> None:
+    matrix = {"prompt": {"a": 0.1, "b": -0.5, "c": 0.3}}
+    ranked = rank_dims_by_kind(matrix, "prompt")
+    assert ranked == [("b", -0.5), ("c", 0.3), ("a", 0.1)]
+
+
+def test_rank_dims_missing_kind_empty() -> None:
+    assert rank_dims_by_kind({"prompt": {"a": 1.0}}, "nonexistent") == []
+
+
+def test_rank_dims_with_limit() -> None:
+    matrix = {"prompt": {"a": 0.1, "b": -0.5, "c": 0.3, "d": 0.05}}
+    ranked = rank_dims_by_kind(matrix, "prompt", limit=2)
+    assert len(ranked) == 2
+    assert ranked == [("b", -0.5), ("c", 0.3)]
+
+
+# ---------------------------------------------------------------------------
+# 3. rank_kinds_by_dim
+# ---------------------------------------------------------------------------
+
+
+def test_rank_kinds_by_dim_sorted_descending_abs() -> None:
+    matrix = {
+        "prompt": {"safety": 0.2},
+        "tool_policy": {"safety": -0.5},
+        "reflection": {"safety": 0.1},
+    }
+    ranked = rank_kinds_by_dim(matrix, "safety")
+    assert ranked == [("tool_policy", -0.5), ("prompt", 0.2), ("reflection", 0.1)]
+
+
+def test_rank_kinds_by_dim_missing_dim_empty() -> None:
+    matrix = {"prompt": {"safety": 0.2}}
+    assert rank_kinds_by_dim(matrix, "nonexistent_dim") == []
+
+
+def test_rank_kinds_skips_kinds_without_dim() -> None:
+    """Only kinds whose dim dict contains the queried dim appear."""
+    matrix = {
+        "prompt": {"safety": 0.2},
+        "tool_policy": {"helpfulness": 0.5},  # no 'safety'
+    }
+    ranked = rank_kinds_by_dim(matrix, "safety")
+    assert len(ranked) == 1
+    assert ranked[0] == ("prompt", 0.2)
+
+
+def test_rank_kinds_with_limit() -> None:
+    matrix = {
+        "prompt": {"safety": 0.2},
+        "tool_policy": {"safety": -0.5},
+        "reflection": {"safety": 0.1},
+        "skill_catalog": {"safety": 0.4},
+    }
+    ranked = rank_kinds_by_dim(matrix, "safety", limit=2)
+    assert len(ranked) == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. Real ApplyRecord + AttributionRecord integration
+# ---------------------------------------------------------------------------
+
+
+def test_works_with_real_records() -> None:
+    """End-to-end with real Pydantic models."""
+    from core.self_improving_loop.attribution import AttributionRecord
+    from core.self_improving_loop.runner import ApplyRecord
+
+    applies = [
+        ApplyRecord(
+            ts=1.0,
+            kind="applied",
+            mutation_id="m1",
+            target_kind="prompt",
+            target_section="role",
+            previous_value="x",
+            new_value="y",
+        )
+    ]
+    attrs = [
+        AttributionRecord(
+            ts=2.0,
+            kind="attribution",
+            mutation_id="m1",
+            observed_dim={"safety": 0.5},
+            attribution_score=1.0,
+        )
+    ]
+    matrix = compute_kind_dim_matrix(applies, attrs)
+    assert matrix == {"prompt": {"safety": 0.5}}


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/kind_dim_matrix.py` — 5 kind × dim 2D matrix observability (F4 fragmentation signal 해소).
- ApplyRecord + AttributionRecord mutation_id inner-join → cumulative attribution_score × observed_dim.
- Pure I/O-free functions; caller (CLI / dashboard) 후속 PR.

## Why
Memory `project_autoresearch_fragmentation_audit.md` 신호 4 — 한 cycle 에 multi-kind mutation 가능 + kind 간 interference dim 단위 attribution 만으로 추적 불가. C.5 backlog 매핑.

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/kind_dim_matrix.py`` | 신규 — compute_kind_dim_matrix + rank_dims_by_kind + rank_kinds_by_dim |
| ``tests/core/self_improving_loop/test_kind_dim_matrix.py`` | 신규 — 18 invariants |
| ``CHANGELOG.md`` | Unreleased entry |

## GAP Audit
| Item | Status |
|------|--------|
| Inner-join on mutation_id | Implemented |
| Signed contribution preservation | Implemented |
| Orphan apply/attribution skip | Implemented |
| Real Pydantic record integration | Implemented |
| Caller (CLI/dashboard) | Deferred — follow-up |

## Verification
- [x] ruff check + format clean (CI parity inc scripts/)
- [x] mypy clean (443 source files)
- [x] tests/core/self_improving_loop/test_kind_dim_matrix.py: 18/18 pass
- [x] tests/core/self_improving_loop/ aggregate: 240/240
- [x] No live test execution

## Reference
- Memory: ``project_autoresearch_fragmentation_audit.md`` F4
- Prereq: PR-12 (#1659) mutations_reader + PR-5 (#1641) attribution.py
- Frontier: Quality-Diversity (Mouret & Clune 2015) + DGM archive lineage