### PR TITLE
feat(seed-gen): per-phase checkpoint + 600s wall-clock (PR-CHECKPOINT-RESUME-TIMEBUDGET)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,20 +48,23 @@ functional change.
 ## [Unreleased]
 
 ### Added
-- **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + 600s
-  wall-clock cap for sub-agents.** `plugins/seed_generation/checkpointer.py`
+- **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + lifted
+  sub-agent wall-clock defaults.** `plugins/seed_generation/checkpointer.py`
   writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-
   generation phase (atomic via `os.replace` of a tmp file); the orchestrator
   appends to `state.completed_phases` on success. New
   `plugins/seed_generation/resume.py` + `geode audit-seeds resume <run_id>`
   CLI hydrate `PipelineState` from the latest checkpoint and continue from
-  the first phase without an on-disk record. `core/agent/sub_agent.py`
-  `SubAgentManager.timeout_s` default lifts 120s → 600s with new
-  `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`);
+  the first phase without an on-disk record. Wall-clock budgets:
+  `core/agent/sub_agent.py` `SubAgentManager.timeout_s` default 120s → 600s
+  with new `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`);
   `core/agent/worker.py` `WorkerRequest.timeout_s` default mirrors the
   bump; `core/agent/plan.py` `_DECOMPOSE_CALL_TIMEOUT_S` 60s → 180s so
   multi-tool plan.decompose calls under load (smoke-16 evolver
   `asyncio.CancelledError` at 122s wall-time) don't trip the inner cap.
