### PR TITLE
fix(seed-gen): extend JSON-enforce gate to 4 missing roles + strengthen evolver (PR-ROLE-JSON-ENFORCE-EXTENSION)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-ROLE-JSON-ENFORCE-EXTENSION — extend PR-HANDOFF-SCHEMAS to the
+  4 remaining JSON-parsing roles + strengthen evolver.** Smoke 17
+  terminal state surfaced gaps beyond PR-PROXIMITY-JSON-ENFORCE: the
+  meta_reviewer phase_failed with `{'raw': 'Meta-review submitted.
+  Densest batch yet (14 candidates, 9 pilot rows, 5 survivors) but 0/5
+  evolution yield…'}` — narrated completion, no JSON. Audit of
+  `_build_description` across all role agents found 4 JSON-parsing
+  roles (critic / literature_review / meta_reviewer / supervisor)
+  missing the "FINAL response must be ONLY the JSON object … Start
+  with `{` and end with `}`" gate. Generator excluded (writes seed
+  via `write_file`, no JSON parse). Evolver already had the gate but
+  smoke 17 showed 5/5 sub-agents exited with `termination_reason=natural`
+  + empty output, treating the `write_file` tool call as the loop
+  terminus; added an explicit "Even after you've successfully called
+  `write_file` and the evolved file exists on disk, the orchestrator
+  still needs the JSON object as your VERY LAST assistant message"
+  reminder. Pinned by
+  `test_all_json_based_role_prompts_carry_final_response_enforcement`
+  (renders each role's prompt at runtime via the public builder
+  methods, asserts the gate text + bracket-pair markers — robust
+  against the "comment satisfies grep" weakness Codex MCP caught in
+  the initial static-source-grep approach).
+
 - **PR-PROXIMITY-JSON-ENFORCE — proximity prompt mirrors the
   PR-HANDOFF-SCHEMAS JSON-only enforcement.** `plugins/seed_generation/
   agents/proximity.py:_build_description` now appends

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -302,7 +302,15 @@ class Critic(BaseSeedAgent):
             "`candidate_id`, `target_dims_actual`, `intended_dim_match`, "
             "`strengths`, `weaknesses`, `judge_risk`, "
             "`discrimination_estimate`, `rewrite_section`. "
-            "Keep total response under 200 tokens."
+            "Keep total response under 200 tokens.\n\n"
+            # PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — same gate
+            # as PR-PROXIMITY-JSON-ENFORCE (#85). Critic was implicitly
+            # safe in smoke 17 (claude-cli enforced --json-schema) but
+            # this language eliminates the prose-preamble failure mode
+            # the codex-oauth + non-strict path can still hit.
+            "Your FINAL response must be ONLY the JSON object matching the "
+            "CRITIQUE_SCHEMA. No prose summary, no markdown bullets, no "
+            "preamble. Start with `{` and end with `}`."
         )
         # PR-SG-SELECTION-ALIGN (2026-05-25) — anchor 3 + scenario_realism
         # + target_dims_attribution surfaced via the HANDOFF CONTEXT

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -378,7 +378,22 @@ class Evolver(BaseSeedAgent):
             "Your FINAL response must be ONLY the JSON object matching the "
             "EVOLVE_SCHEMA (parent_id, evolved_id, evolved_path, "
             "rewrite_section, verdict, notes). No prose summary, no markdown "
-            "change-log, no preamble. Start with `{` and end with `}`."
+            "change-log, no preamble. Start with `{` and end with `}`.\n\n"
+            # PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — smoke 17
+            # evolver phase_failed with 5/5 sub-agents either empty
+            # (``output: ""``, ``termination_reason=natural``) or
+            # emitting "The evolution was already completed in this
+            # session. The evolved file exists at the target path.
+            # Returning the final structured output:" *without* the
+            # JSON. The LLM treated the ``write_file`` tool call as the
+            # task terminus and exited its loop without emitting the
+            # required object. Explicit reminder that file write is
+            # NOT the final step — JSON object IS.
+            "Even after you've successfully called ``write_file`` and the "
+            "evolved file exists on disk, the orchestrator still needs the "
+            "JSON object as your VERY LAST assistant message. The file "
+            "write is a side effect; the JSON object is the contract. Do "
+            "not exit your loop until the JSON object has been emitted."
         )
         weaknesses_list = [str(w) for w in weaknesses]
         # PR-HANDOFF-SCHEMAS — typed handoff. Optional fields elided when

