### PR TITLE
feat(self-improving-loop): A.3 MAP-Elites niche grid helper (PR-24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-24 A.3 MAP-Elites niche grid helper** —
+  `core/self_improving_loop/map_elites.py` adds Quality-Diversity (Mouret & Clune 2015) niche-archive helpers: `MapElitesGrid` (sparse 2D dict — each cell holds the highest-fitness payload, ties rejected), `compute_cell_index(value, bounds, resolution)` for behavior discretization (clamps out-of-range, value at upper bound maps to last cell), `compute_grid_coverage(grid)` (occupied/total ratio), and `insert_many` batch. Complements PR-15 Pareto archive — Pareto prunes by global dominance, MAP-Elites preserves per-niche elites so behavior diversity stays in the archive. Pure helper, caller wiring (archive niche-aware sampling) deferred. Frontier: AlphaEvolve (DeepMind 2025-05).
 - **PR-23 A.2 Tchebycheff scalarization helper** —
   `core/self_improving_loop/tchebycheff.py` adds `compute_tchebycheff(fitness_dim, weights, ideal_point)` and `compute_ideal_point(vectors)` pure helpers. Linear scalarization (`f_total = sum(w*r)`) cannot reach concave Pareto-front regions (Das & Dennis 1997); Tchebycheff (`-max_d w_d * (ideal[d] - fitness[d])`) closes that gap by penalizing the worst dim relative to the ideal point. Pareto-front advantage invariant test pins the canonical 3-point concave example (extreme points tie under linear, B beats both under Tchebycheff). Caller wiring into `apply_group_proposals` 의 pareto_mode 분기 is deferred — PR-15 의 lineage writer 와 짝지을 다음 PR 가 필요.
 - **PR-22 B.4 F1 cross-run SoT 3중첩 invariants** —

--- a/core/self_improving_loop/map_elites.py
+++ b/core/self_improving_loop/map_elites.py
@@ -1,0 +1,154 @@
+"""A.3 (2026-05-25) — MAP-Elites niche grid helper (PR-24).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C6 — Quality-Diversity 패턴 (Mouret & Clune 2015, AlphaEvolve 2025-05).
+
+**Concept**: behavior-characterization dim 2 개 를 grid 의 (x, y) 로 사용,
+각 cell 에 fitness 가장 높은 한 entry 만 보존. 결과 — 다양한 behavior
+niche 의 elite 들이 archive 에 보존되어 exploration vs exploitation 균형.
+
+vs Pareto archive (PR-15):
+- Pareto: dominance 기준 prune (전체 ordering)
+- MAP-Elites: behavior niche 기준 (local ordering per cell)
+- 둘은 보완 — 함께 사용 가능 (Pareto + niche 둘 다 anchor)
+
+본 module = **pure selection-only helper**:
+
+- :func:`compute_cell_index(value, bounds, resolution)` — float → grid cell idx
+- :class:`MapElitesGrid` — sparse dict-based 2D grid + insert/sample
+- :func:`compute_grid_coverage(grid)` — occupied cells / total cells ratio
+
+caller (archive 의 niche-aware sampling) wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def compute_cell_index(
+    value: float,
+    bounds: tuple[float, float],
+    resolution: int,
+) -> int:
+    """Discretize ``value`` into a grid cell index ``[0, resolution)``.
+
+    ``bounds = (lo, hi)``. value clamp to [lo, hi]. value at ``hi`` maps to
+    ``resolution - 1``. ``resolution`` must be >= 1.
+
+    Raises ValueError on bad inputs (resolution <= 0, bounds[0] >= bounds[1]).
+    """
+    if resolution < 1:
+        raise ValueError(f"resolution must be >= 1, got {resolution}")
+    lo, hi = bounds
+    if lo >= hi:
+        raise ValueError(f"bounds must be (lo < hi), got ({lo}, {hi})")
+    clamped = max(lo, min(hi, value))
+    # Map [lo, hi] to [0, resolution) linearly. value=hi must hit
+    # resolution-1 (not resolution); use floor with epsilon-clip.
+    frac = (clamped - lo) / (hi - lo)
+    idx = math.floor(frac * resolution)
+    return min(idx, resolution - 1)
+
+
+@dataclass(frozen=True)
+class _CellKey:
+    """2D cell coordinate — frozen so it's hashable for dict key."""
+
+    x: int
+    y: int
+
+
+@dataclass
+class MapElitesGrid:
+    """Sparse 2D niche grid — only occupied cells stored.
+
+    Each cell maps to a single ``(fitness, payload)`` tuple. Insert
+    replaces the cell's entry only when the new fitness is strictly
+    higher (winner-takes-all per cell).
+
+    ``payload`` is opaque to the grid — caller supplies anything
+    (e.g. mutation_id, full ArchiveEntry, ...).
+    """
+
+    behavior_bounds: tuple[tuple[float, float], tuple[float, float]]
+    """((x_lo, x_hi), (y_lo, y_hi)) — bounds for the 2 behavior dims."""
+
+    resolution: tuple[int, int] = (10, 10)
+    """(x_resolution, y_resolution) — cells per dim. default 10×10 = 100."""
+
+    cells: dict[_CellKey, tuple[float, object]] = field(default_factory=dict)
+    """{cell_key: (fitness, payload)} — only occupied cells."""
+
+    def _cell(self, behavior: tuple[float, float]) -> _CellKey:
+        bx, by = behavior
+        (x_lo, x_hi), (y_lo, y_hi) = self.behavior_bounds
+        rx, ry = self.resolution
+        x_idx = compute_cell_index(bx, (x_lo, x_hi), rx)
+        y_idx = compute_cell_index(by, (y_lo, y_hi), ry)
+        return _CellKey(x_idx, y_idx)
+
+    def insert(
+        self,
+        behavior: tuple[float, float],
+        fitness: float,
+        payload: object,
+    ) -> bool:
+        """Insert ``payload`` at the cell for ``behavior`` if ``fitness``
+        strictly exceeds the existing occupant. Returns True if inserted."""
+        cell = self._cell(behavior)
+        existing = self.cells.get(cell)
+        if existing is not None and existing[0] >= fitness:
+            return False
+        self.cells[cell] = (float(fitness), payload)
+        return True
+
+    def get(self, behavior: tuple[float, float]) -> tuple[float, object] | None:
+        """Return ``(fitness, payload)`` at the cell for ``behavior``, or None."""
+        return self.cells.get(self._cell(behavior))
+
+    def all_payloads(self) -> list[object]:
+        """Return every occupied cell's payload (order unspecified)."""
+        return [payload for _fitness, payload in self.cells.values()]
+
+    def __len__(self) -> int:
+        return len(self.cells)
+
+
+def compute_grid_coverage(grid: MapElitesGrid) -> float:
+    """Ratio of occupied cells to total cells in the grid.
+
+    Result in ``[0.0, 1.0]``. 0.0 = empty, 1.0 = every cell occupied
+    (saturated niche space).
+    """
+    rx, ry = grid.resolution
+    total = rx * ry
+    if total <= 0:
+        return 0.0
+    return len(grid) / total
+
+
+def insert_many(
+    grid: MapElitesGrid,
+    entries: Iterable[tuple[tuple[float, float], float, object]],
+) -> int:
+    """Batch-insert ``(behavior, fitness, payload)`` triples. Returns the
+    count of successful inserts (entries that won their cell)."""
+    inserted = 0
+    for behavior, fitness, payload in entries:
+        if grid.insert(behavior, fitness, payload):
+            inserted += 1
+    return inserted
+
+
+__all__ = [
+    "MapElitesGrid",
+    "compute_cell_index",
+    "compute_grid_coverage",
+    "insert_many",
+]

--- a/tests/core/self_improving_loop/test_map_elites.py
+++ b/tests/core/self_improving_loop/test_map_elites.py
@@ -1,0 +1,195 @@
+"""A.3 (2026-05-25) — MAP-Elites niche grid invariants (PR-24)."""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.map_elites import (
+    MapElitesGrid,
+    compute_cell_index,
+    compute_grid_coverage,
+    insert_many,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_cell_index — discretization
+# ---------------------------------------------------------------------------
+
+
+def test_cell_index_lo_bound_maps_to_zero() -> None:
+    assert compute_cell_index(0.0, (0.0, 1.0), 10) == 0
+
+
+def test_cell_index_hi_bound_maps_to_max() -> None:
+    """value at upper bound → resolution - 1 (last cell)."""
+    assert compute_cell_index(1.0, (0.0, 1.0), 10) == 9
+
+
+def test_cell_index_midpoint() -> None:
+    assert compute_cell_index(0.5, (0.0, 1.0), 10) == 5
+
+
+def test_cell_index_clamp_below_lo() -> None:
+    assert compute_cell_index(-1.0, (0.0, 1.0), 10) == 0
+
+
+def test_cell_index_clamp_above_hi() -> None:
+    assert compute_cell_index(99.0, (0.0, 1.0), 10) == 9
+
+
+def test_cell_index_resolution_1_returns_zero() -> None:
+    """resolution=1 → 모든 value 가 cell 0."""
+    assert compute_cell_index(0.3, (0.0, 1.0), 1) == 0
+    assert compute_cell_index(0.9, (0.0, 1.0), 1) == 0
+
+
+def test_cell_index_invalid_resolution_raises() -> None:
+    with pytest.raises(ValueError, match=r"resolution must be >= 1"):
+        compute_cell_index(0.5, (0.0, 1.0), 0)
+
+
+def test_cell_index_invalid_bounds_raises() -> None:
+    with pytest.raises(ValueError, match=r"bounds must be"):
+        compute_cell_index(0.5, (1.0, 1.0), 10)
+    with pytest.raises(ValueError, match=r"bounds must be"):
+        compute_cell_index(0.5, (2.0, 1.0), 10)
+
+
+# ---------------------------------------------------------------------------
+# 2. MapElitesGrid — insert / replace / get
+# ---------------------------------------------------------------------------
+
+
+def _grid_2d() -> MapElitesGrid:
+    return MapElitesGrid(
+        behavior_bounds=((0.0, 1.0), (0.0, 1.0)),
+        resolution=(10, 10),
+    )
+
+
+def test_grid_starts_empty() -> None:
+    grid = _grid_2d()
+    assert len(grid) == 0
+
+
+def test_grid_insert_into_empty_cell() -> None:
+    grid = _grid_2d()
+    assert grid.insert((0.5, 0.5), fitness=0.7, payload="m1") is True
+    assert len(grid) == 1
+
+
+def test_grid_insert_higher_replaces() -> None:
+    """Same cell, higher fitness → replace."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert grid.insert((0.55, 0.55), 0.9, "m2") is True  # same cell
+    cell_entry = grid.get((0.5, 0.5))
+    assert cell_entry == (0.9, "m2")
+
+
+def test_grid_insert_lower_rejected() -> None:
+    """Same cell, lower fitness → reject."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.9, "m1")
+    assert grid.insert((0.55, 0.55), 0.3, "m2") is False
+    cell_entry = grid.get((0.5, 0.5))
+    assert cell_entry == (0.9, "m1")
+
+
+def test_grid_insert_equal_fitness_rejected() -> None:
+    """Tie → existing wins (strict >)."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert grid.insert((0.55, 0.55), 0.5, "m2") is False
+
+
+def test_grid_different_cells_coexist() -> None:
+    """Different cells = independent occupancy."""
+    grid = _grid_2d()
+    grid.insert((0.1, 0.1), 0.3, "m1")
+    grid.insert((0.9, 0.9), 0.3, "m2")
+    assert len(grid) == 2
+
+
+def test_grid_get_empty_cell_returns_none() -> None:
+    grid = _grid_2d()
+    assert grid.get((0.5, 0.5)) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. all_payloads / coverage / insert_many
+# ---------------------------------------------------------------------------
+
+
+def test_grid_all_payloads_returns_each() -> None:
+    grid = _grid_2d()
+    grid.insert((0.1, 0.1), 0.5, "m1")
+    grid.insert((0.9, 0.9), 0.6, "m2")
+    payloads = grid.all_payloads()
+    assert set(payloads) == {"m1", "m2"}
+
+
+def test_grid_coverage_empty_is_zero() -> None:
+    grid = _grid_2d()
+    assert compute_grid_coverage(grid) == 0.0
+
+
+def test_grid_coverage_full_is_one() -> None:
+    """All 10×10=100 cells occupied → coverage 1.0."""
+    grid = MapElitesGrid(
+        behavior_bounds=((0.0, 1.0), (0.0, 1.0)),
+        resolution=(2, 2),  # 4 cells (manageable for test)
+    )
+    grid.insert((0.0, 0.0), 0.5, "a")
+    grid.insert((0.0, 1.0), 0.5, "b")
+    grid.insert((1.0, 0.0), 0.5, "c")
+    grid.insert((1.0, 1.0), 0.5, "d")
+    assert compute_grid_coverage(grid) == pytest.approx(1.0)
+
+
+def test_grid_coverage_partial() -> None:
+    """1 cell out of 100 → 0.01."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert compute_grid_coverage(grid) == pytest.approx(0.01)
+
+
+def test_insert_many_batches() -> None:
+    grid = _grid_2d()
+    entries = [
+        ((0.1, 0.1), 0.5, "a"),
+        ((0.5, 0.5), 0.7, "b"),
+        ((0.9, 0.9), 0.3, "c"),
+    ]
+    count = insert_many(grid, entries)
+    assert count == 3
+    assert len(grid) == 3
+
+
+def test_insert_many_respects_winner_takes_all() -> None:
+    """Two entries in same cell — only the higher-fitness one inserts."""
+    grid = _grid_2d()
+    entries = [
+        ((0.5, 0.5), 0.3, "loser"),
+        ((0.55, 0.55), 0.9, "winner"),
+    ]
+    count = insert_many(grid, entries)
+    assert count == 2  # both attempt, both succeed (2nd replaces 1st)
+    assert len(grid) == 1
+    cell = grid.get((0.5, 0.5))
+    assert cell == (0.9, "winner")
+
+
+# ---------------------------------------------------------------------------
+# 4. Use case — niche diversity across attempts
+# ---------------------------------------------------------------------------
+
+
+def test_niche_diversity_preserved() -> None:
+    """다양한 behavior 의 mutations 가 same fitness 라도 niche 별로 보존."""
+    grid = _grid_2d()
+    # 3 mutations with same fitness but different behaviors
+    grid.insert((0.1, 0.1), 0.6, "safety-focused")
+    grid.insert((0.5, 0.9), 0.6, "helpfulness-focused")
+    grid.insert((0.9, 0.5), 0.6, "tool-focused")
+    assert len(grid) == 3
+    # All preserved — QD invariant: niche diversity not collapsed


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/map_elites.py` — Quality-Diversity niche-archive helpers (sparse 2D grid + winner-takes-all per cell + coverage metric).
- Pure helpers; caller wiring (archive niche-aware sampling) 후속.

## Why
Plan p2 §C6. PR-15 Pareto archive 가 dominance prune 만 → behavior diversity 손실. MAP-Elites 가 per-niche elite 보존 → diverse phenotype 보존.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/map_elites.py` | 신규 — MapElitesGrid + helpers |
| `tests/core/self_improving_loop/test_map_elites.py` | 신규 — 22 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 22 new + SIL aggregate pass

## Reference
- Plan p2 §C6; Mouret & Clune 2015 (Illuminating search spaces)