+  The seed-generation registry keeps its explicit `timeout_s=1800.0`
+  override in `plugins/seed_generation/_registry_builder.py` — the new
+  600s is the default for callers that don't override.
   Convergence basis: paperclip session JSONL resume + LangGraph SqliteSaver
   thread/checkpoint keying + openclaw per-agent wall-clock + hermes
   IterationBudget. Plan SoT: `docs/plans/2026-05-25-structured-output-3-axis-fix.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + 600s
+  wall-clock cap for sub-agents.** `plugins/seed_generation/checkpointer.py`
+  writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-
+  generation phase (atomic via `os.replace` of a tmp file); the orchestrator
+  appends to `state.completed_phases` on success. New
+  `plugins/seed_generation/resume.py` + `geode audit-seeds resume <run_id>`
+  CLI hydrate `PipelineState` from the latest checkpoint and continue from
+  the first phase without an on-disk record. `core/agent/sub_agent.py`
+  `SubAgentManager.timeout_s` default lifts 120s → 600s with new
+  `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`);
+  `core/agent/worker.py` `WorkerRequest.timeout_s` default mirrors the
+  bump; `core/agent/plan.py` `_DECOMPOSE_CALL_TIMEOUT_S` 60s → 180s so
+  multi-tool plan.decompose calls under load (smoke-16 evolver
+  `asyncio.CancelledError` at 122s wall-time) don't trip the inner cap.
+  Convergence basis: paperclip session JSONL resume + LangGraph SqliteSaver
+  thread/checkpoint keying + openclaw per-agent wall-clock + hermes
+  IterationBudget. Plan SoT: `docs/plans/2026-05-25-structured-output-3-axis-fix.md`
+  §5 + §6.
 - **PR-27 C.7 unified MutatorContextView** —
   `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
 ### Added

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -682,7 +682,8 @@ async def decompose_async(
        ``apply_decomposition_policy`` (ADR-012 SoT — preserves the
        operator-tunable policy surface; only the call site moves).
     3. **LLM call**: ``loop._call_llm`` with ``settings.plan_model``
-       (PR-CL-A6 knob) bounded by 60s timeout.
+       (PR-CL-A6 knob) bounded by ``_DECOMPOSE_CALL_TIMEOUT_S``
+       (180s post-PR-CHECKPOINT-RESUME-TIMEBUDGET, 2026-05-25).
     4. **Parse**: pydantic ``DecompositionResult.model_validate_json``
        — schema-validated, error-on-malformed.
     5. **Skip when** the LLM reports ``is_compound=False`` or only

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -654,7 +654,14 @@ def _build_tool_summary(tools: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-_DECOMPOSE_CALL_TIMEOUT_S: float = 60.0
+# PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — raised 60 → 180
+# (3 min) on operator directive ("야심차게 잡아도 돼"). Smoke 16
+# evolver's `decompose_async` timed out at 122s on the prior 60s cap.
+# The decomposer LLM call can be slow on complex compound requests
+# (multi-tool DAG generation, baseline evidence preamble, etc.); 180s
+# matches the per-LLM-call generosity of openclaw's agent timeout
+# minimum while leaving headroom under the SubAgentManager 600s cap.
+_DECOMPOSE_CALL_TIMEOUT_S: float = 180.0
 
 
 async def decompose_async(

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -73,6 +73,35 @@ def _strip_json_codeblock(text: str) -> str:
     return match.group(1).strip()
 
 
+def _resolve_timeout_s(default: float) -> float:
+    """Apply ``GEODE_SUBAGENT_TIMEOUT_S`` env override with clamp.
+
+    PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — env knob for
+    the SubAgentManager wall-clock cap so deployments can tune
+    without code change. Clamp to ``[10, 3600]``:
+
+    - Lower bound 10s — below this the orchestrator's per-phase
+      framing overhead alone dominates; a sub-agent can't complete
+      meaningful work.
+    - Upper bound 3600s (1h) — matches openclaw's per-agent
+      ``agents.defaults.timeoutSeconds`` documented range; longer
+      runs should checkpoint + resume rather than hold a single
+      subprocess open.
+
+    Non-numeric or empty env values fall through to ``default``.
+    """
+    import os
+
+    raw = os.environ.get("GEODE_SUBAGENT_TIMEOUT_S", "").strip()
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        return float(default)
+    return max(10.0, min(3600.0, value))
+
+
 def _last_balanced_json_object(text: str) -> str | None:
     """Walk the text right-to-left and return the LAST balanced
     ``{...}`` substring whose first attempt at ``json.loads`` succeeds.
@@ -341,7 +370,18 @@ class SubAgentManager:
         runner: IsolatedRunner,
         task_handler: Any | None = None,
         *,
-        timeout_s: float = 120.0,
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — raised
+        # 120 → 600 (10 min) on operator directive ("야심차게 잡아도 돼.
+        # 300초 그이상으로 잡아"). Matches the per-agent-run wall-clock
+        # convergence from openclaw (`agents/timeout.ts:3` 48h default)
+        # while still leaving room for the IsolationConfig outer cap.
+        # 120s was too tight for tool-using sub-agents — smoke 16
+        # evolver TimeoutError surfaced at 122s in
+        # ``plan.decompose_async``. Pilot's 90s Petri audit alone
+        # leaves <30s for plan + tool overhead at 120s; 600s gives
+        # multi-round tool reasoning the headroom it needs. Override
+        # via ``GEODE_SUBAGENT_TIMEOUT_S`` env (clamped [10, 3600]).
+        timeout_s: float = 600.0,
         hooks: HookSystem | None = None,
         agent_registry: AgentRegistry | None = None,
         parent_session_key: str = "",
@@ -359,7 +399,13 @@ class SubAgentManager:
     ) -> None:
         self._runner = runner
         self._task_handler = task_handler
-        self._timeout_s = timeout_s
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — env override
+        # for the wall-clock cap, clamped to a sane range so a bad
+        # `GEODE_SUBAGENT_TIMEOUT_S=abc` or `=99999999` doesn't break
+        # subprocess accounting. 10s lower bound matches the smoke
+        # smallest phase (proximity ~0.2ms is fine; literature_review
+        # ~30s on cache hit needs > 10s headroom).
+        self._timeout_s = _resolve_timeout_s(timeout_s)
         self._time_budget_s = time_budget_s
         self._hooks = hooks
         self._agent_registry = agent_registry

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -50,7 +50,11 @@ class WorkerRequest:
     denied_tools: list[str] = field(default_factory=list)
     model: str = "claude-opus-4-6"
     provider: str = "anthropic"
-    timeout_s: float = 120.0
+    # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — default raised
+    # 120 → 600 to match SubAgentManager default (env-tunable via
+    # ``GEODE_SUBAGENT_TIMEOUT_S``). Smoke 16 evolver hit 122s in
+    # plan.decompose_async on the prior cap.
+    timeout_s: float = 600.0
     time_budget_s: float = 0.0  # 0 = inherit parent's budget
     thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call (legacy)
     effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh" (v0.56.0)
@@ -123,7 +127,7 @@ class WorkerRequest:
             denied_tools=data.get("denied_tools", []),
             model=data.get("model", "claude-opus-4-6"),
             provider=data.get("provider", "anthropic"),
-            timeout_s=data.get("timeout_s", 120.0),
+            timeout_s=data.get("timeout_s", 600.0),
             # v0.55.0 R5 — reasoning depth fields were declared on the
             # dataclass since v0.50.x but never deserialised, so every
             # sub-agent ran at the dataclass defaults regardless of

--- a/docs/plans/2026-05-25-structured-output-3-axis-fix.md
+++ b/docs/plans/2026-05-25-structured-output-3-axis-fix.md
@@ -142,16 +142,140 @@ CLI: `audit-seeds config`, `audit-seeds generate` 2개만. **`resume` 명령 없
 - **mid-phase crash (예: Pipeline 외 raise)** 시 → state.json 미작성, run_dir 의 candidates/ 등 disk 산출만 남음.
 - Per-candidate / per-phase checkpoint 없어 같은 운영 비용으로 재개 불가.
 
-### 5.3 권장 (별도 sprint 후보)
+### 5.3 Frontier reference grounding
 
-| 항목 | LOC |
-|------|-----|
-| Per-phase `_persist_state()` 호출 (각 phase 종료 후 incremental save) | ~30 |
-| `resume` CLI 명령 — `audit-seeds resume <run_id>` → `state.json` 로드 → 다음 phase 부터 재개 | ~150 |
-| Phase 의 idempotency 보장 (이미 작성된 candidate skip, 이미 ranked 면 skip 등) | ~100 |
-| Tests | ~150 |
+| Source | 패턴 | 비고 |
+|--------|------|------|
+| open-coscientist (origin) | LangGraph `ainvoke()` in-memory, 체크포인트 없음 (`generator.py:473`) | crash 시 전부 손실 — GEODE 와 동일 한계 |
+| paperclip (Claude Code) | `~/.claude/projects/<hash>/<session>.jsonl` per-event append-only, resume via session_id | event-level granularity, replay = re-stream |
+| LangGraph `SqliteSaver` | thread_id + checkpoint_id keying, per-node 단위 | API: `aput()` / `aget()` / `alist()` 의 state CRUD |
+| GEODE 현재 | run 끝에 1회 state.json | 인프라 있지만 wire 안 됨 (`pyproject.toml` 에 `langgraph-checkpoint-sqlite>=3.0.0` 명시) |
 
-**Total: ~430 LOC, 별도 PR sprint.**
+**수렴 verdict:** per-phase JSON append-only — paperclip 의 event-level 보다는 거칠지만, GEODE 의 phase 단위 atomic 처리에 fit. LangGraph SqliteSaver 의 thread_id ↔ GEODE 의 run_id 1:1 매핑.
+
+### 5.4 수렴 디자인 (S5 sprint)
+
+**파일 추가:**
+
+```
+plugins/seed_generation/
+├─ checkpointer.py     # NEW — per-phase JSON 작성
+└─ resume.py           # NEW — hydration + skip-completed 로직
+```
+
+**스키마:**
+
+```python
+# checkpointer.py
+@dataclass(frozen=True)
+class PhaseCheckpoint:
+    phase: str                # 'literature_review' | 'generator' | ... | 'meta_reviewer'
+    completed_at: float       # Unix epoch
+    duration_ms: float
+    state_snapshot: dict      # _state_to_json(state) — full PipelineState as JSON
+    error: str | None         # phase 가 error 로 끝났으면 사유, 정상이면 None
+
+def write_checkpoint(run_dir: Path, ck: PhaseCheckpoint) -> Path:
+    """Write to <run_dir>/checkpoints/<phase>.json. Atomic via tmp+rename."""
+
+def list_completed_phases(run_dir: Path) -> list[str]:
+    """Return phase names in order they were completed (mtime sort)."""
+
+# orchestrator.py — PipelineState 에 추가
+completed_phases: list[str] = field(default_factory=list)
+```
+
+**Orchestrator wiring:**
+
+```python
+# arun() 루프 안, await self._arun_phase(phase) 직후
+await self._record_checkpoint(phase)
+
+# resume_from_phase 인자 추가 + 루프 시작 시 skip
+async def arun(self, *, resume_from_phase: str | None = None) -> PipelineState:
+    start_idx = 0
+    if resume_from_phase:
+        start_idx = _PHASE_ORDER.index(resume_from_phase)
+    for phase in _PHASE_ORDER[start_idx:]:
+        ...
+```
+
+**CLI:**
+
+```python
+@audit_seeds_app.command("resume")
+def audit_seeds_resume(
+    run_id: str = typer.Argument(...),
+    from_phase: str | None = typer.Option(None, "--from-phase"),
+) -> None:
+    """Resume a partial run from its last completed checkpoint.
+
+    Auto-detects the next uncompleted phase from
+    ``state/seed-generation/<run_id>/checkpoints/`` unless
+    ``--from-phase`` overrides.
+    """
+```
+
+**Idempotency:**
+
+- Each phase reads `state.candidates`/`reflections`/`pilot_scores` and tolerates already-populated rows.
+- Critic/Pilot/Evolver skip work for candidate_ids already in their respective output dict (state already has the result from a prior checkpoint).
+
+**LOC: ~430**
+- checkpointer.py: ~80
+- resume.py: ~80
+- orchestrator.py modifications: ~60
+- cli.py resume command: ~50
+- Tests (atomic write, list ordering, resume hydration, idempotency × 3 phases): ~160
+
+## 6. time_budget hard cap (사용자 요청)
+
+### 6.1 현 상태
+
+| 위치 | 값 | 단위 | 만료 시 |
+|------|----|------|---------|
+| `core/agent/sub_agent.py:344 SubAgentManager.__init__ timeout_s` | **120.0** | per-subprocess wall-clock | raise TimeoutError |
+| `core/agent/plan.py:657 plan.decompose_async` | **60.0** | per-LLM-call (asyncio.wait_for) | raise TimeoutError → catch + raise sub_agent fail |
+| `core/agent/worker.py:54 WorkerRequest.time_budget_s` | 0.0 (default) | (unused) | **enforced 안 됨** |
+| `core/orchestration/isolated_execution.py IsolationConfig.timeout_s` | 300.0 default | per-subprocess | wait_for timeout |
+
+smoke 16 evolver: plan.decompose_async 122s 만에 timeout. 120s SubAgentManager + 60s plan.decompose 두 cap 모두 짧음.
+
+### 6.2 Frontier reference grounding
+
+| Source | Cap | Granularity | 만료 |
+|--------|-----|-------------|------|
+| hermes-agent | iteration budget (50 turns/sub-agent, `IterationBudget` `run_agent.py:520`) | per-LLM-call | graceful refund |
+| openclaw | **48시간** default (`agents/timeout.ts:3`) | per-agent-run wall-clock | graceful + optional retry |
+| LangGraph | 명시적 wall-time cap 없음 — recursion_limit (default 25 노드) 만 | per-graph traversal | exception |
+| GEODE 현재 | 120s SubAgent + 60s plan.decompose | per-subprocess | raise |
+
+**수렴 verdict:** openclaw 의 per-agent-run wall-clock 모델 — iteration counting 보다 tool-using 에 fit. 48시간은 너무 길지만 GEODE 120s 는 짧음. 중간값 **5분 (300s)** 가 IsolationConfig default 와도 일치.
+
+### 6.3 수렴 디자인 (S6 sprint)
+
+**변경:**
+
+1. `core/agent/sub_agent.py:344` — `timeout_s: float = 120.0` → **300.0** (5분).
+2. env override: `GEODE_SUBAGENT_TIMEOUT_S` 읽어 `[10, 3600]` clamp.
+3. `core/agent/worker.py` — `WorkerRequest.time_budget_s` 를 IsolatedRunner 에 wire-through (현재 dead field). orchestrator/SubAgentManager 가 per-task budget 설정 가능 (예: pilot 300s, critic 120s).
+4. `core/agent/plan.py:657` — `decompose_async` wait_for timeout **60s → 90s** (smoke 16 의 122s 는 plan + tool 합쳐서 — plan 단독은 90s 면 충분 추정).
+
+**Tests:**
+- `SubAgentManager.timeout_s` default = 300 invariant
+- `GEODE_SUBAGENT_TIMEOUT_S` env clamp 동작 (10 / 1800 / 9999 → 3600)
+- `WorkerRequest.time_budget_s` 가 0 이 아니면 IsolationConfig 우선
+- `plan.decompose_async` 90s default
+
+**LOC: ~120**
+- sub_agent.py: ~25 (env override + clamp)
+- worker.py: ~15 (wire-through)
+- plan.py: ~5 (constant raise)
+- Tests: ~75
+
+### 6.4 우선순위
+
+S5 / S6 모두 inter-dependent 한 영역 없음 — 묶거나 분리 자유.
 
 ## 6. Sprint 분해 (제안)
 

--- a/docs/plans/2026-05-25-structured-output-3-axis-fix.md
+++ b/docs/plans/2026-05-25-structured-output-3-axis-fix.md
@@ -1,0 +1,189 @@
+# 2026-05-25 — Structured-output 3-axis fix + checkpointer audit
+
+> Status: **Draft (사용자 승인 대기)**
+> Framing: smoke 15/16 의 prose-vs-JSON regression 을 adapter 3 축 (PAYG / subscription / local-cli) 에서 모두 해소.
+> 선행 관측: PR-HANDOFF-SCHEMAS 의 hard directive ("FINAL response must be ONLY the JSON object... Start with `{` end with `}`") 는 smoke 16 에서 이미 활성 상태였으나 LLM 이 무시 → **prompt-side directive 만으로는 부족** (empirical refutation).
+
+## 1. Background — 관측된 실패 카탈로그
+
+### 1.1 JSON-formatting 실패 (5 건)
+
+| Smoke | Agent | 응답 형태 | Prompt 상태 |
+|-------|-------|----------|-------------|
+| 15 | pilot | prose (~500 토큰, 497s) | PR-HANDOFF-SCHEMAS 이전, soft "Return JSON" 지시만 |
+| 15 | evolver (iter 1) | JSON 있음 (verdict ok) | 동일 |
+| 16 | critic | prose ("**Critique summary:**..." 28s) | hard directive 없음 (critic 만 미적용) |
+| 16 | pilot | prose ("I need to actually run..." 497s) | **hard directive 활성 — 무시됨** |
+| 16 | meta_reviewer | prose ("Meta-review submitted...") | soft 지시만 |
+
+**핵심:** smoke 16 pilot 의 prompt 는 이미 `"Your FINAL response must be ONLY the JSON object... Start with \`{\` and end with \`}\`"` 를 포함했고, HANDOFF CONTEXT JSON block 도 첨부됨. 그럼에도 LLM 이 prose 만 출력. **즉 prompt-only fix 는 무력하다는 empirical 증거.**
+
+### 1.2 Non-JSON 실패 (1 건)
+
+**smoke 16 evolver — TimeoutError at `core/agent/plan.py:721 decompose_async`** (122초). stderr.log 발췌:
+
+```
+File "/opt/homebrew/.../asyncio/streams.py", line 539, in _wait_for_data
+    await self._waiter
+asyncio.exceptions.CancelledError
+...
+File "/Users/mango/workspace/geode/core/agent/plan.py", line 721, in decompose_async
+    response = await asyncio.wait_for(...)
+File "/opt/homebrew/.../asyncio/timeouts.py", line 114, in __aexit__
+    raise TimeoutError from exc_val
+```
+
+`result.json.summary = "Sub-agent failed: termination_reason=natural"` — orchestrator 의 라벨이 misleading. **실제 원인: AgenticLoop 의 plan-decompose 단계가 wall-time timeout** (claude-cli 가 정상 종료했지만 plan 내부 await 이 시간 초과). JSON 포맷과 무관.
+
+## 2. 영속화 — 이전 제시한 4 옵션 (A/B/C/D)
+
+이전 메시지에서 4 갈래 제안. md 영속화.
+
+### Option A — sub_agent.py 의 `_last_balanced_json_object` fallback 강화
+
+**현 상태:** PR-HANDOFF-SCHEMAS 가 이미 prose 안의 `{...}` 블록 추출 시도 (sub_agent.py).
+**확장:** ```json``` fence 안의 JSON 도 우선 시도; 다중 candidate 블록 중 schema-required 필드 가장 많이 매치되는 것 선택; 부분 JSON 의 추가 복원 시도 (예: 마지막 `}` 보강).
+**비용:** ~50 LOC. 효과 부분적 — LLM 이 JSON 어디에도 안 적은 경우 무력.
+
+### Option B — Retry-on-parse-failure
+
+**Idea:** 첫 응답이 parse 실패 시 같은 conversation 에 2번째 turn 추가: `"Your previous response was not valid JSON. Reply ONLY with the JSON object matching the schema. No prose, no markdown. Start with { end with }."`
+**비용:** ~80 LOC + 추가 LLM call (per failure ~30-60s + 토큰). AgenticLoop 의 turn 관리 침습.
+**효과 가설:** higher than (A) — model 이 자기 prose 를 보고 self-correction 가능.
+
+### Option C — Anthropic tool_use 강제 (Anthropic-only)
+
+**Idea:** `tools=[{"name": "submit_result", "input_schema": SCHEMA}]` + `tool_choice={"type": "tool", "name": "submit_result"}`. LLM 은 prose 대신 tool call 로 반드시 응답.
+**Scope 제약:** Anthropic SDK 만 적용 가능. 사용자 directive 가 "Anthropic 한정 조치 자제" 였음 → **단독으론 부적합**, 단 3-axis 의 한 축 (PAYG Anthropic) 으로는 적용 가치.
+**비용:** ~150 LOC (anthropic_payg.py + anthropic_oauth.py).
+
+### Option D — Post-LLM JSON 변환 layer (별도 sonnet 호출)
+
+**Idea:** 첫 응답이 parse 실패 시 별도 cheap-model (haiku 또는 mini) 에 prose 전체 + schema 전달 → "이 prose 를 schema 형식 JSON 으로 변환" 요청. 변환만 하는 single-purpose LLM 호출.
+**비용:** ~100 LOC + 추가 LLM call (저렴). 추가 latency ~5s.
+**효과 가설:** 가장 안전한 안전망 — original LLM 의 prose 가 logically 옳다면 변환 LLM 이 추출.
+
+## 3. 3-axis adapter 구조 + 적용 방안
+
+### 3.1 Adapter 인벤토리 (`core/llm/adapters/`)
+
+| Adapter | Auth | Wire | Structured output 현재 |
+|---------|------|------|-----------------------|
+| `anthropic_payg.py` | API key | Anthropic Messages | **미구현** — `response_schema` plumbing 없음 |
+| `anthropic_oauth.py` | OAuth (Claude.ai bucket) | Anthropic Messages | **미구현** |
+| `claude_cli.py` | Claude Code session | subprocess | `--json-schema <inline>` (soft hint) |
+| `openai_payg.py` | API key | Chat Completions | **미구현** — `response_format` plumbing 없음 |
+| `codex_oauth.py` | OAuth (Codex bucket) | OpenAI Responses | **미구현** — `output_schema` plumbing 없음 |
+| `codex_cli.py` | Codex CLI session | subprocess | `--output-schema <file>` (soft hint) |
+
+### 3.2 SDK 별 구조화 출력 메커니즘 (ctx7 grounded)
+
+**Anthropic SDK (PAYG + OAuth):**
+- 최신 API: `client.messages.parse(messages=..., output_format=PydanticModel)` — Pydantic 자동 hydration. SDK 가 schema 를 force-mode `tools[].input_schema` + `tool_choice` 로 변환.
+- ctx7 출처: `/anthropics/anthropic-sdk-python` — `messages.parse()` signature 에 `output_format`, `output_config` 인자.
+- 효과: provider-level enforcement (true forced structured output).
+
+**OpenAI SDK (PAYG):**
+- `client.chat.completions.create(response_format={"type": "json_schema", "json_schema": {"name": "...", "schema": {...}, "strict": True}})` — strict 모드는 schema 강제 (refusal 또는 schema 외 응답 reject).
+- ctx7 출처: `/openai/openai-cookbook` 의 `Leveraging_model_distillation_to_fine-tune_a_model.ipynb`.
+
+**Codex OAuth (OpenAI subscription axis):**
+- OpenAI Responses API (`/v1/responses`) — `output_schema` field 지원 (`codex_cli.py` 의 `--output-schema` 가 이 wire 의 CLI 래퍼). PAYG 와 동일.
+
+**Local CLI (Codex + Claude Code):**
+- `claude --json-schema <inline-json>` → claude-cli 가 system prompt 로 schema 주입. **enforcement 없음.**
+- `codex --output-schema <file>` → 동일. **enforcement 없음.**
+
+### 3.3 적용 plan — 6 셀 매트릭스
+
+| 셀 | adapter | mechanism | 새 작업 | LOC |
+|----|---------|-----------|---------|-----|
+| **PAYG-Anth** | anthropic_payg.py | `messages.parse(output_format=PydanticModel)` 또는 force `tools[].input_schema` | response_schema → pydantic model 변환 layer | ~120 |
+| **PAYG-OpenAI** | openai_payg.py | `response_format={"type":"json_schema", "strict":True, ...}` | response_schema → response_format 변환 | ~80 |
+| **Sub-OAuth** | codex_oauth.py | Responses API `output_schema` 필드 (= PAYG-OpenAI 와 동일 wire) | 동일 변환 재사용 | ~30 (shared helper) |
+| **CLI-Claude** | claude_cli.py | 이미 soft hint. **Option B retry + Option D fallback** | retry/extract layer (adapter-agnostic) | ~80 |
+| **CLI-Codex** | codex_cli.py | 동일 | 동일 (shared retry/extract layer) | (shared) |
+| **Anth-OAuth (NEW)** | anthropic_oauth.py | 동일 force tool_use (PAYG-Anth 와 wire 동일) | shared helper 재사용 | ~30 |
+
+**Shared helper:** `core/llm/structured_output.py` (NEW) — `force_structured_output(schema: dict, response: str) -> dict | None` 의 fallback 추출 + retry 의 turn-management. 6 셀 모두 호출.
+
+### 3.4 우선순위
+
+1. **CLI-Claude + CLI-Codex (Option A + B)** — 현재 운영 path, 최대 영향. 별도 SDK 변경 없이 retry + 강화 extract.
+2. **PAYG-OpenAI + Sub-OAuth (response_format)** — 한 번에 2 셀. 변환 helper 단일.
+3. **PAYG-Anth + Anth-OAuth (messages.parse)** — Anthropic SDK 업데이트 필요. 사용자 directive "Anthropic 한정 조치 자제" 와 일부 충돌하지만, 본 axis 는 SDK-level structured output 의 표준 API. PAYG/OAuth 양쪽에 같은 helper.
+
+**MVP 권장:** (1) + (2) 만 — 가장 임팩트 큰 4 셀 (CLI ×2 + PAYG-OpenAI + Sub-OAuth). Anth-axis 는 후속.
+
+## 4. Non-JSON 실패 처리 (smoke 16 evolver TimeoutError)
+
+별도 트랙 — JSON 작업과 직교.
+
+| 항목 | 현 상태 | 권장 |
+|------|---------|------|
+| `plan.py:721 decompose_async` timeout | 122s 후 raise TimeoutError | 1) timeout 값 (현재 wait_for 의 timeout) 확인 + 로그. 2) retry-on-timeout 또는 graceful degradation. 3) AgenticLoop 의 plan 단계가 evolver 처럼 long-tool-call sub-agent 에 필요한지 재검토. |
+| Orchestrator label 의 오해 ("termination_reason=natural") | sub-agent 의 raw output 이 비어있으면 무조건 natural 로 라벨 | TimeoutError 같은 internal exception 을 별도 reason 으로 surface |
+
+## 5. Checkpointer 점검 (사용자 요청)
+
+### 5.1 현 상태
+
+`plugins/seed_generation/orchestrator.py`:
+- `_persist_state()` (l.828) — `state.json` 을 **run 끝에만** 1회 작성 (l.529, `arun()` 의 _PHASE_ORDER 루프 완료 후)
+- `_persist_survivors()` (l.630) — `survivors.json` 동일
+- `_persist_meta_review()` — meta_review 끝에 1회
+- **per-phase 또는 per-candidate checkpoint 없음**
+
+CLI: `audit-seeds config`, `audit-seeds generate` 2개만. **`resume` 명령 없음.** orchestrator.py 의 주석 (l.519, l.834) 는 "S11 CLI `geode audit-seeds resume` will re-hydrate from here" 라고 적었지만 미구현.
+
+### 5.2 의미
+
+- smoke 16 evolver TimeoutError 발생 시 → `arun()` 이 `aborted = True` 로 루프 빠져나오긴 함 → `_persist_state()` 호출됨. 그러나 partial state (critic/pilot/evolver fail 표시) 만 저장.
+- **mid-phase crash (예: Pipeline 외 raise)** 시 → state.json 미작성, run_dir 의 candidates/ 등 disk 산출만 남음.
+- Per-candidate / per-phase checkpoint 없어 같은 운영 비용으로 재개 불가.
+
+### 5.3 권장 (별도 sprint 후보)
+
+| 항목 | LOC |
+|------|-----|
+| Per-phase `_persist_state()` 호출 (각 phase 종료 후 incremental save) | ~30 |
+| `resume` CLI 명령 — `audit-seeds resume <run_id>` → `state.json` 로드 → 다음 phase 부터 재개 | ~150 |
+| Phase 의 idempotency 보장 (이미 작성된 candidate skip, 이미 ranked 면 skip 등) | ~100 |
+| Tests | ~150 |
+
+**Total: ~430 LOC, 별도 PR sprint.**
+
+## 6. Sprint 분해 (제안)
+
+| Sprint | scope | LOC | 비용 |
+|--------|-------|-----|------|
+| **S1 — Structured output S/W (CLI axis)** | Option A 강화 + Option B retry + shared `structured_output.py` helper | ~250 | 0 (코드만) |
+| **S2 — PAYG-OpenAI + Sub-OAuth** | response_format / output_schema plumbing | ~120 | 0 |
+| **S3 — PAYG-Anth + Anth-OAuth** | messages.parse force | ~150 | 0 |
+| **S4 — Non-JSON failure: plan.decompose timeout** | timeout 분석 + retry / degradation | ~80 | 0 |
+| **S5 — Checkpointer** | per-phase persist + resume CLI + idempotent phases + tests | ~430 | 0 |
+
+## 7. Socratic Gate
+
+| # | 질문 | 답변 |
+|---|------|------|
+| Q1 | 이미 존재? | (1) `--json-schema`/`--output-schema` 만 soft hint. (2) `_last_balanced_json_object` fallback 있음. (3) per-phase checkpoint X. retry mechanism X. SDK structured output plumbing X. |
+| Q2 | 안 하면? | smoke 17/18 에서 동일 prose regression. 운영 비용 낭비 + 신뢰도 X. 또한 mid-run crash 시 처음부터 다시 — 비용 누적 |
+| Q3 | 측정? | smoke 17 vs smoke 16 의 phase-pass 비율, JSON-emit rate per agent, retry trigger 빈도 |
+| Q4 | 가장 단순? | S1 (CLI retry + extract 강화) 만 먼저 — 가장 영향 큰 path, SDK 변경 없음 |
+| Q5 | frontier 3+? | DSPy / outlines / Instructor / langchain `JsonOutputParser` 모두 retry + parse fallback 패턴 채택. OpenAI SDK + Anthropic SDK 둘 다 force-mode 가 production API. |
+
+## 8. 우선순위 결정 요청
+
+- **Path A** — S1 만 먼저 (CLI retry + extract). 비용 ~250 LOC, smoke 17 으로 효과 측정.
+- **Path B** — S1 + S2 묶음 (CLI + OpenAI SDK 양쪽 한 PR). ~370 LOC.
+- **Path C** — S1 + S2 + S3 전체 (3-axis 모두). ~520 LOC. SDK 변경 포함이라 Anth subscription path 영향 우려.
+- **Path D** — S5 checkpointer 먼저 (run 비용 보호 우선). ~430 LOC. 별도 트랙.
+
+## 9. Status
+
+- [x] Plan SoT 작성 (이 문서)
+- [ ] 우선순위 (Path A/B/C/D) 운영자 결정
+- [ ] S1 (구현)
+- [ ] S2 / S3 후속
+- [ ] S4 / S5 deferred 트랙

--- a/plugins/seed_generation/checkpointer.py
+++ b/plugins/seed_generation/checkpointer.py
@@ -1,0 +1,199 @@
+"""Per-phase checkpoint writer for the seed-generation pipeline.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — append-only JSON
+checkpoint file per completed phase, written to
+``<run_dir>/checkpoints/<phase>.json``. The orchestrator calls
+:func:`write_checkpoint` after each successful phase so a mid-run
+crash (e.g. ``plan.decompose_async`` timeout, claude-cli network
+hang) doesn't lose prior phase output.
+
+Convergence basis (plan §5.3):
+
+- **open-coscientist** (`generator.py:473`) runs LangGraph
+  ``ainvoke()`` in-memory with zero mid-run persistence; crashes
+  lose everything. GEODE was the same pre-S5.
+- **paperclip** (Claude Code) persists per-event JSONL in
+  ``~/.claude/projects/<hash>/<session>.jsonl``; resume re-streams
+  events by ``session_id``. Event-level is too fine for GEODE
+  (8 phases × hundreds of sub-events).
+- **LangGraph SqliteSaver** uses ``thread_id`` + ``checkpoint_id``
+  keyed CRUD with per-node granularity. GEODE's ``run_id`` is
+  the natural ``thread_id`` and phases are the natural nodes.
+
+This module picks the **per-phase** granularity: 1 JSON file per
+phase, atomic write via ``os.replace`` of a tmp file, append-only
+on a successful phase end. Failed phases write nothing — the next
+``audit-seeds resume`` retries them.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CHECKPOINT_SUBDIR",
+    "PhaseCheckpoint",
+    "list_completed_phases",
+    "load_checkpoint",
+    "write_checkpoint",
+]
+
+
+CHECKPOINT_SUBDIR = "checkpoints"
+"""Subdirectory under ``run_dir`` holding the per-phase JSON files."""
+
+
+@dataclass(frozen=True)
+class PhaseCheckpoint:
+    """One record of a phase completing.
+
+    Stored as JSON at ``<run_dir>/checkpoints/<phase>.json``. The
+    ``state_snapshot`` is the full :func:`_state_to_json` output
+    captured at the moment the phase finished — the resume path
+    rehydrates ``PipelineState`` from the latest checkpoint's
+    snapshot and skips already-completed phases.
+
+    ``error`` is non-None when the phase was retried after a prior
+    failure — current MVP only writes the success case so this stays
+    None; the field is reserved for a future "checkpoint-on-failure"
+    extension that captures partial work for debugging.
+    """
+
+    phase: str
+    completed_at: float
+    duration_ms: float
+    state_snapshot: dict[str, Any]
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "completed_at": self.completed_at,
+            "duration_ms": self.duration_ms,
+            "state_snapshot": self.state_snapshot,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> PhaseCheckpoint:
+        return cls(
+            phase=str(payload["phase"]),
+            completed_at=float(payload.get("completed_at", 0.0)),
+            duration_ms=float(payload.get("duration_ms", 0.0)),
+            state_snapshot=dict(payload.get("state_snapshot", {})),
+            error=payload.get("error"),
+        )
+
+
+def write_checkpoint(
+    run_dir: Path,
+    *,
+    phase: str,
+    state_snapshot: dict[str, Any],
+    duration_ms: float,
+    error: str | None = None,
+) -> Path:
+    """Write a phase checkpoint atomically.
+
+    Atomicity: write to ``<phase>.json.tmp``, then ``os.replace``
+    onto ``<phase>.json``. Same invariant as ``mutations.jsonl``'s
+    append-only writer (PR-G5b precedent — silent-ignored file
+    writers caused observability gaps; ``os.replace`` survives
+    partial-write crashes).
+    """
+    ck = PhaseCheckpoint(
+        phase=phase,
+        completed_at=time.time(),
+        duration_ms=duration_ms,
+        state_snapshot=state_snapshot,
+        error=error,
+    )
+    ck_dir = run_dir / CHECKPOINT_SUBDIR
+    ck_dir.mkdir(parents=True, exist_ok=True)
+    target = ck_dir / f"{phase}.json"
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{phase}.",
+        suffix=".tmp",
+        dir=str(ck_dir),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(ck.to_dict(), fh, ensure_ascii=False, indent=2, default=str)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except OSError as exc:
+        # Clean up the temp file on any write failure so the dir
+        # doesn't accumulate stale ``.<phase>.*.tmp`` files.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        log.warning(
+            "checkpointer: failed to write %s checkpoint at %s — %s",
+            phase,
+            target,
+            exc,
+        )
+        raise
+    return target
+
+
+def load_checkpoint(run_dir: Path, phase: str) -> PhaseCheckpoint | None:
+    """Load a single phase's checkpoint, return None when absent.
+
+    Returns None on missing file OR malformed JSON so the caller
+    can fall through to re-running the phase. A future MVP+ may
+    distinguish "missing" from "corrupt" but for now both surface
+    as "rerun this phase".
+    """
+    target = run_dir / CHECKPOINT_SUBDIR / f"{phase}.json"
+    if not target.is_file():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("checkpointer: %s checkpoint at %s unreadable — %s", phase, target, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return PhaseCheckpoint.from_dict(payload)
+    except (KeyError, TypeError, ValueError) as exc:
+        log.warning("checkpointer: %s checkpoint at %s malformed — %s", phase, target, exc)
+        return None
+
+
+def list_completed_phases(run_dir: Path) -> list[str]:
+    """Return phase names with a saved checkpoint, ordered by
+    ``completed_at`` ascending (the order they actually finished).
+
+    The orchestrator's ``_PHASE_ORDER`` is the canonical sequence;
+    the on-disk list may differ (re-runs, manual phase invocations)
+    so callers should intersect with ``_PHASE_ORDER`` when computing
+    "next phase to run".
+    """
+    ck_dir = run_dir / CHECKPOINT_SUBDIR
+    if not ck_dir.is_dir():
+        return []
+    items: list[tuple[float, str]] = []
+    for entry in ck_dir.iterdir():
+        if not entry.is_file() or entry.suffix != ".json":
+            continue
+        phase = entry.stem
+        try:
+            payload = json.loads(entry.read_text(encoding="utf-8"))
+            ts = float(payload.get("completed_at", 0.0))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        items.append((ts, phase))
+    items.sort()
+    return [phase for _ts, phase in items]

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -227,6 +227,156 @@ def audit_seeds_generate(
     raise typer.Exit(code=exit_code)
 
 
+@audit_seeds_app.command("resume")
+def audit_seeds_resume(
+    run_id: str = typer.Argument(
+        ...,
+        help=(
+            "Run id to resume — the ``<gen_tag>-<target_dim>`` directory "
+            "under ``state/seed-generation/``. The pipeline reads the "
+            "latest ``checkpoints/<phase>.json`` for hydration and "
+            "continues from the next pending phase."
+        ),
+    ),
+) -> None:
+    """Resume an interrupted run from per-phase checkpoints.
+
+    PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — when a prior
+    ``audit-seeds generate`` aborted mid-pipeline (e.g.
+    ``plan.decompose_async`` timeout, claude-cli network hang, OS
+    crash), the per-phase checkpoints under
+    ``state/seed-generation/<run_id>/checkpoints/`` let a follow-up
+    invocation skip the already-completed phases instead of paying for
+    them again. Phases without a checkpoint are re-run from the
+    rehydrated state.
+    """
+    exit_code = run_audit_seeds_resume(run_id=run_id)
+    raise typer.Exit(code=exit_code)
+
+
+def run_audit_seeds_resume(
+    *,
+    run_id: str,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+) -> int:
+    """Pure-function entry point for ``audit-seeds resume``.
+
+    Returns the exit code (0 = pipeline succeeded or run already
+    complete; 1 = run_dir missing or checkpoint hydration failure;
+    2 = pipeline run error). Tests inject ``stdout`` / ``stderr`` to
+    capture the rendered summary.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+
+    from core.observability.run_dir import run_dir_scope
+    from core.paths import STATE_SEED_GENERATION_DIR
+    from core.self_improving_loop.run_transcript import RunTranscript, run_transcript_scope
+
+    from plugins.seed_generation.resume import (
+        ResumeError,
+        resolve_resume_target,
+    )
+
+    run_dir = STATE_SEED_GENERATION_DIR / run_id
+    if not run_dir.is_dir():
+        err.write(f"seed-generation resume: run_dir not found at {run_dir}\n")
+        return 1
+
+    try:
+        state, resume_from_phase = resolve_resume_target(run_dir)
+    except ResumeError as exc:
+        err.write(f"seed-generation resume: cannot resume — {exc}\n")
+        return 1
+
+    if resume_from_phase is None:
+        out.write(
+            f"seed-generation resume: run {run_id!r} already complete "
+            f"(every phase has a checkpoint); nothing to do.\n"
+        )
+        return 0
+
+    journal = RunTranscript(
+        session_id=run_id,
+        gen_tag=state.gen_tag,
+        component="seed-generation",
+        path=run_dir / "transcript.jsonl",
+    )
+    with run_dir_scope(run_dir), run_transcript_scope(journal):
+        picker_result = pick_bindings()
+        journal.append(
+            "resume_started",
+            payload={
+                "resume_from_phase": resume_from_phase,
+                "completed_phases": list(state.completed_phases),
+                "candidates": len(state.candidates),
+                "survivors": len(state.survivors),
+            },
+        )
+        out.write(
+            f"seed-generation resume: run_id={run_id!r} resume_from={resume_from_phase!r} "
+            f"completed={list(state.completed_phases)}\n"
+        )
+        out.flush()
+        try:
+            _dispatch_pipeline_resume(
+                picker_result=picker_result,
+                state=state,
+                resume_from_phase=resume_from_phase,
+                out=out,
+                err=err,
+            )
+        except Exception as exc:  # pragma: no cover - bubbles up rich error
+            journal.append(
+                "pipeline_run_failed",
+                level="error",
+                payload={"error": repr(exc)[:200]},
+            )
+            err.write(f"seed-generation resume: run failed — {exc}\n")
+            return 2
+        journal.append("resume_finished", payload={})
+    return 0
+
+
+def _dispatch_pipeline_resume(
+    *,
+    picker_result: PickerResult,
+    state: Any,
+    resume_from_phase: str,
+    out: IO[str],
+    err: IO[str],
+) -> None:
+    """Build orchestrator + run with a pre-hydrated state + resume cursor.
+
+    Skips the picker / cost-preview / pre-flight gates (the run was
+    already past those when it aborted). Mirrors
+    :func:`_dispatch_pipeline` for everything else.
+    """
+    from plugins.seed_generation.orchestrator import (
+        Pipeline,
+        PipelineRegistry,
+    )
+
+    registry = PipelineRegistry()
+    from plugins.seed_generation._registry_builder import populate_registry
+    from plugins.seed_generation.manifest import load_manifest
+
+    populate_registry(registry, picker_result=picker_result, manifest=load_manifest())
+    pipeline = Pipeline(state=state, registry=registry, bindings=dict(picker_result.bindings))
+    out.write(f"seed-generation resume: starting from {resume_from_phase!r}\n")
+    out.flush()
+
+    from core.async_runtime import run_process_coroutine
+
+    run_process_coroutine(pipeline.arun(resume_from_phase=resume_from_phase))
+
+    out.write(
+        f"seed-generation resume: run {state.run_id!r} finished; "
+        f"survivors={len(state.survivors)} usd={state.usd_spent:.4f}\n"
+    )
+
+
 def _resolve_target_dim(
     target_dim: str | None,
     *,

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -349,9 +349,12 @@ def _dispatch_pipeline_resume(
 ) -> None:
     """Build orchestrator + run with a pre-hydrated state + resume cursor.
 
-    Skips the picker / cost-preview / pre-flight gates (the run was
-    already past those when it aborted). Mirrors
-    :func:`_dispatch_pipeline` for everything else.
+    Skips the cost-preview / pre-flight / confirm gates (the run was
+    already past those when it aborted). The picker IS re-resolved
+    against the current ``~/.geode/config.toml`` because the
+    SubAgentManager + per-role agents need live bindings for the
+    phases that still have to run; if the operator edited config
+    between the abort and the resume, the new bindings win.
     """
     from plugins.seed_generation.orchestrator import (
         Pipeline,

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -99,6 +99,13 @@ def _state_to_json(state: PipelineState) -> str:
         # replay knows how many iteration cycles already ran.
         "max_iterations": state.max_iterations,
         "current_iteration": state.current_iteration,
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — per-phase
+        # checkpoint audit trail. ``audit-seeds resume <run_id>`` reads
+        # this list (or the union with on-disk checkpoints/<phase>.json
+        # via ``checkpointer.list_completed_phases``) to skip
+        # already-completed phases on the second walk through
+        # ``_PHASE_ORDER``.
+        "completed_phases": list(state.completed_phases),
         # CSP-8 (2026-05-22) — proximity LLM-clustering output. The
         # meta_reviewer + operator-readable summary both consume these
         # as a coverage signal (replaces the pre-CSP-8 proximity_graph).
@@ -237,6 +244,12 @@ class PipelineState:
     # the cursor (0 = initial draft batch).
     max_iterations: int = 0
     current_iteration: int = 0
+    # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — audit trail
+    # of phases that have written a per-phase checkpoint under
+    # ``<run_dir>/checkpoints/<phase>.json``. ``arun(resume_from_phase=...)``
+    # consults this list (post-hydrate) so a re-run is idempotent —
+    # already-completed phases are skipped on the second pass.
+    completed_phases: list[str] = field(default_factory=list)
     pool_path_in: Path | None = None
     pool_path_out: Path | None = None
     run_dir: Path | None = None
@@ -431,8 +444,17 @@ class Pipeline:
         # inject the values into SubTask creation.
         self.bindings = bindings or {}
 
-    async def arun(self) -> PipelineState:
+    async def arun(self, *, resume_from_phase: str | None = None) -> PipelineState:
         """Walk the 7 phases (then optional iteration cycles). Returns the final state.
+
+        PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — when
+        ``resume_from_phase`` is set, iteration 0 starts at that phase
+        and earlier phases are skipped (idempotent — their checkpoints
+        already populated ``state.candidates`` / ``reflections`` /
+        ``pilot_scores`` etc.). The caller (CLI ``audit-seeds resume``)
+        is responsible for hydrating ``state`` from
+        ``<run_dir>/checkpoints/<phase>.json`` before invoking
+        ``arun``. Pass ``None`` (default) for a fresh run.
 
         PR-Async-Phase-C step 2 (2026-05-22) — async-native pipeline
         walker. Replaces sync ``run`` which is now a deprecation
@@ -487,8 +509,41 @@ class Pipeline:
                     },
                 )
             order = _PHASE_ORDER if iteration == 0 else _ITERATION_PHASE_ORDER
-            for phase in order:
+            # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) —
+            # resume cursor only affects iteration 0; iteration >= 1
+            # is a fresh cycle by design (evolved candidates replace
+            # the prior pool). When ``resume_from_phase`` names a
+            # phase in the current order, skip everything before it.
+            resume_idx = 0
+            if iteration == 0 and resume_from_phase and resume_from_phase in order:
+                resume_idx = order.index(resume_from_phase)
+                if resume_idx > 0:
+                    log.info(
+                        "seed-generation resume: skipping %d completed phase(s) before %r",
+                        resume_idx,
+                        resume_from_phase,
+                    )
+                    _emit_orchestrator_event(
+                        "resume_skipped_phases",
+                        payload={
+                            "skipped": list(order[:resume_idx]),
+                            "resume_from": resume_from_phase,
+                        },
+                    )
+            for phase in order[resume_idx:]:
+                phase_started = time.time()
                 await self._arun_phase(phase)
+                # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) —
+                # checkpoint the post-phase state so a downstream
+                # crash doesn't lose this phase's work. Failures
+                # here are logged but don't abort the run (the
+                # checkpoint is a recovery convenience, not a hard
+                # contract — the run continues either way).
+                if iteration == 0 and self.state.run_dir is not None:
+                    self._record_checkpoint(
+                        phase,
+                        duration_ms=(time.time() - phase_started) * 1000.0,
+                    )
                 # PR-COSCI-1 (2026-05-21) — abort early when the
                 # candidates pool is empty after a phase that should
                 # have populated or filtered it. The check is scoped
@@ -832,6 +887,37 @@ class Pipeline:
             survivors_dir=self.state.pool_path_out,
             meta_review_path=meta_review_path,
         )
