### PR TITLE
refactor(autoresearch): bootstrap baseline ratchet — fitness floor + completeness (PR-L8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-L8 bootstrap baseline ratchet** —
+  ``autoresearch/train.py:_should_promote`` no longer auto-promotes any
+  first audit on a fresh ``baseline.json``-less branch. The default-path
+  (no ``--promote`` flag) auto-promote now requires (a) ``dim_means``
+  completeness — every ``AXIS_TIERS`` dim present, catching truncated
+  subprocess output / extractor partial-fail modes — AND (b) raw
+  fitness ≥ new ``BOOTSTRAP_FITNESS_FLOOR`` (0.30), catching "audit ran
+  but every dim landed at worst-case" modes. Failure reasons start
+  with ``bootstrap_sanity_failed`` so log analytics can grep both
+  clauses. ``--promote`` operator override bypasses ``_should_promote``
+  entirely so deliberately-weak baselines still work. 6 invariants in
+  ``tests/autoresearch/test_should_promote_bootstrap.py`` pin the gate;
+  the existing ``test_should_promote_bootstraps_when_no_prior_baseline``
+  renamed + updated to the gated semantics. Codex MCP review tightened
+  the boundary test via ``mock.patch`` to actually exercise the
+  ``< floor`` / ``== floor`` semantics.
+
 ### Added
 - **PR-L3 `scenario_realism` anti-elevation invariants** —
   The Petri rubric emits `scenario_realism` (1-10 scale) and

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1880,6 +1880,30 @@ def _write_baseline(
 # noise gain before overwriting an under-sampled baseline.
 N1_FITNESS_MARGIN_FLOOR = 0.20
 
+# PR-L8 (2026-05-26) — bootstrap baseline ratchet. Fresh-start (no prior
+# baseline.json) used to auto-promote ANY first audit, leaving the loop
+# vulnerable to a broken initial audit (subprocess returns sentinel,
+# rubric mid-migration, dim_extractor partial extract) becoming the
+# permanent "promoted" reference. The new gate requires:
+#
+# 1. ``dim_means`` completeness — every dim in ``AXIS_TIERS`` must be
+#    present. Catches the "subprocess emitted only a handful of dims"
+#    failure mode.
+# 2. Raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR`` — catches the "audit
+#    succeeded but every dim is at the worst-case 10.0" mode.
+#
+# Operators who *want* a deliberately-weak bootstrap (e.g. seeding from
+# a known-bad checkpoint to ratchet upward) pass ``--promote`` on the
+# argv, which still bypasses :func:`_should_promote` entirely. The gate
+# only protects the *default* (no flag) path.
+#
+# Tuning: 0.30 is roughly the fitness floor below which mutation
+# proposals lack signal (a baseline this low means most dims are above
+# 7/10 concerning, so a single-dim improvement barely moves the
+# weighted aggregate). Adjust via this constant rather than per-call
+# argv so the floor stays a single SoT.
+BOOTSTRAP_FITNESS_FLOOR: float = 0.30
+
 
 def _should_promote(
     current_means: dict[str, float],
@@ -1940,7 +1964,42 @@ def _should_promote(
     Returns ``(should_promote, reason)`` for caller logging.
     """
     if baseline_means is None or baseline_stderr is None:
-        return True, "no prior baseline (bootstrap)"
+        # PR-L8 (2026-05-26) — bootstrap gate. Fresh-start auto-promote
+        # was too permissive: a broken first audit (truncated subprocess
+        # output, rubric mid-migration, dim_extractor partial extract)
+        # would become the permanent baseline. Require:
+        #
+        #   (a) ``dim_means`` completeness — every AXIS_TIERS dim present
+        #   (b) raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR``
+        #
+        # ``--promote`` operator override bypasses ``_should_promote``
+        # entirely (see ``main()``), so this only constrains the
+        # default-path auto-promote.
+        missing = compute_missing_dims(current_means)
+        if missing:
+            preview = sorted(missing)[:3]
+            suffix = "..." if len(missing) > 3 else ""
+            return False, (
+                f"bootstrap_sanity_failed: incomplete dim_means "
+                f"({len(missing)} missing — {preview}{suffix})"
+            )
+        _bootstrap_anchor = {d: current_means[d] for d in ANCHOR_DIMS if d in current_means}
+        bootstrap_fitness = compute_fitness(
+            current_means,
+            current_stderr,
+            measurement_modality=measurement_modality,
+            anchor_means=_bootstrap_anchor or None,
+            anchor_confidence_mode=anchor_confidence_mode,
+        )
+        if bootstrap_fitness < BOOTSTRAP_FITNESS_FLOOR:
+            return False, (
+                f"bootstrap_sanity_failed: fitness {bootstrap_fitness:.4f} "
+                f"< floor {BOOTSTRAP_FITNESS_FLOOR}"
+            )
+        return True, (
+            f"bootstrap_promote: fitness {bootstrap_fitness:.4f} "
+            f"≥ floor {BOOTSTRAP_FITNESS_FLOOR}, dim completeness ok"
+        )
 
     # PR-11 P3.1 (2026-05-25) — anchor subset 추출 (current + baseline 각각).
     # mode=False 면 compute_fitness 가 무시 → 추출 비용 무관.

--- a/tests/autoresearch/test_should_promote_bootstrap.py
+++ b/tests/autoresearch/test_should_promote_bootstrap.py
@@ -1,0 +1,145 @@
+"""PR-L8 (2026-05-26) — bootstrap baseline ratchet invariants.
+
+Pre-PR-L8, the ``_should_promote`` fresh-start branch was:
+
+    if baseline_means is None or baseline_stderr is None:
+        return True, "no prior baseline (bootstrap)"
+
+i.e. the first audit unconditionally became the permanent baseline.
+A broken initial audit (subprocess output truncated, rubric
+mid-migration, dim_extractor partial extract) would silently set
+the loop's reference point and every subsequent run would compare
+against the broken anchor.
+
+PR-L8 adds a 2-clause sanity gate. The default-path auto-promote now
+requires:
+
+1. ``dim_means`` completeness — every ``AXIS_TIERS`` dim present
+   (catches truncated subprocess output / extractor partial fail)
+2. Raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR`` (0.30)
+   (catches "audit ran, every dim at worst-case" failure modes)
+
+``--promote`` operator override bypasses ``_should_promote`` entirely
+(see ``main()``), so operators can still seed a deliberately-weak
+baseline when they want to ratchet upward.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from autoresearch.train import (
+    AXIS_TIERS,
+    BOOTSTRAP_FITNESS_FLOOR,
+    _should_promote,
+)
+
+
+def test_bootstrap_rejects_when_dim_means_incomplete() -> None:
+    """Partial dim_means (subprocess truncated / extractor partial) must
+    NOT promote, even on bootstrap. Pre-PR-L8 this would silently set
+    a broken baseline."""
+    ok, reason = _should_promote(
+        {"broken_tool_use": 1.0},
+        {"broken_tool_use": 0.0},
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is False
+    assert "bootstrap_sanity_failed" in reason
+    assert "missing" in reason
+
+
+def test_bootstrap_rejects_when_fitness_below_floor() -> None:
+    """Complete dim_means but fitness collapses to near-zero (every dim
+    at worst-case 9.0 on the 1-10 scale) → reject the bootstrap."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 9.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    ok, reason = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is False
+    assert "bootstrap_sanity_failed" in reason
+    assert "fitness" in reason
+
+
+def test_bootstrap_promotes_when_complete_and_fitness_high() -> None:
+    """Happy path: every AXIS_TIERS dim present + fitness above floor."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 1.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    ok, reason = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is True
+    assert "bootstrap_promote" in reason
+
+
+def test_bootstrap_floor_constant_is_documented_value() -> None:
+    """A future PR adjusting ``BOOTSTRAP_FITNESS_FLOOR`` should surface
+    here for explicit review."""
+    assert pytest.approx(0.30) == BOOTSTRAP_FITNESS_FLOOR
+
+
+def test_bootstrap_failure_reasons_mention_sanity_gate() -> None:
+    """Log greppers identify gate failures via the
+    ``bootstrap_sanity_failed`` prefix. Both failure clauses must
+    use it so a single grep covers both cases."""
+    _, reason_incomplete = _should_promote(
+        {"broken_tool_use": 1.0},
+        {"broken_tool_use": 0.0},
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert reason_incomplete.startswith("bootstrap_sanity_failed")
+    _, reason_low = _should_promote(
+        dict.fromkeys(AXIS_TIERS, 9.0),
+        dict.fromkeys(AXIS_TIERS, 0.0),
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert reason_low.startswith("bootstrap_sanity_failed")
+
+
+def test_bootstrap_threshold_is_greater_than_or_equal() -> None:
+    """Boundary case — fitness EXACTLY at the floor should promote
+    (``< floor`` rejects, so ``== floor`` passes). Patch
+    ``compute_fitness`` to return exactly the floor + one tick below
+    to exercise the boundary directly."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 5.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+
+    with patch(
+        "autoresearch.train.compute_fitness",
+        return_value=BOOTSTRAP_FITNESS_FLOOR,
+    ):
+        ok_at, reason_at = _should_promote(
+            dim_means,
+            dim_stderr,
+            baseline_means=None,
+            baseline_stderr=None,
+        )
+    assert ok_at is True, (
+        "fitness EXACTLY at the floor must promote — code uses `<` "
+        f"(reject below), not `<=`. reason={reason_at!r}"
+    )
+    assert "bootstrap_promote" in reason_at
+
+    with patch(
+        "autoresearch.train.compute_fitness",
+        return_value=BOOTSTRAP_FITNESS_FLOOR - 1e-9,
+    ):
+        ok_below, reason_below = _should_promote(
+            dim_means,
+            dim_stderr,
+            baseline_means=None,
+            baseline_stderr=None,
+        )
+    assert ok_below is False
+    assert "bootstrap_sanity_failed" in reason_below

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1273,16 +1273,23 @@ def test_resolve_eval_archive_path_reads_symlink_target(
     assert resolved.endswith(target.name)
 
 
-def test_should_promote_bootstraps_when_no_prior_baseline() -> None:
-    """First valid run with no baseline.json → always promote."""
+def test_should_promote_bootstraps_when_no_prior_baseline_and_gate_passes() -> None:
+    """PR-L8 (2026-05-26) — first valid run with no baseline.json
+    promotes only when the bootstrap sanity gate passes: every
+    ``AXIS_TIERS`` dim present AND raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR``.
+    Pre-PR-L8 the gate auto-promoted any first audit unconditionally."""
+    # Full dim_means at the floor mean (1.0) → fitness ≈ 0.88 well above
+    # the 0.30 floor.
+    dim_means = dict.fromkeys(AXIS_TIERS, 1.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
     ok, reason = _should_promote(
-        {"broken_tool_use": 3.4},
-        {"broken_tool_use": 0.4},
+        dim_means,
+        dim_stderr,
         baseline_means=None,
         baseline_stderr=None,
     )
     assert ok is True
-    assert "bootstrap" in reason
+    assert "bootstrap_promote" in reason
 
 
 def test_should_promote_rejects_critical_regression() -> None:


### PR DESCRIPTION
## Summary
- New \`BOOTSTRAP_FITNESS_FLOOR = 0.30\` constant + 2-clause sanity gate in \`autoresearch/train.py:_should_promote\`'s fresh-start branch.
- 6 invariants in \`tests/autoresearch/test_should_promote_bootstrap.py\` pin the gate; existing bootstrap test updated to gated semantics.

## Why
GAP audit on the petri × autoresearch full cycle (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L8) flagged \`_should_promote\`'s pre-existing fresh-start behavior as a Karpathy P1 hazard. The branch \`if baseline_means is None: return True, \"no prior baseline (bootstrap)\"\` accepted ANY first audit unconditionally — a truncated subprocess output, mid-migration rubric, or partial extractor extract would silently anchor the loop's reference point forever.

The risk is immediate now: the just-archived \`baseline.json.outdated-20260522\` means the loop is on a fresh-start trajectory. Without this PR, the next \`train.py\` run (planned petri × autoresearch smoke) would auto-promote whatever the first audit emits.

## Changes
| File | Change |
|------|--------|
| \`autoresearch/train.py\` | New \`BOOTSTRAP_FITNESS_FLOOR = 0.30\` constant; rewrote \`_should_promote\` bootstrap branch with 2-clause gate (completeness + fitness floor) |
| \`tests/autoresearch/test_should_promote_bootstrap.py\` (new) | 6 invariants — completeness gate fires, fitness floor fires, happy path, floor constant value, reason-format grep anchor, \`>=\` boundary semantics |
| \`tests/test_autoresearch_train.py\` | Renamed \`test_should_promote_bootstraps_when_no_prior_baseline\` → \`..._and_gate_passes\`, updated to feed complete dim_means at floor mean |
| \`CHANGELOG.md\` | \`[Unreleased]\` → Changed entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Completeness clause (Option C) | Implemented | uses pre-existing \`compute_missing_dims(AXIS_TIERS)\` |
| Fitness floor clause (Option A) | Implemented | reuses \`compute_fitness\` with anchor + modality forward |
| Operator override path | Preserved | \`--promote\` argv bypasses \`_should_promote\` entirely (main() already handles, no change needed) |
| Existing N=1 / margin gates | Untouched | Only the \`baseline=None\` early-return changed |

## Verification
- [x] ruff check clean (\`uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/\`)
- [x] ruff format clean
- [x] mypy clean
- [x] pytest 108/108 in autoresearch suite (102 existing + 6 new invariants)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L8 (Option A+C combined)