### PR TITLE
fix(seed-gen): close 3 Codex MCP findings on PR-SG-SELECTION-ALIGN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,31 @@ functional change.
   `group_advantage`, but the per-dim partition itself is a local
   heuristic — not a direct DAPO/GRPO formula.
 
+### Fixed
+- **PR-SG-SELECTION-ALIGN-FIX** — Codex MCP review of
+  PR-SG-SELECTION-ALIGN flagged 3 half-wires. All fixed.
+  (V3) Tier-mapping drift test now parses the markdown tier table
+  per .md file and asserts the dim set in each tier row equals
+  `{d for d, t in AXIS_TIERS.items() if t == tier}` bidirectionally.
+  Pre-fix the tests only checked "every catalog dim appears
+  somewhere in the file", so a dim under the wrong tier in .md
+  would pass silently. New parametric test
+  `test_md_tier_mapping_matches_axis_tiers` × 3 files.
+  (V4) `PipelineState.pareto_mode: bool = False` field added,
+  threaded from `AutoresearchConfig.pareto_mode` via
+  `_dispatch_pipeline`. Evolver `_build_description` now gates
+  the `pareto_front` HANDOFF embed on `state.pareto_mode` — a
+  stale `baseline_archive.jsonl` from a prior `pareto_mode=True`
+  cycle no longer leaks into the evolver prompt when the current
+  cycle has linear scalarization. New test
+  `test_pareto_front_omitted_when_pareto_mode_false`.
+  (V5) `--target-dims-attribution` auto-pick narrowed to fire only
+  when `--target-dim` itself was auto-picked (None or `"auto"`).
+  Pre-fix it also fired for explicit `--target-dim broken_tool_use`
+  whenever a baseline existed, contradicting plan §5.3 / CLI help
+  text. The singular intent is now the operator's choice; the
+  plural Pareto scope only expands when both are auto.
+
 ## [0.99.58] - 2026-05-25
 
 Bundles PR-SG-SELECTION-ALIGN + PR-12/13/14 from develop (mutations_reader + meta_judge + propose_swarm wiring). seed-gen now surfaces the same selection-layer signals (anchor 3 / scenario_realism / tier model / Pareto front / target_dims_attribution) that autoresearch fitness reads.

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -280,8 +280,14 @@ class Evolver(BaseSeedAgent):
                 # PR-SG-SELECTION-ALIGN (2026-05-25) — selection-layer
                 # context: Pareto-scope dim list + run_dir for the
                 # pareto_front reader to locate baseline_archive.jsonl.
+                # PR-SG-SELECTION-ALIGN-FIX (V4) — `pareto_mode` gate
+                # from PipelineState (default False) so a stale archive
+                # from a prior `pareto_mode=True` cycle doesn't leak
+                # into evolver handoff when the current cycle is
+                # linear-scalarization.
                 target_dims_attribution=list(state.target_dims_attribution),
                 run_dir=state.run_dir,