+
+    def _record_checkpoint(self, phase: str, *, duration_ms: float) -> None:
+        """Write a ``<run_dir>/checkpoints/<phase>.json`` snapshot.
+
+        PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — recovery
+        path: a future ``audit-seeds resume <run_id>`` invocation
+        reads these files to skip already-completed phases. Failures
+        log a WARNING and continue — the run's primary state lives
+        in memory + final ``state.json``; checkpoints are a
+        convenience for crash recovery.
+        """
+        if self.state.run_dir is None:
+            return
+        try:
+            from plugins.seed_generation.checkpointer import write_checkpoint
+
+            snapshot = json.loads(_state_to_json(self.state))
+            write_checkpoint(
+                self.state.run_dir,
+                phase=phase,
+                state_snapshot=snapshot,
+                duration_ms=duration_ms,
+            )
+            if phase not in self.state.completed_phases:
+                self.state.completed_phases.append(phase)
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "seed-generation: failed to write %s checkpoint — %s",
+                phase,
+                exc,
+            )
 
     def _persist_state(self) -> None:
         """Write a JSON snapshot of state to ``<run_dir>/state.json``.

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -74,6 +74,13 @@ def _state_to_json(state: PipelineState) -> str:
         # ADR-012 S4 (2026-05-21) — persist cohort so a state.json
         # replay re-hydrates the same picker semantics.
         "cohort": state.cohort,
+        # PR-SG-SELECTION-ALIGN (2026-05-25, G4) — Pareto attribution
+        # set. Resume path must rehydrate this; otherwise the evolver's
+        # HANDOFF pareto_front embedding silently changes between the
+        # pre-checkpoint and resumed run. Codex MCP review of
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET caught the omission.
+        "target_dims_attribution": list(state.target_dims_attribution),
+        "pareto_mode": state.pareto_mode,
         "gen_tag": state.gen_tag,
         "candidates_requested": state.candidates_requested,
         "pool_path_in": str(state.pool_path_in) if state.pool_path_in else None,
@@ -903,6 +910,12 @@ class Pipeline:
         try:
             from plugins.seed_generation.checkpointer import write_checkpoint
 
+            # Codex MCP review of PR-CHECKPOINT-RESUME-TIMEBUDGET — append
+            # BEFORE serializing so the snapshot's ``completed_phases``
+            # reflects the just-completed phase. Pre-fix the on-disk
+            # snapshot was one phase behind the in-memory state.
+            if phase not in self.state.completed_phases:
+                self.state.completed_phases.append(phase)
             snapshot = json.loads(_state_to_json(self.state))
             write_checkpoint(
                 self.state.run_dir,
@@ -910,8 +923,6 @@ class Pipeline:
                 state_snapshot=snapshot,
                 duration_ms=duration_ms,
             )
-            if phase not in self.state.completed_phases:
-                self.state.completed_phases.append(phase)
         except Exception as exc:  # pragma: no cover — defensive
             log.warning(
                 "seed-generation: failed to write %s checkpoint — %s",

--- a/plugins/seed_generation/resume.py
+++ b/plugins/seed_generation/resume.py
@@ -1,0 +1,186 @@
+"""Resume an interrupted seed-generation run from per-phase checkpoints.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — companion to
+:mod:`plugins.seed_generation.checkpointer`. The orchestrator writes
+``<run_dir>/checkpoints/<phase>.json`` after each successful phase; this
+module hydrates a :class:`PipelineState` from the *latest* checkpoint
+and computes the next phase to run (the first phase in
+``_PHASE_ORDER`` that has no checkpoint on disk).
+
+Design — single-flight, append-only:
+
+- Each checkpoint embeds the **full** ``state_snapshot`` captured at
+  end-of-phase, so re-hydrating from the last successful phase
+  recovers every field the downstream phases need (candidates,
+  reflections, pilot_scores, elo_ratings, evolved_candidates, …).
+  No partial-merge logic — the latest checkpoint is the SoT.
+- ``next_phase_to_run`` walks ``_PHASE_ORDER`` and returns the first
+  phase NOT present in ``list_completed_phases`` (the on-disk
+  audit trail). If every phase is on disk, the run is already
+  complete and we return None — the caller surfaces "already done"
+  and exits 0.
+
+Convergence basis: paperclip's ``loadOrCreateSession`` flow reads the
+session JSONL → rebuilds in-memory message history → resumes the
+next pending turn. We adapt this to GEODE's phase granularity
+(7 checkpoints per run × 1 file per phase = a far simpler index).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from plugins.seed_generation.checkpointer import (
+    list_completed_phases,
+    load_checkpoint,
+)
+from plugins.seed_generation.orchestrator import (
+    _ITERATION_PHASE_ORDER,
+    _PHASE_ORDER,
+    PipelineState,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "ResumeError",
+    "hydrate_state",
+    "next_phase_to_run",
+    "resolve_resume_target",
+]
+
+
+class ResumeError(RuntimeError):
+    """Raised when the run directory can't be resumed (missing / corrupt)."""
+
+
+def next_phase_to_run(run_dir: Path) -> str | None:
+    """Return the first ``_PHASE_ORDER`` phase with no on-disk checkpoint.
+
+    Returns ``None`` when every iteration-0 phase has a checkpoint —
+    the caller's run is already complete.
+    """
+    completed = set(list_completed_phases(run_dir))
+    for phase in _PHASE_ORDER:
+        if phase not in completed:
+            return phase
+    return None
+
+
+def _latest_completed_phase(run_dir: Path) -> str | None:
+    """Latest phase with a checkpoint on disk, ordered by completed_at.
+
+    Returns None when no checkpoints exist (fresh / aborted-pre-first-phase
+    run dir). Used to pick the snapshot to hydrate from.
+    """
+    completed = list_completed_phases(run_dir)
+    return completed[-1] if completed else None
+
+
+def hydrate_state(run_dir: Path) -> PipelineState:
+    """Rebuild :class:`PipelineState` from the latest checkpoint.
+
+    Reads ``<run_dir>/checkpoints/<latest>.json`` (latest by
+    ``completed_at``). Path-typed fields (``run_dir``, ``pool_path_in``,
+    ``pool_path_out``) come back as strings — coerce to :class:`Path`.
+
+    Raises :class:`ResumeError` when no checkpoint is present or the
+    payload is missing required identity fields.
+    """
+    latest = _latest_completed_phase(run_dir)
+    if latest is None:
+        raise ResumeError(f"no checkpoints under {run_dir / 'checkpoints'} — nothing to resume")
+    ck = load_checkpoint(run_dir, latest)
+    if ck is None:
+        raise ResumeError(f"checkpoint {latest!r} unreadable under {run_dir / 'checkpoints'}")
+    snap = ck.state_snapshot
+    if not snap.get("run_id") or not snap.get("target_dim") or not snap.get("gen_tag"):
+        raise ResumeError(
+            f"checkpoint {latest!r} missing identity fields "
+            f"(run_id/target_dim/gen_tag); refusing to resume"
+        )
+    state = PipelineState(
+        run_id=str(snap["run_id"]),
+        target_dim=str(snap["target_dim"]),
+        gen_tag=str(snap["gen_tag"]),
+        cohort=str(snap.get("cohort", "petri_17dim")),
+        target_dims_attribution=list(snap.get("target_dims_attribution", []) or []),
+        pareto_mode=bool(snap.get("pareto_mode", False)),
+        candidates_requested=int(snap.get("candidates_requested", 15)),
+        max_iterations=int(snap.get("max_iterations", 0)),
+        current_iteration=int(snap.get("current_iteration", 0)),
+        completed_phases=list(snap.get("completed_phases", []) or []),
+        pool_path_in=_path_or_none(snap.get("pool_path_in")),
+        pool_path_out=_path_or_none(snap.get("pool_path_out")),
+        run_dir=_path_or_none(snap.get("run_dir")) or run_dir,
+        candidates=list(snap.get("candidates", []) or []),
+        reflections=dict(snap.get("reflections", {}) or {}),
+        pilot_scores=dict(snap.get("pilot_scores", {}) or {}),
+        elo_ratings=dict(snap.get("elo_ratings", {}) or {}),
+        survivors=list(snap.get("survivors", []) or []),
+        evolved_candidates=list(snap.get("evolved_candidates", []) or []),
+        meta_review=dict(snap.get("meta_review", {}) or {}),
+        similarity_clusters=list(snap.get("similarity_clusters", []) or []),
+        removed_duplicates=list(snap.get("removed_duplicates", []) or []),
+        usd_spent=float(snap.get("usd_spent", 0.0)),
+        prompt_tokens=int(snap.get("prompt_tokens", 0)),
+        completion_tokens=int(snap.get("completion_tokens", 0)),
+        baseline_means=_dict_or_none(snap.get("baseline_means")),
+        baseline_stderr=_dict_or_none(snap.get("baseline_stderr")),
+        supervisor_guidance=dict(snap.get("supervisor_guidance", {}) or {}),
+        articles_with_reasoning=str(snap.get("articles_with_reasoning", "")),
+        literature_snapshots=dict(snap.get("literature_snapshots", {}) or {}),
+        debate_transcripts=dict(snap.get("debate_transcripts", {}) or {}),
+    )
+    log.info(
+        "seed-generation resume: hydrated state from %r checkpoint at %s "
+        "(candidates=%d survivors=%d completed_phases=%s)",
+        latest,
+        run_dir / "checkpoints" / f"{latest}.json",
+        len(state.candidates),
+        len(state.survivors),
+        state.completed_phases,
+    )
+    return state
+
+
+def resolve_resume_target(run_dir: Path) -> tuple[PipelineState, str | None]:
+    """One-call resolve — returns ``(hydrated_state, resume_from_phase)``.
+
+    ``resume_from_phase`` is ``None`` when every phase has a checkpoint
+    (run already complete); the CLI surfaces this case as exit-0 with
+    no Pipeline construction.
+    """
+    state = hydrate_state(run_dir)
+    next_phase = next_phase_to_run(run_dir)
+    return state, next_phase
+
+
+def _path_or_none(value: Any) -> Path | None:
+    if value in (None, ""):
+        return None
+    return Path(str(value))
+
+
+def _dict_or_none(value: Any) -> dict[str, float] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return {str(k): float(v) for k, v in value.items()}
+
+
+# Re-export _ITERATION_PHASE_ORDER for tests that assert symmetry with
+# the orchestrator's iteration cycle (iteration >= 1 doesn't take a
+# resume cursor — it's a fresh re-entry by design).
+__phase_orders__ = (_PHASE_ORDER, _ITERATION_PHASE_ORDER)
+
+
+def _ensure_phase_orders_consumed() -> None:
+    """No-op reference so the re-export stays detectable by linters."""
+    _ = __phase_orders__
+
+
+_ensure_phase_orders_consumed()

