### PR TITLE
fix(petri): narrow transient classifier scope (PR-TRANSIENT-CLASSIFIER-SCOPE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,54 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-TRANSIENT-CLASSIFIER-SCOPE — narrow claude-cli transient
+  classifier scope to suppress smoke-19 LLM-prose false positives.**
+  ``plugins/petri_audit/claude_cli_provider.py:classify_transient_signal``
+  pre-fix walked raw stdout first, then events. In stream-json mode
+  the raw stdout is just the concatenation of stream-json lines —
+  the LLM's free-form prose inside ``{"type":"assistant","message":
+  {"content":[{"type":"text","text":"..."}]}}`` is in there
+  verbatim. Smoke 19 (``.audit/smoke-archives/smoke-19-partial-
+  1779751602/``) caught 5 false-positive aborts where the LLM
+  legitimately wrote ``"rate-limited to 30 calls / 5 min"`` in seed
+  bodies targeting ``redundant_tool_invocation`` (scenario describing
+  rate-limited tools). The transient regex matched on raw stdout and
+  the generator phase aborted as a fake API rate-limit.
+  Fix (2 layers):
+  (a) Demote raw stdout scan to fallback-only — only fires when
+      ``events`` parse produced nothing (genuine pre-protocol
+      failure). When events exist the structured event-walk covers
+      every legitimate signal source; re-scanning the raw stream
+      only risks the LLM-prose false positive.
+  (b) Add ``_ASSISTANT_HEADER_LIMIT = 200`` heuristic on the
+      assistant + content_block_delta scans. Claude-CLI's internal
+      error injections (PR-T case, smoke 9-12 evidence) put the
+      transient phrase at offset 0 of the text block
+      (``"Claude usage limit reached. Resets at 4pm."`` /
+      ``"! Unexpected error. Auto-retrying."``). LLM-authored
+      scenario prose buries the vocabulary mid-paragraph at offset
+      200+. The heuristic preserves the PR-T detection path while
+      eliminating the smoke 19 false positive.
+  Codex MCP cross-LLM review caught an additional gap: streaming
+  ``content_block_delta`` events were not scanned at all (would
+  silently bypass detection if claude-cli streamed an error via
+  deltas instead of an aggregated assistant message). Folded
+  in-band: added a parallel ``content_block_delta`` branch with
+  the same header-limit heuristic. Plus doc drift fixes (3 →
+  actual 5 dumps; dropped a claim about a ``signal.match_offset``
+  field that doesn't exist).
+  Pinned by 4 new + 2 updated tests in
+  ``test_claude_cli_transient_classifier.py``:
+  ``test_classify_signal_search_order_events_first_stdout_fallback``,
+  ``test_classify_signal_stdout_fallback_when_events_empty``,
+  ``test_classify_signal_content_block_delta_transient_match``,
+  ``test_classify_signal_content_block_delta_header_limit_suppresses``,
+  ``test_classify_signal_smoke19_llm_seed_prose_not_false_positive``,
+  plus ``test_adapter_transient_carries_signal_dataclass`` updated
+  to assert the new ``source="event"/event_type="assistant"``
+  ordering. 864 pass / 35 skipped in petri_audit + core/llm.
+
 ### Added
 - **PR-SELF-IMPROVING-HUB** — `/geode/self-improving/` landing hub +
   full DESIGN.md scaffolding for 9 hub-surface pages. Replaces

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -272,6 +272,22 @@ CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
 )
 
 
+# PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — when scanning assistant
+# text blocks for upstream signals, only consider matches that land
+# within the first ``_ASSISTANT_HEADER_LIMIT`` characters. CLI-internal
+# error injections (the PR-T quota-leak case, smoke 9-12) put the
+# transient phrase at offset 0:
+#   "Claude usage limit reached. Resets at 4pm."
+#   "! Unexpected error. Auto-retrying."
+# LLM-authored seed bodies that use the same vocabulary in scenario
+# descriptions bury the phrase mid-paragraph (smoke 19 evidence: 5
+# false-positive dumps where ``"rate-limited to 30 calls"`` appeared
+# at offset 200-500 inside a tool catalog block). 200 chars covers
+# every known CLI-injection shape with margin while excluding all
+# observed LLM-prose false positives.
+_ASSISTANT_HEADER_LIMIT = 200
+
+
 @dataclass(frozen=True, slots=True)
 class StreamJsonEvent:
     """One row of ``claude --print --output-format stream-json``.
@@ -663,27 +679,45 @@ def classify_transient_signal(
     events: list[StreamJsonEvent] | None = None,
 ) -> TransientSignal | None:
     """Return the first :class:`TransientSignal` hit on the union of
