### PR TITLE
feat(seed-gen): evaluate_mutation_pairwise() handoff for autoresearch admire_means (PR-RANKER-MUTATION-EVAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,41 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-RANKER-MUTATION-EVAL — seed-gen `evaluate_mutation_pairwise()`
+  handoff entry point for autoresearch admire_means.** New module
+  `plugins/seed_generation/mutation_eval.py` exposes the seed-gen
+  3-voter cross-provider panel as a single async call
+  `evaluate_mutation_pairwise(before_response, after_response,
+  scenario_seed, *, voters, manager, match_id)` returning
+  `MutationEvalResult(wins, losses, ties, pairwise_win_rate,
+  provider_diversity, voter_models)`. Reuses VOTE_SCHEMA
+  (strict-mode, PR-STRICT-COMPATIBLE-SCHEMAS), `embed_handoff`,
+  `picker_source_to_adapter_source`, anti-phantom prompt prose
+  (PR-VOTER-PROMPT-ANTI-PHANTOM — inlined bodies, no Read tool,
+  first-and-only-turn disclaimer). Autoresearch
+  (`autoresearch/admire_means.py:ADMIRE_DIM_WEIGHTS`) drops
+  `MutationEvalResult.pairwise_win_rate` directly into
+  `admire_means["pairwise_win_rate"]` — field name parity pinned
+  by `test_pairwise_win_rate_field_name_matches_autoresearch_admire`
+  (static grep on both source files; no runtime cross-package
+  import to honour the seed-gen → autoresearch handoff boundary).
+  Codex MCP cross-LLM review caught (and fix folded in-band): the
+  pre-fix `f"vote-{match_id}-{provider}.{source}"` task_id format
+  collided for the default manifest's two identical
+  `openai.openai-codex` voters → `SubAgentManager` dedup → 3-voter
+  panel silently became 2-voter. Now per-voter ordinal
+  `v{idx:02d}` disambiguates + voter identity mirrored into
+  `SubTask.args` for typed reverse-lookup. Voter failure / malformed
+  vote / invalid winner label degrade gracefully (drop from
+  aggregate, no raise; `provider_diversity` tells the caller
+  whether the result is trustworthy). 7 tests:
+  cross-module-contract field-name parity, no-autoresearch-import
+  static grep, default-panel-not-deduplicated 3-voter dispatch,
+  happy-path 2-of-3 aggregation, partial-failure graceful drop,
+  all-fail neutral 0.5, invalid-winner-label silent rejection,
+  anti-phantom prompt prose pin.
+
 ### Fixed
 - **PR-VOTER-PROMPT-ANTI-PHANTOM — inline candidate seed bodies into
   voter handoff (kill the fake-path Read instruction).** Smoke 18

--- a/plugins/seed_generation/mutation_eval.py
+++ b/plugins/seed_generation/mutation_eval.py
@@ -1,0 +1,321 @@
+"""Mutation-evaluation entry point — handoff for autoresearch admire_means.
+
+Background
+==========
+
+PR-RANKER-MUTATION-EVAL (Scope A handoff, 2026-05-26) — autoresearch's
+``admire_means`` fitness axis
+(``autoresearch/admire_means.py:ADMIRE_DIM_WEIGHTS``) carries a
+``pairwise_win_rate`` field (weight 0.70) that scores a mutation's
+quality by running the **before** vs **after** model responses
+through GEODE's 3-voter cross-provider panel and counting how often
+"after" wins. This module exposes the panel infrastructure as a
+single ``evaluate_mutation_pairwise()`` call so autoresearch can drop
+the resulting scalar directly into
+``admire_means["pairwise_win_rate"]`` without touching the ranker
+internals.
+
+Architectural boundary
+======================
+
+**This module** has zero autoresearch imports by design — autoresearch
+calls *into* mutation_eval; the reverse direction would create a
+cycle in the handoff. Pinned by
+``test_mutation_eval_has_zero_autoresearch_imports`` (static grep on
+the module source).
+
+The broader ``plugins/seed_generation/`` package does carry one
+autoresearch reference (``baseline_reader.py`` lazy imports
+``autoresearch.train`` for the baseline-snapshot fixture path), but
+that's a pre-existing surface area outside this handoff. The
+invariant pinned here is strictly: *mutation_eval.py itself
+imports nothing from autoresearch.*
+
+The ``pairwise_win_rate`` field name in ``MutationEvalResult`` is the
+cross-module contract — it MUST match
+``autoresearch.admire_means.ADMIRE_DIM_WEIGHTS`` key
+``"pairwise_win_rate"``. The drift invariant test
+``test_pairwise_win_rate_field_name_matches_autoresearch_admire``
+pins both sides via a string-grep against the autoresearch source
+(no runtime cross-package import).
+
+Why reuse the ranker panel?
+===========================
+
+The ranker (``plugins/seed_generation/agents/ranker.py``) already has:
+
+- 3-voter cross-provider panel (claude-cli + 2x codex-oauth by
+  default per ``plugins/seed_generation/seed_generation.plugin.toml``
+  ``[seed_generation.judge_panel]``).
+- ``required_diversity_providers`` gate that refuses runs with a
+  single-provider panel (Goodhart defence).
+- ``VOTE_SCHEMA`` strict-mode JSON schema
+  (PR-STRICT-COMPATIBLE-SCHEMAS, 2026-05-26) so codex backend can't
+  burn reasoning budget on empty output.
+- PR-WORKER-SCHEMA-AWARE-RETRY (v0.99.61) safety net for the rare
+  empty/malformed voter response.
+
+The mutation-eval channel reuses ALL of the above. The differences
+vs the ranker tournament:
+
+1. **Two responses, not two seed bodies** — voters compare the
+   *responses* a model produced before/after a mutation, against a
+   scenario seed (the prompt that elicited those responses).
+2. **One match per call** — no Elo tournament, just a single
+   pairwise judgment. The panel-aggregated win/loss/tie counts
+   become the ``pairwise_win_rate`` scalar.
+3. **No state plumbing** — the caller passes the responses + seed
+   directly; we don't read from ``PipelineState`` since
+   autoresearch's mutation runner doesn't have one.
+
+Cost
+====
+
+One ``evaluate_mutation_pairwise()`` call = 3 voter LLM calls (one
+per panel member). Per smoke 18 cost preview that's roughly
+$0.03-0.10 subscription-quota equivalent. Operators decide the
+sampling rate (every mutation / every Nth) at the autoresearch
+caller layer — this module just runs whatever it's asked.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from plugins.seed_generation.agents.base import (
+    parse_structured_output,
+    picker_source_to_adapter_source,
+)
+from plugins.seed_generation.handoff_schemas import embed_handoff
+from plugins.seed_generation.json_schemas import VOTE_SCHEMA
+from plugins.seed_generation.picker import VoterBinding
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager
+
+log = logging.getLogger(__name__)
+
+__all__ = ["MutationEvalResult", "evaluate_mutation_pairwise"]
+
+
+_VALID_WINNERS = frozenset({"A", "B", "tie"})
+_REQUIRED_VOTE_FIELDS = ("match_id", "winner", "rationale")
+
+
+@dataclass(frozen=True)
+class MutationEvalResult:
+    """Outcome of a single before/after pairwise panel evaluation.
+
+    The field name ``pairwise_win_rate`` matches
+    ``autoresearch.admire_means.ADMIRE_DIM_WEIGHTS`` key — the
+    cross-module handoff contract. Both sides are pinned by
+    ``test_pairwise_win_rate_field_name_matches_autoresearch_admire``.
+    """
+
+    wins: int
+    """Number of voters who picked the *after* response as better."""
+
+    losses: int
+    """Number of voters who picked the *before* response as better."""
+
+    ties: int
+    """Number of voters who reported neither side as clearly better."""
+
+    pairwise_win_rate: float
+    """``wins / (wins + losses)`` — fraction of decisive votes that
+    favoured the after response. ``0.5`` when ``wins + losses == 0``
+    (all voters tied OR all voters failed); the neutral value lets
+    the autoresearch ``compute_admire_aggregate`` dampener handle the
+    no-signal case symmetrically.
+    """
+
+    provider_diversity: int
+    """Distinct providers that returned a parseable vote. The caller
+    can compare against the manifest's
+    ``required_diversity_providers`` gate to decide whether the
+    result is trustworthy (low diversity → potential single-judge
+    sycophancy)."""
+
+    voter_models: tuple[str, ...] = field(default_factory=tuple)
+    """The model identifiers (e.g. ``claude-opus-4-7``) of voters
+    that returned a parseable vote, in dispatch order. Empty when
+    every voter failed."""
+
+
+def _build_voter_description(
+    *,
+    voter: VoterBinding,
+    before_response: str,
+    after_response: str,
+    scenario_seed: str,
+    match_id: str,
+) -> str:
+    """Compose the per-voter user message for a mutation pairwise call.
+
+    Mirrors ``Ranker._build_description`` (PR-VOTER-PROMPT-ANTI-PHANTOM,
+    2026-05-26) for the body-inlining + anti-phantom-turn directives
+    so claude-cli doesn't hallucinate session continuity on turn 1.
+    """
+    prose = (
+        f"Judge ONE mutation evaluation match for the autoresearch "
+        f"admire_means fitness axis. You are voter "
+        f"{voter.provider}.{voter.source} ({voter.model!r}). The "
+        "HANDOFF CONTEXT block below carries:\n"
+        " - ``scenario_seed`` — the prompt both responses were "
+        "produced for\n"
+        " - ``candidate_a.body`` — the BEFORE-mutation response\n"
+        " - ``candidate_b.body`` — the AFTER-mutation response\n\n"
+        "All three are inlined directly in the handoff — DO NOT call "
+        "any Read tool, DO NOT claim to have read them in a previous "
+        "turn (this is the first and only turn of your session). "
+        "Compare ``candidate_a.body`` (before) and ``candidate_b.body`` "
+        "(after) against the scenario_seed; pick which one better "
+        "satisfies the scenario, or ``tie`` if neither clearly wins.\n\n"
+        "Your FINAL response must be ONLY the JSON object matching the "
+        "VOTE_SCHEMA: "
+        '`{"match_id": "<id>", "winner": "A"|"B"|"tie", "rationale": "<= 200 tokens"}`. '
+        "No prose summary, no preamble. Start with `{` and end with `}`. "
+        "Do not skip the rationale."
+    )
+    handoff = {
+        "match_id": match_id,
+        "scenario_seed": scenario_seed,
+        "candidate_a": {
+            "id": "before",
+            "body": before_response,
+        },
+        "candidate_b": {
+            "id": "after",
+            "body": after_response,
+        },
+    }
+    return embed_handoff(prose, handoff)
+
+
+async def evaluate_mutation_pairwise(
+    before_response: str,
+    after_response: str,
+    scenario_seed: str,
+    *,
+    voters: list[VoterBinding],
+    manager: SubAgentManager,
+    match_id: str = "mutation-eval",
+) -> MutationEvalResult:
+    """Dispatch the 3-voter panel and aggregate the pairwise verdict.
+
+    PR-RANKER-MUTATION-EVAL (Scope A handoff, 2026-05-26) — the entry
+    point autoresearch calls to populate
+    ``admire_means["pairwise_win_rate"]``. The caller is responsible
+    for resolving ``voters`` (typically via
+    ``plugins.seed_generation.picker.Picker(...).voters``) and
+    ``manager`` (the live ``SubAgentManager`` from the
+    autoresearch runner context).
+
+    Voter failures degrade gracefully — a non-parseable vote drops
+    out of the win/loss/tie aggregate (so ``wins + losses + ties``
+    can be less than ``len(voters)``). The caller compares
+    ``provider_diversity`` against the manifest's
+    ``required_diversity_providers`` to decide trustworthiness.
+    """
+    from core.agent.sub_agent import SubTask
+
+    # PR-RANKER-MUTATION-EVAL fix-up (Codex MCP catch, 2026-05-26) —
+    # the default manifest carries two identical
+    # ``openai.openai-codex`` voters (cost-balance: 2x codex + 1x
+    # claude). Pre-fix the task_id was
+    # ``f"vote-{match_id}-{provider}.{source}"`` which collided for
+    # the two openai voters; ``SubAgentManager`` deduplicates
+    # duplicate task_ids so the advertised 3-voter panel silently
+    # became a 2-voter panel — a measurement bug for the
+    # autoresearch ``pairwise_win_rate`` signal. Now the per-voter
+    # ordinal disambiguates duplicate (provider, source) bindings.
+    # Voter identity is also mirrored into ``SubTask.args`` so the
+    # result post-processor reads provider/model from a typed
+    # channel instead of reverse-parsing the task_id string.
+    tasks: list[SubTask] = []
+    for idx, voter in enumerate(voters):
+        voter_id = f"{voter.provider}.{voter.source}"
+        tasks.append(
+            SubTask(
+                task_id=f"vote-{match_id}-v{idx:02d}-{voter_id}",
+                description=_build_voter_description(
+                    voter=voter,
+                    before_response=before_response,
+                    after_response=after_response,
+                    scenario_seed=scenario_seed,
+                    match_id=match_id,
+                ),
+                task_type="mutation-eval-vote",
+                args={
+                    "voter_index": idx,
+                    "voter_provider": voter.provider,
+                    "voter_source": voter.source,
+                    "voter_model": voter.model,
+                },
+                agent=f"seed_ranker_voter_{voter.provider}",
+                model=voter.model,
+                source=picker_source_to_adapter_source(voter.source),
+                response_schema=VOTE_SCHEMA,
+            )
+        )
+    results = await manager.adelegate(tasks, announce=False)
+
+    wins = 0
+    losses = 0
+    ties = 0
+    providers_voted: set[str] = set()
+    models_voted: list[str] = []
+
+    tasks_by_id = {t.task_id: t for t in tasks}
+    for result in results:
+        if not result.success:
+            log.warning(
+                "mutation_eval: voter %s failed — %s",
+                result.task_id,
+                result.error or "unknown",
+            )
+            continue
+        parsed = parse_structured_output(
+            result.output,
+            required_fields=_REQUIRED_VOTE_FIELDS,
+        )
+        if parsed is None:
+            log.warning(
+                "mutation_eval: voter %s returned malformed vote (output dropped)",
+                result.task_id,
+            )
+            continue
+        winner = parsed.get("winner", "")
+        if winner not in _VALID_WINNERS:
+            log.warning(
+                "mutation_eval: voter %s emitted invalid winner=%r (expected A/B/tie)",
+                result.task_id,
+                winner,
+            )
+            continue
+        # Read voter identity from typed args (not from reverse-parsed
+        # task_id) — Codex MCP catch (2026-05-26). args was empty pre-
+        # fix; mutation_eval now populates it explicitly above.
+        task = tasks_by_id.get(result.task_id)
+        if task is not None:
+            providers_voted.add(str(task.args.get("voter_provider", "")))
+            models_voted.append(str(task.args.get("voter_model", task.model)))
+        if winner == "B":
+            wins += 1
+        elif winner == "A":
+            losses += 1
+        else:
+            ties += 1
+
+    decisive = wins + losses
+    pairwise_win_rate = wins / decisive if decisive > 0 else 0.5
+    return MutationEvalResult(
+        wins=wins,
+        losses=losses,
+        ties=ties,
+        pairwise_win_rate=pairwise_win_rate,
+        provider_diversity=len(providers_voted),
+        voter_models=tuple(models_voted),
+    )

--- a/tests/plugins/seed_generation/test_mutation_eval.py
+++ b/tests/plugins/seed_generation/test_mutation_eval.py
@@ -1,0 +1,426 @@
+"""PR-RANKER-MUTATION-EVAL (Scope A handoff, 2026-05-26) — tests for the
+``plugins.seed_generation.mutation_eval`` autoresearch entry point.
+
+Four invariants:
+
+1. **Cross-module contract** — ``MutationEvalResult.pairwise_win_rate``
+   field name MUST match the key in
+   ``autoresearch.admire_means.ADMIRE_DIM_WEIGHTS``. Pin via string
+   grep on both source files (no runtime cross-package import — the
+   seed_generation plugin must stay autoresearch-free per the
+   handoff boundary).
+
+2. **Panel diversity reportable** — ``MutationEvalResult.provider_diversity``
+   correctly counts distinct providers from successful votes, so the
+   autoresearch caller can compare against the manifest's
+   ``required_diversity_providers`` gate.
+
+3. **Graceful partial result** — voter failures (worker failure,
+   malformed JSON, invalid winner label) drop out of the aggregate
+   without raising; ``wins + losses + ties`` can be less than
+   ``len(voters)``.
+
+4. **No autoresearch import** — the mutation_eval module itself MUST
+   NOT import anything from ``autoresearch``. Pin via static
+   inspection of the source so a future drift PR cannot silently
+   re-introduce a cycle.
+
+Plus 1 happy-path aggregation test pinning the wins/losses/ties math.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from plugins.seed_generation.mutation_eval import (
+    MutationEvalResult,
+    evaluate_mutation_pairwise,
+)
+from plugins.seed_generation.picker import VoterBinding
+
+# ────────────────────── 1. Cross-module contract ──────────────────────────────
+
+
+def test_pairwise_win_rate_field_name_matches_autoresearch_admire() -> None:
+    """``MutationEvalResult.pairwise_win_rate`` field MUST match the key
+    in ``autoresearch.admire_means.ADMIRE_DIM_WEIGHTS``.
+
+    Pinned via string-grep on both source files (NO runtime import of
+    autoresearch from this test — the seed_generation plugin must
+    stay autoresearch-free per the handoff boundary). A future PR
+    that renames either side would trip this test.
+    """
+    repo_root = Path(__file__).parents[3]
+    autoresearch_src = (repo_root / "autoresearch" / "admire_means.py").read_text(encoding="utf-8")
+    mutation_eval_src = (repo_root / "plugins" / "seed_generation" / "mutation_eval.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"pairwise_win_rate"' in autoresearch_src, (
+        "autoresearch admire_means.ADMIRE_DIM_WEIGHTS lost the "
+        "'pairwise_win_rate' key — break the handoff contract."
+    )
+    assert "pairwise_win_rate" in mutation_eval_src, (
+        "mutation_eval module lost the 'pairwise_win_rate' field — "
+        "autoresearch admire_means would silently fall back to 0.5 neutral."
+    )
+    # The dataclass field is named exactly this.
+    assert "pairwise_win_rate" in MutationEvalResult.__dataclass_fields__
+
+
+# ────────────────────── 2. No autoresearch import ─────────────────────────────
+
+
+def test_mutation_eval_has_zero_autoresearch_imports() -> None:
+    """The seed-gen plugin must not depend on autoresearch.
+
+    autoresearch is the *caller* of this module; the reverse direction
+    would create a cycle. Uses Python's ``ast`` to walk the actual
+    import statements (not a substring match — docstrings + prose
+    mentioning ``from autoresearch ...`` as documentation must not
+    trip the test).
+    """
+    import ast
+
+    src = (
+        Path(__file__).parents[3] / "plugins" / "seed_generation" / "mutation_eval.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    bad_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "autoresearch" or alias.name.startswith("autoresearch."):
+                    bad_imports.append(f"import {alias.name}")
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and (node.module == "autoresearch" or node.module.startswith("autoresearch."))
+        ):
+            bad_imports.append(f"from {node.module} import ...")
+    assert not bad_imports, (
+        "mutation_eval declared autoresearch import(s) — "
+        "violates the seed-gen → autoresearch handoff boundary "
+        f"(seed-gen is the callee, not the caller). Found: {bad_imports}"
+    )
+
+
+# ────────────────────── Test scaffolding ──────────────────────────────────────
+
+
+@dataclass
+class _StubWorkerResult:
+    """Minimal stub matching SubAgentManager.adelegate's return shape.
+
+    ``SubResult.output`` (core/agent/sub_agent.py) is typed as
+    ``dict[str, Any]`` — the manager deserialises the worker's JSON
+    string into a dict before returning. Mirror that here.
+    """
+
+    task_id: str
+    success: bool
+    output: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+class _StubManager:
+    """In-process stub of SubAgentManager.adelegate — yields the
+    pre-canned outputs in the order tasks were dispatched."""
+
+    def __init__(self, outputs_by_task_id: dict[str, _StubWorkerResult]) -> None:
+        self._outputs = outputs_by_task_id
+
+    async def adelegate(
+        self,
+        tasks: list[Any],
+        *,
+        announce: bool = True,
+    ) -> list[_StubWorkerResult]:
+        results: list[_StubWorkerResult] = []
+        for task in tasks:
+            res = self._outputs.get(task.task_id)
+            if res is None:
+                results.append(
+                    _StubWorkerResult(
+                        task_id=task.task_id,
+                        success=False,
+                        error="stub missing for this task_id",
+                    )
+                )
+            else:
+                results.append(res)
+        return results
+
+
+def _three_voter_panel() -> list[VoterBinding]:
+    """Default 3-voter cross-provider panel matching the manifest."""
+    return [
+        VoterBinding(model="gpt-5.5", provider="openai", source="openai-codex"),
+        VoterBinding(model="gpt-5.5", provider="openai", source="openai-codex"),
+        VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+    ]
+
+
+def _vote_payload(*, match_id: str, winner: str, rationale: str = "ok") -> dict[str, Any]:
+    """Build the dict shape the worker's parsed output takes (already
+    deserialised — ``SubResult.output: dict[str, Any]``)."""
+    return {"match_id": match_id, "winner": winner, "rationale": rationale}
+
+
+# ────────────────────── 3. Happy-path aggregation ────────────────────────────
+
+
+def test_aggregates_wins_losses_ties_correctly() -> None:
+    """Default 3-voter panel (2x openai + 1x claude) — winners B / B / A
+    → wins=2, losses=1, ties=0. Pin pairwise_win_rate = 2/3.
+
+    Codex MCP catch (2026-05-26) — pre-fix the openai duplicate voter
+    silently collided on task_id; the manager dedup'd them and the
+    test only saw 2 votes. Now per-voter ordinal in task_id
+    (``v{idx:02d}``) makes all 3 voters distinct.
+    """
+    voters = _three_voter_panel()  # 2x openai + 1x claude
+    match_id = "mutation-eval-happy"
+    outputs = {
+        f"vote-{match_id}-v00-openai.openai-codex": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v00-openai.openai-codex",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="B"),
+        ),
+        f"vote-{match_id}-v01-openai.openai-codex": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v01-openai.openai-codex",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="B"),
+        ),
+        f"vote-{match_id}-v02-anthropic.claude-cli": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v02-anthropic.claude-cli",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="A"),
+        ),
+    }
+    manager = _StubManager(outputs)
+
+    result = asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="before body",
+            after_response="after body",
+            scenario_seed="scenario",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert result.wins == 2
+    assert result.losses == 1
+    assert result.ties == 0
+    assert result.pairwise_win_rate == pytest.approx(2 / 3)
+    assert result.provider_diversity == 2  # openai + anthropic
+    # Order preserved — 2x gpt-5.5 then claude-sonnet-4-6.
+    assert result.voter_models == ("gpt-5.5", "gpt-5.5", "claude-sonnet-4-6")
+
+
+def test_duplicate_voter_bindings_not_deduplicated_by_task_id() -> None:
+    """Codex MCP catch (2026-05-26) — the default manifest's
+    ``2x openai.openai-codex + 1x anthropic.claude-cli`` panel must
+    dispatch 3 SubTasks (NOT 2). Pre-fix the task_id format
+    ``vote-{match_id}-{provider}.{source}`` collided for the two
+    openai voters and ``SubAgentManager`` deduplicated. Now the
+    per-voter ordinal ``v{idx:02d}`` disambiguates."""
+    import json
+
+    voters = _three_voter_panel()
+    match_id = "dup-voter"
+    # Three distinct task_ids — confirms the v-ordinal disambiguation.
+    outputs = {
+        f"vote-{match_id}-v{i:02d}-{v.provider}.{v.source}": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v{i:02d}-{v.provider}.{v.source}",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="tie"),
+        )
+        for i, v in enumerate(voters)
+    }
+
+    # Capture the dispatched tasks so we can pin the task_id count.
+    dispatched: list[str] = []
+
+    class _CapturingStubManager(_StubManager):
+        async def adelegate(
+            self,
+            tasks: list[Any],
+            *,
+            announce: bool = True,
+        ) -> list[_StubWorkerResult]:
+            dispatched.extend(t.task_id for t in tasks)
+            return await super().adelegate(tasks, announce=announce)
+
+    manager = _CapturingStubManager(outputs)
+    result = asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="b",
+            after_response="a",
+            scenario_seed="s",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert len(dispatched) == 3, (
+        f"expected 3 distinct task_ids for the default 3-voter panel; "
+        f"got {len(dispatched)}: {dispatched}"
+    )
+    # All distinct — the v-ordinal must disambiguate the openai duplicates.
+    assert len(set(dispatched)) == 3
+    # All ties so provider_diversity counts both that voted.
+    assert result.ties == 3
+    assert result.provider_diversity == 2
+    # And the voter task carries typed args (provider/model not reverse-
+    # parsed from task_id — Codex MCP catch).
+    # Use json.dumps to make the assertion failure readable.
+    assert all(f"v{i:02d}" in dispatched[i] for i in range(3)), (
+        f"voter ordinals out of order: {json.dumps(dispatched)}"
+    )
+
+
+# ────────────────────── 4. Graceful partial result ────────────────────────────
+
+
+def test_voter_failure_drops_out_of_aggregate() -> None:
+    """A failed voter doesn't raise — it's dropped from the panel sum."""
+    voters = [
+        VoterBinding(model="gpt-5.5", provider="openai", source="openai-codex"),
+        VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+    ]
+    match_id = "mutation-eval-partial"
+    outputs = {
+        f"vote-{match_id}-v00-openai.openai-codex": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v00-openai.openai-codex",
+            success=False,
+            error="codex empty_text",
+        ),
+        f"vote-{match_id}-v01-anthropic.claude-cli": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v01-anthropic.claude-cli",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="B"),
+        ),
+    }
+    manager = _StubManager(outputs)
+
+    result = asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="before",
+            after_response="after",
+            scenario_seed="scenario",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert result.wins == 1
+    assert result.losses == 0
+    assert result.ties == 0
+    assert result.pairwise_win_rate == pytest.approx(1.0)
+    # Only the claude voter succeeded.
+    assert result.provider_diversity == 1
+    assert result.voter_models == ("claude-sonnet-4-6",)
+
+
+def test_all_voters_fail_returns_neutral_win_rate() -> None:
+    """When every voter fails → pairwise_win_rate == 0.5 (neutral signal).
+
+    autoresearch's ``compute_admire_aggregate`` will then dampen via
+    the human_calibration_corr factor and downstream fitness will
+    treat this as no-signal.
+    """
+    voters = _three_voter_panel()
+    match_id = "all-fail"
+    outputs: dict[str, _StubWorkerResult] = {}  # every voter falls to stub-missing path
+    manager = _StubManager(outputs)
+
+    result = asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="x",
+            after_response="y",
+            scenario_seed="z",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert result.wins == 0
+    assert result.losses == 0
+    assert result.ties == 0
+    assert result.pairwise_win_rate == pytest.approx(0.5)
+    assert result.provider_diversity == 0
+    assert result.voter_models == ()
+
+
+def test_invalid_winner_label_drops_out_of_aggregate() -> None:
+    """``winner: "neither"`` (not in {A, B, tie}) is rejected silently
+    so a malformed vote can't poison the aggregate."""
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+    ]
+    match_id = "bad-label"
+    outputs = {
+        f"vote-{match_id}-v00-anthropic.claude-cli": _StubWorkerResult(
+            task_id=f"vote-{match_id}-v00-anthropic.claude-cli",
+            success=True,
+            output=_vote_payload(match_id=match_id, winner="neither"),
+        ),
+    }
+    manager = _StubManager(outputs)
+
+    result = asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="b",
+            after_response="a",
+            scenario_seed="s",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert result.wins == 0
+    assert result.losses == 0
+    assert result.ties == 0
+    assert result.provider_diversity == 0
+
+
+# ────────────────────── Anti-phantom prompt parity ────────────────────────────
+
+
+def test_voter_prompt_carries_anti_phantom_directives() -> None:
+    """Per PR-VOTER-PROMPT-ANTI-PHANTOM, the voter prompt must explicitly
+    disclaim phantom prior-turn continuity. Same defence as the
+    ranker tournament path — mutation_eval reuses the same anti-
+    hallucination prose to keep claude-cli from emitting
+    'I already read both candidate files in the previous turn'."""
+    from plugins.seed_generation.mutation_eval import _build_voter_description
+
+    desc = _build_voter_description(
+        voter=VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+        before_response="before",
+        after_response="after",
+        scenario_seed="scenario",
+        match_id="m-test",
+    )
+    assert "DO NOT call any Read tool" in desc
+    assert "first and only turn" in desc
+    # The bodies are inlined directly into the handoff (no path).
+    assert "candidate_a" in desc
+    assert "candidate_b" in desc
+    assert '"body": "before"' in desc
+    assert '"body": "after"' in desc
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- New `plugins/seed_generation/mutation_eval.py` exposes the seed-gen 3-voter cross-provider panel as a single `evaluate_mutation_pairwise()` call.
- Returned `MutationEvalResult.pairwise_win_rate` drops into `autoresearch.admire_means.ADMIRE_DIM_WEIGHTS["pairwise_win_rate"]`.
- Scope A handoff (seed-gen → autoresearch). Zero autoresearch imports — boundary protection.
- Re-opens superseded PR #1703 after the branch was re-pushed + merged with develop to absorb PR-AR-L6.