--- a/plugins/seed_generation/resume.py
+++ b/plugins/seed_generation/resume.py
@@ -23,7 +23,8 @@ Design — single-flight, append-only:
 Convergence basis: paperclip's ``loadOrCreateSession`` flow reads the
 session JSONL → rebuilds in-memory message history → resumes the
 next pending turn. We adapt this to GEODE's phase granularity
-(7 checkpoints per run × 1 file per phase = a far simpler index).
+(9 phases in ``_PHASE_ORDER`` × 1 file per phase = a far simpler
+index than per-event JSONL).
 """
 
 from __future__ import annotations

--- a/tests/core/agent/test_sub_agent_timeout_resolve.py
+++ b/tests/core/agent/test_sub_agent_timeout_resolve.py
@@ -1,0 +1,61 @@
+"""Pin :func:`core.agent.sub_agent._resolve_timeout_s` contract.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — wall-clock cap
+honors ``GEODE_SUBAGENT_TIMEOUT_S`` env (clamped ``[10, 3600]``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.sub_agent import _resolve_timeout_s
+
+
+def test_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_SUBAGENT_TIMEOUT_S", raising=False)
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_env_override_within_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "900")
+    assert _resolve_timeout_s(600.0) == pytest.approx(900.0)
+
+
+def test_env_override_clamped_to_lower(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "3")
+    assert _resolve_timeout_s(600.0) == pytest.approx(10.0)
+
+
+def test_env_override_clamped_to_upper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "100000")
+    assert _resolve_timeout_s(600.0) == pytest.approx(3600.0)
+
+
+def test_non_numeric_env_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "abc")
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_empty_env_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "   ")
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_sub_agent_manager_default_is_600_seconds() -> None:
+    """SubAgentManager.timeout_s default lifted from 120s (pre-S6) to
+    600s. PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25)."""
+    import inspect
+
+    from core.agent.sub_agent import SubAgentManager
+
+    sig = inspect.signature(SubAgentManager.__init__)
+    assert sig.parameters["timeout_s"].default == 600.0
+
+
+def test_worker_request_default_is_600_seconds() -> None:
+    """WorkerRequest.timeout_s default lifted from 120s (pre-S6) to 600s."""
+    import inspect
+
+    from core.agent.worker import WorkerRequest
+
+    sig = inspect.signature(WorkerRequest.__init__)
+    assert sig.parameters["timeout_s"].default == 600.0