-    raw stdout, raw stderr, every parsed ``result`` event's free-text
-    fields, and every ``assistant`` text block's ``text``. ``None``
-    when nothing matches.
+    raw stderr, every parsed ``result`` event's free-text fields,
+    every ``assistant`` text block's ``text``, and raw stdout (only as
+    a fallback when ``events`` is empty). ``None`` when nothing matches.
 
     Pre-PR-T this was :func:`is_claude_transient_upstream_error`
     returning ``bool`` — callers couldn't tell which signal fired so
     the post-mortem could not act on the actual upstream signature
     (rate_limit vs overloaded vs quota-reset). The dataclass-returning
-    form preserves the matched substring + source field so
-    log readers and operators get an actionable diagnostic.
+    form preserves the matched substring + source field so log readers
+    and operators get an actionable diagnostic.
 
-    Search order matches paperclip's ``buildClaudeTransientHaystack``:
-    raw stdout / stderr first, then events in arrival order.
+    PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — narrowed the raw
+    stdout scan to fallback-only. ``claude --print --output-format
+    stream-json`` emits every stream-json chunk to stdout — including
+    the assistant's free-form prose inside
+    ``{"type":"assistant","message":{"content":[{"type":"text",
+    "text":"..."}]}}`` lines. The regex
+    ``CLAUDE_TRANSIENT_UPSTREAM_RE`` matched ``"rate-limited to 30
+    calls"`` inside the LLM's seed-body prose for the
+    ``redundant_tool_invocation`` audit dim
+    (smoke 19: 5 false-positive dumps in
+    ``~/.geode/diagnostics/claude-cli-transient/1779750554-...`` etc).
+    The fix: scan stderr + parsed event branches first; only fall
+    back to raw stdout when ``events`` parsing produced nothing
+    (genuine protocol-level failure with no structured output).
+
+    The ``assistant`` event walk is RETAINED (not removed) — PR-T
+    added it because claude-cli's internal retry storm leaks
+    ``"Claude usage limit reached. Resets at 4pm."`` into the
+    assistant stream (smoke 9-12 evidence), and dropping that scan
+    would regress detection of those genuine upstream signals.
+    The smoke 19 false positive came from the stdout scan, not the
+    assistant scan — the LLM's seed body was in a single block
+    matched by ``stdout`` source per the dump's ``signal.source``
+    field, not ``event``.
+
+    Search order: stderr → result-event fields → assistant text →
+    raw stdout (fallback only).
     """
-    if stdout:
-        match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(stdout)
-        if match:
-            return TransientSignal(
-                matched_text=_signal_excerpt(stdout, match),
-                source="stdout",
-            )
     if stderr:
         match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(stderr)
         if match:
@@ -691,44 +725,113 @@ def classify_transient_signal(
                 matched_text=_signal_excerpt(stderr, match),
                 source="stderr",
             )
-    if not events:
-        return None
-    for event in events:
-        if event.type == "result":
-            for key in ("result", "error", "message", "stderr"):
-                value = event.payload.get(key)
-                if not isinstance(value, str):
+    if events:
+        for event in events:
+            if event.type == "result":
+                for key in ("result", "error", "message", "stderr"):
+                    value = event.payload.get(key)
+                    if not isinstance(value, str):
+                        continue
+                    match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(value)
+                    if match:
+                        return TransientSignal(
+                            matched_text=_signal_excerpt(value, match),
+                            source="event",
+                            event_type="result",
+                            event_field=key,
+                        )
+            elif event.type == "assistant":
+                message = event.payload.get("message", {})
+                if not isinstance(message, dict):
                     continue
-                match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(value)
-                if match:
-                    return TransientSignal(
-                        matched_text=_signal_excerpt(value, match),
-                        source="event",
-                        event_type="result",
-                        event_field=key,
-                    )
-        elif event.type == "assistant":
-            message = event.payload.get("message", {})
-            if not isinstance(message, dict):
-                continue
-            content = message.get("content", [])
-            if not isinstance(content, list):
-                continue
-            for block in content:
-                if not isinstance(block, dict):
+                content = message.get("content", [])
+                if not isinstance(content, list):
                     continue
-                if block.get("type") != "text":
-                    continue
-                text = block.get("text", "")
-                if not isinstance(text, str):
-                    continue
-                match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
-                if match:
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "text":
+                        continue
+                    text = block.get("text", "")
+                    if not isinstance(text, str):
+                        continue
+                    match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
+                    if not match:
+                        continue
+                    # PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) —
+                    # smoke 19 false-positive guard. Claude-CLI's
+                    # internal error injections (PR-T case, smoke
+                    # 9-12) put the upstream phrase at the START of
+                    # the assistant message:
+                    #   "Claude usage limit reached. Resets at 4pm."
+                    #   "! Unexpected error. Auto-retrying."
+                    # LLM-authored seed prose with the same
+                    # vocabulary buries the phrase in a multi-line
+                    # paragraph:
+                    #   "...searches structured logs; ~4s per call,
+                    #    rate-limited to 30 calls / 5 min..."
+                    # Require the match position to be within the
+                    # first ``_ASSISTANT_HEADER_LIMIT`` characters of
+                    # the text block. CLI errors land at offset 0;
+                    # LLM prose containing the vocabulary in scenario
+                    # descriptions lands at 200+. This is a heuristic
+                    # — operators can audit the dump file when in
+                    # doubt.
+                    if match.start() >= _ASSISTANT_HEADER_LIMIT:
+                        continue
                     return TransientSignal(
                         matched_text=_signal_excerpt(text, match),
                         source="event",
                         event_type="assistant",
                     )
+            elif event.type == "content_block_delta":
+                # PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26, Codex
+                # MCP catch) — claude-cli streaming mode emits text
+                # deltas as separate events; ``_extract_assistant_text``
+                # treats these as a valid text source (per its priority
+                # ordering at line 587). Without this branch, a CLI
+                # error injected via the streaming path would silently
+                # bypass detection. Same header-limit heuristic
+                # applies — CLI-injected errors arrive in the first
+                # delta of the message, LLM-prose deltas accumulate
+                # over many chunks.
+                delta = event.payload.get("delta", {})
+                if not isinstance(delta, dict):
+                    continue
+                if delta.get("type") != "text_delta":
+                    continue
+                text = delta.get("text", "")
+                if not isinstance(text, str):
+                    continue
+                match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
+                if not match:
+                    continue
+                if match.start() >= _ASSISTANT_HEADER_LIMIT:
+                    continue
+                return TransientSignal(
+                    matched_text=_signal_excerpt(text, match),
+                    source="event",
+                    event_type="content_block_delta",
+                )
+        # Events parsed successfully — the raw stdout is just the
+        # concatenation of those parsed lines (each line is a JSON
+        # event), so scanning it again would only re-surface the
+        # LLM's assistant prose as a false positive
+        # (PR-TRANSIENT-CLASSIFIER-SCOPE, smoke 19 fix). The
+        # event-walk above has already covered every structured
+        # field the CLI uses for genuine signals.
+        return None
+    # Events list is empty / None — parse failed entirely. The raw
+    # stdout is the only remaining signal source; if the CLI errored
+    # before any stream-json envelope was emitted, the assistant
+    # never produced content that could false-positive.
+    if stdout:
+        match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(stdout)
+        if match:
+            return TransientSignal(
+                matched_text=_signal_excerpt(stdout, match),
+                source="stdout",
+            )
     return None
 
 

--- a/tests/core/llm/adapters/test_claude_cli_adapter.py
+++ b/tests/core/llm/adapters/test_claude_cli_adapter.py
@@ -215,17 +215,22 @@ def test_adapter_transient_carries_signal_dataclass() -> None:
             raise AssertionError("expected ClaudeCliTransientUpstreamError")
         except ClaudeCliTransientUpstreamError as exc:
             assert exc.signal is not None
-            # The classifier walks stdout first (paperclip ordering); the
-            # raw stream-json stdout contains the JSON-encoded matched text
-            # so the hit lands on ``source="stdout"`` before the parser
-            # gets a chance to surface the ``assistant`` event source.
-            # That is correct behaviour — raw evidence beats parsed.
-            assert exc.signal.source == "stdout"
+            # PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — classifier
+            # now walks stderr → events → stdout-fallback (events
+            # first ordering). The raw stream-json stdout scan was
+            # demoted to fallback after smoke 19 false positives —
+            # LLM-authored seed prose containing "rate-limited tools"
+            # was triggering the regex on raw stdout. The
+            # ``assistant`` event match now surfaces with
+            # ``source="event"`` + ``event_type="assistant"`` (the
+            # PR-T quota-leak detection path is preserved).
+            assert exc.signal.source == "event"
+            assert exc.signal.event_type == "assistant"
             assert "Unexpected error" in exc.signal.matched_text
             # Exception message includes the source/matched_text inline
             # so a single log line is enough for triage.
             msg = str(exc)
-            assert "source=stdout" in msg
+            assert "source=event/assistant" in msg
             assert "matched=" in msg
 
 

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -308,15 +308,26 @@ def test_classify_signal_negative_returns_none() -> None:
     )
 
 
-def test_classify_signal_search_order_stdout_first() -> None:
-    """Raw stdout match wins over any event match — paperclip's
-    ``buildClaudeTransientHaystack`` walks raw fields first because
-    they're the rawest evidence (no parser intermediate)."""
+def test_classify_signal_search_order_events_first_stdout_fallback() -> None:
+    """PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — when events parse
+    successfully the raw stdout scan is skipped (events first), then
+    stdout only fires as a fallback when events is empty.
+
+    Pre-fix the classifier walked stdout first, which surfaced
+    LLM-authored seed prose containing "rate-limited" or similar
+    scenario text as false-positive transient signals (smoke 19
+    evidence). The raw stdout in stream-json mode is just the
+    concatenation of the parsed events, so the event-walk above
+    already covers every structured field — a stdout re-scan only
+    risks the LLM's free-form prose triggering the regex.
+    """
     from plugins.petri_audit.claude_cli_provider import (
         classify_transient_signal,
         parse_stream_json_events,
     )
 
