### PR TITLE
feat(agent): platform-aware + family-aware system prompt (PR-HERMES-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,16 +52,26 @@ functional change.
   prompt fragments. `core/llm/platform_hints.py` (184 LOC) maps 6 GEODE
   surfaces (`cli`, `serve_repl`, `slack`, `cron`, `worktree`,
   `mcp_remote`) to short directive blocks; `core/llm/model_guidance.py`
-  (131 LOC) maps the 4 LLM families (Anthropic / OpenAI / Google / xAI)
-  to tool-grammar + reasoning-visibility directives. Surface resolution
-  is env-override (`$GEODE_SURFACE_TYPE`) → ContextVar → default
-  `"cli"`; family resolution is a heuristic substring match against the
-  model string. Both are wired into
+  (~180 LOC) maps 5 LLM families (Anthropic / OpenAI / Google / xAI /
+  GLM-5+) to tool-grammar + reasoning-visibility directives. Surface
+  resolution is env-override (`$GEODE_SURFACE_TYPE`) → ContextVar →
+  default `"cli"`; family resolution is a heuristic substring match
+  against the model string, ordered to favour the more-specific
+  `claude-` / `glm-` prefixes over the broader `gpt-` / `o3-`
+  heuristics. GLM resolution carries an operator-decision filter
+  (2026-05-26) — only `glm-5.0+` resolves to `FAMILY_GLM`; older
+  `glm-4.x` strings still appear in the `/model` picker for
+  compatibility but receive no Phase 2 directive because their
+  tool-call grammar diverges from GLM-5. GLM-5 directive content is
+  grounded in `/zai-org/glm-5` ctx7 spec (OpenAI-compatible
+  `/v1/chat/completions` schema, `tool_calls.function.arguments` as
+  JSON-encoded string). Both renderers are wired into
   `core/agent/system_prompt.build_system_prompt` in the dynamic section
   (model_guidance after model_card, platform_hint before date_context).
   Audit-mode strips both blocks so Petri scenarios never leak GEODE
-  surface hints. 23 invariant tests pin module exports, resolution
-  order, block shape, and wiring symmetry.
+  surface hints. 58 invariant tests pin module exports, resolution
+  order, per-surface and per-family rendered body coverage, GLM-4.x
+  rejection, and wiring symmetry.
 - **PR-SELF-IMPROVING-HUB** — `/geode/self-improving/` landing hub +
   full DESIGN.md scaffolding for 9 hub-surface pages. Replaces
   `/geode/petri-bundle/` as the primary entry point for Petri audit /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-HERMES-2** — Hermes Phase 2 platform-aware + family-aware system
+  prompt fragments. `core/llm/platform_hints.py` (184 LOC) maps 6 GEODE
+  surfaces (`cli`, `serve_repl`, `slack`, `cron`, `worktree`,
+  `mcp_remote`) to short directive blocks; `core/llm/model_guidance.py`
+  (131 LOC) maps the 4 LLM families (Anthropic / OpenAI / Google / xAI)
+  to tool-grammar + reasoning-visibility directives. Surface resolution
+  is env-override (`$GEODE_SURFACE_TYPE`) → ContextVar → default
+  `"cli"`; family resolution is a heuristic substring match against the
+  model string. Both are wired into
+  `core/agent/system_prompt.build_system_prompt` in the dynamic section
+  (model_guidance after model_card, platform_hint before date_context).
+  Audit-mode strips both blocks so Petri scenarios never leak GEODE
+  surface hints. 23 invariant tests pin module exports, resolution
+  order, block shape, and wiring symmetry.
 - **PR-SELF-IMPROVING-HUB** — `/geode/self-improving/` landing hub +
   full DESIGN.md scaffolding for 9 hub-surface pages. Replaces
   `/geode/petri-bundle/` as the primary entry point for Petri audit /

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -31,6 +31,8 @@ from core.agent.style_guide_policy import (
     _load_style_guide_override,
     apply_style_guide_policy,
 )
+from core.llm.model_guidance import render_model_guidance
+from core.llm.platform_hints import render_platform_hint
 from core.llm.prompt_assembler import with_math_output_formatting
 from core.llm.prompts import ROUTER_SYSTEM
 from core.paths import GLOBAL_WRAPPER_SECTIONS_PATH, get_project_root
@@ -241,6 +243,18 @@ def build_system_prompt(model: str = "") -> str:
         model_card = _build_model_card(model)
         if model_card:
             dynamic_parts.append(model_card)
+        # Hermes Phase 2 — family-aware guidance (Anthropic / OpenAI / Google
+        # / xAI). Graceful no-op when family unresolved.
+        guidance = render_model_guidance(model)
+        if guidance:
+            dynamic_parts.append(guidance)
+
+    # Hermes Phase 2 — surface-aware hint (cli / serve_repl / slack / cron /
+    # worktree / mcp_remote). Resolution honours $GEODE_SURFACE_TYPE then
+    # the ContextVar then "cli". Graceful no-op when surface unmapped.
+    hint = render_platform_hint()
+    if hint:
+        dynamic_parts.append(hint)
 
     dynamic_parts.append(_build_date_context())
 

--- a/core/llm/model_guidance.py
+++ b/core/llm/model_guidance.py
@@ -28,11 +28,13 @@ uses for the routing manifest. Unknown family → no hint block
 from __future__ import annotations
 
 import logging
+import re
 
 log = logging.getLogger(__name__)
 
 __all__ = [
     "FAMILY_ANTHROPIC",
+    "FAMILY_GLM",
     "FAMILY_GOOGLE",
     "FAMILY_OPENAI",
     "FAMILY_XAI",
@@ -46,9 +48,10 @@ FAMILY_ANTHROPIC = "anthropic"
 FAMILY_OPENAI = "openai"
 FAMILY_GOOGLE = "google"
 FAMILY_XAI = "xai"
+FAMILY_GLM = "glm"
 
 VALID_FAMILIES: frozenset[str] = frozenset(
-    {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI}
+    {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI, FAMILY_GLM}
 )
 
 MODEL_GUIDANCE: dict[str, str] = {
@@ -78,17 +81,30 @@ MODEL_GUIDANCE: dict[str, str] = {
         "structured response per turn. Reasoning is verbose by default; "
         "keep the final answer block concise for the operator."
     ),
+    FAMILY_GLM: (
+        "You are a GLM-5+ model (Zhipu — 744B sparse-attention, optimised "
+        "for long-horizon agentic tasks). Tool calls follow the "
+        "OpenAI-compatible ``/v1/chat/completions`` schema — emit a "
+        "``tool_calls`` array whose ``function.arguments`` is a "
+        "JSON-encoded string, not a dict. Reasoning interleaves with the "
+        "assistant turn during streaming; finalise structured outputs "
+        "before closing the turn so downstream parsers can extract them."
+    ),
 }
 
 
 # Heuristic prefix / suffix patterns. Keep in sync with the routing
-# manifest at ``core/config/routing_manifest.py`` for consistency.
+# manifest at ``core/config/routing.toml`` ``[router.prefix_map]`` for
+# consistency.
 _FAMILY_PATTERNS: list[tuple[str, str]] = [
-    # (substring, family) — first match wins; ordered by specificity.
+    # (substring, family) — first match wins; ordered by specificity so
+    # the more-specific ``claude-`` / ``glm-`` prefixes resolve before
+    # the broader ``gpt-`` / ``o3-`` heuristics.
     ("claude", FAMILY_ANTHROPIC),
     ("opus", FAMILY_ANTHROPIC),
     ("sonnet", FAMILY_ANTHROPIC),
     ("haiku", FAMILY_ANTHROPIC),
+    ("glm", FAMILY_GLM),
     ("gpt", FAMILY_OPENAI),
     ("o1", FAMILY_OPENAI),
     ("o3", FAMILY_OPENAI),
@@ -98,6 +114,38 @@ _FAMILY_PATTERNS: list[tuple[str, str]] = [
     ("grok", FAMILY_XAI),
 ]
 
+# 2026-05-26 operator decision: only GLM-5.0+ is in scope for the
+# Phase 2 guidance (older 4.x variants are still exposed via the
+# ``/model`` picker for compatibility, but their tool-call grammar is
+# different enough that the GLM-5 directives would mislead). Anything
+# matching ``glm`` is filtered through this regex before being labelled
+# :data:`FAMILY_GLM` — a non-match falls through to no-hint.
+_GLM_SUPPORTED_RE = re.compile(r"glm-(\d+)")
+_GLM_MIN_MAJOR = 5
+
+
+def _is_supported_glm(lowered_model: str) -> bool:
+    """Return True for ``glm-5.x`` / ``glm-6.x`` / ... and False for
+    ``glm-4.x`` or any GLM string lacking a parseable major version.
+
+    Examples:
+        >>> _is_supported_glm("glm-5.1")
+        True
+        >>> _is_supported_glm("glm-5")
+        True
+        >>> _is_supported_glm("glm-4.7-flash")
+        False
+        >>> _is_supported_glm("glm-ocr")
+        False
+    """
+    match = _GLM_SUPPORTED_RE.search(lowered_model)
+    if not match:
+        return False
+    try:
+        return int(match.group(1)) >= _GLM_MIN_MAJOR
+    except ValueError:
+        return False
+
 
 def resolve_family(model: str) -> str | None:
     """Return the family identifier for ``model``, or ``None`` if unrecognised.
@@ -105,12 +153,22 @@ def resolve_family(model: str) -> str | None:
     Match is case-insensitive substring against
     :data:`_FAMILY_PATTERNS`. Unknown / empty model → ``None`` (caller
     falls through to no-hint).
+
+    GLM is special-cased — only ``glm-5.0+`` resolves to
+    :data:`FAMILY_GLM` (per operator decision on 2026-05-26). Older
+    ``glm-4.x`` variants stay exposed in the ``/model`` picker but
+    receive no Phase 2 directive because their tool-call grammar
+    diverges from GLM-5.
     """
     if not model:
         return None
     lowered = model.lower()
     for needle, family in _FAMILY_PATTERNS:
         if needle in lowered:
+            if family == FAMILY_GLM and not _is_supported_glm(lowered):
+                # Fall through — the older GLM string carries no Phase 2
+                # directive and must not match a later pattern either.
+                return None
             return family
     return None
 

--- a/core/llm/model_guidance.py
+++ b/core/llm/model_guidance.py
@@ -1,0 +1,131 @@
+"""Model-family-aware system prompt fragments — Hermes absorption Phase 2.
+
+Different LLM families enforce different *internal contracts* that the
+prompt has to respect:
+
+* Anthropic Claude — strict tool-use grammar (parallel calls allowed,
+  ``tool_use`` block content blocks), thinking visible when
+  ``thinking`` block present, computer-use opt-in.
+* OpenAI GPT — responses API supports ``parallel_tool_calls``,
+  reasoning traces hidden by default, function calls require
+  serialised JSON args (not Anthropic's input dict shape).
+* Google Gemini — function-call grammar differs again; less strict
+  about reasoning visibility; no computer-use yet.
+* xAI Grok — minimal tool contract; reasoning verbose by default.
+
+A single static prompt can't capture all four — and the *agentic loop's*
+robustness depends on the LLM knowing its own family conventions. Hermes
+ships ``MODEL_GUIDANCE`` for this; GEODE Phase 2 absorbs the dict and
+the lookup helper.
+
+**Resolution**: family is resolved from the model string passed to
+:func:`render_model_guidance`. The mapping is heuristic (prefix +
+suffix patterns) — same approach ``core/config._resolve_provider``
+uses for the routing manifest. Unknown family → no hint block
+(graceful no-op).
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "FAMILY_ANTHROPIC",
+    "FAMILY_GOOGLE",
+    "FAMILY_OPENAI",
+    "FAMILY_XAI",
+    "MODEL_GUIDANCE",
+    "VALID_FAMILIES",
+    "render_model_guidance",
+    "resolve_family",
+]
+
+FAMILY_ANTHROPIC = "anthropic"
+FAMILY_OPENAI = "openai"
+FAMILY_GOOGLE = "google"
+FAMILY_XAI = "xai"
+
+VALID_FAMILIES: frozenset[str] = frozenset(
+    {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI}
+)
+
+MODEL_GUIDANCE: dict[str, str] = {
+    FAMILY_ANTHROPIC: (
+        "You are a Claude model. Tool calls use the Anthropic ``tool_use`` "
+        "block grammar — input is a dict, not a JSON string. Parallel tool "
+        "calls are supported within one response; emit multiple "
+        "``tool_use`` blocks when their inputs are independent. When "
+        "``thinking`` blocks appear in your output they are visible to the "
+        "operator — be honest, not performative."
+    ),
+    FAMILY_OPENAI: (
+        "You are a GPT model. Tool calls use the OpenAI Responses API "
+        "``function`` call grammar — arguments are a JSON-encoded string, "
+        "not a dict. Parallel tool calls obey ``parallel_tool_calls``. "
+        "Reasoning traces are hidden by default; the operator sees only "
+        "the final response unless ``reasoning.summary`` is requested."
+    ),
+    FAMILY_GOOGLE: (
+        "You are a Gemini model. Tool calls follow Google's function-call "
+        "grammar — verify the schema by name. Reasoning visibility is "
+        "model-dependent; assume it is visible unless told otherwise. "
+        "Computer-use is not yet supported on this provider."
+    ),
+    FAMILY_XAI: (
+        "You are a Grok model. Tool contract is minimal — emit a single "
+        "structured response per turn. Reasoning is verbose by default; "
+        "keep the final answer block concise for the operator."
+    ),
+}
+
+
+# Heuristic prefix / suffix patterns. Keep in sync with the routing
+# manifest at ``core/config/routing_manifest.py`` for consistency.
+_FAMILY_PATTERNS: list[tuple[str, str]] = [
+    # (substring, family) — first match wins; ordered by specificity.
+    ("claude", FAMILY_ANTHROPIC),
+    ("opus", FAMILY_ANTHROPIC),
+    ("sonnet", FAMILY_ANTHROPIC),
+    ("haiku", FAMILY_ANTHROPIC),
+    ("gpt", FAMILY_OPENAI),
+    ("o1", FAMILY_OPENAI),
+    ("o3", FAMILY_OPENAI),
+    ("o4", FAMILY_OPENAI),
+    ("codex", FAMILY_OPENAI),
+    ("gemini", FAMILY_GOOGLE),
+    ("grok", FAMILY_XAI),
+]
+
+
+def resolve_family(model: str) -> str | None:
+    """Return the family identifier for ``model``, or ``None`` if unrecognised.
+
+    Match is case-insensitive substring against
+    :data:`_FAMILY_PATTERNS`. Unknown / empty model → ``None`` (caller
+    falls through to no-hint).
+    """
+    if not model:
+        return None
+    lowered = model.lower()
+    for needle, family in _FAMILY_PATTERNS:
+        if needle in lowered:
+            return family
+    return None
+
+
+def render_model_guidance(model: str) -> str:
+    """Return a ``<model_guidance>`` block for ``model``'s family, or ``""``.
+
+    Used by ``core/agent/system_prompt.py::build_system_prompt`` to
+    inject family-aware directives just after the existing
+    ``<model_card>`` block.
+    """
+    family = resolve_family(model)
+    if not family:
+        return ""
+    body = MODEL_GUIDANCE.get(family)
+    if not body:
+        return ""
+    return f"<model_guidance family={family!r}>\n{body}\n</model_guidance>"

--- a/core/llm/platform_hints.py
+++ b/core/llm/platform_hints.py
@@ -1,0 +1,184 @@
+"""Platform-aware system prompt fragments — Hermes absorption Phase 2.
+
+GEODE is reachable through multiple surfaces — interactive CLI, the
+``geode serve`` REPL, Slack gateway, scheduler cron, sandboxed worktree
+runs, and the future remote-MCP path. Each surface has different
+constraints: Slack truncates long replies, cron must finish in one
+turn, the worktree CLI has tool access to the local repo. A
+single one-size-fits-all system prompt is leaving capability on the
+table.
+
+Hermes' fix (per ``hermes_state.py:1130``) is a ``PLATFORM_HINTS`` dict
+keyed by surface, returning a short directive block that gets appended
+to the system prompt at assembly time. GEODE Phase 2 absorbs that
+pattern with surface labels that match the GEODE entry-points.
+
+**Resolution**:
+
+1. ``$GEODE_SURFACE_TYPE`` env var (operator override) — useful when
+   running ad-hoc CLI inside a containerised env that misidentifies
+   itself.
+2. ContextVar (entry-point-set; Phase 2.5 will wire this). Currently
+   unset by default → falls through to step 3.
+3. ``"cli"`` default — the most common interactive case.
+
+Missing / unknown surface → no hint block appended (graceful no-op).
+
+**4 frontier comparisons** (why this matters):
+
+* Claude Code prepends an OS / shell / cwd block before every
+  conversation.
+* Codex CLI's ``<system-reminder>`` surfaces the sandbox + working
+  directory.
+* OpenClaw gateway injects channel-specific tool-policy reminders.
+* Hermes itself routes surface-specific guidance through
+  ``BasePromptCustomizer.platform_guidance``.
+
+GEODE's version surfaces all four uses as a single declarative dict
+the mutator can later evolve (T-series surface, eventually).
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "GEODE_SURFACE_TYPE_ENV",
+    "PLATFORM_HINTS",
+    "SURFACE_CLI",
+    "SURFACE_CRON",
+    "SURFACE_MCP_REMOTE",
+    "SURFACE_SERVE_REPL",
+    "SURFACE_SLACK",
+    "SURFACE_WORKTREE",
+    "VALID_SURFACES",
+    "get_current_surface",
+    "render_platform_hint",
+    "set_current_surface",
+]
+
+GEODE_SURFACE_TYPE_ENV = "GEODE_SURFACE_TYPE"
+
+# Canonical surface identifiers — keep alphabetised for diff stability.
+SURFACE_CLI = "cli"
+SURFACE_CRON = "cron"
+SURFACE_MCP_REMOTE = "mcp_remote"
+SURFACE_SERVE_REPL = "serve_repl"
+SURFACE_SLACK = "slack"
+SURFACE_WORKTREE = "worktree"
+
+VALID_SURFACES: frozenset[str] = frozenset(
+    {
+        SURFACE_CLI,
+        SURFACE_CRON,
+        SURFACE_MCP_REMOTE,
+        SURFACE_SERVE_REPL,
+        SURFACE_SLACK,
+        SURFACE_WORKTREE,
+    }
+)
+
+PLATFORM_HINTS: dict[str, str] = {
+    SURFACE_CLI: (
+        "You are running through the GEODE interactive CLI in a developer's "
+        "terminal. Output is rendered with Rich markdown. Long code blocks "
+        "are fine; the user can scroll. Tools include filesystem and shell "
+        "access via the local repo's working directory."
+    ),
+    SURFACE_SERVE_REPL: (
+        "You are running inside the persistent ``geode serve`` REPL. "
+        "Conversation state is mirrored to SQLite for cross-session recall "
+        "(use ``session_search`` to look up prior turns). The REPL streams "
+        "output token-by-token; keep responses cohesive turn-by-turn."
+    ),
+    SURFACE_SLACK: (
+        "You are reachable through the Slack gateway. Replies should be "
+        "concise (1–4 paragraphs). Avoid wide tables — Slack mangles them. "
+        "Use Slack-flavored mrkdwn (``*bold*`` not ``**bold**``)."
+    ),
+    SURFACE_CRON: (
+        "You are running as a non-interactive scheduled job. There is no "
+        "human in the loop to answer clarifying questions — make a "
+        "reasonable default and document the assumption in the output. "
+        "Long-running tools that prompt for input will fail; prefer "
+        "non-interactive flags."
+    ),
+    SURFACE_WORKTREE: (
+        "You are running inside a sandboxed git worktree. Treat the "
+        "checkout as ephemeral — anything not committed and pushed before "
+        "exit is lost. Filesystem changes outside the worktree are not "
+        "permitted. Coordinate with the parent session via the worktree's "
+        "``.owner`` file when in doubt about ownership."
+    ),
+    SURFACE_MCP_REMOTE: (
+        "You are exposed as a remote MCP server. The caller may be another "
+        "agent; respond with structured JSON when the tool contract asks "
+        "for it. Avoid colorised output — the MCP client may not strip ANSI."
+    ),
+}
+
+
+_current_surface: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "geode_surface_type", default=None
+)
+
+
+def set_current_surface(surface: str | None) -> contextvars.Token[str | None]:
+    """Bind the surface to the current ContextVar scope. Returns the reset token.
+
+    Entry-points (Phase 2.5 follow-up) call this once at startup so every
+    LLM call inside that process sees the right surface in
+    :func:`get_current_surface`. Passing ``None`` clears the binding.
+    """
+    return _current_surface.set(surface)
+
+
+def get_current_surface() -> str:
+    """Resolve the active surface, honouring the env override then ContextVar.
+
+    Resolution order:
+
+    1. ``$GEODE_SURFACE_TYPE`` (operator override) — if it's a recognised
+       surface name, use it. Unknown values log DEBUG and fall through.
+    2. :data:`_current_surface` ContextVar — entry-point-set value.
+    3. ``"cli"`` default — the most common interactive case.
+    """
+    override = os.environ.get(GEODE_SURFACE_TYPE_ENV)
+    if override:
+        if override in VALID_SURFACES:
+            return override
+        log.debug(
+            "%s=%r is not a recognised surface (valid: %s); ignoring",
+            GEODE_SURFACE_TYPE_ENV,
+            override,
+            sorted(VALID_SURFACES),
+        )
+    ctx_val = _current_surface.get()
+    if ctx_val and ctx_val in VALID_SURFACES:
+        return ctx_val
+    return SURFACE_CLI
+
+
+def render_platform_hint(surface: str | None = None) -> str:
+    """Return a ``<platform_hint>`` block for the resolved surface, or ``""``.
+
+    Args:
+        surface: Explicit surface name; ``None`` triggers
+            :func:`get_current_surface`. Useful for tests + future
+            multi-surface report renderers.
+
+    Returns:
+        ``"<platform_hint>...\\n</platform_hint>"`` formatted block, or
+        the empty string when the surface isn't in
+        :data:`PLATFORM_HINTS` (graceful — caller's prompt remains
+        valid).
+    """
+    target = surface or get_current_surface()
+    body = PLATFORM_HINTS.get(target)
+    if not body:
+        return ""
+    return f"<platform_hint surface={target!r}>\n{body}\n</platform_hint>"

--- a/tests/core/agent/test_system_prompt_hermes2_wiring.py
+++ b/tests/core/agent/test_system_prompt_hermes2_wiring.py
@@ -1,0 +1,71 @@
+"""Hermes Phase 2 — system_prompt wiring invariants.
+
+Pins that ``build_system_prompt`` actually appends ``<platform_hint>``
+and ``<model_guidance>`` blocks when the resolved surface / family is
+known, and that audit-mode keeps emitting the minimal prompt without
+either block (Petri scenarios must not see GEODE-side surface hints).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.platform_hints import (
+    GEODE_SURFACE_TYPE_ENV,
+    SURFACE_SLACK,
+)
+
+from core.agent import system_prompt
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(GEODE_SURFACE_TYPE_ENV, raising=False)
+    monkeypatch.delenv("GEODE_AUDIT_UNRESTRICTED", raising=False)
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+
+
+def test_platform_hint_block_appears_under_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, SURFACE_SLACK)
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    assert "<platform_hint surface='slack'>" in prompt
+
+
+def test_model_guidance_block_appears_for_known_family(monkeypatch: pytest.MonkeyPatch):
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    assert "<model_guidance family='anthropic'>" in prompt
+
+
+def test_model_guidance_omitted_for_unknown_model(monkeypatch: pytest.MonkeyPatch):
+    prompt = system_prompt.build_system_prompt(model="mistral-large")
+    assert "<model_guidance" not in prompt
+
+
+def test_platform_hint_omitted_when_resolution_unknown(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, "telegram")
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    # Unknown env value → fall-through to default "cli", which is mapped → block appears.
+    assert "<platform_hint surface='cli'>" in prompt
+
+
+def test_audit_mode_strips_both_blocks(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GEODE_AUDIT_UNRESTRICTED", "1")
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, SURFACE_SLACK)
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    assert "<platform_hint" not in prompt, "Petri audit mode must not leak surface hints"
+    assert "<model_guidance" not in prompt, "Petri audit mode must not leak family hints"
+
+
+def test_default_cli_surface_when_env_unset():
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    assert "<platform_hint surface='cli'>" in prompt
+
+
+def test_order_model_guidance_before_platform_hint():
+    """The dynamic section appends in order: model_card → model_guidance →
+    platform_hint → date. Pin that order so future re-arrangements
+    surface in tests."""
+    prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
+    mg = prompt.find("<model_guidance")
+    ph = prompt.find("<platform_hint")
+    assert mg != -1 and ph != -1
+    assert mg < ph, "model_guidance must precede platform_hint in dynamic section"

--- a/tests/core/agent/test_system_prompt_hermes2_wiring.py
+++ b/tests/core/agent/test_system_prompt_hermes2_wiring.py
@@ -40,11 +40,12 @@ def test_model_guidance_omitted_for_unknown_model(monkeypatch: pytest.MonkeyPatc
     assert "<model_guidance" not in prompt
 
 
-def test_platform_hint_omitted_when_resolution_unknown(monkeypatch: pytest.MonkeyPatch):
+def test_unknown_env_surface_falls_through_to_cli_block(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, "telegram")
     prompt = system_prompt.build_system_prompt(model="claude-opus-4-7")
     # Unknown env value → fall-through to default "cli", which is mapped → block appears.
     assert "<platform_hint surface='cli'>" in prompt
+    assert "<platform_hint surface='telegram'>" not in prompt
 
 
 def test_audit_mode_strips_both_blocks(monkeypatch: pytest.MonkeyPatch):

--- a/tests/core/llm/test_model_guidance.py
+++ b/tests/core/llm/test_model_guidance.py
@@ -1,0 +1,99 @@
+"""Hermes Phase 2 — ``core.llm.model_guidance`` invariants.
+
+Pins the family resolution heuristic, the ``<model_guidance>`` block
+shape, and the graceful no-op for unrecognised models.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.model_guidance import (
+    FAMILY_ANTHROPIC,
+    FAMILY_GOOGLE,
+    FAMILY_OPENAI,
+    FAMILY_XAI,
+    MODEL_GUIDANCE,
+    VALID_FAMILIES,
+    render_model_guidance,
+    resolve_family,
+)
+
+from core.llm import model_guidance
+
+
+def test_four_canonical_families_covered():
+    expected = {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI}
+    assert expected == VALID_FAMILIES
+    assert set(MODEL_GUIDANCE) == expected, "every family must have a guidance body"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("claude-opus-4-7", FAMILY_ANTHROPIC),
+        ("claude-sonnet-4-6", FAMILY_ANTHROPIC),
+        ("claude-haiku-4-5-20251001", FAMILY_ANTHROPIC),
+        ("opus-4.7", FAMILY_ANTHROPIC),
+        ("gpt-5", FAMILY_OPENAI),
+        ("gpt-4o-mini", FAMILY_OPENAI),
+        ("o3-mini", FAMILY_OPENAI),
+        ("o1-preview", FAMILY_OPENAI),
+        ("o4", FAMILY_OPENAI),
+        ("codex-cli", FAMILY_OPENAI),
+        ("gemini-2.5-pro", FAMILY_GOOGLE),
+        ("grok-4", FAMILY_XAI),
+    ],
+)
+def test_resolve_family_known(model: str, expected: str):
+    assert resolve_family(model) == expected
+
+
+def test_resolve_family_case_insensitive():
+    assert resolve_family("CLAUDE-OPUS-4-7") == FAMILY_ANTHROPIC
+    assert resolve_family("GPT-5") == FAMILY_OPENAI
+
+
+def test_resolve_family_unknown_returns_none():
+    assert resolve_family("mistral-large") is None
+    assert resolve_family("") is None
+
+
+def test_render_returns_xml_block_for_each_family():
+    for family in VALID_FAMILIES:
+        sample = next(
+            iter(
+                [
+                    m
+                    for m, f in {
+                        "claude-opus-4-7": FAMILY_ANTHROPIC,
+                        "gpt-5": FAMILY_OPENAI,
+                        "gemini-2.5-pro": FAMILY_GOOGLE,
+                        "grok-4": FAMILY_XAI,
+                    }.items()
+                    if f == family
+                ]
+            )
+        )
+        block = render_model_guidance(sample)
+        assert block.startswith("<model_guidance"), f"family={family}"
+        assert block.rstrip().endswith("</model_guidance>"), f"family={family}"
+        assert MODEL_GUIDANCE[family] in block, f"family={family} body missing"
+
+
+def test_render_unknown_returns_empty_string():
+    assert render_model_guidance("mistral-large") == ""
+    assert render_model_guidance("") == ""
+
+
+def test_module_exports_stable():
+    expected = {
+        "FAMILY_ANTHROPIC",
+        "FAMILY_GOOGLE",
+        "FAMILY_OPENAI",
+        "FAMILY_XAI",
+        "MODEL_GUIDANCE",
+        "VALID_FAMILIES",
+        "resolve_family",
+        "render_model_guidance",
+    }
+    assert set(model_guidance.__all__) == expected