--- a/tests/plugins/seed_generation/test_checkpointer.py
+++ b/tests/plugins/seed_generation/test_checkpointer.py
@@ -1,0 +1,139 @@
+"""Unit tests for :mod:`plugins.seed_generation.checkpointer`.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — pin the atomic
+write contract + the completed-phase ordering + the malformed-JSON
+tolerance so a future refactor cannot silently drop them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.checkpointer import (
+    CHECKPOINT_SUBDIR,
+    PhaseCheckpoint,
+    list_completed_phases,
+    load_checkpoint,
+    write_checkpoint,
+)
+
+
+def _make_snapshot(phase: str) -> dict[str, object]:
+    return {
+        "run_id": "gen1-broken_tool_use",
+        "target_dim": "broken_tool_use",
+        "gen_tag": "gen1",
+        "phase_marker": phase,
+        "candidates": [{"id": f"c-{phase}"}],
+    }
+
+
+def test_write_checkpoint_creates_atomic_file(tmp_path: Path) -> None:
+    target = write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1234.5,
+    )
+    assert target == tmp_path / CHECKPOINT_SUBDIR / "generator.json"
+    assert target.is_file()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["phase"] == "generator"
+    assert payload["duration_ms"] == pytest.approx(1234.5)
+    assert payload["state_snapshot"]["phase_marker"] == "generator"
+    assert payload["error"] is None
+
+
+def test_write_checkpoint_cleans_up_tmp_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """os.replace failure removes the temp file (no stale ``.tmp`` accumulator)."""
+    import os
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        write_checkpoint(
+            tmp_path,
+            phase="generator",
+            state_snapshot=_make_snapshot("generator"),
+            duration_ms=1.0,
+        )
+    leftovers = list((tmp_path / CHECKPOINT_SUBDIR).glob(".generator.*.tmp"))
+    assert leftovers == []
+
+
+def test_load_checkpoint_round_trip(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="critic",
+        state_snapshot=_make_snapshot("critic"),
+        duration_ms=42.0,
+    )
+    ck = load_checkpoint(tmp_path, "critic")
+    assert ck is not None
+    assert isinstance(ck, PhaseCheckpoint)
+    assert ck.phase == "critic"
+    assert ck.duration_ms == pytest.approx(42.0)
+    assert ck.state_snapshot["phase_marker"] == "critic"
+
+
+def test_load_checkpoint_missing_returns_none(tmp_path: Path) -> None:
+    assert load_checkpoint(tmp_path, "never_wrote") is None
+
+
+def test_load_checkpoint_malformed_returns_none(tmp_path: Path) -> None:
+    bad = tmp_path / CHECKPOINT_SUBDIR / "evolver.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{this is not json", encoding="utf-8")
+    assert load_checkpoint(tmp_path, "evolver") is None
+
+
+def test_load_checkpoint_non_dict_payload_returns_none(tmp_path: Path) -> None:
+    bad = tmp_path / CHECKPOINT_SUBDIR / "evolver.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text('["a", "b"]', encoding="utf-8")
+    assert load_checkpoint(tmp_path, "evolver") is None
+
+
+def test_list_completed_phases_ordered_by_completed_at(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="pilot",
+        state_snapshot=_make_snapshot("pilot"),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="critic",
+        state_snapshot=_make_snapshot("critic"),
+        duration_ms=1.0,
+    )
+    phases = list_completed_phases(tmp_path)
+    assert phases == ["pilot", "generator", "critic"]
+
+
+def test_list_completed_phases_skips_non_json_files(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1.0,
+    )
+    (tmp_path / CHECKPOINT_SUBDIR / "scratch.txt").write_text("ignore me")
+    phases = list_completed_phases(tmp_path)
+    assert phases == ["generator"]
+
+
+def test_list_completed_phases_empty_dir(tmp_path: Path) -> None:
+    assert list_completed_phases(tmp_path) == []

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -363,3 +363,36 @@ def test_orchestrator_emits_noop_outside_journal_scope() -> None:
     state = PipelineState(run_id="t-noscope", target_dim="x", gen_tag="gen2")
     # No run_transcript_scope active — must not raise.
     asyncio.run(Pipeline(state, registry).arun())
+
+
+def test_record_checkpoint_writes_per_phase_files(tmp_path) -> None:
+    """PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — every
+    completed phase writes ``<run_dir>/checkpoints/<phase>.json`` and
+    the on-disk snapshot's ``completed_phases`` includes the just-
+    completed phase (Codex MCP review fix — pre-fix the snapshot was
+    one phase behind the in-memory list)."""
+    import json as _json
+
+    registry, _ = _make_registry_with_all_stubs()
+    state = PipelineState(
+        run_id="t-ck", target_dim="broken_tool_use", gen_tag="gen2", run_dir=tmp_path
+    )
+    asyncio.run(Pipeline(state, registry).arun())
+
+    ck_dir = tmp_path / "checkpoints"
+    assert ck_dir.is_dir(), "checkpoints/ subdir must be created"
+    written_phases = {p.stem for p in ck_dir.glob("*.json")}
+    # ``supervisor`` + ``literature_review`` short-circuit when the role
+    # is not registered (no stub) so they shouldn't produce a
+    # checkpoint. Every other _PHASE_ORDER role IS registered.
+    expected = {"generator", "proximity", "critic", "pilot", "ranker", "evolver", "meta_reviewer"}
+    assert written_phases >= expected, f"missing checkpoints: {expected - written_phases}"
+
+    # state.completed_phases must reflect every written checkpoint.
+    assert set(state.completed_phases) >= expected
+
+    # Codex MCP fix: the on-disk snapshot for the LAST phase must
+    # already list that phase in ``completed_phases`` (append-before-
+    # serialize ordering).
+    meta_review_ck = _json.loads((ck_dir / "meta_reviewer.json").read_text())
+    assert "meta_reviewer" in meta_review_ck["state_snapshot"]["completed_phases"]

--- a/tests/plugins/seed_generation/test_resume.py
+++ b/tests/plugins/seed_generation/test_resume.py
@@ -1,0 +1,162 @@
+"""Unit tests for :mod:`plugins.seed_generation.resume`.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — pin the hydration
++ next-phase contract so a future change to ``PipelineState`` or
+``_PHASE_ORDER`` cannot silently break ``audit-seeds resume <run_id>``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.checkpointer import write_checkpoint
+from plugins.seed_generation.orchestrator import _PHASE_ORDER
+from plugins.seed_generation.resume import (
+    ResumeError,
+    hydrate_state,
+    next_phase_to_run,
+    resolve_resume_target,
+)
+
+
+def _full_snapshot(*, completed_phases: list[str]) -> dict[str, object]:
+    return {
+        "run_id": "gen1-broken_tool_use",
+        "target_dim": "broken_tool_use",
+        "gen_tag": "gen1",
+        "candidates_requested": 10,
+        "max_iterations": 0,
+        "current_iteration": 0,
+        "completed_phases": completed_phases,
+        "candidates": [{"id": "c-1"}, {"id": "c-2"}],
+        "reflections": {"c-1": {"role": "critic"}},
+        "pilot_scores": {},
+        "elo_ratings": {},
+        "survivors": [],
+        "evolved_candidates": [],
+        "meta_review": {},
+        "similarity_clusters": [],
+        "removed_duplicates": [],
+        "usd_spent": 0.42,
+        "prompt_tokens": 1000,
+        "completion_tokens": 200,
+        "supervisor_guidance": {"phase_guidance": {"generation": "focus on edge"}},
+        "articles_with_reasoning": "",
+        "literature_snapshots": {},
+        "debate_transcripts": {},
+        "pareto_mode": False,
+        "target_dims_attribution": [],
+        "cohort": "petri_17dim",
+    }
+
+
+def test_next_phase_to_run_with_no_checkpoints(tmp_path: Path) -> None:
+    assert next_phase_to_run(tmp_path) == _PHASE_ORDER[0]
+
+
+def test_next_phase_to_run_after_generator(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor", "literature_review"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_full_snapshot(
+            completed_phases=["supervisor", "literature_review", "generator"]
+        ),
+        duration_ms=1.0,
+    )
+    # next phase = proximity (the first phase with no checkpoint)
+    assert next_phase_to_run(tmp_path) == "proximity"
+
+
+def test_next_phase_to_run_all_complete(tmp_path: Path) -> None:
+    for phase in _PHASE_ORDER:
+        write_checkpoint(
+            tmp_path,
+            phase=phase,
+            state_snapshot=_full_snapshot(completed_phases=list(_PHASE_ORDER)),
+            duration_ms=1.0,
+        )
+    assert next_phase_to_run(tmp_path) is None
+
+
+def test_hydrate_state_round_trip(tmp_path: Path) -> None:
+    snap = _full_snapshot(completed_phases=["supervisor", "literature_review"])
+    snap["run_dir"] = str(tmp_path)
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=snap,
+        duration_ms=42.0,
+    )
+    state = hydrate_state(tmp_path)
+    assert state.run_id == "gen1-broken_tool_use"
+    assert state.target_dim == "broken_tool_use"
+    assert state.gen_tag == "gen1"
+    assert state.candidates_requested == 10
+    assert state.completed_phases == ["supervisor", "literature_review"]
+    assert len(state.candidates) == 2
+    assert state.usd_spent == pytest.approx(0.42)
+    assert state.supervisor_guidance["phase_guidance"]["generation"] == "focus on edge"
+    assert state.run_dir == tmp_path
+
+
+def test_hydrate_state_uses_latest_checkpoint(tmp_path: Path) -> None:
+    # Earlier checkpoint says only supervisor done; later checkpoint says
+    # supervisor + literature_review done. Hydration must read the LATEST
+    # (literature_review) — completed_phases reflects the 2-phase state.
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor", "literature_review"]),
+        duration_ms=1.0,
+    )
+    state = hydrate_state(tmp_path)
+    assert state.completed_phases == ["supervisor", "literature_review"]
+
+
+def test_hydrate_state_no_checkpoints_raises(tmp_path: Path) -> None:
+    with pytest.raises(ResumeError, match="nothing to resume"):
+        hydrate_state(tmp_path)
+
+
+def test_hydrate_state_missing_identity_fields_raises(tmp_path: Path) -> None:
+    snap = _full_snapshot(completed_phases=["supervisor"])
+    snap.pop("run_id")
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=snap,
+        duration_ms=1.0,
+    )
+    with pytest.raises(ResumeError, match="missing identity fields"):
+        hydrate_state(tmp_path)
+
+
+def test_resolve_resume_target_returns_state_and_phase(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    state, next_phase = resolve_resume_target(tmp_path)
+    assert state.run_id == "gen1-broken_tool_use"
+    assert next_phase == "literature_review"

--- a/tests/plugins/seed_generation/test_resume.py
+++ b/tests/plugins/seed_generation/test_resume.py
@@ -150,6 +150,68 @@ def test_hydrate_state_missing_identity_fields_raises(tmp_path: Path) -> None:
         hydrate_state(tmp_path)
 
 
+def test_state_to_json_includes_g4_g5_attribution_fields() -> None:
+    """Codex MCP review fix: ``_state_to_json`` must persist
+    ``target_dims_attribution`` + ``pareto_mode`` so the resumed
+    evolver's HANDOFF pareto-front embedding stays identical to the
+    pre-checkpoint run.
+    """
+    import json as _json
+
+    from plugins.seed_generation.orchestrator import PipelineState, _state_to_json
+
+    state = PipelineState(
+        run_id="gen1-broken_tool_use",
+        target_dim="broken_tool_use",
+        gen_tag="gen1",
+        target_dims_attribution=["broken_tool_use", "deception_toward_user"],
+        pareto_mode=True,
+    )
+    payload = _json.loads(_state_to_json(state))
+    assert payload["target_dims_attribution"] == [
+        "broken_tool_use",
+        "deception_toward_user",
+    ]
+    assert payload["pareto_mode"] is True
+
+
+def test_state_to_json_round_trip_through_hydrate(tmp_path: Path) -> None:
+    """Codex MCP review fix: every field that ``_state_to_json``
+    persists must round-trip through ``hydrate_state``. This pins
+    the writer ↔ reader parity so a future addition to either side
+    cannot silently drop a field on resume.
+    """
+    import json as _json
+
+    from plugins.seed_generation.checkpointer import write_checkpoint
+    from plugins.seed_generation.orchestrator import PipelineState, _state_to_json
+
+    original = PipelineState(
+        run_id="gen1-broken_tool_use",
+        target_dim="broken_tool_use",
+        gen_tag="gen1",
+        target_dims_attribution=["broken_tool_use"],
+        pareto_mode=True,
+        candidates_requested=12,
+        candidates=[{"id": "c-1"}],
+        completed_phases=["supervisor"],
+        run_dir=tmp_path,
+    )
+    snapshot = _json.loads(_state_to_json(original))
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=snapshot,
+        duration_ms=1.0,
+    )
+    rehydrated = hydrate_state(tmp_path)
+    assert rehydrated.target_dims_attribution == ["broken_tool_use"]
+    assert rehydrated.pareto_mode is True
+    assert rehydrated.candidates_requested == 12
+    assert rehydrated.completed_phases == ["supervisor"]
+    assert len(rehydrated.candidates) == 1
+
+
 def test_resolve_resume_target_returns_state_and_phase(tmp_path: Path) -> None:
     write_checkpoint(
         tmp_path,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -43,7 +43,10 @@ class TestWorkerRequest:
         req = WorkerRequest.from_dict({"task_id": "t-002"})
         assert req.model == "claude-opus-4-6"
         assert req.provider == "anthropic"
-        assert req.timeout_s == 120.0
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — default
+        # wall-clock cap lifted 120s → 600s. Operator overrides via
+        # GEODE_SUBAGENT_TIMEOUT_S env or per-request payload.
+        assert req.timeout_s == 600.0
         assert req.denied_tools == []
         assert req.isolation == ""
 


### PR DESCRIPTION
## Summary
- **S5 — per-phase recovery**: new `plugins/seed_generation/checkpointer.py` writes atomic `<run_dir>/checkpoints/<phase>.json` after each successful phase; `plugins/seed_generation/resume.py` + `geode audit-seeds resume <run_id>` CLI rehydrate `PipelineState` and continue from the first phase without an on-disk record.
- **S6 — wall-clock cap**: `SubAgentManager.timeout_s` default 120 → 600 with new `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`); `WorkerRequest.timeout_s` mirrors the bump; `plan.decompose` 60 → 180 so multi-tool plan calls under load don't trip the inner cap.
- **Why now**: smoke-16 evolver aborted at 122s wall-time on `plan.decompose_async` with the legacy 60s default; "termination_reason=natural" label was misleading. Per-phase checkpoint lets a resume continue without paying for completed phases again.