--- a/plugins/seed_generation/agents/literature_review.py
+++ b/plugins/seed_generation/agents/literature_review.py
@@ -239,7 +239,17 @@ class LiteratureReview(BaseSeedAgent):
             "analyse the abstract against target_dim, (4) synthesise into "
             "a single ``articles_with_reasoning`` markdown block. Return "
             "JSON with keys ``articles_with_reasoning`` (str) and "
-            "``snapshots`` (dict[arxiv_id, snapshot_path])."
+            "``snapshots`` (dict[arxiv_id, snapshot_path]).\n\n"
+            # PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — even though
+            # the orchestrator gracefully degrades on JSON parse failure
+            # (Loop 3 is opt-in evidence, not a hard prerequisite), the
+            # enforcement language eliminates the failure path entirely
+            # so downstream Generator / Critic actually receive the
+            # evidence block when ``max_papers >= 1``.
+            "Your FINAL response must be ONLY the JSON object with the "
+            "two required keys (`articles_with_reasoning`, `snapshots`). "
+            "No prose summary, no markdown bullets, no preamble. "
+            "Start with `{` and end with `}`."
         )
 
 

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -219,7 +219,23 @@ class MetaReviewer(BaseSeedAgent):
             f"{snapshot['candidate_ids'][:5]!r} (showing first 5 of "
             f"{len(snapshot['candidate_ids'])}). Use `read_document` to "
             "inspect specific candidates as needed; do NOT request the "
-            f"entire pool body.{debate_block}"
+            f"entire pool body.{debate_block}\n\n"
+            # PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — smoke 17
+            # meta_reviewer phase_failed with ``{'raw': 'Meta-review
+            # submitted. Densest batch yet (14 candidates, 9 pilot rows,
+            # 5 survivors) but 0/5 evolution yield…'}`` — the LLM
+            # narrated completion instead of emitting the JSON object.
+            # Mirrors PR-HANDOFF-SCHEMAS / PR-PROXIMITY-JSON-ENFORCE.
+            # The gate lands AT THE END of the description (after the
+            # optional debate_block context) so "Start with `{` and end
+            # with `}`" is the last thing the model reads, maximising
+            # adherence. The companion ``debate_block_under_500_chars``
+            # test was relaxed to measure only the debate fragment.
+            "Your FINAL response must be ONLY the JSON object matching the "
+            "META_REVIEW_SCHEMA (`coverage`, `underrepresented_dims`, "
+            "`overrepresented_dims`, `next_gen_priors`, `elo_distribution`, "
+            "`evolution_yield`, `session_summary`). No prose summary, no "
+            "markdown bullets, no preamble. Start with `{` and end with `}`."
         )
 
 

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -213,7 +213,17 @@ class Supervisor(BaseSeedAgent):
             "(keys: generation, critique, evolution), and "
             "`session_summary` (<= 200 tokens). Read upstream "
             "snapshots via `read_document` if you need the raw rows; "
-            "the description above only gives counts."
+            "the description above only gives counts.\n\n"
+            # PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — mirror the
+            # PR-HANDOFF-SCHEMAS gate so the LLM can't slip prose past
+            # the parser. Supervisor wasn't observed failing in smoke
+            # 17 because the role isn't registered in default test
+            # fixtures, but the same gap pattern applies once the role
+            # is enabled in production.
+            "Your FINAL response must be ONLY the JSON object with fields "
+            "`research_goal_analysis`, `phase_guidance` (keys: generation, "
+            "critique, evolution), `session_summary`. No prose summary, no "
+            "markdown bullets, no preamble. Start with `{` and end with `}`."
         )
 
 

--- a/tests/plugins/seed_generation/test_meta_reviewer.py
+++ b/tests/plugins/seed_generation/test_meta_reviewer.py
@@ -337,13 +337,18 @@ def test_meta_reviewer_debate_block_under_500_chars() -> None:
     manager = _StubManager()
     asyncio.run(MetaReviewer(manager=manager).aexecute(state))  # type: ignore[arg-type]
     task = manager.received_tasks[0]
