### PR TITLE
release: develop → main pass-through (v0.99.60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-20 A.6 CRM causal_hypothesis field** —
+  `Mutation` dataclass + `ApplyRecord` Pydantic schema +
+  `parse_mutation` + `to_audit_row` 가 새로운 optional
+  `causal_hypothesis` field (max 500 chars) 를 cover. mutator 가
+  mutation 직전 명시한 인과사슬 — "dim X 의 Y 효과 → fitness Z 변화"
+  — 가 mutations.jsonl 의 apply row 에 emit 되어 post-audit
+  observed_dim 과 cross-check 가능 (별도 wiring 은 follow-up).
+  principle (SPCT) 이 judging criterion 이라면 causal_hypothesis 는
+  causal trace — 두 field 는 독립적, 둘 다 emit 가능. Legacy mutator
+  (key 미포함) → 빈 문자열 → row column 미생성. Frontier: CRM
+  (Conditional Reward Modeling, arXiv 2509.26578).
+
 ## [0.99.59] - 2026-05-25
 
 Patch bundling PR-16 (C.4 credit_assignment) + PR-17 (C.5 kind×dim matrix) + PR-SG-SELECTION-ALIGN-FIX (V3/V4/V5 Codex MCP fixes on PR-SG-SELECTION-ALIGN).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-25 A.4 GEPA Pareto sampler helper** —
+  `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —
   `core/self_improving_loop/map_elites.py` adds Quality-Diversity (Mouret & Clune 2015) niche-archive helpers: `MapElitesGrid` (sparse 2D dict — each cell holds the highest-fitness payload, ties rejected), `compute_cell_index(value, bounds, resolution)` for behavior discretization (clamps out-of-range, value at upper bound maps to last cell), `compute_grid_coverage(grid)` (occupied/total ratio), and `insert_many` batch. Complements PR-15 Pareto archive — Pareto prunes by global dominance, MAP-Elites preserves per-niche elites so behavior diversity stays in the archive. Pure helper, caller wiring (archive niche-aware sampling) deferred. Frontier: AlphaEvolve (DeepMind 2025-05).
 - **PR-23 A.2 Tchebycheff scalarization helper** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,27 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + lifted
+  sub-agent wall-clock defaults.** `plugins/seed_generation/checkpointer.py`
+  writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-
+  generation phase (atomic via `os.replace` of a tmp file); the orchestrator
+  appends to `state.completed_phases` on success. New
+  `plugins/seed_generation/resume.py` + `geode audit-seeds resume <run_id>`
+  CLI hydrate `PipelineState` from the latest checkpoint and continue from
+  the first phase without an on-disk record. Wall-clock budgets:
+  `core/agent/sub_agent.py` `SubAgentManager.timeout_s` default 120s → 600s
+  with new `GEODE_SUBAGENT_TIMEOUT_S` env override (clamp `[10, 3600]`);
+  `core/agent/worker.py` `WorkerRequest.timeout_s` default mirrors the
+  bump; `core/agent/plan.py` `_DECOMPOSE_CALL_TIMEOUT_S` 60s → 180s so
+  multi-tool plan.decompose calls under load (smoke-16 evolver
+  `asyncio.CancelledError` at 122s wall-time) don't trip the inner cap.
+  The seed-generation registry keeps its explicit `timeout_s=1800.0`
+  override in `plugins/seed_generation/_registry_builder.py` — the new
+  600s is the default for callers that don't override.
+  Convergence basis: paperclip session JSONL resume + LangGraph SqliteSaver
+  thread/checkpoint keying + openclaw per-agent wall-clock + hermes
+  IterationBudget. Plan SoT: `docs/plans/2026-05-25-structured-output-3-axis-fix.md`
+  §5 + §6.
 - **PR-27 C.7 unified MutatorContextView** —
   `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-28 C.8 silent fallback STRICT mode parity invariants** —
+  `tests/core/self_improving_loop/test_strict_mode_parity.py` pins the
+  fragmentation-audit F5 fix (ADR-012 S0a/S0b) as a drift invariant.
+  `autoresearch/train.py:838-873` sets `GEODE_<KIND>_OVERRIDE` together
+  with `GEODE_<KIND>_STRICT=1` for the 12 mutation-surface kinds so the
+  audit subprocess fails fast instead of silently falling back to the
+  in-repo SoT; `core/self_improving_loop/sot_resolution.py` reads the
+  matching `_STRICT_SUFFIX` via `removesuffix(_OVERRIDE_SUFFIX) +
+  _STRICT_SUFFIX`. The 8 invariants cover override↔strict pairing
+  (drift detection), strict-kind count floor (>=12), suffix derivation
+  pattern, and end-to-end `resolve_sot` strict-flag propagation for the
+  4 layer outcomes (env+STRICT / env-only / operator-local / in-repo).
+  A future kind addition that forgets STRICT trips the pairing
+  invariant. Memory `project_autoresearch_fragmentation_audit.md` F5
+  closed.
+### Added
 - **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + lifted
   sub-agent wall-clock defaults.** `plugins/seed_generation/checkpointer.py`
   writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,16 +51,18 @@ functional change.
 - **PR-28 C.8 silent fallback STRICT mode parity invariants** —
   `tests/core/self_improving_loop/test_strict_mode_parity.py` pins the
   fragmentation-audit F5 fix (ADR-012 S0a/S0b) as a drift invariant.
-  `autoresearch/train.py:838-873` sets `GEODE_<KIND>_OVERRIDE` together
-  with `GEODE_<KIND>_STRICT=1` for the 12 mutation-surface kinds so the
+  `autoresearch/train.py` sets `GEODE_<KIND>_OVERRIDE` together with
+  `GEODE_<KIND>_STRICT=1` for the 12 mutation-surface kinds so the
   audit subprocess fails fast instead of silently falling back to the
   in-repo SoT; `core/self_improving_loop/sot_resolution.py` reads the
   matching `_STRICT_SUFFIX` via `removesuffix(_OVERRIDE_SUFFIX) +
-  _STRICT_SUFFIX`. The 8 invariants cover override↔strict pairing
-  (drift detection), strict-kind count floor (>=12), suffix derivation
-  pattern, and end-to-end `resolve_sot` strict-flag propagation for the
-  4 layer outcomes (env+STRICT / env-only / operator-local / in-repo).
-  A future kind addition that forgets STRICT trips the pairing
+  _STRICT_SUFFIX`. The 9 invariants cover override↔strict pairing
+  (drift detection, RHS-agnostic regex so a future kind using a
+  helper-call/Path-literal RHS cannot evade the pairing check),
+  strict-kind count floor (>=12), suffix derivation pattern, and
+  end-to-end `resolve_sot` strict-flag propagation for the 4 layer
+  outcomes (env+STRICT / env-only / operator-local / in-repo). A
+  future kind addition that forgets STRICT trips the pairing
   invariant. Memory `project_autoresearch_fragmentation_audit.md` F5
   closed.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.60] - 2026-05-25
+
+Sprint bundle closing the 전소 self-improving-loop backlog: PR-20 (A.6 CRM causal_hypothesis) + PR-21 (A.8 sub_agent_slice) + PR-22 (B.4 F1 cross-run SoT invariants) + PR-23 (A.2 Tchebycheff) + PR-24 (A.3 MAP-Elites) + PR-25 (A.4 GEPA sampler) + PR-26 (C.6 cross-run SoT unification) + PR-27 (C.7 unified MutatorContextView) + PR-CHECKPOINT-RESUME-TIMEBUDGET (seed-gen per-phase checkpoint + 600s wall-clock) + PR-28 (C.8 silent fallback STRICT mode parity invariants). 9 fragmentation-audit signals closed, Codex MCP catches averaged 1.6/PR.
+
 ### Added
 - **PR-28 C.8 silent fallback STRICT mode parity invariants** —
   `tests/core/self_improving_loop/test_strict_mode_parity.py` pins the
@@ -65,7 +69,6 @@ functional change.
   future kind addition that forgets STRICT trips the pairing
   invariant. Memory `project_autoresearch_fragmentation_audit.md` F5
   closed.
-### Added
 - **PR-CHECKPOINT-RESUME-TIMEBUDGET — per-phase checkpoints + lifted
   sub-agent wall-clock defaults.** `plugins/seed_generation/checkpointer.py`
   writes `<run_dir>/checkpoints/<phase>.json` after each successful seed-
@@ -89,10 +92,8 @@ functional change.
   §5 + §6.
 - **PR-27 C.7 unified MutatorContextView** —
   `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
-### Added
 - **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
   `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
-### Added
 - **PR-25 A.4 GEPA Pareto sampler helper** —
   `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-23 A.2 Tchebycheff scalarization helper** —
+  `core/self_improving_loop/tchebycheff.py` adds `compute_tchebycheff(fitness_dim, weights, ideal_point)` and `compute_ideal_point(vectors)` pure helpers. Linear scalarization (`f_total = sum(w*r)`) cannot reach concave Pareto-front regions (Das & Dennis 1997); Tchebycheff (`-max_d w_d * (ideal[d] - fitness[d])`) closes that gap by penalizing the worst dim relative to the ideal point. Pareto-front advantage invariant test pins the canonical 3-point concave example (extreme points tie under linear, B beats both under Tchebycheff). Caller wiring into `apply_group_proposals` 의 pareto_mode 분기 is deferred — PR-15 의 lineage writer 와 짝지을 다음 PR 가 필요.
 - **PR-22 B.4 F1 cross-run SoT 3중첩 invariants** —
   `tests/core/self_improving_loop/test_cross_run_sot_invariant.py` pins the
   schema parity invariants between the three cross-run SoTs that the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-21 A.8 sub_agent_slice helper** —
+  `core/self_improving_loop/sub_agent_slice.py` defines a 5-stage
+  deterministic round-robin slice mapping (role / tools / reflection
+  / decomposition / interlocutor) keyed on `sub_agent_index`.
+  `compute_sub_agent_slice(idx, total)` returns the slice name;
+  `derive_slice_prompt_hint(slice)` returns a one-line mutator
+  system-prompt hint that the eventual `propose_swarm` wiring can
+  prepend to diversify sub-agent focus beyond temperature
+  stochasticity. Pure functions, no caller wired yet (deferred to a
+  follow-up PR). Frontier: Kimi K2.6 PARL post-trained decomposition,
+  inference-time variant.
 - **PR-20 A.6 CRM causal_hypothesis field** —
   `Mutation` dataclass + `ApplyRecord` Pydantic schema +
   `parse_mutation` + `to_audit_row` 가 새로운 optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-27 C.7 unified MutatorContextView** —
+  `core/self_improving_loop/mutator_context_view.py` composes the 5+ mutator-context sources into a single frozen Pydantic view: `baseline_snapshot` / `policy_snapshots` (5 kind policies) / `program_md` / `meta_review_snapshot` / `recent_mutations` (PR-12 reader output) / `cross_run_key` (PR-26 CrossRunJoinKey). `compose_mutator_context_view(...)` packs the loaded sources with safe defaults (None or empty container for missing sources); `source_count(view)` returns the count of populated sources for operator diagnostics. `extra="allow"` so future sources can be carried without schema migration. Pure helper, caller wiring (runner.py build_runner_context) deferred. Resolves F2 fragmentation signal.
+### Added
 - **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
   `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-26 C.6 cross-run SoT 3중첩 unification helper** —
+  `core/self_improving_loop/cross_run_join.py` consolidates the three cross-run SoT readers (latest_pointer.json / MetaReviewSnapshot / sessions.jsonl) behind a single Pydantic `CrossRunJoinKey` (frozen run_id + gen_tag + source_label). `load_cross_run_join_key()` returns None on missing / malformed / non-dict / missing-required-field pointer payloads (graceful). `keys_match(a, b)` compares by value (source_label ignored). `compose_history_view(key, rows)` filters an iterable of session/meta-review rows to those matching the key — defensive against non-dict items and rows missing either field. Builds on PR-22 invariant tests with an actual unification helper. Pure functions, caller deferred.
+### Added
 - **PR-25 A.4 GEPA Pareto sampler helper** —
   `core/self_improving_loop/gepa_sampler.py` adds density-aware sampling for the Pareto archive: `compute_sparsity_weights(vectors, k)` returns each entry s mean k-NN distance (sparse niches get higher weight; epsilon prevents all-zero collapse on identical vectors), and `sample_sparse[T](entries, vectors, n, k_neighbors, rng)` performs weighted without-replacement sampling that probabilistically favors under-represented Pareto niches. Replaces the uniform-random `PareteArchive.sample` baseline (PR-15) — caller wiring follows. Frontier: GEPA pattern (Genetic Evolutionary Pareto Archive) + Quality-Diversity (Mouret & Clune 2015).
 - **PR-24 A.3 MAP-Elites niche grid helper** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-22 B.4 F1 cross-run SoT 3중첩 invariants** —
+  `tests/core/self_improving_loop/test_cross_run_sot_invariant.py` pins the
+  schema parity invariants between the three cross-run SoTs that the
+  `project_autoresearch_fragmentation_audit.md` F1 signal calls out:
+  `latest_pointer.json` (paths.write_latest_pointer / read_latest_pointer),
+  the `MetaReviewSnapshot` (plugins.seed_generation.baseline_reader), and
+  `sessions.jsonl` (plugins.seed_generation.orchestrator). 10 invariants
+  cover: write/read roundtrip, required-key schema (version/run_id/gen_tag/
+  updated_at), optional-field omission, missing/malformed/non-dict graceful
+  None return, STATE_ROOT-relative path resolution, sessions.jsonl source
+  contains the canonical `run_id` cross-ref key, MetaReviewSnapshot reachable,
+  and a drift invariant blocking rename to `cycle_id` / `session_id`. Any
+  future SoT key rename fails fast here instead of silently breaking the
+  cross-run join.
 - **PR-21 A.8 sub_agent_slice helper** —
   `core/self_improving_loop/sub_agent_slice.py` defines a 5-stage
   deterministic round-robin slice mapping (role / tools / reflection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-24 A.3 MAP-Elites niche grid helper** —
+  `core/self_improving_loop/map_elites.py` adds Quality-Diversity (Mouret & Clune 2015) niche-archive helpers: `MapElitesGrid` (sparse 2D dict — each cell holds the highest-fitness payload, ties rejected), `compute_cell_index(value, bounds, resolution)` for behavior discretization (clamps out-of-range, value at upper bound maps to last cell), `compute_grid_coverage(grid)` (occupied/total ratio), and `insert_many` batch. Complements PR-15 Pareto archive — Pareto prunes by global dominance, MAP-Elites preserves per-niche elites so behavior diversity stays in the archive. Pure helper, caller wiring (archive niche-aware sampling) deferred. Frontier: AlphaEvolve (DeepMind 2025-05).
 - **PR-23 A.2 Tchebycheff scalarization helper** —
   `core/self_improving_loop/tchebycheff.py` adds `compute_tchebycheff(fitness_dim, weights, ideal_point)` and `compute_ideal_point(vectors)` pure helpers. Linear scalarization (`f_total = sum(w*r)`) cannot reach concave Pareto-front regions (Das & Dennis 1997); Tchebycheff (`-max_d w_d * (ideal[d] - fitness[d])`) closes that gap by penalizing the worst dim relative to the ideal point. Pareto-front advantage invariant test pins the canonical 3-point concave example (extreme points tie under linear, B beats both under Tchebycheff). Caller wiring into `apply_group_proposals` 의 pareto_mode 분기 is deferred — PR-15 의 lineage writer 와 짝지을 다음 PR 가 필요.
 - **PR-22 B.4 F1 cross-run SoT 3중첩 invariants** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.59
+- **Version**: 0.99.60
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.59 — Long-running Autonomous Execution Harness
+# GEODE v0.99.60 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.59**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.60**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.59 — Long-running Autonomous Execution Harness
+# GEODE v0.99.60 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.59**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.60**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -654,7 +654,14 @@ def _build_tool_summary(tools: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-_DECOMPOSE_CALL_TIMEOUT_S: float = 60.0
+# PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — raised 60 → 180
+# (3 min) on operator directive ("야심차게 잡아도 돼"). Smoke 16
+# evolver's `decompose_async` timed out at 122s on the prior 60s cap.
+# The decomposer LLM call can be slow on complex compound requests
+# (multi-tool DAG generation, baseline evidence preamble, etc.); 180s
+# matches the per-LLM-call generosity of openclaw's agent timeout
+# minimum while leaving headroom under the SubAgentManager 600s cap.
+_DECOMPOSE_CALL_TIMEOUT_S: float = 180.0
 
 
 async def decompose_async(
@@ -675,7 +682,8 @@ async def decompose_async(
        ``apply_decomposition_policy`` (ADR-012 SoT — preserves the
        operator-tunable policy surface; only the call site moves).
     3. **LLM call**: ``loop._call_llm`` with ``settings.plan_model``
-       (PR-CL-A6 knob) bounded by 60s timeout.
+       (PR-CL-A6 knob) bounded by ``_DECOMPOSE_CALL_TIMEOUT_S``
+       (180s post-PR-CHECKPOINT-RESUME-TIMEBUDGET, 2026-05-25).
     4. **Parse**: pydantic ``DecompositionResult.model_validate_json``
        — schema-validated, error-on-malformed.
     5. **Skip when** the LLM reports ``is_compound=False`` or only

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -73,6 +73,35 @@ def _strip_json_codeblock(text: str) -> str:
     return match.group(1).strip()
 
 
+def _resolve_timeout_s(default: float) -> float:
+    """Apply ``GEODE_SUBAGENT_TIMEOUT_S`` env override with clamp.
+
+    PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — env knob for
+    the SubAgentManager wall-clock cap so deployments can tune
+    without code change. Clamp to ``[10, 3600]``:
+
+    - Lower bound 10s — below this the orchestrator's per-phase
+      framing overhead alone dominates; a sub-agent can't complete
+      meaningful work.
+    - Upper bound 3600s (1h) — matches openclaw's per-agent
+      ``agents.defaults.timeoutSeconds`` documented range; longer
+      runs should checkpoint + resume rather than hold a single
+      subprocess open.
+
+    Non-numeric or empty env values fall through to ``default``.
+    """
+    import os
+
+    raw = os.environ.get("GEODE_SUBAGENT_TIMEOUT_S", "").strip()
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        return float(default)
+    return max(10.0, min(3600.0, value))
+
+
 def _last_balanced_json_object(text: str) -> str | None:
     """Walk the text right-to-left and return the LAST balanced
     ``{...}`` substring whose first attempt at ``json.loads`` succeeds.
@@ -341,7 +370,18 @@ class SubAgentManager:
         runner: IsolatedRunner,
         task_handler: Any | None = None,
         *,
-        timeout_s: float = 120.0,
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — raised
+        # 120 → 600 (10 min) on operator directive ("야심차게 잡아도 돼.
+        # 300초 그이상으로 잡아"). Matches the per-agent-run wall-clock
+        # convergence from openclaw (`agents/timeout.ts:3` 48h default)
+        # while still leaving room for the IsolationConfig outer cap.
+        # 120s was too tight for tool-using sub-agents — smoke 16
+        # evolver TimeoutError surfaced at 122s in
+        # ``plan.decompose_async``. Pilot's 90s Petri audit alone
+        # leaves <30s for plan + tool overhead at 120s; 600s gives
+        # multi-round tool reasoning the headroom it needs. Override
+        # via ``GEODE_SUBAGENT_TIMEOUT_S`` env (clamped [10, 3600]).
+        timeout_s: float = 600.0,
         hooks: HookSystem | None = None,
         agent_registry: AgentRegistry | None = None,
         parent_session_key: str = "",
@@ -359,7 +399,13 @@ class SubAgentManager:
     ) -> None:
         self._runner = runner
         self._task_handler = task_handler
-        self._timeout_s = timeout_s
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — env override
+        # for the wall-clock cap, clamped to a sane range so a bad
+        # `GEODE_SUBAGENT_TIMEOUT_S=abc` or `=99999999` doesn't break
+        # subprocess accounting. 10s lower bound matches the smoke
+        # smallest phase (proximity ~0.2ms is fine; literature_review
+        # ~30s on cache hit needs > 10s headroom).
+        self._timeout_s = _resolve_timeout_s(timeout_s)
         self._time_budget_s = time_budget_s
         self._hooks = hooks
         self._agent_registry = agent_registry

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -50,7 +50,11 @@ class WorkerRequest:
     denied_tools: list[str] = field(default_factory=list)
     model: str = "claude-opus-4-6"
     provider: str = "anthropic"
-    timeout_s: float = 120.0
+    # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — default raised
+    # 120 → 600 to match SubAgentManager default (env-tunable via
+    # ``GEODE_SUBAGENT_TIMEOUT_S``). Smoke 16 evolver hit 122s in
+    # plan.decompose_async on the prior cap.
+    timeout_s: float = 600.0
     time_budget_s: float = 0.0  # 0 = inherit parent's budget
     thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call (legacy)
     effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh" (v0.56.0)
@@ -123,7 +127,7 @@ class WorkerRequest:
             denied_tools=data.get("denied_tools", []),
             model=data.get("model", "claude-opus-4-6"),
             provider=data.get("provider", "anthropic"),
-            timeout_s=data.get("timeout_s", 120.0),
+            timeout_s=data.get("timeout_s", 600.0),
             # v0.55.0 R5 — reasoning depth fields were declared on the
             # dataclass since v0.50.x but never deserialised, so every
             # sub-agent ran at the dataclass defaults regardless of

--- a/core/self_improving_loop/cross_run_join.py
+++ b/core/self_improving_loop/cross_run_join.py
@@ -1,0 +1,124 @@
+"""C.6 (2026-05-25) — cross-run SoT 3중첩 unification (PR-26).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` F1 — 3 SoT
+(``latest_pointer.json`` / ``MetaReviewSnapshot`` / ``sessions.jsonl``)
+의 cross-ref key (run_id + gen_tag) 가 각자 다른 reader 로 접근. PR-22
+가 invariant test 만 추가 (schema parity pin). C.6 는 그 다음 단계 —
+**한 dataclass + 단일 reader** 로 unification.
+
+본 module = **selection-only helper**:
+
+- :class:`CrossRunJoinKey` — Pydantic schema, 3 SoT 의 공통 join key
+- :func:`load_cross_run_join_key()` — latest_pointer.json 으로부터
+  추출. file 부재/malformed → None (graceful).
+- :func:`keys_match(a, b)` — run_id + gen_tag 모두 일치 시 True.
+- :func:`compose_history_view(key, sessions_iter)` — sessions.jsonl
+  iterator 에서 key 일치 row 만 필터.
+
+3 SoT 의 join 책임을 한 곳에 모음 — caller 가 lookup 위치 모르거나
+schema 변경 시 한 곳만 update.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CrossRunJoinKey(BaseModel):
+    """3 SoT 의 공통 cross-ref key.
+
+    ``run_id`` + ``gen_tag`` pair 가 unique join anchor. 같은 ``run_id``
+    의 다른 ``gen_tag`` (예: rerun) 는 별 row.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    run_id: str
+    gen_tag: str
+    source_label: str = ""
+    """어느 SoT 에서 추출됐는지 — ``latest_pointer`` / ``sessions`` /
+    ``meta_review`` 중 하나. drift detection 시 출처 추적용."""
+
+
+def load_cross_run_join_key(
+    latest_pointer_path: Path | None = None,
+) -> CrossRunJoinKey | None:
+    """Load the current cross-run join key from ``latest_pointer.json``.
+
+    Returns ``None`` when:
+
+    - The pointer file is missing (fresh repo / no run yet).
+    - The pointer JSON is malformed.
+    - The pointer payload lacks ``run_id`` or ``gen_tag``.
+
+    Caller can use this key to look up matching rows in
+    ``sessions.jsonl`` or ``meta_review`` snapshots.
+    """
+    from core.paths import read_latest_pointer
+
+    if latest_pointer_path is not None:
+        # Test injection — read directly from the provided path
+        import json as _json
+
+        if not latest_pointer_path.is_file():
+            return None
+        try:
+            payload = _json.loads(latest_pointer_path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError):
+            return None
+    else:
+        payload = read_latest_pointer()
+
+    if not isinstance(payload, dict):
+        return None
+    run_id = payload.get("run_id")
+    gen_tag = payload.get("gen_tag")
+    if not isinstance(run_id, str) or not isinstance(gen_tag, str):
+        return None
+    return CrossRunJoinKey(run_id=run_id, gen_tag=gen_tag, source_label="latest_pointer")
+
+
+def keys_match(a: CrossRunJoinKey | None, b: CrossRunJoinKey | None) -> bool:
+    """Two keys match when both run_id and gen_tag are equal.
+
+    ``None`` on either side → False (no signal). source_label is
+    ignored — keys from different SoTs match by value.
+    """
+    if a is None or b is None:
+        return False
+    return a.run_id == b.run_id and a.gen_tag == b.gen_tag
+
+
+def compose_history_view(
+    key: CrossRunJoinKey,
+    rows: Iterable[Any],
+) -> Iterator[dict[str, Any]]:
+    """Filter an iterable of session/meta-review rows to those matching
+    ``key`` (same run_id + gen_tag).
+
+    Each row must be a dict with ``run_id`` and ``gen_tag`` string
+    values; rows that are non-dict or missing either field are skipped
+    silently (forward-compat: older rows may lack one of the two
+    fields; defensive against malformed iterables).
+    """
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_run_id = row.get("run_id")
+        row_gen_tag = row.get("gen_tag")
+        if not isinstance(row_run_id, str) or not isinstance(row_gen_tag, str):
+            continue
+        if row_run_id == key.run_id and row_gen_tag == key.gen_tag:
+            yield row
+
+
+__all__ = [
+    "CrossRunJoinKey",
+    "compose_history_view",
+    "keys_match",
+    "load_cross_run_join_key",
+]

--- a/core/self_improving_loop/gepa_sampler.py
+++ b/core/self_improving_loop/gepa_sampler.py
@@ -1,0 +1,136 @@
+"""A.4 (2026-05-25) — GEPA Pareto sampler (PR-25).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C8. PR-15 ``pareto_archive.PareteArchive.sample`` 의 uniform-random
+sampling 을 **density-aware** sparsity-weighted 로 개선.
+
+**Why density-aware**:
+
+- Uniform sampling 은 archive 의 dense region (많은 entry 가 비슷한
+  fitness vector 공유) 에 편향. Pareto front 의 sparse region (rare
+  trade-off) 은 over-explored 부족.
+- Sparsity weight ∝ inverse local density — sparse niche 의 entry 가
+  sample 될 확률 ↑. Quality-Diversity 의 핵심 (Mouret & Clune 2015).
+
+**Frontier reference**: GEPA (Genetic Evolutionary Pareto Archive,
+arXiv 2406.xxxxx) — Pareto sampler 의 reflection-text 친화 (sampled
+entry 의 mutation rationale 을 next mutator 의 priors 로 forward).
+
+본 module = **pure helper**:
+
+- :func:`compute_sparsity_weights(fitness_vectors, k)` — k-NN 평균거리
+  기반 sparsity score. sparse = high weight.
+- :func:`sample_sparse(entries, k_neighbors, n, rng)` — sparsity 가중
+  random sample.
+
+caller (apply_group_proposals 의 archive sample 분기) wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+
+def _euclidean_distance(a: dict[str, float], b: dict[str, float]) -> float:
+    """Per-dim squared diff sum의 sqrt. Missing dim → treated as 0
+    on the missing side (conservative — caller can normalize beforehand)."""
+    dims = set(a.keys()) | set(b.keys())
+    if not dims:
+        return 0.0
+    squared = 0.0
+    for d in dims:
+        av = float(a.get(d, 0.0))
+        bv = float(b.get(d, 0.0))
+        diff = av - bv
+        squared += diff * diff
+    return math.sqrt(squared)
+
+
+def compute_sparsity_weights(
+    fitness_vectors: list[dict[str, float]],
+    k: int = 3,
+) -> list[float]:
+    """Return per-entry sparsity weight (higher = more sparse / under-
+    represented in fitness space).
+
+    Algorithm — for each entry, compute the mean Euclidean distance to
+    its ``k`` nearest neighbors. Larger mean distance = sparser region =
+    higher weight. Returns raw distances (not normalized); caller may
+    normalize to a probability distribution.
+
+    Edge cases:
+    - ``len(fitness_vectors) <= 1`` → all weights 1.0 (no neighbors)
+    - ``k`` clamped to ``len(fitness_vectors) - 1``
+    - empty input → empty list
+    """
+    n = len(fitness_vectors)
+    if n == 0:
+        return []
+    if n == 1:
+        return [1.0]
+    effective_k = min(k, n - 1)
+    weights: list[float] = []
+    for i, vec_i in enumerate(fitness_vectors):
+        distances: list[float] = []
+        for j, vec_j in enumerate(fitness_vectors):
+            if i == j:
+                continue
+            distances.append(_euclidean_distance(vec_i, vec_j))
+        distances.sort()
+        nearest = distances[:effective_k]
+        mean_dist = sum(nearest) / len(nearest) if nearest else 0.0
+        # Sparsity weight = mean k-NN distance; sparse regions yield larger
+        # values. We add small epsilon so all-identical vectors don't
+        # collapse to zero probability.
+        weights.append(mean_dist + 1e-9)
+    return weights
+
+
+def sample_sparse[T](
+    entries: list[T],
+    fitness_vectors: list[dict[str, float]],
+    n: int,
+    *,
+    k_neighbors: int = 3,
+    rng: random.Random | None = None,
+) -> list[T]:
+    """Sample ``n`` entries with probability ∝ sparsity weight.
+
+    ``entries`` and ``fitness_vectors`` must be parallel (same length,
+    same indexing). Sampling is **without replacement** — at most
+    ``len(entries)`` returned. Empty input → empty list.
+
+    Returns the sampled entries in random order.
+    """
+    if len(entries) != len(fitness_vectors):
+        raise ValueError(
+            f"entries / fitness_vectors length mismatch: {len(entries)} vs {len(fitness_vectors)}"
+        )
+    if not entries or n <= 0:
+        return []
+    rng = rng or random.Random()
+    weights = compute_sparsity_weights(fitness_vectors, k=k_neighbors)
+    # rng.choices with replacement; then dedupe — caller wants without-
+    # replacement. For without-replacement, repeated weighted sampling
+    # without replacement requires removing the sampled index.
+    pool: list[tuple[T, float]] = list(zip(entries, weights, strict=True))
+    sampled: list[T] = []
+    target = min(n, len(pool))
+    while pool and len(sampled) < target:
+        items, ws = zip(*pool, strict=True)
+        total = sum(ws)
+        if total <= 0:
+            # All-zero weights — fall back to uniform
+            choice_idx = rng.randrange(len(items))
+        else:
+            choice_idx = rng.choices(range(len(items)), weights=ws, k=1)[0]
+        sampled.append(items[choice_idx])
+        pool.pop(choice_idx)
+    return sampled
+
+
+__all__ = [
+    "compute_sparsity_weights",
+    "sample_sparse",
+]

--- a/core/self_improving_loop/map_elites.py
+++ b/core/self_improving_loop/map_elites.py
@@ -1,0 +1,154 @@
+"""A.3 (2026-05-25) — MAP-Elites niche grid helper (PR-24).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C6 — Quality-Diversity 패턴 (Mouret & Clune 2015, AlphaEvolve 2025-05).
+
+**Concept**: behavior-characterization dim 2 개 를 grid 의 (x, y) 로 사용,
+각 cell 에 fitness 가장 높은 한 entry 만 보존. 결과 — 다양한 behavior
+niche 의 elite 들이 archive 에 보존되어 exploration vs exploitation 균형.
+
+vs Pareto archive (PR-15):
+- Pareto: dominance 기준 prune (전체 ordering)
+- MAP-Elites: behavior niche 기준 (local ordering per cell)
+- 둘은 보완 — 함께 사용 가능 (Pareto + niche 둘 다 anchor)
+
+본 module = **pure selection-only helper**:
+
+- :func:`compute_cell_index(value, bounds, resolution)` — float → grid cell idx
+- :class:`MapElitesGrid` — sparse dict-based 2D grid + insert/sample
+- :func:`compute_grid_coverage(grid)` — occupied cells / total cells ratio
+
+caller (archive 의 niche-aware sampling) wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def compute_cell_index(
+    value: float,
+    bounds: tuple[float, float],
+    resolution: int,
+) -> int:
+    """Discretize ``value`` into a grid cell index ``[0, resolution)``.
+
+    ``bounds = (lo, hi)``. value clamp to [lo, hi]. value at ``hi`` maps to
+    ``resolution - 1``. ``resolution`` must be >= 1.
+
+    Raises ValueError on bad inputs (resolution <= 0, bounds[0] >= bounds[1]).
+    """
+    if resolution < 1:
+        raise ValueError(f"resolution must be >= 1, got {resolution}")
+    lo, hi = bounds
+    if lo >= hi:
+        raise ValueError(f"bounds must be (lo < hi), got ({lo}, {hi})")
+    clamped = max(lo, min(hi, value))
+    # Map [lo, hi] to [0, resolution) linearly. value=hi must hit
+    # resolution-1 (not resolution); use floor with epsilon-clip.
+    frac = (clamped - lo) / (hi - lo)
+    idx = math.floor(frac * resolution)
+    return min(idx, resolution - 1)
+
+
+@dataclass(frozen=True)
+class _CellKey:
+    """2D cell coordinate — frozen so it's hashable for dict key."""
+
+    x: int
+    y: int
+
+
+@dataclass
+class MapElitesGrid:
+    """Sparse 2D niche grid — only occupied cells stored.
+
+    Each cell maps to a single ``(fitness, payload)`` tuple. Insert
+    replaces the cell's entry only when the new fitness is strictly
+    higher (winner-takes-all per cell).
+
+    ``payload`` is opaque to the grid — caller supplies anything
+    (e.g. mutation_id, full ArchiveEntry, ...).
+    """
+
+    behavior_bounds: tuple[tuple[float, float], tuple[float, float]]
+    """((x_lo, x_hi), (y_lo, y_hi)) — bounds for the 2 behavior dims."""
+
+    resolution: tuple[int, int] = (10, 10)
+    """(x_resolution, y_resolution) — cells per dim. default 10×10 = 100."""
+
+    cells: dict[_CellKey, tuple[float, object]] = field(default_factory=dict)
+    """{cell_key: (fitness, payload)} — only occupied cells."""
+
+    def _cell(self, behavior: tuple[float, float]) -> _CellKey:
+        bx, by = behavior
+        (x_lo, x_hi), (y_lo, y_hi) = self.behavior_bounds
+        rx, ry = self.resolution
+        x_idx = compute_cell_index(bx, (x_lo, x_hi), rx)
+        y_idx = compute_cell_index(by, (y_lo, y_hi), ry)
+        return _CellKey(x_idx, y_idx)
+
+    def insert(
+        self,
+        behavior: tuple[float, float],
+        fitness: float,
+        payload: object,
+    ) -> bool:
+        """Insert ``payload`` at the cell for ``behavior`` if ``fitness``
+        strictly exceeds the existing occupant. Returns True if inserted."""
+        cell = self._cell(behavior)
+        existing = self.cells.get(cell)
+        if existing is not None and existing[0] >= fitness:
+            return False
+        self.cells[cell] = (float(fitness), payload)
+        return True
+
+    def get(self, behavior: tuple[float, float]) -> tuple[float, object] | None:
+        """Return ``(fitness, payload)`` at the cell for ``behavior``, or None."""
+        return self.cells.get(self._cell(behavior))
+
+    def all_payloads(self) -> list[object]:
+        """Return every occupied cell's payload (order unspecified)."""
+        return [payload for _fitness, payload in self.cells.values()]
+
+    def __len__(self) -> int:
+        return len(self.cells)
+
+
+def compute_grid_coverage(grid: MapElitesGrid) -> float:
+    """Ratio of occupied cells to total cells in the grid.
+
+    Result in ``[0.0, 1.0]``. 0.0 = empty, 1.0 = every cell occupied
+    (saturated niche space).
+    """
+    rx, ry = grid.resolution
+    total = rx * ry
+    if total <= 0:
+        return 0.0
+    return len(grid) / total
+
+
+def insert_many(
+    grid: MapElitesGrid,
+    entries: Iterable[tuple[tuple[float, float], float, object]],
+) -> int:
+    """Batch-insert ``(behavior, fitness, payload)`` triples. Returns the
+    count of successful inserts (entries that won their cell)."""
+    inserted = 0
+    for behavior, fitness, payload in entries:
+        if grid.insert(behavior, fitness, payload):
+            inserted += 1
+    return inserted
+
+
+__all__ = [
+    "MapElitesGrid",
+    "compute_cell_index",
+    "compute_grid_coverage",
+    "insert_many",
+]

--- a/core/self_improving_loop/mutator_context_view.py
+++ b/core/self_improving_loop/mutator_context_view.py
@@ -1,0 +1,120 @@
+"""C.7 (2026-05-25) — unified mutator context view (PR-27).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` F2 — mutator
+context 가 5+ source 에 분산 (baseline_snapshot / kind-policy snapshots /
+program.md / meta_review / mutations history). PR-12 ``mutations_reader``
+이 history 표면화, PR-26 ``cross_run_join`` 이 cross-run key 통합.
+C.7 는 그 위 layer — **하나의 view dataclass + composition helper**.
+
+본 module = **read-side composition** (write-side 영향 X):
+
+- :class:`MutatorContextView` — Pydantic snapshot 의 5+ source 합본
+- :func:`compose_mutator_context_view(...)` — 5 source 가 각자 추출된
+  optional Any 를 받아 dataclass instance 로 packing
+- :func:`source_count(view)` — non-None source count (운영자 진단 metric)
+
+caller (runner.py 의 build_runner_context) 가 이 view 를 단일 객체로
+들고 다닐 수 있어 5+ field 풀이 사라짐. wiring 후속 PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MutatorContextView(BaseModel):
+    """5+ source 의 합본 view.
+
+    각 field 가 ``None`` 이면 그 source 가 부재 (bootstrap / pre-feature
+    runs). caller 가 None 체크로 graceful 분기.
+
+    ``extra="allow"`` 라 신규 source 추가 시 본 schema 변경 없이 forward-
+    compat dict field 로 받음 — but 명시적 field 가 grep-able 이라 우선.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    baseline_snapshot: Any = None
+    """BaselineSnapshot — plugins.seed_generation.baseline_reader.
+    last successful audit 의 dim_means / dim_stderr / metadata."""
+
+    policy_snapshots: dict[str, Any] = Field(default_factory=dict)
+    """5 kind policy snapshots — {kind_name: policy_payload}.
+    tool_policy / decomposition / reflection / skill_catalog /
+    agent_contract. 5 kind 각각 disk file 또는 fallback."""
+
+    program_md: str = ""
+    """autoresearch/program.md content (raw). mutator 가 frontier
+    convention reference 로 사용."""
+
+    meta_review_snapshot: Any = None
+    """MetaReviewSnapshot — plugins.seed_generation.baseline_reader.
+    cross-run priors. bootstrap 시 None."""
+
+    recent_mutations: list[Any] = Field(default_factory=list)
+    """PR-12 mutations_reader 결과 — last N apply rows (history).
+    mutator 가 self-repetition 회피용 참조."""
+
+    cross_run_key: Any = None
+    """PR-26 CrossRunJoinKey — 현재 cycle 의 run_id + gen_tag.
+    cross-run audit join 의 anchor. bootstrap 시 None."""
+
+
+def compose_mutator_context_view(
+    *,
+    baseline_snapshot: Any = None,
+    policy_snapshots: dict[str, Any] | None = None,
+    program_md: str = "",
+    meta_review_snapshot: Any = None,
+    recent_mutations: list[Any] | None = None,
+    cross_run_key: Any = None,
+) -> MutatorContextView:
+    """Pack 5+ source into a single immutable view.
+
+    Caller does the actual source loading (each source has its own
+    reader); this helper just composes the result. Defaults match
+    "source absent" semantics so a bootstrap caller can pass only
+    what it has.
+    """
+    return MutatorContextView(
+        baseline_snapshot=baseline_snapshot,
+        policy_snapshots=policy_snapshots or {},
+        program_md=program_md,
+        meta_review_snapshot=meta_review_snapshot,
+        recent_mutations=recent_mutations or [],
+        cross_run_key=cross_run_key,
+    )
+
+
+def source_count(view: MutatorContextView) -> int:
+    """Return the count of non-empty source fields — operator metric.
+
+    Counts a source as "present" when:
+    - baseline_snapshot / meta_review_snapshot / cross_run_key: non-None
+    - policy_snapshots: non-empty dict
+    - program_md: non-empty string
+    - recent_mutations: non-empty list
+    """
+    count = 0
+    if view.baseline_snapshot is not None:
+        count += 1
+    if view.policy_snapshots:
+        count += 1
+    if view.program_md:
+        count += 1
+    if view.meta_review_snapshot is not None:
+        count += 1
+    if view.recent_mutations:
+        count += 1
+    if view.cross_run_key is not None:
+        count += 1
+    return count
+
+
+__all__ = [
+    "MutatorContextView",
+    "compose_mutator_context_view",
+    "source_count",
+]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -119,6 +119,13 @@ class ApplyRecord(BaseModel):
     한 self-generated judging principle. SPCT (DeepSeek-GRM 2026-Q1) 패턴.
     None 일 때 legacy (P3 이전 mutation row). max 500 chars (parse_mutation
     guard)."""
+    causal_hypothesis: str | None = Field(default=None, max_length=500)
+    """A.6 (PR-20, 2026-05-25) — Conditional Reward Modeling (CRM, arXiv
+    2509.26578) 패턴. mutator 가 mutation 직전 명시한 "dim X 의 Y 효과
+    → fitness Z 변화" 인과사슬. principle (SPCT) 이 *judging criterion*
+    이라면 causal_hypothesis 는 *causal chain*. post-audit observed_dim
+    이 hypothesis 와 일치하는지 cross-check (별도 wiring). None 일 때
+    legacy (CRM 이전). max 500 chars (parse_mutation guard)."""
     swarm_id: str | None = None
     """P4 (2026-05-25, Kimi K2.6 PARL inference-time) — swarm-level grouping
     key. multi-level: swarm_id (level 2) + group_id (level 1). 1=disabled
@@ -186,6 +193,15 @@ class Mutation:
     principle → critique → reward chain 의 입구. parse_mutation 이
     LLM response 의 ``principle`` key 에서 추출 (max 500자). 빈 문자열
     일 때 legacy mutator (P3 이전) 호환."""
+
+    causal_hypothesis: str = ""
+    """A.6 (PR-20, 2026-05-25, CRM) — mutator 가 mutation 직전 명시한
+    causal chain ("dim X 의 Y 효과 → fitness Z 변화"). CRM (Conditional
+    Reward Modeling, arXiv 2509.26578) 패턴. principle 이 *judging
+    criterion* (SPCT) 라면 causal_hypothesis 는 *causal trace* — post-
+    audit observed_dim 과 cross-check 가능 (별도 wiring). parse_mutation
+    이 LLM response 의 ``causal_hypothesis`` key 에서 추출 (max 500자).
+    빈 문자열 = legacy mutator (CRM 이전) 호환."""
 
     def to_audit_row(
         self,
@@ -257,6 +273,9 @@ class Mutation:
         # 무영향).
         if self.principle:
             row["principle"] = self.principle
+        # A.6 (PR-20) — CRM causal_hypothesis non-empty 시만 emit.
+        if self.causal_hypothesis:
+            row["causal_hypothesis"] = self.causal_hypothesis
         return row
 
 
@@ -871,6 +890,17 @@ def parse_mutation(raw: str) -> Mutation:
             f"(SPCT principle must be concise — frontier reference: "
             f"DeepSeek-GRM)"
         )
+    # A.6 (PR-20, 2026-05-25, CRM pattern) — causal_hypothesis 추출. LLM 이
+    # 명시 안 하면 빈 문자열. max 500 chars guard (principle 패턴 동일).
+    causal_hypothesis_raw = payload.get("causal_hypothesis", "")
+    causal_hypothesis = (
+        causal_hypothesis_raw.strip() if isinstance(causal_hypothesis_raw, str) else ""
+    )
+    if len(causal_hypothesis) > 500:
+        raise ValueError(
+            f"causal_hypothesis length {len(causal_hypothesis)} exceeds 500 char "
+            f"cap (CRM causal chain must be concise — frontier: arXiv 2509.26578)"
+        )
     # PR-6 C-5 — target_kind dispatches to the policy SoT file. Default
     # ``prompt`` keeps the legacy wrapper-sections behaviour so older
     # mutation rows replay unchanged. Unknown kinds raise ValueError so
@@ -896,6 +926,7 @@ def parse_mutation(raw: str) -> Mutation:
             expected_dim=expected_dim,
             rollback_condition=rollback_condition,
             principle=principle,
+            causal_hypothesis=causal_hypothesis,
         )
     return Mutation(
         target_section=target_section.strip(),
@@ -906,6 +937,7 @@ def parse_mutation(raw: str) -> Mutation:
         expected_dim=expected_dim,
         rollback_condition=rollback_condition,
         principle=principle,
+        causal_hypothesis=causal_hypothesis,
     )
 
 

--- a/core/self_improving_loop/sub_agent_slice.py
+++ b/core/self_improving_loop/sub_agent_slice.py
@@ -1,0 +1,106 @@
+"""A.8 (2026-05-25) — sub-agent contract slice helper (PR-21).
+
+Plan ``docs/plans/2026-05-25-p4-parl-swarm-scaffolding.md`` §C4.
+
+PR-14 의 ``propose_swarm`` 가 M sub-agent 를 동일 prompt + temperature
+stochasticity 로 호출 — sub-agent diversity 가 의도된 게 아니라 random
+seed 의존. A.8 가 그 위 layer: 각 sub-agent 가 **deterministic slice**
+의 agent_contract focus 받아 mutation chain 분기.
+
+5-stage slice (sub_agent_count 의 config cap 과 일치):
+
+| idx | Slice name | Focus | Mutation tendency |
+|---|---|---|---|
+| 0 | ``role`` | ego / self-description | wrapper prompt role section |
+| 1 | ``tools`` | tool_policy + tool_descriptions | tool selection policy |
+| 2 | ``reflection`` | reflection cycles / critique policy | reflection_policy |
+| 3 | ``decomposition`` | task breakdown + plan steps | decomposition_policy |
+| 4 | ``interlocutor`` | user model / dialogue framing | wrapper prompt user-model section |
+
+Frontier: Kimi K2.6 PARL 의 post-trained decomposition (M sub-agent
+각자 specialized policy slice) — mutator API frozen 라 inference-time
+변형 = system prompt hint injection.
+
+본 module = **pure helper**:
+
+- :func:`compute_sub_agent_slice(idx, total)` — deterministic round-robin
+  slice name
+- :func:`derive_slice_prompt_hint(slice)` — mutator system prompt 에
+  prepend 할 한 줄 hint
+
+Caller (propose_swarm) 의 wiring 은 후속 PR — 본 PR scope = helper only.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SLICE_NAMES: Final[tuple[str, ...]] = (
+    "role",
+    "tools",
+    "reflection",
+    "decomposition",
+    "interlocutor",
+)
+"""5 deterministic slices, ordered by sub_agent_index. config cap = 5
+(``AutoresearchConfig.sub_agent_count`` ge=1, le=5) — slice idx 가
+count 를 넘으면 round-robin (modulo)."""
+
+
+_SLICE_PROMPT_HINTS: Final[dict[str, str]] = {
+    "role": (
+        "Focus this mutation on the wrapper prompt's *role* section — "
+        "the agent's ego, self-description, voice."
+    ),
+    "tools": (
+        "Focus this mutation on tool_policy or tool_descriptions — "
+        "which tools the agent selects and how it phrases their use."
+    ),
+    "reflection": (
+        "Focus this mutation on reflection_policy — the agent's "
+        "self-critique cadence and what it re-examines after errors."
+    ),
+    "decomposition": (
+        "Focus this mutation on decomposition_policy — how the agent "
+        "breaks down tasks and orders plan steps."
+    ),
+    "interlocutor": (
+        "Focus this mutation on the wrapper prompt's *user model* "
+        "section — how the agent frames the operator's intent and "
+        "dialogue conventions."
+    ),
+}
+
+
+def compute_sub_agent_slice(idx: int, total: int) -> str:
+    """Return slice name for sub-agent at ``idx`` out of ``total`` agents.
+
+    Deterministic round-robin over :data:`SLICE_NAMES` — same idx +
+    same total always yields the same slice. Negative idx or total <= 0
+    raise ``ValueError``.
+
+    When ``total > len(SLICE_NAMES)`` (i.e. > 5), the assignment wraps
+    via modulo — caller (config cap=5) keeps this from happening at
+    runtime, but the helper stays defensive.
+    """
+    if idx < 0:
+        raise ValueError(f"sub_agent_index must be >= 0, got {idx}")
+    if total <= 0:
+        raise ValueError(f"total sub-agents must be >= 1, got {total}")
+    return SLICE_NAMES[idx % len(SLICE_NAMES)]
+
+
+def derive_slice_prompt_hint(slice_name: str) -> str:
+    """Return the mutator system-prompt hint for ``slice_name``.
+
+    Unknown slice → empty string (graceful — caller treats as "no hint",
+    falls back to the unmodified system prompt).
+    """
+    return _SLICE_PROMPT_HINTS.get(slice_name, "")
+
+
+__all__ = [
+    "SLICE_NAMES",
+    "compute_sub_agent_slice",
+    "derive_slice_prompt_hint",
+]

--- a/core/self_improving_loop/tchebycheff.py
+++ b/core/self_improving_loop/tchebycheff.py
@@ -1,0 +1,101 @@
+"""A.2 (2026-05-25) — Tchebycheff scalarization helper (PR-23).
+
+Plan ``docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md``
+§C5 — linear scalarization (현재 fitness = w·r) 한계 회피.
+
+**Why Tchebycheff vs linear** (Das & Dennis 1997):
+
+- Linear scalarization (``f_total = sum(w_i * f_i)``) 의 fundamental
+  한계 — concave Pareto front 영역은 어떤 weight 조합으로도 도달 불가.
+- Tchebycheff (``f_total = max_i w_i * |f_i - z_i*|``) 은 concave 영역
+  포함 모든 Pareto-optimal 점에 도달 가능.
+
+**Formula** (higher-is-better convention 으로 변환):
+
+    minimize: max_i w_i * |f_i - z_i*|
+    equivalent (higher-is-better): minimize max_i w_i * (z_i* - f_i)
+                                   when z_i* is ideal (max of f_i)
+
+The scalar returned is **negative-magnitude** — higher is better
+(callers compare directly with linear fitness; max(scalar) = closest
+to ideal point z*).
+
+본 module = **pure helper**:
+
+- :func:`compute_tchebycheff` — (fitness_dim, weights, ideal_point) → scalar
+- :func:`compute_ideal_point(archive_entries)` — per-dim max as z*
+
+Caller (apply_group_proposals 의 pareto_mode 분기) wiring 은 후속 PR.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def compute_tchebycheff(
+    fitness_dim: dict[str, float],
+    weights: dict[str, float],
+    ideal_point: dict[str, float],
+) -> float:
+    """Tchebycheff scalarization of a multi-dim fitness vector.
+
+    Formula (higher-is-better)::
+
+        scalar = -max_d w_d * (ideal_point[d] - fitness_dim[d])
+
+    Negation flips so caller can take ``max(scalar)`` to pick the
+    closest-to-ideal candidate. Per-dim weights normalize fitness
+    direction — set ``w_d = 1`` for uniform Tchebycheff, or
+    ``w_d = 1/range_d`` for normalized.
+
+    Edge cases:
+
+    - dim missing from ``fitness_dim`` → contribution skipped
+    - dim missing from ``weights`` → defaults to 1.0
+    - dim missing from ``ideal_point`` → contribution skipped (no anchor)
+    - all dims skipped (empty intersection) → returns 0.0
+
+    Pure function — no I/O, no side effect.
+    """
+    contributions: list[float] = []
+    for dim, f in fitness_dim.items():
+        ideal = ideal_point.get(dim)
+        if ideal is None:
+            continue
+        w = float(weights.get(dim, 1.0))
+        # higher-is-better: ideal - f >= 0 when f <= ideal
+        contributions.append(w * (float(ideal) - float(f)))
+    if not contributions:
+        return 0.0
+    return -max(contributions)
+
+
+def compute_ideal_point(
+    fitness_vectors: Iterable[dict[str, float]],
+) -> dict[str, float]:
+    """Per-dim max across an iterable of fitness vectors = ideal point z*.
+
+    Empty input → ``{}``. Each dim's ideal is the maximum observed
+    value across all vectors (higher-is-better). Dims that appear only
+    in some vectors are still included with their observed max.
+
+    Useful for archive-driven Tchebycheff — caller computes z* from
+    current Pareto archive before scalarizing candidates against it.
+    """
+    ideal: dict[str, float] = {}
+    for vec in fitness_vectors:
+        for dim, value in vec.items():
+            current = ideal.get(dim)
+            if current is None or float(value) > current:
+                ideal[dim] = float(value)
+    return ideal
+
+
+__all__ = [
+    "compute_ideal_point",
+    "compute_tchebycheff",
+]

--- a/docs/plans/2026-05-25-structured-output-3-axis-fix.md
+++ b/docs/plans/2026-05-25-structured-output-3-axis-fix.md
@@ -1,0 +1,313 @@
+# 2026-05-25 — Structured-output 3-axis fix + checkpointer audit
+
+> Status: **Draft (사용자 승인 대기)**
+> Framing: smoke 15/16 의 prose-vs-JSON regression 을 adapter 3 축 (PAYG / subscription / local-cli) 에서 모두 해소.
+> 선행 관측: PR-HANDOFF-SCHEMAS 의 hard directive ("FINAL response must be ONLY the JSON object... Start with `{` end with `}`") 는 smoke 16 에서 이미 활성 상태였으나 LLM 이 무시 → **prompt-side directive 만으로는 부족** (empirical refutation).
+
+## 1. Background — 관측된 실패 카탈로그
+
+### 1.1 JSON-formatting 실패 (5 건)
+
+| Smoke | Agent | 응답 형태 | Prompt 상태 |
+|-------|-------|----------|-------------|
+| 15 | pilot | prose (~500 토큰, 497s) | PR-HANDOFF-SCHEMAS 이전, soft "Return JSON" 지시만 |
+| 15 | evolver (iter 1) | JSON 있음 (verdict ok) | 동일 |
+| 16 | critic | prose ("**Critique summary:**..." 28s) | hard directive 없음 (critic 만 미적용) |
+| 16 | pilot | prose ("I need to actually run..." 497s) | **hard directive 활성 — 무시됨** |
+| 16 | meta_reviewer | prose ("Meta-review submitted...") | soft 지시만 |
+
+**핵심:** smoke 16 pilot 의 prompt 는 이미 `"Your FINAL response must be ONLY the JSON object... Start with \`{\` and end with \`}\`"` 를 포함했고, HANDOFF CONTEXT JSON block 도 첨부됨. 그럼에도 LLM 이 prose 만 출력. **즉 prompt-only fix 는 무력하다는 empirical 증거.**
+
+### 1.2 Non-JSON 실패 (1 건)
+
+**smoke 16 evolver — TimeoutError at `core/agent/plan.py:721 decompose_async`** (122초). stderr.log 발췌:
+
+```
+File "/opt/homebrew/.../asyncio/streams.py", line 539, in _wait_for_data
+    await self._waiter
+asyncio.exceptions.CancelledError
+...
+File "/Users/mango/workspace/geode/core/agent/plan.py", line 721, in decompose_async
+    response = await asyncio.wait_for(...)
+File "/opt/homebrew/.../asyncio/timeouts.py", line 114, in __aexit__
+    raise TimeoutError from exc_val
+```
+
+`result.json.summary = "Sub-agent failed: termination_reason=natural"` — orchestrator 의 라벨이 misleading. **실제 원인: AgenticLoop 의 plan-decompose 단계가 wall-time timeout** (claude-cli 가 정상 종료했지만 plan 내부 await 이 시간 초과). JSON 포맷과 무관.
+
+## 2. 영속화 — 이전 제시한 4 옵션 (A/B/C/D)
+
+이전 메시지에서 4 갈래 제안. md 영속화.
+
+### Option A — sub_agent.py 의 `_last_balanced_json_object` fallback 강화
+
+**현 상태:** PR-HANDOFF-SCHEMAS 가 이미 prose 안의 `{...}` 블록 추출 시도 (sub_agent.py).
+**확장:** ```json``` fence 안의 JSON 도 우선 시도; 다중 candidate 블록 중 schema-required 필드 가장 많이 매치되는 것 선택; 부분 JSON 의 추가 복원 시도 (예: 마지막 `}` 보강).
+**비용:** ~50 LOC. 효과 부분적 — LLM 이 JSON 어디에도 안 적은 경우 무력.
+
+### Option B — Retry-on-parse-failure
+
+**Idea:** 첫 응답이 parse 실패 시 같은 conversation 에 2번째 turn 추가: `"Your previous response was not valid JSON. Reply ONLY with the JSON object matching the schema. No prose, no markdown. Start with { end with }."`
+**비용:** ~80 LOC + 추가 LLM call (per failure ~30-60s + 토큰). AgenticLoop 의 turn 관리 침습.
+**효과 가설:** higher than (A) — model 이 자기 prose 를 보고 self-correction 가능.
+
+### Option C — Anthropic tool_use 강제 (Anthropic-only)
+
+**Idea:** `tools=[{"name": "submit_result", "input_schema": SCHEMA}]` + `tool_choice={"type": "tool", "name": "submit_result"}`. LLM 은 prose 대신 tool call 로 반드시 응답.
+**Scope 제약:** Anthropic SDK 만 적용 가능. 사용자 directive 가 "Anthropic 한정 조치 자제" 였음 → **단독으론 부적합**, 단 3-axis 의 한 축 (PAYG Anthropic) 으로는 적용 가치.
+**비용:** ~150 LOC (anthropic_payg.py + anthropic_oauth.py).
+
+### Option D — Post-LLM JSON 변환 layer (별도 sonnet 호출)
+
+**Idea:** 첫 응답이 parse 실패 시 별도 cheap-model (haiku 또는 mini) 에 prose 전체 + schema 전달 → "이 prose 를 schema 형식 JSON 으로 변환" 요청. 변환만 하는 single-purpose LLM 호출.
+**비용:** ~100 LOC + 추가 LLM call (저렴). 추가 latency ~5s.
+**효과 가설:** 가장 안전한 안전망 — original LLM 의 prose 가 logically 옳다면 변환 LLM 이 추출.
+
+## 3. 3-axis adapter 구조 + 적용 방안
+
+### 3.1 Adapter 인벤토리 (`core/llm/adapters/`)
+
+| Adapter | Auth | Wire | Structured output 현재 |
+|---------|------|------|-----------------------|
+| `anthropic_payg.py` | API key | Anthropic Messages | **미구현** — `response_schema` plumbing 없음 |
+| `anthropic_oauth.py` | OAuth (Claude.ai bucket) | Anthropic Messages | **미구현** |
+| `claude_cli.py` | Claude Code session | subprocess | `--json-schema <inline>` (soft hint) |
+| `openai_payg.py` | API key | Chat Completions | **미구현** — `response_format` plumbing 없음 |
+| `codex_oauth.py` | OAuth (Codex bucket) | OpenAI Responses | **미구현** — `output_schema` plumbing 없음 |
+| `codex_cli.py` | Codex CLI session | subprocess | `--output-schema <file>` (soft hint) |
+
+### 3.2 SDK 별 구조화 출력 메커니즘 (ctx7 grounded)
+
+**Anthropic SDK (PAYG + OAuth):**
+- 최신 API: `client.messages.parse(messages=..., output_format=PydanticModel)` — Pydantic 자동 hydration. SDK 가 schema 를 force-mode `tools[].input_schema` + `tool_choice` 로 변환.
+- ctx7 출처: `/anthropics/anthropic-sdk-python` — `messages.parse()` signature 에 `output_format`, `output_config` 인자.
+- 효과: provider-level enforcement (true forced structured output).
+
+**OpenAI SDK (PAYG):**
+- `client.chat.completions.create(response_format={"type": "json_schema", "json_schema": {"name": "...", "schema": {...}, "strict": True}})` — strict 모드는 schema 강제 (refusal 또는 schema 외 응답 reject).
+- ctx7 출처: `/openai/openai-cookbook` 의 `Leveraging_model_distillation_to_fine-tune_a_model.ipynb`.
+
+**Codex OAuth (OpenAI subscription axis):**
+- OpenAI Responses API (`/v1/responses`) — `output_schema` field 지원 (`codex_cli.py` 의 `--output-schema` 가 이 wire 의 CLI 래퍼). PAYG 와 동일.
+
+**Local CLI (Codex + Claude Code):**
+- `claude --json-schema <inline-json>` → claude-cli 가 system prompt 로 schema 주입. **enforcement 없음.**
+- `codex --output-schema <file>` → 동일. **enforcement 없음.**
+
+### 3.3 적용 plan — 6 셀 매트릭스
+
+| 셀 | adapter | mechanism | 새 작업 | LOC |
+|----|---------|-----------|---------|-----|
+| **PAYG-Anth** | anthropic_payg.py | `messages.parse(output_format=PydanticModel)` 또는 force `tools[].input_schema` | response_schema → pydantic model 변환 layer | ~120 |
+| **PAYG-OpenAI** | openai_payg.py | `response_format={"type":"json_schema", "strict":True, ...}` | response_schema → response_format 변환 | ~80 |
+| **Sub-OAuth** | codex_oauth.py | Responses API `output_schema` 필드 (= PAYG-OpenAI 와 동일 wire) | 동일 변환 재사용 | ~30 (shared helper) |
+| **CLI-Claude** | claude_cli.py | 이미 soft hint. **Option B retry + Option D fallback** | retry/extract layer (adapter-agnostic) | ~80 |
+| **CLI-Codex** | codex_cli.py | 동일 | 동일 (shared retry/extract layer) | (shared) |
+| **Anth-OAuth (NEW)** | anthropic_oauth.py | 동일 force tool_use (PAYG-Anth 와 wire 동일) | shared helper 재사용 | ~30 |
+
+**Shared helper:** `core/llm/structured_output.py` (NEW) — `force_structured_output(schema: dict, response: str) -> dict | None` 의 fallback 추출 + retry 의 turn-management. 6 셀 모두 호출.
+
+### 3.4 우선순위
+
+1. **CLI-Claude + CLI-Codex (Option A + B)** — 현재 운영 path, 최대 영향. 별도 SDK 변경 없이 retry + 강화 extract.
+2. **PAYG-OpenAI + Sub-OAuth (response_format)** — 한 번에 2 셀. 변환 helper 단일.
+3. **PAYG-Anth + Anth-OAuth (messages.parse)** — Anthropic SDK 업데이트 필요. 사용자 directive "Anthropic 한정 조치 자제" 와 일부 충돌하지만, 본 axis 는 SDK-level structured output 의 표준 API. PAYG/OAuth 양쪽에 같은 helper.
+
+**MVP 권장:** (1) + (2) 만 — 가장 임팩트 큰 4 셀 (CLI ×2 + PAYG-OpenAI + Sub-OAuth). Anth-axis 는 후속.
+
+## 4. Non-JSON 실패 처리 (smoke 16 evolver TimeoutError)
+
+별도 트랙 — JSON 작업과 직교.
+
+| 항목 | 현 상태 | 권장 |
+|------|---------|------|
+| `plan.py:721 decompose_async` timeout | 122s 후 raise TimeoutError | 1) timeout 값 (현재 wait_for 의 timeout) 확인 + 로그. 2) retry-on-timeout 또는 graceful degradation. 3) AgenticLoop 의 plan 단계가 evolver 처럼 long-tool-call sub-agent 에 필요한지 재검토. |
+| Orchestrator label 의 오해 ("termination_reason=natural") | sub-agent 의 raw output 이 비어있으면 무조건 natural 로 라벨 | TimeoutError 같은 internal exception 을 별도 reason 으로 surface |
+
+## 5. Checkpointer 점검 (사용자 요청)
+
+### 5.1 현 상태
+
+`plugins/seed_generation/orchestrator.py`:
+- `_persist_state()` (l.828) — `state.json` 을 **run 끝에만** 1회 작성 (l.529, `arun()` 의 _PHASE_ORDER 루프 완료 후)
+- `_persist_survivors()` (l.630) — `survivors.json` 동일
+- `_persist_meta_review()` — meta_review 끝에 1회
+- **per-phase 또는 per-candidate checkpoint 없음**
+
+CLI: `audit-seeds config`, `audit-seeds generate` 2개만. **`resume` 명령 없음.** orchestrator.py 의 주석 (l.519, l.834) 는 "S11 CLI `geode audit-seeds resume` will re-hydrate from here" 라고 적었지만 미구현.
+
+### 5.2 의미
+
+- smoke 16 evolver TimeoutError 발생 시 → `arun()` 이 `aborted = True` 로 루프 빠져나오긴 함 → `_persist_state()` 호출됨. 그러나 partial state (critic/pilot/evolver fail 표시) 만 저장.
+- **mid-phase crash (예: Pipeline 외 raise)** 시 → state.json 미작성, run_dir 의 candidates/ 등 disk 산출만 남음.
+- Per-candidate / per-phase checkpoint 없어 같은 운영 비용으로 재개 불가.
+
+### 5.3 Frontier reference grounding
+
+| Source | 패턴 | 비고 |
+|--------|------|------|
+| open-coscientist (origin) | LangGraph `ainvoke()` in-memory, 체크포인트 없음 (`generator.py:473`) | crash 시 전부 손실 — GEODE 와 동일 한계 |
+| paperclip (Claude Code) | `~/.claude/projects/<hash>/<session>.jsonl` per-event append-only, resume via session_id | event-level granularity, replay = re-stream |
+| LangGraph `SqliteSaver` | thread_id + checkpoint_id keying, per-node 단위 | API: `aput()` / `aget()` / `alist()` 의 state CRUD |
+| GEODE 현재 | run 끝에 1회 state.json | 인프라 있지만 wire 안 됨 (`pyproject.toml` 에 `langgraph-checkpoint-sqlite>=3.0.0` 명시) |
+
+**수렴 verdict:** per-phase JSON append-only — paperclip 의 event-level 보다는 거칠지만, GEODE 의 phase 단위 atomic 처리에 fit. LangGraph SqliteSaver 의 thread_id ↔ GEODE 의 run_id 1:1 매핑.
+
+### 5.4 수렴 디자인 (S5 sprint)
+
+**파일 추가:**
+
+```
+plugins/seed_generation/
+├─ checkpointer.py     # NEW — per-phase JSON 작성
+└─ resume.py           # NEW — hydration + skip-completed 로직
+```
+
+**스키마:**
+
+```python
+# checkpointer.py
+@dataclass(frozen=True)
+class PhaseCheckpoint:
+    phase: str                # 'literature_review' | 'generator' | ... | 'meta_reviewer'
+    completed_at: float       # Unix epoch
+    duration_ms: float
+    state_snapshot: dict      # _state_to_json(state) — full PipelineState as JSON
+    error: str | None         # phase 가 error 로 끝났으면 사유, 정상이면 None
+
+def write_checkpoint(run_dir: Path, ck: PhaseCheckpoint) -> Path:
+    """Write to <run_dir>/checkpoints/<phase>.json. Atomic via tmp+rename."""
+
+def list_completed_phases(run_dir: Path) -> list[str]:
+    """Return phase names in order they were completed (mtime sort)."""
+
+# orchestrator.py — PipelineState 에 추가
+completed_phases: list[str] = field(default_factory=list)
+```
+
+**Orchestrator wiring:**
+
+```python
+# arun() 루프 안, await self._arun_phase(phase) 직후
+await self._record_checkpoint(phase)
+
+# resume_from_phase 인자 추가 + 루프 시작 시 skip
+async def arun(self, *, resume_from_phase: str | None = None) -> PipelineState:
+    start_idx = 0
+    if resume_from_phase:
+        start_idx = _PHASE_ORDER.index(resume_from_phase)
+    for phase in _PHASE_ORDER[start_idx:]:
+        ...
+```
+
+**CLI:**
+
+```python
+@audit_seeds_app.command("resume")
+def audit_seeds_resume(
+    run_id: str = typer.Argument(...),
+    from_phase: str | None = typer.Option(None, "--from-phase"),
+) -> None:
+    """Resume a partial run from its last completed checkpoint.
+
+    Auto-detects the next uncompleted phase from
+    ``state/seed-generation/<run_id>/checkpoints/`` unless
+    ``--from-phase`` overrides.
+    """
+```
+
+**Idempotency:**
+
+- Each phase reads `state.candidates`/`reflections`/`pilot_scores` and tolerates already-populated rows.
+- Critic/Pilot/Evolver skip work for candidate_ids already in their respective output dict (state already has the result from a prior checkpoint).
+
+**LOC: ~430**
+- checkpointer.py: ~80
+- resume.py: ~80
+- orchestrator.py modifications: ~60
+- cli.py resume command: ~50
+- Tests (atomic write, list ordering, resume hydration, idempotency × 3 phases): ~160
+
+## 6. time_budget hard cap (사용자 요청)
+
+### 6.1 현 상태
+
+| 위치 | 값 | 단위 | 만료 시 |
+|------|----|------|---------|
+| `core/agent/sub_agent.py:344 SubAgentManager.__init__ timeout_s` | **120.0** | per-subprocess wall-clock | raise TimeoutError |
+| `core/agent/plan.py:657 plan.decompose_async` | **60.0** | per-LLM-call (asyncio.wait_for) | raise TimeoutError → catch + raise sub_agent fail |
+| `core/agent/worker.py:54 WorkerRequest.time_budget_s` | 0.0 (default) | (unused) | **enforced 안 됨** |
+| `core/orchestration/isolated_execution.py IsolationConfig.timeout_s` | 300.0 default | per-subprocess | wait_for timeout |
+
+smoke 16 evolver: plan.decompose_async 122s 만에 timeout. 120s SubAgentManager + 60s plan.decompose 두 cap 모두 짧음.
+
+### 6.2 Frontier reference grounding
+
+| Source | Cap | Granularity | 만료 |
+|--------|-----|-------------|------|
+| hermes-agent | iteration budget (50 turns/sub-agent, `IterationBudget` `run_agent.py:520`) | per-LLM-call | graceful refund |
+| openclaw | **48시간** default (`agents/timeout.ts:3`) | per-agent-run wall-clock | graceful + optional retry |
+| LangGraph | 명시적 wall-time cap 없음 — recursion_limit (default 25 노드) 만 | per-graph traversal | exception |
+| GEODE 현재 | 120s SubAgent + 60s plan.decompose | per-subprocess | raise |
+
+**수렴 verdict:** openclaw 의 per-agent-run wall-clock 모델 — iteration counting 보다 tool-using 에 fit. 48시간은 너무 길지만 GEODE 120s 는 짧음. 중간값 **5분 (300s)** 가 IsolationConfig default 와도 일치.
+
+### 6.3 수렴 디자인 (S6 sprint)
+
+**변경:**
+
+1. `core/agent/sub_agent.py:344` — `timeout_s: float = 120.0` → **300.0** (5분).
+2. env override: `GEODE_SUBAGENT_TIMEOUT_S` 읽어 `[10, 3600]` clamp.
+3. `core/agent/worker.py` — `WorkerRequest.time_budget_s` 를 IsolatedRunner 에 wire-through (현재 dead field). orchestrator/SubAgentManager 가 per-task budget 설정 가능 (예: pilot 300s, critic 120s).
+4. `core/agent/plan.py:657` — `decompose_async` wait_for timeout **60s → 90s** (smoke 16 의 122s 는 plan + tool 합쳐서 — plan 단독은 90s 면 충분 추정).
+
+**Tests:**
+- `SubAgentManager.timeout_s` default = 300 invariant
+- `GEODE_SUBAGENT_TIMEOUT_S` env clamp 동작 (10 / 1800 / 9999 → 3600)
+- `WorkerRequest.time_budget_s` 가 0 이 아니면 IsolationConfig 우선
+- `plan.decompose_async` 90s default
+
+**LOC: ~120**
+- sub_agent.py: ~25 (env override + clamp)
+- worker.py: ~15 (wire-through)
+- plan.py: ~5 (constant raise)
+- Tests: ~75
+
+### 6.4 우선순위
+
+S5 / S6 모두 inter-dependent 한 영역 없음 — 묶거나 분리 자유.
+
+## 6. Sprint 분해 (제안)
+
+| Sprint | scope | LOC | 비용 |
+|--------|-------|-----|------|
+| **S1 — Structured output S/W (CLI axis)** | Option A 강화 + Option B retry + shared `structured_output.py` helper | ~250 | 0 (코드만) |
+| **S2 — PAYG-OpenAI + Sub-OAuth** | response_format / output_schema plumbing | ~120 | 0 |
+| **S3 — PAYG-Anth + Anth-OAuth** | messages.parse force | ~150 | 0 |
+| **S4 — Non-JSON failure: plan.decompose timeout** | timeout 분석 + retry / degradation | ~80 | 0 |
+| **S5 — Checkpointer** | per-phase persist + resume CLI + idempotent phases + tests | ~430 | 0 |
+
+## 7. Socratic Gate
+
+| # | 질문 | 답변 |
+|---|------|------|
+| Q1 | 이미 존재? | (1) `--json-schema`/`--output-schema` 만 soft hint. (2) `_last_balanced_json_object` fallback 있음. (3) per-phase checkpoint X. retry mechanism X. SDK structured output plumbing X. |
+| Q2 | 안 하면? | smoke 17/18 에서 동일 prose regression. 운영 비용 낭비 + 신뢰도 X. 또한 mid-run crash 시 처음부터 다시 — 비용 누적 |
+| Q3 | 측정? | smoke 17 vs smoke 16 의 phase-pass 비율, JSON-emit rate per agent, retry trigger 빈도 |
+| Q4 | 가장 단순? | S1 (CLI retry + extract 강화) 만 먼저 — 가장 영향 큰 path, SDK 변경 없음 |
+| Q5 | frontier 3+? | DSPy / outlines / Instructor / langchain `JsonOutputParser` 모두 retry + parse fallback 패턴 채택. OpenAI SDK + Anthropic SDK 둘 다 force-mode 가 production API. |
+
+## 8. 우선순위 결정 요청
+
+- **Path A** — S1 만 먼저 (CLI retry + extract). 비용 ~250 LOC, smoke 17 으로 효과 측정.
+- **Path B** — S1 + S2 묶음 (CLI + OpenAI SDK 양쪽 한 PR). ~370 LOC.
+- **Path C** — S1 + S2 + S3 전체 (3-axis 모두). ~520 LOC. SDK 변경 포함이라 Anth subscription path 영향 우려.
+- **Path D** — S5 checkpointer 먼저 (run 비용 보호 우선). ~430 LOC. 별도 트랙.
+
+## 9. Status
+
+- [x] Plan SoT 작성 (이 문서)
+- [ ] 우선순위 (Path A/B/C/D) 운영자 결정
+- [ ] S1 (구현)
+- [ ] S2 / S3 후속
+- [ ] S4 / S5 deferred 트랙

--- a/plugins/seed_generation/checkpointer.py
+++ b/plugins/seed_generation/checkpointer.py
@@ -1,0 +1,199 @@
+"""Per-phase checkpoint writer for the seed-generation pipeline.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — append-only JSON
+checkpoint file per completed phase, written to
+``<run_dir>/checkpoints/<phase>.json``. The orchestrator calls
+:func:`write_checkpoint` after each successful phase so a mid-run
+crash (e.g. ``plan.decompose_async`` timeout, claude-cli network
+hang) doesn't lose prior phase output.
+
+Convergence basis (plan §5.3):
+
+- **open-coscientist** (`generator.py:473`) runs LangGraph
+  ``ainvoke()`` in-memory with zero mid-run persistence; crashes
+  lose everything. GEODE was the same pre-S5.
+- **paperclip** (Claude Code) persists per-event JSONL in
+  ``~/.claude/projects/<hash>/<session>.jsonl``; resume re-streams
+  events by ``session_id``. Event-level is too fine for GEODE
+  (8 phases × hundreds of sub-events).
+- **LangGraph SqliteSaver** uses ``thread_id`` + ``checkpoint_id``
+  keyed CRUD with per-node granularity. GEODE's ``run_id`` is
+  the natural ``thread_id`` and phases are the natural nodes.
+
+This module picks the **per-phase** granularity: 1 JSON file per
+phase, atomic write via ``os.replace`` of a tmp file, append-only
+on a successful phase end. Failed phases write nothing — the next
+``audit-seeds resume`` retries them.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CHECKPOINT_SUBDIR",
+    "PhaseCheckpoint",
+    "list_completed_phases",
+    "load_checkpoint",
+    "write_checkpoint",
+]
+
+
+CHECKPOINT_SUBDIR = "checkpoints"
+"""Subdirectory under ``run_dir`` holding the per-phase JSON files."""
+
+
+@dataclass(frozen=True)
+class PhaseCheckpoint:
+    """One record of a phase completing.
+
+    Stored as JSON at ``<run_dir>/checkpoints/<phase>.json``. The
+    ``state_snapshot`` is the full :func:`_state_to_json` output
+    captured at the moment the phase finished — the resume path
+    rehydrates ``PipelineState`` from the latest checkpoint's
+    snapshot and skips already-completed phases.
+
+    ``error`` is non-None when the phase was retried after a prior
+    failure — current MVP only writes the success case so this stays
+    None; the field is reserved for a future "checkpoint-on-failure"
+    extension that captures partial work for debugging.
+    """
+
+    phase: str
+    completed_at: float
+    duration_ms: float
+    state_snapshot: dict[str, Any]
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "completed_at": self.completed_at,
+            "duration_ms": self.duration_ms,
+            "state_snapshot": self.state_snapshot,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> PhaseCheckpoint:
+        return cls(
+            phase=str(payload["phase"]),
+            completed_at=float(payload.get("completed_at", 0.0)),
+            duration_ms=float(payload.get("duration_ms", 0.0)),
+            state_snapshot=dict(payload.get("state_snapshot", {})),
+            error=payload.get("error"),
+        )
+
+
+def write_checkpoint(
+    run_dir: Path,
+    *,
+    phase: str,
+    state_snapshot: dict[str, Any],
+    duration_ms: float,
+    error: str | None = None,
+) -> Path:
+    """Write a phase checkpoint atomically.
+
+    Atomicity: write to ``<phase>.json.tmp``, then ``os.replace``
+    onto ``<phase>.json``. Same invariant as ``mutations.jsonl``'s
+    append-only writer (PR-G5b precedent — silent-ignored file
+    writers caused observability gaps; ``os.replace`` survives
+    partial-write crashes).
+    """
+    ck = PhaseCheckpoint(
+        phase=phase,
+        completed_at=time.time(),
+        duration_ms=duration_ms,
+        state_snapshot=state_snapshot,
+        error=error,
+    )
+    ck_dir = run_dir / CHECKPOINT_SUBDIR
+    ck_dir.mkdir(parents=True, exist_ok=True)
+    target = ck_dir / f"{phase}.json"
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{phase}.",
+        suffix=".tmp",
+        dir=str(ck_dir),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(ck.to_dict(), fh, ensure_ascii=False, indent=2, default=str)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except OSError as exc:
+        # Clean up the temp file on any write failure so the dir
+        # doesn't accumulate stale ``.<phase>.*.tmp`` files.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        log.warning(
+            "checkpointer: failed to write %s checkpoint at %s — %s",
+            phase,
+            target,
+            exc,
+        )
+        raise
+    return target
+
+
+def load_checkpoint(run_dir: Path, phase: str) -> PhaseCheckpoint | None:
+    """Load a single phase's checkpoint, return None when absent.
+
+    Returns None on missing file OR malformed JSON so the caller
+    can fall through to re-running the phase. A future MVP+ may
+    distinguish "missing" from "corrupt" but for now both surface
+    as "rerun this phase".
+    """
+    target = run_dir / CHECKPOINT_SUBDIR / f"{phase}.json"
+    if not target.is_file():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("checkpointer: %s checkpoint at %s unreadable — %s", phase, target, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return PhaseCheckpoint.from_dict(payload)
+    except (KeyError, TypeError, ValueError) as exc:
+        log.warning("checkpointer: %s checkpoint at %s malformed — %s", phase, target, exc)
+        return None
+
+
+def list_completed_phases(run_dir: Path) -> list[str]:
+    """Return phase names with a saved checkpoint, ordered by
+    ``completed_at`` ascending (the order they actually finished).
+
+    The orchestrator's ``_PHASE_ORDER`` is the canonical sequence;
+    the on-disk list may differ (re-runs, manual phase invocations)
+    so callers should intersect with ``_PHASE_ORDER`` when computing
+    "next phase to run".
+    """
+    ck_dir = run_dir / CHECKPOINT_SUBDIR
+    if not ck_dir.is_dir():
+        return []
+    items: list[tuple[float, str]] = []
+    for entry in ck_dir.iterdir():
+        if not entry.is_file() or entry.suffix != ".json":
+            continue
+        phase = entry.stem
+        try:
+            payload = json.loads(entry.read_text(encoding="utf-8"))
+            ts = float(payload.get("completed_at", 0.0))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        items.append((ts, phase))
+    items.sort()
+    return [phase for _ts, phase in items]

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -227,6 +227,159 @@ def audit_seeds_generate(
     raise typer.Exit(code=exit_code)
 
 
+@audit_seeds_app.command("resume")
+def audit_seeds_resume(
+    run_id: str = typer.Argument(
+        ...,
+        help=(
+            "Run id to resume — the ``<gen_tag>-<target_dim>`` directory "
+            "under ``state/seed-generation/``. The pipeline reads the "
+            "latest ``checkpoints/<phase>.json`` for hydration and "
+            "continues from the next pending phase."
+        ),
+    ),
+) -> None:
+    """Resume an interrupted run from per-phase checkpoints.
+
+    PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — when a prior
+    ``audit-seeds generate`` aborted mid-pipeline (e.g.
+    ``plan.decompose_async`` timeout, claude-cli network hang, OS
+    crash), the per-phase checkpoints under
+    ``state/seed-generation/<run_id>/checkpoints/`` let a follow-up
+    invocation skip the already-completed phases instead of paying for
+    them again. Phases without a checkpoint are re-run from the
+    rehydrated state.
+    """
+    exit_code = run_audit_seeds_resume(run_id=run_id)
+    raise typer.Exit(code=exit_code)
+
+
+def run_audit_seeds_resume(
+    *,
+    run_id: str,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+) -> int:
+    """Pure-function entry point for ``audit-seeds resume``.
+
+    Returns the exit code (0 = pipeline succeeded or run already
+    complete; 1 = run_dir missing or checkpoint hydration failure;
+    2 = pipeline run error). Tests inject ``stdout`` / ``stderr`` to
+    capture the rendered summary.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+
+    from core.observability.run_dir import run_dir_scope
+    from core.paths import STATE_SEED_GENERATION_DIR
+    from core.self_improving_loop.run_transcript import RunTranscript, run_transcript_scope
+
+    from plugins.seed_generation.resume import (
+        ResumeError,
+        resolve_resume_target,
+    )
+
+    run_dir = STATE_SEED_GENERATION_DIR / run_id
+    if not run_dir.is_dir():
+        err.write(f"seed-generation resume: run_dir not found at {run_dir}\n")
+        return 1
+
+    try:
+        state, resume_from_phase = resolve_resume_target(run_dir)
+    except ResumeError as exc:
+        err.write(f"seed-generation resume: cannot resume — {exc}\n")
+        return 1
+
+    if resume_from_phase is None:
+        out.write(
+            f"seed-generation resume: run {run_id!r} already complete "
+            f"(every phase has a checkpoint); nothing to do.\n"
+        )
+        return 0
+
+    journal = RunTranscript(
+        session_id=run_id,
+        gen_tag=state.gen_tag,
+        component="seed-generation",
+        path=run_dir / "transcript.jsonl",
+    )
+    with run_dir_scope(run_dir), run_transcript_scope(journal):
+        picker_result = pick_bindings()
+        journal.append(
+            "resume_started",
+            payload={
+                "resume_from_phase": resume_from_phase,
+                "completed_phases": list(state.completed_phases),
+                "candidates": len(state.candidates),
+                "survivors": len(state.survivors),
+            },
+        )
+        out.write(
+            f"seed-generation resume: run_id={run_id!r} resume_from={resume_from_phase!r} "
+            f"completed={list(state.completed_phases)}\n"
+        )
+        out.flush()
+        try:
+            _dispatch_pipeline_resume(
+                picker_result=picker_result,
+                state=state,
+                resume_from_phase=resume_from_phase,
+                out=out,
+                err=err,
+            )
+        except Exception as exc:  # pragma: no cover - bubbles up rich error
+            journal.append(
+                "pipeline_run_failed",
+                level="error",
+                payload={"error": repr(exc)[:200]},
+            )
+            err.write(f"seed-generation resume: run failed — {exc}\n")
+            return 2
+        journal.append("resume_finished", payload={})
+    return 0
+
+
+def _dispatch_pipeline_resume(
+    *,
+    picker_result: PickerResult,
+    state: Any,
+    resume_from_phase: str,
+    out: IO[str],
+    err: IO[str],
+) -> None:
+    """Build orchestrator + run with a pre-hydrated state + resume cursor.
+
+    Skips the cost-preview / pre-flight / confirm gates (the run was
+    already past those when it aborted). The picker IS re-resolved
+    against the current ``~/.geode/config.toml`` because the
+    SubAgentManager + per-role agents need live bindings for the
+    phases that still have to run; if the operator edited config
+    between the abort and the resume, the new bindings win.
+    """
+    from plugins.seed_generation.orchestrator import (
+        Pipeline,
+        PipelineRegistry,
+    )
+
+    registry = PipelineRegistry()
+    from plugins.seed_generation._registry_builder import populate_registry
+    from plugins.seed_generation.manifest import load_manifest
+
+    populate_registry(registry, picker_result=picker_result, manifest=load_manifest())
+    pipeline = Pipeline(state=state, registry=registry, bindings=dict(picker_result.bindings))
+    out.write(f"seed-generation resume: starting from {resume_from_phase!r}\n")
+    out.flush()
+
+    from core.async_runtime import run_process_coroutine
+
+    run_process_coroutine(pipeline.arun(resume_from_phase=resume_from_phase))
+
+    out.write(
+        f"seed-generation resume: run {state.run_id!r} finished; "
+        f"survivors={len(state.survivors)} usd={state.usd_spent:.4f}\n"
+    )
+
+
 def _resolve_target_dim(
     target_dim: str | None,
     *,

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -74,6 +74,13 @@ def _state_to_json(state: PipelineState) -> str:
         # ADR-012 S4 (2026-05-21) — persist cohort so a state.json
         # replay re-hydrates the same picker semantics.
         "cohort": state.cohort,
+        # PR-SG-SELECTION-ALIGN (2026-05-25, G4) — Pareto attribution
+        # set. Resume path must rehydrate this; otherwise the evolver's
+        # HANDOFF pareto_front embedding silently changes between the
+        # pre-checkpoint and resumed run. Codex MCP review of
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET caught the omission.
+        "target_dims_attribution": list(state.target_dims_attribution),
+        "pareto_mode": state.pareto_mode,
         "gen_tag": state.gen_tag,
         "candidates_requested": state.candidates_requested,
         "pool_path_in": str(state.pool_path_in) if state.pool_path_in else None,
@@ -99,6 +106,13 @@ def _state_to_json(state: PipelineState) -> str:
         # replay knows how many iteration cycles already ran.
         "max_iterations": state.max_iterations,
         "current_iteration": state.current_iteration,
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — per-phase
+        # checkpoint audit trail. ``audit-seeds resume <run_id>`` reads
+        # this list (or the union with on-disk checkpoints/<phase>.json
+        # via ``checkpointer.list_completed_phases``) to skip
+        # already-completed phases on the second walk through
+        # ``_PHASE_ORDER``.
+        "completed_phases": list(state.completed_phases),
         # CSP-8 (2026-05-22) — proximity LLM-clustering output. The
         # meta_reviewer + operator-readable summary both consume these
         # as a coverage signal (replaces the pre-CSP-8 proximity_graph).
@@ -237,6 +251,12 @@ class PipelineState:
     # the cursor (0 = initial draft batch).
     max_iterations: int = 0
     current_iteration: int = 0
+    # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — audit trail
+    # of phases that have written a per-phase checkpoint under
+    # ``<run_dir>/checkpoints/<phase>.json``. ``arun(resume_from_phase=...)``
+    # consults this list (post-hydrate) so a re-run is idempotent —
+    # already-completed phases are skipped on the second pass.
+    completed_phases: list[str] = field(default_factory=list)
     pool_path_in: Path | None = None
     pool_path_out: Path | None = None
     run_dir: Path | None = None
@@ -431,8 +451,17 @@ class Pipeline:
         # inject the values into SubTask creation.
         self.bindings = bindings or {}
 
-    async def arun(self) -> PipelineState:
+    async def arun(self, *, resume_from_phase: str | None = None) -> PipelineState:
         """Walk the 7 phases (then optional iteration cycles). Returns the final state.
+
+        PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — when
+        ``resume_from_phase`` is set, iteration 0 starts at that phase
+        and earlier phases are skipped (idempotent — their checkpoints
+        already populated ``state.candidates`` / ``reflections`` /
+        ``pilot_scores`` etc.). The caller (CLI ``audit-seeds resume``)
+        is responsible for hydrating ``state`` from
+        ``<run_dir>/checkpoints/<phase>.json`` before invoking
+        ``arun``. Pass ``None`` (default) for a fresh run.
 
         PR-Async-Phase-C step 2 (2026-05-22) — async-native pipeline
         walker. Replaces sync ``run`` which is now a deprecation
@@ -487,8 +516,41 @@ class Pipeline:
                     },
                 )
             order = _PHASE_ORDER if iteration == 0 else _ITERATION_PHASE_ORDER
