### PR TITLE
feat(self-improving-loop): A.6 CRM causal_hypothesis field (PR-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-20 A.6 CRM causal_hypothesis field** —
+  `Mutation` dataclass + `ApplyRecord` Pydantic schema +
+  `parse_mutation` + `to_audit_row` 가 새로운 optional
+  `causal_hypothesis` field (max 500 chars) 를 cover. mutator 가
+  mutation 직전 명시한 인과사슬 — "dim X 의 Y 효과 → fitness Z 변화"
+  — 가 mutations.jsonl 의 apply row 에 emit 되어 post-audit
+  observed_dim 과 cross-check 가능 (별도 wiring 은 follow-up).
+  principle (SPCT) 이 judging criterion 이라면 causal_hypothesis 는
+  causal trace — 두 field 는 독립적, 둘 다 emit 가능. Legacy mutator
+  (key 미포함) → 빈 문자열 → row column 미생성. Frontier: CRM
+  (Conditional Reward Modeling, arXiv 2509.26578).
+
 ## [0.99.59] - 2026-05-25
 
 Patch bundling PR-16 (C.4 credit_assignment) + PR-17 (C.5 kind×dim matrix) + PR-SG-SELECTION-ALIGN-FIX (V3/V4/V5 Codex MCP fixes on PR-SG-SELECTION-ALIGN).

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -119,6 +119,13 @@ class ApplyRecord(BaseModel):
     한 self-generated judging principle. SPCT (DeepSeek-GRM 2026-Q1) 패턴.
     None 일 때 legacy (P3 이전 mutation row). max 500 chars (parse_mutation
     guard)."""
+    causal_hypothesis: str | None = Field(default=None, max_length=500)
+    """A.6 (PR-20, 2026-05-25) — Conditional Reward Modeling (CRM, arXiv
+    2509.26578) 패턴. mutator 가 mutation 직전 명시한 "dim X 의 Y 효과
+    → fitness Z 변화" 인과사슬. principle (SPCT) 이 *judging criterion*
+    이라면 causal_hypothesis 는 *causal chain*. post-audit observed_dim
+    이 hypothesis 와 일치하는지 cross-check (별도 wiring). None 일 때
+    legacy (CRM 이전). max 500 chars (parse_mutation guard)."""
     swarm_id: str | None = None
     """P4 (2026-05-25, Kimi K2.6 PARL inference-time) — swarm-level grouping
     key. multi-level: swarm_id (level 2) + group_id (level 1). 1=disabled
@@ -186,6 +193,15 @@ class Mutation:
     principle → critique → reward chain 의 입구. parse_mutation 이
     LLM response 의 ``principle`` key 에서 추출 (max 500자). 빈 문자열
     일 때 legacy mutator (P3 이전) 호환."""
+
+    causal_hypothesis: str = ""
+    """A.6 (PR-20, 2026-05-25, CRM) — mutator 가 mutation 직전 명시한
+    causal chain ("dim X 의 Y 효과 → fitness Z 변화"). CRM (Conditional
+    Reward Modeling, arXiv 2509.26578) 패턴. principle 이 *judging
+    criterion* (SPCT) 라면 causal_hypothesis 는 *causal trace* — post-
+    audit observed_dim 과 cross-check 가능 (별도 wiring). parse_mutation
+    이 LLM response 의 ``causal_hypothesis`` key 에서 추출 (max 500자).
+    빈 문자열 = legacy mutator (CRM 이전) 호환."""
 
     def to_audit_row(
         self,
@@ -257,6 +273,9 @@ class Mutation:
         # 무영향).
         if self.principle:
             row["principle"] = self.principle
+        # A.6 (PR-20) — CRM causal_hypothesis non-empty 시만 emit.
+        if self.causal_hypothesis:
+            row["causal_hypothesis"] = self.causal_hypothesis
         return row
 
 
@@ -871,6 +890,17 @@ def parse_mutation(raw: str) -> Mutation:
             f"(SPCT principle must be concise — frontier reference: "
             f"DeepSeek-GRM)"
         )
+    # A.6 (PR-20, 2026-05-25, CRM pattern) — causal_hypothesis 추출. LLM 이
+    # 명시 안 하면 빈 문자열. max 500 chars guard (principle 패턴 동일).
+    causal_hypothesis_raw = payload.get("causal_hypothesis", "")
+    causal_hypothesis = (
+        causal_hypothesis_raw.strip() if isinstance(causal_hypothesis_raw, str) else ""
+    )
+    if len(causal_hypothesis) > 500:
+        raise ValueError(
+            f"causal_hypothesis length {len(causal_hypothesis)} exceeds 500 char "
+            f"cap (CRM causal chain must be concise — frontier: arXiv 2509.26578)"
+        )
     # PR-6 C-5 — target_kind dispatches to the policy SoT file. Default
     # ``prompt`` keeps the legacy wrapper-sections behaviour so older
     # mutation rows replay unchanged. Unknown kinds raise ValueError so
@@ -896,6 +926,7 @@ def parse_mutation(raw: str) -> Mutation:
             expected_dim=expected_dim,
             rollback_condition=rollback_condition,
             principle=principle,
+            causal_hypothesis=causal_hypothesis,
         )
     return Mutation(
         target_section=target_section.strip(),
@@ -906,6 +937,7 @@ def parse_mutation(raw: str) -> Mutation:
         expected_dim=expected_dim,
         rollback_condition=rollback_condition,
         principle=principle,
+        causal_hypothesis=causal_hypothesis,
     )
 
 

--- a/tests/core/self_improving_loop/test_causal_hypothesis.py
+++ b/tests/core/self_improving_loop/test_causal_hypothesis.py
@@ -1,0 +1,167 @@
+"""A.6 (2026-05-25) — Mutation.causal_hypothesis (CRM) invariants (PR-20).
+
+Scope:
+- Mutation dataclass field default ("")
+- ApplyRecord Pydantic field default (None)
+- parse_mutation extracts ``causal_hypothesis`` from LLM payload
+- to_audit_row emits causal_hypothesis only when non-empty
+- parse_mutation 500-char cap raises ValueError
+- legacy mutator (no causal_hypothesis key) → empty string
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from core.self_improving_loop.runner import (
+    ApplyRecord,
+    Mutation,
+    parse_mutation,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Mutation dataclass — default ""
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_default_causal_hypothesis_empty() -> None:
+    m = Mutation(target_section="role", new_value="v", rationale="t")
+    assert m.causal_hypothesis == ""
+
+
+def test_mutation_explicit_causal_hypothesis() -> None:
+    m = Mutation(
+        target_section="role",
+        new_value="v",
+        rationale="t",
+        causal_hypothesis="X improves Y by Z chain",
+    )
+    assert m.causal_hypothesis == "X improves Y by Z chain"
+
+
+# ---------------------------------------------------------------------------
+# 2. ApplyRecord Pydantic — default None
+# ---------------------------------------------------------------------------
+
+
+def test_apply_record_default_causal_hypothesis_none() -> None:
+    record = ApplyRecord(
+        ts=1.0,
+        kind="applied",
+        mutation_id="m1",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="x",
+        new_value="y",
+    )
+    assert record.causal_hypothesis is None
+
+
+def test_apply_record_with_causal_hypothesis() -> None:
+    record = ApplyRecord(
+        ts=1.0,
+        kind="applied",
+        mutation_id="m1",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="x",
+        new_value="y",
+        causal_hypothesis="dim drops because role is more cautious",
+    )
+    assert record.causal_hypothesis == "dim drops because role is more cautious"
+
+
+def test_apply_record_500_char_cap() -> None:
+    """Pydantic max_length 500 enforced."""
+    too_long = "x" * 501
+    with pytest.raises(Exception):  # ValidationError
+        ApplyRecord(
+            ts=1.0,
+            kind="applied",
+            mutation_id="m1",
+            target_kind="prompt",
+            target_section="role",
+            previous_value="x",
+            new_value="y",
+            causal_hypothesis=too_long,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. parse_mutation — LLM payload extraction
+# ---------------------------------------------------------------------------
+
+
+def _payload(**overrides) -> str:
+    base = {
+        "target_section": "role",
+        "new_value": "y",
+        "rationale": "test",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+def test_parse_mutation_extracts_causal_hypothesis() -> None:
+    raw = _payload(causal_hypothesis="dim X → fitness Z via Y")
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == "dim X → fitness Z via Y"
+
+
+def test_parse_mutation_legacy_no_causal_hypothesis_key() -> None:
+    """Legacy mutator (P3 이전) 가 causal_hypothesis key 안 emit → 빈 문자열."""
+    raw = _payload()
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == ""
+
+
+def test_parse_mutation_500_char_cap_raises() -> None:
+    too_long = "x" * 501
+    raw = _payload(causal_hypothesis=too_long)
+    with pytest.raises(ValueError, match=r"exceeds 500 char"):
+        parse_mutation(raw)
+
+
+def test_parse_mutation_non_string_causal_hypothesis_treated_empty() -> None:
+    """Non-string value (None / list / int) → 빈 문자열 (graceful)."""
+    raw = _payload(causal_hypothesis=None)
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == ""
+
+
+# ---------------------------------------------------------------------------
+# 4. to_audit_row — emit only when non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_to_audit_row_omits_causal_hypothesis_when_empty() -> None:
+    m = Mutation(target_section="role", new_value="y", rationale="t")
+    row = m.to_audit_row(previous_value="x")
+    assert "causal_hypothesis" not in row
+
+
+def test_to_audit_row_emits_causal_hypothesis_when_set() -> None:
+    m = Mutation(
+        target_section="role",
+        new_value="y",
+        rationale="t",
+        causal_hypothesis="role becomes cautious → broken_tool_use rises",
+    )
+    row = m.to_audit_row(previous_value="x")
+    assert row["causal_hypothesis"] == "role becomes cautious → broken_tool_use rises"
+
+
+def test_to_audit_row_principle_and_causal_hypothesis_independent() -> None:
+    """principle (SPCT) 와 causal_hypothesis (CRM) 는 별도 field — 둘 다
+    emit 가능."""
+    m = Mutation(
+        target_section="role",
+        new_value="y",
+        rationale="t",
+        principle="judge alignment over correctness",
+        causal_hypothesis="role caution → tool_use dim regress",
+    )
+    row = m.to_audit_row(previous_value="x")
+    assert row["principle"] == "judge alignment over correctness"
+    assert row["causal_hypothesis"] == "role caution → tool_use dim regress"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.58"
+version = "0.99.59"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Mutation + ApplyRecord + parse_mutation + to_audit_row 의 신규 optional `causal_hypothesis` (max 500 chars) field.
- CRM (Conditional Reward Modeling, arXiv 2509.26578) 패턴 — mutator 의 causal trace를 mutations.jsonl 에 보존.
- principle (SPCT) 과 별도 — judging criterion vs causal trace.

## Why
Plan `docs/plans/2026-05-25-p3-anchor-calibration-crm-spct.md` §C6. mutator 의 인과 가설 ("dim X 의 Y 효과 → fitness Z 변화") 이 post-audit 와 cross-check 가능하도록 schema 보존. 후속 wiring 은 dim_means subprocess capture 후.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | Mutation/ApplyRecord field + parse_mutation extract + to_audit_row emit |
| `tests/core/self_improving_loop/test_causal_hypothesis.py` | 12 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 12 new + 280 SIL aggregate pass
- [x] No live test

## Reference
- Plan §C6
- Frontier: CRM arXiv 2509.26578