### PR TITLE
feat(seed-gen): convert 5 schemas to OpenAI strict-mode (PR-STRICT-COMPATIBLE-SCHEMAS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,49 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-STRICT-COMPATIBLE-SCHEMAS — convert 5 seed-gen schemas to
+  OpenAI strict-mode (Codex `text.format` constraint).** Pre-fix all
+  seed-gen schemas used the permissive `_additive()` helper (no
+  `additionalProperties:false`), so the Codex OAuth adapter's
+  `_is_openai_strict_compatible` detector
+  (`core/llm/adapters/codex_oauth.py`) always returned False → the
+  Responses API received `text.format.strict=False` → schema
+  behaviour collapsed to a *server hint* rather than an enforced
+  *constraint*. gpt-5.5 reasoning models could then consume the
+  entire output budget on `encrypted_reasoning` items and return
+  empty `output_text` (smoke 18:
+  `.audit/smoke-archives/smoke-18-partial-1779728410/sub_agents/
+  vote-m000-openai.openai-codex/dialogue.jsonl` turn 1 — cost
+  $0.0358, 0 `assistant_message`). New `_strict_additive()` helper
+  derives `required` from `properties.keys()` + sets
+  `additionalProperties:false`; recursive `_strict_additive` on
+  nested objects + array items. Converted: PROXIMITY, CRITIQUE,
+  VOTE, EVOLVE, SUPERVISOR. Three exceptions remain non-strict
+  because they use typed-additional maps that depend on
+  runtime-known keys (Petri 24-dim catalog / arxiv-id snapshot
+  map): PILOT, META_REVIEW, LITERATURE_REVIEW. Side fixes folded
+  in-band: (a) `CRITIQUE_SCHEMA` adds `rewrite_section` field
+  (`["string","null"]`) — pre-fix the field was tolerated by
+  permissive `_additive` but `evolver.py:_consume_rewrite_target`
+  + `eval_export.py:355` actively consume it, so strict mode
+  required it be declared (Codex MCP catch); (b) `EVOLVE_SCHEMA`
+  promotes `notes` from optional → required with empty-string
+  sentinel (`evolver.md` + `_REQUIRED_EVOLVE_FIELDS` updated to
+  match); (c) `LITERATURE_REVIEW_SCHEMA` fixes 2 type drifts vs
+  parser — `articles_with_reasoning` was `array` but parser reads
+  as string, `snapshots` was `array` but parser reads as
+  `{arxiv_id: snapshot_path}` dict. Pinned by 4 new tests:
+  `test_strict_role_schemas_pass_openai_strict_check` (parametrize
+  5 strict roles), `test_non_strict_role_schemas_documented_reason`
+  (parametrize 3 non-strict roles, guards against silent
+  tightening), `test_strict_helper_derives_required_from_properties_keys`,
+  + existing `test_critique_schema_required_matches_parser_required`
+  now `==`. Codex MCP cross-LLM review caught the
+  `rewrite_section` omission (would have broken critic→evolver
+  handoff under strict mode) + CHANGELOG/docstring drift; both
+  folded in-band before merge.
+
 ### Fixed
 - **PR-SCHEMA-PARSER-DRIFT-CLOSE — close 3 schema ↔ parser SoT
   drifts surfaced by smoke 18 dialogue audit.** smoke 18 archive

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -75,6 +75,13 @@ _REQUIRED_CRITIQUE_FIELDS = (
     "weaknesses",
     "judge_risk",
     "discrimination_estimate",
+    # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — strict-mode schema
+    # requires every property in required. ``rewrite_section`` is
+    # nullable per critic.md (``null`` when no clear weak section),
+    # but the key MUST be present. The Evolver
+    # (``evolver.py:_consume_rewrite_target``) + ``eval_export.py``
+    # serialiser both handle the null case gracefully.
+    "rewrite_section",
 )
 
 

--- a/plugins/seed_generation/agents/evolver.md
+++ b/plugins/seed_generation/agents/evolver.md
@@ -54,7 +54,7 @@ Your FINAL response — after the candidate file has been written — must be ON
 - `evolved_path` (string) is the absolute path of the file you just wrote.
 - `rewrite_section` (string) names the section you rewrote (mirrors the input).
 - `verdict` (one of `ok`, `evolution_skipped`, `failed`).
-- `notes` (string, optional) — short rationale; the orchestrator's Jaccard guard (PR-EVOLVER-JACCARD-OBS) is the deterministic safety net for "barely changed" output, so do not pad this field.
+- `notes` (string, required, may be `""`) — short rationale; the orchestrator's Jaccard guard (PR-EVOLVER-JACCARD-OBS) is the deterministic safety net for "barely changed" output, so do not pad this field. Emit an empty string `""` when there is nothing worth surfacing (strict-mode schema requires the key be present per PR-STRICT-COMPATIBLE-SCHEMAS).
 
 ## Quality bar
 

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -66,6 +66,13 @@ _REQUIRED_EVOLVE_FIELDS = (
     "evolved_path",
     "rewrite_section",
     "verdict",
+    # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — promoted from
+    # optional. EVOLVE_SCHEMA now requires every property (so codex
+    # ``text.format`` can wire strict-mode); the evolver agent
+    # contract still allows ``notes=""`` to mean "no notes worth
+    # surfacing", but the field must be present (empty-string
+    # sentinel).
+    "notes",
 )
 _VALID_VERDICTS = frozenset({"ok", "evolution_skipped", "failed"})
 

--- a/plugins/seed_generation/json_schemas.py
+++ b/plugins/seed_generation/json_schemas.py
@@ -18,6 +18,30 @@ The required-field tuples here mirror the
 (``plugins/seed_generation/agents/<role>.py``) — keeping them in
 lockstep is a manual invariant for now; a future ratchet PR can
 generate one from the other via a fixture if drift becomes a problem.
+
+PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — Codex OAuth's
+``text.format`` wire-through (PR-CODEX-OAUTH-RESPONSE-SCHEMA, v0.99.61)
+auto-detects strict-mode via
+``core.llm.adapters.codex_oauth._is_openai_strict_compatible``. The
+detector requires every ``type:"object"`` subschema to set
+``additionalProperties:false`` AND list every property in
+``required``. Pre-fix all our schemas used ``_additive()`` (permissive),
+so codex backend always landed on ``strict=False`` → text.format
+became a *hint* rather than a *constraint* → gpt-5.5 reasoning models
+could burn their output budget on encrypted-reasoning items and
+return empty ``output_text`` (smoke 18 vote-m000-openai.openai-codex
+turn 1: cost $0.0358, 0 assistant_message).
+
+The ``_strict_additive()`` helper enforces both invariants. Schemas
+whose shape allows it (no typed ``additionalProperties``, no truly
+optional fields) are converted; the three exceptions (PILOT,
+META_REVIEW, LITERATURE_REVIEW) all use ``additionalProperties:
+{"type": "number"}`` / ``true`` / ``{"type": "string"}`` to carry
+per-Petri-dim numeric maps or per-arxiv-id snapshot path maps whose
+key set is determined at runtime — enumerating those would couple
+the schema to a catalog this module shouldn't import, and the actual
+failure mode for those roles is ``no field at all`` (caught by
+required-gate) not key drift.
 """
 
 from __future__ import annotations
@@ -32,6 +56,10 @@ def _additive(properties: dict[str, Any], required: list[str]) -> dict[str, Any]
     — the model may emit auxiliary fields (e.g. ``rationale``, ``notes``)
     that the parser ignores via the required-field gate; declaring them
     forbidden would reject otherwise-valid responses.
+
+    Use ``_strict_additive`` instead when the role's shape is fully
+    enumerated (no auxiliary fields needed) — that variant unlocks
+    strict-mode at the OpenAI Responses backend.
     """
     return {
         "type": "object",
@@ -40,40 +68,69 @@ def _additive(properties: dict[str, Any], required: list[str]) -> dict[str, Any]
     }
 
 
-PROXIMITY_SCHEMA: Final[dict[str, Any]] = _additive(
+def _strict_additive(properties: dict[str, Any]) -> dict[str, Any]:
+    """OpenAI strict-mode compatible variant of ``_additive``.
+
+    PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — for the codex
+    backend's ``text.format`` to be a hard *constraint* (not a hint),
+    ``_is_openai_strict_compatible`` (codex_oauth.py) requires:
+
+    - ``additionalProperties: false`` on every ``type:"object"``
+      subschema (typed-additional or True is rejected).
+    - Every property key listed in ``required`` (no optionals).
+
+    This helper enforces both: ``required`` is derived from
+    ``properties.keys()`` (no separate list to drift from), and
+    ``additionalProperties`` is set to False. The caller is
+    responsible for nested objects + array ``items`` ALSO using
+    ``_strict_additive`` (the detector recurses; one non-strict
+    nested object disables strict mode for the whole schema).
+
+    Use ``_additive`` (permissive) when:
+
+    - The role's output uses typed-additional maps (``dim_means``
+      with per-Petri-dim float keys — META_REVIEW, PILOT).
+    - An auxiliary field is genuinely optional and must not be
+      synthesized when absent (rare; usually better to make it
+      required with an empty-string sentinel).
+    """
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties.keys()),
+        "additionalProperties": False,
+    }
+
+
+PROXIMITY_SCHEMA: Final[dict[str, Any]] = _strict_additive(
     properties={
         "similarity_clusters": {
             "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
+            "items": _strict_additive(
+                properties={
                     "cluster_id": {"type": "string"},
                     "topic": {"type": "string"},
                     "similar_hypotheses": {
                         "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
+                        "items": _strict_additive(
+                            properties={
                                 "candidate_id": {"type": "string"},
                                 "similarity_degree": {
                                     "type": "string",
                                     "enum": ["high", "medium", "low"],
                                 },
-                            },
-                            "required": ["candidate_id", "similarity_degree"],
-                        },
+                            }
+                        ),
                     },
-                },
-                "required": ["cluster_id", "topic", "similar_hypotheses"],
-            },
+                }
+            ),
         },
     },
