### PR TITLE
fix(worker): schema-aware retry when response_schema is set (PR-WORKER-SCHEMA-AWARE-RETRY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,37 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-WORKER-SCHEMA-AWARE-RETRY — worker-side schema-aware retry when
+  the role declared a `response_schema`.** `core/agent/worker.py:_run_agentic`
+  now calls `_needs_schema_retry(agentic_result, request.response_schema)`
+  after the first `loop.arun(prompt)` and, if it returns True AND the
+  elapsed-time gate (`elapsed_before_retry < 0.5 * request.timeout_s`)
+  passes, issues a second `loop.arun(feedback_prompt)` with the
+  validator verdict + inline schema (paperclip + open-scientist
+  `validate_and_retry` pattern). Retry budget is exactly one — a third
+  pass would burn cost without changing the underlying role contract.
+  `_needs_schema_retry` treats empty / unparseable / `required`-missing
+  first attempts as retry triggers; JSON embedded in prose passes
+  because the parent's `_last_balanced_json_object` parser already
+  tolerates it. PR-ROLE-JSON-ENFORCE-EXTENSION + PR-PROXIMITY-JSON-
+  ENFORCE made the prompt-level gate uniform, but smoke 17 confirmed
+  prompt-level gating is best-effort: the structural retry is the last
+  safety net before the parent records `phase_failed` and aborts the
+  run. Two Codex MCP cross-LLM review catches (2026-05-26) folded
+  in-band: (1) `_NO_RETRY_TERMINATION_REASONS` (`input_blocked` /
+  `user_cancelled` / `user_clarification_needed`) short-circuits the
+  helper so success exits with intentional non-JSON text aren't
+  re-issued (would override cancel intent); (2) the elapsed-time gate
+  prevents the retry from getting another full `time_budget_s` after
+  `AgenticLoop.arun` resets `_loop_start_time` per call. Pinned by
+  `TestNeedsSchemaRetry` (14 cases including 3 no-retry-success
+  parametrize), `TestBuildSchemaRetryPrompt` (4 cases including
+  4096-char schema truncation + 800-char prior-text truncation), and
+  `TestSchemaAwareRetryWiring` (10 wiring cases — retry-once-on-empty
+  / no-retry-on-success / no-retry-without-schema / cap-at-one / 3
+  no-retry-success parametrize / elapsed-time-gate / retry prompt
+  carries schema body + bracket-pair markers).
+
 - **PR-ROLE-JSON-ENFORCE-EXTENSION — extend PR-HANDOFF-SCHEMAS to the
   4 remaining JSON-parsing roles + strengthen evolver.** Smoke 17
   terminal state surfaced gaps beyond PR-PROXIMITY-JSON-ENFORCE: the

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -421,6 +421,63 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     # 8. Run
     agentic_result = run_process_coroutine(loop.arun(prompt))
 
+    # PR-WORKER-SCHEMA-AWARE-RETRY (2026-05-26) — when the caller declared
+    # a ``response_schema`` (PR-JSON-WIRE wired per-role schemas through
+    # ``WorkerRequest`` → ``AgenticLoop``) but the first run produced
+    # empty / unparseable / schema-missing-keys output, the prompt-level
+    # PR-HANDOFF-SCHEMAS gate already failed for this task. Inject the
+    # validator's verdict as a follow-up user turn (paperclip + open-
+    # scientist validation-feedback pattern) and re-issue the loop once.
+    # Cap at exactly one retry — a third pass would burn budget without
+    # changing the underlying behaviour (the role contract is the same).
+    #
+    # Codex MCP review (2026-05-26) caught two pre-merge issues, both
+    # patched below:
+    #
+    # 1. ``AgenticLoop.arun`` resets ``_loop_start_time`` on every call
+    #    (``agent_loop.py:1463``), so the second pass would get another
+    #    full ``time_budget_s`` rather than the remainder. Guard the
+    #    retry on ``elapsed_before_retry < 0.5 * request.timeout_s`` so
+    #    a worker pegged near its wall-clock cap doesn't get pushed past
+    #    it (the subprocess ``asyncio.wait_for`` would kill the retry
+    #    mid-flight, leaving the parent with no usable signal).
+    # 2. The no-retry success exits (``input_blocked`` / ``user_cancelled``
+    #    / ``user_clarification_needed``) carry intentional non-JSON text
+    #    that the parent expects to surface as-is. The earlier guard would
+    #    have fired the retry on these because they aren't in
+    #    ``_FAILURE_TERMINATION_REASONS``; ``_needs_schema_retry`` now
+    #    checks ``_NO_RETRY_TERMINATION_REASONS`` (see helper below).
+    elapsed_before_retry = time.time() - started
+    if (
+        request.response_schema is not None
+        and _needs_schema_retry(agentic_result, request.response_schema)
+        and elapsed_before_retry < 0.5 * request.timeout_s
+    ):
+        feedback_prompt = _build_schema_retry_prompt(request.response_schema, agentic_result)
+        log.warning(
+            "worker.schema_retry task_id=%s reason=empty_or_malformed "
+            "first_text_len=%d elapsed=%.1fs cap=%.1fs — re-issuing with "
+            "validator feedback",
+            request.task_id,
+            len(agentic_result.text) if agentic_result else 0,
+            elapsed_before_retry,
+            request.timeout_s,
+        )
+        agentic_result = run_process_coroutine(loop.arun(feedback_prompt))
+    elif request.response_schema is not None and _needs_schema_retry(
+        agentic_result, request.response_schema
+    ):
+        # Same trigger fired, but the elapsed-time gate vetoed the retry.
+        # Observability: surface why so an operator reading the worker
+        # log can correlate "no retry" with "out of budget".
+        log.warning(
+            "worker.schema_retry_skipped task_id=%s elapsed=%.1fs cap=%.1fs "
+            "— retry would push past 50%% of wall-clock cap",
+            request.task_id,
+            elapsed_before_retry,
+            request.timeout_s,
+        )
+
     elapsed_ms = (time.time() - started) * 1000
     success, summary, text = _resolve_worker_outcome(agentic_result)
 
@@ -469,6 +526,148 @@ _FAILURE_TERMINATION_REASONS: frozenset[str] = frozenset(
         "convergence_detected",
     }
 )
