### PR TITLE
feat(self-improving-loop): A.8 sub_agent_slice helper (PR-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-21 A.8 sub_agent_slice helper** —
+  `core/self_improving_loop/sub_agent_slice.py` defines a 5-stage
+  deterministic round-robin slice mapping (role / tools / reflection
+  / decomposition / interlocutor) keyed on `sub_agent_index`.
+  `compute_sub_agent_slice(idx, total)` returns the slice name;
+  `derive_slice_prompt_hint(slice)` returns a one-line mutator
+  system-prompt hint that the eventual `propose_swarm` wiring can
+  prepend to diversify sub-agent focus beyond temperature
+  stochasticity. Pure functions, no caller wired yet (deferred to a
+  follow-up PR). Frontier: Kimi K2.6 PARL post-trained decomposition,
+  inference-time variant.
 - **PR-20 A.6 CRM causal_hypothesis field** —
   `Mutation` dataclass + `ApplyRecord` Pydantic schema +
   `parse_mutation` + `to_audit_row` 가 새로운 optional

--- a/core/self_improving_loop/sub_agent_slice.py
+++ b/core/self_improving_loop/sub_agent_slice.py
@@ -1,0 +1,106 @@
+"""A.8 (2026-05-25) — sub-agent contract slice helper (PR-21).
+
+Plan ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md`` §C4.
+
+PR-14 의 ``propose_swarm`` 가 M sub-agent 를 동일 prompt + temperature
+stochasticity 로 호출 — sub-agent diversity 가 의도된 게 아니라 random
+seed 의존. A.8 가 그 위 layer: 각 sub-agent 가 **deterministic slice**
+의 agent_contract focus 받아 mutation chain 분기.
+
+5-stage slice (sub_agent_count 의 config cap 과 일치):
+
+| idx | Slice name | Focus | Mutation tendency |
+|---|---|---|---|
+| 0 | ``role`` | ego / self-description | wrapper prompt role section |
+| 1 | ``tools`` | tool_policy + tool_descriptions | tool selection policy |
+| 2 | ``reflection`` | reflection cycles / critique policy | reflection_policy |
+| 3 | ``decomposition`` | task breakdown + plan steps | decomposition_policy |
+| 4 | ``interlocutor`` | user model / dialogue framing | wrapper prompt user-model section |
+
+Frontier: Kimi K2.6 PARL 의 post-trained decomposition (M sub-agent
+각자 specialized policy slice) — mutator API frozen 라 inference-time
+변형 = system prompt hint injection.
+
+본 module = **pure helper**:
+
+- :func:`compute_sub_agent_slice(idx, total)` — deterministic round-robin
+  slice name
+- :func:`derive_slice_prompt_hint(slice)` — mutator system prompt 에
+  prepend 할 한 줄 hint
+
+Caller (propose_swarm) 의 wiring 은 후속 PR — 본 PR scope = helper only.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SLICE_NAMES: Final[tuple[str, ...]] = (
+    "role",
+    "tools",
+    "reflection",
+    "decomposition",
+    "interlocutor",
+)
+"""5 deterministic slices, ordered by sub_agent_index. config cap = 5
+(``AutoresearchConfig.sub_agent_count`` ge=1, le=5) — slice idx 가
+count 를 넘으면 round-robin (modulo)."""
+
+
+_SLICE_PROMPT_HINTS: Final[dict[str, str]] = {
+    "role": (
+        "Focus this mutation on the wrapper prompt's *role* section — "
+        "the agent's ego, self-description, voice."
+    ),
+    "tools": (
+        "Focus this mutation on tool_policy or tool_descriptions — "
+        "which tools the agent selects and how it phrases their use."
+    ),
+    "reflection": (
+        "Focus this mutation on reflection_policy — the agent's "
+        "self-critique cadence and what it re-examines after errors."
+    ),
+    "decomposition": (
+        "Focus this mutation on decomposition_policy — how the agent "
+        "breaks down tasks and orders plan steps."
+    ),
+    "interlocutor": (
+        "Focus this mutation on the wrapper prompt's *user model* "
+        "section — how the agent frames the operator's intent and "
+        "dialogue conventions."
+    ),
+}
+
+
+def compute_sub_agent_slice(idx: int, total: int) -> str:
+    """Return slice name for sub-agent at ``idx`` out of ``total`` agents.
+
+    Deterministic round-robin over :data:`SLICE_NAMES` — same idx +
+    same total always yields the same slice. Negative idx or total <= 0
+    raise ``ValueError``.
+
+    When ``total > len(SLICE_NAMES)`` (i.e. > 5), the assignment wraps
+    via modulo — caller (config cap=5) keeps this from happening at
+    runtime, but the helper stays defensive.
+    """
+    if idx < 0:
+        raise ValueError(f"sub_agent_index must be >= 0, got {idx}")
+    if total <= 0:
+        raise ValueError(f"total sub-agents must be >= 1, got {total}")
+    return SLICE_NAMES[idx % len(SLICE_NAMES)]
+
+
+def derive_slice_prompt_hint(slice_name: str) -> str:
+    """Return the mutator system-prompt hint for ``slice_name``.
+
+    Unknown slice → empty string (graceful — caller treats as "no hint",
+    falls back to the unmodified system prompt).
+    """
+    return _SLICE_PROMPT_HINTS.get(slice_name, "")
+
+
+__all__ = [
+    "SLICE_NAMES",
+    "compute_sub_agent_slice",
+    "derive_slice_prompt_hint",
+]

--- a/tests/core/self_improving_loop/test_sub_agent_slice.py
+++ b/tests/core/self_improving_loop/test_sub_agent_slice.py
@@ -1,0 +1,127 @@
+"""A.8 (2026-05-25) — sub_agent_slice helper invariants (PR-21).
+
+Scope:
+- compute_sub_agent_slice: deterministic round-robin / negative idx raises /
+  zero total raises / round-robin wrap when total > 5
+- derive_slice_prompt_hint: known slices return non-empty / unknown empty
+- SLICE_NAMES order matches plan §C4 5-stage spec
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.sub_agent_slice import (
+    SLICE_NAMES,
+    compute_sub_agent_slice,
+    derive_slice_prompt_hint,
+)
+
+# ---------------------------------------------------------------------------
+# 1. SLICE_NAMES constant
+# ---------------------------------------------------------------------------
+
+
+def test_slice_names_5_stage_order() -> None:
+    """Plan §C4 의 5-stage 순서 — role / tools / reflection / decomposition /
+    interlocutor."""
+    assert SLICE_NAMES == (
+        "role",
+        "tools",
+        "reflection",
+        "decomposition",
+        "interlocutor",
+    )
+
+
+def test_slice_names_count_matches_config_cap() -> None:
+    """sub_agent_count config cap = 5 (Field(ge=1, le=5)). SLICE_NAMES
+    길이가 cap 과 일치 — round-robin wrap 안 일어남."""
+    assert len(SLICE_NAMES) == 5
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_sub_agent_slice — deterministic round-robin
+# ---------------------------------------------------------------------------
+
+
+def test_compute_slice_idx_0_returns_role() -> None:
+    assert compute_sub_agent_slice(0, 5) == "role"
+
+
+def test_compute_slice_idx_1_returns_tools() -> None:
+    assert compute_sub_agent_slice(1, 5) == "tools"
+
+
+def test_compute_slice_idx_4_returns_interlocutor() -> None:
+    assert compute_sub_agent_slice(4, 5) == "interlocutor"
+
+
+def test_compute_slice_is_deterministic() -> None:
+    """Same (idx, total) always yields same slice — pure function."""
+    for idx in range(5):
+        assert compute_sub_agent_slice(idx, 5) == compute_sub_agent_slice(idx, 5)
+
+
+def test_compute_slice_total_smaller_than_max() -> None:
+    """total=2 sub-agents — idx 0 + 1 모두 유효 slice."""
+    assert compute_sub_agent_slice(0, 2) == "role"
+    assert compute_sub_agent_slice(1, 2) == "tools"
+
+
+def test_compute_slice_negative_idx_raises() -> None:
+    with pytest.raises(ValueError, match=r"sub_agent_index must be >= 0"):
+        compute_sub_agent_slice(-1, 5)
+
+
+def test_compute_slice_zero_total_raises() -> None:
+    with pytest.raises(ValueError, match=r"total sub-agents must be >= 1"):
+        compute_sub_agent_slice(0, 0)
+
+
+def test_compute_slice_negative_total_raises() -> None:
+    with pytest.raises(ValueError, match=r"total sub-agents must be >= 1"):
+        compute_sub_agent_slice(0, -3)
+
+
+def test_compute_slice_round_robin_wrap() -> None:
+    """idx > len(SLICE_NAMES) (방어적 — config cap 으로 정상 안 도달).
+    idx=5 → 5 % 5 = 0 → 'role'."""
+    assert compute_sub_agent_slice(5, 10) == "role"
+    assert compute_sub_agent_slice(6, 10) == "tools"
+
+
+# ---------------------------------------------------------------------------
+# 3. derive_slice_prompt_hint
+# ---------------------------------------------------------------------------
+
+
+def test_derive_hint_known_slices_non_empty() -> None:
+    for slice_name in SLICE_NAMES:
+        hint = derive_slice_prompt_hint(slice_name)
+        assert hint != "", f"slice {slice_name!r} has empty hint"
+
+
+def test_derive_hint_unknown_slice_returns_empty() -> None:
+    """Unknown slice → empty (graceful, caller falls back)."""
+    assert derive_slice_prompt_hint("nonexistent_slice") == ""
+
+
+def test_derive_hint_role_mentions_role() -> None:
+    assert "role" in derive_slice_prompt_hint("role").lower()
+
+
+def test_derive_hint_tools_mentions_tool() -> None:
+    assert "tool" in derive_slice_prompt_hint("tools").lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Integration — pipeline pattern
+# ---------------------------------------------------------------------------
+
+
+def test_full_pipeline_idx_to_hint() -> None:
+    """compute_sub_agent_slice → derive_slice_prompt_hint pipeline."""
+    slice_name = compute_sub_agent_slice(2, 5)
+    hint = derive_slice_prompt_hint(slice_name)
+    assert slice_name == "reflection"
+    assert "reflection" in hint.lower()


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/sub_agent_slice.py` — 5-stage deterministic slice mapping (role/tools/reflection/decomposition/interlocutor) + mutator hint.
- Pure functions; propose_swarm wiring 은 follow-up.

## Why
PR-14 의 propose_swarm 이 stochastic temperature 만으로 sub-agent diversity 제공. A.8 가 deterministic slice 분기 추가 — Kimi K2.6 PARL inference-time 변형.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/sub_agent_slice.py` | 신규 — SLICE_NAMES + compute_sub_agent_slice + derive_slice_prompt_hint |
| `tests/core/self_improving_loop/test_sub_agent_slice.py` | 신규 — 16 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 16 new + 296 SIL aggregate pass

## Reference
- Plan p4 §C4, frontier Kimi K2.6 PARL