### PR TITLE
feat(self-improving-loop): C.6 cross-run SoT 3중첩 unification (PR-26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
+  `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
+### Added
 - **PR-25 A.4 GEPA Pareto sampler helper** —
   `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —

--- a/core/self_improving_loop/cross_run_join.py
+++ b/core/self_improving_loop/cross_run_join.py
@@ -1,0 +1,124 @@
+"""C.6 (2026-05-25) — cross-run SoT 3중첩 unification (PR-26).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` F1 — 3 SoT
+(``latest_pointer.json`` / ``MetaReviewSnapshot`` / ``sessions.jsonl``)
+의 cross-ref key (run_id + gen_tag) 가 각자 다른 reader 로 접근. PR-22
+가 invariant test 만 추가 (schema parity pin). C.6 는 그 다음 단계 —
+**한 dataclass + 단일 reader** 로 unification.
+
+본 module = **selection-only helper**:
+
+- :class:`CrossRunJoinKey` — Pydantic schema, 3 SoT 의 공통 join key
+- :func:`load_cross_run_join_key()` — latest_pointer.json 으로부터
+  추출. file 부재/malformed → None (graceful).
+- :func:`keys_match(a, b)` — run_id + gen_tag 모두 일치 시 True.
+- :func:`compose_history_view(key, sessions_iter)` — sessions.jsonl
+  iterator 에서 key 일치 row 만 필터.
+
+3 SoT 의 join 책임을 한 곳에 모음 — caller 가 lookup 위치 모르거나
+schema 변경 시 한 곳만 update.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CrossRunJoinKey(BaseModel):
+    """3 SoT 의 공통 cross-ref key.
+
+    ``run_id`` + ``gen_tag`` pair 가 unique join anchor. 같은 ``run_id``
+    의 다른 ``gen_tag`` (예: rerun) 는 별 row.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    run_id: str
+    gen_tag: str
+    source_label: str = ""
+    """어느 SoT 에서 추출됐는지 — ``latest_pointer`` / ``sessions`` /
+    ``meta_review`` 중 하나. drift detection 시 출처 추적용."""
+
+
+def load_cross_run_join_key(
+    latest_pointer_path: Path | None = None,
+) -> CrossRunJoinKey | None:
+    """Load the current cross-run join key from ``latest_pointer.json``.
+
+    Returns ``None`` when:
+
+    - The pointer file is missing (fresh repo / no run yet).
+    - The pointer JSON is malformed.
+    - The pointer payload lacks ``run_id`` or ``gen_tag``.
+
+    Caller can use this key to look up matching rows in
+    ``sessions.jsonl`` or ``meta_review`` snapshots.
+    """
+    from core.paths import read_latest_pointer
+
+    if latest_pointer_path is not None:
+        # Test injection — read directly from the provided path
+        import json as _json
+
+        if not latest_pointer_path.is_file():
+            return None
+        try:
+            payload = _json.loads(latest_pointer_path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError):
+            return None
+    else:
+        payload = read_latest_pointer()
+
+    if not isinstance(payload, dict):
+        return None
+    run_id = payload.get("run_id")
+    gen_tag = payload.get("gen_tag")
+    if not isinstance(run_id, str) or not isinstance(gen_tag, str):
+        return None
+    return CrossRunJoinKey(run_id=run_id, gen_tag=gen_tag, source_label="latest_pointer")
+
+
+def keys_match(a: CrossRunJoinKey | None, b: CrossRunJoinKey | None) -> bool:
+    """Two keys match when both run_id and gen_tag are equal.
+
+    ``None`` on either side → False (no signal). source_label is
+    ignored — keys from different SoTs match by value.
+    """
+    if a is None or b is None:
+        return False
+    return a.run_id == b.run_id and a.gen_tag == b.gen_tag
+
+
+def compose_history_view(
+    key: CrossRunJoinKey,
+    rows: Iterable[Any],
+) -> Iterator[dict[str, Any]]:
+    """Filter an iterable of session/meta-review rows to those matching
+    ``key`` (same run_id + gen_tag).
+
+    Each row must be a dict with ``run_id`` and ``gen_tag`` string
+    values; rows that are non-dict or missing either field are skipped
+    silently (forward-compat: older rows may lack one of the two
+    fields; defensive against malformed iterables).
+    """
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_run_id = row.get("run_id")
+        row_gen_tag = row.get("gen_tag")
+        if not isinstance(row_run_id, str) or not isinstance(row_gen_tag, str):
+            continue
+        if row_run_id == key.run_id and row_gen_tag == key.gen_tag:
+            yield row
+
+
+__all__ = [
+    "CrossRunJoinKey",
+    "compose_history_view",
+    "keys_match",
+    "load_cross_run_join_key",
+]

--- a/tests/core/self_improving_loop/test_cross_run_join.py
+++ b/tests/core/self_improving_loop/test_cross_run_join.py
@@ -1,0 +1,189 @@
+"""C.6 (2026-05-25) — cross-run SoT 3중첩 unification invariants (PR-26)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.self_improving_loop.cross_run_join import (
+    CrossRunJoinKey,
+    compose_history_view,
+    keys_match,
+    load_cross_run_join_key,
+)
+
+# ---------------------------------------------------------------------------
+# 1. CrossRunJoinKey — schema
+# ---------------------------------------------------------------------------
+
+
+def test_key_minimal_construction() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert key.run_id == "r1"
+    assert key.gen_tag == "g1"
+    assert key.source_label == ""  # default
+
+
+def test_key_with_source_label() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="latest_pointer")
+    assert key.source_label == "latest_pointer"
+
+
+def test_key_is_frozen() -> None:
+    """Pydantic frozen=True — immutable after construction."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    import pytest
+
+    with pytest.raises(Exception):  # ValidationError
+        key.run_id = "r2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. load_cross_run_join_key — latest_pointer reader
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_pointer_returns_none(tmp_path: Path) -> None:
+    missing = tmp_path / "latest_pointer.json"
+    assert load_cross_run_join_key(missing) is None
+
+
+def test_load_valid_pointer_returns_key(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(
+        json.dumps({"version": 1, "run_id": "2026-05-25", "gen_tag": "g7"}),
+        encoding="utf-8",
+    )
+    key = load_cross_run_join_key(pointer)
+    assert key is not None
+    assert key.run_id == "2026-05-25"
+    assert key.gen_tag == "g7"
+    assert key.source_label == "latest_pointer"
+
+
+def test_load_malformed_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text("not json {", encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_missing_run_id_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps({"gen_tag": "g1"}), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_missing_gen_tag_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps({"run_id": "r1"}), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_non_dict_payload_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. keys_match
+# ---------------------------------------------------------------------------
+
+
+def test_keys_match_identical() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="A")
+    b = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="B")
+    assert keys_match(a, b) is True
+
+
+def test_keys_match_different_run_id() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    b = CrossRunJoinKey(run_id="r2", gen_tag="g1")
+    assert keys_match(a, b) is False
+
+
+def test_keys_match_different_gen_tag() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    b = CrossRunJoinKey(run_id="r1", gen_tag="g2")
+    assert keys_match(a, b) is False
+
+
+def test_keys_match_none_returns_false() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert keys_match(a, None) is False
+    assert keys_match(None, a) is False
+    assert keys_match(None, None) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. compose_history_view
+# ---------------------------------------------------------------------------
+
+
+def test_compose_history_filters_matching_rows() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1", "data": "A"},  # match
+        {"run_id": "r2", "gen_tag": "g1", "data": "B"},  # different run_id
+        {"run_id": "r1", "gen_tag": "g2", "data": "C"},  # different gen_tag
+        {"run_id": "r1", "gen_tag": "g1", "data": "D"},  # match
+    ]
+    result = list(compose_history_view(key, rows))
+    assert len(result) == 2
+    assert [r["data"] for r in result] == ["A", "D"]
+
+
+def test_compose_history_empty_iterator() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert list(compose_history_view(key, [])) == []
+
+
+def test_compose_history_skips_rows_missing_keys() -> None:
+    """Rows lacking run_id or gen_tag → skip (forward-compat)."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1"},  # match
+        {"run_id": "r1"},  # missing gen_tag
+        {"gen_tag": "g1"},  # missing run_id
+        {"unrelated": "x"},  # neither
+    ]
+    result = list(compose_history_view(key, rows))
+    assert len(result) == 1
+
+
+def test_compose_history_skips_non_dict_rows() -> None:
+    """Non-dict items in iterator → skip (defensive)."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1"},
+        "not a dict",  # type: ignore[list-item]
+        ["also not a dict"],
+        None,
+    ]
+    result = list(compose_history_view(key, rows))  # type: ignore[arg-type]
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. End-to-end — latest_pointer → join key → history filter
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_pointer_to_history_filter(tmp_path: Path) -> None:
+    """latest_pointer.json 의 key 로 sessions.jsonl iterator 필터."""
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(
+        json.dumps({"version": 1, "run_id": "R-9", "gen_tag": "G-3"}),
+        encoding="utf-8",
+    )
+    key = load_cross_run_join_key(pointer)
+    assert key is not None
+
+    sessions = [
+        {"run_id": "R-9", "gen_tag": "G-3", "row": 0},
+        {"run_id": "R-9", "gen_tag": "G-2", "row": 1},
+        {"run_id": "R-8", "gen_tag": "G-3", "row": 2},
+        {"run_id": "R-9", "gen_tag": "G-3", "row": 3},
+    ]
+    matched = list(compose_history_view(key, sessions))
+    assert [r["row"] for r in matched] == [0, 3]


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/cross_run_join.py` — 3 SoT 의 cross-ref key 통합 helper.
- CrossRunJoinKey (Pydantic frozen) + load / match / compose pure functions.

## Why
F1 (memory `project_autoresearch_fragmentation_audit.md`) — 3 SoT 의 cross-ref reader 분산. PR-22 invariant pin 후 단계 — unification helper.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/cross_run_join.py` | 신규 — CrossRunJoinKey + load_cross_run_join_key + keys_match + compose_history_view |
| `tests/core/self_improving_loop/test_cross_run_join.py` | 신규 — 18 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 18 new pass

## Reference
- Memory: `project_autoresearch_fragmentation_audit.md` F1
- Prereq: PR-22 (#1677) F1 invariant pin