--- a/tests/core/llm/test_model_guidance.py
+++ b/tests/core/llm/test_model_guidance.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 from core.llm.model_guidance import (
     FAMILY_ANTHROPIC,
+    FAMILY_GLM,
     FAMILY_GOOGLE,
     FAMILY_OPENAI,
     FAMILY_XAI,
@@ -21,8 +22,8 @@ from core.llm.model_guidance import (
 from core.llm import model_guidance
 
 
-def test_four_canonical_families_covered():
-    expected = {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI}
+def test_five_canonical_families_covered():
+    expected = {FAMILY_ANTHROPIC, FAMILY_OPENAI, FAMILY_GOOGLE, FAMILY_XAI, FAMILY_GLM}
     assert expected == VALID_FAMILIES
     assert set(MODEL_GUIDANCE) == expected, "every family must have a guidance body"
 
@@ -42,6 +43,10 @@ def test_four_canonical_families_covered():
         ("codex-cli", FAMILY_OPENAI),
         ("gemini-2.5-pro", FAMILY_GOOGLE),
         ("grok-4", FAMILY_XAI),
+        ("glm-5.1", FAMILY_GLM),
+        ("glm-5", FAMILY_GLM),
+        ("glm-5-turbo", FAMILY_GLM),
+        ("glm-6.0", FAMILY_GLM),
     ],
 )
 def test_resolve_family_known(model: str, expected: str):
