### PR TITLE
fix(codex): preserve reasoning item summary on multi-turn replay (PR-CODEX-MULTITURN-SUMMARY-PRESERVE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,47 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-MULTITURN-SUMMARY-PRESERVE — Codex Responses API
+  multi-turn replay must carry `summary` on every reasoning item.**
+  Smoke 19 evidence: ~10 voter failures across the ranker phase, all
+  from `vote-m*-openai.openai-codex` retries, with
+  ``"✕ Invalid request. Missing required parameter:
+  'input[N].summary'."`` Root cause: the codex_oauth capture path at
+  ``core/llm/adapters/_openai_common.py:translate_codex_response``
+  only added the `summary` field when truthy:
+  ``if summary: entry["summary"] = summary``. On a high-effort gpt-5.x
+  run with no chain-of-thought summary, the captured reasoning item
+  lacked the field entirely. On the next-turn replay through
+  ``build_codex_input`` (PR-WORKER-SCHEMA-AWARE-RETRY's validator-
+  feedback retry triggered this exact path), the OpenAI Responses
+  API rejected the input because reasoning items REQUIRE a `summary`
+  field per spec (ctx7-grounded against
+  ``/websites/developers_openai_api`` "Keeping reasoning items in
+  context" + "Migrate to Responses" — `summary: []` is the empty-but-
+  present shape).
+  Fix: 2-layer defence:
+  (a) Capture-time (``translate_codex_response``):
+      ``entry["summary"] = summary if summary else []`` — always
+      present the field on freshly captured items.
+  (b) Replay-time (``build_codex_input``):
+      ``replayed.setdefault("summary", [])`` — defensive injection
+      against legacy persisted codex_reasoning_items dicts that lack
+      the field (Codex MCP catch — covers cross-process state
+      snapshots + externally constructed Message instances).
+  Pinned by 2 new tests in
+  ``tests/core/llm/adapters/test_codex_reasoning_replay.py``:
+  ``test_codex_reasoning_replay_preserves_empty_summary`` (legacy
+  captured dict missing summary still replays correctly) +
+  ``test_reasoning_item_capture_always_has_summary_field`` (capture
+  defaults summary to `[]` when SDK item has None / missing).
+  Codex MCP cross-LLM review caught 4 issues — all folded in-band:
+  defence-in-depth replay injection, strict test assertion (was
+  permissive `if "summary" in entry`), docstring accuracy fix, and
+  followup task #101 (PR-CODEX-MULTITURN-PHASE-PRESERVE) for the
+  spec's `phase` parameter (separate concern, no current failure
+  evidence).
+
 ### Added
 - **PR-SELF-IMPROVING-HUB** — `/geode/self-improving/` landing hub +
   full DESIGN.md scaffolding for 9 hub-surface pages. Replaces

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -357,7 +357,23 @@ def build_codex_input(req: AdapterCallRequest) -> list[dict[str, Any]]:
             for ri in m.codex_reasoning_items:
                 if not isinstance(ri, dict) or not ri.get("encrypted_content"):
                     continue
-                out.append({k: v for k, v in ri.items() if k != "id"})
+                replayed = {k: v for k, v in ri.items() if k != "id"}
+                # PR-CODEX-MULTITURN-SUMMARY-PRESERVE (2026-05-26,
+                # Codex MCP catch) — defensive injection at the
+                # replay layer. The capture-path fix at
+                # ``translate_codex_response`` now always emits
+                # ``summary`` on newly captured items, but legacy
+                # ``codex_reasoning_items`` dicts (persisted across
+                # process restarts, deserialised from older state
+                # snapshots, or constructed by external callers) may
+                # still lack the field. The OpenAI Responses API
+                # rejects with ``"Missing required parameter:
+                # 'input[N].summary'"`` whenever it's absent, so we
+                # inject ``summary: []`` here too — defence in depth
+                # against both the capture-time and the persisted-
+                # data drift surfaces.
+                replayed.setdefault("summary", [])
+                out.append(replayed)
             out.extend(_convert_assistant_msg_to_responses(m.content))
             continue
         if m.role == "user":