-    # Locate the debate block — everything between the first "Debate (Loop 2)"
-    # and the next sentence boundary. It must be small (the LLM should call
-    # read_document for the sidecar bodies if it wants the actual text).
+    # Locate the debate block — measured from ``Debate (Loop 2)`` to the
+    # JSON-enforce gate (which now ends the description per
+    # PR-ROLE-JSON-ENFORCE-EXTENSION 2026-05-26; pre-fix the debate
+    # block was the final fragment). It must be small (the LLM should
+    # call read_document for the sidecar bodies if it wants the actual
+    # text).
     desc = task.description
     debate_start = desc.find("Debate (Loop 2)")
     assert debate_start != -1
-    debate_block_len = len(desc) - debate_start
+    gate_start = desc.find("FINAL response must be ONLY", debate_start)
+    debate_block_end = gate_start if gate_start != -1 else len(desc)
+    debate_block_len = debate_block_end - debate_start
     assert debate_block_len < 500, (
         f"debate block grew to {debate_block_len} chars — aggregate must stay terse"
     )

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -506,3 +506,151 @@ def test_phase_failed_soft_failure_does_not_write_checkpoint(tmp_path) -> None:
     # All phases that DID succeed must still be checkpointed.
     expected_success = {"generator", "critic", "pilot", "ranker", "evolver", "meta_reviewer"}
     assert written_phases >= expected_success