@@ -58,26 +63,48 @@ def test_resolve_family_unknown_returns_none():
     assert resolve_family("") is None
 
 
-def test_render_returns_xml_block_for_each_family():
-    for family in VALID_FAMILIES:
-        sample = next(
-            iter(
-                [
-                    m
-                    for m, f in {
-                        "claude-opus-4-7": FAMILY_ANTHROPIC,
-                        "gpt-5": FAMILY_OPENAI,
-                        "gemini-2.5-pro": FAMILY_GOOGLE,
-                        "grok-4": FAMILY_XAI,
-                    }.items()
-                    if f == family
-                ]
-            )
-        )
-        block = render_model_guidance(sample)
-        assert block.startswith("<model_guidance"), f"family={family}"
-        assert block.rstrip().endswith("</model_guidance>"), f"family={family}"
-        assert MODEL_GUIDANCE[family] in block, f"family={family} body missing"
+@pytest.mark.parametrize(
+    "legacy_glm",
+    [
+        "glm-4.7-flash",
+        "glm-4.7-flashx",
+        "glm-4.7",
+        "glm-4.6",
+        "glm-4.6v",
+        "glm-4.5",
+        "glm-4.5-air",
+        "glm-4.5-flash",
+    ],
+)
+def test_resolve_family_glm_4x_returns_none(legacy_glm: str):
+    """Operator decision (2026-05-26): only GLM-5.0+ receives the Phase 2
+    directive. Older 4.x variants remain exposed via ``/model`` for
+    compatibility but resolve to no family here."""
+    assert resolve_family(legacy_glm) is None
+
+
+def test_resolve_family_glm_without_version_returns_none():
+    """A bare ``glm`` / ``glm-ocr`` string carries no major version → no hint."""
+    assert resolve_family("glm") is None
+    assert resolve_family("glm-ocr") is None
+
+
+_FAMILY_SAMPLE_MODEL: dict[str, str] = {
+    FAMILY_ANTHROPIC: "claude-opus-4-7",
+    FAMILY_OPENAI: "gpt-5",
+    FAMILY_GOOGLE: "gemini-2.5-pro",
+    FAMILY_XAI: "grok-4",
+    FAMILY_GLM: "glm-5.1",
+}
+
+
+@pytest.mark.parametrize("family", sorted(VALID_FAMILIES))
+def test_render_returns_xml_block_for_each_family(family: str):
+    sample = _FAMILY_SAMPLE_MODEL[family]
+    block = render_model_guidance(sample)
+    assert block.startswith(f"<model_guidance family={family!r}>"), f"family={family}"
+    assert block.rstrip().endswith("</model_guidance>"), f"family={family}"
+    assert MODEL_GUIDANCE[family] in block, f"family={family} body missing"
 
 
 def test_render_unknown_returns_empty_string():
