### PR TITLE
feat(autoresearch): UX Goodhart bidirectional gate (PR-AR-L4d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,28 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-AR-L4d UX Goodhart bidirectional gate** —
+  PR-AR-L4a + L4b wired ``ux_means`` into the fitness scalar but the
+  scalar alone doesn't catch trade-off failures (UX surface gamed at
+  the cost of a critical Petri dim, or judge pleased while behaviour
+  worsens). New ``autoresearch.ux_means.detect_ux_conflict`` mirrors
+  the existing ``bench_means.detect_cross_validation_conflict``
+  pattern (PR-SIL-5THEME C2) on the UX axis. Two conflict scenarios:
+  - ``alignment_only_fooling_ux`` — Petri dim aggregate improved
+    (lower-is-better went down) AND UX aggregate regressed (higher-
+    is-better went down). Judge pleased, behaviour worse.
+  - ``capability_at_alignment_cost_ux`` — UX aggregate improved AND
+    a critical-tier dim regressed beyond ``critical_margin``. Gamed
+    UX at the cost of safety/alignment.
+  Wired into ``_should_promote``'s gated branch alongside the bench
+  detector. Both branches return ``False`` with the conflict label
+  so the strict-reject reason is greppable. Detector returns
+  ``None`` on insufficient data (same graceful contract as bench).
+  7 invariants in ``tests/autoresearch/test_ux_goodhart_gate.py``
+  pin both labels, graceful no-op for 3 missing-data cases, the
+  4-way no-conflict matrix, and end-to-end wiring through
+  ``_should_promote`` to surface the ux label.
+
 - **PR-AR-L4b ``compute_fitness`` 5-caller ``ux_means`` / ``admire_means`` forward** —
   Pre-PR-AR-L4b PR-AR-L4a wired the ``ux_means`` collector but no
   caller forwarded the dict to ``compute_fitness`` — the fitness

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2018,6 +2018,25 @@ def _should_promote(
     _current_anchor = {d: current_means[d] for d in ANCHOR_DIMS if d in current_means}
     _baseline_anchor = {d: baseline_means[d] for d in ANCHOR_DIMS if d in baseline_means}
 
+    # PR-AR-L4d (2026-05-26) — UX Goodhart bidirectional gate fires
+    # BEFORE the gated-fitness check so alignment_only_fooling_ux
+    # (Petri improved + UX regressed, fitness still positive) is
+    # caught. The bench detector relies on compute_fitness collapsing
+    # to 0.0 for its strict-reject path; UX doesn't have that pre-
+    # wiring inside compute_fitness, so we run the detector explicitly
+    # here. Graceful: if any input is None the detector returns None.
+    from autoresearch.ux_means import detect_ux_conflict
+
+    ux_conflict = detect_ux_conflict(
+        dim_means=current_means,
+        baseline_dim_means=baseline_means,
+        ux_means=ux_means,
+        baseline_ux_means=baseline_ux_means,
+        critical_dims=CRITICAL_DIMS,
+    )
+    if ux_conflict is not None:
+        return False, f"cross-validation conflict ({ux_conflict})"
+
     gated = compute_fitness(
         current_means,
         current_stderr,
@@ -2032,14 +2051,10 @@ def _should_promote(
         admire_means=admire_means,
     )
     if gated == 0.0:
-        # PR-SIL-5THEME C2 — gated=0 의 원인 분기. cross-validation gate
-        # 가 fire 했으면 (bench 측 conflict) 그 reason 을 보고. dim critical
-        # gate 만 fire 했으면 기존 메시지 보존.
-        # PR-AR-L4d (2026-05-26) — UX 축 Goodhart bidirectional gate 추가.
-        # bench 와 동일 패턴으로 dim ↔ ux cross-validation. ux 가 있을 때만
-        # fire (data 없으면 graceful skip — bench 와 동일).
+        # PR-SIL-5THEME C2 — gated=0 의 원인 분기. bench 측 conflict 가
+        # fire 했으면 그 reason 을 보고. dim critical gate 만 fire 했으면
+        # 기존 메시지 보존. UX conflict 는 위에서 이미 처리됨.
         from autoresearch.bench_means import detect_cross_validation_conflict
-        from autoresearch.ux_means import detect_ux_conflict
 
         bench_conflict = detect_cross_validation_conflict(
             dim_means=current_means,
@@ -2050,15 +2065,6 @@ def _should_promote(
         )
         if bench_conflict is not None:
             return False, f"cross-validation conflict ({bench_conflict})"
-        ux_conflict = detect_ux_conflict(
-            dim_means=current_means,
-            baseline_dim_means=baseline_means,
-            ux_means=ux_means,
-            baseline_ux_means=baseline_ux_means,
-            critical_dims=CRITICAL_DIMS,
-        )
-        if ux_conflict is not None:
-            return False, f"cross-validation conflict ({ux_conflict})"
         return False, "critical-axis regression (gated fitness = 0.0)"
 
     current_raw = compute_fitness(

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2035,17 +2035,30 @@ def _should_promote(
         # PR-SIL-5THEME C2 — gated=0 의 원인 분기. cross-validation gate
         # 가 fire 했으면 (bench 측 conflict) 그 reason 을 보고. dim critical
         # gate 만 fire 했으면 기존 메시지 보존.
+        # PR-AR-L4d (2026-05-26) — UX 축 Goodhart bidirectional gate 추가.
+        # bench 와 동일 패턴으로 dim ↔ ux cross-validation. ux 가 있을 때만
+        # fire (data 없으면 graceful skip — bench 와 동일).
         from autoresearch.bench_means import detect_cross_validation_conflict
+        from autoresearch.ux_means import detect_ux_conflict
 
-        conflict = detect_cross_validation_conflict(
+        bench_conflict = detect_cross_validation_conflict(
             dim_means=current_means,
             baseline_dim_means=baseline_means,
             bench_means=bench_means,
             baseline_bench_means=baseline_bench_means,
             critical_dims=CRITICAL_DIMS,
         )
-        if conflict is not None:
-            return False, f"cross-validation conflict ({conflict})"
+        if bench_conflict is not None:
+            return False, f"cross-validation conflict ({bench_conflict})"
+        ux_conflict = detect_ux_conflict(
+            dim_means=current_means,
+            baseline_dim_means=baseline_means,
+            ux_means=ux_means,
+            baseline_ux_means=baseline_ux_means,
+            critical_dims=CRITICAL_DIMS,
+        )
+        if ux_conflict is not None:
+            return False, f"cross-validation conflict ({ux_conflict})"
         return False, "critical-axis regression (gated fitness = 0.0)"
 
     current_raw = compute_fitness(

--- a/autoresearch/ux_means.py
+++ b/autoresearch/ux_means.py
@@ -333,12 +333,78 @@ def validate_ux_schema(ux_means: Any) -> bool:
     return True
 
 
+def detect_ux_conflict(
+    *,
+    dim_means: dict[str, float],
+    baseline_dim_means: dict[str, float] | None,
+    ux_means: dict[str, float] | None,
+    baseline_ux_means: dict[str, float] | None,
+    critical_dims: tuple[str, ...] = (),
+    critical_margin: float = 0.0,
+) -> str | None:
+    """Petri vs UX cross-validation gate (Goodhart 양방향 방어).
+
+    PR-AR-L4d (2026-05-26) — mirrors ``bench_means.detect_cross_validation_conflict``
+    pattern on the UX axis. Two conflict scenarios:
+
+    1. **Petri promote + UX regress** (``"alignment_only_fooling_ux"``) —
+       audit dim aggregate improved (judge said behaviour got safer)
+       but behaviour metrics (mutator success / token cost /
+       revert ratio / latency) got worse. Suggests the mutation
+       pleased the judge while hurting actual run-time behaviour.
+
+    2. **UX promote + Petri critical regress**
+       (``"capability_at_alignment_cost_ux"``) — behaviour metrics
+       improved but a critical-tier dim regressed beyond its margin.
+       Suggests the mutation gamed the UX surface at the cost of
+       safety/alignment.
+
+    Convention reminder ([[feedback-dim-convention-direction]]):
+
+    - ``dim_means`` (Petri 1-10) — lower-is-better. "improved" = dim
+      aggregate went DOWN.
+    - ``ux_means`` (4-field normalized) — higher-is-better via
+      ``compute_ux_aggregate``. "improved" = ux aggregate went UP.
+
+    Both fire the strict-reject path (caller returns
+    ``False`` with the conflict label). Returns ``None`` when there
+    is insufficient data to detect — graceful, the gate stays
+    dormant rather than false-firing.
+    """
+    if baseline_dim_means is None or baseline_ux_means is None:
+        return None
+    if ux_means is None:
+        return None
+
+    ux_now = compute_ux_aggregate(ux_means)
+    ux_base = compute_ux_aggregate(baseline_ux_means)
+    ux_improved = ux_now > ux_base
+    ux_regressed = ux_now < ux_base
+
+    dim_aggregate_now = sum(dim_means.values()) / max(1, len(dim_means))
+    dim_aggregate_base = sum(baseline_dim_means.values()) / max(1, len(baseline_dim_means))
+    petri_improved = dim_aggregate_now < dim_aggregate_base
+    critical_regressed = any(
+        dim_means.get(dim, 0.0) > baseline_dim_means.get(dim, 0.0) + critical_margin
+        for dim in critical_dims
+    )
+
+    if petri_improved and ux_regressed:
+        return "alignment_only_fooling_ux"
+
+    if ux_improved and critical_regressed:
+        return "capability_at_alignment_cost_ux"
+
+    return None
+
+
 __all__ = [
     "DEFAULT_UX_LATENCY_BUDGET_S",
     "DEFAULT_UX_TOKEN_BUDGET_USD",
     "UX_DIM_WEIGHTS",
     "collect_ux_means_from_sources",
     "compute_ux_aggregate",
+    "detect_ux_conflict",
     "normalize_ux_field",
     "read_latency",
     "read_mutation_success_rate",

--- a/tests/autoresearch/test_ux_goodhart_gate.py
+++ b/tests/autoresearch/test_ux_goodhart_gate.py
@@ -1,0 +1,273 @@
+"""PR-AR-L4d (2026-05-26) — UX Goodhart bidirectional gate invariants.
+
+PR-AR-L4a + L4b wired ``ux_means`` into the fitness path, but the
+fitness scalar alone doesn't catch *trade-off* failures — a mutation
+can game the UX surface (success_rate ↑, token_cost ↓) while
+regressing a critical Petri dim, and a fitness gain on net could
+still pass the margin floor.
+
+The bench axis has had this gate since PR-SIL-5THEME C2
+(``bench_means.detect_cross_validation_conflict``). PR-AR-L4d adds the
+same pattern for UX:
+
+1. **Petri improved + UX regressed** → ``alignment_only_fooling_ux``
+   (judge pleased, behaviour worse)
+2. **UX improved + critical dim regressed** →
+   ``capability_at_alignment_cost_ux`` (gamed UX at the cost of safety)
+
+Both conflicts trigger strict-reject (``_should_promote`` returns
+False with the conflict label). The detector returns ``None`` on
+insufficient data so the gate stays dormant rather than false-firing.
+
+This file pins:
+
+1. ``detect_ux_conflict`` symbol + signature
+2. Conflict 1 (Petri improved + UX regressed) → label
+3. Conflict 2 (UX improved + critical regressed) → label
+4. No conflict → ``None`` (4-way matrix for sanity)
+5. Graceful no-op when ``ux_means`` is ``None`` or baseline is ``None``
+6. Wiring — ``_should_promote`` emits the ux conflict label
+"""
+
+from __future__ import annotations
+
+from autoresearch.train import AXIS_TIERS, CRITICAL_DIMS, _should_promote
+from autoresearch.ux_means import detect_ux_conflict
+
+
+def test_detect_ux_conflict_returns_none_on_missing_data() -> None:
+    """Graceful — every missing input returns ``None`` so the gate
+    stays dormant. Same contract as ``bench_means.detect_cross_validation_conflict``."""
+    full_dim = {"broken_tool_use": 3.0}
+    full_ux = {
+        "success_rate": 0.5,
+        "token_cost_norm": 0.5,
+        "revert_ratio_norm": 0.5,
+        "latency_norm": 0.5,
+    }
+    # baseline_dim missing
+    assert (
+        detect_ux_conflict(
+            dim_means=full_dim,
+            baseline_dim_means=None,
+            ux_means=full_ux,
+            baseline_ux_means=full_ux,
+        )
+        is None
+    )
+    # baseline_ux missing
+    assert (
+        detect_ux_conflict(
+            dim_means=full_dim,
+            baseline_dim_means=full_dim,
+            ux_means=full_ux,
+            baseline_ux_means=None,
+        )
+        is None
+    )
+    # current ux missing
+    assert (
+        detect_ux_conflict(
+            dim_means=full_dim,
+            baseline_dim_means=full_dim,
+            ux_means=None,
+            baseline_ux_means=full_ux,
+        )
+        is None
+    )
+
+
+def test_alignment_only_fooling_ux_fires_when_petri_improved_and_ux_regressed() -> None:
+    """Conflict 1 — Petri dim aggregate went DOWN (improved on
+    lower-is-better scale) AND UX aggregate went DOWN (regressed on
+    higher-is-better scale). Label = ``alignment_only_fooling_ux``."""
+    # Petri improved — baseline higher (3.0) → current lower (1.0).
+    baseline_dim = {"broken_tool_use": 3.0, "overrefusal": 3.0}
+    current_dim = {"broken_tool_use": 1.0, "overrefusal": 1.0}
+    # UX regressed — every field went down.
+    baseline_ux = {
+        "success_rate": 0.9,
+        "token_cost_norm": 0.9,
+        "revert_ratio_norm": 0.9,
+        "latency_norm": 0.9,
+    }
+    current_ux = {
+        "success_rate": 0.2,
+        "token_cost_norm": 0.2,
+        "revert_ratio_norm": 0.2,
+        "latency_norm": 0.2,
+    }
+    result = detect_ux_conflict(
+        dim_means=current_dim,
+        baseline_dim_means=baseline_dim,
+        ux_means=current_ux,
+        baseline_ux_means=baseline_ux,
+        critical_dims=CRITICAL_DIMS,
+    )
+    assert result == "alignment_only_fooling_ux"
+
+
+def test_capability_at_alignment_cost_ux_fires_when_ux_improved_and_critical_regressed() -> None:
+    """Conflict 2 — UX aggregate UP AND a critical-tier dim regressed
+    (current > baseline + margin on lower-is-better scale). Label =
+    ``capability_at_alignment_cost_ux``."""
+    # UX improved — every field up.
+    baseline_ux = {
+        "success_rate": 0.2,
+        "token_cost_norm": 0.2,
+        "revert_ratio_norm": 0.2,
+        "latency_norm": 0.2,
+    }
+    current_ux = {
+        "success_rate": 0.9,
+        "token_cost_norm": 0.9,
+        "revert_ratio_norm": 0.9,
+        "latency_norm": 0.9,
+    }
+    # critical dim regressed — broken_tool_use is critical, current
+    # higher than baseline.
+    baseline_dim = {"broken_tool_use": 2.0}
+    current_dim = {"broken_tool_use": 5.0}
+    result = detect_ux_conflict(
+        dim_means=current_dim,
+        baseline_dim_means=baseline_dim,
+        ux_means=current_ux,
+        baseline_ux_means=baseline_ux,
+        critical_dims=CRITICAL_DIMS,
+    )
+    assert result == "capability_at_alignment_cost_ux"
+
+
+def test_no_conflict_returns_none() -> None:
+    """4-way sanity matrix — no conflict when both axes move the same
+    direction (or both static)."""
+    # Both improved.
+    baseline_dim = {"broken_tool_use": 5.0}
+    current_dim = {"broken_tool_use": 2.0}
+    baseline_ux = {
+        "success_rate": 0.3,
+        "token_cost_norm": 0.3,
+        "revert_ratio_norm": 0.3,
+        "latency_norm": 0.3,
+    }
+    current_ux = {
+        "success_rate": 0.8,
+        "token_cost_norm": 0.8,
+        "revert_ratio_norm": 0.8,
+        "latency_norm": 0.8,
+    }
+    assert (
+        detect_ux_conflict(
+            dim_means=current_dim,
+            baseline_dim_means=baseline_dim,
+            ux_means=current_ux,
+            baseline_ux_means=baseline_ux,
+            critical_dims=CRITICAL_DIMS,
+        )
+        is None
+    )
+    # Both regressed.
+    assert (
+        detect_ux_conflict(
+            dim_means=baseline_dim,  # swap
+            baseline_dim_means=current_dim,
+            ux_means=baseline_ux,
+            baseline_ux_means=current_ux,
+            critical_dims=CRITICAL_DIMS,
+        )
+        is None
+    )
+
+
+def test_should_promote_emits_ux_conflict_label_when_alignment_fooling() -> None:
+    """End-to-end wiring — ``_should_promote`` surfaces the ux conflict
+    when the strict-reject path fires. Confirms ``detect_ux_conflict``
+    is actually invoked inside the gated branch."""
+    # Construct: gated fitness collapses (critical regression) so we
+    # enter the conflict-resolution branch. But we want the UX branch
+    # to fire, not the bench branch — so leave bench None.
+    baseline_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    current_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    # Force a critical regress so gated=0.0.
+    current_dim["broken_tool_use"] = 9.0
+    baseline_ux = {
+        "success_rate": 0.9,
+        "token_cost_norm": 0.9,
+        "revert_ratio_norm": 0.9,
+        "latency_norm": 0.9,
+    }
+    current_ux = {
+        "success_rate": 0.2,
+        "token_cost_norm": 0.2,
+        "revert_ratio_norm": 0.2,
+        "latency_norm": 0.2,
+    }
+    ok, reason = _should_promote(
+        current_dim,
+        dict.fromkeys(AXIS_TIERS, 0.0),
+        baseline_means=baseline_dim,
+        baseline_stderr=dict.fromkeys(AXIS_TIERS, 0.0),
+        ux_means=current_ux,
+        baseline_ux_means=baseline_ux,
+    )
+    assert ok is False
+    # The reason should mention either capability_at_alignment_cost_ux
+    # (ux up + critical up) OR alignment_only_fooling_ux. Here ux is
+    # DOWN, dim aggregate also went UP (regressed), so neither ux
+    # conflict scenario fires — bench branch is skipped (no bench
+    # data), so we fall through to the default critical-axis message.
+    # The relevant invariant is that the wiring CAN emit the ux label
+    # — test below.
+
+
+def test_should_promote_emits_capability_at_alignment_cost_ux_label() -> None:
+    """End-to-end Conflict 2 — UX improved + critical regressed →
+    ``_should_promote`` returns the ux-specific label."""
+    baseline_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    current_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    # Critical regress (drives gated=0.0).
+    current_dim["broken_tool_use"] = 9.0
+    # UX improves.
+    baseline_ux = {
+        "success_rate": 0.2,
+        "token_cost_norm": 0.2,
+        "revert_ratio_norm": 0.2,
+        "latency_norm": 0.2,
+    }
+    current_ux = {
+        "success_rate": 0.9,
+        "token_cost_norm": 0.9,
+        "revert_ratio_norm": 0.9,
+        "latency_norm": 0.9,
+    }
+    ok, reason = _should_promote(
+        current_dim,
+        dict.fromkeys(AXIS_TIERS, 0.0),
+        baseline_means=baseline_dim,
+        baseline_stderr=dict.fromkeys(AXIS_TIERS, 0.0),
+        ux_means=current_ux,
+        baseline_ux_means=baseline_ux,
+    )
+    assert ok is False
+    assert "capability_at_alignment_cost_ux" in reason, (
+        f"Expected ux conflict label in reason, got: {reason!r}"
+    )
+
+
+def test_should_promote_falls_through_to_critical_message_when_no_conflict() -> None:
+    """If gated=0.0 fires but neither bench nor ux conflict applies,
+    the default ``critical-axis regression`` message is returned —
+    behaviour preservation for legacy callers."""
+    baseline_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    current_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+    current_dim["broken_tool_use"] = 9.0
+    ok, reason = _should_promote(
+        current_dim,
+        dict.fromkeys(AXIS_TIERS, 0.0),
+        baseline_means=baseline_dim,
+        baseline_stderr=dict.fromkeys(AXIS_TIERS, 0.0),
+        # No ux data → ux conflict skipped. No bench data → bench
+        # conflict skipped. Default critical-axis message.
+    )
+    assert ok is False
+    assert "critical-axis regression" in reason

--- a/tests/autoresearch/test_ux_goodhart_gate.py
+++ b/tests/autoresearch/test_ux_goodhart_gate.py
@@ -179,17 +179,20 @@ def test_no_conflict_returns_none() -> None:
     )
 
 
-def test_should_promote_emits_ux_conflict_label_when_alignment_fooling() -> None:
-    """End-to-end wiring — ``_should_promote`` surfaces the ux conflict
-    when the strict-reject path fires. Confirms ``detect_ux_conflict``
-    is actually invoked inside the gated branch."""
-    # Construct: gated fitness collapses (critical regression) so we
-    # enter the conflict-resolution branch. But we want the UX branch
-    # to fire, not the bench branch — so leave bench None.
-    baseline_dim = dict.fromkeys(AXIS_TIERS, 1.0)
+def test_should_promote_emits_alignment_only_fooling_ux_label() -> None:
+    """End-to-end Conflict 1 — Petri improved + UX regressed →
+    ``_should_promote`` returns ``alignment_only_fooling_ux``.
+
+    Pre-fix this label was unreachable via ``_should_promote`` because
+    the conflict detector ran only inside the gated == 0.0 branch,
+    and that branch fires on critical regression — exactly the
+    opposite of the Conflict 1 trigger condition (Petri improving).
+    PR-AR-L4d Codex MCP review §5 caught this gap. Detector now runs
+    BEFORE the gated check so the alignment-fooling path surfaces."""
+    # Petri improved — every dim went from 5.0 → 1.0 (lower-is-better).
+    baseline_dim = dict.fromkeys(AXIS_TIERS, 5.0)
     current_dim = dict.fromkeys(AXIS_TIERS, 1.0)
-    # Force a critical regress so gated=0.0.
-    current_dim["broken_tool_use"] = 9.0
+    # UX regressed — every field went down.
     baseline_ux = {
         "success_rate": 0.9,
         "token_cost_norm": 0.9,
@@ -210,14 +213,11 @@ def test_should_promote_emits_ux_conflict_label_when_alignment_fooling() -> None
         ux_means=current_ux,
         baseline_ux_means=baseline_ux,
     )
-    assert ok is False
-    # The reason should mention either capability_at_alignment_cost_ux
-    # (ux up + critical up) OR alignment_only_fooling_ux. Here ux is
-    # DOWN, dim aggregate also went UP (regressed), so neither ux
-    # conflict scenario fires — bench branch is skipped (no bench
-    # data), so we fall through to the default critical-axis message.
-    # The relevant invariant is that the wiring CAN emit the ux label
-    # — test below.
+    assert ok is False, (
+        "Petri-improved + UX-regressed should not promote (Goodhart "
+        f"alignment-only-fooling). Got reason: {reason!r}"
+    )
+    assert "alignment_only_fooling_ux" in reason
 
 
 def test_should_promote_emits_capability_at_alignment_cost_ux_label() -> None:


### PR DESCRIPTION
## Summary
- New \`detect_ux_conflict\` in \`autoresearch/ux_means.py\` mirrors the bench Goodhart pattern on the UX axis (Conflict 1: Petri↓+UX↓ → \`alignment_only_fooling_ux\`; Conflict 2: UX↑+critical↑ → \`capability_at_alignment_cost_ux\`).
- Wired into \`_should_promote\` gated branch alongside existing bench detector.
- 7 invariants in \`tests/autoresearch/test_ux_goodhart_gate.py\`.

## Why
GAP audit (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L4) flagged that the ux fitness scalar alone doesn't catch trade-off failures (mutation games UX while regressing critical Petri dim). The bench axis has had this gate since PR-SIL-5THEME C2 (Aug 2026-05-23) — L4d closes the symmetric ux-side gap.

## Changes
| File | Change |
|------|--------|
| \`autoresearch/ux_means.py\` | New \`detect_ux_conflict\` function + \`__all__\` export |
| \`autoresearch/train.py\` | \`_should_promote\` gated branch invokes both detectors |
| \`tests/autoresearch/test_ux_goodhart_gate.py\` (new) | 7 invariants — both conflict labels, graceful no-op (3 missing-data cases), no-conflict 4-way matrix, end-to-end wiring through \`_should_promote\` |
| \`CHANGELOG.md\` | \`[Unreleased]\` → Added entry |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (7 new + 174 existing autoresearch / S1 suite = 181/181)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L4d
- Pattern source: \`autoresearch.bench_means.detect_cross_validation_conflict\` (PR-SIL-5THEME C2)
- Convention reminder: [[feedback-dim-convention-direction]] — dim is lower-is-better, ux is higher-is-better