### PR TITLE
fix(seed-gen): register supervisor role (PR-SUPERVISOR-ENABLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-SUPERVISOR-ENABLE — register supervisor in the seed-gen
+  manifest so the orchestrator doesn't `phase_skipped` it.** Pre-fix
+  `enabled_roles` (`plugins/seed_generation/seed_generation.plugin.toml`)
+  had 8 roles and `supervisor` was NOT one of them; `[seed_generation.
+  role.supervisor]` section did not exist either. Smoke 19 transcript
+  caught the consequence on line 4: `"event": "phase_skipped",
+  "payload": {"role": "supervisor", "reason": "agent_not_registered"}`.
+  Per the run's `state/seed-generation/<run_id>/sub_agents/` dir the
+  supervisor never spawned; per `checkpoints/` no `supervisor.json`
+  landed. PR-1 (#1698) SUPERVISOR_SCHEMA wire was a necessary fix
+  but not sufficient — schema couldn't reach the LLM because the
+  registry builder's main loop never visited supervisor (it iterates
+  `manifest.enabled_roles`). Fix: add `supervisor` to enabled_roles +
+  the matching role spec section (default_model `claude-opus-4-7`
+  per the Supervisor.py docstring, allowed list mirrors
+  meta_reviewer's run-level analyst pattern). `_ROLE_TO_CLASS` in
+  `_registry_builder.py` adds `Supervisor` so the main loop registers
+  it cleanly (the legacy fallback at the end stays as defensive code
+  for future manifest revisions). Pinned by 4 invariants in
+  `test_registry_wireup.py::test_populate_registry_supervisor_registered`
+  (manifest enabled_roles + role spec + picker binding + registry
+  registration + concrete-class check + model wiring) +
+  `test_bundled_manifest_loads` updated to include supervisor in the
+  expected enabled set.
+
 ### Added
 - **PR-SELF-IMPROVING-HUB** — `/geode/self-improving/` landing hub +
   full DESIGN.md scaffolding for 9 hub-surface pages. Replaces

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -177,6 +177,7 @@ def populate_registry(
     from plugins.seed_generation.agents.pilot import Pilot
     from plugins.seed_generation.agents.proximity import Proximity
     from plugins.seed_generation.agents.ranker import Ranker
+    from plugins.seed_generation.agents.supervisor import Supervisor
 
     _ROLE_TO_CLASS: dict[str, type[BaseSeedAgent]] = {
         "generator": Generator,
@@ -186,6 +187,16 @@ def populate_registry(
         "evolver": Evolver,
         "meta_reviewer": MetaReviewer,
         "literature_review": LiteratureReview,
+        # PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor now in
+        # ``enabled_roles`` (manifest fix). Registering via the main
+        # loop avoids the legacy ``"no agent class for role"`` warning
+        # the fallback path would have emitted, and makes the
+        # supervisor wiring symmetric with the other 7 roles. The
+        # legacy ``if "supervisor" not in registry.list_roles()``
+        # fallback below stays as defensive code (handles future
+        # manifest revisions that drop supervisor from enabled_roles
+        # but still expect it to spawn).
+        "supervisor": Supervisor,
     }
 
     for role_name in manifest.enabled_roles:

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -40,6 +40,17 @@ enabled_roles = [
     "pilot",
     "proximity",
     "ranker",
+    # PR-SUPERVISOR-ENABLE (2026-05-26) — pre-fix the supervisor role
+    # had no ``[seed_generation.role.supervisor]`` section AND was not
+    # in this enabled_roles list, so ``_registry_builder.py`` 's
+    # ``for role_name in manifest.enabled_roles`` loop never registered
+    # it. The orchestrator emitted ``phase_skipped
+    # reason=agent_not_registered`` for supervisor on every run.
+    # Smoke 19 confirmed: checkpoints/ had no ``supervisor.json``,
+    # ``sub_agents/`` had no ``supervisor-*`` dir, transcript line 4
+    # carried the explicit skip reason. PR-1 (#1698) SUPERVISOR_SCHEMA
+    # wire was a partial fix — necessary but not sufficient.
+    "supervisor",
 ]
 
 # ── Roles ────────────────────────────────────────────────────────────────────
@@ -134,6 +145,22 @@ allowed_models = [
     "gpt-5.5",
 ]
 role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
+
+# PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor role spec section.
+# Defaults mirror ``plugins/seed_generation/agents/supervisor.py``'s
+# ``_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"`` (per the role
+# docstring: "Run-level strategy synthesis. Dispatches ONE Opus
+# sub-agent" — Opus chosen because supervisor's output gates the
+# value of every downstream call). Allowed list mirrors meta_reviewer
+# (same single-shot, run-level analyst pattern).
+[seed_generation.role.supervisor]
+default_model = "claude-opus-4-7"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "gpt-5.5",
+]
+role_contract = "plugins/seed_generation/agents/supervisor.md"
 
 # CSP-14 (2026-05-23) — Loop 3 (literature paper-analysis) role of the
 # 3-loop port. Runs once per run, after Supervisor + before Generator.

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -118,6 +118,11 @@ def test_bundled_manifest_loads() -> None:
         "pilot",
         "proximity",
         "ranker",
+        # PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor added to
+        # enabled_roles so _registry_builder.py registers it via the
+        # main loop. Pre-fix smoke 19 transcript caught
+        # phase_skipped reason=agent_not_registered.
+        "supervisor",
     }
     assert manifest.voter_diversity() >= 2
 

--- a/tests/plugins/seed_generation/test_registry_wireup.py
+++ b/tests/plugins/seed_generation/test_registry_wireup.py
@@ -72,3 +72,48 @@ def test_populate_registry_ranker_receives_voters() -> None:
     # The Ranker stores voters on a private attribute; the externally-visible
     # invariant is that the registry has the ranker role + picker has voters.
     assert len(picker.voters) >= 1
+
+
+def test_populate_registry_supervisor_registered() -> None:
+    """PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor must be registered
+    (was silently skipped pre-fix with ``agent_not_registered`` in the
+    orchestrator transcript; smoke 19 evidence).
+
+    Pre-fix: ``enabled_roles`` did not include ``"supervisor"`` AND the
+    ``[seed_generation.role.supervisor]`` section was absent. The
+    main registration loop never visited supervisor, and the fallback
+    ``picker_result.bindings.get("supervisor")`` returned None
+    because the picker only resolves bindings for ``enabled_roles``.
+    Net effect: every smoke run emitted ``phase_skipped
+    reason=agent_not_registered`` for supervisor and the supervisor.json
+    checkpoint never landed.
+
+    Fix: added supervisor to manifest enabled_roles + role section +
+    Supervisor to ``_ROLE_TO_CLASS``. This test pins all three
+    necessary conditions.
+    """
+    picker = pick_bindings(auto_probe=False)
+    manifest = load_manifest()
+    # Necessary condition 1 — manifest enables supervisor.
+    assert "supervisor" in manifest.enabled_roles
+    # Necessary condition 2 — manifest defines a supervisor role spec.
+    assert "supervisor" in manifest.roles
+    # Necessary condition 3 — picker resolves a supervisor binding.
+    assert picker.bindings.get("supervisor") is not None
+    registry = PipelineRegistry()
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    # Sufficient condition — registry has the supervisor role.
+    assert "supervisor" in registry.list_roles(), (
+        "supervisor not registered — orchestrator will emit "
+        "phase_skipped reason=agent_not_registered (smoke 19 regression)"
+    )
+    supervisor = registry.get("supervisor")
+    assert supervisor is not None
+    # Concrete class check — must be Supervisor (not something else
+    # accidentally registered under the same role key).
+    from plugins.seed_generation.agents.supervisor import Supervisor
+
+    assert isinstance(supervisor, Supervisor)
+    # The supervisor binding's model is the manifest default (opus per
+    # the role docstring); confirm the wiring propagated.
+    assert supervisor.model == manifest.roles["supervisor"].default_model


### PR DESCRIPTION
## Summary
- Add `supervisor` to manifest `enabled_roles` + the matching `[seed_generation.role.supervisor]` section.
- Add `Supervisor` to `_registry_builder.py:_ROLE_TO_CLASS` so the main loop registers it.
- Smoke 19 transcript caught the regression: `phase_skipped reason=agent_not_registered` for supervisor.

## Why
PR-1 (#1698) wired SUPERVISOR_SCHEMA into supervisor.py's SubTask but the orchestrator never even reached that code path — the registry builder's main loop iterates `manifest.enabled_roles`, and supervisor was missing from both that list AND the `[seed_generation.role.supervisor]` section, so the phase was skipped upstream. supervisor.json checkpoint never landed across smoke 17/18/19.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/seed_generation.plugin.toml` | Add `supervisor` to `enabled_roles` + new `[seed_generation.role.supervisor]` section |
| `plugins/seed_generation/_registry_builder.py` | Add `Supervisor` to `_ROLE_TO_CLASS` map |
| `tests/plugins/seed_generation/test_registry_wireup.py` | New `test_populate_registry_supervisor_registered` (4 invariants) |
| `tests/plugins/seed_generation/test_manifest.py` | Update expected `enabled_roles` set |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry |

## Verification
- [x] ruff check + format clean
- [x] mypy clean
- [x] pytest tests/plugins/seed_generation/ — 577 pass, 3 skipped

## Reference
- Smoke 19 archive: `.audit/smoke-archives/smoke-19-partial-1779751602/transcript.jsonl` line 4 — the smoking-gun `phase_skipped` event
- Sprint D PR-D1 (3 PRs total: this + #100 transient-classifier + #97 codex-multiturn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)