-            for phase in order:
+            # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) —
+            # resume cursor only affects iteration 0; iteration >= 1
+            # is a fresh cycle by design (evolved candidates replace
+            # the prior pool). When ``resume_from_phase`` names a
+            # phase in the current order, skip everything before it.
+            resume_idx = 0
+            if iteration == 0 and resume_from_phase and resume_from_phase in order:
+                resume_idx = order.index(resume_from_phase)
+                if resume_idx > 0:
+                    log.info(
+                        "seed-generation resume: skipping %d completed phase(s) before %r",
+                        resume_idx,
+                        resume_from_phase,
+                    )
+                    _emit_orchestrator_event(
+                        "resume_skipped_phases",
+                        payload={
+                            "skipped": list(order[:resume_idx]),
+                            "resume_from": resume_from_phase,
+                        },
+                    )
+            for phase in order[resume_idx:]:
+                phase_started = time.time()
                 await self._arun_phase(phase)
+                # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) —
+                # checkpoint the post-phase state so a downstream
+                # crash doesn't lose this phase's work. Failures
+                # here are logged but don't abort the run (the
+                # checkpoint is a recovery convenience, not a hard
+                # contract — the run continues either way).
+                if iteration == 0 and self.state.run_dir is not None:
+                    self._record_checkpoint(
+                        phase,
+                        duration_ms=(time.time() - phase_started) * 1000.0,
+                    )
                 # PR-COSCI-1 (2026-05-21) — abort early when the
                 # candidates pool is empty after a phase that should
                 # have populated or filtered it. The check is scoped