+                pareto_mode=state.pareto_mode,
             )
             tasks.append(
                 SubTask(
@@ -315,6 +321,7 @@ class Evolver(BaseSeedAgent):
         articles_with_reasoning: str = "",
         target_dims_attribution: list[str] | None = None,
         run_dir: Any = None,
+        pareto_mode: bool = False,
     ) -> str:
         """Compose the per-survivor user message for the sub-agent.
 
@@ -411,9 +418,17 @@ class Evolver(BaseSeedAgent):
             handoff["scenario_realism"] = scenario_realism
         if target_dims_attribution:
             handoff["target_dims_attribution"] = list(target_dims_attribution)
-            pareto_front = _read_pareto_front_safe(run_dir, list(target_dims_attribution))
-            if pareto_front:
-                handoff["pareto_front"] = pareto_front
+            # PR-SG-SELECTION-ALIGN-FIX (V4) — gate Pareto front embed
+            # on the live `pareto_mode` knob. Without this, a stale
+            # baseline_archive.jsonl from a prior pareto_mode=True
+            # cycle would leak into the evolver handoff even when the
+            # current cycle has linear scalarization, mis-cuing the
+            # rewrite toward archive points the selection layer no
+            # longer curates.
+            if pareto_mode:
+                pareto_front = _read_pareto_front_safe(run_dir, list(target_dims_attribution))
+                if pareto_front:
+                    handoff["pareto_front"] = pareto_front
         # Keep `weakness_summary` / `means_summary` references — they're
         # consumed only by this function (no leak); local-only.
         _ = (weakness_summary, means_summary)

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -443,8 +443,22 @@ def run_audit_seeds(
             # set (e.g. no baseline yet, explicit single-dim run) the
             # list stays empty and the pre-G4 single-dim behaviour
             # holds.
+            # PR-SG-SELECTION-ALIGN-FIX (2026-05-25, V5) — auto-pick scope
+            # narrowed to the same trigger as ``--target-dim auto``. When
+            # the operator passes ``--target-dim broken_tool_use`` (or any
+            # explicit dim), the singular intent is theirs and the plural
+            # Pareto scope should NOT silently expand to top-3. Auto-pick
+            # of attribution fires only when the singular dim itself was
+            # auto-picked (target_dim None or "auto" on the CLI).
+            target_dim_was_auto = (target_dim is None) or (
+                isinstance(target_dim, str) and target_dim.lower() == "auto"
+            )
             resolved_attribution = target_dims_attribution
-            if resolved_attribution is None and baseline_snapshot is not None:
+            if (
+                resolved_attribution is None
+                and baseline_snapshot is not None
+                and target_dim_was_auto
+            ):
                 from plugins.seed_generation.baseline_reader import (
                     pick_regression_target_dims,
                 )
@@ -455,6 +469,20 @@ def run_audit_seeds(
                         "seed-generation: --target-dims-attribution auto → "
                         f"{resolved_attribution!r} (top-3 worst-regressed)\n"
                     )
+            # PR-SG-SELECTION-ALIGN-FIX (2026-05-25, V4) — read
+            # ``AutoresearchConfig.pareto_mode`` for the G5 gate.
+            # Best-effort: fall through to False when the config
+            # surface is unavailable in test contexts (mirrors the
+            # _get_seed_generation_config defensive pattern above).
+            pareto_mode = False
+            try:
+                from core.config.self_improving_loop import (
+                    load_self_improving_loop_config,
+                )
+
+                pareto_mode = bool(load_self_improving_loop_config().autoresearch.pareto_mode)
+            except Exception:
+                pareto_mode = False
             _dispatch_pipeline(
                 picker_result=picker_result,
                 target_dim=resolved_dim,
@@ -467,6 +495,7 @@ def run_audit_seeds(
                 meta_review_snapshot=meta_review_snapshot,
                 max_iterations=max_iterations,
                 target_dims_attribution=resolved_attribution,
+                pareto_mode=pareto_mode,
             )
         except Exception as exc:  # pragma: no cover - bubbles up rich error
             journal.append(
@@ -500,6 +529,7 @@ def _dispatch_pipeline(
     meta_review_snapshot: Any = None,
     max_iterations: int = 0,
     target_dims_attribution: list[str] | None = None,
+    pareto_mode: bool = False,
 ) -> None:
     """Build orchestrator + run.
 
@@ -535,6 +565,7 @@ def _dispatch_pipeline(
         run_id=run_id,
         target_dim=target_dim,
         target_dims_attribution=list(target_dims_attribution or []),
+        pareto_mode=pareto_mode,
         gen_tag=gen_tag,
         candidates_requested=candidates_requested,
         run_dir=run_dir,

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -218,6 +218,14 @@ class PipelineState:
     # pre-G4 single-dim contract — callers that only set
     # ``target_dim`` behave exactly as before.
     target_dims_attribution: list[str] = field(default_factory=list)
+    # PR-SG-SELECTION-ALIGN-FIX (2026-05-25, V4) — G5 gate. Mirrors
+    # ``core.config.self_improving_loop.AutoresearchConfig.pareto_mode``.
+    # The evolver only embeds ``pareto_front`` into its HANDOFF when
+    # this is True, even if ``baseline_archive.jsonl`` exists from a
+    # prior pareto_mode=True cycle. Prevents the half-disconnect of
+    # surfacing archive state to the LLM while selection layer
+    # isn't actively curating the front.
+    pareto_mode: bool = False
     candidates_requested: int = 15
     # CSP-5 (2026-05-22) — paper §3 iteration loop. Default 0 keeps
     # the pre-CSP-5 single-pass behaviour (Pipeline.arun() executes

--- a/tests/plugins/seed_generation/test_selection_alignment.py
+++ b/tests/plugins/seed_generation/test_selection_alignment.py
@@ -133,6 +133,45 @@ class TestTierDocParity:
             assert f"`{dim}`" in body, f"{md_name} missing info dim {dim}"
 
     @pytest.mark.parametrize("md_name", ["pilot.md", "critic.md", "evolver.md"])
+    def test_md_tier_mapping_matches_axis_tiers(self, md_name: str) -> None:
+        """Parse the tier table in each .md and assert dim -> tier
+        bidirectional equality with ``autoresearch.train.AXIS_TIERS``.
+
+        PR-SG-SELECTION-ALIGN-FIX (2026-05-25, V3) — pre-fix
+        `test_md_lists_every_<tier>_dim` only asserted "every
+        AXIS_TIERS dim appears somewhere in the file"; a dim listed
+        under the WRONG tier or a typo in the .md would still pass.
+        This test parses the markdown row for each tier and checks
+        the dim's actual classification.
+
+        Row format (matched by regex on bold tier label + backticked
+        dim names):
+
+            | **<tier> (N)** | `dim_a`, `dim_b`, ... |
+        """
+        import re
+
+        from autoresearch.train import AXIS_TIERS
+
+        body = (PROMPT_DIR / md_name).read_text(encoding="utf-8")
+        for tier in ("critical", "auxiliary", "info"):
+            pattern = re.compile(
+                rf"\|\s*\*\*{tier}\s*\(\d+\)\*\*\s*\|\s*(.*?)\s*\|",
+                re.DOTALL,
+            )
+            match = pattern.search(body)
+            assert match, f"{md_name}: missing tier row for {tier!r}"
+            row_dims = set(re.findall(r"`([a-z_]+)`", match.group(1)))
+            expected = {d for d, t in AXIS_TIERS.items() if t == tier}
+            assert row_dims == expected, (
+                f"{md_name} tier {tier!r} mismatch:\n"
+                f"  in .md row: {sorted(row_dims)}\n"
+                f"  in AXIS_TIERS: {sorted(expected)}\n"
+                f"  unexpected (in md but not catalog): {sorted(row_dims - expected)}\n"
+                f"  missing (in catalog but not md): {sorted(expected - row_dims)}"
+            )
+
+    @pytest.mark.parametrize("md_name", ["pilot.md", "critic.md", "evolver.md"])
     def test_md_has_anchor_section(self, md_name: str) -> None:
         body = (PROMPT_DIR / md_name).read_text(encoding="utf-8")
         assert "## Anchor 3 dims" in body
@@ -379,7 +418,7 @@ class TestParetoFrontReader:
 
 
 class TestEvolverParetoFrontEmbed:
-    def _state_with_archive(self, tmp_path: Path) -> object:
+    def _state_with_archive(self, tmp_path: Path, *, pareto_mode: bool = True) -> object:
         from plugins.seed_generation.baseline_reader import BaselineSnapshot
         from plugins.seed_generation.orchestrator import PipelineState
 
@@ -401,6 +440,7 @@ class TestEvolverParetoFrontEmbed:
             target_dim="broken_tool_use",
             gen_tag="g",
             target_dims_attribution=["broken_tool_use", "input_hallucination"],
+            pareto_mode=pareto_mode,
             baseline_snapshot=BaselineSnapshot(dim_means={"broken_tool_use": 1.0}, dim_stderr={}),
             run_dir=tmp_path,
         )
@@ -449,6 +489,7 @@ class TestEvolverParetoFrontEmbed:
             target_dim="broken_tool_use",
             gen_tag="g",
             target_dims_attribution=[],  # empty → no Pareto scope
+            pareto_mode=True,
             baseline_snapshot=BaselineSnapshot(dim_means={"broken_tool_use": 1.0}, dim_stderr={}),
             run_dir=tmp_path,
         )
