### PR TITLE
feat(self-improving-loop): A.2 Tchebycheff scalarization helper (PR-23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-23 A.2 Tchebycheff scalarization helper** —
+  `core/self_improving_loop/tchebycheff.py` adds `compute_tchebycheff(fitness_dim, weights, ideal_point)` and `compute_ideal_point(vectors)` pure helpers. Linear scalarization (`f_total = sum(w*r)`) cannot reach concave Pareto-front regions (Das & Dennis 1997); Tchebycheff (`-max_d w_d * (ideal[d] - fitness[d])`) closes that gap by penalizing the worst dim relative to the ideal point. Pareto-front advantage invariant test pins the canonical 3-point concave example (extreme points tie under linear, B beats both under Tchebycheff). Caller wiring into `apply_group_proposals` 의 pareto_mode 분기 is deferred — PR-15 의 lineage writer 와 짝지을 다음 PR 가 필요.
 - **PR-22 B.4 F1 cross-run SoT 3중첩 invariants** —
   `tests/core/self_improving_loop/test_cross_run_sot_invariant.py` pins the
   schema parity invariants between the three cross-run SoTs that the

--- a/core/self_improving_loop/tchebycheff.py
+++ b/core/self_improving_loop/tchebycheff.py
@@ -1,0 +1,101 @@
+"""A.2 (2026-05-25) — Tchebycheff scalarization helper (PR-23).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C5 — linear scalarization (현재 fitness = w·r) 한계 회피.
+
+**Why Tchebycheff vs linear** (Das & Dennis 1997):
+
+- Linear scalarization (``f_total = sum(w_i * f_i)``) 의 fundamental
+  한계 — concave Pareto front 영역은 어떤 weight 조합으로도 도달 불가.
+- Tchebycheff (``f_total = max_i w_i * |f_i - z_i*|``) 은 concave 영역
+  포함 모든 Pareto-optimal 점에 도달 가능.
+
+**Formula** (higher-is-better convention 으로 변환):
+
+    minimize: max_i w_i * |f_i - z_i*|
+    equivalent (higher-is-better): minimize max_i w_i * (z_i* - f_i)
+                                   when z_i* is ideal (max of f_i)
+
+The scalar returned is **negative-magnitude** — higher is better
+(callers compare directly with linear fitness; max(scalar) = closest
+to ideal point z*).
+
+본 module = **pure helper**:
+
+- :func:`compute_tchebycheff` — (fitness_dim, weights, ideal_point) → scalar
+- :func:`compute_ideal_point(archive_entries)` — per-dim max as z*
+
+Caller (apply_group_proposals 의 pareto_mode 분기) wiring 은 후속 PR.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def compute_tchebycheff(
+    fitness_dim: dict[str, float],
+    weights: dict[str, float],
+    ideal_point: dict[str, float],
+) -> float:
+    """Tchebycheff scalarization of a multi-dim fitness vector.
+
+    Formula (higher-is-better)::
+
+        scalar = -max_d w_d * (ideal_point[d] - fitness_dim[d])
+
+    Negation flips so caller can take ``max(scalar)`` to pick the
+    closest-to-ideal candidate. Per-dim weights normalize fitness
+    direction — set ``w_d = 1`` for uniform Tchebycheff, or
+    ``w_d = 1/range_d`` for normalized.
+
+    Edge cases:
+
+    - dim missing from ``fitness_dim`` → contribution skipped
+    - dim missing from ``weights`` → defaults to 1.0
+    - dim missing from ``ideal_point`` → contribution skipped (no anchor)
+    - all dims skipped (empty intersection) → returns 0.0
+
+    Pure function — no I/O, no side effect.
+    """
+    contributions: list[float] = []
+    for dim, f in fitness_dim.items():
+        ideal = ideal_point.get(dim)
+        if ideal is None:
+            continue
+        w = float(weights.get(dim, 1.0))
+        # higher-is-better: ideal - f >= 0 when f <= ideal
+        contributions.append(w * (float(ideal) - float(f)))
+    if not contributions:
+        return 0.0
+    return -max(contributions)
+
+
+def compute_ideal_point(
+    fitness_vectors: Iterable[dict[str, float]],
+) -> dict[str, float]:
+    """Per-dim max across an iterable of fitness vectors = ideal point z*.
+
+    Empty input → ``{}``. Each dim's ideal is the maximum observed
+    value across all vectors (higher-is-better). Dims that appear only
+    in some vectors are still included with their observed max.
+
+    Useful for archive-driven Tchebycheff — caller computes z* from
+    current Pareto archive before scalarizing candidates against it.
+    """
+    ideal: dict[str, float] = {}
+    for vec in fitness_vectors:
+        for dim, value in vec.items():
+            current = ideal.get(dim)
+            if current is None or float(value) > current:
+                ideal[dim] = float(value)
+    return ideal
+
+
+__all__ = [
+    "compute_ideal_point",
+    "compute_tchebycheff",
+]

--- a/tests/core/self_improving_loop/test_tchebycheff.py
+++ b/tests/core/self_improving_loop/test_tchebycheff.py
@@ -1,0 +1,188 @@
+"""A.2 (2026-05-25) — Tchebycheff scalarization invariants (PR-23).
+
+Scope:
+- compute_tchebycheff: empty inputs / single dim / multi-dim / weights /
+  missing dim graceful / ideal point match (scalar = 0) / negation invariant
+- compute_ideal_point: empty / single / multi-vector / dim union
+- pareto front advantage over linear (concave region reachable)
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.tchebycheff import (
+    compute_ideal_point,
+    compute_tchebycheff,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_tchebycheff — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_empty_inputs_returns_zero() -> None:
+    assert compute_tchebycheff({}, {}, {}) == 0.0
+
+
+def test_tchebycheff_single_dim_at_ideal_returns_zero() -> None:
+    """fitness == ideal → scalar = 0 (best possible)."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 1.0},
+        weights={"safety": 1.0},
+        ideal_point={"safety": 1.0},
+    )
+    assert result == 0.0
+
+
+def test_tchebycheff_single_dim_below_ideal_returns_negative() -> None:
+    """fitness < ideal → scalar negative (further from ideal)."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.7},
+        weights={"safety": 1.0},
+        ideal_point={"safety": 1.0},
+    )
+    assert result == pytest.approx(-0.3)
+
+
+def test_tchebycheff_max_d_picks_worst_dim() -> None:
+    """multi-dim — scalar 는 worst dim 의 (weighted) gap 의 음수."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.9, "b": 0.5},
+        weights={"a": 1.0, "b": 1.0},
+        ideal_point={"a": 1.0, "b": 1.0},
+    )
+    # gaps: a=0.1, b=0.5; max=0.5 → scalar = -0.5
+    assert result == pytest.approx(-0.5)
+
+
+def test_tchebycheff_weights_scale_gaps() -> None:
+    """가중치가 dim gap 을 scale — heavier weight = higher penalty."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.9, "b": 0.5},
+        weights={"a": 10.0, "b": 1.0},  # a heavily weighted
+        ideal_point={"a": 1.0, "b": 1.0},
+    )
+    # gaps: a=10*0.1=1.0, b=1*0.5=0.5; max=1.0 → scalar = -1.0
+    assert result == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_tchebycheff — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_missing_ideal_skips_dim() -> None:
+    """ideal 에 없는 dim → contribution skip."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.7, "helpfulness": 0.3},
+        weights={"safety": 1.0, "helpfulness": 1.0},
+        ideal_point={"safety": 1.0},  # no helpfulness
+    )
+    # only safety counted: gap 0.3 → scalar -0.3
+    assert result == pytest.approx(-0.3)
+
+
+def test_tchebycheff_missing_weight_defaults_to_one() -> None:
+    """weight 미지정 dim → 1.0 default."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.5},
+        weights={},  # no weights
+        ideal_point={"safety": 1.0},
+    )
+    assert result == pytest.approx(-0.5)
+
+
+def test_tchebycheff_no_overlap_returns_zero() -> None:
+    """fitness 와 ideal 의 dim 교집합이 empty → 0.0 (no signal)."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.5},
+        weights={"a": 1.0},
+        ideal_point={"b": 1.0},  # different dim
+    )
+    assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_ideal_point — per-dim max
+# ---------------------------------------------------------------------------
+
+
+def test_ideal_point_empty_input() -> None:
+    assert compute_ideal_point([]) == {}
+
+
+def test_ideal_point_single_vector() -> None:
+    result = compute_ideal_point([{"a": 0.5, "b": 0.3}])
+    assert result == {"a": 0.5, "b": 0.3}
+
+
+def test_ideal_point_multi_vector_max_per_dim() -> None:
+    """Per-dim max across all vectors."""
+    vectors = [
+        {"a": 0.5, "b": 0.3},
+        {"a": 0.8, "b": 0.2},
+        {"a": 0.6, "b": 0.7},
+    ]
+    result = compute_ideal_point(vectors)
+    assert result == {"a": 0.8, "b": 0.7}
+
+
+def test_ideal_point_dim_union() -> None:
+    """Vectors with different dim sets → union with each dim's observed max."""
+    vectors = [
+        {"a": 0.5},
+        {"b": 0.3},
+        {"a": 0.7, "c": 0.1},
+    ]
+    result = compute_ideal_point(vectors)
+    assert result == {"a": 0.7, "b": 0.3, "c": 0.1}
+
+
+# ---------------------------------------------------------------------------
+# 4. Pareto-front advantage — concave region reachability
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_reaches_concave_region() -> None:
+    """linear scalarization 으로는 unreachable 한 concave point 가
+    Tchebycheff 로는 unique max 가 됨.
+
+    Setup: 3 Pareto points forming a *concave* front segment.
+    - A = (1.0, 0.0)
+    - B = (0.5, 0.5)  ← concave (linear scalarization 으로 도달 불가)
+    - C = (0.0, 1.0)
+    With uniform weights, linear sum 은 모두 같음 (A=B=C=1.0). Tchebycheff
+    는 B 를 unique max (closest to ideal (1.0, 1.0)).
+    """
+    ideal = {"x": 1.0, "y": 1.0}
+    weights = {"x": 1.0, "y": 1.0}
+    score_a = compute_tchebycheff({"x": 1.0, "y": 0.0}, weights, ideal)
+    score_b = compute_tchebycheff({"x": 0.5, "y": 0.5}, weights, ideal)
+    score_c = compute_tchebycheff({"x": 0.0, "y": 1.0}, weights, ideal)
+    # A: max(0, 1) = 1.0 → -1.0
+    # B: max(0.5, 0.5) = 0.5 → -0.5
+    # C: max(1, 0) = 1.0 → -1.0
+    assert score_b > score_a  # B beats A
+    assert score_b > score_c  # B beats C
+    assert score_a == pytest.approx(score_c)  # extreme points tie
+
+
+# ---------------------------------------------------------------------------
+# 5. Integration — pipeline with archive
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_with_archive_entries() -> None:
+    """compute_ideal_point + compute_tchebycheff — archive 기반 selection."""
+    archive_fitness = [
+        {"safety": 0.9, "helpfulness": 0.5},
+        {"safety": 0.6, "helpfulness": 0.8},
+    ]
+    ideal = compute_ideal_point(archive_fitness)
+    assert ideal == {"safety": 0.9, "helpfulness": 0.8}
+
+    # Candidate: balanced compromise
+    candidate = {"safety": 0.75, "helpfulness": 0.7}
+    score = compute_tchebycheff(candidate, {"safety": 1.0, "helpfulness": 1.0}, ideal)
+    # gaps: 0.15, 0.10; max=0.15 → -0.15
+    assert score == pytest.approx(-0.15)


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/tchebycheff.py` — compute_tchebycheff + compute_ideal_point pure helpers.
- Linear scalarization 의 concave Pareto-front unreachability 회피 (Das & Dennis 1997).
- caller wiring은 후속 PR.

## Why
Plan p2 §C5. PR-15 (#1665) 의 archive writer 가 dominated entry prune. 그러나 scalarization 이 linear 면 concave 영역 도달 불가. Tchebycheff 가 그 한계 해소.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/tchebycheff.py` | 신규 — compute_tchebycheff + compute_ideal_point |
| `tests/core/self_improving_loop/test_tchebycheff.py` | 신규 — 14 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 14 new + 310 SIL aggregate pass

## Reference
- Plan p2 §C5; Das & Dennis 1997