### PR TITLE
feat(agent): tool selection ranker via Wilson LB (PR-CL-A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,10 +91,14 @@ functional change.
   `core/self_improving_loop/in_context_slots.py`) with shared-ledger
   read (`in_context_wiring.apply_in_context_slots` reads
   `episodes.jsonl` once even when both episodic slots are enabled).
-  27 invariant tests pin the Wilson formula (5/5, 9/10, 90/100,
-  900/1000 concrete pins), aggregation gates (MIN_INVOCATIONS,
-  WILSON_THRESHOLD), malformed-row tolerance, schema registration,
-  wiring orchestration, and graceful no-op on ledger read failure.
+  29 invariant tests pin the Wilson formula (concrete pins for
+  5/5 → 0.5655 and 100/100 → 0.9630; convergence ordering for
+  9/10 < 90/100 < 900/1000 < 0.9), aggregation gates
+  (MIN_INVOCATIONS, WILSON_THRESHOLD), malformed-row tolerance,
+  schema registration, wiring orchestration, the
+  `[tool-ranking][tool-hints][BASE]` relative layered order under
+  the dual-slot config, the module-internal loader's graceful
+  no-op on read failure, and the no-SoT fast path.
 - **PR-HERMES-2** — Hermes Phase 2 platform-aware + family-aware system
   prompt fragments. `core/llm/platform_hints.py` (184 LOC) maps 6 GEODE
   surfaces (`cli`, `serve_repl`, `slack`, `cron`, `worktree`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,27 @@ functional change.
   expected enabled set.
 
 ### Added
+- **PR-CL-A2** — Tool Selection ranker (CL-A2 of
+  `docs/plans/agentic-loop-evolution.md`). New
+  `core/agent/tool_search.py` (~210 LOC) ships the data layer the
+  full A*-style policy will sit on top of: a Wilson lower-bound
+  success-rate aggregator over the episodic ledger. Pure functions
+  `wilson_lower_bound(successes, total, z=1.96)`,
+  `find_recommended_tools(episodes, *, top_k, min_invocations=3,
+  wilson_threshold=0.5)`, and `format_tool_ranking_block(rankings)`
+  produce a `<tool-ranking>` block listing the top-K tools whose
+  recent calls succeeded with a 95% CI lower bound above 0.5. The
+  ranker is the success-side counterpart of the existing
+  `tool_hints` slot (failure-side) — together they give the LLM
+  bidirectional evidence ("don't use X" + "prefer Y"). Wired as the
+  5th canonical in-context slot (`SLOT_TOOL_RANKING = "tool_ranking"`,
+  `core/self_improving_loop/in_context_slots.py`) with shared-ledger
+  read (`in_context_wiring.apply_in_context_slots` reads
+  `episodes.jsonl` once even when both episodic slots are enabled).
+  27 invariant tests pin the Wilson formula (5/5, 9/10, 90/100,
+  900/1000 concrete pins), aggregation gates (MIN_INVOCATIONS,
+  WILSON_THRESHOLD), malformed-row tolerance, schema registration,
+  wiring orchestration, and graceful no-op on ledger read failure.
 - **PR-HERMES-2** — Hermes Phase 2 platform-aware + family-aware system
   prompt fragments. `core/llm/platform_hints.py` (184 LOC) maps 6 GEODE
   surfaces (`cli`, `serve_repl`, `slack`, `cron`, `worktree`,

--- a/core/agent/tool_search.py
+++ b/core/agent/tool_search.py
@@ -1,0 +1,221 @@
+"""Tool selection ranking — CL-A2 (Tool Selection as Search).
+
+GEODE's tool selection is currently the LLM's free choice each step —
+no policy. The cognitive-loop-uplift roadmap calls for an A*-style
+policy biased by historical success and current plan step
+(`docs/plans/agentic-loop-evolution.md` § A2, ToolChain* 7.35x
+speedup [2310.13227](https://arxiv.org/abs/2310.13227)). The full A*
+tree search is large; this module ships the data layer the policy
+will sit on top of — a Wilson lower-bound success-rate ranker over
+the episodic ledger.
+
+**Composition with ``tool_hints``** — the existing
+``core.self_improving_loop.tool_hints`` reader surfaces the *negative*
+signal (tools whose recent calls have been failing). This module is
+its positive counterpart — tools whose recent calls have been
+*succeeding* in a statistically defensible way. The two together
+give the LLM bidirectional evidence: don't use X (failure-side
+``<tool-hints>``) AND prefer Y (success-side ``<tool-ranking>``).
+
+**Why Wilson, not raw success_rate**: a single-call success
+(`1/1 → 100%`) is meaningless — Wilson LB ([Wilson 1927](
+https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval))
+penalises low-sample estimates, so a tool needs both high success
+rate *and* enough calls before it surfaces. Ranking by Wilson LB is
+the standard pattern in Reddit / Voyager / autoresearch trust-score
+sorting; it converges to raw success_rate as ``total`` grows.
+
+**Data path**:
+
+1. Read up to ``RECENT_WINDOW`` (default 200) most-recent episodes
+   via ``EpisodicStore.recent``.
+2. Group by ``tool_name``. For each tool, compute
+   ``successes / total`` plus Wilson LB at 95% confidence.
+3. Filter to tools meeting BOTH ``total >= MIN_INVOCATIONS`` (default
+   3 — single-call hits are noise) AND
+   ``wilson_lb >= WILSON_THRESHOLD`` (default 0.5 — at least
+   defensibly-better-than-coin-flip).
+4. Sort by ``wilson_lb`` desc, tiebreak by ``total`` desc (more data
+   = stronger signal).
+5. Cap at ``InContextSlot.max_entries``.
+6. Render one ``- [tool_name] N/M succeeded (LB Z.ZZ)`` line per tool
+   inside a ``<tool-ranking>`` tag.
+
+**Graceful**: missing ``episodes.jsonl`` → empty result. Malformed
+rows are silently dropped (per-row try/except inside
+``EpisodicStore.recent``).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "MIN_INVOCATIONS",
+    "RECENT_WINDOW",
+    "WILSON_CONFIDENCE",
+    "WILSON_THRESHOLD",
+    "ToolRanking",
+    "find_recommended_tools",
+    "format_tool_ranking_block",
+    "load_recent_episodes",
+    "wilson_lower_bound",
+]
+
+RECENT_WINDOW = 200
+"""How many of the most-recent episodes the reader inspects per LLM call."""
+
+MIN_INVOCATIONS = 3
+"""Minimum calls a tool needs in the window before its Wilson LB counts."""
+
+WILSON_CONFIDENCE = 0.95
+"""Two-sided confidence level for the Wilson score interval (z=1.96)."""
+
+WILSON_THRESHOLD = 0.5
+"""Wilson LB must be >= this for a tool to surface as a recommendation.
+
+0.5 means the lower bound of the 95% CI is at least coin-flip — i.e.
+we are 95% confident the true success rate exceeds 50%.
+"""
+
+# z-score for 95% two-sided. Pinned constant so the formula matches the
+# docstring even if WILSON_CONFIDENCE is later parameterised in tests.
+_Z_95 = 1.959963984540054
+
+
+@dataclass(frozen=True, slots=True)
+class ToolRanking:
+    """One tool's recent success signal ready for rendering."""
+
+    tool_name: str
+    success_count: int
+    total: int
+    success_rate: float
+    wilson_lb: float
+
+
+def wilson_lower_bound(successes: int, total: int, *, z: float = _Z_95) -> float:
+    """Return the Wilson score interval lower bound for ``successes/total``.
+
+    Formula (95% CI default):
+
+        p_hat = successes / total
+        LB = (p_hat + z²/(2n) - z·sqrt(p_hat·(1-p_hat)/n + z²/(4n²))) / (1 + z²/n)
+
+    Edge cases:
+
+    * ``total <= 0`` → returns 0.0 (no evidence).
+    * Result is always in ``[0.0, 1.0]`` (clamped — the formula itself
+      can return slightly negative values when successes==0).
+    """
+    if total <= 0:
+        return 0.0
+    p_hat = successes / total
+    z_sq = z * z
+    denominator = 1.0 + z_sq / total
+    centre = p_hat + z_sq / (2.0 * total)
+    margin = z * math.sqrt(p_hat * (1.0 - p_hat) / total + z_sq / (4.0 * total * total))
+    lb = (centre - margin) / denominator
+    if lb < 0.0:
+        return 0.0
+    if lb > 1.0:
+        return 1.0
+    return lb
+
+
+def load_recent_episodes(limit: int = RECENT_WINDOW) -> list[object]:
+    """Return up to ``limit`` most-recent episodes, newest first.
+
+    Returns an empty list on missing ``episodes.jsonl`` or any read
+    failure. Mirrors ``tool_hints.load_recent_episodes`` — the two
+    slots intentionally share one read of the ledger via the
+    ``in_context_wiring`` orchestrator (when both slots are enabled).
+    """
+    try:
+        from core.memory.episodic import EpisodicStore
+    except Exception as exc:  # pragma: no cover — defensive
+        log.debug("tool_search: episodic store import failed: %s", exc)
+        return []
+    try:
+        store = EpisodicStore()
+        return list(store.recent(limit=limit))
+    except Exception as exc:
+        log.debug("tool_search: episodic store read failed: %s", exc)
+        return []
+
+
+def find_recommended_tools(
+    episodes: list[object],
+    *,
+    top_k: int,
+    min_invocations: int = MIN_INVOCATIONS,
+    wilson_threshold: float = WILSON_THRESHOLD,
+) -> list[ToolRanking]:
+    """Aggregate ``episodes`` → per-tool Wilson LB; return top-ranked tools.
+
+    Args:
+        episodes: Iterable of objects exposing ``tool_name`` (str) and
+            ``success`` (bool). Other Episode fields are ignored.
+        top_k: Cap on returned rankings. <=0 → empty.
+        min_invocations: Minimum calls before Wilson LB is considered.
+        wilson_threshold: Inclusive lower bound on the Wilson LB.
+
+    Returns:
+        Sorted by ``wilson_lb`` desc, then ``total`` desc. Tools
+        failing either threshold are excluded.
+    """
+    if top_k <= 0:
+        return []
+    totals: dict[str, int] = {}
+    successes: dict[str, int] = {}
+    for ep in episodes:
+        tool = getattr(ep, "tool_name", None)
+        if not isinstance(tool, str) or not tool:
+            continue
+        success = getattr(ep, "success", None)
+        if not isinstance(success, bool):
+            continue
+        totals[tool] = totals.get(tool, 0) + 1
+        if success:
+            successes[tool] = successes.get(tool, 0) + 1
+    rankings: list[ToolRanking] = []
+    for tool, total in totals.items():
+        if total < min_invocations:
+            continue
+        success_count = successes.get(tool, 0)
+        success_rate = success_count / total
+        lb = wilson_lower_bound(success_count, total)
+        if lb < wilson_threshold:
+            continue
+        rankings.append(
+            ToolRanking(
+                tool_name=tool,
+                success_count=success_count,
+                total=total,
+                success_rate=success_rate,
+                wilson_lb=lb,
+            )
+        )
+    rankings.sort(key=lambda r: (-r.wilson_lb, -r.total))
+    return rankings[:top_k]
+
+
+def format_tool_ranking_block(rankings: list[ToolRanking]) -> str:
+    """Render the recommended-tool list as a ``<tool-ranking>`` block.
+
+    Empty input → ``""`` (the wiring layer skips the slot append when
+    the formatted block is empty).
+    """
+    if not rankings:
+        return ""
+    lines = ["<tool-ranking>"]
+    for r in rankings:
+        lines.append(
+            f"- [{r.tool_name}] {r.success_count}/{r.total} succeeded (LB {r.wilson_lb:.2f})"
+        )
+    lines.append("</tool-ranking>")
+    return "\n".join(lines)

--- a/core/self_improving_loop/in_context_slots.py
+++ b/core/self_improving_loop/in_context_slots.py
@@ -88,17 +88,21 @@ _IN_CONTEXT_SLOTS_SOT_PATH = GLOBAL_IN_CONTEXT_SLOTS_PATH
 _OPERATOR_LOCAL_IN_CONTEXT_SLOTS_PATH = OPERATOR_LOCAL_IN_CONTEXT_SLOTS_PATH
 """Operator-local SoT path. Module-local alias for monkey-patch."""
 
-# 4 canonical slot identifiers.
+# 5 canonical slot identifiers — 4 from the original ADR-012 S5 set
+# plus ``tool_ranking`` (CL-A2, 2026-05-26) which complements
+# ``tool_hints`` with the positive (success-side) signal.
 SLOT_EXEMPLARS = "exemplars"
 SLOT_MEMORY_RECALL = "memory_recall"
 SLOT_RUBRIC_EXCERPTS = "rubric_excerpts"
 SLOT_TOOL_HINTS = "tool_hints"
+SLOT_TOOL_RANKING = "tool_ranking"
 
 CANONICAL_SLOTS: tuple[str, ...] = (
     SLOT_EXEMPLARS,
     SLOT_MEMORY_RECALL,
     SLOT_RUBRIC_EXCERPTS,
     SLOT_TOOL_HINTS,
+    SLOT_TOOL_RANKING,
 )
 
 # Valid ``injection_point`` choices — namespaces the system prompt
@@ -240,6 +244,7 @@ __all__ = [
     "SLOT_MEMORY_RECALL",
     "SLOT_RUBRIC_EXCERPTS",
     "SLOT_TOOL_HINTS",
+    "SLOT_TOOL_RANKING",
     "VALID_INJECTION_POINTS",
     "InContextSlot",
 ]

--- a/core/self_improving_loop/in_context_wiring.py
+++ b/core/self_improving_loop/in_context_wiring.py
@@ -6,7 +6,7 @@ orchestrator consults the 4-slot SoT and applies the configured
 transforms to the outgoing ``messages`` + ``system`` text before they
 reach the provider.
 
-**4 slots → wiring status**:
+**5 slots → wiring status**:
 
 * ``exemplars`` — **wired**. Reads the M3 few-shot exemplar pool
   (`core/llm/few_shot_pool.py`) via ``_load_few_shot_pool_override`` →
@@ -25,7 +25,12 @@ reach the provider.
   (``~/.geode/memory/episodes.jsonl``), aggregates per-tool fail
   rate over a rolling window, and prepends a ``<tool-hints>`` block
   for tools whose recent calls have been failing above the threshold.
-  Closes the M4 sprint — all 4 in-context slots now active.
+* ``tool_ranking`` — **wired (CL-A2, 2026-05-26)**. Wilson LB
+  success-side counterpart of ``tool_hints``. Shares the same
+  episodic-ledger read so the disk-read budget per LLM call stays
+  at 1 even when both slots are active. Prepends a ``<tool-ranking>``
+  block with the top-K Wilson-LB-ranked tools above the confidence
+  threshold.
 
 **No-op fast path**: when ``_load_in_context_slots_override`` returns
 ``None`` (no SoT configured, the GEODE default), the orchestrator
@@ -82,6 +87,7 @@ def apply_in_context_slots(
             SLOT_MEMORY_RECALL,
             SLOT_RUBRIC_EXCERPTS,
             SLOT_TOOL_HINTS,
+            SLOT_TOOL_RANKING,
             _load_in_context_slots_override,
         )
 
@@ -157,27 +163,56 @@ def apply_in_context_slots(
         except Exception as exc:
             log.debug("rubric_excerpts slot apply failed: %s", exc, exc_info=True)
 
-    # tool_hints — M4.4.3 reader active. Reads episodic ledger,
-    # aggregates per-tool fail_rate, prepends a ``<tool-hints>`` block
-    # for tools failing above the threshold. Closes the M4 sprint —
-    # all 4 in-context slots now wired.
+    # tool_hints + tool_ranking — episodic-ledger readers. Share one
+    # read of ``episodes.jsonl`` when both slots are enabled so the
+    # disk-read budget per LLM call stays at 1, not 2.
     tool_hints_cfg = slots.get(SLOT_TOOL_HINTS)
-    if tool_hints_cfg is not None:
+    tool_ranking_cfg = slots.get(SLOT_TOOL_RANKING)
+    if tool_hints_cfg is not None or tool_ranking_cfg is not None:
         try:
-            from core.self_improving_loop.tool_hints import (
-                find_failing_tools,
-                format_tool_hints_block,
-                load_recent_episodes,
-            )
+            from core.self_improving_loop.tool_hints import load_recent_episodes
 
             episodes = load_recent_episodes()
-            if episodes:
-                hints = find_failing_tools(episodes, top_k=tool_hints_cfg.max_entries)
-                block = format_tool_hints_block(hints)
-                if block:
-                    new_system = block + "\n\n" + new_system if new_system else block
         except Exception as exc:
-            log.debug("tool_hints slot apply failed: %s", exc, exc_info=True)
+            log.debug("episodic ledger read failed: %s", exc, exc_info=True)
+            episodes = []
+
+        # tool_hints — M4.4.3 reader (failure-side). Reads episodic
+        # ledger, aggregates per-tool fail_rate, prepends a
+        # ``<tool-hints>`` block for tools failing above the threshold.
+        if tool_hints_cfg is not None:
+            try:
+                from core.self_improving_loop.tool_hints import (
+                    find_failing_tools,
+                    format_tool_hints_block,
+                )
+
+                if episodes:
+                    hints = find_failing_tools(episodes, top_k=tool_hints_cfg.max_entries)
+                    block = format_tool_hints_block(hints)
+                    if block:
+                        new_system = block + "\n\n" + new_system if new_system else block
+            except Exception as exc:
+                log.debug("tool_hints slot apply failed: %s", exc, exc_info=True)
+
+        # tool_ranking — CL-A2 reader (success-side). Wilson LB over
+        # the same episodic window, prepends a ``<tool-ranking>``
+        # block for tools whose recent calls succeeded above the
+        # confidence threshold. Complements tool_hints.
+        if tool_ranking_cfg is not None:
+            try:
+                from core.agent.tool_search import (
+                    find_recommended_tools,
+                    format_tool_ranking_block,
+                )
+
+                if episodes:
+                    ranks = find_recommended_tools(episodes, top_k=tool_ranking_cfg.max_entries)
+                    block = format_tool_ranking_block(ranks)
+                    if block:
+                        new_system = block + "\n\n" + new_system if new_system else block
+            except Exception as exc:
+                log.debug("tool_ranking slot apply failed: %s", exc, exc_info=True)
 
     return new_messages, new_system
 

--- a/core/self_improving_loop/in_context_wiring.py
+++ b/core/self_improving_loop/in_context_wiring.py
@@ -165,7 +165,12 @@ def apply_in_context_slots(
 
     # tool_hints + tool_ranking — episodic-ledger readers. Share one
     # read of ``episodes.jsonl`` when both slots are enabled so the
-    # disk-read budget per LLM call stays at 1, not 2.
+    # disk-read budget per LLM call stays at 1, not 2. Both readers
+    # PREPEND to ``new_system``, so the relative layered order in the
+    # final prompt is ``[tool-ranking][tool-hints][BASE]`` (later
+    # prepend wins the head position). Pinned by
+    # ``test_wiring_emits_both_blocks_under_dual_slot_config``'s order
+    # invariant.
     tool_hints_cfg = slots.get(SLOT_TOOL_HINTS)
     tool_ranking_cfg = slots.get(SLOT_TOOL_RANKING)
     if tool_hints_cfg is not None or tool_ranking_cfg is not None:

--- a/tests/core/agent/test_tool_search.py
+++ b/tests/core/agent/test_tool_search.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+import pytest
 from core.agent.tool_search import (
     MIN_INVOCATIONS,
     WILSON_THRESHOLD,
@@ -232,3 +233,37 @@ def test_min_invocations_constant_matches_tool_hints():
     )
 
     assert MIN_INVOCATIONS == HINTS_MIN_INVOCATIONS
+
+
+def test_load_recent_episodes_handles_missing_store(monkeypatch: pytest.MonkeyPatch):
+    """``tool_search.load_recent_episodes`` is the module-internal loader
+    used when callers invoke the ranker without going through
+    ``in_context_wiring``. The wiring opts to share ``tool_hints``'
+    loader as a shared-read optimisation; this test pins the parallel
+    public API so it isn't quietly dead code."""
+    import core.agent.tool_search as ts_module
+
+    class _ExplodingStore:
+        def recent(self, *, limit: int) -> list[object]:
+            raise OSError("disk on fire")
+
+    monkeypatch.setattr("core.memory.episodic.EpisodicStore", _ExplodingStore)
+    # Read failure → graceful empty list, never raises.
+    result = ts_module.load_recent_episodes()
+    assert result == []
+
+
+def test_load_recent_episodes_returns_store_output(monkeypatch: pytest.MonkeyPatch):
+    """Happy path — loader forwards the store's ``recent()`` result."""
+    import core.agent.tool_search as ts_module
+
+    expected = [_FakeEpisode("read", True), _FakeEpisode("read", False)]
+
+    class _OkStore:
+        def recent(self, *, limit: int) -> list[object]:
+            assert limit == ts_module.RECENT_WINDOW
+            return list(expected)
+
+    monkeypatch.setattr("core.memory.episodic.EpisodicStore", _OkStore)
+    result = ts_module.load_recent_episodes()
+    assert result == expected

--- a/tests/core/agent/test_tool_search.py
+++ b/tests/core/agent/test_tool_search.py
@@ -1,0 +1,234 @@
+"""CL-A2 — ``core.agent.tool_search`` invariants.
+
+Pins the Wilson score interval LB math, the
+``find_recommended_tools`` aggregation contract, and the rendered
+``<tool-ranking>`` block shape. Graceful no-op on empty / malformed
+input.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from core.agent.tool_search import (
+    MIN_INVOCATIONS,
+    WILSON_THRESHOLD,
+    ToolRanking,
+    find_recommended_tools,
+    format_tool_ranking_block,
+    wilson_lower_bound,
+)
+
+from core.agent import tool_search
+
+
+@dataclass
+class _FakeEpisode:
+    """Minimal duck-typed Episode for the aggregator's getattr lookups."""
+
+    tool_name: str
+    success: bool
+
+
+def test_module_exports_stable():
+    expected = {
+        "MIN_INVOCATIONS",
+        "RECENT_WINDOW",
+        "ToolRanking",
+        "WILSON_CONFIDENCE",
+        "WILSON_THRESHOLD",
+        "find_recommended_tools",
+        "format_tool_ranking_block",
+        "load_recent_episodes",
+        "wilson_lower_bound",
+    }
+    assert set(tool_search.__all__) == expected
+
+
+# ── Wilson lower-bound math ───────────────────────────────────────────
+
+
+def test_wilson_lb_zero_total_returns_zero():
+    assert wilson_lower_bound(0, 0) == 0.0
+    assert wilson_lower_bound(5, 0) == 0.0  # successes ignored when total<=0
+
+
+def test_wilson_lb_all_failures_returns_zero():
+    """0 successes out of N → LB clamps to 0 (formula gives slightly negative)."""
+    assert wilson_lower_bound(0, 10) == 0.0
+
+
+def test_wilson_lb_all_successes_below_raw_for_small_n():
+    """5/5 (100%) penalised vs 100/100 — small sample → wider CI → lower LB."""
+    small = wilson_lower_bound(5, 5)
+    big = wilson_lower_bound(100, 100)
+    assert 0.0 < small < big
+    # Concrete pin against the published formula (Wilson 1927, z≈1.9600).
+    assert math.isclose(small, 0.5655175, rel_tol=1e-4)
+    assert math.isclose(big, 0.9630065, rel_tol=1e-4)
+
+
+def test_wilson_lb_converges_to_success_rate_as_n_grows():
+    """For p=0.9, LB(9/10) < LB(90/100) < LB(900/1000) ≈ 0.88."""
+    a = wilson_lower_bound(9, 10)
+    b = wilson_lower_bound(90, 100)
+    c = wilson_lower_bound(900, 1000)
+    assert a < b < c < 0.9
+    # 1000 trials at p=0.9 — Wilson LB lands within ~2.1pp of the raw rate.
+    assert 0.9 - c < 0.03, f"LB(900/1000)={c} should be within 3% of 0.9"
+
+
+def test_wilson_lb_result_in_unit_interval():
+    """Across a range of inputs the LB must stay in [0, 1]."""
+    for s in (0, 1, 3, 7, 10):
+        for n in (1, 5, 10, 50, 100):
+            if s > n:
+                continue
+            lb = wilson_lower_bound(s, n)
+            assert 0.0 <= lb <= 1.0
+
+
+# ── find_recommended_tools aggregation ───────────────────────────────
+
+
+def _make_episodes(*pairs: tuple[str, bool]) -> list[_FakeEpisode]:
+    return [_FakeEpisode(tool_name=n, success=ok) for n, ok in pairs]
+
+
+def test_find_recommended_empty_episodes_returns_empty():
+    assert find_recommended_tools([], top_k=5) == []
+
+
+def test_find_recommended_top_k_zero_returns_empty():
+    eps = _make_episodes(("read", True), ("read", True), ("read", True))
+    assert find_recommended_tools(eps, top_k=0) == []
+    assert find_recommended_tools(eps, top_k=-1) == []
+
+
+def test_find_recommended_min_invocations_gate():
+    """Single-call success → excluded even if 100% success rate."""
+    eps = _make_episodes(("read", True))
+    ranks = find_recommended_tools(eps, top_k=5)
+    assert ranks == [], "below MIN_INVOCATIONS must be excluded"
+
+
+def test_find_recommended_below_wilson_threshold_excluded():
+    """4/5 (80% raw, LB ~0.376) is below default 0.5 threshold."""
+    eps = _make_episodes(*[("read", True)] * 4, ("read", False))
+    ranks = find_recommended_tools(eps, top_k=5)
+    assert ranks == [], "Wilson LB < 0.5 must be excluded"
+
+
+def test_find_recommended_passing_wilson_threshold_surfaces():
+    """100% across 10 calls → LB ~0.722, well above 0.5."""
+    eps = _make_episodes(*[("read", True)] * 10)
+    ranks = find_recommended_tools(eps, top_k=5)
+    assert len(ranks) == 1
+    r = ranks[0]
+    assert r.tool_name == "read"
+    assert r.success_count == 10
+    assert r.total == 10
+    assert r.success_rate == 1.0
+    assert r.wilson_lb >= WILSON_THRESHOLD
+
+
+def test_find_recommended_sorted_by_wilson_lb_desc():
+    """Higher Wilson LB ranks first; ties broken by total desc."""
+    eps = _make_episodes(
+        *[("read", True)] * 50,  # 50/50, LB ~0.929
+        *[("bash", True)] * 10,  # 10/10, LB ~0.722
+        *[("grep", True)] * 5,  # 5/5, LB ~0.565
+    )
+    ranks = find_recommended_tools(eps, top_k=5)
+    names = [r.tool_name for r in ranks]
+    assert names == ["read", "bash", "grep"]
+
+
+def test_find_recommended_top_k_truncates():
+    eps = _make_episodes(
+        *[("a", True)] * 20,
+        *[("b", True)] * 15,
+        *[("c", True)] * 10,
+        *[("d", True)] * 5,
+    )
+    ranks = find_recommended_tools(eps, top_k=2)
+    assert len(ranks) == 2
+    assert [r.tool_name for r in ranks] == ["a", "b"]
+
+
+def test_find_recommended_skips_malformed_rows():
+    """Non-string tool_name or non-bool success → drop, don't crash."""
+    eps: list[object] = list(_make_episodes(*[("read", True)] * 5))
+    eps.append(_FakeEpisode(tool_name="", success=True))  # empty name
+    eps.append(_FakeEpisode(tool_name=None, success=True))  # type: ignore[arg-type]
+    eps.append(_FakeEpisode(tool_name="x", success="yes"))  # type: ignore[arg-type]
+    ranks = find_recommended_tools(eps, top_k=5)
+    assert len(ranks) == 1
+    assert ranks[0].tool_name == "read"
+
+
+def test_find_recommended_mixed_success_failure_pair():
+    """A tool with 8 successes out of 10 (LB ~0.490) is just under
+    threshold; with 9/10 (LB ~0.596) it passes."""
+    eps_8 = _make_episodes(*[("foo", True)] * 8, *[("foo", False)] * 2)
+    eps_9 = _make_episodes(*[("foo", True)] * 9, ("foo", False))
+    assert find_recommended_tools(eps_8, top_k=5) == [], "8/10 below threshold"
+    ranks = find_recommended_tools(eps_9, top_k=5)
+    assert len(ranks) == 1 and ranks[0].tool_name == "foo"
+
+
+def test_find_recommended_min_invocations_param_override():
+    eps = _make_episodes(("read", True), ("read", True))  # only 2 calls
+    # default MIN_INVOCATIONS=3 → empty
+    assert find_recommended_tools(eps, top_k=5) == []
+    # lowered to 2 → surfaces (Wilson LB(2,2) ~0.342 — still below 0.5
+    # threshold, so loosen that too).
+    ranks = find_recommended_tools(eps, top_k=5, min_invocations=2, wilson_threshold=0.0)
+    assert len(ranks) == 1
+    assert ranks[0].success_count == 2
+
+
+# ── format_tool_ranking_block ────────────────────────────────────────
+
+
+def test_format_block_empty_input_returns_empty_string():
+    assert format_tool_ranking_block([]) == ""
+
+
+def test_format_block_shape():
+    ranks = [
+        ToolRanking(
+            tool_name="read",
+            success_count=10,
+            total=10,
+            success_rate=1.0,
+            wilson_lb=0.7224,
+        )
+    ]
+    block = format_tool_ranking_block(ranks)
+    assert block.startswith("<tool-ranking>")
+    assert block.rstrip().endswith("</tool-ranking>")
+    assert "- [read] 10/10 succeeded (LB 0.72)" in block
+
+
+def test_format_block_two_entry_order_preserved():
+    """The formatter renders entries in the order received (caller pre-sorts)."""
+    ranks = [
+        ToolRanking("first", 50, 50, 1.0, 0.93),
+        ToolRanking("second", 10, 10, 1.0, 0.72),
+    ]
+    block = format_tool_ranking_block(ranks)
+    lines = block.split("\n")
+    assert "first" in lines[1]
+    assert "second" in lines[2]
+
+
+def test_min_invocations_constant_matches_tool_hints():
+    """MVP convergence — both readers gate at 3 calls. If one diverges,
+    the docstring claim about a shared window/floor pair breaks."""
+    from core.self_improving_loop.tool_hints import (
+        MIN_INVOCATIONS as HINTS_MIN_INVOCATIONS,
+    )
+
+    assert MIN_INVOCATIONS == HINTS_MIN_INVOCATIONS

--- a/tests/core/self_improving_loop/test_tool_ranking_wiring.py
+++ b/tests/core/self_improving_loop/test_tool_ranking_wiring.py
@@ -172,6 +172,19 @@ def test_wiring_emits_both_blocks_under_dual_slot_config(
     assert "bad_tool" in new_system
     assert call_count["n"] == 1, "ledger must be read once even with both slots"
 
+    # Order invariant — both readers prepend to ``new_system``. Because
+    # tool_hints runs first then tool_ranking second, the final layered
+    # result is ``[tool-ranking][tool-hints][BASE]`` (newest prepend
+    # appears first). Pinned so a future re-shuffle of the orchestrator
+    # block surfaces in tests, not silently in production prompts.
+    ranking_idx = new_system.index("<tool-ranking>")
+    hints_idx = new_system.index("<tool-hints>")
+    base_idx = new_system.index("BASE")
+    assert ranking_idx < hints_idx < base_idx, (
+        f"expected [ranking][hints][BASE], got "
+        f"ranking@{ranking_idx} hints@{hints_idx} base@{base_idx}"
+    )
+
 
 def test_wiring_graceful_when_ledger_read_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """A loader exception → both slots silently no-op, system prompt intact."""

--- a/tests/core/self_improving_loop/test_tool_ranking_wiring.py
+++ b/tests/core/self_improving_loop/test_tool_ranking_wiring.py
@@ -1,0 +1,205 @@
+"""CL-A2 — in-context slot wiring invariants for ``tool_ranking``.
+
+Pins the schema registration (5th canonical slot), the orchestrator
+firing under SoT-active config, the shared-read optimisation when
+both episodic slots are enabled, and the graceful no-op when no SoT
+is configured.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.in_context_slots import (
+    CANONICAL_SLOTS,
+    SLOT_TOOL_HINTS,
+    SLOT_TOOL_RANKING,
+    InContextSlot,
+)
+
+from core.self_improving_loop import in_context_slots, in_context_wiring
+
+
+@dataclass
+class _FakeEpisode:
+    tool_name: str
+    success: bool
+    error: str | None = None
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_IN_CONTEXT_SLOTS_OVERRIDE", raising=False)
+
+
+def test_tool_ranking_in_canonical_slots():
+    assert SLOT_TOOL_RANKING == "tool_ranking"
+    assert SLOT_TOOL_RANKING in CANONICAL_SLOTS
+    assert SLOT_TOOL_HINTS in CANONICAL_SLOTS, "tool_hints should stay in the set"
+    assert len(CANONICAL_SLOTS) == 5, "5 canonical slots after CL-A2"
+
+
+def test_tool_ranking_exported():
+    assert "SLOT_TOOL_RANKING" in in_context_slots.__all__
+
+
+def test_schema_coerce_accepts_tool_ranking_entry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """SoT JSON with a ``tool_ranking`` entry coerces to an InContextSlot."""
+    sot = tmp_path / "in-context-slots.json"
+    sot.write_text(
+        json.dumps(
+            {
+                "tool_ranking": {
+                    "max_entries": 4,
+                    "rank_by": "wilson_lb",
+                    "injection_point": "system_prompt",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_IN_CONTEXT_SLOTS_OVERRIDE", str(sot))
+    monkeypatch.setenv("GEODE_IN_CONTEXT_SLOTS_STRICT", "1")
+    slots = in_context_slots._load_in_context_slots_override()
+    assert slots is not None
+    cfg = slots.get(SLOT_TOOL_RANKING)
+    assert isinstance(cfg, InContextSlot)
+    assert cfg.max_entries == 4
+    assert cfg.rank_by == "wilson_lb"
+
+
+def test_wiring_no_sot_returns_input_identity(monkeypatch: pytest.MonkeyPatch):
+    """No SoT loaded → fast path returns same objects, no allocation."""
+    monkeypatch.setattr(
+        in_context_wiring,
+        "log",
+        in_context_wiring.log,  # keep logger stable
+    )
+    messages = [{"role": "user", "content": "x"}]
+    system = "base"
+    new_messages, new_system = in_context_wiring.apply_in_context_slots(messages, system=system)
+    assert new_messages is messages
+    assert new_system is system
+
+
+def test_wiring_emits_ranking_block_when_episodes_qualify(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """SoT has tool_ranking → orchestrator reads ledger → block appears."""
+    sot = tmp_path / "in-context-slots.json"
+    sot.write_text(
+        json.dumps(
+            {
+                "tool_ranking": {
+                    "max_entries": 3,
+                    "rank_by": "wilson_lb",
+                    "injection_point": "system_prompt",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_IN_CONTEXT_SLOTS_OVERRIDE", str(sot))
+
+    def _fake_loader(limit: int = 200) -> list[object]:
+        # 50 successes out of 50 → Wilson LB ~0.929 → comfortably above 0.5.
+        return [_FakeEpisode("read", True) for _ in range(50)]
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.tool_hints.load_recent_episodes",
+        _fake_loader,
+    )
+
+    _messages, new_system = in_context_wiring.apply_in_context_slots(
+        [{"role": "user", "content": "x"}], system="BASE"
+    )
+    assert "<tool-ranking>" in new_system
+    assert "- [read] 50/50 succeeded" in new_system
+    assert "BASE" in new_system, "system suffix preserved"
+
+
+def test_wiring_emits_both_blocks_under_dual_slot_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Both tool_hints + tool_ranking enabled → both blocks prepend.
+
+    The orchestrator must NOT read the ledger twice — verified by
+    counting ``load_recent_episodes`` calls.
+    """
+    sot = tmp_path / "in-context-slots.json"
+    sot.write_text(
+        json.dumps(
+            {
+                "tool_hints": {
+                    "max_entries": 3,
+                    "rank_by": "fail_rate",
+                    "injection_point": "system_prompt",
+                },
+                "tool_ranking": {
+                    "max_entries": 3,
+                    "rank_by": "wilson_lb",
+                    "injection_point": "system_prompt",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_IN_CONTEXT_SLOTS_OVERRIDE", str(sot))
+
+    call_count = {"n": 0}
+
+    def _fake_loader(limit: int = 200) -> list[object]:
+        call_count["n"] += 1
+        return [
+            *[_FakeEpisode("ok_tool", True) for _ in range(20)],
+            *[_FakeEpisode("bad_tool", False, "boom") for _ in range(10)],
+        ]
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.tool_hints.load_recent_episodes",
+        _fake_loader,
+    )
+
+    _messages, new_system = in_context_wiring.apply_in_context_slots(
+        [{"role": "user", "content": "x"}], system="BASE"
+    )
+    assert "<tool-hints>" in new_system
+    assert "<tool-ranking>" in new_system
+    assert "ok_tool" in new_system
+    assert "bad_tool" in new_system
+    assert call_count["n"] == 1, "ledger must be read once even with both slots"
+
+
+def test_wiring_graceful_when_ledger_read_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A loader exception → both slots silently no-op, system prompt intact."""
+    sot = tmp_path / "in-context-slots.json"
+    sot.write_text(
+        json.dumps(
+            {
+                "tool_ranking": {
+                    "max_entries": 3,
+                    "rank_by": "wilson_lb",
+                    "injection_point": "system_prompt",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_IN_CONTEXT_SLOTS_OVERRIDE", str(sot))
+
+    def _exploding_loader(limit: int = 200) -> list[object]:
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.tool_hints.load_recent_episodes",
+        _exploding_loader,
+    )
+
+    _messages, new_system = in_context_wiring.apply_in_context_slots(
+        [{"role": "user", "content": "x"}], system="BASE"
+    )
+    assert "<tool-ranking>" not in new_system
+    assert new_system == "BASE"

--- a/tests/test_s5_in_context_slots.py
+++ b/tests/test_s5_in_context_slots.py
@@ -50,21 +50,27 @@ def _write(sot: Path, payload: dict[str, Any]) -> None:
 # Canonical schema ------------------------------------------------------------
 
 
-def test_canonical_slots_has_exactly_4_entries() -> None:
+def test_canonical_slots_has_exactly_5_entries() -> None:
+    """CL-A2 (2026-05-26) added ``tool_ranking`` as the 5th canonical
+    slot — the success-side counterpart of ``tool_hints``."""
     assert CANONICAL_SLOTS == (
         "exemplars",
         "memory_recall",
         "rubric_excerpts",
         "tool_hints",
+        "tool_ranking",
     )
-    assert len(CANONICAL_SLOTS) == 4
+    assert len(CANONICAL_SLOTS) == 5
 
 
 def test_slot_identifier_constants_match_canonical() -> None:
+    from core.self_improving_loop.in_context_slots import SLOT_TOOL_RANKING
+
     assert SLOT_EXEMPLARS == "exemplars"
     assert SLOT_MEMORY_RECALL == "memory_recall"
     assert SLOT_RUBRIC_EXCERPTS == "rubric_excerpts"
     assert SLOT_TOOL_HINTS == "tool_hints"
+    assert SLOT_TOOL_RANKING == "tool_ranking"
 
 
 def test_valid_injection_points_has_two_namespaces() -> None:
@@ -134,7 +140,7 @@ def test_load_rejects_bool_as_max_entries(isolated_sot: Path) -> None:
     assert _load_in_context_slots_override() is None
 
 
-def test_load_valid_payload_all_4_slots(isolated_sot: Path) -> None:
+def test_load_valid_payload_all_5_slots(isolated_sot: Path) -> None:
     payload = {
         "exemplars": {
             "max_entries": 3,
@@ -156,6 +162,11 @@ def test_load_valid_payload_all_4_slots(isolated_sot: Path) -> None:
             "rank_by": "success_rate",
             "injection_point": "tool_descriptions",
         },
+        "tool_ranking": {
+            "max_entries": 5,
+            "rank_by": "wilson_lb",
+            "injection_point": "system_prompt",
+        },
     }
     _write(isolated_sot, payload)
     result = _load_in_context_slots_override()
@@ -163,6 +174,7 @@ def test_load_valid_payload_all_4_slots(isolated_sot: Path) -> None:
     assert set(result.keys()) == set(CANONICAL_SLOTS)
     assert result["exemplars"].max_entries == 3
     assert result["tool_hints"].injection_point == "tool_descriptions"
+    assert result["tool_ranking"].rank_by == "wilson_lb"
 
 
 def test_load_partial_slots(isolated_sot: Path) -> None:


### PR DESCRIPTION
## Summary
- Cognitive-loop-uplift A2 ships the **data layer** the full A*-style policy will sit on top of (per `docs/plans/agentic-loop-evolution.md` § A2).
- Wilson lower-bound success-rate ranker over the episodic ledger, surfaced as a `<tool-ranking>` in-context block (positive-side counterpart of the existing `<tool-hints>` failure-side slot).
- 5th canonical in-context slot (`SLOT_TOOL_RANKING`) + shared-ledger read so the disk-read budget per LLM call stays at 1 even with both episodic slots enabled.

## Why
- ToolChain* (2310.13227) achieved 7.35x speedup over DFS by biasing tool choice toward historically-successful options — a defensible success ranker is the necessary first step.
- Existing `tool_hints` only surfaces failure-side ("don't use X"); the agent has no positive signal ("prefer Y") to balance.
- Naïve `success_rate = successes/total` is misleading for low samples (e.g. 1/1 = 100%). Wilson LB at 95% CI penalises small samples (5/5 → 0.566) and converges to the raw rate as `n` grows (900/1000 → 0.880).

## Changes
| File | Change |
|------|--------|
| `core/agent/tool_search.py` (added, ~210 LOC) | `wilson_lower_bound`, `find_recommended_tools`, `format_tool_ranking_block`, `ToolRanking`, `load_recent_episodes` |
| `core/self_improving_loop/in_context_slots.py` (+5 LOC) | `SLOT_TOOL_RANKING = "tool_ranking"` registered as the 5th canonical slot |
| `core/self_improving_loop/in_context_wiring.py` (~50 LOC delta) | Single shared ledger read for both episodic slots; `[tool-ranking][tool-hints][BASE]` order documented |
| `tests/core/agent/test_tool_search.py` (added, 22 invariants) | Wilson math + aggregator + formatter + loader |
| `tests/core/self_improving_loop/test_tool_ranking_wiring.py` (added, 7 invariants) | Slot registration + orchestrator firing + shared-read + order + graceful no-op |
| `tests/test_s5_in_context_slots.py` | 4-slot → 5-slot invariants |
| `CHANGELOG.md` | `[Unreleased] → Added` PR-CL-A2 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `tool_hints` (failure side) | Already implemented (PR M4.4.3) | 176 LOC at `core/self_improving_loop/tool_hints.py` |
| `tool_ranking` (success side, this PR) | Implemented | Wilson LB, MIN_INVOCATIONS=3, WILSON_THRESHOLD=0.5 |
| Full A* tree-search policy | Deferred | Plan budget ~200 LOC; full A* is 500+. Data layer ships first |
| Plan-step-aware biasing | Deferred | A1's PlanStep available but no caller integration yet |

## Verification
- [x] ruff check + format clean (5 modified files)
- [x] mypy clean (456 source files)
- [x] lint-imports clean (4 contracts kept)
- [x] pytest 29/29 on new test files
- [x] pytest 138/138 on broader regression (`-k 'tool_hints or in_context or tool_search or tool_ranking or s5'`)
- [x] Codex MCP review (read-only sandbox): 3 WARNs (CHANGELOG over-claim, untested block order, loader no-caller) all resolved in the fix-up commit

## Reference
- Source plan: `docs/plans/agentic-loop-evolution.md` § Layer 2 / A2
- Formula: Wilson 1927 score interval ([Binomial proportion confidence interval](https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval))
- Frontier convergence: ToolChain* ([2310.13227](https://arxiv.org/abs/2310.13227)) 7.35x speedup; Voyager skill library ranking; autoresearch trust-score sorting
- Composition reference: PR #1425 (`tool_hints` failure-side slot)