@@ -467,3 +508,25 @@ class TestEvolverParetoFrontEmbed:
         handoff = _extract_handoff(tasks[0].description)
         assert "pareto_front" not in handoff
         assert "target_dims_attribution" not in handoff
+
+    def test_pareto_front_omitted_when_pareto_mode_false(self, tmp_path: Path) -> None:
+        """PR-SG-SELECTION-ALIGN-FIX (V4) — gate: even when the
+        archive exists from a prior pareto_mode=True cycle AND the
+        current run has a non-empty target_dims_attribution, the
+        evolver MUST NOT embed pareto_front when ``state.pareto_mode``
+        is False (default). Plan §9 said "when pareto_mode active";
+        Codex MCP review flagged the missing guard.
+        """
+        from plugins.seed_generation.agents.evolver import Evolver
+
+        state = self._state_with_archive(tmp_path, pareto_mode=False)
+        evolver = Evolver(MagicMock())
+        tasks = evolver._build_tasks(state, {state.candidates[0]["id"]: state.candidates[0]})  # type: ignore[attr-defined]
+        handoff = _extract_handoff(tasks[0].description)
+        # target_dims_attribution still surfaces — that's just metadata.
+        assert handoff["target_dims_attribution"] == [
+            "broken_tool_use",
+            "input_hallucination",
+        ]
+        # pareto_front omitted because the live mode is linear scalarization.
+        assert "pareto_front" not in handoff