+
+# PR-WORKER-SCHEMA-AWARE-RETRY (2026-05-26) — termination reasons whose
+# text is intentional non-JSON and MUST NOT be re-issued to the loop
+# even when a ``response_schema`` is set:
+#
+# * ``input_blocked`` — policy filter rejected the prompt. Retrying with
+#   stronger schema language wouldn't change the input that got blocked.
+# * ``user_cancelled`` — operator pressed cancel. The "Interrupted."
+#   marker is the legitimate output (see ``agent_loop.py:705``); a
+#   retry would override the cancel intent.
+# * ``user_clarification_needed`` — overthinking detected; text IS the
+#   follow-up question. Retrying re-burns the budget that the loop
+#   bailed out of in the first place.
+#
+# Sourced from ``_resolve_worker_outcome``'s success-exit catalogue
+# (worker.py ~480-490 docstring) — anything classified as success there
+# must stay success here, otherwise the retry would invalidate the
+# parent's classification.
+_NO_RETRY_TERMINATION_REASONS: frozenset[str] = frozenset(
+    {
+        "input_blocked",
+        "user_cancelled",
+        "user_clarification_needed",
+    }
+)
+
+
+def _needs_schema_retry(
+    agentic_result: AgenticResult | None,
+    response_schema: dict[str, Any],
+) -> bool:
+    """Return True when a structured-output task's first attempt missed.
+
+    PR-WORKER-SCHEMA-AWARE-RETRY (2026-05-26) — the role's prompt-level
+    PR-HANDOFF-SCHEMAS gate ("FINAL response must be ONLY the JSON
+    object … Start with `{` and end with `}`") is best-effort; smoke 17
+    showed Codex + sub-agent runs occasionally finishing with empty
+    output_text or with prose surrounding the JSON. Worker-side this is
+    the last safety net before the parent orchestrator records
+    ``phase_failed`` and the run aborts. Returns True iff:
+
+    * ``agentic_result`` is missing or carries an explicit failure
+      ``error`` / ``termination_reason`` — the loop already gave up;
+    * the loop's text is empty / whitespace-only;
+    * the text does not contain a balanced ``{...}`` block that parses
+      under ``json.loads`` (free-form prose, codeblock fence noise);
+    * the parsed object is missing any ``required`` key declared on
+      ``response_schema`` (the loop emitted *a* JSON, but not the role's
+      schema — e.g. ``{}`` or a partial echo).
+
+    The function deliberately does NOT validate property types or
+    ``enum`` membership — that strictness belongs in the parent
+    orchestrator's parser. Retrying for soft mismatches would just burn
+    budget on the same prompt.
+
+    Codex MCP review (2026-05-26) — the no-retry success exits
+    (``input_blocked``, ``user_cancelled``, ``user_clarification_needed``)
+    carry intentional non-JSON text that the parent expects to surface
+    as-is. ``_resolve_worker_outcome`` already classifies them as
+    ``success=True``. Returning ``True`` here would re-call the loop on
+    a cancelled / blocked / clarification task — wasted budget and
+    semantically wrong. The ``_NO_RETRY_TERMINATION_REASONS`` check
+    below short-circuits those before the text-parse branch.
+    """
+    if agentic_result is None:
+        return True
+    if agentic_result.termination_reason in _NO_RETRY_TERMINATION_REASONS:
+        return False
+    if agentic_result.error:
+        return True
+    if agentic_result.termination_reason in _FAILURE_TERMINATION_REASONS:
+        return True
+
+    text = (agentic_result.text or "").strip()
+    if not text:
+        return True
+
+    # Local import — keep core/agent/worker.py free of a hard sub_agent
+    # dependency at module import time (worker.py is the IPC entry point;
+    # we want it to bootstrap with the minimum import surface).
+    from core.agent.sub_agent import _last_balanced_json_object
+
+    candidate = _last_balanced_json_object(text)
+    if candidate is None:
+        # No balanced + parseable object anywhere in the body.
+        return True
+
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return True
+
+    if not isinstance(parsed, dict):
+        return True
+
+    required = response_schema.get("required") if isinstance(response_schema, dict) else None
+    if isinstance(required, list) and required:
+        missing = [k for k in required if k not in parsed]
+        if missing:
+            return True
+
+    return False
+
+
+def _build_schema_retry_prompt(
+    response_schema: dict[str, Any],
+    agentic_result: AgenticResult | None,
+) -> str:
+    """Construct the validator-feedback follow-up turn for the retry.
+
+    PR-WORKER-SCHEMA-AWARE-RETRY (2026-05-26) — pattern mirrors paperclip
+    session replay + open-scientist ``validate_and_retry`` (llm.py:437):
+    state the verdict, restate the contract, then ask for the JSON
+    object only. The schema is emitted inline (truncated at 4096 chars
+    so a giant role schema doesn't blow the context budget on the
+    retry turn).
+    """
+    schema_text = json.dumps(response_schema, ensure_ascii=False, indent=2)
+    if len(schema_text) > 4096:
+        schema_text = schema_text[:4096] + "\n…(schema truncated; full version pinned upstream)"
+
+    first_text = ""
+    if agentic_result is not None and agentic_result.text:
+        first_text = agentic_result.text.strip()
+    if len(first_text) > 800:
+        first_text = first_text[:800] + "…(truncated)"
+
+    if not first_text:
+        prior_diag = "Your previous response was empty."
+    else:
+        prior_diag = (
+            "Your previous response did not parse as the required JSON object. "
+            f"Excerpt: {first_text!r}"
+        )
+
+    return (
+        f"{prior_diag}\n\n"
+        "You MUST emit ONLY the JSON object matching this schema as your final message. "
+        "No prose, no explanation, no markdown fences — start with `{` and end with `}`. "
+        f"Required keys: {response_schema.get('required', [])}.\n\n"
+        f"Schema:\n{schema_text}"
+    )
 
 
 def _resolve_worker_outcome(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13,6 +13,8 @@ from core.agent.worker import (
     _FAILURE_TERMINATION_REASONS,
     WorkerRequest,
     WorkerResult,
+    _build_schema_retry_prompt,
+    _needs_schema_retry,
     _resolve_worker_outcome,
 )
 
@@ -399,3 +401,466 @@ class TestSubAgentReasoningWiring:
         assert captured.get("effort") == "max"
         assert captured.get("thinking_budget") == 8192
         assert captured.get("time_budget_s") == 240.0
+
+
+# ---------------------------------------------------------------------------
+# PR-WORKER-SCHEMA-AWARE-RETRY (2026-05-26) — schema-aware retry contract
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_ROLE_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["candidate_id", "score"],
+    "properties": {
+        "candidate_id": {"type": "string"},
+        "score": {"type": "number"},
+    },
+}
+
+
+class TestNeedsSchemaRetry:
+    """``_needs_schema_retry`` decides whether the worker re-issues the
+    loop with a validator-feedback follow-up turn. The role's prompt-level
+    PR-HANDOFF-SCHEMAS gate is best-effort; this helper is the last
+    safety net before the parent records ``phase_failed``.
+    """
+
+    def test_none_result_triggers_retry(self) -> None:
+        assert _needs_schema_retry(None, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_empty_text_triggers_retry(self) -> None:
+        result = AgenticResult(text="", termination_reason="unknown")
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_whitespace_only_text_triggers_retry(self) -> None:
+        result = AgenticResult(text="   \n\n   ", termination_reason="unknown")
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_prose_without_json_triggers_retry(self) -> None:
+        result = AgenticResult(
+            text="I think the answer is somewhere around 7 but I'm not sure.",
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_malformed_json_triggers_retry(self) -> None:
+        result = AgenticResult(
+            text='{"candidate_id": "c1", "score":',  # truncated
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_missing_required_keys_triggers_retry(self) -> None:
+        result = AgenticResult(
+            text='{"candidate_id": "c1"}',  # missing ``score``
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_explicit_error_triggers_retry(self) -> None:
+        result = AgenticResult(
+            text='{"candidate_id": "c1", "score": 0.7}',
+            termination_reason="unknown",
+            error="LLM provider timeout",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    @pytest.mark.parametrize(
+        "termination_reason",
+        sorted(_FAILURE_TERMINATION_REASONS),
+    )
+    def test_failure_termination_triggers_retry(self, termination_reason: str) -> None:
+        """Even with a syntactically valid JSON in ``text``, a failure-
+        tagged ``termination_reason`` means the loop bailed — re-issuing
+        gives it a fresh shot at the schema."""
+        result = AgenticResult(
+            text='{"candidate_id": "c1", "score": 0.7}',
+            termination_reason=termination_reason,
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    def test_happy_path_does_not_retry(self) -> None:
+        result = AgenticResult(
+            text='{"candidate_id": "c1", "score": 0.7}',
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is False
+
+    def test_json_embedded_in_prose_does_not_retry(self) -> None:
+        """``_last_balanced_json_object`` already tolerates JSON wrapped in
+        prose (PR-HANDOFF-SCHEMAS parser fallback). The retry helper
+        should match the parser, otherwise it would burn budget on
+        cases the parent will accept anyway."""
+        result = AgenticResult(
+            text=(
+                "After careful review, here is my answer:\n\n"
+                '{"candidate_id": "c1", "score": 0.7}\n\n'
+                "Let me know if you need anything else."
+            ),
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is False
+
+    def test_schema_without_required_treats_any_object_as_valid(self) -> None:
+        """``response_schema`` without a ``required`` list means the
+        caller didn't pin specific keys — any parseable object passes."""
+        schema_no_required: dict = {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {"candidate_id": {"type": "string"}},
+        }
+        result = AgenticResult(text="{}", termination_reason="unknown")
+        assert _needs_schema_retry(result, schema_no_required) is False
+
+    def test_non_dict_root_triggers_retry(self) -> None:
+        """The role contract is always an object; a bare list or scalar
+        cannot satisfy ``required`` and must be retried."""
+        result = AgenticResult(
+            text='["c1", 0.7]',
+            termination_reason="unknown",
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is True
+
+    @pytest.mark.parametrize(
+        "termination_reason",
+        ["input_blocked", "user_cancelled", "user_clarification_needed"],
+    )
+    def test_no_retry_success_exits_do_not_trigger_retry(self, termination_reason: str) -> None:
+        """Codex MCP catch (2026-05-26) — the success exits whose text
+        is intentional non-JSON must not be re-issued, otherwise the
+        retry would override the cancel / block / clarification intent
+        and invalidate ``_resolve_worker_outcome``'s success
+        classification."""
+        result = AgenticResult(
+            text="Interrupted." if termination_reason == "user_cancelled" else "non-JSON body",
+            termination_reason=termination_reason,
+        )
+        assert _needs_schema_retry(result, _SAMPLE_ROLE_SCHEMA) is False
+
+
+class TestBuildSchemaRetryPrompt:
+    def test_empty_prior_text_yields_explicit_empty_diag(self) -> None:
+        prior = AgenticResult(text="", termination_reason="unknown")
+        prompt = _build_schema_retry_prompt(_SAMPLE_ROLE_SCHEMA, prior)
+        assert "Your previous response was empty." in prompt
+        # Schema is embedded.
+        assert '"candidate_id"' in prompt
+        # The retry gate language matches the PR-HANDOFF-SCHEMAS prompt-side gate.
+        assert "start with `{`" in prompt
+        assert "end with `}`" in prompt
+
+    def test_prose_prior_text_is_excerpted(self) -> None:
+        prior = AgenticResult(
+            text="I'm going to think about this in detail before answering.",
+            termination_reason="unknown",
+        )
+        prompt = _build_schema_retry_prompt(_SAMPLE_ROLE_SCHEMA, prior)
+        # The first-attempt excerpt is quoted (truncated repr) so the
+        # model sees what it produced.
+        assert "did not parse" in prompt
+        assert "think about this in detail" in prompt
+
+    def test_long_prior_text_truncated_at_800_chars(self) -> None:
+        prior = AgenticResult(text="x" * 5000, termination_reason="unknown")
+        prompt = _build_schema_retry_prompt(_SAMPLE_ROLE_SCHEMA, prior)
+        assert "…(truncated)" in prompt
+
+    def test_long_schema_truncated_at_4096_chars(self) -> None:
+        big_schema: dict = {
+            "type": "object",
+            "required": ["k"],
+            "properties": {
+                f"k{i}": {"type": "string", "description": "x" * 200} for i in range(50)
+            },
+        }
+        prompt = _build_schema_retry_prompt(big_schema, None)
+        assert "schema truncated" in prompt
+
+
+class TestSchemaAwareRetryWiring:
+    """``_run_agentic`` must call the loop a second time exactly once
+    when ``response_schema`` is set and the first attempt fails the
+    retry helper. With no schema, no retry. With a schema and a passing
+    first attempt, no retry."""
+
+    def _patch_bootstrap(self, monkeypatch, tmp_path, side_effect_seq):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(side_effect=side_effect_seq)
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        return mock_loop, patch, MagicMock
+
+    def test_retry_fires_once_when_schema_set_and_first_is_empty(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(
+            side_effect=[
+                AgenticResult(text="", termination_reason="unknown"),
+                AgenticResult(
+                    text='{"candidate_id": "c1", "score": 0.7}',
+                    termination_reason="unknown",
+                ),
+            ]
+        )
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-1",
+                description="seed scoring",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+            )
+            result = _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 2, (
+            "expected exactly one retry when first attempt is empty"
+        )
+        assert result.success is True
+        assert "candidate_id" in result.output
+
+    def test_no_retry_when_first_attempt_passes(self, monkeypatch, tmp_path) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(
+            return_value=AgenticResult(
+                text='{"candidate_id": "c1", "score": 0.7}',
+                termination_reason="unknown",
+            )
+        )
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-2",
+                description="seed scoring",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+            )
+            _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 1, (
+            "no retry expected when first attempt satisfies the schema"
+        )
+
+    def test_no_retry_when_response_schema_is_none(self, monkeypatch, tmp_path) -> None:
+        """Free-form callers (REPL, gateway, ad-hoc CLI) never opt into
+        the structured retry — an empty response is the caller's
+        problem, not ours."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(
+            return_value=AgenticResult(text="", termination_reason="unknown")
+        )
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-3",
+                description="free-form task",
+                response_schema=None,
+            )
+            _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 1, (
+            "no retry expected when caller did not declare a schema"
+        )
+
+    def test_retry_caps_at_one_even_if_second_attempt_also_fails(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The retry budget is exactly one. A third pass would burn
+        cost without changing the underlying behaviour — the role
+        contract is the same prompt."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(
+            return_value=AgenticResult(text="", termination_reason="unknown")
+        )
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-4",
+                description="seed scoring",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+            )
+            result = _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 2, (
+            "retry must cap at exactly one — third pass not allowed"
+        )
+        # Phase still reports failure so the parent records ``phase_failed``.
+        assert result.success is False
+
+    @pytest.mark.parametrize(
+        "termination_reason",
+        ["input_blocked", "user_cancelled", "user_clarification_needed"],
+    )
+    def test_no_retry_on_success_exits_even_with_schema_set(
+        self, monkeypatch, tmp_path, termination_reason: str
+    ) -> None:
+        """Codex MCP catch (2026-05-26) — when the loop terminates with
+        ``input_blocked`` / ``user_cancelled`` / ``user_clarification_needed``
+        the text is intentional and the parent must surface it as-is.
+        Re-calling the loop on these terminations would be semantically
+        wrong (cancel intent overridden) and a budget burn."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(
+            return_value=AgenticResult(
+                text="non-JSON body",
+                termination_reason=termination_reason,
+            )
+        )
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="no-retry-success",
+                description="seed scoring",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+            )
+            _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 1, (
+            f"termination_reason={termination_reason!r} must not trigger retry "
+            "even with response_schema set"
+        )
+
+    def test_retry_skipped_when_elapsed_past_half_of_timeout_s(self, monkeypatch, tmp_path) -> None:
+        """Codex MCP catch (2026-05-26) — ``AgenticLoop.arun`` resets
+        ``_loop_start_time`` per call so the retry would get another
+        full ``time_budget_s``. Guard the retry on
+        ``elapsed_before_retry < 0.5 * request.timeout_s`` so a worker
+        pegged near its wall-clock cap doesn't get pushed past it."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        async def _slow_arun(_prompt: str) -> AgenticResult:
+            return AgenticResult(text="", termination_reason="unknown")
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(side_effect=_slow_arun)
+
+        # Fake the wall-clock so ``time.time() - started`` looks like
+        # 80% of the cap by the time we hit the retry gate.
+        real_time = __import__("time").time
+        baseline = real_time()
+        call_count = {"n": 0}
+
+        def _fake_time() -> float:
+            call_count["n"] += 1
+            # First call (``started = time.time()``) returns baseline.
+            # Subsequent calls return baseline + 80s — with timeout_s=100
+            # that's 80%, past the 50% gate.
+            if call_count["n"] == 1:
+                return baseline
+            return baseline + 80.0
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        monkeypatch.setattr("core.agent.worker.time.time", _fake_time)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-budget-gate",
+                description="seed scoring",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+                timeout_s=100.0,
+            )
+            _run_agentic(request)
+
+        assert mock_loop.arun.await_count == 1, (
+            "retry must be vetoed when elapsed time > 50%% of wall-clock cap"
+        )
+
+    def test_retry_passes_feedback_prompt_with_schema_to_loop(self, monkeypatch, tmp_path) -> None:
+        """The second ``arun`` call must include the schema text + the
+        explicit ``start with `{` and end with `}``` enforcement — that
+        is the entire point of the retry."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        prompts_seen: list[str] = []
+
+        async def _capture_arun(prompt: str) -> AgenticResult:
+            prompts_seen.append(prompt)
+            if len(prompts_seen) == 1:
+                return AgenticResult(text="", termination_reason="unknown")
+            return AgenticResult(
+                text='{"candidate_id": "c1", "score": 0.7}',
+                termination_reason="unknown",
+            )
+
+        mock_loop = MagicMock()
+        mock_loop.arun = AsyncMock(side_effect=_capture_arun)
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", return_value=mock_loop),
+        ):
+            from core.agent.worker import _run_agentic
+
+            request = WorkerRequest(
+                task_id="retry-5",
+                description="original prompt text",
+                response_schema=_SAMPLE_ROLE_SCHEMA,
+            )
+            _run_agentic(request)
+
+        assert len(prompts_seen) == 2
+        # First attempt is the caller's prompt verbatim.
+        assert "original prompt text" in prompts_seen[0]
+        # Retry carries the validator feedback + schema body.
+        assert "start with `{`" in prompts_seen[1]
+        assert "candidate_id" in prompts_seen[1]


### PR DESCRIPTION
## Summary
- Worker-side structural retry as the last safety net before the parent records `phase_failed`
- When `response_schema` is set and first attempt is empty / unparseable / `required`-missing, re-issue once with validator-feedback prompt
- Retry budget capped at exactly 1, gated on `elapsed_before_retry < 0.5 * request.timeout_s`

## Why
Smoke 17 confirmed that prompt-level PR-HANDOFF-SCHEMAS gating ("FINAL response must be ONLY the JSON object … Start with `{` and end with `}`") is best-effort: Codex / claude-cli sub-agents occasionally finish with empty output_text or prose surrounding the JSON. The parent orchestrator then records `phase_failed` and the entire seed-generation run aborts. PR-PROXIMITY-JSON-ENFORCE + PR-ROLE-JSON-ENFORCE-EXTENSION strengthened the prompt-level gate, but a structural retry is needed for the cases where the LLM still drifts.

This PR ports the paperclip + open-scientist `validate_and_retry` pattern: on the first failure, re-prompt with the validator's verdict + the schema body inline, and re-issue the loop exactly once.

## Changes
| File | Change |
|------|--------|
| `core/agent/worker.py` | Add `_needs_schema_retry`, `_build_schema_retry_prompt`, `_NO_RETRY_TERMINATION_REASONS`. Wire retry call into `_run_agentic` after `loop.arun(prompt)`. |
| `tests/test_worker.py` | `TestNeedsSchemaRetry` (14 cases), `TestBuildSchemaRetryPrompt` (4 cases), `TestSchemaAwareRetryWiring` (10 cases) |
| `CHANGELOG.md` | `[Unreleased]` entry under Fixed |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `_needs_schema_retry` helper | Implemented | grep-provable at `core/agent/worker.py` |
| `_build_schema_retry_prompt` helper | Implemented | grep-provable at `core/agent/worker.py` |
| Retry call in `_run_agentic` | Implemented | After `loop.arun(prompt)` at line ~422 |
| Cap at 1 retry | Implemented | No loop wrapping the second call |
| Elapsed-time gate | Implemented | Codex MCP catch fold-in |
| `_NO_RETRY_TERMINATION_REASONS` for success exits | Implemented | Codex MCP catch fold-in |
| Tests for happy / empty / malformed / required-missing / no-schema / success-exit / elapsed-gate / retry-prompt-content | Implemented | 28 new tests |

## Verification
- [x] ruff check clean (`core/ tests/ plugins/`)
- [x] ruff format clean
- [x] mypy clean (`core/agent/worker.py`)
- [x] lint-imports — 4 contracts kept, 0 broken
- [x] pytest tests/test_worker.py — 64/64 pass
- [x] pytest broader (test_worker + tests/core/agent + tests/plugins/seed_generation) — 690 pass, 3 skipped
- [x] Codex MCP cross-LLM review — 2 fixes folded in-band (`_NO_RETRY_TERMINATION_REASONS` + elapsed-time gate)

## Reference
- PR-HANDOFF-SCHEMAS (`core/agent/sub_agent.py:_last_balanced_json_object`) — parent-side parser that the retry helper mirrors for schema parity
- PR-JSON-WIRE — per-role JSON Schema wire-through that made this retry path live
- open-scientist `llm.py:437` `validate_and_retry` — pattern reference
- paperclip session JSONL replay + bounded retry — pattern reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)