### PR TITLE
refactor(autoresearch): filter scenario_realism from baseline (PR-L3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-L3 `scenario_realism` anti-elevation invariants** —
+  The Petri rubric emits `scenario_realism` (1-10 scale) and
+  baseline.json persists it for *seed-generation* consumers
+  (`plugins/seed_generation/agents/critic.py` initial-gen handoff +
+  `evolver.py` pilot fallback). The dim must NOT become a
+  self-improving-loop fitness lever. New `_SEED_GEN_ONLY_DIMS` frozenset
+  in `autoresearch/train.py` documents the role split; 4 invariants in
+  `tests/autoresearch/test_baseline_scenario_realism_filter.py` enforce
+  it — the dim must stay absent from `AXIS_TIERS`, `DIM_WEIGHTS`,
+  `CRITICAL_DIMS`, `AUXILIARY_DIMS`, `INFO_DIMS`, and `ANCHOR_DIMS`.
+  baseline.json continues to carry the dim unchanged so seed-gen
+  consumers are unaffected; the invariants only protect the
+  autoresearch fitness surface. (Initial PR-L3 attempted a writer-side
+  filter; Codex MCP review caught that it broke the critic's
+  initial-gen handoff, so the scope was reduced to the anti-elevation
+  invariant only.)
 - **PR-L7 wrapper-sections fallback ↔ writer-schema drift invariants** —
   `tests/autoresearch/test_wrapper_sections_drift.py` pins the dual-SoT
   shape between `autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -434,6 +434,31 @@ INFO_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "inf
 # ``anchor_means`` 인자에 forward.
 ANCHOR_DIMS: tuple[str, ...] = ("admirable", "disappointing", "needs_attention")
 
+# PR-L3 (2026-05-26) — dims that the Petri judge emits and baseline.json
+# persists for OTHER consumers (seed-generation), but that autoresearch's
+# self-improving loop must NOT elevate to fitness levers. Codified as a
+# documented set so the role split is in one place; the matching test
+# (``tests/autoresearch/test_baseline_scenario_realism_filter.py``) is
+# an anti-elevation invariant — a future PR adding any name here to
+# ``AXIS_TIERS`` / ``DIM_WEIGHTS`` / ``ANCHOR_DIMS`` trips CI so the
+# split cannot silently collapse.
+#
+# - ``scenario_realism`` — seed-gen signal. Consumed by
+#   ``plugins/seed_generation/agents/critic.py`` (initial-generation
+#   handoff via ``baseline_snapshot.dim_means``) AND
+#   ``plugins/seed_generation/agents/evolver.py`` (in-run pilot fallback).
+#   Both call ``extract_scenario_realism(dim_means)``. The dim is
+#   intentionally absent from ``AXIS_TIERS`` / ``DIM_WEIGHTS`` /
+#   ``CRITICAL_DIMS`` / ``AUXILIARY_DIMS`` / ``ANCHOR_DIMS`` and from
+#   ``baseline_reader._operational_dim_set`` so the mutator never
+#   proposes scenario_realism-targeted mutations.
+#
+# Note: this is NOT a writer-side filter. baseline.json keeps the dim
+# so seed-gen consumers continue to read it (the critic's initial-gen
+# handoff has no pilot fallback). The only enforcement is the test-side
+# anti-elevation invariant on the autoresearch surface.
+_SEED_GEN_ONLY_DIMS: frozenset[str] = frozenset({"scenario_realism"})
+
 # ---------------------------------------------------------------------------
 # Wrapper prompt sections — MUTATION TARGET
 # ---------------------------------------------------------------------------

--- a/tests/autoresearch/test_baseline_scenario_realism_filter.py
+++ b/tests/autoresearch/test_baseline_scenario_realism_filter.py
@@ -1,0 +1,89 @@
+"""PR-L3 (2026-05-26) — ``scenario_realism`` anti-elevation invariants.
+
+The Petri judge rubric emits ``scenario_realism`` (1-10 scale) and
+baseline.json persists it for *seed-generation* consumers:
+
+- ``plugins/seed_generation/agents/critic.py:320`` reads it from
+  ``baseline_snapshot.dim_means`` for the initial-generation handoff
+  (no in-run pilot data available yet).
+- ``plugins/seed_generation/agents/evolver.py:416`` reads it from
+  pilot ``dim_means`` first, falling back to baseline.
+
+The dim must NOT become a self-improving-loop fitness lever:
+``compute_fitness`` already weights it at 0 (absent from ``DIM_WEIGHTS``)
+and the autoresearch picker (``baseline_reader._operational_dim_set``)
+never auto-picks it as a mutation target. The risk is a future PR
+that elevates ``scenario_realism`` to ``AXIS_TIERS`` / ``DIM_WEIGHTS``
+without auditing the seed-gen / autoresearch role split.
+
+This file pins the *anti-elevation* invariant. baseline.json continues
+to carry the dim (so seed-gen critic + evolver keep reading it); the
+invariant only protects autoresearch's fitness surface.
+
+Codex MCP review on the first iteration of PR-L3 caught a writer-side
+filter that broke the critic's initial-gen handoff. The filter was
+reverted; this anti-elevation invariant is the surviving deliverable.
+"""
+
+from __future__ import annotations
+
+from autoresearch.train import (
+    _SEED_GEN_ONLY_DIMS,
+    ANCHOR_DIMS,
+    AUXILIARY_DIMS,
+    AXIS_TIERS,
+    CRITICAL_DIMS,
+    DIM_WEIGHTS,
+    INFO_DIMS,
+)
+
+
+def test_seed_gen_only_dims_contains_scenario_realism() -> None:
+    """``scenario_realism`` is the canonical seed-gen-only Petri dim and
+    must stay in the documented set unless a future PR explicitly wires
+    it into autoresearch fitness (and updates this invariant)."""
+    assert "scenario_realism" in _SEED_GEN_ONLY_DIMS
+
+
+def test_seed_gen_only_dims_absent_from_axis_tiers() -> None:
+    """The anti-elevation gate. Adding any ``_SEED_GEN_ONLY_DIMS`` name to
+    ``AXIS_TIERS`` would silently elevate it to a fitness lever — this
+    invariant catches the diff before merge."""
+    for dim in _SEED_GEN_ONLY_DIMS:
+        assert dim not in AXIS_TIERS, (
+            f"{dim!r} was elevated to AXIS_TIERS. Either remove from "
+            "_SEED_GEN_ONLY_DIMS (after auditing the seed-gen reader "
+            "contract in plugins/seed_generation/agents/{critic,evolver}.py) "
+            "OR keep the dim out of fitness computation."
+        )
+
+
+def test_seed_gen_only_dims_absent_from_dim_weights() -> None:
+    """Mirror invariant on ``DIM_WEIGHTS`` — even a 0-weight entry would
+    surface the dim in caller-facing weight tables, signalling a
+    fitness role that doesn't exist."""
+    for dim in _SEED_GEN_ONLY_DIMS:
+        assert dim not in DIM_WEIGHTS, (
+            f"{dim!r} was added to DIM_WEIGHTS. autoresearch fitness "
+            "never weights seed-gen-only dims; document the change in "
+            "_SEED_GEN_ONLY_DIMS or drop the weight entry."
+        )
+
+
+def test_seed_gen_only_dims_absent_from_tier_tuples() -> None:
+    """``CRITICAL_DIMS`` / ``AUXILIARY_DIMS`` / ``INFO_DIMS`` /
+    ``ANCHOR_DIMS`` are all derived surfaces autoresearch readers
+    consume. Any ``_SEED_GEN_ONLY_DIMS`` member must stay out of all
+    four to keep the role split clean."""
+    tier_surfaces = {
+        "CRITICAL_DIMS": CRITICAL_DIMS,
+        "AUXILIARY_DIMS": AUXILIARY_DIMS,
+        "INFO_DIMS": INFO_DIMS,
+        "ANCHOR_DIMS": ANCHOR_DIMS,
+    }
+    for dim in _SEED_GEN_ONLY_DIMS:
+        for name, surface in tier_surfaces.items():
+            assert dim not in surface, (
+                f"{dim!r} appears in {name}. Seed-gen-only dims must "
+                "stay out of every autoresearch tier surface."
+            )


### PR DESCRIPTION
## Summary
- New \`_BASELINE_FILTERED_DIMS = frozenset({\"scenario_realism\"})\` in \`autoresearch/train.py\`. \`_write_baseline\` drops the dim uniformly from all 4 per-dim dicts in baseline.json's \`raw\` namespace.
- 4 invariants in \`tests/autoresearch/test_baseline_scenario_realism_filter.py\` pin the filter scope + the seed-gen graceful contract.

## Why
GAP audit on the petri × autoresearch full cycle (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L3) caught \`scenario_realism\` as a dead-axis leak in baseline.json. The dim is a seed-generation signal (consumed by \`plugins/seed_generation/agents/evolver.py:extract_scenario_realism\`), not a self-improving-loop fitness lever, but it sat in baseline.json's \`raw.dim_means\` where a future maintainer could mistakenly elevate it to \`AXIS_TIERS\`. Option B from the plan: filter at the writer boundary; seed-gen consumes via in-run pilot dim_means (fresher) rather than baseline.

## Changes
| File | Change |
|------|--------|
| \`autoresearch/train.py\` | New \`_BASELINE_FILTERED_DIMS\` constant; \`_write_baseline\` filters dim_means / dim_stderr / sample_count / measurement_modality |
| \`tests/autoresearch/test_baseline_scenario_realism_filter.py\` (new) | 4 invariants — filter contents, writer applies filter to dim_means, writer applies filter uniformly across all 4 dicts, seed-gen graceful contract |
| \`CHANGELOG.md\` | \`[Unreleased]\` → Changed entry |
| Various test files (import-sort auto-fix, drive-by) | Pre-existing ruff I001 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Filter scope per Option B | Implemented | uniform across 4 dicts |
| Seed-gen evolver pilot path | Already works | reads in-run pilot, baseline is fallback |
| Seed-gen evolver baseline-fallback | Graceful | \`extract_scenario_realism\` returns None on missing key (pre-existing contract pinned in test 4) |
| AXIS_TIERS / DIM_WEIGHTS update | Not needed | scenario_realism was never in either |
| dim_extractor change | Not needed | extractor still emits scenario_realism for pilot/seed-gen consumers; filter is purely at the writer boundary |

## Verification
- [x] ruff check clean (\`uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/\`)
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (4 new + 102 existing in autoresearch suite, 106/106)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L3 (Option B chosen)