### PR TITLE
release: v0.99.60 — self-improving-loop 전소 sprint bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.60] - 2026-05-25
+
+Sprint bundle closing the 전소 self-improving-loop backlog: PR-20 (A.6 CRM causal_hypothesis) + PR-21 (A.8 sub_agent_slice) + PR-22 (B.4 F1 cross-run SoT invariants) + PR-23 (A.2 Tchebycheff) + PR-24 (A.3 MAP-Elites) + PR-25 (A.4 GEPA sampler) + PR-26 (C.6 cross-run SoT unification) + PR-27 (C.7 unified MutatorContextView) + PR-CHECKPOINT-RESUME-TIMEBUDGET (seed-gen per-phase checkpoint + 600s wall-clock) + PR-28 (C.8 silent fallback STRICT mode parity invariants). 9 fragmentation-audit signals closed, Codex MCP catches averaged 1.6/PR.
+
 ### Added
 - **PR-28 C.8 silent fallback STRICT mode parity invariants** —
   `tests/core/self_improving_loop/test_strict_mode_parity.py` pins the
@@ -65,7 +69,6 @@ functional change.
   future kind addition that forgets STRICT trips the pairing
   invariant. Memory `project_autoresearch_fragmentation_audit.md` F5
   closed.
-### Added
 - **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + lifted
   sub-agent wall-clock defaults.** `plugins/seed_generation/checkpointer.py`
   writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-
@@ -89,10 +92,8 @@ functional change.
   §5 + §6.
 - **PR-27 C.7 unified MutatorContextView** —
   `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
-### Added
 - **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
   `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
-### Added
 - **PR-25 A.4 GEPA Pareto sampler helper** —
   `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.59
+- **Version**: 0.99.60
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.59 — Long-running Autonomous Execution Harness
+# GEODE v0.99.60 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.59**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.60**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.59 — Long-running Autonomous Execution Harness
+# GEODE v0.99.60 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.59**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.60**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.59"
+version = "0.99.60"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.59"
+version = "0.99.60"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bundle stamp for the 전소 self-improving-loop sprint (10 PR — PR-20 ~ PR-28 + PR-CHECKPOINT-RESUME-TIMEBUDGET).
- 5-location version stamp (pyproject.toml, CLAUDE.md, README.md, README.ko.md, CHANGELOG.md) to 0.99.60.
- CHANGELOG section retitled to `[0.99.60] - 2026-05-25` with sprint summary header; duplicate sequential-merge `### Added` separators collapsed.

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] 5 version stamps verified (`grep -c 0.99.60` returns expected counts)
- [x] CI will rerun the full suite