## Why
The seed-generation pipeline ran for ~30 minutes before the evolver phase died from `asyncio.exceptions.CancelledError → TimeoutError` on `core/agent/plan.py:721 decompose_async`. The pipeline had no checkpoint, so the next invocation re-ran every phase from scratch ($$+wall-clock cost). The 120s `SubAgentManager.timeout_s` default also clipped opus-class generations at the claude-binary-spawn + OAuth + first-token latency boundary under contention.

Convergence basis (plan §5.3 + §6):
- **paperclip** persists per-event JSONL in `~/.claude/projects/<hash>/<session>.jsonl`; resume re-streams events by `session_id`. Adapted to phase granularity here (8 phases × 1 file vs hundreds of events).
- **LangGraph SqliteSaver** keys checkpoints by `thread_id` + `checkpoint_id` with per-node granularity. `run_id` is the natural `thread_id`; phases are the natural nodes.
- **openclaw** per-agent-run wall-clock timeout (48h default, `agents/timeout.ts:3`) — wall-clock cap > turn cap convergence.
- **hermes** `IterationBudget` (50 turns/sub-agent default) — pairs the wall-clock with a turn budget; we keep `max_rounds=0` (unlimited) and rely on the wall-clock cap alone for now.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/checkpointer.py` | New: `PhaseCheckpoint` + `write_checkpoint` (atomic via `os.replace`) + `load_checkpoint` + `list_completed_phases`. |
| `plugins/seed_generation/resume.py` | New: `hydrate_state` + `next_phase_to_run` + `resolve_resume_target` from the latest checkpoint. |
| `plugins/seed_generation/orchestrator.py` | `PipelineState.completed_phases` field; `_state_to_json` persists it; `_record_checkpoint` called after each phase; `Pipeline.arun(resume_from_phase=...)` skips already-completed iteration-0 phases. |
| `plugins/seed_generation/cli.py` | New `audit-seeds resume <run_id>` command + `run_audit_seeds_resume` + `_dispatch_pipeline_resume` (skips cost/pre-flight gates since the run was past those). |
| `core/agent/sub_agent.py` | `SubAgentManager.timeout_s` default 120 → 600; new `_resolve_timeout_s` helper for `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`). |
| `core/agent/worker.py` | `WorkerRequest.timeout_s` default + `from_dict` fallback both 120 → 600. |
| `core/agent/plan.py` | `_DECOMPOSE_CALL_TIMEOUT_S` 60 → 180. |
| `tests/plugins/seed_generation/test_checkpointer.py` | New: atomic write, malformed-JSON tolerance, completed-phase ordering (8 tests). |
| `tests/plugins/seed_generation/test_resume.py` | New: hydrate round-trip, latest-checkpoint preference, identity-field guard, next-phase computation (7 tests). |
| `tests/core/agent/test_sub_agent_timeout_resolve.py` | New: env override clamp, default-value pin for `SubAgentManager` + `WorkerRequest` (7 tests). |
| `tests/test_worker.py` | Updated default-value assertion 120 → 600 with rationale comment. |
| `CHANGELOG.md` | Added PR-CHECKPOINT-RESUME-TIMEBUDGET entry under `[Unreleased]`. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Checkpoint writer (atomic) | Implemented | `write_checkpoint` uses `tempfile.mkstemp` + `os.replace`; failure cleans up tmp via `contextlib.suppress`. |
| Resume hydrate | Implemented | `hydrate_state` reads latest checkpoint by `completed_at`; guards missing identity fields. |
| Resume CLI command | Implemented | `geode audit-seeds resume <run_id>` registered; help text confirms. |
| Orchestrator wire-through | Implemented | `Pipeline.arun(resume_from_phase=...)` + `_record_checkpoint` per phase. |
| `GEODE_SUBAGENT_TIMEOUT_S` env override | Implemented | `_resolve_timeout_s` clamp `[10, 3600]`; non-numeric falls through. |
| `plan.decompose` 180s | Implemented | `_DECOMPOSE_CALL_TIMEOUT_S = 180.0` (was 60.0). |
| `WorkerRequest.timeout_s` mirror | Implemented | Default + `from_dict` fallback both 600s. |
| Codex MCP cross-LLM verify | Deferred to post-merge | Will run on the merged commit before smoke 17. |

## Verification
- [x] `uv run ruff check plugins/seed_generation/ core/agent/ tests/plugins/seed_generation/ tests/core/agent/` → all checks passed
- [x] `uv run ruff format --check` → clean (2 files reformatted in-PR)
- [x] `uv run mypy plugins/seed_generation/ core/agent/{sub_agent,worker,plan}.py` → Success: no issues found
- [x] `uv run lint-imports` → 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/ -m "not live" --deselect tests/test_seed_eval_export.py` → **7701 passed, 59 skipped** (`test_seed_eval_export` deselect: pre-existing `inspect_ai` missing-module failure, unrelated)
- [x] `uv run geode version` → `GEODE v0.99.59`
- [x] `uv run geode audit-seeds --help` → `resume` subcommand registered

## Reference
- Plan SoT: `docs/plans/2026-05-25-structured-output-3-axis-fix.md` §5 (checkpointer convergence) + §6 (time-budget convergence)
- Smoke 16 stderr.log: `state/seed-generation/<run_id>/sub_agents/.../stderr.log` (evolver `asyncio.CancelledError` → `plan.py:721 decompose_async` → `TimeoutError`)
- Frontier refs: paperclip `loadOrCreateSession`, LangGraph `SqliteSaver`, openclaw `agents/timeout.ts:3`, hermes `IterationBudget`

🤖 Generated with [Claude Code](https://claude.com/claude-code)