### PR DESCRIPTION
## Summary
- V3 tier-mapping test rigor — markdown row → AXIS_TIERS bidirectional check (was: only dim-name presence).
- V4 `pareto_mode` gate — new `PipelineState.pareto_mode` field; evolver `pareto_front` embed only when current cycle has it set.
- V5 CLI auto-pick scope — `--target-dims-attribution` defaults to top-3 ONLY when `--target-dim` itself was auto-picked.

## Why
Codex MCP cross-LLM verify on PR-SG-SELECTION-ALIGN (#1663, commit 7f109670) returned 3 FAILs (V3 / V4 / V5) plus 1 false-positive on V7 (reader-writer parity — V7 PASSES; Codex was reading pre-PR-15 code).

V3: silent type errors in .md would slip past the existing tests.
V4: stale archive leaked into evolver handoff when selection layer didn't curate the front.
V5: contradicted plan §5.3 + CLI help text saying "defaults to top-3 when --target-dim auto-picks".

## Changes
| File | Change |
|------|--------|
| `tests/plugins/seed_generation/test_selection_alignment.py` | NEW `test_md_tier_mapping_matches_axis_tiers` (parametric × 3 files); NEW `test_pareto_front_omitted_when_pareto_mode_false`; `_state_with_archive` accepts `pareto_mode` kwarg. |
| `plugins/seed_generation/orchestrator.py` | `PipelineState.pareto_mode: bool = False` field. |
| `plugins/seed_generation/cli.py` | `_dispatch_pipeline(pareto_mode: bool)`; read `AutoresearchConfig.pareto_mode` via best-effort `load_self_improving_loop_config()`. CLI auto-pick block gated on `target_dim_was_auto`. |
| `plugins/seed_generation/agents/evolver.py` | `_build_description(pareto_mode: bool = False)`; `pareto_front` embed gated on this kwarg. |
| `CHANGELOG.md` | Unreleased Fixed entry. |

## Verification
- [x] 4 new tests pass (3 tier-mapping + 1 pareto_mode-false)
- [x] `uv run pytest tests/plugins/seed_generation tests/core/self_improving_loop tests/core/agent` — 799 passed, 3 skipped
- [x] `ruff check` + `ruff format --check` + `mypy plugins/seed_generation/ core/self_improving_loop/pareto_archive.py` + `lint-imports` — clean
- [ ] CI 5/5 green (pending)

## Reference
- Codex MCP verdict (this session): V3/V4/V5 FAIL, V7 false-positive
- Plan: `docs/plans/2026-05-25-seed-gen-selection-layer-alignment.md` §5.3 (CLI scope) + §9 (pareto_mode gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)