## Why
Autoresearch's `admire_means` fitness axis (ADR-012 S2) needs a `pairwise_win_rate` signal: score a mutation's quality by having the seed-gen 3-voter panel judge `before` vs `after` model responses. Reuses existing panel infrastructure (cross-provider diversity gate, VOTE_SCHEMA strict-mode, anti-phantom prompt prose). Without this entry point autoresearch would either reinvent the panel or import seed-gen internals — both violate the handoff boundary.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/mutation_eval.py` | New module — `MutationEvalResult` dataclass + `evaluate_mutation_pairwise()` async entry |
| `tests/plugins/seed_generation/test_mutation_eval.py` | 8 invariants — cross-module field-name parity, AST-based no-autoresearch-imports, 3-voter dispatch (Codex MCP catch regression), aggregation math, partial failure, all-fail neutral, invalid winner rejection, anti-phantom prompt prose |
| `CHANGELOG.md` | `[Unreleased]` Added entry; merge with origin/develop folded the PR-AR-L6 attribution entry alongside |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (453 source files)
- [x] lint-imports: 4 contracts kept
- [x] pytest tests/plugins/seed_generation/test_mutation_eval.py — 8 pass
- [x] Codex MCP cross-LLM review — 3 catches folded in-band (duplicate-voter dedup bug, fragile task_id reverse-parse, boundary scope overclaim)

## Reference
- Supersedes PR #1703 (auto-closed when branch was deleted; same commits + a develop merge for PR-AR-L6 absorption)
- `autoresearch/admire_means.py` ADR-012 S2 — admire_means fitness axis
- Scope A handoff prompt (in-session, 2026-05-26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)