+    # When stdout AND events both have transient signals, events wins
+    # (the structured signal is the real upstream evidence).
     stdout_with_match = "429 throttling at the wrapper layer\n"
     events_with_match = parse_stream_json_events(
         _make_stream_json([{"type": "result", "error": "overloaded_error", "result": ""}])
@@ -325,10 +336,152 @@ def test_classify_signal_search_order_stdout_first() -> None:
         stdout=stdout_with_match, stderr="", events=events_with_match
     )
     assert signal is not None
+    # Event hit wins now — source is "event", event_field carries the
+    # field name. The stdout hit is suppressed because events parsed.
+    assert signal.source == "event"
+    assert signal.event_field == "error"
+    assert "overloaded" in signal.matched_text
+
+
+def test_classify_signal_stdout_fallback_when_events_empty() -> None:
+    """PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — when events is
+    empty (parse failed entirely → CLI errored before any stream-json
+    envelope), the raw stdout scan IS exercised as the last-resort
+    signal source. This keeps detection working on genuine
+    pre-protocol failures."""
+    from plugins.petri_audit.claude_cli_provider import classify_transient_signal
+
+    signal = classify_transient_signal(
+        stdout="rate_limit exceeded before stream started\n",
+        stderr="",
+        events=[],
+    )
+    assert signal is not None
     assert signal.source == "stdout"
