### PR TITLE
feat(self-improving-loop): C.7 unified MutatorContextView (PR-27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-27 C.7 unified MutatorContextView** —
+  `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
+### Added
 - **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
   `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
 ### Added

--- a/core/self_improving_loop/mutator_context_view.py
+++ b/core/self_improving_loop/mutator_context_view.py
@@ -1,0 +1,120 @@
+"""C.7 (2026-05-25) — unified mutator context view (PR-27).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` F2 — mutator
+context 가 5+ source 에 분산 (baseline_snapshot / kind-policy snapshots /
+program.md / meta_review / mutations history). PR-12 ``mutations_reader``
+이 history 표면화, PR-26 ``cross_run_join`` 이 cross-run key 통합.
+C.7 는 그 위 layer — **하나의 view dataclass + composition helper**.
+
+본 module = **read-side composition** (write-side 영향 X):
+
+- :class:`MutatorContextView` — Pydantic snapshot 의 5+ source 합본
+- :func:`compose_mutator_context_view(...)` — 5 source 가 각자 추출된
+  optional Any 를 받아 dataclass instance 로 packing
+- :func:`source_count(view)` — non-None source count (운영자 진단 metric)
+
+caller (runner.py 의 build_runner_context) 가 이 view 를 단일 객체로
+들고 다닐 수 있어 5+ field 풀이 사라짐. wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MutatorContextView(BaseModel):
+    """5+ source 의 합본 view.
+
+    각 field 가 ``None`` 이면 그 source 가 부재 (bootstrap / pre-feature
+    runs). caller 가 None 체크로 graceful 분기.
+
+    ``extra="allow"`` 라 신규 source 추가 시 본 schema 변경 없이 forward-
+    compat dict field 로 받음 — but 명시적 field 가 grep-able 이라 우선.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    baseline_snapshot: Any = None
+    """BaselineSnapshot — plugins.seed_generation.baseline_reader.
+    last successful audit 의 dim_means / dim_stderr / metadata."""
+
+    policy_snapshots: dict[str, Any] = Field(default_factory=dict)
+    """5 kind policy snapshots — {kind_name: policy_payload}.
+    tool_policy / decomposition / reflection / skill_catalog /
+    agent_contract. 5 kind 각각 disk file 또는 fallback."""
+
+    program_md: str = ""
+    """autoresearch/program.md content (raw). mutator 가 frontier
+    convention reference 로 사용."""
+
+    meta_review_snapshot: Any = None
+    """MetaReviewSnapshot — plugins.seed_generation.baseline_reader.
+    cross-run priors. bootstrap 시 None."""
+
+    recent_mutations: list[Any] = Field(default_factory=list)
+    """PR-12 mutations_reader 결과 — last N apply rows (history).
+    mutator 가 self-repetition 회피용 참조."""
+
+    cross_run_key: Any = None
+    """PR-26 CrossRunJoinKey — 현재 cycle 의 run_id + gen_tag.
+    cross-run audit join 의 anchor. bootstrap 시 None."""
+
+
+def compose_mutator_context_view(
+    *,
+    baseline_snapshot: Any = None,
+    policy_snapshots: dict[str, Any] | None = None,
+    program_md: str = "",
+    meta_review_snapshot: Any = None,
+    recent_mutations: list[Any] | None = None,
+    cross_run_key: Any = None,
+) -> MutatorContextView:
+    """Pack 5+ source into a single immutable view.
+
+    Caller does the actual source loading (each source has its own
+    reader); this helper just composes the result. Defaults match
+    "source absent" semantics so a bootstrap caller can pass only
+    what it has.
+    """
+    return MutatorContextView(
+        baseline_snapshot=baseline_snapshot,
+        policy_snapshots=policy_snapshots or {},
+        program_md=program_md,
+        meta_review_snapshot=meta_review_snapshot,
+        recent_mutations=recent_mutations or [],
+        cross_run_key=cross_run_key,
+    )
+
+
+def source_count(view: MutatorContextView) -> int:
+    """Return the count of non-empty source fields — operator metric.
+
+    Counts a source as "present" when:
+    - baseline_snapshot / meta_review_snapshot / cross_run_key: non-None
+    - policy_snapshots: non-empty dict
+    - program_md: non-empty string
+    - recent_mutations: non-empty list
+    """
+    count = 0
+    if view.baseline_snapshot is not None:
+        count += 1
+    if view.policy_snapshots:
+        count += 1
+    if view.program_md:
+        count += 1
+    if view.meta_review_snapshot is not None:
+        count += 1
+    if view.recent_mutations:
+        count += 1
+    if view.cross_run_key is not None:
+        count += 1
+    return count
+
+
+__all__ = [
+    "MutatorContextView",
+    "compose_mutator_context_view",
+    "source_count",
+]

--- a/tests/core/self_improving_loop/test_mutator_context_view.py
+++ b/tests/core/self_improving_loop/test_mutator_context_view.py
@@ -1,0 +1,132 @@
+"""C.7 (2026-05-25) — MutatorContextView invariants (PR-27)."""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.mutator_context_view import (
+    MutatorContextView,
+    compose_mutator_context_view,
+    source_count,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Default construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_view_all_empty() -> None:
+    view = MutatorContextView()
+    assert view.baseline_snapshot is None
+    assert view.policy_snapshots == {}
+    assert view.program_md == ""
+    assert view.meta_review_snapshot is None
+    assert view.recent_mutations == []
+    assert view.cross_run_key is None
+
+
+def test_default_view_is_frozen() -> None:
+    view = MutatorContextView()
+    with pytest.raises(Exception):  # ValidationError on frozen
+        view.program_md = "x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. compose_mutator_context_view
+# ---------------------------------------------------------------------------
+
+
+def test_compose_with_no_args_returns_empty_view() -> None:
+    view = compose_mutator_context_view()
+    assert source_count(view) == 0
+
+
+def test_compose_with_baseline_only() -> None:
+    view = compose_mutator_context_view(baseline_snapshot={"dim": 1})
+    assert view.baseline_snapshot == {"dim": 1}
+    assert source_count(view) == 1
+
+
+def test_compose_with_all_sources() -> None:
+    view = compose_mutator_context_view(
+        baseline_snapshot={"x": 1},
+        policy_snapshots={"prompt": "y"},
+        program_md="frontier rules",
+        meta_review_snapshot={"meta": True},
+        recent_mutations=[{"mut": 1}],
+        cross_run_key={"run_id": "r1"},
+    )
+    assert source_count(view) == 6
+
+
+def test_compose_policy_snapshots_default_empty() -> None:
+    """policy_snapshots=None → {} (graceful)."""
+    view = compose_mutator_context_view(policy_snapshots=None)
+    assert view.policy_snapshots == {}
+
+
+def test_compose_recent_mutations_default_empty() -> None:
+    view = compose_mutator_context_view(recent_mutations=None)
+    assert view.recent_mutations == []
+
+
+# ---------------------------------------------------------------------------
+# 3. source_count
+# ---------------------------------------------------------------------------
+
+
+def test_source_count_empty_view() -> None:
+    assert source_count(MutatorContextView()) == 0
+
+
+def test_source_count_only_baseline() -> None:
+    view = MutatorContextView(baseline_snapshot="x")
+    assert source_count(view) == 1
+
+
+def test_source_count_only_program_md() -> None:
+    view = MutatorContextView(program_md="content")
+    assert source_count(view) == 1
+
+
+def test_source_count_empty_program_md_not_counted() -> None:
+    """program_md="" → not counted (empty string falsy)."""
+    view = MutatorContextView(program_md="")
+    assert source_count(view) == 0
+
+
+def test_source_count_empty_dict_not_counted() -> None:
+    """policy_snapshots={} → not counted."""
+    view = MutatorContextView(policy_snapshots={})
+    assert source_count(view) == 0
+
+
+def test_source_count_empty_list_not_counted() -> None:
+    """recent_mutations=[] → not counted."""
+    view = MutatorContextView(recent_mutations=[])
+    assert source_count(view) == 0
+
+
+def test_source_count_all_max() -> None:
+    """All 6 sources populated → count 6."""
+    view = MutatorContextView(
+        baseline_snapshot="a",
+        policy_snapshots={"k": "v"},
+        program_md="md",
+        meta_review_snapshot={"m": 1},
+        recent_mutations=[1],
+        cross_run_key={"k": "v"},
+    )
+    assert source_count(view) == 6
+
+
+# ---------------------------------------------------------------------------
+# 4. extra="allow" forward-compat
+# ---------------------------------------------------------------------------
+
+
+def test_extra_allow_accepts_future_fields() -> None:
+    """신규 source field 추가 시 schema 변경 없이 forward-compat."""
+    view = MutatorContextView(future_source="new")  # type: ignore[call-arg]
+    # extra="allow" → extra field stored under model_extra
+    assert view.model_extra is not None
+    assert view.model_extra.get("future_source") == "new"


### PR DESCRIPTION
## Summary
- 신규 `core/self_improving_loop/mutator_context_view.py` — 6 source slot (baseline / policy / program / meta_review / recent_mutations / cross_run_key) Pydantic view.
- F2 fragmentation signal 해소 — read-side unification helper.

## Why
Memory `project_autoresearch_fragmentation_audit.md` F2. PR-12/PR-26 가 individual reader 통합. C.7 가 view-level composition.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/mutator_context_view.py` | 신규 — view + compose + source_count |
| `tests/core/self_improving_loop/test_mutator_context_view.py` | 신규 — 15 invariants |
| `CHANGELOG.md` | Unreleased entry |

## Verification
- [x] ruff + format + mypy clean (CI parity)
- [x] 15 new pass

## Reference
- Memory: F2 fragmentation; Prereq: PR-12, PR-26