@@ -88,6 +115,7 @@ def test_render_unknown_returns_empty_string():
 def test_module_exports_stable():
     expected = {
         "FAMILY_ANTHROPIC",
+        "FAMILY_GLM",
         "FAMILY_GOOGLE",
         "FAMILY_OPENAI",
         "FAMILY_XAI",

--- a/tests/core/llm/test_platform_hints.py
+++ b/tests/core/llm/test_platform_hints.py
@@ -100,6 +100,14 @@ def test_render_unknown_surface_returns_empty_string():
     assert render_platform_hint("telegram") == ""
 
 
+@pytest.mark.parametrize("surface", sorted(VALID_SURFACES))
+def test_render_returns_xml_block_for_each_surface(surface: str):
+    block = render_platform_hint(surface)
+    assert block.startswith(f"<platform_hint surface={surface!r}>"), f"surface={surface}"
+    assert block.rstrip().endswith("</platform_hint>"), f"surface={surface}"
+    assert PLATFORM_HINTS[surface] in block, f"surface={surface} body missing"
+
+
 def test_module_exports_stable():
     expected = {
         "GEODE_SURFACE_TYPE_ENV",

--- a/tests/core/llm/test_platform_hints.py
+++ b/tests/core/llm/test_platform_hints.py
@@ -1,0 +1,118 @@
+"""Hermes Phase 2 — ``core.llm.platform_hints`` invariants.
+
+Pins the resolution order (env override → ContextVar → ``cli`` default),
+the ``<platform_hint>`` block shape, and the graceful no-op for
+unrecognised surfaces.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+import pytest
+from core.llm.platform_hints import (
+    GEODE_SURFACE_TYPE_ENV,
+    PLATFORM_HINTS,
+    SURFACE_CLI,
+    SURFACE_CRON,
+    SURFACE_MCP_REMOTE,
+    SURFACE_SERVE_REPL,
+    SURFACE_SLACK,
+    SURFACE_WORKTREE,
+    VALID_SURFACES,
+    get_current_surface,
+    render_platform_hint,
+    set_current_surface,
+)
+
+from core.llm import platform_hints
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(GEODE_SURFACE_TYPE_ENV, raising=False)
+
+
+def test_six_canonical_surfaces_covered():
+    expected = {
+        SURFACE_CLI,
+        SURFACE_CRON,
+        SURFACE_MCP_REMOTE,
+        SURFACE_SERVE_REPL,
+        SURFACE_SLACK,
+        SURFACE_WORKTREE,
+    }
+    assert expected == VALID_SURFACES
+    assert set(PLATFORM_HINTS) == expected, "every surface must have a hint body"
+
+
+def test_get_current_surface_default_cli():
+    assert get_current_surface() == SURFACE_CLI
+
+
+def test_env_override_wins(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, SURFACE_SLACK)
+    assert get_current_surface() == SURFACE_SLACK
+
+
+def test_env_unknown_value_falls_through_to_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, "telegram")
+    assert get_current_surface() == SURFACE_CLI
+
+
+def test_context_var_used_when_env_unset():
+    def _scoped() -> str:
+        set_current_surface(SURFACE_CRON)
+        return get_current_surface()
+
+    ctx = contextvars.copy_context()
+    assert ctx.run(_scoped) == SURFACE_CRON
+    # Outside the copied context the binding does not leak.
+    assert get_current_surface() == SURFACE_CLI
+
+
+def test_env_beats_context_var(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, SURFACE_WORKTREE)
+
+    def _scoped() -> str:
+        set_current_surface(SURFACE_SLACK)
+        return get_current_surface()
+
+    ctx = contextvars.copy_context()
+    assert ctx.run(_scoped) == SURFACE_WORKTREE
+
+
+def test_render_uses_resolved_surface(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(GEODE_SURFACE_TYPE_ENV, SURFACE_SLACK)
+    block = render_platform_hint()
+    assert block.startswith("<platform_hint surface='slack'>")
+    assert block.rstrip().endswith("</platform_hint>")
+    assert PLATFORM_HINTS[SURFACE_SLACK] in block
+
+
+def test_render_explicit_surface_overrides_lookup():
+    block = render_platform_hint(SURFACE_MCP_REMOTE)
+    assert "surface='mcp_remote'" in block
+    assert PLATFORM_HINTS[SURFACE_MCP_REMOTE] in block
+
+
+def test_render_unknown_surface_returns_empty_string():
+    assert render_platform_hint("telegram") == ""
+
+
+def test_module_exports_stable():
+    expected = {
+        "GEODE_SURFACE_TYPE_ENV",
+        "PLATFORM_HINTS",
+        "SURFACE_CLI",
+        "SURFACE_CRON",
+        "SURFACE_MCP_REMOTE",
+        "SURFACE_SERVE_REPL",
+        "SURFACE_SLACK",
+        "SURFACE_WORKTREE",
+        "VALID_SURFACES",
+        "get_current_surface",
+        "render_platform_hint",
+        "set_current_surface",
+    }
+    assert set(platform_hints.__all__) == expected


### PR DESCRIPTION
## Summary
- Hermes Phase 2 absorption — surface-aware (`<platform_hint>`) + family-aware (`<model_guidance>`) directive blocks in the system prompt's dynamic section.
- 6 surfaces × 5 LLM families (Anthropic / OpenAI / Google / xAI / GLM-5+) with graceful no-op for unknowns.
- 58 invariant tests pinning resolution order, body coverage, GLM-4.x rejection, audit-mode strip, and wiring symmetry.

## Why
- `feature/hermes-2-platform-aware` WIP branch (commit `c7958296`, 2026-05-22) was paused for outer-loop closure (Scope B shipped 2026-05-26). Phase 2 absorption is the next Hermes step per `docs/plans/2026-05-14-hermes-strengths-absorption.md`.
- Without per-surface hints the prompt is identical in Slack (where wide tables mangle), in cron (no human to clarify), and in worktree runs (filesystem boundaries differ). Without per-family hints the model assumes the wrong tool-call grammar (Anthropic `tool_use` dict vs OpenAI `function` JSON-string).
- GLM-5.0+ operator-decision filter (2026-05-26) prevents the GLM-5 directive from leaking into the older 4.x picker entries whose tool-call grammar diverges.

## Changes
| File | Change |
|------|--------|
| `core/llm/platform_hints.py` (added, 184 LOC) | 6-surface dict + `$GEODE_SURFACE_TYPE` env → ContextVar → `"cli"` resolution + `render_platform_hint` |
| `core/llm/model_guidance.py` (added, ~180 LOC) | 5-family dict + heuristic substring match ordered by specificity + `_is_supported_glm` GLM-5.0+ filter + `render_model_guidance` |
| `core/agent/system_prompt.py` (+14 LOC) | Wires both renderers into `build_system_prompt` dynamic section; audit-mode early-return preserved |
| `tests/core/llm/test_platform_hints.py` (added, 16 invariants) | resolution order + per-surface rendered body + module exports + graceful no-op |
| `tests/core/llm/test_model_guidance.py` (added, 35 invariants) | family resolve + per-family rendered body + GLM-4.x rejection (8 variants) + bare-glm / glm-ocr rejection + module exports |
| `tests/core/agent/test_system_prompt_hermes2_wiring.py` (added, 7 invariants) | env override visible in prompt + family block visible + audit-mode strips both + unknown model omits guidance + default CLI fall-through + ordering invariant |
| `CHANGELOG.md` | `[Unreleased] → Added` PR-HERMES-2 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Phase 1c (FTS5 + trigram) | Already implemented | `core/memory/session_manager.py:271-317` (PR #1439) |
| Phase 1d (session_search) | Partial | `core/tools/session_search.py` exists (current-project scope); cross-project `global.db` deferred to follow-up |
| Phase 2 (platform-aware) | This PR | Cherry-picked + wired + ctx7-grounded |
| Phase 3 (4-phase compaction) | Backlog | `core/orchestration/compaction.py` is single-phase LLM summary |
| Phase 4 (Multi-proc WAL) | Already implemented | `core/memory/session_manager.py:437` PRAGMA journal_mode=WAL |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ autoresearch/)
- [x] ruff format clean
- [x] mypy clean (core/ plugins/, 455 source files)
- [x] lint-imports clean (4 contracts kept)
- [x] pytest 58/58 passed on the 3 hermes-2 test files
- [x] pytest `-k system_prompt` regression: 44/44 passed
- [x] Codex MCP review (read-only sandbox): catches resolved in fix-up commit

## Reference
- Source plan: `docs/plans/2026-05-14-hermes-strengths-absorption.md` § Phase 2
- WIP origin: `feature/hermes-2-platform-aware` branch commit `c7958296` (2026-05-22)
- GLM-5 spec grounding: ctx7 `/zai-org/glm-5` (function calling + streaming sections)
- Frontier convergence: Claude Code (OS/shell/cwd block), Codex CLI (`<system-reminder>` sandbox + cwd), Hermes (`hermes_state.py:1130` PLATFORM_HINTS), OpenClaw (channel-specific tool-policy)