+
+
+def test_all_json_based_role_prompts_carry_final_response_enforcement() -> None:
+    """PR-ROLE-JSON-ENFORCE-EXTENSION (2026-05-26) — every role that
+    parses a JSON response (i.e. uses ``parse_structured_output`` or
+    ``response_schema``) must carry the PR-HANDOFF-SCHEMAS "FINAL
+    response must be ONLY the JSON object" gate in the **runtime
+    prompt**, not just somewhere in the source file.
+
+    Pre-fix smoke 17 phase_failed at meta_reviewer with
+    ``{'raw': 'Meta-review submitted. Densest batch yet (14 candidates,
+    9 pilot rows, 5 survivors)…'}`` — the LLM narrated completion
+    instead of emitting the META_REVIEW_SCHEMA JSON. 4 non-proximity
+    roles missed the enforcement language (critic / literature_review /
+    meta_reviewer / supervisor — proximity already fixed in
+    PR-PROXIMITY-JSON-ENFORCE). Generator is excluded — it writes the
+    seed via ``write_file`` and the orchestrator picks up the file from
+    disk; the sub-agent's response shape isn't parsed.
+
+    Codex MCP review of PR-ROLE-JSON-ENFORCE-EXTENSION caught that a
+    raw-source grep can be satisfied by comments/docstrings even after
+    the production prompt loses the gate. So this test instantiates
+    each agent with a stub manager, calls the prompt builder, and
+    asserts the RENDERED string carries the gate.
+    """
+    # Directly invoke each role's prompt-builder method (avoiding the
+    # full aexecute side-effect chain). Each role exposes one of
+    # ``_build_description`` or ``_build_task`` — we render the string
+    # and grep for the gate language. This avoids needing to set up
+    # full pipeline state for every role (survivors, reflections, etc.)
+    # while still asserting on the runtime-rendered prompt rather than
+    # raw source text.
+    import random
+
+    from plugins.seed_generation.agents.critic import Critic
+    from plugins.seed_generation.agents.evolver import Evolver
+    from plugins.seed_generation.agents.literature_review import LiteratureReview
+    from plugins.seed_generation.agents.meta_reviewer import MetaReviewer
+    from plugins.seed_generation.agents.pilot import Pilot
+    from plugins.seed_generation.agents.proximity import Proximity
+    from plugins.seed_generation.agents.ranker import Ranker
+    from plugins.seed_generation.agents.supervisor import Supervisor
+    from plugins.seed_generation.picker import VoterBinding
+
+    state = PipelineState(run_id="t-prompt-gate", target_dim="broken_tool_use", gen_tag="gen2")
+
+    class _NoOp:
+        pass
+
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+        VoterBinding(model="claude-opus-4-7", provider="anthropic", source="claude-cli"),
+        VoterBinding(model="claude-haiku-4-5", provider="anthropic", source="claude-cli"),
+    ]
+
+    def _critic_prompt() -> str:
+        agent = Critic(manager=_NoOp())  # type: ignore[arg-type]
+        return agent._build_description(
+            candidate_id="c-0",
+            candidate_path="/dev/null",
+            target_dim="broken_tool_use",
+        )
+
+    def _evolver_prompt() -> str:
+        agent = Evolver(manager=_NoOp())  # type: ignore[arg-type]
+        return agent._build_description(
+            candidate={"id": "c-0", "path": "/dev/null", "target_dim": "broken_tool_use"},
+            rewrite_section="prompt",
+            weaknesses=["w1"],
+            dim_means={},
+        )
+
+    def _literature_review_prompt() -> str:
+        agent = LiteratureReview(manager=_NoOp())  # type: ignore[arg-type]
+        return agent._build_description(state, max_papers=1, queries_per_run=1)
+
+    def _meta_reviewer_prompt() -> str:
+        agent = MetaReviewer(manager=_NoOp())  # type: ignore[arg-type]
+        snapshot = {
+            "summary": "test",
+            "candidate_ids": ["c-0"],
+            "baseline_evidence_count": 0,
+            "baseline_evidence_for_target": 0,
+            "has_meta_review_snapshot": False,
+        }
+        return agent._build_description(state, snapshot)
+
+    def _pilot_prompt() -> str:
+        agent = Pilot(manager=_NoOp())  # type: ignore[arg-type]
+        return agent._build_description(
+            candidate_id="c-0",
+            candidate_path="/dev/null",
+            target_dim="broken_tool_use",
+        )
+
+    def _proximity_prompt() -> str:
+        agent = Proximity(manager=_NoOp())  # type: ignore[arg-type]
+        state_with_cands = PipelineState(
+            run_id="t",
+            target_dim="x",
+            gen_tag="g",
+            candidates=[{"id": "c-0"}, {"id": "c-1"}],
+        )
+        return agent._build_description(state_with_cands, "- c-0\n- c-1")
+
+    def _ranker_prompt() -> str:
+        from plugins.seed_generation.tournament import MatchPlan
+
+        agent = Ranker(manager=_NoOp(), voters=voters, rng=random.Random(0))  # type: ignore[arg-type]
+        return agent._build_description(
+            match=MatchPlan(match_id="m0", a="c-0", b="c-1"),
+            voter=voters[0],
+            means_a={},
+            means_b={},
+        )
+
+    def _supervisor_prompt() -> str:
+        agent = Supervisor(manager=_NoOp())  # type: ignore[arg-type]
+        snapshot = {
+            "summary": "test",
+            "baseline_evidence_count": 0,
+            "baseline_evidence_for_target": 0,
+            "has_meta_review_snapshot": False,
+        }
+        return agent._build_description(state, snapshot)
+
+    builders = [
+        ("critic", _critic_prompt),
+        ("evolver", _evolver_prompt),
+        ("literature_review", _literature_review_prompt),
+        ("meta_reviewer", _meta_reviewer_prompt),
+        ("pilot", _pilot_prompt),
+        ("proximity", _proximity_prompt),
+        ("ranker", _ranker_prompt),
+        ("supervisor", _supervisor_prompt),
+    ]
+    for role, build in builders:
+        prompt = build()
+        assert prompt, f"{role}: prompt builder returned empty string"
+        assert "FINAL response must be ONLY the JSON object" in prompt, (
+            f"{role} runtime prompt is missing the PR-HANDOFF-SCHEMAS enforcement "
+            f"language. The source file may have the language only in comments — "
+            f"that doesn't count. Add the gate to the actual description string."
+        )
+        assert "Start with `{`" in prompt and "end with `}`" in prompt, (
+            f"{role} runtime prompt has the FINAL response language but not the "
+            f"bracket-pair markers (`Start with `{{` and end with `}}``)."
+        )