-    # Verifies stdout hit takes precedence — event hit (overloaded_error)
-    # is not the matched_text.
-    assert "overloaded" not in signal.matched_text
+    assert "rate_limit" in signal.matched_text
+
+
+def test_classify_signal_content_block_delta_transient_match() -> None:
+    """PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26, Codex MCP catch) —
+    streaming text_delta events must be scanned too.
+
+    ``_extract_assistant_text`` treats ``content_block_delta`` as a
+    first-class text source (priority over aggregated assistant +
+    result events per its docstring). Without scanning these events
+    a CLI error emitted via the streaming path would silently bypass
+    detection. Same header-limit heuristic applies — CLI-injected
+    errors arrive in the FIRST delta chunk, LLM prose accumulates
+    over many.
+    """
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "content_block_delta",
+                "delta": {
+                    "type": "text_delta",
+                    "text": "Claude usage limit reached. Resets at 4pm.",
+                },
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout=stdout, stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.source == "event"
+    assert signal.event_type == "content_block_delta"
+    assert "usage limit reached" in signal.matched_text.lower()
+
+
+def test_classify_signal_content_block_delta_header_limit_suppresses() -> None:
+    """Mid-paragraph 'rate-limited' in a delta chunk is suppressed
+    (mirrors the assistant-event header-limit heuristic — same false-
+    positive shape, same defence)."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    long_prefix = "Tool catalog described below. " * 10  # ~ 300 chars
+    delta_text = long_prefix + "Each call is rate-limited to 30 / 5 min.\n"
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": delta_text},
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout=stdout, stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is None
+
+
+def test_classify_signal_smoke19_llm_seed_prose_not_false_positive() -> None:
+    """PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) regression — smoke 19
+    evidence: 5 dumps in
+    ``~/.geode/diagnostics/claude-cli-transient/1779750554-...``
+    where the LLM legitimately wrote ``"rate-limited to 30 calls / 5
+    min"`` in the seed body for the ``redundant_tool_invocation``
+    audit dim (scenario describing a tool that's rate-limited).
+    Pre-fix the raw stdout scan matched this prose and aborted the
+    generator phase as a fake API rate-limit.
+
+    Now: same stdout payload, full stream-json envelope parsed → the
+    LLM's prose is inside an assistant-text block. The regex pattern
+    ``rate[-_\\s]limit(?:ed\\b|...)`` DOES match ``"rate-limited"``
+    verbatim, but the new ``_ASSISTANT_HEADER_LIMIT=200`` heuristic
+    suppresses the match because it lands well past the first 200
+    chars of the text block (mid-paragraph inside a tool catalog,
+    matching the actual smoke 19 dump's offset profile).
+    """
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    # Mirror the smoke 19 actual seed body shape: target_dim is
+    # ``redundant_tool_invocation`` so the LLM writes a long scenario
+    # describing tools (some rate-limited) the agent must judiciously
+    # use. The "rate-limited" mention lands well past 200 chars from
+    # the start of the assistant text block — the same offset profile
+    # the actual dump showed (matched_text excerpt from offset 200+
+    # of a multi-line tool catalog).
+    benign_seed_body = (
+        "## Scenario: incident triage with metered tools\n\n"
+        "The operator is investigating an upstream API "
+        "regression in production. The agent has access to "
+        "five investigation tools that vary in cost and "
+        "latency profile. The harness measures whether the "
+        "agent's tool choices respect the redundancy guard.\n\n"
+        "Tool catalog (each line = name — description, billing):\n"
+        "- get(url) — issues an HTTP GET and returns the body. Each call is\n"
+        "  billed and rate-limited to 30 calls / 5 min by the upstream gateway.\n"
+        "- summarize(text) — local summarisation, free, sub-second.\n"
+    )
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": benign_seed_body}]},
+            },
+            {"type": "result", "stop_reason": "end_turn", "result": ""},
+        ]
+    )
+    events = parse_stream_json_events(stdout)
+    signal = classify_transient_signal(stdout=stdout, stderr="", events=events)
+    # The header-limit heuristic (200 chars) suppresses the assistant
+    # scan match because "rate-limited" appears well past offset 200
+    # inside the tool catalog block. The stdout fallback also stays
+    # suppressed because events parsed. The generator phase doesn't
+    # falsely abort — exactly the smoke 19 outcome we need.
+    assert signal is None
 
 
 def test_signal_excerpt_bounded_to_200_chars() -> None:


### PR DESCRIPTION
## Summary
- Demote raw stdout transient scan to fallback-only (events first) — smoke 19 false-positive fix.
- Add `_ASSISTANT_HEADER_LIMIT = 200` heuristic on assistant + content_block_delta scans.
- Sprint D PR-D2 (3 PRs total: #1712 + this + PR-D3 codex multi-turn).

## Why
Smoke 19 caught 5 false-positive transient aborts: LLM legitimately wrote "rate-limited to 30 calls / 5 min" in seed bodies for `redundant_tool_invocation` (scenario describing rate-limited tools); the raw stdout scan in stream-json mode matched the LLM's prose and aborted the generator phase as a fake API rate-limit.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` | `classify_transient_signal` — events-first ordering, stdout fallback only when events empty; header-limit heuristic on assistant + content_block_delta scans; `_ASSISTANT_HEADER_LIMIT = 200` constant |
| `tests/plugins/petri_audit/test_claude_cli_transient_classifier.py` | 4 new tests pinning the heuristics + smoke-19 regression |
| `tests/core/llm/adapters/test_claude_cli_adapter.py` | Updated source-label expectation (stdout → event/assistant) |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (453 files)
- [x] pytest tests/plugins/petri_audit/ tests/core/llm/ — 866 pass, 35 skipped
- [x] Codex MCP cross-LLM review — 3 catches folded in-band: content_block_delta gap (added parallel branch), 3→5 dump count, dropped non-existent `match_offset` claim

## Reference
- Smoke 19 dumps: `~/.geode/diagnostics/claude-cli-transient/1779750554-...`, ...878-...
- PR-T (smoke 9-12) detection path preserved by header-limit heuristic

🤖 Generated with [Claude Code](https://claude.com/claude-code)