@@ -614,18 +630,27 @@ def translate_codex_response(
             enc = _attr_or_key(item, "encrypted_content")
             if enc:
                 entry["encrypted_content"] = enc
+            # PR-CODEX-MULTITURN-SUMMARY-PRESERVE (2026-05-26) —
+            # ALWAYS include ``summary`` (default to empty list when
+            # gpt-5.x didn't emit one). Pre-fix the field was only
+            # populated when ``summary`` was truthy; on replay the
+            # OpenAI Responses API requires every reasoning item to
+            # carry ``summary`` (even ``[]``) and rejects with
+            # ``"Missing required parameter: 'input[N].summary'"``
+            # when it's absent (smoke 19 evidence:
+            # vote-m000-openai.openai-codex/dialogue.jsonl turn 2 +
+            # ~10 voter failures across the ranker phase). Per
+            # ctx7-grounded Responses API docs (``/websites/
+            # developers_openai_api`` "Keeping reasoning items in
+            # context") the field is structurally required even when
+            # there's no chain-of-thought summary to surface.
             summary = _attr_or_key(item, "summary")
-            if summary:
-                entry["summary"] = summary
-                if isinstance(summary, list):
-                    for s in summary:
-                        t = (
-                            s.get("text", "")
-                            if isinstance(s, dict)
-                            else getattr(s, "text", "") or ""
-                        )
-                        if t:
-                            reasoning_summaries.append(t)
+            entry["summary"] = summary if summary else []
+            if summary and isinstance(summary, list):
+                for s in summary:
+                    t = s.get("text", "") if isinstance(s, dict) else getattr(s, "text", "") or ""
+                    if t:
+                        reasoning_summaries.append(t)
             iid = _attr_or_key(item, "id")
             if iid:
                 entry["id"] = iid

--- a/tests/core/llm/adapters/test_codex_reasoning_replay.py
+++ b/tests/core/llm/adapters/test_codex_reasoning_replay.py
@@ -220,6 +220,129 @@ def test_codex_call_kwargs_no_reasoning_when_empty() -> None:
     assert kwargs["input"][0] == {"role": "user", "content": "hello"}
 
 
+def test_codex_reasoning_replay_preserves_empty_summary() -> None:
+    """PR-CODEX-MULTITURN-SUMMARY-PRESERVE (2026-05-26) — when a
+    reasoning item is captured from a prior turn WITHOUT a summary
+    (gpt-5.x default for high-effort reasoning is to omit detailed
+    chain-of-thought summaries), the replay MUST still include
+    ``summary: []`` per OpenAI Responses API spec. Pre-fix the
+    capture path at ``_openai_common.py:617-619`` only added the
+    field when truthy — round-tripped items lacked the key and the
+    API returned ``"Missing required parameter: 'input[N].summary'"``
+    on the retry attempt (smoke 19 evidence:
+    vote-m000-openai.openai-codex/dialogue.jsonl turn 2 +
+    ~10 voter failures across the ranker phase).
+    """
+    from core.llm.adapters._openai_common import build_codex_input
+    from core.llm.adapters.base import AdapterCallRequest, Message
+
+    # Capture-shape: reasoning item WITHOUT summary key (matches
+    # pre-fix output where ``if summary:`` skipped the assignment).
+    captured_item_no_summary = {
+        "type": "reasoning",
+        "encrypted_content": "encrypted_blob_no_summary",
+    }
+    # Capture-shape: reasoning item with empty summary list (matches
+    # post-fix output — explicit ``[]`` instead of missing key).
+    captured_item_empty_summary = {
+        "type": "reasoning",
+        "encrypted_content": "encrypted_blob_empty_summary",
+        "summary": [],
+    }
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="",
+        messages=[
+            Message(role="user", content="q1"),
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "a1"}],
+                codex_reasoning_items=(captured_item_no_summary,),
+            ),
+            Message(role="user", content="q2"),
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "a2"}],
+                codex_reasoning_items=(captured_item_empty_summary,),
+            ),
+            Message(role="user", content="q3"),
+        ],
+    )
+    inputs = build_codex_input(req)
+    # The two reasoning items land just before their assistant entries.
+    reasoning_entries = [item for item in inputs if item.get("type") == "reasoning"]
+    assert len(reasoning_entries) == 2
+    # PR-CODEX-MULTITURN-SUMMARY-PRESERVE — capture-time fix
+    # guarantees ``summary`` is always present, even when the input
+    # item omitted it (legacy capture) or carried an explicit empty
+    # list (post-fix capture). The replay code at
+    # ``_openai_common.py:357-360`` just strips the ``id`` field and
+    # forwards every other key; the summary must therefore be in the
+    # captured shape for it to survive the round-trip.
+    #
+    # Note: this test exercises the REPLAY path (build_codex_input).
+    # The capture-path fix is exercised in
+    # ``test_codex_multiturn_reasoning.py``'s extraction tests +
+    # the new ``test_reasoning_item_capture_always_has_summary_field``
+    # below.
+    for entry in reasoning_entries:
+        # PR-CODEX-MULTITURN-SUMMARY-PRESERVE (2026-05-26) — strict
+        # cross-module contract: every replayed reasoning item MUST
+        # carry ``summary`` (empty list or populated, never absent).
+        # Both the capture-time fix (``translate_codex_response``)
+        # AND the replay-time defensive injection
+        # (``build_codex_input.setdefault("summary", [])``) guarantee
+        # this. Pre-fix this assertion failed for the legacy
+        # captured-dict-missing-summary fixture, exactly the smoke 19
+        # failure mode.
+        assert "summary" in entry, (
+            f"reasoning entry replayed without summary field — "
+            f"OpenAI Responses API will 400 with "
+            f"'Missing required parameter: input[N].summary'. "
+            f"Entry: {entry!r}"
+        )
+        assert isinstance(entry["summary"], list)
+
+
+def test_reasoning_item_capture_always_has_summary_field() -> None:
+    """PR-CODEX-MULTITURN-SUMMARY-PRESERVE (2026-05-26) — direct test
+    of the capture-path fix in ``_openai_common.py``. When the codex
+    response carries a reasoning item without a summary, the
+    extracted item MUST default ``summary`` to ``[]`` so downstream
+    replay can satisfy the OpenAI Responses API requirement.
+    """
+    from types import SimpleNamespace
+
+    from core.llm.adapters._openai_common import translate_codex_response
+
+    # Reasoning item where summary is None (gpt-5.x high-effort runs
+    # may emit ``summary: None`` even when summary="auto" was set —
+    # the model decides whether to surface a summary). The capture
+    # path must default to ``[]`` so the next-turn replay satisfies
+    # the API's required-field invariant.
+    reasoning_item = SimpleNamespace(
+        type="reasoning",
+        encrypted_content="blob_x",
+        summary=None,
+        id="rs_test_1",
+    )
+    response = SimpleNamespace(
+        output_text="",
+        output=[reasoning_item],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        status="completed",
+    )
+    result = translate_codex_response(response)
+    assert len(result.reasoning_items) == 1
+    captured = result.reasoning_items[0]
+    assert captured["type"] == "reasoning"
+    assert captured["encrypted_content"] == "blob_x"
+    # The key invariant — summary MUST be present (default empty list)
+    # so the next-turn replay can round-trip without 400.
+    assert "summary" in captured
+    assert captured["summary"] == []
+
+
 @pytest.mark.parametrize(
     ("tool_choice", "expected"),
     [


### PR DESCRIPTION
## Summary
- Codex Responses API multi-turn replay must carry `summary` on every reasoning item (even empty `[]`).
- 2-layer fix: capture-time default + replay-time defensive injection.
- Sprint D PR-D3 (final). ctx7-grounded spec verification.

## Why
Smoke 19 evidence: ~10 voter failures across the ranker phase, all `vote-m*-openai.openai-codex` retries, error:
```
✕ Invalid request. Missing required parameter: 'input[N].summary'.
```
Root: capture path at `_openai_common.py:translate_codex_response` only added `summary` when truthy. High-effort gpt-5.x runs with no chain-of-thought summary → captured item lacked the field → replay sent without it → API 400.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/_openai_common.py` | `translate_codex_response` defaults summary to `[]`; `build_codex_input` defensively `setdefault("summary", [])` for legacy items |
| `tests/core/llm/adapters/test_codex_reasoning_replay.py` | 2 new tests pinning capture-time default + replay-time invariant |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Capture-time summary default | Fixed | always emit `summary` field |
| Replay-time defensive injection | Fixed (Codex MCP catch) | covers legacy persisted dicts |
| Strict test assertion | Fixed (Codex MCP catch) | was permissive `if "summary" in entry` |
| `phase` parameter preservation | Deferred | Task #101 PR-CODEX-MULTITURN-PHASE-PRESERVE (no current failure evidence; ctx7-grounded as recommended-but-optional) |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (453 files)
- [x] pytest tests/core/llm/ + tests/plugins/petri_audit/ — 864 pass, 35 skipped
- [x] Codex MCP cross-LLM review — 4 catches folded in-band (replay defence, strict assertion, docstring accuracy, phase backlog task)
- [x] ctx7 cross-verified against OpenAI Responses API docs:
  - `/websites/developers_openai_api` "Keeping reasoning items in context"
  - `/websites/developers_openai_api` "Migrate to Responses"
  - Confirmed `summary: []` is the empty-but-present shape

## Reference
- Smoke 19 archive: `.audit/smoke-archives/smoke-19-partial-1779751602/sub_agents/vote-m000-openai.openai-codex/dialogue.jsonl` turn 2 = the exact error
- OpenAI Responses API spec via ctx7: `/websites/developers_openai_api`
- PR-WORKER-SCHEMA-AWARE-RETRY (v0.99.61) — the retry path that triggered this exact replay flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)