### PR TITLE
refactor(autoresearch): remove dead audit_logs/ dir (PR-L9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ site/tsconfig.tsbuildinfo
 !site/public/**/*.svg
 !site/public/**/*.ico
 
-# autoresearch outer-loop runtime artifact (results.tsv, audit_logs/, failure_log)
+# autoresearch outer-loop runtime artifact (results.tsv, failure_log)
 autoresearch/state/*
 !autoresearch/state/.gitkeep
 # G5b.fix1 (2026-05-20) — mutation audit ledger is the git-as-optimiser SoT;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+### Removed
+- **PR-L9 dead `audit_logs/` directory cleanup** —
+  `autoresearch/state/audit_logs/` was created via
+  `AUDIT_OUT_DIR.mkdir(parents=True, exist_ok=True)` at
+  `autoresearch/train.py:run_audit` but no caller ever wrote into it
+  (grep across `core/` / `plugins/` / `autoresearch/` confirms zero
+  writers and zero readers besides the mkdir itself). The constant +
+  the mkdir call are deleted; 5 test sites that monkeypatched
+  `AUDIT_OUT_DIR` are stripped. New
+  `tests/autoresearch/test_no_dead_audit_logs_dir.py` pins the cleanup
+  as a drift invariant so a future PR re-introducing the dead path
+  fails fast (per CLAUDE.md "Writer destination tracked" rule —
+  add a real writer + reader pair before re-introducing a state
+  subdirectory).
+
 ### Fixed
 - **PR-ROLE-JSON-ENFORCE-EXTENSION — extend PR-HANDOFF-SCHEMAS to the
   4 remaining JSON-parsing roles + strengthen evolver.** Smoke 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17573,3 +17573,4 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 [0.7.0]: https://github.com/mangowhoiscloud/geode/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mangowhoiscloud/geode/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mangowhoiscloud/geode/releases/tag/v0.6.0
+

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -106,7 +106,7 @@ autoresearch/
 ├── program.md     — agent instructions (humans modify)
 ├── README.md      — this file
 └── state/         — runtime artefacts (gitignored: results.tsv,
-                     results.jsonl, baseline.json, audit_logs/, …)
+                     results.jsonl, baseline.json, …)
 ```
 
 ## Cross-loop handoff (P0b)

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -551,7 +551,6 @@ def write_wrapper_prompt_sections(sections: dict[str, str]) -> None:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STATE_DIR = REPO_ROOT / "autoresearch" / "state"
 RUN_LOG = STATE_DIR / "run.log"
-AUDIT_OUT_DIR = STATE_DIR / "audit_logs"
 
 # G5a — file-backed SoT for the wrapper prompt sections, shared between
 # autoresearch (writer when the G5b runner promotes a mutation),
@@ -762,7 +761,6 @@ def run_audit(
     skipped when either is empty.
     """
     started = time.time()
-    AUDIT_OUT_DIR.mkdir(parents=True, exist_ok=True)
     override_path = _dump_wrapper_override()
     _emit_journal(
         session_id,

--- a/docs/architecture/autoresearch.md
+++ b/docs/architecture/autoresearch.md
@@ -53,8 +53,7 @@ geode/
 │   └── state/                   ← .gitignored runtime artifact
 │       ├── results.tsv          ← generation 별 fitness + verdict (append-only)
 │       ├── wrapper-override.json← mutation 의 GEODE runtime 전달 path
-│       ├── run.log              ← audit subprocess stdout/stderr
-│       └── audit_logs/          ← per-experiment archive
+│       └── run.log              ← audit subprocess stdout/stderr
 ├── plugins/petri_audit/         ← inner-loop harness (Karpathy prepare 등가, 고정)
 └── core/agent/system_prompt.py  ← `_load_wrapper_override` (active hook)
 ```

--- a/site/src/app/docs/capabilities/autoresearch/page.tsx
+++ b/site/src/app/docs/capabilities/autoresearch/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
               <li><code>autoresearch/train.py</code>. 메인 루프</li>
               <li><code>autoresearch/prepare.py</code>. 데이터/모델 준비</li>
               <li><code>autoresearch/program.md</code>. 매 generation 마다 LLM 이 읽는 program 문서</li>
-              <li><code>autoresearch/state/</code>. 누적 결과 (results.tsv, audit_logs/, failure_log)</li>
+              <li><code>autoresearch/state/</code>. 누적 결과 (results.tsv, failure_log)</li>
             </ul>
 
             <h2>Closed-loop 안정성 게이트 (G1-G6)</h2>
@@ -55,7 +55,7 @@ cat autoresearch/state/results.tsv | tail -10`}</pre>
               <li><code>autoresearch/train.py</code>. main loop</li>
               <li><code>autoresearch/prepare.py</code>. data + model setup</li>
               <li><code>autoresearch/program.md</code>. the program doc the LLM rereads each generation</li>
-              <li><code>autoresearch/state/</code>. cumulative state (results.tsv, audit_logs/, failure_log)</li>
+              <li><code>autoresearch/state/</code>. cumulative state (results.tsv, failure_log)</li>
             </ul>
 
             <h2>Closed-loop stability gates (G1-G6)</h2>

--- a/tests/autoresearch/test_no_dead_audit_logs_dir.py
+++ b/tests/autoresearch/test_no_dead_audit_logs_dir.py
@@ -1,0 +1,40 @@
+"""PR-L9 (2026-05-26) — invariant: ``audit_logs/`` dead-dir resurrection guard.
+
+`autoresearch/state/audit_logs/` had a writer-less ``mkdir(parents=True,
+exist_ok=True)`` at ``train.py:run_audit`` for an unclear historical
+reason. grep showed no caller actually wrote anything inside, so the
+constant + mkdir were removed (PR-L9). This invariant pins the cleanup
+so a future PR re-introducing ``AUDIT_OUT_DIR = STATE_DIR /
+"audit_logs"`` fails fast.
+
+If a real ledger writer is needed, document the writer + reader pair in
+the same PR (see CLAUDE.md "Writer destination tracked" rule) so the
+directory isn't a phantom side-effect again.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from autoresearch import train as auto_train
+
+
+def test_audit_out_dir_constant_not_reintroduced() -> None:
+    """``AUDIT_OUT_DIR`` constant must stay deleted."""
+    assert not hasattr(auto_train, "AUDIT_OUT_DIR"), (
+        "AUDIT_OUT_DIR was deleted in PR-L9 (no writer, no reader). "
+        "If you re-introduce it, also wire a real writer/reader pair "
+        "and document them in the PR per CLAUDE.md 'Writer destination "
+        "tracked' rule."
+    )
+
+
+def test_train_py_does_not_reference_audit_logs_subdir() -> None:
+    """train.py source must not reference the dead ``audit_logs`` subdir."""
+    source = inspect.getsource(auto_train)
+    assert '"audit_logs"' not in source, (
+        "Reference to autoresearch/state/audit_logs/ found in train.py. "
+        "If this is intentional, add a writer that actually emits files "
+        "into the directory + a reader that consumes them, and update "
+        "this invariant accordingly."
+    )

--- a/tests/autoresearch/test_no_dead_audit_logs_dir.py
+++ b/tests/autoresearch/test_no_dead_audit_logs_dir.py
@@ -30,11 +30,17 @@ def test_audit_out_dir_constant_not_reintroduced() -> None:
 
 
 def test_train_py_does_not_reference_audit_logs_subdir() -> None:
-    """train.py source must not reference the dead ``audit_logs`` subdir."""
+    """train.py source must not reference the dead ``audit_logs`` subdir.
+
+    Codex MCP review #1688 widened the original literal-only check to
+    catch both quote styles + bare path fragments, so re-introducing
+    via ``STATE_DIR / 'audit_logs'`` or a renamed constant still trips.
+    """
     source = inspect.getsource(auto_train)
-    assert '"audit_logs"' not in source, (
-        "Reference to autoresearch/state/audit_logs/ found in train.py. "
-        "If this is intentional, add a writer that actually emits files "
-        "into the directory + a reader that consumes them, and update "
-        "this invariant accordingly."
-    )
+    for needle in ('"audit_logs"', "'audit_logs'", "audit_logs/"):
+        assert needle not in source, (
+            f"Reference to autoresearch/state/audit_logs/ ({needle!r}) found "
+            "in train.py. If this is intentional, add a writer that actually "
+            "emits files into the directory + a reader that consumes them, "
+            "and update this invariant accordingly."
+        )

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -185,8 +185,9 @@ def test_build_runner_context_with_baseline_and_priors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """All 3 lookups feed the RunnerContext + target_dim auto-picked."""
-    from autoresearch import train as auto_train
     from plugins.seed_generation.baseline_reader import BaselineSnapshot, MetaReviewSnapshot
+
+    from autoresearch import train as auto_train
 
     sot_path = tmp_path / "wrapper-sections.json"
     sot_path.write_text(json.dumps({"role": "r"}), encoding="utf-8")
@@ -341,8 +342,9 @@ def test_runner_uses_baseline_evidence_in_user_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When baseline has evidence for target_dim, the user prompt embeds it."""
-    from autoresearch import train as auto_train
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+    from autoresearch import train as auto_train
 
     sot_path = tmp_path / "wrapper-sections.json"
     monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
@@ -493,7 +495,6 @@ def test_run_once_uses_program_md_in_system_prompt(
 ) -> None:
     """End-to-end: SelfImprovingLoopRunner.run_once passes program.md body to LLM."""
     from autoresearch import train as auto_train
-
     from core.self_improving_loop import runner
 
     sot_path = tmp_path / "wrapper-sections.json"
@@ -543,7 +544,6 @@ def test_runner_rolls_back_sot_when_audit_log_fails(
     """If append_audit_log raises OSError after SoT mutation, the SoT must
     revert to the pre-mutation state so the next iteration sees consistency."""
     from autoresearch import train as auto_train
-
     from core.self_improving_loop import runner
 
     sot_path = tmp_path / "wrapper-sections.json"
@@ -589,7 +589,6 @@ def test_runner_success_path_unchanged_by_rollback_logic(
 ) -> None:
     """When audit-log write succeeds, SoT carries the mutation forward."""
     from autoresearch import train as auto_train
-
     from core.self_improving_loop import runner
 
     sot_path = tmp_path / "wrapper-sections.json"

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -20,7 +20,6 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from autoresearch import train as auto_train
 from autoresearch.train import (
     AUXILIARY_DIMS,
     AXIS_TIERS,
@@ -43,6 +42,8 @@ from autoresearch.train import (
     compute_missing_dims,
     run_audit,
 )
+
+from autoresearch import train as auto_train
 
 
 def test_build_audit_command_uses_current_geode_audit_flags() -> None:
@@ -408,7 +409,6 @@ def test_real_mode_invokes_subprocess_with_override_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", tmp_path / "state" / "audit_logs")
     monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
 
     captured: dict[str, Any] = {}
@@ -445,7 +445,6 @@ def test_real_mode_parses_dim_stderr_when_emitted(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", tmp_path / "state" / "audit_logs")
     monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
 
     def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
@@ -473,7 +472,6 @@ def test_real_mode_raises_when_summary_json_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", tmp_path / "state" / "audit_logs")
     monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
 
     def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
@@ -1795,7 +1793,6 @@ def _drive_main_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tupl
     state_dir = tmp_path / "state"
     monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
     monkeypatch.setattr(auto_train, "RUN_LOG", state_dir / "run.log")
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
     monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
     # No baseline file → baseline_decision payload reflects the empty case.
     monkeypatch.setenv("AUTORESEARCH_VERDICT", "pending")
@@ -1933,7 +1930,6 @@ def test_run_audit_subprocess_timeout_emits_event(
     # State-dir redirects so wrapper_override write doesn't touch the repo.
     state_dir = tmp_path / "state"
     monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
 
     def _raise_timeout(*_args: object, **kwargs: object) -> object:
         raise subprocess.TimeoutExpired(cmd=["geode", "audit"], timeout=420)

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -362,8 +362,9 @@ def test_run_once_loads_target_kind_policy_not_wrapper_sections(
     apply_mutation, which would write wrapper-prompt content into the
     wrong SoT for non-prompt target_kinds. Pin that run_once now
     loads the correct policy via ``load_policy(mutation.target_kind)``."""
-    from autoresearch import train as _train
     from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    from autoresearch import train as _train
 
     # Redirect tool_policy SoT to a tmp path so the test never touches
     # ~/.geode/. Pre-populate with one entry to confirm load_policy is
@@ -457,8 +458,9 @@ def test_rollback_sot_prompt_kind_still_uses_legacy_writer(
     """Pin that the prompt branch still routes through
     autoresearch.train.write_wrapper_prompt_sections — schema
     enforcement (single-paragraph 600-char cap) must survive PR-6."""
-    from autoresearch import train as _train
     from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    from autoresearch import train as _train
 
     written: list[dict[str, str]] = []
     monkeypatch.setattr(_train, "write_wrapper_prompt_sections", lambda s: written.append(dict(s)))

--- a/tests/test_system_prompt_wrapper_override.py
+++ b/tests/test_system_prompt_wrapper_override.py
@@ -172,7 +172,6 @@ def test_sot_path_parity_with_autoresearch() -> None:
     intact, so the parity must be pinned by a test instead.
     """
     from autoresearch import train as auto_train
-
     from core.agent import system_prompt
 
     assert auto_train.WRAPPER_SECTIONS_SOT_PATH == system_prompt._WRAPPER_SECTIONS_SOT_PATH


### PR DESCRIPTION
## Summary
- Remove `autoresearch/state/audit_logs/` constant + mkdir (writer/reader 0건 grep-verified).
- Pin cleanup with `tests/autoresearch/test_no_dead_audit_logs_dir.py` so future PRs re-introducing the dead path fail fast.
- Drive-by: 9 pre-existing ruff I001 import-sort errors fixed (auto-fix only) — these slipped past v0.99.60 release CI because the lint step is conditional on `needs.changes.outputs.code` and release PR touched only version stamps.

## Why
GAP audit on the petri × autoresearch full cycle (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L9) caught \`autoresearch/state/audit_logs/\` as a writer-less directory: \`run_audit\` creates it but nothing emits files inside. The directory was confusing operators ("what writes here?") and violates CLAUDE.md \"Writer destination tracked\" rule.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | Delete `AUDIT_OUT_DIR` constant + the `mkdir` call in `run_audit` |
| `tests/test_autoresearch_train.py` | Drop 5 `monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", ...)` lines |
| `tests/autoresearch/test_no_dead_audit_logs_dir.py` (new) | 2 invariants — constant must stay deleted, `"audit_logs"` string literal must not return to train.py |
| `.gitignore` | Drop stale `audit_logs/` mention from comment |
| `CHANGELOG.md` | `[Unreleased]` → Removed entry |
| Various test files (import-sort auto-fix) | `tests/core/self_improving_loop/test_runner.py`, `tests/test_policy_mutation.py`, `tests/test_system_prompt_wrapper_override.py` |

## Verification
- [x] ruff check clean (`uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/`)
- [x] ruff format clean
- [x] mypy clean (`uv run mypy core/ plugins/ autoresearch/ scripts/`)
- [x] pytest pass (104 in test_autoresearch_train + 2 in new invariant file)
- [ ] Codex MCP review pending

## Reference
- Plan SoT: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L9