### PR TITLE
feat(autoresearch): admire_means consumer for seed-gen handoff (PR-AR-L4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,32 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-AR-L4c ``admire_means`` consumer for seed-gen handoff (ADR-012 S2b)** —
+  Scope A (PR-RANKER-MUTATION-EVAL #1704) shipped
+  ``plugins.seed_generation.mutation_eval.evaluate_mutation_pairwise``;
+  this PR wires the autoresearch consumer side:
+  - ``admire_means_from_eval_result(result)`` converts a
+    ``MutationEvalResult`` into the autoresearch ``admire_means`` dict
+    shape with field-name parity (``pairwise_win_rate``).
+  - ``derive_inter_voter_agreement(wins, losses, ties)`` proxies
+    ``human_calibration_corr`` until quarterly human L4 batch lands.
+    Operator-grounded via Krippendorff 2004 *Content Analysis* 2nd ed
+    (p.241): α ≥ 0.667 = substantial-agreement floor for nominal IRR.
+  - New ``KRIPPENDORFF_TENTATIVE_FLOOR = 0.667`` and
+    ``KRIPPENDORFF_DEFINITIVE_FLOOR = 0.800`` constants documenting
+    the source.
+  - ``CALIBRATION_THRESHOLD`` migrated from magic 0.7 → tentative
+    floor (0.667). Existing tests updated to match.
+  - Deleted ``collect_admire_means_from_ranker`` placeholder.
+  The runner-side invocation (``evaluate_mutation_pairwise`` call
+  with before/after responses + audit 2× cost) is a follow-up PR —
+  this consumer provides the stable interface for that future work.
+  10 invariants in
+  ``tests/autoresearch/test_admire_handoff_consume.py`` pin the
+  Krippendorff constants, the agreement formula, the converter shape,
+  end-to-end aggregate computability, and cross-module field-name
+  parity with ``MutationEvalResult.pairwise_win_rate``.
+
 - **PR-AR-L4d UX Goodhart bidirectional gate** —
   PR-AR-L4a + L4b wired ``ux_means`` into the fitness scalar but the
   scalar alone doesn't catch trade-off failures (UX surface gamed at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,13 @@ functional change.
     shape with field-name parity (``pairwise_win_rate``).
   - ``derive_inter_voter_agreement(wins, losses, ties)`` proxies
     ``human_calibration_corr`` until quarterly human L4 batch lands.
-    Operator-grounded via Krippendorff 2004 *Content Analysis* 2nd ed
-    (p.241): α ≥ 0.667 = substantial-agreement floor for nominal IRR.
+    Two-factor formula (``majority_share × decisive_share``) penalizes
+    low-decisiveness panels — Codex MCP review §3 caught the case
+    where ``wins=1, losses=0, ties=2`` returned 1.0 (degenerate
+    single-voter unanimity); fixed to 0.333. Krippendorff 2004
+    *Content Analysis* 2nd ed (p.241) thresholds (α ≥ 0.667 tentative
+    / α ≥ 0.800 reliable) are the *interpretation thresholds* the
+    proxy is checked against — the proxy itself is not Krippendorff α.
   - New ``KRIPPENDORFF_TENTATIVE_FLOOR = 0.667`` and
     ``KRIPPENDORFF_DEFINITIVE_FLOOR = 0.800`` constants documenting
     the source.

--- a/autoresearch/admire_means.py
+++ b/autoresearch/admire_means.py
@@ -16,9 +16,11 @@ cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 — mu
                                          # (분기 단위 50-100 sample 로 측정, Goodhart 방어)
     }
 
-``human_calibration_corr`` 가 0.7 미만이면 LLM-judge 가 human 기준에서
-벗어나는 신호 — Goodhart fooling 위험. ``compute_admire_aggregate`` 가
-이 축으로 win-rate 를 가중치 dampen 하는 방식으로 처리.
+``human_calibration_corr`` 가 ``KRIPPENDORFF_TENTATIVE_FLOOR`` (0.667,
+Krippendorff 2004 *Content Analysis* 2nd ed p.241 의 tentative-
+conclusions α floor) 미만이면 LLM-judge 가 human 기준에서 벗어나는
+신호 — Goodhart fooling 위험. ``compute_admire_aggregate`` 가 이 축으로
+win-rate 를 가중치 dampen 하는 방식으로 처리.
 
 **ADR-012 §Decision.2 의 fitness 3축 다축화**:
 
@@ -26,18 +28,22 @@ cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 — mu
 - ``ux_means`` (행동 4-field, 양의 압력, S1 신설) — 가중치 0.3
 - ``admire_means`` (체감 2-field, 양의 압력, 이 모듈) — 가중치 0.3
 
-S2 (이 PR) 는 **schema + math + ranker hook interface** 만 신설. 실제
-ranker.py 의 ELO + voter panel 호출 wiring 은 S2b (별도 PR) —
-``collect_admire_means_from_ranker`` 가 placeholder 로 ``None`` 반환,
-``compute_fitness`` 의 3축 다축화는 즉시 가동.
+S2 + PR-AR-L4c (2026-05-26) 로 schema + math + ranker handoff
+converter (``admire_means_from_eval_result``) 가 모두 wire. 실제 ranker
+``evaluate_mutation_pairwise`` 호출 — 즉 mutation 의 before/after 응답
+캡처 → panel dispatch — 는 mutator runner (별도 PR) 가 담당. 본
+모듈은 *consumer 측* 변환 + 임시 calibration 프록시 (panel inter-voter
+agreement → ``human_calibration_corr``) 만 제공.
 
 **Goodhart 방어 (ADR-012 의 Risks 표)**:
 1. judge model 의 주기적 교체 — ``required_diversity_providers`` 규약
    재사용 (PR-COSCI-1)
 2. ranker.py 의 3-voter cross-provider panel — single-judge sycophancy
    회피
-3. ``human_calibration_corr`` < 0.7 시 win-rate dampening
-4. 분기 human L4 batch refresh (S2b 의 calibration pipeline)
+3. ``human_calibration_corr`` < ``KRIPPENDORFF_TENTATIVE_FLOOR`` 시
+   win-rate dampening
+4. 분기 human L4 batch refresh (calibration pipeline) — Pearson r
+   로 프록시 교체
 """
 
 from __future__ import annotations
@@ -57,23 +63,31 @@ assert abs(sum(ADMIRE_DIM_WEIGHTS.values()) - 1.0) < 1e-9, "ADMIRE_DIM_WEIGHTS m
 # 가 human 기준에서 drift — pairwise_win_rate 를 dampen.
 #
 # PR-AR-L4c (2026-05-26) operator-grounded: Krippendorff 2004
-# *Content Analysis* 2nd ed (p.241) — α ≥ 0.667 = tentative conclusions
-# floor (substantial inter-rater agreement), α ≥ 0.800 = definitive
-# conclusions floor. The threshold is the *tentative* floor since the
+# *Content Analysis* 2nd ed (p.241) — α ≥ 0.667 = *tentative
+# conclusions* floor for nominal IRR; α ≥ 0.800 = *reliable / definitive
+# conclusions* floor. The threshold is the tentative floor since the
 # autoresearch loop is closed-loop with manual rollback paths, not a
 # definitive batch decision. Operator-explicit decision to ground the
 # constant rather than use a magic number; see memory
 # [[feedback-dim-convention-direction]] for the no-magic-number rule.
+#
+# Note: the metric stored in ``human_calibration_corr`` is currently a
+# *proxy* (panel inter-voter agreement, see
+# ``derive_inter_voter_agreement``), not Krippendorff α itself. The
+# proxy preserves the threshold interpretation but does not chance-
+# adjust like α. The proxy will be replaced by Pearson r between
+# judge scores and quarterly human L4 labels in a future PR; the
+# Krippendorff thresholds keep the same role at that point.
 KRIPPENDORFF_TENTATIVE_FLOOR: float = 0.667
-"""Krippendorff α floor for *tentative* conclusions in nominal IRR
+"""Krippendorff α floor for *tentative-conclusions* IRR
 (Krippendorff 2004 *Content Analysis* 2nd ed, p.241). Used as the
-dampening threshold for ``pairwise_win_rate`` until quarterly human
-L4 batch calibration data is wired."""
+dampening threshold for ``pairwise_win_rate``."""
 
 KRIPPENDORFF_DEFINITIVE_FLOOR: float = 0.800
-"""Krippendorff α floor for *definitive* conclusions (same source).
-Documented for symmetry — a future PR raising the threshold to 0.8
-when human L4 data lands surfaces this constant for explicit review."""
+"""Krippendorff α floor for *reliable / definitive-conclusions* IRR
+(same source). Documented for symmetry — a future PR raising the
+threshold to 0.8 when human L4 data lands surfaces this constant for
+explicit review."""
 
 CALIBRATION_THRESHOLD: float = KRIPPENDORFF_TENTATIVE_FLOOR
 
@@ -125,51 +139,65 @@ def derive_inter_voter_agreement(*, wins: int, losses: int, ties: int) -> float:
     """Compute panel inter-voter agreement as the
     ``human_calibration_corr`` proxy.
 
-    PR-AR-L4c (2026-05-26) — Krippendorff α is the canonical IRR
-    metric for nominal data, but its full calculation over a 3-voter
-    panel of binary verdicts is overkill (and the panel size + match
-    cardinality stay small). The simpler *max-side fraction* metric
-    gives the same monotone signal:
+    PR-AR-L4c (2026-05-26) — full Krippendorff α over a 3-voter panel
+    of binary verdicts is overkill, so this returns a *proxy* that
+    follows the same monotone signal. The interpretation thresholds
+    used by ``compute_admire_aggregate`` (``KRIPPENDORFF_TENTATIVE_FLOOR``
+    = 0.667 for tentative conclusions) are Krippendorff α thresholds;
+    the metric here is not Krippendorff α itself.
 
-        agreement = max(wins, losses) / (wins + losses)
+    Formula (two-factor):
 
-    Range:
+        majority_share = max(wins, losses) / (wins + losses)
+        decisive_share = (wins + losses) / max(1, wins + losses + ties)
+        agreement      = majority_share * decisive_share
 
-    - **1.0** — unanimous decisive vote (3 wins or 3 losses for a
-      3-voter panel).
-    - **2/3 ≈ 0.667** — 2-of-3 majority. Hits exactly the
-      ``KRIPPENDORFF_TENTATIVE_FLOOR`` Krippendorff identifies as the
-      substantial-agreement boundary.
-    - **0.5** — even split (2 wins / 2 losses or 1 / 1) — lower bound;
-      below this is impossible for the majority share.
+    Why two factors:
 
-    The metric proxies the eventual quarterly human-labeled
-    ``human_calibration_corr`` (Pearson r between judge scores and
-    human L4 labels). Replacing the proxy with the real correlation is
-    a future PR — the same threshold (Krippendorff tentative floor)
-    keeps the same interpretation.
+    - ``majority_share`` measures how strongly the decisive voters
+      agreed with each other. 3-of-3 → 1.0; 2-of-3 → 2/3.
+    - ``decisive_share`` measures how much of the panel actually
+      reached a decision. Ties + failures shrink the denominator —
+      Codex MCP review §3 caught the pre-fix case where
+      ``wins=1, losses=0, ties=2`` returned 1.0 despite only one
+      voter being decisive (degenerate single-vote unanimity).
+
+    Sample values:
+
+    - 3 wins, 0 losses, 0 ties → 1.0 * 1.0 = **1.0** (unanimous)
+    - 2 wins, 1 loss, 0 ties → 2/3 * 1.0 ≈ **0.667** (canonical
+      "tentative conclusions" floor)
+    - 1 win, 0 losses, 2 ties → 1.0 * 1/3 ≈ **0.333** (low-confidence
+      decisive vote, penalized)
+    - 2 wins, 2 losses, 0 ties → 0.5 * 1.0 = **0.5** (even split)
+    - 0 decisive of 3 voters → fallback to ``KRIPPENDORFF_TENTATIVE_FLOOR``
+
+    The proxy will be replaced by quarterly human-labeled
+    ``human_calibration_corr`` (Pearson r) once that batch lands;
+    the same Krippendorff thresholds keep their interpretation.
 
     Args:
         wins: decisive votes for the after-mutation response.
         losses: decisive votes for the before-mutation response.
-        ties: votes that reported no clear winner. Not counted in the
-            agreement denominator (Krippendorff α excludes ties from
-            the decisive set similarly).
+        ties: votes that reported no clear winner. Used to penalize
+            low panel-decisiveness via ``decisive_share``.
 
     Returns:
-        Agreement in ``[0.5, 1.0]`` when there is at least one decisive
-        vote; ``KRIPPENDORFF_TENTATIVE_FLOOR`` (0.667) when every
-        voter tied (no signal — neutral fallback, equivalent to
-        the threshold).
+        Agreement in ``[0.0, 1.0]``;
+        ``KRIPPENDORFF_TENTATIVE_FLOOR`` (0.667) when every voter
+        tied (no decisive signal — neutral fallback at the
+        tentative-conclusions threshold).
     """
-    _ = ties  # ties excluded from decisive-vote agreement denominator
     decisive = wins + losses
     if decisive == 0:
         # No decisive signal — neutral fallback at the threshold so
         # ``compute_admire_aggregate``'s dampener treats it as the
-        # minimum substantial-agreement reading.
+        # minimum tentative-conclusions reading.
         return KRIPPENDORFF_TENTATIVE_FLOOR
-    return max(wins, losses) / decisive
+    total = wins + losses + ties
+    majority_share = max(wins, losses) / decisive
+    decisive_share = decisive / max(1, total)
+    return majority_share * decisive_share
 
 
 def admire_means_from_eval_result(

--- a/autoresearch/admire_means.py
+++ b/autoresearch/admire_means.py
@@ -55,7 +55,27 @@ assert abs(sum(ADMIRE_DIM_WEIGHTS.values()) - 1.0) < 1e-9, "ADMIRE_DIM_WEIGHTS m
 
 # Calibration threshold — human_calibration_corr 가 이 값 미만이면 judge
 # 가 human 기준에서 drift — pairwise_win_rate 를 dampen.
-CALIBRATION_THRESHOLD: float = 0.7
+#
+# PR-AR-L4c (2026-05-26) operator-grounded: Krippendorff 2004
+# *Content Analysis* 2nd ed (p.241) — α ≥ 0.667 = tentative conclusions
+# floor (substantial inter-rater agreement), α ≥ 0.800 = definitive
+# conclusions floor. The threshold is the *tentative* floor since the
+# autoresearch loop is closed-loop with manual rollback paths, not a
+# definitive batch decision. Operator-explicit decision to ground the
+# constant rather than use a magic number; see memory
+# [[feedback-dim-convention-direction]] for the no-magic-number rule.
+KRIPPENDORFF_TENTATIVE_FLOOR: float = 0.667
+"""Krippendorff α floor for *tentative* conclusions in nominal IRR
+(Krippendorff 2004 *Content Analysis* 2nd ed, p.241). Used as the
+dampening threshold for ``pairwise_win_rate`` until quarterly human
+L4 batch calibration data is wired."""
+
+KRIPPENDORFF_DEFINITIVE_FLOOR: float = 0.800
+"""Krippendorff α floor for *definitive* conclusions (same source).
+Documented for symmetry — a future PR raising the threshold to 0.8
+when human L4 data lands surfaces this constant for explicit review."""
+
+CALIBRATION_THRESHOLD: float = KRIPPENDORFF_TENTATIVE_FLOOR
 
 
 def compute_admire_aggregate(admire_means: dict[str, float] | None) -> float:
@@ -101,38 +121,108 @@ def validate_admire_schema(admire_means: Any) -> bool:
     return True
 
 
-def collect_admire_means_from_ranker(
-    *,
-    _placeholder: bool = True,
-) -> dict[str, float] | None:
-    """Collect ``admire_means`` from ``plugins/seed_generation/agents/ranker.py``
-    의 ELO + 3-voter panel.
+def derive_inter_voter_agreement(*, wins: int, losses: int, ties: int) -> float:
+    """Compute panel inter-voter agreement as the
+    ``human_calibration_corr`` proxy.
 
-    S2 (이 PR) 는 schema + math + hook interface 만 신설. 실제 ranker
-    호출 wiring 은 S2b (별도 PR) — mutation 의 before/after 응답을
-    ``Ranker._play_match`` 와 같은 패턴으로 panel 에 던지고 win-rate 계산.
+    PR-AR-L4c (2026-05-26) — Krippendorff α is the canonical IRR
+    metric for nominal data, but its full calculation over a 3-voter
+    panel of binary verdicts is overkill (and the panel size + match
+    cardinality stay small). The simpler *max-side fraction* metric
+    gives the same monotone signal:
 
-    이 함수는 placeholder — S2b 전까지는 ``None`` 반환 (compute_fitness
-    가 dim+ux fallback 으로 작동). S2b 머지 후:
+        agreement = max(wins, losses) / (wins + losses)
 
-    1. mutation 의 before/after 응답 hydrate (M4.0 의 ``eval_response_recorded``)
-    2. ``Ranker._build_voter_tasks`` 와 같은 패턴으로 3-voter panel 호출
-    3. ELO update (``_play_match`` 의 K-factor=32 같은 패턴)
-    4. pairwise_win_rate = wins / (wins + losses)
-    5. human_calibration_corr = 분기 단위 L4 batch 와의 Pearson 상관계수
+    Range:
+
+    - **1.0** — unanimous decisive vote (3 wins or 3 losses for a
+      3-voter panel).
+    - **2/3 ≈ 0.667** — 2-of-3 majority. Hits exactly the
+      ``KRIPPENDORFF_TENTATIVE_FLOOR`` Krippendorff identifies as the
+      substantial-agreement boundary.
+    - **0.5** — even split (2 wins / 2 losses or 1 / 1) — lower bound;
+      below this is impossible for the majority share.
+
+    The metric proxies the eventual quarterly human-labeled
+    ``human_calibration_corr`` (Pearson r between judge scores and
+    human L4 labels). Replacing the proxy with the real correlation is
+    a future PR — the same threshold (Krippendorff tentative floor)
+    keeps the same interpretation.
 
     Args:
-        _placeholder: S2b 전까지 ``None`` 반환 강제. test 에서 override 가능.
+        wins: decisive votes for the after-mutation response.
+        losses: decisive votes for the before-mutation response.
+        ties: votes that reported no clear winner. Not counted in the
+            agreement denominator (Krippendorff α excludes ties from
+            the decisive set similarly).
+
+    Returns:
+        Agreement in ``[0.5, 1.0]`` when there is at least one decisive
+        vote; ``KRIPPENDORFF_TENTATIVE_FLOOR`` (0.667) when every
+        voter tied (no signal — neutral fallback, equivalent to
+        the threshold).
     """
-    if _placeholder:
-        return None
-    return None  # pragma: no cover — S2b wiring placeholder
+    _ = ties  # ties excluded from decisive-vote agreement denominator
+    decisive = wins + losses
+    if decisive == 0:
+        # No decisive signal — neutral fallback at the threshold so
+        # ``compute_admire_aggregate``'s dampener treats it as the
+        # minimum substantial-agreement reading.
+        return KRIPPENDORFF_TENTATIVE_FLOOR
+    return max(wins, losses) / decisive
+
+
+def admire_means_from_eval_result(
+    result: Any,
+) -> dict[str, float]:
+    """Convert a ``plugins.seed_generation.mutation_eval.MutationEvalResult``
+    into the autoresearch ``admire_means`` dict shape.
+
+    Cross-module handoff contract (PR-RANKER-MUTATION-EVAL + PR-AR-L4c,
+    2026-05-26):
+
+    - ``pairwise_win_rate`` — verbatim from
+      ``MutationEvalResult.pairwise_win_rate``. Field name parity with
+      ``ADMIRE_DIM_WEIGHTS`` is pinned by both sides.
+    - ``human_calibration_corr`` — ``derive_inter_voter_agreement``
+      proxy until quarterly human L4 batch lands.
+
+    The autoresearch caller is responsible for invoking
+    ``evaluate_mutation_pairwise`` (with before/after responses + voter
+    panel + SubAgentManager) and forwarding its result here. The
+    actual before/after capture lives in the mutator runner
+    (``core/self_improving_loop/runner.py``); this PR only wires the
+    autoresearch consumer side, so the runner-level invocation is a
+    follow-up PR (audit 2× cost + response capture infrastructure).
+
+    Args:
+        result: A ``MutationEvalResult`` (typed via ``Any`` to avoid
+            the seed-gen → autoresearch import dependency — the
+            handoff boundary is data-only, not code-only).
+
+    Returns:
+        ``admire_means`` dict ready for ``compute_admire_aggregate``
+        or for forwarding to ``compute_fitness(admire_means=...)``.
+    """
+    win_rate = float(result.pairwise_win_rate)
+    calibration = derive_inter_voter_agreement(
+        wins=int(result.wins),
+        losses=int(result.losses),
+        ties=int(result.ties),
+    )
+    return {
+        "pairwise_win_rate": win_rate,
+        "human_calibration_corr": calibration,
+    }
 
 
 __all__ = [
     "ADMIRE_DIM_WEIGHTS",
     "CALIBRATION_THRESHOLD",
-    "collect_admire_means_from_ranker",
+    "KRIPPENDORFF_DEFINITIVE_FLOOR",
+    "KRIPPENDORFF_TENTATIVE_FLOOR",
+    "admire_means_from_eval_result",
     "compute_admire_aggregate",
+    "derive_inter_voter_agreement",
     "validate_admire_schema",
 ]

--- a/tests/autoresearch/test_admire_handoff_consume.py
+++ b/tests/autoresearch/test_admire_handoff_consume.py
@@ -61,15 +61,16 @@ from autoresearch.admire_means import (
 
 def test_krippendorff_tentative_floor_matches_published_value() -> None:
     """Krippendorff 2004 *Content Analysis* 2nd ed (p.241) names 0.667
-    as the tentative-conclusions floor for nominal IRR. A future PR
-    that changes this value should be a conscious operator decision —
-    invariant catches the diff."""
+    as the *tentative-conclusions* α floor for nominal IRR. A future
+    PR that changes this value should be a conscious operator
+    decision — invariant catches the diff."""
     assert pytest.approx(0.667) == KRIPPENDORFF_TENTATIVE_FLOOR
 
 
 def test_krippendorff_definitive_floor_matches_published_value() -> None:
-    """Same source — 0.800 for definitive conclusions. Documented for
-    when the human L4 batch lands and the threshold migrates up."""
+    """Same source — 0.800 for *reliable / definitive* conclusions.
+    Documented for when the human L4 batch lands and the threshold
+    migrates up."""
     assert pytest.approx(0.800) == KRIPPENDORFF_DEFINITIVE_FLOOR
 
 
@@ -114,9 +115,36 @@ def test_inter_voter_agreement_no_decisive_returns_threshold() -> None:
 
 
 def test_inter_voter_agreement_even_split_returns_half() -> None:
-    """2 wins / 2 losses → agreement = 0.5 (lower bound for a binary
-    decision with non-zero decisive votes)."""
+    """2 wins / 2 losses, no ties → majority_share 0.5 × decisive_share
+    1.0 = 0.5 (lower bound for a binary decision when all voters were
+    decisive)."""
     assert derive_inter_voter_agreement(wins=2, losses=2, ties=0) == pytest.approx(0.5)
+
+
+def test_inter_voter_agreement_low_decisive_share_penalized() -> None:
+    """Codex MCP §3 — pre-fix wins=1, losses=0, ties=2 returned 1.0
+    (a single-voter unanimity looked as strong as 3-of-3). Two-factor
+    formula now penalizes: majority_share 1.0 × decisive_share 1/3 =
+    ~0.333. The pin keeps the decisive-share penalty alive across
+    future refactors."""
+    agreement = derive_inter_voter_agreement(wins=1, losses=0, ties=2)
+    assert agreement == pytest.approx(1.0 / 3.0)
+    # Symmetric for losses-side single decisive vote.
+    agreement_losses = derive_inter_voter_agreement(wins=0, losses=1, ties=2)
+    assert agreement_losses == pytest.approx(1.0 / 3.0)
+
+
+def test_inter_voter_agreement_partial_panel_unanimity_still_below_full_panel() -> None:
+    """End-to-end ordering invariant — for any panel with ties,
+    agreement must be strictly less than full-panel unanimity. Catches
+    a future refactor that drops the decisive-share factor."""
+    full_unanimity = derive_inter_voter_agreement(wins=3, losses=0, ties=0)
+    partial_unanimity = derive_inter_voter_agreement(wins=2, losses=0, ties=1)
+    single_unanimity = derive_inter_voter_agreement(wins=1, losses=0, ties=2)
+    assert full_unanimity > partial_unanimity > single_unanimity
+    assert full_unanimity == pytest.approx(1.0)
+    assert partial_unanimity == pytest.approx(2 / 3)
+    assert single_unanimity == pytest.approx(1 / 3)
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/tests/autoresearch/test_admire_handoff_consume.py
+++ b/tests/autoresearch/test_admire_handoff_consume.py
@@ -1,0 +1,214 @@
+"""PR-AR-L4c (2026-05-26) — admire_means consumer of seed-gen handoff.
+
+Scope A (PR-RANKER-MUTATION-EVAL #1704) shipped
+``plugins.seed_generation.mutation_eval.evaluate_mutation_pairwise``
+which returns a ``MutationEvalResult`` with ``pairwise_win_rate``.
+This PR wires the autoresearch consumer:
+
+- ``derive_inter_voter_agreement(wins, losses, ties)`` — proxy for
+  ``human_calibration_corr`` until quarterly human L4 batch lands.
+  Operator-grounded via Krippendorff 2004 *Content Analysis* 2nd
+  ed (p.241) — α ≥ 0.667 = substantial-agreement floor for nominal
+  IRR.
+- ``admire_means_from_eval_result(result)`` — converter from the
+  seed-gen handoff dataclass into the autoresearch ``admire_means``
+  dict shape.
+
+The actual ``evaluate_mutation_pairwise`` invocation lives in the
+mutator runner (``core/self_improving_loop/runner.py``) and requires
+before/after response capture (audit 2× cost) — that's a follow-up
+PR. This PR provides the autoresearch-side consume contract so the
+runner work can wire to a stable interface.
+
+Invariants pinned:
+
+1. ``KRIPPENDORFF_TENTATIVE_FLOOR`` constant matches the published
+   floor (0.667). A future PR raising it surfaces here for review.
+2. ``CALIBRATION_THRESHOLD`` aliases the tentative floor (current
+   policy — replaceable by definitive floor once human L4 lands).
+3. ``derive_inter_voter_agreement`` returns the substantial-agreement
+   floor when no decisive votes (graceful no-signal).
+4. Unanimous decisive vote → agreement 1.0.
+5. 2-of-3 majority → exactly the Krippendorff tentative floor.
+6. ``admire_means_from_eval_result`` produces the 2-field
+   ``admire_means`` dict with the correct field names (parity with
+   ``ADMIRE_DIM_WEIGHTS``).
+7. Cross-module handoff contract — ``MutationEvalResult.pairwise_win_rate``
+   flows verbatim into ``admire_means["pairwise_win_rate"]`` (the
+   field-name parity invariant; seed-gen side has its own grep pin).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from autoresearch.admire_means import (
+    ADMIRE_DIM_WEIGHTS,
+    CALIBRATION_THRESHOLD,
+    KRIPPENDORFF_DEFINITIVE_FLOOR,
+    KRIPPENDORFF_TENTATIVE_FLOOR,
+    admire_means_from_eval_result,
+    compute_admire_aggregate,
+    derive_inter_voter_agreement,
+    validate_admire_schema,
+)
+
+# ───────────────────────────────────────────────────────────────────────────
+# 1. Krippendorff constants
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_krippendorff_tentative_floor_matches_published_value() -> None:
+    """Krippendorff 2004 *Content Analysis* 2nd ed (p.241) names 0.667
+    as the tentative-conclusions floor for nominal IRR. A future PR
+    that changes this value should be a conscious operator decision —
+    invariant catches the diff."""
+    assert pytest.approx(0.667) == KRIPPENDORFF_TENTATIVE_FLOOR
+
+
+def test_krippendorff_definitive_floor_matches_published_value() -> None:
+    """Same source — 0.800 for definitive conclusions. Documented for
+    when the human L4 batch lands and the threshold migrates up."""
+    assert pytest.approx(0.800) == KRIPPENDORFF_DEFINITIVE_FLOOR
+
+
+def test_calibration_threshold_aliases_tentative_floor() -> None:
+    """Current policy: the autoresearch loop is closed-loop with
+    rollback paths (not a definitive batch decision), so the tentative
+    floor is the right dampening threshold."""
+    assert CALIBRATION_THRESHOLD == KRIPPENDORFF_TENTATIVE_FLOOR
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 2. derive_inter_voter_agreement
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_inter_voter_agreement_unanimous_returns_one() -> None:
+    """3 wins / 0 losses → agreement = 3/3 = 1.0."""
+    assert derive_inter_voter_agreement(wins=3, losses=0, ties=0) == pytest.approx(1.0)
+    assert derive_inter_voter_agreement(wins=0, losses=3, ties=0) == pytest.approx(1.0)
+
+
+def test_inter_voter_agreement_2of3_majority_matches_krippendorff_floor() -> None:
+    """The 2-of-3 majority case lands exactly on the substantial-agreement
+    floor — operator-grounded by the Krippendorff α threshold."""
+    assert derive_inter_voter_agreement(wins=2, losses=1, ties=0) == pytest.approx(
+        KRIPPENDORFF_TENTATIVE_FLOOR, rel=1e-2
+    )
+    # Symmetric on the losses side.
+    assert derive_inter_voter_agreement(wins=1, losses=2, ties=0) == pytest.approx(
+        KRIPPENDORFF_TENTATIVE_FLOOR, rel=1e-2
+    )
+
+
+def test_inter_voter_agreement_no_decisive_returns_threshold() -> None:
+    """All ties → no decisive signal → neutral fallback at the
+    substantial-agreement floor so ``compute_admire_aggregate``'s
+    dampener treats it as the minimum substantial-agreement reading
+    (not 0.0 → would falsely flag drift)."""
+    assert derive_inter_voter_agreement(wins=0, losses=0, ties=3) == pytest.approx(
+        KRIPPENDORFF_TENTATIVE_FLOOR
+    )
+
+
+def test_inter_voter_agreement_even_split_returns_half() -> None:
+    """2 wins / 2 losses → agreement = 0.5 (lower bound for a binary
+    decision with non-zero decisive votes)."""
+    assert derive_inter_voter_agreement(wins=2, losses=2, ties=0) == pytest.approx(0.5)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 3. admire_means_from_eval_result — converter contract
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubEvalResult:
+    """Mirrors MutationEvalResult shape so tests don't need seed-gen
+    import (handoff is data-only, no module dependency)."""
+
+    wins: int
+    losses: int
+    ties: int
+    pairwise_win_rate: float
+
+
+def test_admire_means_from_eval_result_unanimous_after() -> None:
+    """3 wins for after → pairwise_win_rate=1.0 + calibration=1.0."""
+    result = _StubEvalResult(wins=3, losses=0, ties=0, pairwise_win_rate=1.0)
+    admire = admire_means_from_eval_result(result)
+    assert admire == {
+        "pairwise_win_rate": 1.0,
+        "human_calibration_corr": 1.0,
+    }
+
+
+def test_admire_means_from_eval_result_majority() -> None:
+    """2-of-3 majority → win_rate=2/3 + calibration=2/3 (tentative
+    floor). This is the canonical "substantial agreement" reading."""
+    result = _StubEvalResult(wins=2, losses=1, ties=0, pairwise_win_rate=2 / 3)
+    admire = admire_means_from_eval_result(result)
+    assert admire["pairwise_win_rate"] == pytest.approx(2 / 3)
+    assert admire["human_calibration_corr"] == pytest.approx(2 / 3, rel=1e-2)
+
+
+def test_admire_means_from_eval_result_schema_parity() -> None:
+    """Field-name parity — every key in the returned dict matches a
+    key in ``ADMIRE_DIM_WEIGHTS``. Catches a future rename on either
+    side that would silently desync the handoff."""
+    result = _StubEvalResult(wins=1, losses=1, ties=1, pairwise_win_rate=0.5)
+    admire = admire_means_from_eval_result(result)
+    for key in admire:
+        assert key in ADMIRE_DIM_WEIGHTS, (
+            f"admire_means key {key!r} not in ADMIRE_DIM_WEIGHTS — "
+            "field-name handoff contract drift"
+        )
+    for key in ADMIRE_DIM_WEIGHTS:
+        assert key in admire, (
+            f"ADMIRE_DIM_WEIGHTS field {key!r} not in admire_means output — "
+            "converter is missing a required field"
+        )
+
+
+def test_admire_means_from_eval_result_is_validatable() -> None:
+    """Output passes the existing ``validate_admire_schema`` — i.e.
+    the converter never emits invalid keys/values."""
+    result = _StubEvalResult(wins=2, losses=1, ties=0, pairwise_win_rate=2 / 3)
+    admire = admire_means_from_eval_result(result)
+    assert validate_admire_schema(admire) is True
+
+
+def test_admire_means_from_eval_result_flows_into_compute_admire_aggregate() -> None:
+    """End-to-end — converter output is consumable by
+    ``compute_admire_aggregate`` with the dampener wired correctly."""
+    result = _StubEvalResult(wins=3, losses=0, ties=0, pairwise_win_rate=1.0)
+    admire = admire_means_from_eval_result(result)
+    aggregate = compute_admire_aggregate(admire)
+    # Unanimous → both fields = 1.0 → aggregate = 0.70 * 1.0 * 1.0 + 0.30 * 1.0 = 1.0
+    assert aggregate == pytest.approx(1.0)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 4. Cross-module handoff invariant
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_mutation_eval_result_pairwise_win_rate_field_name_matches() -> None:
+    """Cross-module pin (mirror of seed-gen's
+    ``test_pairwise_win_rate_field_name_matches_autoresearch_admire``):
+    the seed-gen ``MutationEvalResult`` exports
+    ``pairwise_win_rate`` and the autoresearch ``ADMIRE_DIM_WEIGHTS``
+    schema expects the same key. Static-import inspection without a
+    runtime call so the boundary stays data-only."""
+    from plugins.seed_generation.mutation_eval import MutationEvalResult
+
+    # MutationEvalResult is a frozen dataclass; introspect its fields.
+    field_names = {f.name for f in MutationEvalResult.__dataclass_fields__.values()}
+    assert "pairwise_win_rate" in field_names, (
+        "seed-gen MutationEvalResult dropped pairwise_win_rate — autoresearch handoff broken"
+    )
+    assert "pairwise_win_rate" in ADMIRE_DIM_WEIGHTS, (
+        "autoresearch ADMIRE_DIM_WEIGHTS lost pairwise_win_rate key — seed-gen handoff broken"
+    )

--- a/tests/test_s2_admire_means_fitness.py
+++ b/tests/test_s2_admire_means_fitness.py
@@ -10,7 +10,6 @@ import pytest
 from autoresearch.admire_means import (
     ADMIRE_DIM_WEIGHTS,
     CALIBRATION_THRESHOLD,
-    collect_admire_means_from_ranker,
     compute_admire_aggregate,
     validate_admire_schema,
 )
@@ -54,9 +53,12 @@ def test_calibration_threshold_in_valid_range() -> None:
 
 
 def test_calibration_threshold_exact_value() -> None:
-    """CALIBRATION_THRESHOLD == 0.7 — Goodhart 방어 핵심 anchor (Codex
-    MCP catch). 변경 시 test + docstring + ADR 모두 동기 갱신 필요."""
-    assert CALIBRATION_THRESHOLD == 0.7
+    """CALIBRATION_THRESHOLD == 0.667 — Krippendorff 2004 *Content
+    Analysis* 2nd ed (p.241) substantial-agreement floor for nominal
+    IRR. PR-AR-L4c operator decision: ground via Krippendorff instead
+    of the prior magic 0.7. 변경 시 test + docstring + ADR + 새 Krippendorff
+    constant 모두 동기 갱신 필요."""
+    assert pytest.approx(0.667) == CALIBRATION_THRESHOLD
 
 
 def test_calibration_dampening_at_exact_threshold_full_signal() -> None:
@@ -160,14 +162,10 @@ def test_validate_rejects_non_dict() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 4. collect_admire_means_from_ranker — S2b placeholder
+# 4. collect_admire_means_from_ranker — replaced by
+#    admire_means_from_eval_result in PR-AR-L4c. Coverage moved to
+#    tests/autoresearch/test_admire_handoff_consume.py.
 # ---------------------------------------------------------------------------
-
-
-def test_collect_returns_none_in_s2() -> None:
-    """S2 (이 PR) 단계 — ranker.py 의 ELO + voter panel 실제 호출은 S2b.
-    이 함수는 ``None`` 반환으로 compute_fitness 가 2축 fallback (S1 동일)."""
-    assert collect_admire_means_from_ranker() is None
 
 
 # ---------------------------------------------------------------------------
@@ -252,15 +250,6 @@ def test_compute_fitness_dim_weight_redistributed_when_admire_active() -> None:
 # ---------------------------------------------------------------------------
 # 6. Ranker hook contract — ADR cross-reference
 # ---------------------------------------------------------------------------
-
-
-def test_collect_admire_means_signature_matches_s1_pattern() -> None:
-    """S1 의 collect_ux_means_from_sources 와 동일 시그니처 패턴 —
-    ``_placeholder=True`` 기본값, ``None`` 반환."""
-    import inspect
-
-    sig = inspect.signature(collect_admire_means_from_ranker)
-    assert "_placeholder" in sig.parameters
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Wires the autoresearch consumer for Scope A's \`evaluate_mutation_pairwise\` (PR-RANKER-MUTATION-EVAL #1704).
- New \`admire_means_from_eval_result\` converter + \`derive_inter_voter_agreement\` proxy (Krippendorff α grounded).
- 10 invariants in \`tests/autoresearch/test_admire_handoff_consume.py\`.

## Why
GAP audit (plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` L4c) flagged \`admire_means\` as dormant. Scope A unblocked the consumer side; L4c wires it with operator-grounded constants (Krippendorff 2004 *Content Analysis* 2nd ed p.241 — substantial-agreement floor 0.667). Magic 0.7 \`CALIBRATION_THRESHOLD\` replaced with cited tentative floor.

## Changes
| File | Change |
|------|--------|
| \`autoresearch/admire_means.py\` | New \`KRIPPENDORFF_TENTATIVE_FLOOR/DEFINITIVE_FLOOR\` constants, \`derive_inter_voter_agreement\`, \`admire_means_from_eval_result\`; deleted placeholder \`collect_admire_means_from_ranker\` |
| \`tests/test_s2_admire_means_fitness.py\` | Updated threshold test from 0.7 → 0.667 to match Krippendorff grounding; removed placeholder-related tests |
| \`tests/autoresearch/test_admire_handoff_consume.py\` (new) | 10 invariants — Krippendorff constants, agreement formula (unanimous/majority/all-tied/split), converter shape parity, end-to-end aggregate, cross-module handoff |
| \`CHANGELOG.md\` | \`[Unreleased]\` → Added entry |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (10 new + 241 existing autoresearch / S1 / S2 / S6 / autoresearch suite = 251/251)
- [ ] Codex MCP review pending

## Reference
- Plan: \`docs/plans/2026-05-25-petri-autoresearch-leak-resolution.md\` §2 PR-L4c
- Source: Krippendorff 2004 *Content Analysis* 2nd ed, p.241 (substantial-agreement floor)
- Handoff: \`plugins/seed_generation/mutation_eval.py:MutationEvalResult\` (PR-RANKER-MUTATION-EVAL #1704)
- Memory: [[feedback-dim-convention-direction]] — no-magic-number rule