### PR TITLE
test(autoresearch): pin wrapper-sections fallback drift (PR-L7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-L7 wrapper-sections fallback ↔ writer-schema drift invariants** —
+  `tests/autoresearch/test_wrapper_sections_drift.py` pins the dual-SoT
+  shape between `autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`
+  (bootstrap default when the canonical
+  `autoresearch/state/policies/wrapper-sections.json` is absent) and
+  `write_wrapper_prompt_sections` (writer the mutator goes through).
+  5 invariants cover: fallback satisfies writer validator (roundtrip),
+  fallback shape (non-empty str dict), 5 canonical section anchors
+  (`role` / `tool_result_handling` / `shell_caution` / `refusal_policy`
+  / `thinking_visibility`), loader bootstrap path returns a fallback
+  copy on canonical-absent and on malformed JSON. Mirrors PR-MINIMAL-2
+  #1398's `program.md` ↔ `_FALLBACK_SYSTEM_PROMPT` pattern.
+
 ## [0.99.61] - 2026-05-26
 
 Structured-output 3-axis-plan smoke 17 closeout bundle + autoresearch

--- a/tests/autoresearch/test_wrapper_sections_drift.py
+++ b/tests/autoresearch/test_wrapper_sections_drift.py
@@ -1,0 +1,132 @@
+"""PR-L7 (2026-05-26) — wrapper-sections fallback ↔ writer-schema drift invariants.
+
+Pattern source: PR-MINIMAL-2 #1398 — `_FALLBACK_SYSTEM_PROMPT` ↔ `program.md`
+shared-anchor invariant. Same dual-SoT shape risk applies here:
+
+- ``autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`` — bootstrap
+  default loaded when ``autoresearch/state/policies/wrapper-sections.json``
+  (canonical, mutator-written runtime SoT) is absent.
+- ``autoresearch/train.py:write_wrapper_prompt_sections`` — validator the
+  mutator goes through when promoting a wrapper-prompt mutation.
+
+A future PR could:
+
+- Change one validator constraint (e.g. add a per-section length minimum)
+  without updating the fallback to satisfy it → daily fresh checkouts ship
+  a fallback the writer would refuse, but the loader's read path stays
+  silent.
+- Edit the fallback dict and drop a section key the rest of the codebase
+  relies on (e.g. seed-generation evolver assumes ``role``).
+
+This file pins:
+
+1. **fallback ↔ writer schema parity** — every fallback section value
+   satisfies ``write_wrapper_prompt_sections``'s validator without raising.
+2. **fallback shape invariant** — non-empty dict, ≥ 5 sections, every
+   key + value is a non-empty string.
+3. **canonical 5-section anchor** — the 5 documented intent buckets
+   (``role`` / ``tool_result_handling`` / ``shell_caution`` /
+   ``refusal_policy`` / ``thinking_visibility``) stay present so a
+   careless rename breaks here, not silently at runtime.
+4. **loader bootstrap path** — with the canonical SoT absent,
+   ``load_wrapper_prompt_sections`` returns a copy of the fallback
+   (defence against operator deleting the disk SoT mid-cycle).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from autoresearch.train import (
+    _WRAPPER_PROMPT_SECTIONS_FALLBACK,
+    load_wrapper_prompt_sections,
+    write_wrapper_prompt_sections,
+)
+
+from autoresearch import train as auto_train
+
+# The 5 documented intent buckets. Renaming any of these requires updating
+# this list AND auditing every consumer (core/agent/system_prompt.py
+# reader, seed-generation evolver scenario_realism handoff, etc.).
+_CANONICAL_SECTION_KEYS: tuple[str, ...] = (
+    "role",
+    "tool_result_handling",
+    "shell_caution",
+    "refusal_policy",
+    "thinking_visibility",
+)
+
+
+def test_fallback_satisfies_writer_validator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback dict must round-trip through ``write_wrapper_prompt_sections``
+    without raising. A future tightening of the writer's validation that
+    breaks the fallback would land here first."""
+    target = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", target)
+    write_wrapper_prompt_sections(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
+    # Roundtrip readback to verify the writer accepted the payload.
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+
+
+def test_fallback_is_non_empty_str_dict() -> None:
+    """Fallback shape: non-empty dict, every key + value is a non-empty
+    string. Mirrors the writer's validation invariants so the loader
+    bootstrap path is always safe."""
+    assert isinstance(_WRAPPER_PROMPT_SECTIONS_FALLBACK, dict)
+    assert _WRAPPER_PROMPT_SECTIONS_FALLBACK, "fallback must not be empty"
+    for key, value in _WRAPPER_PROMPT_SECTIONS_FALLBACK.items():
+        assert isinstance(key, str) and key, f"non-string or empty key: {key!r}"
+        assert isinstance(value, str) and value.strip(), (
+            f"non-string or empty value at {key!r}: {value!r}"
+        )
+
+
+def test_fallback_contains_canonical_section_keys() -> None:
+    """Renaming or dropping any of the 5 canonical section buckets is a
+    breaking change for the wrapper-prompt mutation surface — the
+    seed-generation evolver and the daily ``geode`` runtime both
+    consume these keys. Adding new keys is fine; removing or renaming
+    requires updating ``_CANONICAL_SECTION_KEYS`` here + auditing
+    every consumer in the same PR."""
+    fallback_keys = set(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
+    missing = set(_CANONICAL_SECTION_KEYS) - fallback_keys
+    assert not missing, (
+        f"fallback dropped canonical section(s): {sorted(missing)}. "
+        "Either restore the key(s) or update _CANONICAL_SECTION_KEYS "
+        "after auditing all wrapper-section consumers."
+    )
+
+
+def test_load_returns_fallback_copy_when_canonical_sot_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loader must return the fallback (not None / not empty) when the
+    canonical disk SoT is missing. Defends the loop against operator
+    accidentally deleting ``autoresearch/state/policies/wrapper-sections.json``
+    mid-cycle."""
+    missing = tmp_path / "definitely-not-there.json"
+    assert not missing.exists()
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", missing)
+    result = load_wrapper_prompt_sections()
+    assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+    # Must be a copy — loader's docstring says callers may mutate.
+    assert result is not _WRAPPER_PROMPT_SECTIONS_FALLBACK
+
+
+def test_load_returns_fallback_copy_when_canonical_sot_malformed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loader must return the fallback (not raise) when the canonical
+    SoT exists but is malformed JSON. ``load_wrapper_prompt_sections``
+    docstring guarantees the autoresearch loop never crashes on a bad
+    on-disk patch."""
+    bad = tmp_path / "wrapper-sections.json"
+    bad.write_text("{ not valid json", encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", bad)
+    result = load_wrapper_prompt_sections()
+    assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK

--- a/tests/autoresearch/test_wrapper_sections_drift.py
+++ b/tests/autoresearch/test_wrapper_sections_drift.py
@@ -47,9 +47,13 @@ from autoresearch.train import (
 
 from autoresearch import train as auto_train
 
-# The 5 documented intent buckets. Renaming any of these requires updating
-# this list AND auditing every consumer (core/agent/system_prompt.py
-# reader, seed-generation evolver scenario_realism handoff, etc.).
+# The 5 documented bootstrap section anchors. These are not "required by
+# every consumer" — `core/agent/system_prompt.py` only validates
+# ``dict[str, str]`` and joins values, and the mutator accepts arbitrary
+# new ``target_section`` strings. The anchors are a drift ratchet: a
+# careless PR dropping one of these keys from the fallback dict trips
+# here, forcing a conscious update of this tuple AND a sweep of any
+# documentation / runbook that depends on the legacy 5-section layout.
 _CANONICAL_SECTION_KEYS: tuple[str, ...] = (
     "role",
     "tool_result_handling",
@@ -87,12 +91,13 @@ def test_fallback_is_non_empty_str_dict() -> None:
 
 
 def test_fallback_contains_canonical_section_keys() -> None:
-    """Renaming or dropping any of the 5 canonical section buckets is a
-    breaking change for the wrapper-prompt mutation surface — the
-    seed-generation evolver and the daily ``geode`` runtime both
-    consume these keys. Adding new keys is fine; removing or renaming
-    requires updating ``_CANONICAL_SECTION_KEYS`` here + auditing
-    every consumer in the same PR."""
+    """The 5 canonical bootstrap anchors stay present. These are
+    NOT required by every consumer (``core.agent.system_prompt``
+    accepts any ``dict[str, str]``); they are documented intent
+    buckets that the operator-facing docs + the fallback dict have
+    grown around. Dropping or renaming one here forces a conscious
+    update of ``_CANONICAL_SECTION_KEYS`` + a sweep of docs/runbooks
+    that reference the legacy layout."""
     fallback_keys = set(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
     missing = set(_CANONICAL_SECTION_KEYS) - fallback_keys
     assert not missing, (
@@ -130,3 +135,8 @@ def test_load_returns_fallback_copy_when_canonical_sot_malformed(
     monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", bad)
     result = load_wrapper_prompt_sections()
     assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+    # Codex MCP review catch — equality alone passes even if the loader
+    # returned the module dict itself, leaving the caller free to mutate
+    # the shared fallback. Pin "copy, not identity" so mutation safety
+    # is enforced symmetric to the absent-SoT test above.
+    assert result is not _WRAPPER_PROMPT_SECTIONS_FALLBACK


### PR DESCRIPTION
## Summary
- Add `tests/autoresearch/test_wrapper_sections_drift.py` — 5 invariants pinning the dual-SoT shape between `_WRAPPER_PROMPT_SECTIONS_FALLBACK` (bootstrap default) and `write_wrapper_prompt_sections` (mutator's writer + validator).
- Mirrors PR-MINIMAL-2 #1398's `program.md` ↔ `_FALLBACK_SYSTEM_PROMPT` shared-anchor invariant pattern (see [[feedback-dual-sot-drift-invariant]]).

## Why
GAP audit on the petri × autoresearch full cycle (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L7) caught the wrapper-section dual SoT as a drift-risk surface — a future PR tightening the writer's validation, renaming a section key, or editing the fallback dict could silently desync the bootstrap path from the runtime SoT.

## Changes
| File | Change |
|------|--------|
| `tests/autoresearch/test_wrapper_sections_drift.py` (new) | 5 invariants — fallback ↔ writer roundtrip, shape, 5 canonical anchors, loader bootstrap on absent SoT, loader bootstrap on malformed JSON |
| `CHANGELOG.md` | `[Unreleased]` → Added entry |
| Various test files (import-sort auto-fix, drive-by) | Pre-existing ruff I001 errors fixed |

## Verification
- [x] ruff check clean (`uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/`)
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (5/5 new invariants)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L7
- Pattern source: PR-MINIMAL-2 #1398
- Memory: [[feedback-dual-sot-drift-invariant]]