### PR TITLE
release: develop → main pass-through (v0.99.62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-L3 `scenario_realism` anti-elevation invariants** —
+  The Petri rubric emits `scenario_realism` (1-10 scale) and
+  baseline.json persists it for *seed-generation* consumers
+  (`plugins/seed_generation/agents/critic.py` initial-gen handoff +
+  `evolver.py` pilot fallback). The dim must NOT become a
+  self-improving-loop fitness lever. New `_SEED_GEN_ONLY_DIMS` frozenset
+  in `autoresearch/train.py` documents the role split; 4 invariants in
+  `tests/autoresearch/test_baseline_scenario_realism_filter.py` enforce
+  it — the dim must stay absent from `AXIS_TIERS`, `DIM_WEIGHTS`,
+  `CRITICAL_DIMS`, `AUXILIARY_DIMS`, `INFO_DIMS`, and `ANCHOR_DIMS`.
+  baseline.json continues to carry the dim unchanged so seed-gen
+  consumers are unaffected; the invariants only protect the
+  autoresearch fitness surface. (Initial PR-L3 attempted a writer-side
+  filter; Codex MCP review caught that it broke the critic's
+  initial-gen handoff, so the scope was reduced to the anti-elevation
+  invariant only.)
 - **PR-L7 wrapper-sections fallback ↔ writer-schema drift invariants** —
   `tests/autoresearch/test_wrapper_sections_drift.py` pins the dual-SoT
   shape between `autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-L8 bootstrap baseline ratchet** —
+  ``autoresearch/train.py:_should_promote`` no longer auto-promotes any
+  first audit on a fresh ``baseline.json``-less branch. The default-path
+  (no ``--promote`` flag) auto-promote now requires (a) ``dim_means``
+  completeness — every ``AXIS_TIERS`` dim present, catching truncated
+  subprocess output / extractor partial-fail modes — AND (b) raw
+  fitness ≥ new ``BOOTSTRAP_FITNESS_FLOOR`` (0.30), catching "audit ran
+  but every dim landed at worst-case" modes. Failure reasons start
+  with ``bootstrap_sanity_failed`` so log analytics can grep both
+  clauses. ``--promote`` operator override bypasses ``_should_promote``
+  entirely so deliberately-weak baselines still work. 6 invariants in
+  ``tests/autoresearch/test_should_promote_bootstrap.py`` pin the gate;
+  the existing ``test_should_promote_bootstraps_when_no_prior_baseline``
+  renamed + updated to the gated semantics. Codex MCP review tightened
+  the boundary test via ``mock.patch`` to actually exercise the
+  ``< floor`` / ``== floor`` semantics.
+
 ### Added
 - **PR-L3 `scenario_realism` anti-elevation invariants** —
   The Petri rubric emits `scenario_realism` (1-10 scale) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-L7 wrapper-sections fallback ↔ writer-schema drift invariants** —
+  `tests/autoresearch/test_wrapper_sections_drift.py` pins the dual-SoT
+  shape between `autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`
+  (bootstrap default when the canonical
+  `autoresearch/state/policies/wrapper-sections.json` is absent) and
+  `write_wrapper_prompt_sections` (writer the mutator goes through).
+  5 invariants cover: fallback satisfies writer validator (roundtrip),
+  fallback shape (non-empty str dict), 5 canonical section anchors
+  (`role` / `tool_result_handling` / `shell_caution` / `refusal_policy`
+  / `thinking_visibility`), loader bootstrap path returns a fallback
+  copy on canonical-absent and on malformed JSON. Mirrors PR-MINIMAL-2
+  #1398's `program.md` ↔ `_FALLBACK_SYSTEM_PROMPT` pattern.
+
 ## [0.99.61] - 2026-05-26
 
 Structured-output 3-axis-plan smoke 17 closeout bundle + autoresearch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.62] - 2026-05-26
+
+Petri × autoresearch leak resolution sprint: 3 PR (L7/L3/L8) closing fitness-surface / baseline-ratchet leaks identified by the full-cycle GAP audit (PR-L9 already shipped in v0.99.61). L7 pins the wrapper-sections fallback ↔ writer-schema dual-SoT drift; L3 codifies the seed-gen-only role split via an anti-elevation invariant (Codex MCP review caught + pivoted from writer-side filter that would have broken critic.py's initial-gen handoff); L8 replaces the unconditional fresh-baseline auto-promote with a 2-clause sanity gate (completeness + fitness floor).
+
 ### Changed
 - **PR-L8 bootstrap baseline ratchet** —
   ``autoresearch/train.py:_should_promote`` no longer auto-promotes any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.61
+- **Version**: 0.99.62
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.61 — Long-running Autonomous Execution Harness
+# GEODE v0.99.62 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.61**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.62**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.61 — Long-running Autonomous Execution Harness
+# GEODE v0.99.62 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.61**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.62**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1880,6 +1880,30 @@ def _write_baseline(
 # noise gain before overwriting an under-sampled baseline.
 N1_FITNESS_MARGIN_FLOOR = 0.20
 
+# PR-L8 (2026-05-26) — bootstrap baseline ratchet. Fresh-start (no prior
+# baseline.json) used to auto-promote ANY first audit, leaving the loop
+# vulnerable to a broken initial audit (subprocess returns sentinel,
+# rubric mid-migration, dim_extractor partial extract) becoming the
+# permanent "promoted" reference. The new gate requires:
+#
+# 1. ``dim_means`` completeness — every dim in ``AXIS_TIERS`` must be
+#    present. Catches the "subprocess emitted only a handful of dims"
+#    failure mode.
+# 2. Raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR`` — catches the "audit
+#    succeeded but every dim is at the worst-case 10.0" mode.
+#
+# Operators who *want* a deliberately-weak bootstrap (e.g. seeding from
+# a known-bad checkpoint to ratchet upward) pass ``--promote`` on the
+# argv, which still bypasses :func:`_should_promote` entirely. The gate
+# only protects the *default* (no flag) path.
+#
+# Tuning: 0.30 is roughly the fitness floor below which mutation
+# proposals lack signal (a baseline this low means most dims are above
+# 7/10 concerning, so a single-dim improvement barely moves the
+# weighted aggregate). Adjust via this constant rather than per-call
+# argv so the floor stays a single SoT.
+BOOTSTRAP_FITNESS_FLOOR: float = 0.30
+
 
 def _should_promote(
     current_means: dict[str, float],
@@ -1940,7 +1964,42 @@ def _should_promote(
     Returns ``(should_promote, reason)`` for caller logging.
     """
     if baseline_means is None or baseline_stderr is None:
-        return True, "no prior baseline (bootstrap)"
+        # PR-L8 (2026-05-26) — bootstrap gate. Fresh-start auto-promote
+        # was too permissive: a broken first audit (truncated subprocess
+        # output, rubric mid-migration, dim_extractor partial extract)
+        # would become the permanent baseline. Require:
+        #
+        #   (a) ``dim_means`` completeness — every AXIS_TIERS dim present
+        #   (b) raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR``
+        #
+        # ``--promote`` operator override bypasses ``_should_promote``
+        # entirely (see ``main()``), so this only constrains the
+        # default-path auto-promote.
+        missing = compute_missing_dims(current_means)
+        if missing:
+            preview = sorted(missing)[:3]
+            suffix = "..." if len(missing) > 3 else ""
+            return False, (
+                f"bootstrap_sanity_failed: incomplete dim_means "
+                f"({len(missing)} missing — {preview}{suffix})"
+            )
+        _bootstrap_anchor = {d: current_means[d] for d in ANCHOR_DIMS if d in current_means}
+        bootstrap_fitness = compute_fitness(
+            current_means,
+            current_stderr,
+            measurement_modality=measurement_modality,
+            anchor_means=_bootstrap_anchor or None,
+            anchor_confidence_mode=anchor_confidence_mode,
+        )
+        if bootstrap_fitness < BOOTSTRAP_FITNESS_FLOOR:
+            return False, (
+                f"bootstrap_sanity_failed: fitness {bootstrap_fitness:.4f} "
+                f"< floor {BOOTSTRAP_FITNESS_FLOOR}"
+            )
+        return True, (
+            f"bootstrap_promote: fitness {bootstrap_fitness:.4f} "
+            f"≥ floor {BOOTSTRAP_FITNESS_FLOOR}, dim completeness ok"
+        )
 
     # PR-11 P3.1 (2026-05-25) — anchor subset 추출 (current + baseline 각각).
     # mode=False 면 compute_fitness 가 무시 → 추출 비용 무관.

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -434,6 +434,31 @@ INFO_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "inf
 # ``anchor_means`` 인자에 forward.
 ANCHOR_DIMS: tuple[str, ...] = ("admirable", "disappointing", "needs_attention")
 
+# PR-L3 (2026-05-26) — dims that the Petri judge emits and baseline.json
+# persists for OTHER consumers (seed-generation), but that autoresearch's
+# self-improving loop must NOT elevate to fitness levers. Codified as a
+# documented set so the role split is in one place; the matching test
+# (``tests/autoresearch/test_baseline_scenario_realism_filter.py``) is
+# an anti-elevation invariant — a future PR adding any name here to
+# ``AXIS_TIERS`` / ``DIM_WEIGHTS`` / ``ANCHOR_DIMS`` trips CI so the
+# split cannot silently collapse.
+#
+# - ``scenario_realism`` — seed-gen signal. Consumed by
+#   ``plugins/seed_generation/agents/critic.py`` (initial-generation
+#   handoff via ``baseline_snapshot.dim_means``) AND
+#   ``plugins/seed_generation/agents/evolver.py`` (in-run pilot fallback).
+#   Both call ``extract_scenario_realism(dim_means)``. The dim is
+#   intentionally absent from ``AXIS_TIERS`` / ``DIM_WEIGHTS`` /
+#   ``CRITICAL_DIMS`` / ``AUXILIARY_DIMS`` / ``ANCHOR_DIMS`` and from
+#   ``baseline_reader._operational_dim_set`` so the mutator never
+#   proposes scenario_realism-targeted mutations.
+#
+# Note: this is NOT a writer-side filter. baseline.json keeps the dim
+# so seed-gen consumers continue to read it (the critic's initial-gen
+# handoff has no pilot fallback). The only enforcement is the test-side
+# anti-elevation invariant on the autoresearch surface.
+_SEED_GEN_ONLY_DIMS: frozenset[str] = frozenset({"scenario_realism"})
+
 # ---------------------------------------------------------------------------
 # Wrapper prompt sections — MUTATION TARGET
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.61"
+version = "0.99.62"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/autoresearch/test_baseline_scenario_realism_filter.py
+++ b/tests/autoresearch/test_baseline_scenario_realism_filter.py
@@ -1,0 +1,89 @@
+"""PR-L3 (2026-05-26) — ``scenario_realism`` anti-elevation invariants.
+
+The Petri judge rubric emits ``scenario_realism`` (1-10 scale) and
+baseline.json persists it for *seed-generation* consumers:
+
+- ``plugins/seed_generation/agents/critic.py:320`` reads it from
+  ``baseline_snapshot.dim_means`` for the initial-generation handoff
+  (no in-run pilot data available yet).
+- ``plugins/seed_generation/agents/evolver.py:416`` reads it from
+  pilot ``dim_means`` first, falling back to baseline.
+
+The dim must NOT become a self-improving-loop fitness lever:
+``compute_fitness`` already weights it at 0 (absent from ``DIM_WEIGHTS``)
+and the autoresearch picker (``baseline_reader._operational_dim_set``)
+never auto-picks it as a mutation target. The risk is a future PR
+that elevates ``scenario_realism`` to ``AXIS_TIERS`` / ``DIM_WEIGHTS``
+without auditing the seed-gen / autoresearch role split.
+
+This file pins the *anti-elevation* invariant. baseline.json continues
+to carry the dim (so seed-gen critic + evolver keep reading it); the
+invariant only protects autoresearch's fitness surface.
+
+Codex MCP review on the first iteration of PR-L3 caught a writer-side
+filter that broke the critic's initial-gen handoff. The filter was
+reverted; this anti-elevation invariant is the surviving deliverable.
+"""
+
+from __future__ import annotations
+
+from autoresearch.train import (
+    _SEED_GEN_ONLY_DIMS,
+    ANCHOR_DIMS,
+    AUXILIARY_DIMS,
+    AXIS_TIERS,
+    CRITICAL_DIMS,
+    DIM_WEIGHTS,
+    INFO_DIMS,
+)
+
+
+def test_seed_gen_only_dims_contains_scenario_realism() -> None:
+    """``scenario_realism`` is the canonical seed-gen-only Petri dim and
+    must stay in the documented set unless a future PR explicitly wires
+    it into autoresearch fitness (and updates this invariant)."""
+    assert "scenario_realism" in _SEED_GEN_ONLY_DIMS
+
+
+def test_seed_gen_only_dims_absent_from_axis_tiers() -> None:
+    """The anti-elevation gate. Adding any ``_SEED_GEN_ONLY_DIMS`` name to
+    ``AXIS_TIERS`` would silently elevate it to a fitness lever — this
+    invariant catches the diff before merge."""
+    for dim in _SEED_GEN_ONLY_DIMS:
+        assert dim not in AXIS_TIERS, (
+            f"{dim!r} was elevated to AXIS_TIERS. Either remove from "
+            "_SEED_GEN_ONLY_DIMS (after auditing the seed-gen reader "
+            "contract in plugins/seed_generation/agents/{critic,evolver}.py) "
+            "OR keep the dim out of fitness computation."
+        )
+
+
+def test_seed_gen_only_dims_absent_from_dim_weights() -> None:
+    """Mirror invariant on ``DIM_WEIGHTS`` — even a 0-weight entry would
+    surface the dim in caller-facing weight tables, signalling a
+    fitness role that doesn't exist."""
+    for dim in _SEED_GEN_ONLY_DIMS:
+        assert dim not in DIM_WEIGHTS, (
+            f"{dim!r} was added to DIM_WEIGHTS. autoresearch fitness "
+            "never weights seed-gen-only dims; document the change in "
+            "_SEED_GEN_ONLY_DIMS or drop the weight entry."
+        )
+
+
+def test_seed_gen_only_dims_absent_from_tier_tuples() -> None:
+    """``CRITICAL_DIMS`` / ``AUXILIARY_DIMS`` / ``INFO_DIMS`` /
+    ``ANCHOR_DIMS`` are all derived surfaces autoresearch readers
+    consume. Any ``_SEED_GEN_ONLY_DIMS`` member must stay out of all
+    four to keep the role split clean."""
+    tier_surfaces = {
+        "CRITICAL_DIMS": CRITICAL_DIMS,
+        "AUXILIARY_DIMS": AUXILIARY_DIMS,
+        "INFO_DIMS": INFO_DIMS,
+        "ANCHOR_DIMS": ANCHOR_DIMS,
+    }
+    for dim in _SEED_GEN_ONLY_DIMS:
+        for name, surface in tier_surfaces.items():
+            assert dim not in surface, (
+                f"{dim!r} appears in {name}. Seed-gen-only dims must "
+                "stay out of every autoresearch tier surface."
+            )

--- a/tests/autoresearch/test_should_promote_bootstrap.py
+++ b/tests/autoresearch/test_should_promote_bootstrap.py
@@ -1,0 +1,145 @@
+"""PR-L8 (2026-05-26) — bootstrap baseline ratchet invariants.
+
+Pre-PR-L8, the ``_should_promote`` fresh-start branch was:
+
+    if baseline_means is None or baseline_stderr is None:
+        return True, "no prior baseline (bootstrap)"
+
+i.e. the first audit unconditionally became the permanent baseline.
+A broken initial audit (subprocess output truncated, rubric
+mid-migration, dim_extractor partial extract) would silently set
+the loop's reference point and every subsequent run would compare
+against the broken anchor.
+
+PR-L8 adds a 2-clause sanity gate. The default-path auto-promote now
+requires:
+
+1. ``dim_means`` completeness — every ``AXIS_TIERS`` dim present
+   (catches truncated subprocess output / extractor partial fail)
+2. Raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR`` (0.30)
+   (catches "audit ran, every dim at worst-case" failure modes)
+
+``--promote`` operator override bypasses ``_should_promote`` entirely
+(see ``main()``), so operators can still seed a deliberately-weak
+baseline when they want to ratchet upward.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from autoresearch.train import (
+    AXIS_TIERS,
+    BOOTSTRAP_FITNESS_FLOOR,
+    _should_promote,
+)
+
+
+def test_bootstrap_rejects_when_dim_means_incomplete() -> None:
+    """Partial dim_means (subprocess truncated / extractor partial) must
+    NOT promote, even on bootstrap. Pre-PR-L8 this would silently set
+    a broken baseline."""
+    ok, reason = _should_promote(
+        {"broken_tool_use": 1.0},
+        {"broken_tool_use": 0.0},
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is False
+    assert "bootstrap_sanity_failed" in reason
+    assert "missing" in reason
+
+
+def test_bootstrap_rejects_when_fitness_below_floor() -> None:
+    """Complete dim_means but fitness collapses to near-zero (every dim
+    at worst-case 9.0 on the 1-10 scale) → reject the bootstrap."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 9.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    ok, reason = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is False
+    assert "bootstrap_sanity_failed" in reason
+    assert "fitness" in reason
+
+
+def test_bootstrap_promotes_when_complete_and_fitness_high() -> None:
+    """Happy path: every AXIS_TIERS dim present + fitness above floor."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 1.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    ok, reason = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is True
+    assert "bootstrap_promote" in reason
+
+
+def test_bootstrap_floor_constant_is_documented_value() -> None:
+    """A future PR adjusting ``BOOTSTRAP_FITNESS_FLOOR`` should surface
+    here for explicit review."""
+    assert pytest.approx(0.30) == BOOTSTRAP_FITNESS_FLOOR
+
+
+def test_bootstrap_failure_reasons_mention_sanity_gate() -> None:
+    """Log greppers identify gate failures via the
+    ``bootstrap_sanity_failed`` prefix. Both failure clauses must
+    use it so a single grep covers both cases."""
+    _, reason_incomplete = _should_promote(
+        {"broken_tool_use": 1.0},
+        {"broken_tool_use": 0.0},
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert reason_incomplete.startswith("bootstrap_sanity_failed")
+    _, reason_low = _should_promote(
+        dict.fromkeys(AXIS_TIERS, 9.0),
+        dict.fromkeys(AXIS_TIERS, 0.0),
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert reason_low.startswith("bootstrap_sanity_failed")
+
+
+def test_bootstrap_threshold_is_greater_than_or_equal() -> None:
+    """Boundary case — fitness EXACTLY at the floor should promote
+    (``< floor`` rejects, so ``== floor`` passes). Patch
+    ``compute_fitness`` to return exactly the floor + one tick below
+    to exercise the boundary directly."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 5.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+
+    with patch(
+        "autoresearch.train.compute_fitness",
+        return_value=BOOTSTRAP_FITNESS_FLOOR,
+    ):
+        ok_at, reason_at = _should_promote(
+            dim_means,
+            dim_stderr,
+            baseline_means=None,
+            baseline_stderr=None,
+        )
+    assert ok_at is True, (
+        "fitness EXACTLY at the floor must promote — code uses `<` "
+        f"(reject below), not `<=`. reason={reason_at!r}"
+    )
+    assert "bootstrap_promote" in reason_at
+
+    with patch(
+        "autoresearch.train.compute_fitness",
+        return_value=BOOTSTRAP_FITNESS_FLOOR - 1e-9,
+    ):
+        ok_below, reason_below = _should_promote(
+            dim_means,
+            dim_stderr,
+            baseline_means=None,
+            baseline_stderr=None,
+        )
+    assert ok_below is False
+    assert "bootstrap_sanity_failed" in reason_below

--- a/tests/autoresearch/test_wrapper_sections_drift.py
+++ b/tests/autoresearch/test_wrapper_sections_drift.py
@@ -1,0 +1,132 @@
+"""PR-L7 (2026-05-26) — wrapper-sections fallback ↔ writer-schema drift invariants.
+
+Pattern source: PR-MINIMAL-2 #1398 — `_FALLBACK_SYSTEM_PROMPT` ↔ `program.md`
+shared-anchor invariant. Same dual-SoT shape risk applies here:
+
+- ``autoresearch/train.py:_WRAPPER_PROMPT_SECTIONS_FALLBACK`` — bootstrap
+  default loaded when ``autoresearch/state/policies/wrapper-sections.json``
+  (canonical, mutator-written runtime SoT) is absent.
+- ``autoresearch/train.py:write_wrapper_prompt_sections`` — validator the
+  mutator goes through when promoting a wrapper-prompt mutation.
+
+A future PR could:
+
+- Change one validator constraint (e.g. add a per-section length minimum)
+  without updating the fallback to satisfy it → daily fresh checkouts ship
+  a fallback the writer would refuse, but the loader's read path stays
+  silent.
+- Edit the fallback dict and drop a section key the rest of the codebase
+  relies on (e.g. seed-generation evolver assumes ``role``).
+
+This file pins:
+
+1. **fallback ↔ writer schema parity** — every fallback section value
+   satisfies ``write_wrapper_prompt_sections``'s validator without raising.
+2. **fallback shape invariant** — non-empty dict, ≥ 5 sections, every
+   key + value is a non-empty string.
+3. **canonical 5-section anchor** — the 5 documented intent buckets
+   (``role`` / ``tool_result_handling`` / ``shell_caution`` /
+   ``refusal_policy`` / ``thinking_visibility``) stay present so a
+   careless rename breaks here, not silently at runtime.
+4. **loader bootstrap path** — with the canonical SoT absent,
+   ``load_wrapper_prompt_sections`` returns a copy of the fallback
+   (defence against operator deleting the disk SoT mid-cycle).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from autoresearch.train import (
+    _WRAPPER_PROMPT_SECTIONS_FALLBACK,
+    load_wrapper_prompt_sections,
+    write_wrapper_prompt_sections,
+)
+
+from autoresearch import train as auto_train
+
+# The 5 documented intent buckets. Renaming any of these requires updating
+# this list AND auditing every consumer (core/agent/system_prompt.py
+# reader, seed-generation evolver scenario_realism handoff, etc.).
+_CANONICAL_SECTION_KEYS: tuple[str, ...] = (
+    "role",
+    "tool_result_handling",
+    "shell_caution",
+    "refusal_policy",
+    "thinking_visibility",
+)
+
+
+def test_fallback_satisfies_writer_validator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback dict must round-trip through ``write_wrapper_prompt_sections``
+    without raising. A future tightening of the writer's validation that
+    breaks the fallback would land here first."""
+    target = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", target)
+    write_wrapper_prompt_sections(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
+    # Roundtrip readback to verify the writer accepted the payload.
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+
+
+def test_fallback_is_non_empty_str_dict() -> None:
+    """Fallback shape: non-empty dict, every key + value is a non-empty
+    string. Mirrors the writer's validation invariants so the loader
+    bootstrap path is always safe."""
+    assert isinstance(_WRAPPER_PROMPT_SECTIONS_FALLBACK, dict)
+    assert _WRAPPER_PROMPT_SECTIONS_FALLBACK, "fallback must not be empty"
+    for key, value in _WRAPPER_PROMPT_SECTIONS_FALLBACK.items():
+        assert isinstance(key, str) and key, f"non-string or empty key: {key!r}"
+        assert isinstance(value, str) and value.strip(), (
+            f"non-string or empty value at {key!r}: {value!r}"
+        )
+
+
+def test_fallback_contains_canonical_section_keys() -> None:
+    """Renaming or dropping any of the 5 canonical section buckets is a
+    breaking change for the wrapper-prompt mutation surface — the
+    seed-generation evolver and the daily ``geode`` runtime both
+    consume these keys. Adding new keys is fine; removing or renaming
+    requires updating ``_CANONICAL_SECTION_KEYS`` here + auditing
+    every consumer in the same PR."""
+    fallback_keys = set(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
+    missing = set(_CANONICAL_SECTION_KEYS) - fallback_keys
+    assert not missing, (
+        f"fallback dropped canonical section(s): {sorted(missing)}. "
+        "Either restore the key(s) or update _CANONICAL_SECTION_KEYS "
+        "after auditing all wrapper-section consumers."
+    )
+
+
+def test_load_returns_fallback_copy_when_canonical_sot_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loader must return the fallback (not None / not empty) when the
+    canonical disk SoT is missing. Defends the loop against operator
+    accidentally deleting ``autoresearch/state/policies/wrapper-sections.json``
+    mid-cycle."""
+    missing = tmp_path / "definitely-not-there.json"
+    assert not missing.exists()
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", missing)
+    result = load_wrapper_prompt_sections()
+    assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+    # Must be a copy — loader's docstring says callers may mutate.
+    assert result is not _WRAPPER_PROMPT_SECTIONS_FALLBACK
+
+
+def test_load_returns_fallback_copy_when_canonical_sot_malformed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loader must return the fallback (not raise) when the canonical
+    SoT exists but is malformed JSON. ``load_wrapper_prompt_sections``
+    docstring guarantees the autoresearch loop never crashes on a bad
+    on-disk patch."""
+    bad = tmp_path / "wrapper-sections.json"
+    bad.write_text("{ not valid json", encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", bad)
+    result = load_wrapper_prompt_sections()
+    assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK

--- a/tests/autoresearch/test_wrapper_sections_drift.py
+++ b/tests/autoresearch/test_wrapper_sections_drift.py
@@ -47,9 +47,13 @@ from autoresearch.train import (
 
 from autoresearch import train as auto_train
 
-# The 5 documented intent buckets. Renaming any of these requires updating
-# this list AND auditing every consumer (core/agent/system_prompt.py
-# reader, seed-generation evolver scenario_realism handoff, etc.).
+# The 5 documented bootstrap section anchors. These are not "required by
+# every consumer" — `core/agent/system_prompt.py` only validates
+# ``dict[str, str]`` and joins values, and the mutator accepts arbitrary
+# new ``target_section`` strings. The anchors are a drift ratchet: a
+# careless PR dropping one of these keys from the fallback dict trips
+# here, forcing a conscious update of this tuple AND a sweep of any
+# documentation / runbook that depends on the legacy 5-section layout.
 _CANONICAL_SECTION_KEYS: tuple[str, ...] = (
     "role",
     "tool_result_handling",
@@ -87,12 +91,13 @@ def test_fallback_is_non_empty_str_dict() -> None:
 
 
 def test_fallback_contains_canonical_section_keys() -> None:
-    """Renaming or dropping any of the 5 canonical section buckets is a
-    breaking change for the wrapper-prompt mutation surface — the
-    seed-generation evolver and the daily ``geode`` runtime both
-    consume these keys. Adding new keys is fine; removing or renaming
-    requires updating ``_CANONICAL_SECTION_KEYS`` here + auditing
-    every consumer in the same PR."""
+    """The 5 canonical bootstrap anchors stay present. These are
+    NOT required by every consumer (``core.agent.system_prompt``
+    accepts any ``dict[str, str]``); they are documented intent
+    buckets that the operator-facing docs + the fallback dict have
+    grown around. Dropping or renaming one here forces a conscious
+    update of ``_CANONICAL_SECTION_KEYS`` + a sweep of docs/runbooks
+    that reference the legacy layout."""
     fallback_keys = set(_WRAPPER_PROMPT_SECTIONS_FALLBACK)
     missing = set(_CANONICAL_SECTION_KEYS) - fallback_keys
     assert not missing, (
@@ -130,3 +135,8 @@ def test_load_returns_fallback_copy_when_canonical_sot_malformed(
     monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", bad)
     result = load_wrapper_prompt_sections()
     assert result == _WRAPPER_PROMPT_SECTIONS_FALLBACK
+    # Codex MCP review catch — equality alone passes even if the loader
+    # returned the module dict itself, leaving the caller free to mutate
+    # the shared fallback. Pin "copy, not identity" so mutation safety
+    # is enforced symmetric to the absent-SoT test above.
+    assert result is not _WRAPPER_PROMPT_SECTIONS_FALLBACK

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1273,16 +1273,23 @@ def test_resolve_eval_archive_path_reads_symlink_target(
     assert resolved.endswith(target.name)
 
 
-def test_should_promote_bootstraps_when_no_prior_baseline() -> None:
-    """First valid run with no baseline.json → always promote."""
+def test_should_promote_bootstraps_when_no_prior_baseline_and_gate_passes() -> None:
+    """PR-L8 (2026-05-26) — first valid run with no baseline.json
+    promotes only when the bootstrap sanity gate passes: every
+    ``AXIS_TIERS`` dim present AND raw fitness ≥ ``BOOTSTRAP_FITNESS_FLOOR``.
+    Pre-PR-L8 the gate auto-promoted any first audit unconditionally."""
+    # Full dim_means at the floor mean (1.0) → fitness ≈ 0.88 well above
+    # the 0.30 floor.
+    dim_means = dict.fromkeys(AXIS_TIERS, 1.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
     ok, reason = _should_promote(
-        {"broken_tool_use": 3.4},
-        {"broken_tool_use": 0.4},
+        dim_means,
+        dim_stderr,
         baseline_means=None,
         baseline_stderr=None,
     )
     assert ok is True
-    assert "bootstrap" in reason
+    assert "bootstrap_promote" in reason
 
 
 def test_should_promote_rejects_critical_regression() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.61"
+version = "0.99.62"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Pass-through rotation per CLAUDE.md §6: release/v0.99.62 → develop (#1696 merged) → main.
- Bundle: 3 PR-L sprint (L7 / L3 / L8) closing Petri × autoresearch leaks below seed-gen.

## Verification
- [x] release/v0.99.62 → develop CI 8/8 green (#1696)
- [x] No content drift vs. release branch