### PR TITLE
feat(autoresearch): compute_fitness 5-caller ux/admire forward (PR-AR-L4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,36 @@ functional change.
 ## [Unreleased]
 
 ### Added
-<<<<<<< HEAD
+- **PR-AR-L4b ``compute_fitness`` 5-caller ``ux_means`` / ``admire_means`` forward** —
+  Pre-PR-AR-L4b PR-AR-L4a wired the ``ux_means`` collector but no
+  caller forwarded the dict to ``compute_fitness`` — the fitness
+  scalar stayed dim-only despite the data being available.
+  Wires the 4 ``_should_promote`` internal ``compute_fitness`` calls
+  (bootstrap / gated / current_raw / prior_raw) + the 1 ``main()``
+  call to forward ``ux_means`` (from ``collect_ux_means_from_sources``)
+  and ``baseline_ux_means`` (from ``_load_baseline`` 5-tuple). The
+  4 new ``_should_promote`` kwargs (``ux_means`` /
+  ``baseline_ux_means`` / ``admire_means`` / ``baseline_admire_means``)
+  default to ``None`` for backward-compat with legacy callers.
+  ``admire_means`` slot is reserved — PR-AR-L4c wires the seed-gen
+  ranker handoff after Scope A (PR-RANKER-MUTATION-EVAL) ships
+  ``evaluate_mutation_pairwise``.
+  ``_write_baseline`` now persists ``axes.ux_means`` (slot existed
+  pre-PR-AR-L4b but was always emitted as ``None``).
+  7 invariants in
+  ``tests/autoresearch/test_ux_admire_caller_forward.py`` pin:
+  - ``_should_promote`` signature exposes the 4 new kwargs (default None)
+  - 5 ``compute_fitness`` call blocks all mention ``ux_means=`` and
+    ``admire_means=`` (caller-symmetry grep — PR-11 anchor multiplier
+    pattern from [[feedback-signature-forward-audit]])
+  - end-to-end exercise: bootstrap fitness changes when ux_means is
+    supplied vs not (forward actually reaches compute_fitness)
+  - ``prior_raw`` baseline-side asymmetry — baseline_ux_means
+    actually reaches the prior_raw compute_fitness call (Codex MCP
+    catch §6)
+  - ``_write_baseline`` roundtrips the ``axes.ux_means`` slot
+  - main caller invokes ``collect_ux_means_from_sources``
+
 - **PR-RANKER-MUTATION-EVAL — seed-gen `evaluate_mutation_pairwise()`
   handoff entry point for autoresearch admire_means.** New module
   `plugins/seed_generation/mutation_eval.py` exposes the seed-gen

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1919,6 +1919,16 @@ def _should_promote(
     # 결정 영향력 0. 이제 bench + baseline_bench 둘 다 받아서 gate fire.
     bench_means: dict[str, float] | None = None,
     baseline_bench_means: dict[str, float] | None = None,
+    # PR-AR-L4b (2026-05-26) — ux_means / admire_means caller forward.
+    # 이전엔 internal compute_fitness 4 호출에 ux/admire 전달 0 → ADR-012
+    # 3-axis fitness 의 ux/admire 축이 promote gate 에 미반영. 이제
+    # caller 가 current + baseline 둘 다 받아서 cross-axis 비교 가능.
+    # admire_means 는 Scope A (seed-gen ranker mutation-eval) 머지 후
+    # 실제 채워짐 — 본 PR 은 signature slot 만 예약. legacy=None.
+    ux_means: dict[str, float] | None = None,
+    baseline_ux_means: dict[str, float] | None = None,
+    admire_means: dict[str, float] | None = None,
+    baseline_admire_means: dict[str, float] | None = None,
     # PR-SIL-5THEME C3 (2026-05-23) — P3 modality 가중 분리. dim 측
     # modality (judge_llm vs analytics) 를 internal compute_fitness 호출에
     # forward — modality-aware weight + N=1 widening guard 적용. None 이면
@@ -1990,6 +2000,8 @@ def _should_promote(
             measurement_modality=measurement_modality,
             anchor_means=_bootstrap_anchor or None,
             anchor_confidence_mode=anchor_confidence_mode,
+            ux_means=ux_means,
+            admire_means=admire_means,
         )
         if bootstrap_fitness < BOOTSTRAP_FITNESS_FLOOR:
             return False, (
@@ -2016,6 +2028,8 @@ def _should_promote(
         measurement_modality=measurement_modality,
         anchor_means=_current_anchor or None,
         anchor_confidence_mode=anchor_confidence_mode,
+        ux_means=ux_means,
+        admire_means=admire_means,
     )
     if gated == 0.0:
         # PR-SIL-5THEME C2 — gated=0 의 원인 분기. cross-validation gate
@@ -2040,6 +2054,8 @@ def _should_promote(
         measurement_modality=measurement_modality,
         anchor_means=_current_anchor or None,
         anchor_confidence_mode=anchor_confidence_mode,
+        ux_means=ux_means,
+        admire_means=admire_means,
     )
     prior_raw = compute_fitness(
         baseline_means,
@@ -2047,6 +2063,8 @@ def _should_promote(
         measurement_modality=baseline_measurement_modality,
         anchor_means=_baseline_anchor or None,
         anchor_confidence_mode=anchor_confidence_mode,
+        ux_means=baseline_ux_means,
+        admire_means=baseline_admire_means,
     )
     # PR-3 — N=1 detector. Walks the critical tier (most safety-relevant)
     # against the per-dim sample_count; if any critical dim was measured
@@ -2170,6 +2188,8 @@ def main() -> int:
     if args.no_baseline:
         baseline_means, baseline_stderr = None, None
         baseline_bench_means: dict[str, float] = {}
+        _baseline_ux_means: dict[str, float] = {}
+        _baseline_admire_means: dict[str, float] = {}
     else:
         (
             baseline_means,
@@ -2234,6 +2254,19 @@ def main() -> int:
     _anchor_mode_env = os.environ.get("GEODE_SIL_ANCHOR_CONFIDENCE_MODE", "").strip()
     _anchor_confidence_mode = _anchor_mode_env == "1"
     _anchor_means_current = {d: dim_means[d] for d in ANCHOR_DIMS if d in dim_means}
+    # PR-AR-L4b (2026-05-26) — ux_means / admire_means caller wiring.
+    # ``collect_ux_means_from_sources`` reads the 4 ledger-based metrics
+    # (mutator success_rate, token_cost_norm, revert_ratio_norm,
+    # latency_norm). Returns ``None`` until the loop has run at least
+    # one cycle (no attribution rows yet) → ``compute_fitness`` then
+    # falls back to dim-only fitness (no-op signal). admire_means is
+    # the Scope A handoff slot — reserved as None here; PR-AR-L4c wires
+    # the ranker pairwise win_rate consume after seed-gen ships the
+    # ``evaluate_mutation_pairwise`` entry point.
+    from autoresearch.ux_means import collect_ux_means_from_sources
+
+    ux_means_current = collect_ux_means_from_sources()
+    admire_means_current: dict[str, float] | None = None
     fitness = compute_fitness(
         dim_means,
         dim_stderr,
@@ -2244,6 +2277,8 @@ def main() -> int:
         measurement_modality=measurement_modality or None,
         anchor_means=_anchor_means_current or None,
         anchor_confidence_mode=_anchor_confidence_mode,
+        ux_means=ux_means_current,
+        admire_means=admire_means_current,
     )
     # P0b — per-dim score breakdown lives in the journal (event-scoped).
     # Aggregate fitness is recorded in sessions.jsonl (SoT, P0a §6); the
@@ -2344,6 +2379,11 @@ def main() -> int:
         "bench_stderr": bench_provenance.bench_stderr or None,
         "bench_sample_count": bench_provenance.bench_sample_count or None,
         "bench_rubric_version": bench_provenance.rubric_version,
+        # PR-AR-L4b (2026-05-26) — persist ux_means current value so the
+        # next baseline-load returns a non-empty ux slot. admire_means
+        # stays None until PR-AR-L4c wires the ranker handoff.
+        "ux_means": ux_means_current,
+        "admire_means": admire_means_current,
     }
     if args.dry_run:
         promoted_line = "false (dry-run)"
@@ -2382,6 +2422,14 @@ def main() -> int:
             # 적용 또는 둘 다 raw) 로 비교됨. _should_promote 가 ANCHOR_DIMS
             # subset 을 current_means / baseline_means 에서 자동 추출.
             anchor_confidence_mode=_anchor_confidence_mode,
+            # PR-AR-L4b (2026-05-26) — ux_means / admire_means forward to
+            # _should_promote's 4 internal compute_fitness calls. baseline
+            # ux/admire come from _load_baseline; current ux from the
+            # collector. admire is reserved (None) — PR-AR-L4c wires it.
+            ux_means=ux_means_current,
+            baseline_ux_means=_baseline_ux_means or None,
+            admire_means=admire_means_current,
+            baseline_admire_means=_baseline_admire_means or None,
         )
         if ok:
             _write_baseline(dim_means, dim_stderr, **_baseline_provenance)

--- a/tests/autoresearch/test_ux_admire_caller_forward.py
+++ b/tests/autoresearch/test_ux_admire_caller_forward.py
@@ -1,0 +1,203 @@
+"""PR-AR-L4b (2026-05-26) — ``compute_fitness`` 5-caller forward invariants.
+
+Pre-PR-AR-L4b ``autoresearch.ux_means.collect_ux_means_from_sources``
+returned a real dict (per PR-AR-L4a) but no caller forwarded it to
+``compute_fitness``. The fitness scalar therefore stayed dim-only,
+ignoring the entire ux axis even when the data was available.
+
+PR-AR-L4b wires the 5 ``compute_fitness`` call sites:
+
+- main caller at ``train.py:fitness = compute_fitness(...)`` (line ~2237)
+- 4 internal ``_should_promote`` calls (bootstrap / gated / current_raw
+  / prior_raw)
+
+All 5 must forward the same ``ux_means`` / ``admire_means`` kwargs to
+maintain caller symmetry (PR-11 anchor multiplier pattern from
+[[feedback-signature-forward-audit]]). ``admire_means`` is reserved as
+``None`` here — PR-AR-L4c wires the seed-gen ranker handoff after
+Scope A ships ``evaluate_mutation_pairwise``.
+
+This file pins:
+
+1. ``_should_promote`` signature accepts the 4 new kwargs
+2. All 5 ``compute_fitness`` call sites mention both ``ux_means=``
+   and ``admire_means=`` kwargs (grep invariant — PR-11 caught the
+   missing-forward bug via this exact pattern)
+3. ``_write_baseline`` persists the ``ux_means`` slot when caller
+   supplies a non-empty dict
+4. baseline.json roundtrip — ``_load_baseline`` reads the slot back
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+
+import pytest
+from autoresearch.train import (
+    AXIS_TIERS,
+    _load_baseline,
+    _should_promote,
+    _write_baseline,
+)
+
+
+def test_should_promote_accepts_ux_admire_kwargs() -> None:
+    """``_should_promote`` signature must expose the 4 new kwargs so
+    callers can forward without TypeErrors."""
+    sig = inspect.signature(_should_promote)
+    for kw in ("ux_means", "baseline_ux_means", "admire_means", "baseline_admire_means"):
+        assert kw in sig.parameters, f"{kw} missing from _should_promote signature"
+        assert sig.parameters[kw].default is None, (
+            f"{kw} must default to None for backward-compat with legacy callers"
+        )
+
+
+def test_compute_fitness_callers_all_forward_ux_means() -> None:
+    """Caller-symmetry grep — every ``compute_fitness(`` call in
+    ``train.py`` must reference ``ux_means=`` somewhere in its
+    argument block. The PR-11 anchor multiplier pattern caught a
+    Codex regression where 4 internal calls forwarded the kwarg but
+    1 didn't (silent half-wired fitness). Same pattern, same risk
+    here. The check is a defence-in-depth on top of the test that
+    actually exercises the 5 paths."""
+    from autoresearch import train as auto_train
+
+    source = inspect.getsource(auto_train)
+    # Strip the function definition line itself (compute_fitness signature
+    # doesn't count as a "call" — only invocations matter).
+    call_blocks = re.findall(r"compute_fitness\((.*?)\)", source, flags=re.DOTALL)
+    # Expect 5 invocations (4 in _should_promote + 1 in main()) PLUS
+    # 1 type-only self-reference inside the docstring example. Real
+    # call blocks contain ``dim_means`` / ``current_means`` as first
+    # positional — filter on that.
+    real_calls = [block for block in call_blocks if "_means" in block or "current_means" in block]
+    assert len(real_calls) >= 5, (
+        f"Expected at least 5 compute_fitness call blocks in train.py "
+        f"(1 main caller + 4 _should_promote internals). Got {len(real_calls)}."
+    )
+    for idx, block in enumerate(real_calls):
+        assert "ux_means" in block, (
+            f"compute_fitness call #{idx + 1} missing ux_means= forward. "
+            f"Caller symmetry violated — [[feedback-signature-forward-audit]] "
+            f"pattern. Block:\n{block}"
+        )
+        assert "admire_means" in block, (
+            f"compute_fitness call #{idx + 1} missing admire_means= forward. "
+            f"Same caller symmetry rule. Block:\n{block}"
+        )
+
+
+def test_should_promote_internal_calls_forward_ux_admire() -> None:
+    """End-to-end exercise — feed a `_should_promote` call with non-None
+    ux_means and verify the bootstrap branch fitness drifts from a
+    dim-only baseline. Catches the case where the kwarg was added to
+    signature but forgotten in the internal compute_fitness call body."""
+    dim_means = dict.fromkeys(AXIS_TIERS, 1.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    # Bootstrap path (baseline=None) — fitness signature must change
+    # when ux_means is non-None vs None. compute_fitness's 3-axis
+    # math (UX_FITNESS_DIM_WEIGHT × dim + UX_FITNESS_UX_WEIGHT × ux)
+    # diverges from dim-only fitness when ux_means is supplied.
+    ok_without_ux, reason_without = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    ok_with_ux, reason_with = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=None,
+        baseline_stderr=None,
+        ux_means={
+            "success_rate": 0.0,
+            "token_cost_norm": 0.0,
+            "revert_ratio_norm": 0.0,
+            "latency_norm": 0.0,
+        },
+    )
+    # Both must promote (full dim_means, fitness above floor) — the
+    # test isn't about the verdict, it's about the fitness scalar
+    # appearing in the reason changing.
+    assert ok_without_ux is True
+    assert ok_with_ux is True
+    # The fitness numbers in the reasons differ → the kwarg actually
+    # reaches compute_fitness inside the bootstrap branch.
+    fit_without = float(reason_without.split("fitness ")[1].split(" ")[0])
+    fit_with = float(reason_with.split("fitness ")[1].split(" ")[0])
+    assert fit_with != fit_without, (
+        f"ux_means kwarg has no effect on bootstrap fitness ({fit_without} == "
+        f"{fit_with}) — the forward is broken inside _should_promote's "
+        f"bootstrap branch."
+    )
+    # ux all zeros should drag fitness DOWN vs dim-only (which falls
+    # back to ux_means=None → ux_aggregate=0.5 neutral).
+    assert fit_with < fit_without
+
+
+def test_write_baseline_persists_ux_means_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_write_baseline`` writes the ``axes.ux_means`` slot when
+    caller forwards a non-empty dict. Pin so the slot stays populated
+    end-to-end (compute → forward → persist → load)."""
+    from autoresearch import train as auto_train
+
+    target = tmp_path / "baseline.json"
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", target)
+    ux = {
+        "success_rate": 0.7,
+        "token_cost_norm": 0.9,
+        "revert_ratio_norm": 0.8,
+        "latency_norm": 0.95,
+    }
+    _write_baseline(
+        dim_means=dict.fromkeys(AXIS_TIERS, 1.0),
+        dim_stderr=dict.fromkeys(AXIS_TIERS, 0.0),
+        ux_means=ux,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert "axes" in payload
+    assert payload["axes"]["ux_means"] == pytest.approx(ux)
+
+
+def test_load_baseline_roundtrips_ux_means_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end roundtrip — write → load → caller gets the ux dict
+    back. This is the slot wiring's full lifecycle pinned in one test."""
+    from autoresearch import train as auto_train
+
+    target = tmp_path / "baseline.json"
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", target)
+    ux = {
+        "success_rate": 0.66,
+        "token_cost_norm": 0.99,
+        "revert_ratio_norm": 0.66,
+        "latency_norm": 0.95,
+    }
+    _write_baseline(
+        dim_means=dict.fromkeys(AXIS_TIERS, 1.0),
+        dim_stderr=dict.fromkeys(AXIS_TIERS, 0.0),
+        ux_means=ux,
+    )
+    _, _, baseline_ux, _, _ = _load_baseline()
+    assert baseline_ux == pytest.approx(ux)
+
+
+def test_main_caller_collects_ux_means_via_l4a_collector() -> None:
+    """The main ``fitness = compute_fitness(...)`` call must reach
+    ``collect_ux_means_from_sources`` to gather current ux. grep
+    invariant — a future refactor removing the call would silently
+    half-disconnect the ux axis (signature still has slot, just always
+    forwards None)."""
+    from autoresearch import train as auto_train
+
+    source = inspect.getsource(auto_train)
+    assert "collect_ux_means_from_sources" in source, (
+        "train.py must call collect_ux_means_from_sources for the main "
+        "compute_fitness invocation. PR-AR-L4b wiring contract."
+    )

--- a/tests/autoresearch/test_ux_admire_caller_forward.py
+++ b/tests/autoresearch/test_ux_admire_caller_forward.py
@@ -188,6 +188,96 @@ def test_load_baseline_roundtrips_ux_means_slot(
     assert baseline_ux == pytest.approx(ux)
 
 
+def test_prior_raw_branch_uses_baseline_ux_means_not_current() -> None:
+    """The ``prior_raw`` internal ``compute_fitness`` call inside
+    ``_should_promote`` must use ``baseline_ux_means`` (not current
+    ``ux_means``) so prior-vs-current fitness comparison is fair.
+    Subtle asymmetry — Codex MCP review §6 flagged that the bootstrap
+    end-to-end test exercises only the current-side path. This test
+    pins the baseline-side forward explicitly.
+
+    Construct two _should_promote calls with the SAME current
+    ux_means but DIFFERENT baseline_ux_means. The promote decision
+    margin must differ (prior_raw changes when baseline_ux_means
+    changes)."""
+    from autoresearch.train import compute_fitness
+
+    dim_means = dict.fromkeys(AXIS_TIERS, 3.0)
+    dim_stderr = dict.fromkeys(AXIS_TIERS, 0.0)
+    baseline_means_dict = dict.fromkeys(AXIS_TIERS, 3.0)
+    baseline_stderr_dict = dict.fromkeys(AXIS_TIERS, 0.05)
+    current_ux = {
+        "success_rate": 0.5,
+        "token_cost_norm": 0.5,
+        "revert_ratio_norm": 0.5,
+        "latency_norm": 0.5,
+    }
+    # Two prior_raw fitness values — same current means, different
+    # baseline_ux. If the code wrongly used current ux for prior_raw,
+    # these would be identical.
+    prior_low = compute_fitness(
+        baseline_means_dict,
+        baseline_stderr_dict,
+        ux_means={
+            "success_rate": 0.0,
+            "token_cost_norm": 0.0,
+            "revert_ratio_norm": 0.0,
+            "latency_norm": 0.0,
+        },
+    )
+    prior_high = compute_fitness(
+        baseline_means_dict,
+        baseline_stderr_dict,
+        ux_means={
+            "success_rate": 1.0,
+            "token_cost_norm": 1.0,
+            "revert_ratio_norm": 1.0,
+            "latency_norm": 1.0,
+        },
+    )
+    # Sanity — compute_fitness itself is sensitive to ux_means.
+    assert prior_low != prior_high
+
+    # Now exercise _should_promote with current_ux fixed and baseline_ux
+    # varying. If the forward is correct, the gated/prior_raw fitness
+    # used internally differs → margin differs → decision can flip.
+    # We don't assert decision flips (depends on margin math); we assert
+    # the reason string carries different fitness numbers.
+    _, reason_low_baseline = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=baseline_means_dict,
+        baseline_stderr=baseline_stderr_dict,
+        ux_means=current_ux,
+        baseline_ux_means={
+            "success_rate": 0.0,
+            "token_cost_norm": 0.0,
+            "revert_ratio_norm": 0.0,
+            "latency_norm": 0.0,
+        },
+    )
+    _, reason_high_baseline = _should_promote(
+        dim_means,
+        dim_stderr,
+        baseline_means=baseline_means_dict,
+        baseline_stderr=baseline_stderr_dict,
+        ux_means=current_ux,
+        baseline_ux_means={
+            "success_rate": 1.0,
+            "token_cost_norm": 1.0,
+            "revert_ratio_norm": 1.0,
+            "latency_norm": 1.0,
+        },
+    )
+    # Reasons must differ because prior_raw fitness differs between the
+    # two calls — if the code wrongly used current ux_means for
+    # prior_raw, both reasons would be identical.
+    assert reason_low_baseline != reason_high_baseline, (
+        "prior_raw appears to use current ux_means instead of "
+        "baseline_ux_means — the asymmetric forward is broken."
+    )
+
+
 def test_main_caller_collects_ux_means_via_l4a_collector() -> None:
     """The main ``fitness = compute_fitness(...)`` call must reach
     ``collect_ux_means_from_sources`` to gather current ux. grep


### PR DESCRIPTION
## Summary
- 5 \`compute_fitness\` call sites in \`autoresearch/train.py\` now forward \`ux_means\` / \`admire_means\` kwargs (main caller + 4 internal \`_should_promote\` calls).
- \`_should_promote\` signature grows 4 new kwargs (default \`None\` for backward-compat).
- \`_write_baseline\` persists \`axes.ux_means\` (no schema change — slot existed but was always \`None\`).
- 6 invariants in \`tests/autoresearch/test_ux_admire_caller_forward.py\`.

## Why
GAP audit (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L4) flagged the multi-axis Goodhart gate as dormant. PR-AR-L4a wired the \`ux_means\` collector but no caller forwarded it — fitness stayed dim-only. PR-AR-L4b closes the wiring at the caller boundary; \`admire_means\` is reserved as \`None\` until Scope A (seed-gen ranker mutation-eval) ships and PR-AR-L4c consumes it.

## Changes
| File | Change |
|------|--------|
| \`autoresearch/train.py\` | \`_should_promote\` signature + 4 internal compute_fitness forward + main caller collects ux + \`_baseline_provenance\` carries ux_means |
| \`tests/autoresearch/test_ux_admire_caller_forward.py\` (new) | 6 invariants — signature, caller-symmetry grep, bootstrap end-to-end, write/load roundtrip, main-caller collector contract |
| \`CHANGELOG.md\` | \`[Unreleased]\` → Added entry |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (6 new + 167 existing autoresearch / S1 / autoresearch suite = 173/173)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L4b
- ADR-012 §Decision.2 (3-axis fitness)
- Caller-symmetry pattern: PR-11 anchor multiplier ([[feedback-signature-forward-audit]])