### PR DESCRIPTION
## Summary
- Apply the PR-HANDOFF-SCHEMAS (#81) / PR-PROXIMITY-JSON-ENFORCE (#85) "FINAL response must be ONLY the JSON object … Start with `{` and end with `}`" gate to the 4 JSON-parsing role agents that missed it: **critic / literature_review / meta_reviewer / supervisor**.
- Strengthen **evolver** (which already had the gate) with a tool-use-loop-exit reminder — smoke 17 showed 5/5 evolver sub-agents exited with `termination_reason=natural` + empty output despite the gate, treating the `write_file` tool call as the loop terminus.
- Add a runtime-rendering sentinel test that invokes each role's prompt builder and greps the resolved string (not raw source) so future regressions can't hide in comments.

## Why
Smoke 17 (`state/seed-generation/gen1-redundant_tool_invocation/`) terminal state captured:
- **meta_reviewer phase_failed** with `{'raw': 'Meta-review submitted. Densest batch yet (14 candidates, 9 pilot rows, 5 survivors) but 0/5 evolution yield…'}` — exactly the raw-narrative failure shape PR-PROXIMITY-JSON-ENFORCE closed for proximity, never extended to meta_reviewer.
- **evolver phase_failed** with 4/5 sub-agents `success=false, output="", summary="Sub-agent failed: termination_reason=natural"` + 1/5 with output `"The evolution was already completed in this session. The evolved file exists at the target path. Returning the final structured output:"` (trailing colon, no JSON object). The LLM treated the file-write tool call as the task terminus and skipped the JSON emission.

The 4 missing roles all use `parse_structured_output` / `response_schema`. Generator is excluded — writes the seed via `write_file`; orchestrator reads the file from disk; no JSON parse on the sub-agent's response.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/agents/critic.py` | append gate to `_build_description` |
| `plugins/seed_generation/agents/evolver.py` | append tool-use-loop-exit reminder after existing gate |
| `plugins/seed_generation/agents/literature_review.py` | append gate |
| `plugins/seed_generation/agents/meta_reviewer.py` | append gate at end-of-description (after `debate_block` suffix) |
| `plugins/seed_generation/agents/supervisor.py` | append gate (no schema name reference — uses field-list wording per Codex MCP anti-deception catch) |
| `tests/plugins/seed_generation/test_orchestrator.py` | new sentinel test renders each role's prompt at runtime + greps for gate |
| `tests/plugins/seed_generation/test_meta_reviewer.py` | adjust `debate_block_under_500_chars` measurement to span only the debate fragment (gate now follows debate, ends description) |
| `CHANGELOG.md` | new entry under `[Unreleased]` ### Fixed |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| critic JSON gate | ✅ Implemented | pinned by sentinel |
| literature_review JSON gate | ✅ Implemented | pinned by sentinel |
| meta_reviewer JSON gate | ✅ Implemented | pinned by sentinel + 500-char test refactor |
| supervisor JSON gate | ✅ Implemented | uses field-list (no `SUPERVISOR_SCHEMA` fabricated reference) |
| evolver tool-use-loop reminder | ✅ Implemented | covers the `write_file → exit` failure path smoke 17 observed |
| Codex MCP P0 / Medium nits | ✅ All resolved | SUPERVISOR_SCHEMA / sentinel robustness / debate_block placement / structural-retry follow-up registered as Task #91 |
| Worker-side schema-aware retry | ⏭ Follow-up | Task #91 PR-WORKER-SCHEMA-AWARE-RETRY — complements (not replaces) this prompt-level fix |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy plugins/seed_generation/` — Success, no issues found
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run pytest tests/plugins/seed_generation/ tests/core/agent/ tests/core/llm/adapters/ tests/test_worker.py` → **807 pass**
- [ ] E2E (post-merge): smoke 18 launch — expect zero `phase_failed` from `{'raw': ...}` narrative responses on meta_reviewer / evolver

## Reference
- Plan + audit: in-conversation analysis of smoke 17 terminal state (`state/seed-generation/gen1-redundant_tool_invocation/`)
- Codex MCP review transcript (in-conversation) — 4 medium findings all resolved
- Precedent: PR-HANDOFF-SCHEMAS (#81), PR-PROXIMITY-JSON-ENFORCE (PR #1687)
- Follow-up: Task #91 PR-WORKER-SCHEMA-AWARE-RETRY (structural worker retry for the empty-output path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)