-    required=["similarity_clusters"],
 )
-"""Proximity agent — single-shot clustering output."""
+"""Proximity agent — single-shot clustering output (strict-compatible)."""
 
 
-CRITIQUE_SCHEMA: Final[dict[str, Any]] = _additive(
+CRITIQUE_SCHEMA: Final[dict[str, Any]] = _strict_additive(
     properties={
         "candidate_id": {"type": "string"},
         "target_dims_actual": {"type": "array", "items": {"type": "string"}},
@@ -81,7 +138,7 @@ CRITIQUE_SCHEMA: Final[dict[str, Any]] = _additive(
         "strengths": {"type": "array", "items": {"type": "string"}},
         "weaknesses": {"type": "array", "items": {"type": "string"}},
         "judge_risk": {"type": "string"},
-        # PR-SCHEMA-PARSER-DRIFT-CLOSE (2026-05-26) — pre-fix
+        # PR-SCHEMA-PARSER-DRIFT-CLOSE (2026-05-26, #1698) — pre-fix
         # ``_REQUIRED_CRITIQUE_FIELDS`` (critic.py:70) gated this field
         # but ``CRITIQUE_SCHEMA.required`` omitted it. The worker-side
         # ``_needs_schema_retry`` only fires when a schema ``required``
@@ -93,18 +150,20 @@ CRITIQUE_SCHEMA: Final[dict[str, Any]] = _additive(
         # ``critic.md`` (used by ``eval_export.py`` to compute
         # ``avg_discrimination_estimate``).
         "discrimination_estimate": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26, Codex MCP catch) —
+        # critic.md:47 + critic.py:304 advertise a ``rewrite_section``
+        # field that the Evolver consumes
+        # (``evolver.py:_consume_rewrite_target``) + that
+        # ``eval_export.py:355`` serialises into the per-critique
+        # action row. Pre-fix the field was tolerated because
+        # ``_additive()`` allowed additional properties; the strict
+        # variant rejects unknown keys, so the field MUST be declared.
+        # Nullable per critic.md (``"otherwise null"``); OpenAI strict
+        # mode accepts ``"type": ["string", "null"]``.
+        "rewrite_section": {"type": ["string", "null"]},
     },
-    required=[
-        "candidate_id",
-        "target_dims_actual",
-        "intended_dim_match",
-        "strengths",
-        "weaknesses",
-        "judge_risk",
-        "discrimination_estimate",
-    ],
 )
-"""Critic agent — per-candidate critique."""
+"""Critic agent — per-candidate critique (strict-compatible)."""
 
 
 PILOT_SCHEMA: Final[dict[str, Any]] = _additive(
@@ -116,7 +175,10 @@ PILOT_SCHEMA: Final[dict[str, Any]] = _additive(
             # full set without listing each (the LLM has the dim catalog
             # via the system prompt; this schema gates "no dim_means
             # field at all" + "values are wrong type", which is the
-            # actual failure mode smoke 14 hit).
+            # actual failure mode smoke 14 hit). Typed-additional means
+            # this schema CANNOT use ``_strict_additive`` — enumerating
+            # all 24 dims here would couple json_schemas.py to the
+            # autoresearch dim catalog this module shouldn't import.
             "additionalProperties": {"type": "number"},
         },
         "dim_stderr": {
@@ -130,21 +192,39 @@ PILOT_SCHEMA: Final[dict[str, Any]] = _additive(
     },
     required=["candidate_id", "dim_means", "dim_stderr", "status"],
 )
-"""Pilot agent — Petri inner-loop audit per candidate."""
+"""Pilot agent — Petri inner-loop audit per candidate.
+
+NOT strict-compatible — ``dim_means`` / ``dim_stderr`` use typed
+``additionalProperties`` to accept the Petri 24-dim catalog without
+enumerating it; OpenAI strict mode rejects typed-additional. Caller
+codex backend falls through to ``strict: False`` for this schema
+(server hint, not constraint). Acceptable trade-off: pilot's actual
+failure mode is ``no field at all`` (caught by required gate), not
+key drift inside dim_means.
+"""
 
 
-VOTE_SCHEMA: Final[dict[str, Any]] = _additive(
+VOTE_SCHEMA: Final[dict[str, Any]] = _strict_additive(
     properties={
         "match_id": {"type": "string"},
         "winner": {"type": "string", "enum": ["A", "B", "tie"]},
         "rationale": {"type": "string"},
     },
-    required=["match_id", "winner", "rationale"],
 )
-"""Ranker voter — per-match A/B/tie verdict."""
+"""Ranker voter — per-match A/B/tie verdict (strict-compatible).
+
+PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — strict-mode required for
+codex backend so gpt-5.5 cannot burn reasoning budget on empty
+``output_text``. smoke 18 evidence: vote-m000-openai.openai-codex
+turn 1 cost $0.0358 with 0 assistant_message (encrypted_reasoning
+consumed the budget; permissive ``text.format`` did not constrain
+the model to emit JSON). Prose-decomposed
+``judgment_breakdown`` variant deferred to PR-CRITIQUE-PROSE-DECOMPOSE
+(#95).
+"""
 
 
-EVOLVE_SCHEMA: Final[dict[str, Any]] = _additive(
+EVOLVE_SCHEMA: Final[dict[str, Any]] = _strict_additive(
     properties={
         "parent_id": {"type": "string"},
         "evolved_id": {"type": "string"},
@@ -154,11 +234,17 @@ EVOLVE_SCHEMA: Final[dict[str, Any]] = _additive(
             "type": "string",
             "enum": ["ok", "evolution_skipped", "failed"],
         },
+        # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — promoted from
+        # optional to required (with empty-string sentinel). Pre-fix
+        # ``required`` listed 5 keys; ``notes`` was the one optional
+        # — keeping it optional disabled strict mode for the entire
+        # schema. The evolver agent contract treats ``""`` as "no
+        # notes worth surfacing", so requiring an explicit empty
+        # string costs zero LLM behavior change.
         "notes": {"type": "string"},
     },
-    required=["parent_id", "evolved_id", "evolved_path", "rewrite_section", "verdict"],
 )
-"""Evolver agent — per-candidate evolution output."""
+"""Evolver agent — per-candidate evolution output (strict-compatible)."""
 
 
 META_REVIEW_SCHEMA: Final[dict[str, Any]] = _additive(
@@ -193,21 +279,60 @@ META_REVIEW_SCHEMA: Final[dict[str, Any]] = _additive(
         "session_summary",
     ],
 )
-"""Meta-reviewer agent — full-run coverage / quality summary."""
+"""Meta-reviewer agent — full-run coverage / quality summary.
+
+NOT strict-compatible — ``coverage`` uses typed ``additionalProperties``
+(per-dim float map), and ``next_gen_priors`` / ``elo_distribution`` /
+``evolution_yield`` use ``additionalProperties: true`` (unstructured
+audit maps the meta-reviewer designs at runtime). Codex backend falls
+through to ``strict: False`` for this schema.
+"""
 
 
 LITERATURE_REVIEW_SCHEMA: Final[dict[str, Any]] = _additive(
     properties={
-        "articles_with_reasoning": {"type": "array"},
-        "snapshots": {"type": "array"},
+        # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — fixed 2 type
+        # drifts vs the parser + agent contract:
+        # 1. Pre-fix the schema declared ``articles_with_reasoning``
+        #    as an untyped ``array`` but literature_review.py:163
+        #    reads it as
+        #    ``str(parsed.get("articles_with_reasoning", "") or "")``
+        #    — a markdown block, not a list. The agent contract
+        #    (``literature_review.md``) treats this as a single prose
+        #    block; aligned to ``"string"``.
+        # 2. Pre-fix the schema declared ``snapshots`` as an untyped
+        #    ``array`` but literature_review.py:165 reads it as
+        #    ``parsed.get("snapshots", {}) or {}`` then ``isinstance(
+        #    snapshots_raw, dict)`` — a ``{arxiv_id: snapshot_path}``
+        #    map per the agent contract example. Aligned to
+        #    ``"object"`` with typed-additional string values. This
+        #    forces the schema to stay non-strict (typed-additional
+        #    isn't strict-compatible), but the literature_review
+        #    phase short-circuits with ``max_papers=0`` by default so
+        #    the codex empty-output blast radius is limited compared
+        #    to per-candidate roles.
+        "articles_with_reasoning": {"type": "string"},
+        "snapshots": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
     },
     required=["articles_with_reasoning", "snapshots"],
 )
-"""Literature review — augmentation snapshots."""
+"""Literature review — augmentation snapshots.
+
+NOT strict-compatible — ``snapshots`` is a ``{arxiv_id:
+snapshot_path}`` map keyed on arbitrary arxiv IDs the literature
+search produced at runtime; enumerating those would require
+runtime-schema generation. The role short-circuits with
+``max_papers=0`` by default (manifest knob), so the strict-mode
+blast radius is limited. Operators flipping ``max_papers >= 1``
+accept the trade-off.
+"""
 
 
-# PR-SCHEMA-PARSER-DRIFT-CLOSE (2026-05-26) — supervisor was the only
-# Loop-1 phase with ``_REQUIRED_*_FIELDS`` (supervisor.py:86) but no
+# PR-SCHEMA-PARSER-DRIFT-CLOSE (2026-05-26, #1698) — supervisor was the
+# only Loop-1 phase with ``_REQUIRED_*_FIELDS`` (supervisor.py:86) but no
 # corresponding ``*_SCHEMA``. Its SubTask spawned without
 # ``response_schema=``, so the worker-side
 # ``_needs_schema_retry`` never fired on supervisor failures; the
@@ -218,31 +343,26 @@ LITERATURE_REVIEW_SCHEMA: Final[dict[str, Any]] = _additive(
 # the schema-gated path, leaving ``phase_result.success`` False and
 # the checkpoint un-written (PR-CHECKPOINT-ON-FAILURE invariant).
 # Sub-property structure mirrors ``supervisor.md`` 's typed contract.
-SUPERVISOR_SCHEMA: Final[dict[str, Any]] = _additive(
+SUPERVISOR_SCHEMA: Final[dict[str, Any]] = _strict_additive(
     properties={
-        "research_goal_analysis": {
-            "type": "object",
-            "properties": {
+        "research_goal_analysis": _strict_additive(
+            properties={
                 "target_dim_focus": {"type": "string"},
                 "sub_dim_priorities": {"type": "array", "items": {"type": "string"}},
                 "key_constraints": {"type": "array", "items": {"type": "string"}},
-            },
-            "required": ["target_dim_focus", "sub_dim_priorities", "key_constraints"],
-        },
-        "phase_guidance": {
-            "type": "object",
-            "properties": {
+            }
+        ),
+        "phase_guidance": _strict_additive(
+            properties={
                 "generation": {"type": "string"},
                 "critique": {"type": "string"},
                 "evolution": {"type": "string"},
-            },
-            "required": ["generation", "critique", "evolution"],
-        },
+            }
+        ),
         "session_summary": {"type": "string"},
     },
-    required=["research_goal_analysis", "phase_guidance", "session_summary"],
 )
-"""Supervisor agent — run-level strategy synthesis."""
+"""Supervisor agent — run-level strategy synthesis (strict-compatible)."""
 
 
 __all__ = [

--- a/tests/plugins/seed_generation/test_evolver_anti_convergence.py
+++ b/tests/plugins/seed_generation/test_evolver_anti_convergence.py
@@ -160,6 +160,10 @@ class TestEvolverExecuteAdmissionFlow:
                 "evolved_path": a_path,
                 "rewrite_section": "Body",
                 "verdict": "ok",
+                # PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — notes
+                # promoted from optional → required (empty-string
+                # sentinel allowed).
+                "notes": "",
             },
             "evolve-c1": {
                 "parent_id": "c1",
@@ -167,6 +171,7 @@ class TestEvolverExecuteAdmissionFlow:
                 "evolved_path": b_path,
                 "rewrite_section": "Body",
                 "verdict": "ok",
+                "notes": "",
             },
         }
 

--- a/tests/plugins/seed_generation/test_json_schemas_wire.py
+++ b/tests/plugins/seed_generation/test_json_schemas_wire.py
@@ -277,5 +277,101 @@ def test_subagent_manager_threads_schema_to_worker_request() -> None:
     assert request.response_schema == schema
 
 
+# ────────────────────── PR-STRICT-COMPATIBLE-SCHEMAS invariants ──────────────
+
+
+# PR-STRICT-COMPATIBLE-SCHEMAS (2026-05-26) — the codex_oauth adapter
+# auto-detects strict-mode for ``text.format`` via
+# ``_is_openai_strict_compatible``. Pre-fix every seed-gen schema
+# used the permissive ``_additive()`` helper, so codex always landed
+# on ``strict: False`` → text.format became a *hint*, not a
+# *constraint* → gpt-5.5 reasoning models could burn the output
+# budget on encrypted reasoning items and return empty
+# ``output_text`` (smoke 18: vote-m000-openai.openai-codex turn 1
+# cost $0.0358 with 0 assistant_message).
+#
+# The schemas listed in _STRICT_ROLES below were converted to
+# ``_strict_additive`` (additionalProperties:false + every property
+# in required). The remaining two (PILOT, META_REVIEW,
+# LITERATURE_REVIEW) cannot be strict because they use
+# typed-additional maps (Petri dim catalog / arxiv-id keyed
+# snapshots) the schema can't enumerate at compile time.
+
+
+_STRICT_ROLES = {
+    "PROXIMITY_SCHEMA": PROXIMITY_SCHEMA,
+    "CRITIQUE_SCHEMA": CRITIQUE_SCHEMA,
+    "VOTE_SCHEMA": VOTE_SCHEMA,
+    "EVOLVE_SCHEMA": EVOLVE_SCHEMA,
+    "SUPERVISOR_SCHEMA": SUPERVISOR_SCHEMA,
+}
+
+_NON_STRICT_ROLES = {
+    "PILOT_SCHEMA": PILOT_SCHEMA,
+    "META_REVIEW_SCHEMA": META_REVIEW_SCHEMA,
+    "LITERATURE_REVIEW_SCHEMA": LITERATURE_REVIEW_SCHEMA,
+}
+
+
+@pytest.mark.parametrize("name,schema", list(_STRICT_ROLES.items()))
+def test_strict_role_schemas_pass_openai_strict_check(name: str, schema: dict) -> None:
+    """Every converted schema satisfies OpenAI's strict-mode subset.
+
+    Asserts ``_is_openai_strict_compatible`` returns True so the codex
+    backend wires ``strict: True`` into ``text.format`` — the
+    constraint that prevents gpt-5.5's reasoning budget from consuming
+    the entire output budget on empty responses.
+    """
+    from core.llm.adapters.codex_oauth import _is_openai_strict_compatible
+
+    assert _is_openai_strict_compatible(schema), (
+        f"{name} declared strict-compatible but failed the codex adapter's "
+        "strict-detector check. Verify every nested object uses "
+        "_strict_additive (additionalProperties:false + required = "
+        "list(properties.keys())) and every array items entry is strict-compatible."
+    )
+
+
+@pytest.mark.parametrize("name,schema", list(_NON_STRICT_ROLES.items()))
+def test_non_strict_role_schemas_documented_reason(name: str, schema: dict) -> None:
+    """The roles flagged non-strict-compatible by design must FAIL the
+    strict-detector check.
+
+    If a future PR accidentally tightens these (e.g. enumerates the
+    Petri dim catalog into properties), this test catches the
+    silent strict-mode flip — operators reading the
+    ``additionalProperties: typed`` would expect the schema to remain
+    permissive, but the detector would now return True and codex
+    would start enforcing strict on a schema the role doesn't
+    actually conform to.
+    """
+    from core.llm.adapters.codex_oauth import _is_openai_strict_compatible
+
+    assert not _is_openai_strict_compatible(schema), (
+        f"{name} is documented as non-strict-compatible "
+        "(typed-additionalProperties for per-dim or per-arxiv-id maps) "
+        "but now passes the strict-detector check. Either the schema "
+        "actually became strict-compatible (update the docstring + "
+        "move it to _STRICT_ROLES) or a property accidentally lost "
+        "its typed-additional escape (regression — restore it)."
+    )
+
+
+def test_strict_helper_derives_required_from_properties_keys() -> None:
+    """``_strict_additive`` must list every property in required;
+    this is what makes the schema strict-compatible.
+    """
+    from plugins.seed_generation.json_schemas import _strict_additive
+
+    schema = _strict_additive(
+        properties={
+            "a": {"type": "string"},
+            "b": {"type": "number"},
+        }
+    )
+    assert schema["required"] == ["a", "b"]
+    assert schema["additionalProperties"] is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Convert 5 seed-gen schemas (PROXIMITY, CRITIQUE, VOTE, EVOLVE, SUPERVISOR) to OpenAI strict-mode compatible — Codex `text.format` auto-detector now wires `strict:True` for these roles.
- Forces gpt-5.5 reasoning models to emit text instead of burning the output budget on encrypted_reasoning items.
- Sprint C PR-2 (3 PRs total).

## Why
Smoke 18 evidence: `vote-m000-openai.openai-codex` turn 1 cost $0.0358 with 0 `assistant_message`. gpt-5.5 reasoning models consumed the entire output budget on `encrypted_reasoning` items because `text.format` was permissive (`strict:False`) — a hint, not a constraint. Root cause: `_is_openai_strict_compatible` (codex_oauth.py) requires `additionalProperties:false` + every property in `required`; pre-fix all schemas used permissive `_additive()` which fails both. PR-CODEX-OAUTH-RESPONSE-SCHEMA (v0.99.61) wired the auto-detector but no schema actually qualified.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/json_schemas.py` | Add `_strict_additive()` helper; convert 5 schemas + recursive nested objects/items; fix LITERATURE_REVIEW type drifts |
| `plugins/seed_generation/agents/critic.py` | `_REQUIRED_CRITIQUE_FIELDS` += `rewrite_section` |
| `plugins/seed_generation/agents/evolver.py` | `_REQUIRED_EVOLVE_FIELDS` += `notes` |
| `plugins/seed_generation/agents/evolver.md` | `notes`: optional → required (empty-string sentinel allowed) |
| `tests/plugins/seed_generation/test_json_schemas_wire.py` | +3 new invariant tests + 1 helper test |
| `tests/plugins/seed_generation/test_evolver_anti_convergence.py` | Add `notes:""` to mock fixtures |
| `CHANGELOG.md` | `[Unreleased]` Changed entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5 strict-eligible roles converted | Implemented | PROXIMITY, CRITIQUE, VOTE, EVOLVE, SUPERVISOR |
| 3 non-strict-eligible roles documented | Implemented | PILOT, META_REVIEW, LITERATURE_REVIEW (typed-additional maps) |
| `rewrite_section` consumer continuity | Fixed | Codex MCP catch — was in critic prose but absent from schema; strict mode would have broken evolver/eval_export handoff |
| LITERATURE_REVIEW type drift (parser vs schema) | Fixed | `articles_with_reasoning` array→string; `snapshots` array→object |
| Co-scientist prose decomposition (judge_risk / VOTE judgment_breakdown) | Deferred | Task #95 PR-CRITIQUE-PROSE-DECOMPOSE (next sprint after smoke 19 validates this) |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (452 source files)
- [x] lint-imports: 4 contracts kept
- [x] pytest tests/plugins/seed_generation/ + tests/core/llm/adapters/ — 718 pass, 3 skipped
- [x] Codex MCP cross-LLM review (round 1) — 3 catches folded in-band: rewrite_section omission, CHANGELOG miss, docstring drift
- [x] Strict-detector verified directly: 5/5 strict roles PASS, 3/3 non-strict roles correctly REJECTED

## Reference
- co-scientist `schemas.py` `RANKING_SCHEMA` — strict + structured judgment_explanation pattern (deferred to PR-CRITIQUE-PROSE-DECOMPOSE)
- OpenAI Responses API strict mode spec: `additionalProperties:false` + all properties required recursively
- `core/llm/adapters/codex_oauth.py:_is_openai_strict_compatible`
- Smoke 18 archive: `.audit/smoke-archives/smoke-18-partial-1779728410/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)