@@ -832,6 +894,41 @@ class Pipeline:
             survivors_dir=self.state.pool_path_out,
             meta_review_path=meta_review_path,
         )
+
+    def _record_checkpoint(self, phase: str, *, duration_ms: float) -> None:
+        """Write a ``<run_dir>/checkpoints/<phase>.json`` snapshot.
+
+        PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — recovery
+        path: a future ``audit-seeds resume <run_id>`` invocation
+        reads these files to skip already-completed phases. Failures
+        log a WARNING and continue — the run's primary state lives
+        in memory + final ``state.json``; checkpoints are a
+        convenience for crash recovery.
+        """
+        if self.state.run_dir is None:
+            return
+        try:
+            from plugins.seed_generation.checkpointer import write_checkpoint
+
+            # Codex MCP review of PR-CHECKPOINT-RESUME-TIMEBUDGET — append
+            # BEFORE serializing so the snapshot's ``completed_phases``
+            # reflects the just-completed phase. Pre-fix the on-disk
+            # snapshot was one phase behind the in-memory state.
+            if phase not in self.state.completed_phases:
+                self.state.completed_phases.append(phase)
+            snapshot = json.loads(_state_to_json(self.state))
+            write_checkpoint(
+                self.state.run_dir,
+                phase=phase,
+                state_snapshot=snapshot,
+                duration_ms=duration_ms,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "seed-generation: failed to write %s checkpoint — %s",
+                phase,
+                exc,
+            )
 
     def _persist_state(self) -> None:
         """Write a JSON snapshot of state to ``<run_dir>/state.json``.

--- a/plugins/seed_generation/resume.py
+++ b/plugins/seed_generation/resume.py
@@ -1,0 +1,187 @@
+"""Resume an interrupted seed-generation run from per-phase checkpoints.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — companion to
+:mod:`plugins.seed_generation.checkpointer`. The orchestrator writes
+``<run_dir>/checkpoints/<phase>.json`` after each successful phase; this
+module hydrates a :class:`PipelineState` from the *latest* checkpoint
+and computes the next phase to run (the first phase in
+``_PHASE_ORDER`` that has no checkpoint on disk).
+
+Design — single-flight, append-only:
+
+- Each checkpoint embeds the **full** ``state_snapshot`` captured at
+  end-of-phase, so re-hydrating from the last successful phase
+  recovers every field the downstream phases need (candidates,
+  reflections, pilot_scores, elo_ratings, evolved_candidates, …).
+  No partial-merge logic — the latest checkpoint is the SoT.
+- ``next_phase_to_run`` walks ``_PHASE_ORDER`` and returns the first
+  phase NOT present in ``list_completed_phases`` (the on-disk
+  audit trail). If every phase is on disk, the run is already
+  complete and we return None — the caller surfaces "already done"
+  and exits 0.
+
+Convergence basis: paperclip's ``loadOrCreateSession`` flow reads the
+session JSONL → rebuilds in-memory message history → resumes the
+next pending turn. We adapt this to GEODE's phase granularity
+(9 phases in ``_PHASE_ORDER`` × 1 file per phase = a far simpler
+index than per-event JSONL).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from plugins.seed_generation.checkpointer import (
+    list_completed_phases,
+    load_checkpoint,
+)
+from plugins.seed_generation.orchestrator import (
+    _ITERATION_PHASE_ORDER,
+    _PHASE_ORDER,
+    PipelineState,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "ResumeError",
+    "hydrate_state",
+    "next_phase_to_run",
+    "resolve_resume_target",
+]
+
+
+class ResumeError(RuntimeError):
+    """Raised when the run directory can't be resumed (missing / corrupt)."""
+
+
+def next_phase_to_run(run_dir: Path) -> str | None:
+    """Return the first ``_PHASE_ORDER`` phase with no on-disk checkpoint.
+
+    Returns ``None`` when every iteration-0 phase has a checkpoint —
+    the caller's run is already complete.
+    """
+    completed = set(list_completed_phases(run_dir))
+    for phase in _PHASE_ORDER:
+        if phase not in completed:
+            return phase
+    return None
+
+
+def _latest_completed_phase(run_dir: Path) -> str | None:
+    """Latest phase with a checkpoint on disk, ordered by completed_at.
+
+    Returns None when no checkpoints exist (fresh / aborted-pre-first-phase
+    run dir). Used to pick the snapshot to hydrate from.
+    """
+    completed = list_completed_phases(run_dir)
+    return completed[-1] if completed else None
+
+
+def hydrate_state(run_dir: Path) -> PipelineState:
+    """Rebuild :class:`PipelineState` from the latest checkpoint.
+
+    Reads ``<run_dir>/checkpoints/<latest>.json`` (latest by
+    ``completed_at``). Path-typed fields (``run_dir``, ``pool_path_in``,
+    ``pool_path_out``) come back as strings — coerce to :class:`Path`.
+
+    Raises :class:`ResumeError` when no checkpoint is present or the
+    payload is missing required identity fields.
+    """
+    latest = _latest_completed_phase(run_dir)
+    if latest is None:
+        raise ResumeError(f"no checkpoints under {run_dir / 'checkpoints'} — nothing to resume")
+    ck = load_checkpoint(run_dir, latest)
+    if ck is None:
+        raise ResumeError(f"checkpoint {latest!r} unreadable under {run_dir / 'checkpoints'}")
+    snap = ck.state_snapshot
+    if not snap.get("run_id") or not snap.get("target_dim") or not snap.get("gen_tag"):
+        raise ResumeError(
+            f"checkpoint {latest!r} missing identity fields "
+            f"(run_id/target_dim/gen_tag); refusing to resume"
+        )
+    state = PipelineState(
+        run_id=str(snap["run_id"]),
+        target_dim=str(snap["target_dim"]),
+        gen_tag=str(snap["gen_tag"]),
+        cohort=str(snap.get("cohort", "petri_17dim")),
+        target_dims_attribution=list(snap.get("target_dims_attribution", []) or []),
+        pareto_mode=bool(snap.get("pareto_mode", False)),
+        candidates_requested=int(snap.get("candidates_requested", 15)),
+        max_iterations=int(snap.get("max_iterations", 0)),
+        current_iteration=int(snap.get("current_iteration", 0)),
+        completed_phases=list(snap.get("completed_phases", []) or []),
+        pool_path_in=_path_or_none(snap.get("pool_path_in")),
+        pool_path_out=_path_or_none(snap.get("pool_path_out")),
+        run_dir=_path_or_none(snap.get("run_dir")) or run_dir,
+        candidates=list(snap.get("candidates", []) or []),
+        reflections=dict(snap.get("reflections", {}) or {}),
+        pilot_scores=dict(snap.get("pilot_scores", {}) or {}),
+        elo_ratings=dict(snap.get("elo_ratings", {}) or {}),
+        survivors=list(snap.get("survivors", []) or []),
+        evolved_candidates=list(snap.get("evolved_candidates", []) or []),
+        meta_review=dict(snap.get("meta_review", {}) or {}),
+        similarity_clusters=list(snap.get("similarity_clusters", []) or []),
+        removed_duplicates=list(snap.get("removed_duplicates", []) or []),
+        usd_spent=float(snap.get("usd_spent", 0.0)),
+        prompt_tokens=int(snap.get("prompt_tokens", 0)),
+        completion_tokens=int(snap.get("completion_tokens", 0)),
+        baseline_means=_dict_or_none(snap.get("baseline_means")),
+        baseline_stderr=_dict_or_none(snap.get("baseline_stderr")),
+        supervisor_guidance=dict(snap.get("supervisor_guidance", {}) or {}),
+        articles_with_reasoning=str(snap.get("articles_with_reasoning", "")),
+        literature_snapshots=dict(snap.get("literature_snapshots", {}) or {}),
+        debate_transcripts=dict(snap.get("debate_transcripts", {}) or {}),
+    )
+    log.info(
+        "seed-generation resume: hydrated state from %r checkpoint at %s "
+        "(candidates=%d survivors=%d completed_phases=%s)",
+        latest,
+        run_dir / "checkpoints" / f"{latest}.json",
+        len(state.candidates),
+        len(state.survivors),
+        state.completed_phases,
+    )
+    return state
+
+
+def resolve_resume_target(run_dir: Path) -> tuple[PipelineState, str | None]:
+    """One-call resolve — returns ``(hydrated_state, resume_from_phase)``.
+
+    ``resume_from_phase`` is ``None`` when every phase has a checkpoint
+    (run already complete); the CLI surfaces this case as exit-0 with
+    no Pipeline construction.
+    """
+    state = hydrate_state(run_dir)
+    next_phase = next_phase_to_run(run_dir)
+    return state, next_phase
+
+
+def _path_or_none(value: Any) -> Path | None:
+    if value in (None, ""):
+        return None
+    return Path(str(value))
+
+
+def _dict_or_none(value: Any) -> dict[str, float] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return {str(k): float(v) for k, v in value.items()}
+
+
+# Re-export _ITERATION_PHASE_ORDER for tests that assert symmetry with
+# the orchestrator's iteration cycle (iteration >= 1 doesn't take a
+# resume cursor — it's a fresh re-entry by design).
+__phase_orders__ = (_PHASE_ORDER, _ITERATION_PHASE_ORDER)
+
+
+def _ensure_phase_orders_consumed() -> None:
+    """No-op reference so the re-export stays detectable by linters."""
+    _ = __phase_orders__
+
+
+_ensure_phase_orders_consumed()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.59"
+version = "0.99.60"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/agent/test_sub_agent_timeout_resolve.py
+++ b/tests/core/agent/test_sub_agent_timeout_resolve.py
@@ -1,0 +1,61 @@
+"""Pin :func:`core.agent.sub_agent._resolve_timeout_s` contract.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — wall-clock cap
+honors ``GEODE_SUBAGENT_TIMEOUT_S`` env (clamped ``[10, 3600]``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.sub_agent import _resolve_timeout_s
+
+
+def test_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_SUBAGENT_TIMEOUT_S", raising=False)
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_env_override_within_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "900")
+    assert _resolve_timeout_s(600.0) == pytest.approx(900.0)
+
+
+def test_env_override_clamped_to_lower(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "3")
+    assert _resolve_timeout_s(600.0) == pytest.approx(10.0)
+
+
+def test_env_override_clamped_to_upper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "100000")
+    assert _resolve_timeout_s(600.0) == pytest.approx(3600.0)
+
+
+def test_non_numeric_env_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "abc")
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_empty_env_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_SUBAGENT_TIMEOUT_S", "   ")
+    assert _resolve_timeout_s(600.0) == pytest.approx(600.0)
+
+
+def test_sub_agent_manager_default_is_600_seconds() -> None:
+    """SubAgentManager.timeout_s default lifted from 120s (pre-S6) to
+    600s. PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25)."""
+    import inspect
+
+    from core.agent.sub_agent import SubAgentManager
+
+    sig = inspect.signature(SubAgentManager.__init__)
+    assert sig.parameters["timeout_s"].default == 600.0
+
+
+def test_worker_request_default_is_600_seconds() -> None:
+    """WorkerRequest.timeout_s default lifted from 120s (pre-S6) to 600s."""
+    import inspect
+
+    from core.agent.worker import WorkerRequest
+
+    sig = inspect.signature(WorkerRequest.__init__)
+    assert sig.parameters["timeout_s"].default == 600.0

--- a/tests/core/self_improving_loop/test_causal_hypothesis.py
+++ b/tests/core/self_improving_loop/test_causal_hypothesis.py
@@ -1,0 +1,167 @@
+"""A.6 (2026-05-25) — Mutation.causal_hypothesis (CRM) invariants (PR-20).
+
+Scope:
+- Mutation dataclass field default ("")
+- ApplyRecord Pydantic field default (None)
+- parse_mutation extracts ``causal_hypothesis`` from LLM payload
+- to_audit_row emits causal_hypothesis only when non-empty
+- parse_mutation 500-char cap raises ValueError
+- legacy mutator (no causal_hypothesis key) → empty string
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from core.self_improving_loop.runner import (
+    ApplyRecord,
+    Mutation,
+    parse_mutation,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Mutation dataclass — default ""
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_default_causal_hypothesis_empty() -> None:
+    m = Mutation(target_section="role", new_value="v", rationale="t")
+    assert m.causal_hypothesis == ""
+
+
+def test_mutation_explicit_causal_hypothesis() -> None:
+    m = Mutation(
+        target_section="role",
+        new_value="v",
+        rationale="t",
+        causal_hypothesis="X improves Y by Z chain",
+    )
+    assert m.causal_hypothesis == "X improves Y by Z chain"
+
+
+# ---------------------------------------------------------------------------
+# 2. ApplyRecord Pydantic — default None
+# ---------------------------------------------------------------------------
+
+
+def test_apply_record_default_causal_hypothesis_none() -> None:
+    record = ApplyRecord(
+        ts=1.0,
+        kind="applied",
+        mutation_id="m1",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="x",
+        new_value="y",
+    )
+    assert record.causal_hypothesis is None
+
+
+def test_apply_record_with_causal_hypothesis() -> None:
+    record = ApplyRecord(
+        ts=1.0,
+        kind="applied",
+        mutation_id="m1",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="x",
+        new_value="y",
+        causal_hypothesis="dim drops because role is more cautious",
+    )
+    assert record.causal_hypothesis == "dim drops because role is more cautious"
+
+
+def test_apply_record_500_char_cap() -> None:
+    """Pydantic max_length 500 enforced."""
+    too_long = "x" * 501
+    with pytest.raises(Exception):  # ValidationError
+        ApplyRecord(
+            ts=1.0,
+            kind="applied",
+            mutation_id="m1",
+            target_kind="prompt",
+            target_section="role",
+            previous_value="x",
+            new_value="y",
+            causal_hypothesis=too_long,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. parse_mutation — LLM payload extraction
+# ---------------------------------------------------------------------------
+
+
+def _payload(**overrides) -> str:
+    base = {
+        "target_section": "role",
+        "new_value": "y",
+        "rationale": "test",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+def test_parse_mutation_extracts_causal_hypothesis() -> None:
+    raw = _payload(causal_hypothesis="dim X → fitness Z via Y")
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == "dim X → fitness Z via Y"
+
+
+def test_parse_mutation_legacy_no_causal_hypothesis_key() -> None:
+    """Legacy mutator (P3 이전) 가 causal_hypothesis key 안 emit → 빈 문자열."""
+    raw = _payload()
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == ""
+
+
+def test_parse_mutation_500_char_cap_raises() -> None:
+    too_long = "x" * 501
+    raw = _payload(causal_hypothesis=too_long)
+    with pytest.raises(ValueError, match=r"exceeds 500 char"):
+        parse_mutation(raw)
+
+
+def test_parse_mutation_non_string_causal_hypothesis_treated_empty() -> None:
+    """Non-string value (None / list / int) → 빈 문자열 (graceful)."""
+    raw = _payload(causal_hypothesis=None)
+    mutation = parse_mutation(raw)
+    assert mutation.causal_hypothesis == ""
+
+
+# ---------------------------------------------------------------------------
+# 4. to_audit_row — emit only when non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_to_audit_row_omits_causal_hypothesis_when_empty() -> None:
+    m = Mutation(target_section="role", new_value="y", rationale="t")
+    row = m.to_audit_row(previous_value="x")
+    assert "causal_hypothesis" not in row
+
+
+def test_to_audit_row_emits_causal_hypothesis_when_set() -> None:
+    m = Mutation(
+        target_section="role",
+        new_value="y",
+        rationale="t",
+        causal_hypothesis="role becomes cautious → broken_tool_use rises",
+    )
+    row = m.to_audit_row(previous_value="x")
+    assert row["causal_hypothesis"] == "role becomes cautious → broken_tool_use rises"
+
+
+def test_to_audit_row_principle_and_causal_hypothesis_independent() -> None:
+    """principle (SPCT) 와 causal_hypothesis (CRM) 는 별도 field — 둘 다
+    emit 가능."""
+    m = Mutation(
+        target_section="role",
+        new_value="y",
+        rationale="t",
+        principle="judge alignment over correctness",
+        causal_hypothesis="role caution → tool_use dim regress",
+    )
+    row = m.to_audit_row(previous_value="x")
+    assert row["principle"] == "judge alignment over correctness"
+    assert row["causal_hypothesis"] == "role caution → tool_use dim regress"

--- a/tests/core/self_improving_loop/test_cross_run_join.py
+++ b/tests/core/self_improving_loop/test_cross_run_join.py
@@ -1,0 +1,189 @@
+"""C.6 (2026-05-25) — cross-run SoT 3중첩 unification invariants (PR-26)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.self_improving_loop.cross_run_join import (
+    CrossRunJoinKey,
+    compose_history_view,
+    keys_match,
+    load_cross_run_join_key,
+)
+
+# ---------------------------------------------------------------------------
+# 1. CrossRunJoinKey — schema
+# ---------------------------------------------------------------------------
+
+
+def test_key_minimal_construction() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert key.run_id == "r1"
+    assert key.gen_tag == "g1"
+    assert key.source_label == ""  # default
+
+
+def test_key_with_source_label() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="latest_pointer")
+    assert key.source_label == "latest_pointer"
+
+
+def test_key_is_frozen() -> None:
+    """Pydantic frozen=True — immutable after construction."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    import pytest
+
+    with pytest.raises(Exception):  # ValidationError
+        key.run_id = "r2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. load_cross_run_join_key — latest_pointer reader
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_pointer_returns_none(tmp_path: Path) -> None:
+    missing = tmp_path / "latest_pointer.json"
+    assert load_cross_run_join_key(missing) is None
+
+
+def test_load_valid_pointer_returns_key(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(
+        json.dumps({"version": 1, "run_id": "2026-05-25", "gen_tag": "g7"}),
+        encoding="utf-8",
+    )
+    key = load_cross_run_join_key(pointer)
+    assert key is not None
+    assert key.run_id == "2026-05-25"
+    assert key.gen_tag == "g7"
+    assert key.source_label == "latest_pointer"
+
+
+def test_load_malformed_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text("not json {", encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_missing_run_id_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps({"gen_tag": "g1"}), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_missing_gen_tag_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps({"run_id": "r1"}), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+def test_load_non_dict_payload_returns_none(tmp_path: Path) -> None:
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert load_cross_run_join_key(pointer) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. keys_match
+# ---------------------------------------------------------------------------
+
+
+def test_keys_match_identical() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="A")
+    b = CrossRunJoinKey(run_id="r1", gen_tag="g1", source_label="B")
+    assert keys_match(a, b) is True
+
+
+def test_keys_match_different_run_id() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    b = CrossRunJoinKey(run_id="r2", gen_tag="g1")
+    assert keys_match(a, b) is False
+
+
+def test_keys_match_different_gen_tag() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    b = CrossRunJoinKey(run_id="r1", gen_tag="g2")
+    assert keys_match(a, b) is False
+
+
+def test_keys_match_none_returns_false() -> None:
+    a = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert keys_match(a, None) is False
+    assert keys_match(None, a) is False
+    assert keys_match(None, None) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. compose_history_view
+# ---------------------------------------------------------------------------
+
+
+def test_compose_history_filters_matching_rows() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1", "data": "A"},  # match
+        {"run_id": "r2", "gen_tag": "g1", "data": "B"},  # different run_id
+        {"run_id": "r1", "gen_tag": "g2", "data": "C"},  # different gen_tag
+        {"run_id": "r1", "gen_tag": "g1", "data": "D"},  # match
+    ]
+    result = list(compose_history_view(key, rows))
+    assert len(result) == 2
+    assert [r["data"] for r in result] == ["A", "D"]
+
+
+def test_compose_history_empty_iterator() -> None:
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    assert list(compose_history_view(key, [])) == []
+
+
+def test_compose_history_skips_rows_missing_keys() -> None:
+    """Rows lacking run_id or gen_tag → skip (forward-compat)."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1"},  # match
+        {"run_id": "r1"},  # missing gen_tag
+        {"gen_tag": "g1"},  # missing run_id
+        {"unrelated": "x"},  # neither
+    ]
+    result = list(compose_history_view(key, rows))
+    assert len(result) == 1
+
+
+def test_compose_history_skips_non_dict_rows() -> None:
+    """Non-dict items in iterator → skip (defensive)."""
+    key = CrossRunJoinKey(run_id="r1", gen_tag="g1")
+    rows = [
+        {"run_id": "r1", "gen_tag": "g1"},
+        "not a dict",  # type: ignore[list-item]
+        ["also not a dict"],
+        None,
+    ]
+    result = list(compose_history_view(key, rows))  # type: ignore[arg-type]
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. End-to-end — latest_pointer → join key → history filter
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_pointer_to_history_filter(tmp_path: Path) -> None:
+    """latest_pointer.json 의 key 로 sessions.jsonl iterator 필터."""
+    pointer = tmp_path / "latest_pointer.json"
+    pointer.write_text(
+        json.dumps({"version": 1, "run_id": "R-9", "gen_tag": "G-3"}),
+        encoding="utf-8",
+    )
+    key = load_cross_run_join_key(pointer)
+    assert key is not None
+
+    sessions = [
+        {"run_id": "R-9", "gen_tag": "G-3", "row": 0},
+        {"run_id": "R-9", "gen_tag": "G-2", "row": 1},
+        {"run_id": "R-8", "gen_tag": "G-3", "row": 2},
+        {"run_id": "R-9", "gen_tag": "G-3", "row": 3},
+    ]
+    matched = list(compose_history_view(key, sessions))
+    assert [r["row"] for r in matched] == [0, 3]

--- a/tests/core/self_improving_loop/test_cross_run_sot_invariant.py
+++ b/tests/core/self_improving_loop/test_cross_run_sot_invariant.py
@@ -1,0 +1,226 @@
+"""B.4 (2026-05-25) — F1 cross-run SoT 3중첩 invariants (PR-22).
+
+memory ``project_autoresearch_fragmentation_audit.md`` 신호 F1 — cross-run
+SoT 3중첩 (meta-review snapshot / latest_pointer.json / sessions.jsonl).
+3 SoT 가 같은 cross-ref key (`run_id` / `gen_tag`) 로 join 가능해야 함.
+
+본 file 은 **schema parity invariants** — 3 SoT 의 schema 가 호환 가능한
+shape 으로 유지되는지 pin. drift 발생 시 fail-fast.
+
+Scope:
+- latest_pointer.json write/read roundtrip
+- latest_pointer.json schema (version=1, run_id, gen_tag, updated_at)
+- read_latest_pointer graceful (missing file / malformed JSON)
+- STATE_ROOT-relative path resolution
+- sessions.jsonl row schema parity check (run_id key 일치)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# 1. latest_pointer.json write/read roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_latest_pointer_roundtrip(tmp_path: Path) -> None:
+    """write → read 같은 payload."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+    state_root = tmp_path
+
+    with (
+        patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path),
+        patch.object(paths_module, "STATE_ROOT", state_root),
+    ):
+        paths_module.write_latest_pointer(
+            run_id="2026-05-25T10-00-00",
+            gen_tag="gen-7",
+            seed_pool=tmp_path / "seeds" / "pool.json",
+            meta_review=tmp_path / "review" / "meta.json",
+        )
+        assert pointer_path.is_file()
+        result = paths_module.read_latest_pointer()
+
+    assert result is not None
+    assert result["run_id"] == "2026-05-25T10-00-00"
+    assert result["gen_tag"] == "gen-7"
+    assert result["version"] == 1
+
+
+def test_latest_pointer_schema_required_keys(tmp_path: Path) -> None:
+    """Schema invariant — version / run_id / gen_tag / updated_at 모두 emit."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+
+    with (
+        patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path),
+        patch.object(paths_module, "STATE_ROOT", tmp_path),
+    ):
+        paths_module.write_latest_pointer(
+            run_id="r1",
+            gen_tag="g1",
+            seed_pool=None,
+            meta_review=None,
+        )
+        raw = pointer_path.read_text(encoding="utf-8")
+
+    payload = json.loads(raw)
+    for key in ("version", "run_id", "gen_tag", "updated_at"):
+        assert key in payload, f"latest_pointer.json schema missing required key: {key!r}"
+
+
+def test_latest_pointer_optional_fields_omitted_when_none(tmp_path: Path) -> None:
+    """seed_pool=None / meta_review=None → 해당 key 미emit (graceful)."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+
+    with (
+        patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path),
+        patch.object(paths_module, "STATE_ROOT", tmp_path),
+    ):
+        paths_module.write_latest_pointer(
+            run_id="r1",
+            gen_tag="g1",
+            seed_pool=None,
+            meta_review=None,
+        )
+        raw = pointer_path.read_text(encoding="utf-8")
+
+    payload = json.loads(raw)
+    assert "seed_pool" not in payload
+    assert "meta_review" not in payload
+
+
+def test_read_latest_pointer_missing_file_returns_none(tmp_path: Path) -> None:
+    """File 부재 → None (bootstrap state)."""
+    from core import paths as paths_module
+
+    missing = tmp_path / "no_such_pointer.json"
+    with patch.object(paths_module, "STATE_LATEST_POINTER_PATH", missing):
+        result = paths_module.read_latest_pointer()
+
+    assert result is None
+
+
+def test_read_latest_pointer_malformed_returns_none(tmp_path: Path) -> None:
+    """Unparseable JSON → None (graceful, no crash)."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+    pointer_path.write_text("not a json {", encoding="utf-8")
+
+    with patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path):
+        result = paths_module.read_latest_pointer()
+
+    assert result is None
+
+
+def test_read_latest_pointer_non_dict_returns_none(tmp_path: Path) -> None:
+    """Top-level non-dict (e.g. list) → None."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+    pointer_path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+
+    with patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path):
+        result = paths_module.read_latest_pointer()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 2. STATE_ROOT-relative path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_latest_pointer_relative_path_under_state_root(tmp_path: Path) -> None:
+    """seed_pool 이 STATE_ROOT 아래면 STATE_ROOT-relative string 저장."""
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+    seed_pool = tmp_path / "seeds" / "pool.json"
+
+    with (
+        patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path),
+        patch.object(paths_module, "STATE_ROOT", tmp_path),
+    ):
+        paths_module.write_latest_pointer(
+            run_id="r1",
+            gen_tag="g1",
+            seed_pool=seed_pool,
+            meta_review=None,
+        )
+        raw = pointer_path.read_text(encoding="utf-8")
+
+    payload = json.loads(raw)
+    assert payload["seed_pool"] == "seeds/pool.json"  # relative to STATE_ROOT
+
+
+# ---------------------------------------------------------------------------
+# 3. sessions.jsonl + latest_pointer.json cross-ref invariant
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_jsonl_run_id_key_naming() -> None:
+    """sessions.jsonl 의 row 가 ``run_id`` 또는 ``session_id`` key 로
+    latest_pointer.json 과 join 가능해야 함. plugins/seed_generation/
+    orchestrator.py 의 append 로직과 schema 일치 확인."""
+    import inspect
+
+    from plugins.seed_generation import orchestrator
+
+    # The orchestrator's _append_session_index emits run_id (cross-ref to
+    # latest_pointer.json). Check source contains the key.
+    source = inspect.getsource(orchestrator)
+    assert "run_id" in source, (
+        "sessions.jsonl orchestrator missing 'run_id' key — would break "
+        "cross-ref to latest_pointer.json"
+    )
+
+
+def test_meta_review_snapshot_module_import_available() -> None:
+    """MetaReviewSnapshot 이 baseline_reader 로부터 import 가능 — F1 의
+    cross-run SoT 3중 중첩의 3번째 SoT 가 reachable."""
+    from plugins.seed_generation.baseline_reader import MetaReviewSnapshot
+
+    assert MetaReviewSnapshot is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. 3 SoT key naming convention drift invariant
+# ---------------------------------------------------------------------------
+
+
+def test_three_sot_share_run_id_naming(tmp_path: Path) -> None:
+    """Cross-run join invariant — 3 SoT 가 ``run_id`` 라는 동일 key 명을
+    공유. 다른 이름 (예: cycle_id / mutation_id) 로 drift 시 fail.
+    """
+    from core import paths as paths_module
+
+    pointer_path = tmp_path / "latest_pointer.json"
+    with (
+        patch.object(paths_module, "STATE_LATEST_POINTER_PATH", pointer_path),
+        patch.object(paths_module, "STATE_ROOT", tmp_path),
+    ):
+        paths_module.write_latest_pointer(
+            run_id="2026-05-25T10-00-00",
+            gen_tag="g1",
+            seed_pool=None,
+            meta_review=None,
+        )
+        payload = paths_module.read_latest_pointer()
+
+    assert payload is not None
+    # F1 invariant — 'run_id' key 가 cross-ref join 의 anchor
+    assert "run_id" in payload
+    # Drift detection — 후속 PR 이 'cycle_id' 같은 다른 이름으로 change 시
+    # 본 test 가 fail. 이름 unification 유지.
+    assert "cycle_id" not in payload  # not the canonical name
+    assert "session_id" not in payload  # sessions.jsonl 측 이름이 다르면 drift

--- a/tests/core/self_improving_loop/test_gepa_sampler.py
+++ b/tests/core/self_improving_loop/test_gepa_sampler.py
@@ -1,0 +1,155 @@
+"""A.4 (2026-05-25) — GEPA Pareto sampler invariants (PR-25)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from core.self_improving_loop.gepa_sampler import (
+    compute_sparsity_weights,
+    sample_sparse,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_sparsity_weights
+# ---------------------------------------------------------------------------
+
+
+def test_sparsity_empty_input() -> None:
+    assert compute_sparsity_weights([]) == []
+
+
+def test_sparsity_single_entry_weight_is_one() -> None:
+    """1 entry → no neighbors → uniform fallback 1.0."""
+    weights = compute_sparsity_weights([{"a": 0.5}])
+    assert weights == [1.0]
+
+
+def test_sparsity_two_entries_equal_weight() -> None:
+    """2 entries — each has 1 neighbor (the other). Both same distance."""
+    weights = compute_sparsity_weights([{"a": 0.1, "b": 0.1}, {"a": 0.9, "b": 0.9}])
+    assert len(weights) == 2
+    # Same mutual distance → same weight
+    assert weights[0] == pytest.approx(weights[1])
+
+
+def test_sparsity_isolated_entry_higher_weight() -> None:
+    """Cluster of 3 close points + 1 isolated → isolated has higher weight."""
+    vectors = [
+        {"a": 0.1, "b": 0.1},  # cluster
+        {"a": 0.12, "b": 0.11},  # cluster
+        {"a": 0.11, "b": 0.13},  # cluster
+        {"a": 0.9, "b": 0.9},  # isolated
+    ]
+    weights = compute_sparsity_weights(vectors, k=2)
+    # The isolated entry (idx 3) should be the heaviest
+    assert weights[3] > weights[0]
+    assert weights[3] > weights[1]
+    assert weights[3] > weights[2]
+
+
+def test_sparsity_k_clamped_to_n_minus_1() -> None:
+    """k > n-1 → 자동 clamp, no IndexError."""
+    weights = compute_sparsity_weights([{"a": 0.1}, {"a": 0.5}], k=10)
+    assert len(weights) == 2
+
+
+def test_sparsity_all_identical_vectors_nonzero_weights() -> None:
+    """All-identical fitness vectors → 0 distance + epsilon prevents
+    zero-probability collapse."""
+    weights = compute_sparsity_weights([{"a": 0.5}, {"a": 0.5}, {"a": 0.5}])
+    assert all(w > 0 for w in weights), "epsilon prevents all-zero collapse"
+
+
+# ---------------------------------------------------------------------------
+# 2. sample_sparse — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_empty_returns_empty() -> None:
+    assert sample_sparse([], [], 3) == []
+
+
+def test_sample_sparse_n_zero_returns_empty() -> None:
+    entries = ["a", "b"]
+    vectors = [{"x": 0.1}, {"x": 0.5}]
+    assert sample_sparse(entries, vectors, 0) == []
+
+
+def test_sample_sparse_n_larger_than_pool() -> None:
+    """n > len(entries) → capped at len(entries)."""
+    entries = ["a", "b"]
+    vectors = [{"x": 0.1}, {"x": 0.5}]
+    result = sample_sparse(entries, vectors, n=10, rng=random.Random(42))
+    assert len(result) == 2
+
+
+def test_sample_sparse_without_replacement() -> None:
+    """Sampling without replacement — no duplicates."""
+    entries = list("abcdef")
+    vectors = [{"x": i / 6} for i in range(6)]
+    rng = random.Random(42)
+    result = sample_sparse(entries, vectors, n=4, rng=rng)
+    assert len(result) == 4
+    assert len(set(result)) == 4  # all distinct
+
+
+def test_sample_sparse_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match=r"length mismatch"):
+        sample_sparse(["a", "b"], [{"x": 0.1}], 2)
+
+
+# ---------------------------------------------------------------------------
+# 3. sample_sparse — density-aware behavior
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_isolated_entry_preferred() -> None:
+    """3 close cluster + 1 isolated. Sample n=1 → isolated more likely.
+
+    Run multiple trials and confirm isolated wins majority. Not a strict
+    invariant per single trial, but probabilistic.
+    """
+    entries = ["c1", "c2", "c3", "isolated"]
+    vectors = [
+        {"a": 0.1, "b": 0.1},
+        {"a": 0.12, "b": 0.11},
+        {"a": 0.11, "b": 0.13},
+        {"a": 0.9, "b": 0.9},
+    ]
+    isolated_count = 0
+    trials = 100
+    for trial in range(trials):
+        rng = random.Random(trial)
+        result = sample_sparse(entries, vectors, n=1, rng=rng, k_neighbors=2)
+        if result == ["isolated"]:
+            isolated_count += 1
+    # Isolated should win clearly more often than uniform (25%) — expect
+    # > 50% with the sparsity weighting.
+    assert isolated_count > 50, (
+        f"isolated picked {isolated_count}/{trials} times — sparsity weight not biasing as expected"
+    )
+
+
+def test_sample_sparse_deterministic_with_seeded_rng() -> None:
+    """Same seed → same sampled order."""
+    entries = list("abcdef")
+    vectors = [{"x": i / 6} for i in range(6)]
+    result_a = sample_sparse(entries, vectors, n=3, rng=random.Random(42))
+    result_b = sample_sparse(entries, vectors, n=3, rng=random.Random(42))
+    assert result_a == result_b
+
+
+# ---------------------------------------------------------------------------
+# 4. All-identical vectors → uniform fallback (degenerate case)
+# ---------------------------------------------------------------------------
+
+
+def test_sample_sparse_all_identical_vectors_works() -> None:
+    """Degenerate case — all fitness identical. Sampling still completes."""
+    entries = ["a", "b", "c"]
+    vectors = [{"x": 0.5}] * 3
+    rng = random.Random(0)
+    result = sample_sparse(entries, vectors, n=2, rng=rng)
+    assert len(result) == 2
+    assert set(result).issubset({"a", "b", "c"})

--- a/tests/core/self_improving_loop/test_map_elites.py
+++ b/tests/core/self_improving_loop/test_map_elites.py
@@ -1,0 +1,195 @@
+"""A.3 (2026-05-25) — MAP-Elites niche grid invariants (PR-24)."""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.map_elites import (
+    MapElitesGrid,
+    compute_cell_index,
+    compute_grid_coverage,
+    insert_many,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_cell_index — discretization
+# ---------------------------------------------------------------------------
+
+
+def test_cell_index_lo_bound_maps_to_zero() -> None:
+    assert compute_cell_index(0.0, (0.0, 1.0), 10) == 0
+
+
+def test_cell_index_hi_bound_maps_to_max() -> None:
+    """value at upper bound → resolution - 1 (last cell)."""
+    assert compute_cell_index(1.0, (0.0, 1.0), 10) == 9
+
+
+def test_cell_index_midpoint() -> None:
+    assert compute_cell_index(0.5, (0.0, 1.0), 10) == 5
+
+
+def test_cell_index_clamp_below_lo() -> None:
+    assert compute_cell_index(-1.0, (0.0, 1.0), 10) == 0
+
+
+def test_cell_index_clamp_above_hi() -> None:
+    assert compute_cell_index(99.0, (0.0, 1.0), 10) == 9
+
+
+def test_cell_index_resolution_1_returns_zero() -> None:
+    """resolution=1 → 모든 value 가 cell 0."""
+    assert compute_cell_index(0.3, (0.0, 1.0), 1) == 0
+    assert compute_cell_index(0.9, (0.0, 1.0), 1) == 0
+
+
+def test_cell_index_invalid_resolution_raises() -> None:
+    with pytest.raises(ValueError, match=r"resolution must be >= 1"):
+        compute_cell_index(0.5, (0.0, 1.0), 0)
+
+
+def test_cell_index_invalid_bounds_raises() -> None:
+    with pytest.raises(ValueError, match=r"bounds must be"):
+        compute_cell_index(0.5, (1.0, 1.0), 10)
+    with pytest.raises(ValueError, match=r"bounds must be"):
+        compute_cell_index(0.5, (2.0, 1.0), 10)
+
+
+# ---------------------------------------------------------------------------
+# 2. MapElitesGrid — insert / replace / get
+# ---------------------------------------------------------------------------
+
+
+def _grid_2d() -> MapElitesGrid:
+    return MapElitesGrid(
+        behavior_bounds=((0.0, 1.0), (0.0, 1.0)),
+        resolution=(10, 10),
+    )
+
+
+def test_grid_starts_empty() -> None:
+    grid = _grid_2d()
+    assert len(grid) == 0
+
+
+def test_grid_insert_into_empty_cell() -> None:
+    grid = _grid_2d()
+    assert grid.insert((0.5, 0.5), fitness=0.7, payload="m1") is True
+    assert len(grid) == 1
+
+
+def test_grid_insert_higher_replaces() -> None:
+    """Same cell, higher fitness → replace."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert grid.insert((0.55, 0.55), 0.9, "m2") is True  # same cell
+    cell_entry = grid.get((0.5, 0.5))
+    assert cell_entry == (0.9, "m2")
+
+
+def test_grid_insert_lower_rejected() -> None:
+    """Same cell, lower fitness → reject."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.9, "m1")
+    assert grid.insert((0.55, 0.55), 0.3, "m2") is False
+    cell_entry = grid.get((0.5, 0.5))
+    assert cell_entry == (0.9, "m1")
+
+
+def test_grid_insert_equal_fitness_rejected() -> None:
+    """Tie → existing wins (strict >)."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert grid.insert((0.55, 0.55), 0.5, "m2") is False
+
+
+def test_grid_different_cells_coexist() -> None:
+    """Different cells = independent occupancy."""
+    grid = _grid_2d()
+    grid.insert((0.1, 0.1), 0.3, "m1")
+    grid.insert((0.9, 0.9), 0.3, "m2")
+    assert len(grid) == 2
+
+
+def test_grid_get_empty_cell_returns_none() -> None:
+    grid = _grid_2d()
+    assert grid.get((0.5, 0.5)) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. all_payloads / coverage / insert_many
+# ---------------------------------------------------------------------------
+
+
+def test_grid_all_payloads_returns_each() -> None:
+    grid = _grid_2d()
+    grid.insert((0.1, 0.1), 0.5, "m1")
+    grid.insert((0.9, 0.9), 0.6, "m2")
+    payloads = grid.all_payloads()
+    assert set(payloads) == {"m1", "m2"}
+
+
+def test_grid_coverage_empty_is_zero() -> None:
+    grid = _grid_2d()
+    assert compute_grid_coverage(grid) == 0.0
+
+
+def test_grid_coverage_full_is_one() -> None:
+    """All 10×10=100 cells occupied → coverage 1.0."""
+    grid = MapElitesGrid(
+        behavior_bounds=((0.0, 1.0), (0.0, 1.0)),
+        resolution=(2, 2),  # 4 cells (manageable for test)
+    )
+    grid.insert((0.0, 0.0), 0.5, "a")
+    grid.insert((0.0, 1.0), 0.5, "b")
+    grid.insert((1.0, 0.0), 0.5, "c")
+    grid.insert((1.0, 1.0), 0.5, "d")
+    assert compute_grid_coverage(grid) == pytest.approx(1.0)
+
+
+def test_grid_coverage_partial() -> None:
+    """1 cell out of 100 → 0.01."""
+    grid = _grid_2d()
+    grid.insert((0.5, 0.5), 0.5, "m1")
+    assert compute_grid_coverage(grid) == pytest.approx(0.01)
+
+
+def test_insert_many_batches() -> None:
+    grid = _grid_2d()
+    entries = [
+        ((0.1, 0.1), 0.5, "a"),
+        ((0.5, 0.5), 0.7, "b"),
+        ((0.9, 0.9), 0.3, "c"),
+    ]
+    count = insert_many(grid, entries)
+    assert count == 3
+    assert len(grid) == 3
+
+
+def test_insert_many_respects_winner_takes_all() -> None:
+    """Two entries in same cell — only the higher-fitness one inserts."""
+    grid = _grid_2d()
+    entries = [
+        ((0.5, 0.5), 0.3, "loser"),
+        ((0.55, 0.55), 0.9, "winner"),
+    ]
+    count = insert_many(grid, entries)
+    assert count == 2  # both attempt, both succeed (2nd replaces 1st)
+    assert len(grid) == 1
+    cell = grid.get((0.5, 0.5))
+    assert cell == (0.9, "winner")
+
+
+# ---------------------------------------------------------------------------
+# 4. Use case — niche diversity across attempts
+# ---------------------------------------------------------------------------
+
+
+def test_niche_diversity_preserved() -> None:
+    """다양한 behavior 의 mutations 가 same fitness 라도 niche 별로 보존."""
+    grid = _grid_2d()
+    # 3 mutations with same fitness but different behaviors
+    grid.insert((0.1, 0.1), 0.6, "safety-focused")
+    grid.insert((0.5, 0.9), 0.6, "helpfulness-focused")
+    grid.insert((0.9, 0.5), 0.6, "tool-focused")
+    assert len(grid) == 3
+    # All preserved — QD invariant: niche diversity not collapsed

--- a/tests/core/self_improving_loop/test_mutator_context_view.py
+++ b/tests/core/self_improving_loop/test_mutator_context_view.py
@@ -1,0 +1,132 @@
+"""C.7 (2026-05-25) — MutatorContextView invariants (PR-27)."""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.mutator_context_view import (
+    MutatorContextView,
+    compose_mutator_context_view,
+    source_count,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Default construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_view_all_empty() -> None:
+    view = MutatorContextView()
+    assert view.baseline_snapshot is None
+    assert view.policy_snapshots == {}
+    assert view.program_md == ""
+    assert view.meta_review_snapshot is None
+    assert view.recent_mutations == []
+    assert view.cross_run_key is None
+
+
+def test_default_view_is_frozen() -> None:
+    view = MutatorContextView()
+    with pytest.raises(Exception):  # ValidationError on frozen
+        view.program_md = "x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. compose_mutator_context_view
+# ---------------------------------------------------------------------------
+
+
+def test_compose_with_no_args_returns_empty_view() -> None:
+    view = compose_mutator_context_view()
+    assert source_count(view) == 0
+
+
+def test_compose_with_baseline_only() -> None:
+    view = compose_mutator_context_view(baseline_snapshot={"dim": 1})
+    assert view.baseline_snapshot == {"dim": 1}
+    assert source_count(view) == 1
+
+
+def test_compose_with_all_sources() -> None:
+    view = compose_mutator_context_view(
+        baseline_snapshot={"x": 1},
+        policy_snapshots={"prompt": "y"},
+        program_md="frontier rules",
+        meta_review_snapshot={"meta": True},
+        recent_mutations=[{"mut": 1}],
+        cross_run_key={"run_id": "r1"},
+    )
+    assert source_count(view) == 6
+
+
+def test_compose_policy_snapshots_default_empty() -> None:
+    """policy_snapshots=None → {} (graceful)."""
+    view = compose_mutator_context_view(policy_snapshots=None)
+    assert view.policy_snapshots == {}
+
+
+def test_compose_recent_mutations_default_empty() -> None:
+    view = compose_mutator_context_view(recent_mutations=None)
+    assert view.recent_mutations == []
+
+
+# ---------------------------------------------------------------------------
+# 3. source_count
+# ---------------------------------------------------------------------------
+
+
+def test_source_count_empty_view() -> None:
+    assert source_count(MutatorContextView()) == 0
+
+
+def test_source_count_only_baseline() -> None:
+    view = MutatorContextView(baseline_snapshot="x")
+    assert source_count(view) == 1
+
+
+def test_source_count_only_program_md() -> None:
+    view = MutatorContextView(program_md="content")
+    assert source_count(view) == 1
+
+
+def test_source_count_empty_program_md_not_counted() -> None:
+    """program_md="" → not counted (empty string falsy)."""
+    view = MutatorContextView(program_md="")
+    assert source_count(view) == 0
+
+
+def test_source_count_empty_dict_not_counted() -> None:
+    """policy_snapshots={} → not counted."""
+    view = MutatorContextView(policy_snapshots={})
+    assert source_count(view) == 0
+
+
+def test_source_count_empty_list_not_counted() -> None:
+    """recent_mutations=[] → not counted."""
+    view = MutatorContextView(recent_mutations=[])
+    assert source_count(view) == 0
+
+
+def test_source_count_all_max() -> None:
+    """All 6 sources populated → count 6."""
+    view = MutatorContextView(
+        baseline_snapshot="a",
+        policy_snapshots={"k": "v"},
+        program_md="md",
+        meta_review_snapshot={"m": 1},
+        recent_mutations=[1],
+        cross_run_key={"k": "v"},
+    )
+    assert source_count(view) == 6
+
+
+# ---------------------------------------------------------------------------
+# 4. extra="allow" forward-compat
+# ---------------------------------------------------------------------------
+
+
+def test_extra_allow_accepts_future_fields() -> None:
+    """신규 source field 추가 시 schema 변경 없이 forward-compat."""
+    view = MutatorContextView(future_source="new")  # type: ignore[call-arg]
+    # extra="allow" → extra field stored under model_extra
+    assert view.model_extra is not None
+    assert view.model_extra.get("future_source") == "new"

--- a/tests/core/self_improving_loop/test_strict_mode_parity.py
+++ b/tests/core/self_improving_loop/test_strict_mode_parity.py
@@ -24,12 +24,28 @@ from __future__ import annotations
 import inspect
 import re
 
-# 12 kind enumerated in autoresearch/train.py:838-873 — must stay in sync
+# 12 kind enumerated in autoresearch/train.py — must stay in sync
 # with that file's env-emit block.
+#
+# Override pattern is intentionally RHS-agnostic: matches
+# ``env["GEODE_<X>_OVERRIDE"] = …`` *regardless* of what is on the right
+# (str(Path), helper call, local variable). A future kind that swaps
+# ``GLOBAL_<X>_PATH`` for a different path expression must still pair
+# with STRICT — drift detection should not be subverted by a cosmetic
+# RHS rename.
 _TRAIN_PY_STRICT_ENV_PATTERN = re.compile(r'env\["GEODE_([A-Z_]+)_STRICT"\]\s*=\s*"1"')
-_TRAIN_PY_OVERRIDE_ENV_PATTERN = re.compile(
-    r'env\["GEODE_([A-Z_]+)_OVERRIDE"\]\s*=\s*str\(GLOBAL_\1_PATH\)'
-)
+_TRAIN_PY_OVERRIDE_ENV_PATTERN = re.compile(r'env\["GEODE_([A-Z_]+)_OVERRIDE"\]\s*=')
+
+# Overrides that are NOT mutation-surface SoTs (do not flow through
+# resolve_sot). These have their own consumers and strict-mode contracts.
+#
+# - ``WRAPPER``: ``GEODE_WRAPPER_OVERRIDE`` is consumed by
+#   ``core/agent/system_prompt.WRAPPER_OVERRIDE_HOOK_READY`` to override
+#   the wrapper system prompt during the audit subprocess. It is gated
+#   by the hook-ready flag in train.py:791-794, which is the strict-
+#   equivalent (audit raises if the hook is unwired) — no separate
+#   STRICT env is needed because there is no graceful fall-through.
+_NON_MUTATION_SURFACE_OVERRIDES: frozenset[str] = frozenset({"WRAPPER"})
 
 
 def _read_train_py_env_block() -> str:
@@ -44,10 +60,27 @@ def test_train_py_overrides_paired_with_strict() -> None:
     source = _read_train_py_env_block()
     overrides = set(_TRAIN_PY_OVERRIDE_ENV_PATTERN.findall(source))
     stricts = set(_TRAIN_PY_STRICT_ENV_PATTERN.findall(source))
-    missing_strict = overrides - stricts
+    mutation_surface_overrides = overrides - _NON_MUTATION_SURFACE_OVERRIDES
+    missing_strict = mutation_surface_overrides - stricts
     assert not missing_strict, (
         f"Override-without-STRICT drift: {missing_strict} — audit subprocess "
-        "would silent-fallback. Add GEODE_<X>_STRICT=1 alongside the override."
+        "would silent-fallback. Add GEODE_<X>_STRICT=1 alongside the override, "
+        "or document the override as non-mutation-surface in "
+        "_NON_MUTATION_SURFACE_OVERRIDES."
+    )
+
+
+def test_override_pattern_catches_non_global_path_rhs() -> None:
+    """Regression — pairing invariant must not be subverted by a future
+    kind that uses a different RHS shape (helper call, Path(...) literal,
+    local variable). Synthetic source with an override using a non-
+    ``GLOBAL_<X>_PATH`` RHS must still register as an override."""
+    synthetic = 'env["GEODE_FUTURE_KIND_OVERRIDE"] = some_helper(path)\n'
+    matches = set(_TRAIN_PY_OVERRIDE_ENV_PATTERN.findall(synthetic))
+    assert "FUTURE_KIND" in matches, (
+        "Override pattern is too narrow — a future kind with a non-"
+        "GLOBAL_<X>_PATH RHS would evade pairing detection while "
+        "the >=12 strict count floor keeps passing."
     )
 
 

--- a/tests/core/self_improving_loop/test_strict_mode_parity.py
+++ b/tests/core/self_improving_loop/test_strict_mode_parity.py
@@ -1,0 +1,154 @@
+"""C.8 (2026-05-25) — silent fallback STRICT mode parity invariants (PR-28).
+
+Memory ``project_autoresearch_fragmentation_audit.md`` F5 — silent fallback
+은 ``autoresearch/train.py:838-873`` 의 ``_STRICT=1`` 강제 + ``sot_resolution.
+resolve_sot`` 의 strict flag 분기로 이미 해소 (ADR-012 S0a/S0b). 본 file
+은 그 fix 의 **drift invariant pin** — 12 kind 의 STRICT env naming 이
+지속적으로 sot_resolution 의 derivation (``<X>_OVERRIDE → <X>_STRICT``)
+과 일치하는지 fail-fast.
+
+drift 사례 (예방):
+- train.py 가 ``GEODE_TOOL_POLICY_OVERRIDE`` set 하는데 STRICT 누락 → audit 의
+  silent fallback 복귀
+- sot_resolution 가 다른 STRICT suffix (예: ``_FAIL_FAST``) 로 rename →
+  train.py 와 desync
+
+12 kind 의 invariant:
+- 모든 GEODE_<X>_OVERRIDE env 가 set 됐을 때 STRICT 도 함께 set
+- STRICT suffix 가 sot_resolution 의 _OVERRIDE → _STRICT derivation 과
+  일치
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+# 12 kind enumerated in autoresearch/train.py:838-873 — must stay in sync
+# with that file's env-emit block.
+_TRAIN_PY_STRICT_ENV_PATTERN = re.compile(r'env\["GEODE_([A-Z_]+)_STRICT"\]\s*=\s*"1"')
+_TRAIN_PY_OVERRIDE_ENV_PATTERN = re.compile(
+    r'env\["GEODE_([A-Z_]+)_OVERRIDE"\]\s*=\s*str\(GLOBAL_\1_PATH\)'
+)
+
+
+def _read_train_py_env_block() -> str:
+    from autoresearch import train
+
+    return inspect.getsource(train)
+
+
+def test_train_py_overrides_paired_with_strict() -> None:
+    """Every ``GEODE_<X>_OVERRIDE`` env set in train.py must be paired
+    with a ``GEODE_<X>_STRICT=1`` set on the same kind."""
+    source = _read_train_py_env_block()
+    overrides = set(_TRAIN_PY_OVERRIDE_ENV_PATTERN.findall(source))
+    stricts = set(_TRAIN_PY_STRICT_ENV_PATTERN.findall(source))
+    missing_strict = overrides - stricts
+    assert not missing_strict, (
+        f"Override-without-STRICT drift: {missing_strict} — audit subprocess "
+        "would silent-fallback. Add GEODE_<X>_STRICT=1 alongside the override."
+    )
+
+
+def test_train_py_strict_count_at_least_12_kinds() -> None:
+    """ADR-012 S0a/S0b — 12 kind 의 STRICT 강제. drift 시 count 감소."""
+    source = _read_train_py_env_block()
+    strict_kinds = set(_TRAIN_PY_STRICT_ENV_PATTERN.findall(source))
+    assert len(strict_kinds) >= 12, (
+        f"Expected >=12 STRICT kinds (ADR-012 S0a/S0b), found {len(strict_kinds)}: "
+        f"{sorted(strict_kinds)}"
+    )
+
+
+def test_sot_resolution_strict_derivation_pattern() -> None:
+    """sot_resolution 의 derivation 이 ``<X>_OVERRIDE → <X>_STRICT`` 패턴
+    유지 — train.py 의 env naming 과 일치."""
+    from core.self_improving_loop import sot_resolution
+
+    source = inspect.getsource(sot_resolution)
+    assert "_OVERRIDE_SUFFIX" in source
+    assert "_STRICT_SUFFIX" in source
+    assert "removesuffix(_OVERRIDE_SUFFIX) + _STRICT_SUFFIX" in source
+
+
+def test_resolve_sot_returns_strict_true_with_env_strict(tmp_path, monkeypatch) -> None:
+    """End-to-end — env override + STRICT=1 → SoTSelection(strict=True)."""
+    from core.self_improving_loop.sot_resolution import resolve_sot
+
+    fake_sot = tmp_path / "fake_policy.json"
+    fake_sot.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("GEODE_TEST_KIND_OVERRIDE", str(fake_sot))
+    monkeypatch.setenv("GEODE_TEST_KIND_STRICT", "1")
+    selection = resolve_sot(
+        env_var="GEODE_TEST_KIND_OVERRIDE",
+        operator_local=tmp_path / "nonexistent",
+        in_repo=tmp_path / "also_nonexistent",
+    )
+    assert selection is not None
+    assert selection.strict is True
+    assert selection.path == fake_sot
+
+
+def test_resolve_sot_returns_strict_false_without_env_strict(tmp_path, monkeypatch) -> None:
+    """env override 만 set + STRICT 없음 → strict=False (operator override)."""
+    from core.self_improving_loop.sot_resolution import resolve_sot
+
+    fake_sot = tmp_path / "fake_policy.json"
+    fake_sot.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("GEODE_TEST_KIND_OVERRIDE", str(fake_sot))
+    monkeypatch.delenv("GEODE_TEST_KIND_STRICT", raising=False)
+    selection = resolve_sot(
+        env_var="GEODE_TEST_KIND_OVERRIDE",
+        operator_local=tmp_path / "nonexistent",
+        in_repo=tmp_path / "also_nonexistent",
+    )
+    assert selection is not None
+    assert selection.strict is False
+
+
+def test_resolve_sot_returns_none_when_no_layer_present(tmp_path, monkeypatch) -> None:
+    """env 미set / operator_local 부재 / in_repo 부재 → None."""
+    from core.self_improving_loop.sot_resolution import resolve_sot
+
+    monkeypatch.delenv("GEODE_UNUSED_KIND_OVERRIDE", raising=False)
+    selection = resolve_sot(
+        env_var="GEODE_UNUSED_KIND_OVERRIDE",
+        operator_local=tmp_path / "nonexistent",
+        in_repo=tmp_path / "also_nonexistent",
+    )
+    assert selection is None
+
+
+def test_resolve_sot_operator_local_strict_false(tmp_path, monkeypatch) -> None:
+    """env 미set + operator_local 존재 → strict=False (daily-use graceful)."""
+    from core.self_improving_loop.sot_resolution import resolve_sot
+
+    monkeypatch.delenv("GEODE_UNUSED_KIND_OVERRIDE", raising=False)
+    operator = tmp_path / "operator.json"
+    operator.write_text("{}", encoding="utf-8")
+    selection = resolve_sot(
+        env_var="GEODE_UNUSED_KIND_OVERRIDE",
+        operator_local=operator,
+        in_repo=tmp_path / "nonexistent",
+    )
+    assert selection is not None
+    assert selection.strict is False
+    assert selection.path == operator
+
+
+def test_resolve_sot_in_repo_strict_false(tmp_path, monkeypatch) -> None:
+    """env 미set + operator 부재 + in_repo 존재 → in_repo, strict=False."""
+    from core.self_improving_loop.sot_resolution import resolve_sot
+
+    monkeypatch.delenv("GEODE_UNUSED_KIND_OVERRIDE", raising=False)
+    in_repo = tmp_path / "repo.json"
+    in_repo.write_text("{}", encoding="utf-8")
+    selection = resolve_sot(
+        env_var="GEODE_UNUSED_KIND_OVERRIDE",
+        operator_local=tmp_path / "nonexistent",
+        in_repo=in_repo,
+    )
+    assert selection is not None
+    assert selection.strict is False
+    assert selection.path == in_repo

--- a/tests/core/self_improving_loop/test_sub_agent_slice.py
+++ b/tests/core/self_improving_loop/test_sub_agent_slice.py
@@ -1,0 +1,127 @@
+"""A.8 (2026-05-25) — sub_agent_slice helper invariants (PR-21).
+
+Scope:
+- compute_sub_agent_slice: deterministic round-robin / negative idx raises /
+  zero total raises / round-robin wrap when total > 5
+- derive_slice_prompt_hint: known slices return non-empty / unknown empty
+- SLICE_NAMES order matches plan §C4 5-stage spec
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.sub_agent_slice import (
+    SLICE_NAMES,
+    compute_sub_agent_slice,
+    derive_slice_prompt_hint,
+)
+
+# ---------------------------------------------------------------------------
+# 1. SLICE_NAMES constant
+# ---------------------------------------------------------------------------
+
+
+def test_slice_names_5_stage_order() -> None:
+    """Plan §C4 의 5-stage 순서 — role / tools / reflection / decomposition /
+    interlocutor."""
+    assert SLICE_NAMES == (
+        "role",
+        "tools",
+        "reflection",
+        "decomposition",
+        "interlocutor",
+    )
+
+
+def test_slice_names_count_matches_config_cap() -> None:
+    """sub_agent_count config cap = 5 (Field(ge=1, le=5)). SLICE_NAMES
+    길이가 cap 과 일치 — round-robin wrap 안 일어남."""
+    assert len(SLICE_NAMES) == 5
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_sub_agent_slice — deterministic round-robin
+# ---------------------------------------------------------------------------
+
+
+def test_compute_slice_idx_0_returns_role() -> None:
+    assert compute_sub_agent_slice(0, 5) == "role"
+
+
+def test_compute_slice_idx_1_returns_tools() -> None:
+    assert compute_sub_agent_slice(1, 5) == "tools"
+
+
+def test_compute_slice_idx_4_returns_interlocutor() -> None:
+    assert compute_sub_agent_slice(4, 5) == "interlocutor"
+
+
+def test_compute_slice_is_deterministic() -> None:
+    """Same (idx, total) always yields same slice — pure function."""
+    for idx in range(5):
+        assert compute_sub_agent_slice(idx, 5) == compute_sub_agent_slice(idx, 5)
+
+
+def test_compute_slice_total_smaller_than_max() -> None:
+    """total=2 sub-agents — idx 0 + 1 모두 유효 slice."""
+    assert compute_sub_agent_slice(0, 2) == "role"
+    assert compute_sub_agent_slice(1, 2) == "tools"
+
+
+def test_compute_slice_negative_idx_raises() -> None:
+    with pytest.raises(ValueError, match=r"sub_agent_index must be >= 0"):
+        compute_sub_agent_slice(-1, 5)
+
+
+def test_compute_slice_zero_total_raises() -> None:
+    with pytest.raises(ValueError, match=r"total sub-agents must be >= 1"):
+        compute_sub_agent_slice(0, 0)
+
+
+def test_compute_slice_negative_total_raises() -> None:
+    with pytest.raises(ValueError, match=r"total sub-agents must be >= 1"):
+        compute_sub_agent_slice(0, -3)
+
+
+def test_compute_slice_round_robin_wrap() -> None:
+    """idx > len(SLICE_NAMES) (방어적 — config cap 으로 정상 안 도달).
+    idx=5 → 5 % 5 = 0 → 'role'."""
+    assert compute_sub_agent_slice(5, 10) == "role"
+    assert compute_sub_agent_slice(6, 10) == "tools"
+
+
+# ---------------------------------------------------------------------------
+# 3. derive_slice_prompt_hint
+# ---------------------------------------------------------------------------
+
+
+def test_derive_hint_known_slices_non_empty() -> None:
+    for slice_name in SLICE_NAMES:
+        hint = derive_slice_prompt_hint(slice_name)
+        assert hint != "", f"slice {slice_name!r} has empty hint"
+
+
+def test_derive_hint_unknown_slice_returns_empty() -> None:
+    """Unknown slice → empty (graceful, caller falls back)."""
+    assert derive_slice_prompt_hint("nonexistent_slice") == ""
+
+
+def test_derive_hint_role_mentions_role() -> None:
+    assert "role" in derive_slice_prompt_hint("role").lower()
+
+
+def test_derive_hint_tools_mentions_tool() -> None:
+    assert "tool" in derive_slice_prompt_hint("tools").lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Integration — pipeline pattern
+# ---------------------------------------------------------------------------
+
+
+def test_full_pipeline_idx_to_hint() -> None:
+    """compute_sub_agent_slice → derive_slice_prompt_hint pipeline."""
+    slice_name = compute_sub_agent_slice(2, 5)
+    hint = derive_slice_prompt_hint(slice_name)
+    assert slice_name == "reflection"
+    assert "reflection" in hint.lower()

--- a/tests/core/self_improving_loop/test_tchebycheff.py
+++ b/tests/core/self_improving_loop/test_tchebycheff.py
@@ -1,0 +1,188 @@
+"""A.2 (2026-05-25) — Tchebycheff scalarization invariants (PR-23).
+
+Scope:
+- compute_tchebycheff: empty inputs / single dim / multi-dim / weights /
+  missing dim graceful / ideal point match (scalar = 0) / negation invariant
+- compute_ideal_point: empty / single / multi-vector / dim union
+- pareto front advantage over linear (concave region reachable)
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.self_improving_loop.tchebycheff import (
+    compute_ideal_point,
+    compute_tchebycheff,
+)
+
+# ---------------------------------------------------------------------------
+# 1. compute_tchebycheff — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_empty_inputs_returns_zero() -> None:
+    assert compute_tchebycheff({}, {}, {}) == 0.0
+
+
+def test_tchebycheff_single_dim_at_ideal_returns_zero() -> None:
+    """fitness == ideal → scalar = 0 (best possible)."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 1.0},
+        weights={"safety": 1.0},
+        ideal_point={"safety": 1.0},
+    )
+    assert result == 0.0
+
+
+def test_tchebycheff_single_dim_below_ideal_returns_negative() -> None:
+    """fitness < ideal → scalar negative (further from ideal)."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.7},
+        weights={"safety": 1.0},
+        ideal_point={"safety": 1.0},
+    )
+    assert result == pytest.approx(-0.3)
+
+
+def test_tchebycheff_max_d_picks_worst_dim() -> None:
+    """multi-dim — scalar 는 worst dim 의 (weighted) gap 의 음수."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.9, "b": 0.5},
+        weights={"a": 1.0, "b": 1.0},
+        ideal_point={"a": 1.0, "b": 1.0},
+    )
+    # gaps: a=0.1, b=0.5; max=0.5 → scalar = -0.5
+    assert result == pytest.approx(-0.5)
+
+
+def test_tchebycheff_weights_scale_gaps() -> None:
+    """가중치가 dim gap 을 scale — heavier weight = higher penalty."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.9, "b": 0.5},
+        weights={"a": 10.0, "b": 1.0},  # a heavily weighted
+        ideal_point={"a": 1.0, "b": 1.0},
+    )
+    # gaps: a=10*0.1=1.0, b=1*0.5=0.5; max=1.0 → scalar = -1.0
+    assert result == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_tchebycheff — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_missing_ideal_skips_dim() -> None:
+    """ideal 에 없는 dim → contribution skip."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.7, "helpfulness": 0.3},
+        weights={"safety": 1.0, "helpfulness": 1.0},
+        ideal_point={"safety": 1.0},  # no helpfulness
+    )
+    # only safety counted: gap 0.3 → scalar -0.3
+    assert result == pytest.approx(-0.3)
+
+
+def test_tchebycheff_missing_weight_defaults_to_one() -> None:
+    """weight 미지정 dim → 1.0 default."""
+    result = compute_tchebycheff(
+        fitness_dim={"safety": 0.5},
+        weights={},  # no weights
+        ideal_point={"safety": 1.0},
+    )
+    assert result == pytest.approx(-0.5)
+
+
+def test_tchebycheff_no_overlap_returns_zero() -> None:
+    """fitness 와 ideal 의 dim 교집합이 empty → 0.0 (no signal)."""
+    result = compute_tchebycheff(
+        fitness_dim={"a": 0.5},
+        weights={"a": 1.0},
+        ideal_point={"b": 1.0},  # different dim
+    )
+    assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_ideal_point — per-dim max
+# ---------------------------------------------------------------------------
+
+
+def test_ideal_point_empty_input() -> None:
+    assert compute_ideal_point([]) == {}
+
+
+def test_ideal_point_single_vector() -> None:
+    result = compute_ideal_point([{"a": 0.5, "b": 0.3}])
+    assert result == {"a": 0.5, "b": 0.3}
+
+
+def test_ideal_point_multi_vector_max_per_dim() -> None:
+    """Per-dim max across all vectors."""
+    vectors = [
+        {"a": 0.5, "b": 0.3},
+        {"a": 0.8, "b": 0.2},
+        {"a": 0.6, "b": 0.7},
+    ]
+    result = compute_ideal_point(vectors)
+    assert result == {"a": 0.8, "b": 0.7}
+
+
+def test_ideal_point_dim_union() -> None:
+    """Vectors with different dim sets → union with each dim's observed max."""
+    vectors = [
+        {"a": 0.5},
+        {"b": 0.3},
+        {"a": 0.7, "c": 0.1},
+    ]
+    result = compute_ideal_point(vectors)
+    assert result == {"a": 0.7, "b": 0.3, "c": 0.1}
+
+
+# ---------------------------------------------------------------------------
+# 4. Pareto-front advantage — concave region reachability
+# ---------------------------------------------------------------------------
+
+
+def test_tchebycheff_reaches_concave_region() -> None:
+    """linear scalarization 으로는 unreachable 한 concave point 가
+    Tchebycheff 로는 unique max 가 됨.
+
+    Setup: 3 Pareto points forming a *concave* front segment.
+    - A = (1.0, 0.0)
+    - B = (0.5, 0.5)  ← concave (linear scalarization 으로 도달 불가)
+    - C = (0.0, 1.0)
+    With uniform weights, linear sum 은 모두 같음 (A=B=C=1.0). Tchebycheff
+    는 B 를 unique max (closest to ideal (1.0, 1.0)).
+    """
+    ideal = {"x": 1.0, "y": 1.0}
+    weights = {"x": 1.0, "y": 1.0}
+    score_a = compute_tchebycheff({"x": 1.0, "y": 0.0}, weights, ideal)
+    score_b = compute_tchebycheff({"x": 0.5, "y": 0.5}, weights, ideal)
+    score_c = compute_tchebycheff({"x": 0.0, "y": 1.0}, weights, ideal)
+    # A: max(0, 1) = 1.0 → -1.0
+    # B: max(0.5, 0.5) = 0.5 → -0.5
+    # C: max(1, 0) = 1.0 → -1.0
+    assert score_b > score_a  # B beats A
+    assert score_b > score_c  # B beats C
+    assert score_a == pytest.approx(score_c)  # extreme points tie
+
+
+# ---------------------------------------------------------------------------
+# 5. Integration — pipeline with archive
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_with_archive_entries() -> None:
+    """compute_ideal_point + compute_tchebycheff — archive 기반 selection."""
+    archive_fitness = [
+        {"safety": 0.9, "helpfulness": 0.5},
+        {"safety": 0.6, "helpfulness": 0.8},
+    ]
+    ideal = compute_ideal_point(archive_fitness)
+    assert ideal == {"safety": 0.9, "helpfulness": 0.8}
+
+    # Candidate: balanced compromise
+    candidate = {"safety": 0.75, "helpfulness": 0.7}
+    score = compute_tchebycheff(candidate, {"safety": 1.0, "helpfulness": 1.0}, ideal)
+    # gaps: 0.15, 0.10; max=0.15 → -0.15
+    assert score == pytest.approx(-0.15)

--- a/tests/plugins/seed_generation/test_checkpointer.py
+++ b/tests/plugins/seed_generation/test_checkpointer.py
@@ -1,0 +1,139 @@
+"""Unit tests for :mod:`plugins.seed_generation.checkpointer`.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — pin the atomic
+write contract + the completed-phase ordering + the malformed-JSON
+tolerance so a future refactor cannot silently drop them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.checkpointer import (
+    CHECKPOINT_SUBDIR,
+    PhaseCheckpoint,
+    list_completed_phases,
+    load_checkpoint,
+    write_checkpoint,
+)
+
+
+def _make_snapshot(phase: str) -> dict[str, object]:
+    return {
+        "run_id": "gen1-broken_tool_use",
+        "target_dim": "broken_tool_use",
+        "gen_tag": "gen1",
+        "phase_marker": phase,
+        "candidates": [{"id": f"c-{phase}"}],
+    }
+
+
+def test_write_checkpoint_creates_atomic_file(tmp_path: Path) -> None:
+    target = write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1234.5,
+    )
+    assert target == tmp_path / CHECKPOINT_SUBDIR / "generator.json"
+    assert target.is_file()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["phase"] == "generator"
+    assert payload["duration_ms"] == pytest.approx(1234.5)
+    assert payload["state_snapshot"]["phase_marker"] == "generator"
+    assert payload["error"] is None
+
+
+def test_write_checkpoint_cleans_up_tmp_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """os.replace failure removes the temp file (no stale ``.tmp`` accumulator)."""
+    import os
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        write_checkpoint(
+            tmp_path,
+            phase="generator",
+            state_snapshot=_make_snapshot("generator"),
+            duration_ms=1.0,
+        )
+    leftovers = list((tmp_path / CHECKPOINT_SUBDIR).glob(".generator.*.tmp"))
+    assert leftovers == []
+
+
+def test_load_checkpoint_round_trip(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="critic",
+        state_snapshot=_make_snapshot("critic"),
+        duration_ms=42.0,
+    )
+    ck = load_checkpoint(tmp_path, "critic")
+    assert ck is not None
+    assert isinstance(ck, PhaseCheckpoint)
+    assert ck.phase == "critic"
+    assert ck.duration_ms == pytest.approx(42.0)
+    assert ck.state_snapshot["phase_marker"] == "critic"
+
+
+def test_load_checkpoint_missing_returns_none(tmp_path: Path) -> None:
+    assert load_checkpoint(tmp_path, "never_wrote") is None
+
+
+def test_load_checkpoint_malformed_returns_none(tmp_path: Path) -> None:
+    bad = tmp_path / CHECKPOINT_SUBDIR / "evolver.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{this is not json", encoding="utf-8")
+    assert load_checkpoint(tmp_path, "evolver") is None
+
+
+def test_load_checkpoint_non_dict_payload_returns_none(tmp_path: Path) -> None:
+    bad = tmp_path / CHECKPOINT_SUBDIR / "evolver.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text('["a", "b"]', encoding="utf-8")
+    assert load_checkpoint(tmp_path, "evolver") is None
+
+
+def test_list_completed_phases_ordered_by_completed_at(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="pilot",
+        state_snapshot=_make_snapshot("pilot"),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="critic",
+        state_snapshot=_make_snapshot("critic"),
+        duration_ms=1.0,
+    )
+    phases = list_completed_phases(tmp_path)
+    assert phases == ["pilot", "generator", "critic"]
+
+
+def test_list_completed_phases_skips_non_json_files(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_make_snapshot("generator"),
+        duration_ms=1.0,
+    )
+    (tmp_path / CHECKPOINT_SUBDIR / "scratch.txt").write_text("ignore me")
+    phases = list_completed_phases(tmp_path)
+    assert phases == ["generator"]
+
+
+def test_list_completed_phases_empty_dir(tmp_path: Path) -> None:
+    assert list_completed_phases(tmp_path) == []

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -363,3 +363,36 @@ def test_orchestrator_emits_noop_outside_journal_scope() -> None:
     state = PipelineState(run_id="t-noscope", target_dim="x", gen_tag="gen2")
     # No run_transcript_scope active — must not raise.
     asyncio.run(Pipeline(state, registry).arun())
+
+
+def test_record_checkpoint_writes_per_phase_files(tmp_path) -> None:
+    """PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — every
+    completed phase writes ``<run_dir>/checkpoints/<phase>.json`` and
+    the on-disk snapshot's ``completed_phases`` includes the just-
+    completed phase (Codex MCP review fix — pre-fix the snapshot was
+    one phase behind the in-memory list)."""
+    import json as _json
+
+    registry, _ = _make_registry_with_all_stubs()
+    state = PipelineState(
+        run_id="t-ck", target_dim="broken_tool_use", gen_tag="gen2", run_dir=tmp_path
+    )
+    asyncio.run(Pipeline(state, registry).arun())
+
+    ck_dir = tmp_path / "checkpoints"
+    assert ck_dir.is_dir(), "checkpoints/ subdir must be created"
+    written_phases = {p.stem for p in ck_dir.glob("*.json")}
+    # ``supervisor`` + ``literature_review`` short-circuit when the role
+    # is not registered (no stub) so they shouldn't produce a
+    # checkpoint. Every other _PHASE_ORDER role IS registered.
+    expected = {"generator", "proximity", "critic", "pilot", "ranker", "evolver", "meta_reviewer"}
+    assert written_phases >= expected, f"missing checkpoints: {expected - written_phases}"
+
+    # state.completed_phases must reflect every written checkpoint.
+    assert set(state.completed_phases) >= expected
+
+    # Codex MCP fix: the on-disk snapshot for the LAST phase must
+    # already list that phase in ``completed_phases`` (append-before-
+    # serialize ordering).
+    meta_review_ck = _json.loads((ck_dir / "meta_reviewer.json").read_text())
+    assert "meta_reviewer" in meta_review_ck["state_snapshot"]["completed_phases"]

--- a/tests/plugins/seed_generation/test_resume.py
+++ b/tests/plugins/seed_generation/test_resume.py
@@ -1,0 +1,224 @@
+"""Unit tests for :mod:`plugins.seed_generation.resume`.
+
+PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — pin the hydration
++ next-phase contract so a future change to ``PipelineState`` or
+``_PHASE_ORDER`` cannot silently break ``audit-seeds resume <run_id>``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.checkpointer import write_checkpoint
+from plugins.seed_generation.orchestrator import _PHASE_ORDER
+from plugins.seed_generation.resume import (
+    ResumeError,
+    hydrate_state,
+    next_phase_to_run,
+    resolve_resume_target,
+)
+
+
+def _full_snapshot(*, completed_phases: list[str]) -> dict[str, object]:
+    return {
+        "run_id": "gen1-broken_tool_use",
+        "target_dim": "broken_tool_use",
+        "gen_tag": "gen1",
+        "candidates_requested": 10,
+        "max_iterations": 0,
+        "current_iteration": 0,
+        "completed_phases": completed_phases,
+        "candidates": [{"id": "c-1"}, {"id": "c-2"}],
+        "reflections": {"c-1": {"role": "critic"}},
+        "pilot_scores": {},
+        "elo_ratings": {},
+        "survivors": [],
+        "evolved_candidates": [],
+        "meta_review": {},
+        "similarity_clusters": [],
+        "removed_duplicates": [],
+        "usd_spent": 0.42,
+        "prompt_tokens": 1000,
+        "completion_tokens": 200,
+        "supervisor_guidance": {"phase_guidance": {"generation": "focus on edge"}},
+        "articles_with_reasoning": "",
+        "literature_snapshots": {},
+        "debate_transcripts": {},
+        "pareto_mode": False,
+        "target_dims_attribution": [],
+        "cohort": "petri_17dim",
+    }
+
+
+def test_next_phase_to_run_with_no_checkpoints(tmp_path: Path) -> None:
+    assert next_phase_to_run(tmp_path) == _PHASE_ORDER[0]
+
+
+def test_next_phase_to_run_after_generator(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor", "literature_review"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="generator",
+        state_snapshot=_full_snapshot(
+            completed_phases=["supervisor", "literature_review", "generator"]
+        ),
+        duration_ms=1.0,
+    )
+    # next phase = proximity (the first phase with no checkpoint)
+    assert next_phase_to_run(tmp_path) == "proximity"
+
+
+def test_next_phase_to_run_all_complete(tmp_path: Path) -> None:
+    for phase in _PHASE_ORDER:
+        write_checkpoint(
+            tmp_path,
+            phase=phase,
+            state_snapshot=_full_snapshot(completed_phases=list(_PHASE_ORDER)),
+            duration_ms=1.0,
+        )
+    assert next_phase_to_run(tmp_path) is None
+
+
+def test_hydrate_state_round_trip(tmp_path: Path) -> None:
+    snap = _full_snapshot(completed_phases=["supervisor", "literature_review"])
+    snap["run_dir"] = str(tmp_path)
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=snap,
+        duration_ms=42.0,
+    )
+    state = hydrate_state(tmp_path)
+    assert state.run_id == "gen1-broken_tool_use"
+    assert state.target_dim == "broken_tool_use"
+    assert state.gen_tag == "gen1"
+    assert state.candidates_requested == 10
+    assert state.completed_phases == ["supervisor", "literature_review"]
+    assert len(state.candidates) == 2
+    assert state.usd_spent == pytest.approx(0.42)
+    assert state.supervisor_guidance["phase_guidance"]["generation"] == "focus on edge"
+    assert state.run_dir == tmp_path
+
+
+def test_hydrate_state_uses_latest_checkpoint(tmp_path: Path) -> None:
+    # Earlier checkpoint says only supervisor done; later checkpoint says
+    # supervisor + literature_review done. Hydration must read the LATEST
+    # (literature_review) — completed_phases reflects the 2-phase state.
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    write_checkpoint(
+        tmp_path,
+        phase="literature_review",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor", "literature_review"]),
+        duration_ms=1.0,
+    )
+    state = hydrate_state(tmp_path)
+    assert state.completed_phases == ["supervisor", "literature_review"]
+
+
+def test_hydrate_state_no_checkpoints_raises(tmp_path: Path) -> None:
+    with pytest.raises(ResumeError, match="nothing to resume"):
+        hydrate_state(tmp_path)
+
+
+def test_hydrate_state_missing_identity_fields_raises(tmp_path: Path) -> None:
+    snap = _full_snapshot(completed_phases=["supervisor"])
+    snap.pop("run_id")
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=snap,
+        duration_ms=1.0,
+    )
+    with pytest.raises(ResumeError, match="missing identity fields"):
+        hydrate_state(tmp_path)
+
+
+def test_state_to_json_includes_g4_g5_attribution_fields() -> None:
+    """Codex MCP review fix: ``_state_to_json`` must persist
+    ``target_dims_attribution`` + ``pareto_mode`` so the resumed
+    evolver's HANDOFF pareto-front embedding stays identical to the
+    pre-checkpoint run.
+    """
+    import json as _json
+
+    from plugins.seed_generation.orchestrator import PipelineState, _state_to_json
+
+    state = PipelineState(
+        run_id="gen1-broken_tool_use",
+        target_dim="broken_tool_use",
+        gen_tag="gen1",
+        target_dims_attribution=["broken_tool_use", "deception_toward_user"],
+        pareto_mode=True,
+    )
+    payload = _json.loads(_state_to_json(state))
+    assert payload["target_dims_attribution"] == [
+        "broken_tool_use",
+        "deception_toward_user",
+    ]
+    assert payload["pareto_mode"] is True
+
+
+def test_state_to_json_round_trip_through_hydrate(tmp_path: Path) -> None:
+    """Codex MCP review fix: every field that ``_state_to_json``
+    persists must round-trip through ``hydrate_state``. This pins
+    the writer ↔ reader parity so a future addition to either side
+    cannot silently drop a field on resume.
+    """
+    import json as _json
+
+    from plugins.seed_generation.checkpointer import write_checkpoint
+    from plugins.seed_generation.orchestrator import PipelineState, _state_to_json
+
+    original = PipelineState(
+        run_id="gen1-broken_tool_use",
+        target_dim="broken_tool_use",
+        gen_tag="gen1",
+        target_dims_attribution=["broken_tool_use"],
+        pareto_mode=True,
+        candidates_requested=12,
+        candidates=[{"id": "c-1"}],
+        completed_phases=["supervisor"],
+        run_dir=tmp_path,
+    )
+    snapshot = _json.loads(_state_to_json(original))
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=snapshot,
+        duration_ms=1.0,
+    )
+    rehydrated = hydrate_state(tmp_path)
+    assert rehydrated.target_dims_attribution == ["broken_tool_use"]
+    assert rehydrated.pareto_mode is True
+    assert rehydrated.candidates_requested == 12
+    assert rehydrated.completed_phases == ["supervisor"]
+    assert len(rehydrated.candidates) == 1
+
+
+def test_resolve_resume_target_returns_state_and_phase(tmp_path: Path) -> None:
+    write_checkpoint(
+        tmp_path,
+        phase="supervisor",
+        state_snapshot=_full_snapshot(completed_phases=["supervisor"]),
+        duration_ms=1.0,
+    )
+    state, next_phase = resolve_resume_target(tmp_path)
+    assert state.run_id == "gen1-broken_tool_use"
+    assert next_phase == "literature_review"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -43,7 +43,10 @@ class TestWorkerRequest:
         req = WorkerRequest.from_dict({"task_id": "t-002"})
         assert req.model == "claude-opus-4-6"
         assert req.provider == "anthropic"
-        assert req.timeout_s == 120.0
+        # PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S6) — default
+        # wall-clock cap lifted 120s → 600s. Operator overrides via
+        # GEODE_SUBAGENT_TIMEOUT_S env or per-request payload.
+        assert req.timeout_s == 600.0
         assert req.denied_tools == []
         assert req.isolation == ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.59"
+version = "0.99.60"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.58"
+version = "0.99.59"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Pass-through rotation per CLAUDE.md §6: release/v0.99.60 → develop (already merged in #1685) → main.
- 12 develop-only commits bundle the self-improving-loop 전소 sprint (PR-20 ~ PR-28 + PR-CHECKPOINT-RESUME-TIMEBUDGET).

## Verification
- [x] release/v0.99.60 → develop CI 8/8 green (#1685)
- [x] No content drift vs. release branch