### PR TITLE
feat(self-improving-loop): A.4 GEPA Pareto sampler helper (PR-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-25 A.4 GEPA Pareto sampler helper** —
+  `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —
   `core/self_improving_loop/map_elites.py` adds Quality-Diversity (Mouret & Clune 2015) niche-archive helpers: `MapElitesGrid` (sparse 2D dict — each cell holds the highest-fitness payload, ties rejected), `compute_cell_index(value, bounds, resolution)` for behavior discretization (clamps out-of-range, value at upper bound maps to last cell), `compute_grid_coverage(grid)` (occupied/total ratio), and `insert_many` batch. Complements PR-15 Pareto archive — Pareto prunes by global dominance, MAP-Elites preserves per-niche elites so behavior diversity stays in the archive. Pure helper, caller wiring (archive niche-aware sampling) deferred. Frontier: AlphaEvolve (DeepMind 2025-05).
 - **PR-23 A.2 Tchebycheff scalarization helper** —

--- a/core/self_improving_loop/gepa_sampler.py
+++ b/core/self_improving_loop/gepa_sampler.py
@@ -1,0 +1,136 @@
+"""A.4 (2026-05-25) — GEPA Pareto sampler (PR-25).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C8. PR-15 ``pareto_archive.PareteArchive.sample`` 의 uniform-random
+sampling 을 **density-aware** sparsity-weighted 로 개선.
+
+**Why density-aware**:
+
+- Uniform sampling 은 archive 의 dense region (많은 entry 가 비슷한
+  fitness vector 공유) 에 편향. Pareto front 의 sparse region (rare
+  trade-off) 은 over-explored 부족.
+- Sparsity weight ∝ inverse local density — sparse niche 의 entry 가
+  sample 될 확률 ↑. Quality-Diversity 의 핵심 (Mouret & Clune 2015).
+
+**Frontier reference**: GEPA (Genetic Evolutionary Pareto Archive,
+arXiv 2406.xxxxx) — Pareto sampler 의 reflection-text 친화 (sampled
+entry 의 mutation rationale 을 next mutator 의 priors 로 forward).
+
+본 module = **pure helper**:
+
+- :func:`compute_sparsity_weights(fitness_vectors, k)` — k-NN 평균거리
+  기반 sparsity score. sparse = high weight.
+- :func:`sample_sparse(entries, k_neighbors, n, rng)` — sparsity 가중
+  random sample.
+
+caller (apply_group_proposals 의 archive sample 분기) wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+
+def _euclidean_distance(a: dict[str, float], b: dict[str, float]) -> float:
+    """Per-dim squared diff sum의 sqrt. Missing dim → treated as 0
+    on the missing side (conservative — caller can normalize beforehand)."""
+    dims = set(a.keys()) | set(b.keys())
+    if not dims:
+        return 0.0
+    squared = 0.0
+    for d in dims:
+        av = float(a.get(d, 0.0))
+        bv = float(b.get(d, 0.0))
+        diff = av - bv
+        squared += diff * diff
+    return math.sqrt(squared)
+
+
+def compute_sparsity_weights(
+    fitness_vectors: list[dict[str, float]],
+    k: int = 3,
+) -> list[float]:
+    """Return per-entry sparsity weight (higher = more sparse / under-
+    represented in fitness space).
+
+    Algorithm — for each entry, compute the mean Euclidean distance to
+    its ``k`` nearest neighbors. Larger mean distance = sparser region =
+    higher weight. Returns raw distances (not normalized); caller may
+    normalize to a probability distribution.
+
+    Edge cases:
+    - ``len(fitness_vectors) <= 1`` → all weights 1.0 (no neighbors)
+    - ``k`` clamped to ``len(fitness_vectors) - 1``
+    - empty input → empty list
+    """
+    n = len(fitness_vectors)
+    if n == 0:
+        return []
+    if n == 1:
+        return [1.0]
+    effective_k = min(k, n - 1)
+    weights: list[float] = []
+    for i, vec_i in enumerate(fitness_vectors):
+        distances: list[float] = []
+        for j, vec_j in enumerate(fitness_vectors):
+            if i == j:
+                continue
+            distances.append(_euclidean_distance(vec_i, vec_j))
+        distances.sort()
+        nearest = distances[:effective_k]
+        mean_dist = sum(nearest) / len(nearest) if nearest else 0.0
+        # Sparsity weight = mean k-NN distance; sparse regions yield larger
+        # values. We add small epsilon so all-identical vectors don't
+        # collapse to zero probability.
+        weights.append(mean_dist + 1e-9)
+    return weights
+
+
+def sample_sparse[T](
+    entries: list[T],
+    fitness_vectors: list[dict[str, float]],
+    n: int,
+    *,
+    k_neighbors: int = 3,
+    rng: random.Random | None = None,
+) -> list[T]:
+    """Sample ``n`` entries with probability ∝ sparsity weight.
+
+    ``entries`` and ``fitness_vectors`` must be parallel (same length,
+    same indexing). Sampling is **without replacement** — at most
+    ``len(entries)`` returned. Empty input → empty list.
+
+    Returns the sampled entries in random order.
+    """
+    if len(entries) != len(fitness_vectors):
+        raise ValueError(
+            f"entries / fitness_vectors length mismatch: {len(entries)} vs {len(fitness_vectors)}"
+        )
+    if not entries or n <= 0:
+        return []
+    rng = rng or random.Random()
+    weights = compute_sparsity_weights(fitness_vectors, k=k_neighbors)
+    # rng.choices with replacement; then dedupe — caller wants without-
+    # replacement. For without-replacement, repeated weighted sampling
+    # without replacement requires removing the sampled index.
+    pool: list[tuple[T, float]] = list(zip(entries, weights, strict=True))
+    sampled: list[T] = []
+    target = min(n, len(pool))
+    while pool and len(sampled) < target:
+        items, ws = zip(*pool, strict=True)
+        total = sum(ws)
+        if total <= 0:
+            # All-zero weights — fall back to uniform
+            choice_idx = rng.randrange(len(items))
+        else:
+            choice_idx = rng.choices(range(len(items)), weights=ws, k=1)[0]
+        sampled.append(items[choice_idx])
+        pool.pop(choice_idx)
+    return sampled
+
+
+__all__ = [
+    "compute_sparsity_weights",
+    "sample_sparse",
+]

--- a/tests/core/self_improving_loop/test_gepa_sampler.py
+++ b/tests/core/self_improving_loop/test_gepa_sampler.py
@@ -1,0 +1,155 @@
+"""A.4 (2026-05-25) — GEPA Pareto sampler invariants (PR-25)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from core.self_improving_loop.gepa_sampler import (
+    compute_sparsity_weights,
+    sample_sparse,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_sparsity_weights
+# ---------------------------------------------------------------------------
+
+
+def test_sparsity_empty_input() -> None:
+    assert compute_sparsity_weights([]) == []
+
+
+def test_sparsity_single_entry_weight_is_one() -> None:
+    """1 entry → no neighbors → uniform fallback 1.0."""
+    weights = compute_sparsity_weights([{"a": 0.5}])
+    assert weights == [1.0]
+
+
+def test_sparsity_two_entries_equal_weight() -> None:
+    """2 entries — each has 1 neighbor (the other). Both same distance."""
+    weights = compute_sparsity_weights([{"a": 0.1, "b": 0.1}, {"a": 0.9, "b": 0.9}])
+    assert len(weights) == 2
+    # Same mutual distance → same weight
+    assert weights[0] == pytest.approx(weights[1])
+
+
+def test_sparsity_isolated_entry_higher_weight() -> None:
+    """Cluster of 3 close points + 1 isolated → isolated has higher weight."""
+    vectors = [
+        {"a": 0.1, "b": 0.1},  # cluster
+        {"a": 0.12, "b": 0.11},  # cluster
+        {"a": 0.11, "b": 0.13},  # cluster
+        {"a": 0.9, "b": 0.9},  # isolated
+    ]
+    weights = compute_sparsity_weights(vectors, k=2)
+    # The isolated entry (idx 3) should be the heaviest
+    assert weights[3] > weights[0]
+    assert weights[3] > weights[1]
+    assert weights[3] > weights[2]
+
+
+def test_sparsity_k_clamped_to_n_minus_1() -> None:
+    """k > n-1 → 자동 clamp, no IndexError."""
+    weights = compute_sparsity_weights([{"a": 0.1}, {"a": 0.5}], k=10)
+    assert len(weights) == 2
+
+
+def test_sparsity_all_identical_vectors_nonzero_weights() -> None:
+    """All-identical fitness vectors → 0 distance + epsilon prevents
+    zero-probability collapse."""
+    weights = compute_sparsity_weights([{"a": 0.5}, {"a": 0.5}, {"a": 0.5}])
+    assert all(w > 0 for w in weights), "epsilon prevents all-zero collapse"
+
+
+# ---------------------------------------------------------------------------
+# 2. sample_sparse — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_empty_returns_empty() -> None:
+    assert sample_sparse([], [], 3) == []
+
+
+def test_sample_sparse_n_zero_returns_empty() -> None:
+    entries = ["a", "b"]
+    vectors = [{"x": 0.1}, {"x": 0.5}]
+    assert sample_sparse(entries, vectors, 0) == []
+
+
+def test_sample_sparse_n_larger_than_pool() -> None:
+    """n > len(entries) → capped at len(entries)."""
+    entries = ["a", "b"]
+    vectors = [{"x": 0.1}, {"x": 0.5}]
+    result = sample_sparse(entries, vectors, n=10, rng=random.Random(42))
+    assert len(result) == 2
+
+
+def test_sample_sparse_without_replacement() -> None:
+    """Sampling without replacement — no duplicates."""
+    entries = list("abcdef")
+    vectors = [{"x": i / 6} for i in range(6)]
+    rng = random.Random(42)
+    result = sample_sparse(entries, vectors, n=4, rng=rng)
+    assert len(result) == 4
+    assert len(set(result)) == 4  # all distinct
+
+
+def test_sample_sparse_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match=r"length mismatch"):
+        sample_sparse(["a", "b"], [{"x": 0.1}], 2)
+
+
+# ---------------------------------------------------------------------------
+# 3. sample_sparse — density-aware behavior
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_isolated_entry_preferred() -> None:
+    """3 close cluster + 1 isolated. Sample n=1 → isolated more likely.
+
+    Run multiple trials and confirm isolated wins majority. Not a strict
+    invariant per single trial, but probabilistic.
+    """
+    entries = ["c1", "c2", "c3", "isolated"]
+    vectors = [
+        {"a": 0.1, "b": 0.1},
+        {"a": 0.12, "b": 0.11},
+        {"a": 0.11, "b": 0.13},
+        {"a": 0.9, "b": 0.9},
+    ]
+    isolated_count = 0
+    trials = 100
+    for trial in range(trials):
+        rng = random.Random(trial)
+        result = sample_sparse(entries, vectors, n=1, rng=rng, k_neighbors=2)
+        if result == ["isolated"]:
+            isolated_count += 1
+    # Isolated should win clearly more often than uniform (25%) — expect
+    # > 50% with the sparsity weighting.
+    assert isolated_count > 50, (
+        f"isolated picked {isolated_count}/{trials} times — sparsity weight not biasing as expected"
+    )
+
+
+def test_sample_sparse_deterministic_with_seeded_rng() -> None:
+    """Same seed → same sampled order."""
+    entries = list("abcdef")
+    vectors = [{"x": i / 6} for i in range(6)]
+    result_a = sample_sparse(entries, vectors, n=3, rng=random.Random(42))
+    result_b = sample_sparse(entries, vectors, n=3, rng=random.Random(42))
+    assert result_a == result_b
+
+
+# ---------------------------------------------------------------------------
+# 4. All-identical vectors → uniform fallback (degenerate case)
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_all_identical_vectors_works() -> None:
+    """Degenerate case — all fitness identical. Sampling still completes."""
+    entries = ["a", "b", "c"]
+    vectors = [{"x": 0.5}] * 3
+    rng = random.Random(0)
+    result = sample_sparse(entries, vectors, n=2, rng=rng)
+    assert len(result) == 2
+    assert set(result).issubset({"a", "b", "c"})


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/gepa_sampler.py` — density-aware Pareto sampling.
- PR-15 의 uniform sample 한계 (dense region 편향) 회피, sparse niche 가중.

## Why
Plan p2 §C8. uniform sampling 은 over-explored region 에 편향. sparsity-weighted 가 rare trade-off 의 exploration ↑.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/gepa_sampler.py` | 신규 — compute_sparsity_weights + sample_sparse |
| `tests/core/self_improving_loop/test_gepa_sampler.py` | 신규 — 14 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 14 new pass

## Reference
- Plan p2 §C8; GEPA pattern; Mouret & Clune 2015 (QD)