### PR TITLE
PR-CODEX-GPT55-OUTPUT-EMIT — gpt-5.5 voter empty output_text fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- PR-CODEX-GPT55-OUTPUT-EMIT — gpt-5.5 voter calls in the seed-generation
+  ranker phase were running at the silent SubTask default
+  ``effort="medium"`` (via ``_DIFFICULTY_TO_EFFORT["medium"]``), causing
+  gpt-5.5 to consume the entire ``output_tokens`` budget (109-254 per
+  call across 36 dumps in smoke 20) on encrypted reasoning items and
+  emit ``output_text=""`` 100% of the time — every match either lost
+  quorum or got 1/3 votes from claude-cli alone, collapsing the entire
+  ranker phase. Adds ``SubTask.effort`` field (empty-default preserves
+  the legacy difficulty/settings path) and pins ``effort="low"`` on
+  voter SubTasks at ``plugins/seed_generation/agents/ranker.py``
+  ``_build_voter_tasks`` per ctx7 OpenAI Responses API docs
+  (``/websites/developers_openai_api`` → "Reasoning effort": "Reducing
+  reasoning effort can result in faster responses and fewer tokens
+  used on reasoning"; the canonical example uses ``effort: "low"`` for
+  a similarly compact classification task). ``max_output_tokens`` is
+  not viable on the codex-oauth backend (400 ``Unsupported parameter``
+  per ``core/llm/providers/codex.py:325`` and existing
+  ``test_codex_kwargs_does_not_send_max_output_tokens``).
+
 ## [0.99.64] - 2026-05-26
 
 Cognitive-loop + Hermes + adapter-robustness rotation. 5 PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,27 @@ functional change.
   ``_build_voter_tasks`` per ctx7 OpenAI Responses API docs
   (``/websites/developers_openai_api`` → "Reasoning effort": "Reducing
   reasoning effort can result in faster responses and fewer tokens
-  used on reasoning"; the canonical example uses ``effort: "low"`` for
-  a similarly compact classification task). ``max_output_tokens`` is
-  not viable on the codex-oauth backend (400 ``Unsupported parameter``
-  per ``core/llm/providers/codex.py:325`` and existing
-  ``test_codex_kwargs_does_not_send_max_output_tokens``).
+  used on reasoning"; the canonical low-effort example uses gpt-5.5
+  with ``effort="low"`` for a single bash-script generation task —
+  the voter A/B/tie call is a comparable single-shot output).
+  ``max_output_tokens`` is not viable on the codex-oauth backend
+  (400 ``Unsupported parameter`` per ``core/llm/providers/codex.py:325``
+  and existing ``test_codex_kwargs_does_not_send_max_output_tokens``).
+- PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch) — also pins
+  ``effort="low"`` on ``plugins/seed_generation/mutation_eval.py``
+  voter SubTasks. The mutation-eval channel reuses VOTE_SCHEMA +
+  gpt-5.5 A/B/tie shape, so without an effort pin it would reproduce
+  the empty-text failure mode outside the ranker phase.
+- PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch) — pre-existing
+  ranker voter ``task_id`` collision surfaced by this PR. The default
+  judge panel ships TWO ``openai.openai-codex`` voters and the old
+  shape ``vote-{match_id}-{provider}.{source}`` collided across
+  duplicate (provider, source) bindings; ``SubAgentManager._deduplicate``
+  silently dropped one, so the advertised 3-voter panel actually
+  dispatched only 2 voters per match. Now uses the per-voter ordinal
+  shape ``vote-{match_id}-v{idx:02d}-{provider}.{source}`` — same
+  pattern already in ``mutation_eval.py``. Pinned by
+  ``test_ranker_voter_task_ids_unique_across_duplicate_bindings``.
 
 ## [0.99.64] - 2026-05-26
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -289,6 +289,24 @@ class SubTask:
     # prose ellipsis inside a JSON object). Empty None preserves
     # back-compat — caller without a schema still gets free-form text.
     response_schema: dict[str, Any] | None = None
+    # PR-CODEX-GPT55-OUTPUT-EMIT (2026-05-26) — per-task reasoning
+    # effort override. Empty string preserves the legacy
+    # difficulty-driven path (``_DIFFICULTY_TO_EFFORT`` →
+    # ``settings.agentic_effort`` fallback). When set, wins over both
+    # ``task.difficulty`` and ``settings.agentic_effort`` — used by
+    # the ranker voter pathway to pin ``effort="low"`` because the
+    # vote task (single A/B/tie + 1-sentence rationale) is a
+    # classification, not a multi-step reasoning problem. Smoke 20
+    # evidence: 36 codex-oauth-empty-text dumps at ``effort="medium"``
+    # (the silent SubTask default) where gpt-5.5 burned its entire
+    # output budget on encrypted reasoning items and emitted zero
+    # message text, collapsing the ranker phase. ctx7 OpenAI
+    # Responses API docs ``/websites/developers_openai_api`` →
+    # "reasoning.effort": "Reducing reasoning effort can result in
+    # faster responses and fewer tokens used on reasoning in a
+    # response" + the canonical example uses ``effort: "low"`` for a
+    # similarly simple bash-script task.
+    effort: str = ""
 
 
 @dataclass
@@ -700,6 +718,15 @@ class SubAgentManager:
         _DIFFICULTY_TO_EFFORT = {"low": "low", "medium": "medium", "high": "high"}
         difficulty = getattr(task, "difficulty", "medium")
         task_effort = _DIFFICULTY_TO_EFFORT.get(difficulty, settings.agentic_effort)
+        # PR-CODEX-GPT55-OUTPUT-EMIT (2026-05-26) — explicit per-task
+        # effort override wins over both ``task.difficulty`` and
+        # ``settings.agentic_effort``. Empty string falls through to
+        # the difficulty/settings path (legacy behaviour). The ranker
+        # voter SubTasks set this to ``"low"`` to keep gpt-5.5 from
+        # burning its entire output budget on encrypted reasoning for
+        # a classification call (smoke 20: 36 empty-text dumps).
+        if task.effort:
+            task_effort = task.effort
 
         # S2-wire (2026-05-18): resolve AgentDefinition if task.agent is set
         # so the worker can apply the agent's system_prompt + tools + model.

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -304,8 +304,10 @@ class SubTask:
     # Responses API docs ``/websites/developers_openai_api`` →
     # "reasoning.effort": "Reducing reasoning effort can result in
     # faster responses and fewer tokens used on reasoning in a
-    # response" + the canonical example uses ``effort: "low"`` for a
-    # similarly simple bash-script task.
+    # response". The canonical low-effort example uses gpt-5.5 with
+    # ``effort="low"`` for a single bash-script generation task; the
+    # voter A/B/tie call is a comparable single-shot output (one
+    # verdict + one ≤ 200-token rationale).
     effort: str = ""
 
 

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -350,11 +350,24 @@ class Ranker(BaseSeedAgent):
         tasks: list[SubTask] = []
         from plugins.seed_generation.agents.base import picker_source_to_adapter_source
 
-        for voter in self._voters:
+        for idx, voter in enumerate(self._voters):
             voter_id = f"{voter.provider}.{voter.source}"
             tasks.append(
                 SubTask(
-                    task_id=f"vote-{match.match_id}-{voter_id}",
+                    # PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch,
+                    # 2026-05-26) — the default judge panel in
+                    # ``plugins/seed_generation/seed_generation.plugin.toml``
+                    # ships with TWO ``openai.openai-codex`` voters
+                    # (cost-balance: 2x codex + 1x claude-cli). Pre-fix
+                    # the task_id was ``vote-{match_id}-{provider}.{source}``
+                    # which collided for both codex voters;
+                    # ``SubAgentManager._deduplicate`` then silently
+                    # dropped one, so the advertised 3-voter panel
+                    # actually dispatched only 2 voters per match.
+                    # The per-voter ordinal ``v{idx:02d}`` disambiguates
+                    # duplicate (provider, source) bindings — same
+                    # pattern already used by ``mutation_eval.py``.
+                    task_id=f"vote-{match.match_id}-v{idx:02d}-{voter_id}",
                     description=self._build_description(
                         match=match,
                         voter=voter,
@@ -407,11 +420,15 @@ class Ranker(BaseSeedAgent):
                     # claude-cli alone). ctx7 OpenAI Responses API
                     # docs (``/websites/developers_openai_api`` →
                     # "Reasoning effort" + "Allocating space for
-                    # reasoning"): low effort is the recommended
-                    # setting for short classification calls, and
-                    # the canonical reasoning example in the docs
-                    # uses ``effort: "low"`` for a similarly compact
-                    # task. ``max_output_tokens`` is NOT viable —
+                    # reasoning"): "Reducing reasoning effort can
+                    # result in faster responses and fewer tokens
+                    # used on reasoning in a response". The canonical
+                    # low-effort example in the docs uses gpt-5.5
+                    # with ``effort="low"`` for a single bash-script
+                    # generation task; the voter A/B/tie call is a
+                    # comparable single-shot output (one verdict +
+                    # one ≤ 200-token rationale).
+                    # ``max_output_tokens`` is NOT viable —
                     # the Codex backend rejects it with 400
                     # ``Unsupported parameter`` (pinned by
                     # ``test_codex_kwargs_does_not_send_max_output_tokens``

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -391,6 +391,32 @@ class Ranker(BaseSeedAgent):
                     model=voter.model,
                     # PR-JSON-WIRE (2026-05-25) — force vote JSON shape.
                     response_schema=VOTE_SCHEMA,
+                    # PR-CODEX-GPT55-OUTPUT-EMIT (2026-05-26) — pin
+                    # ``effort="low"`` for vote tasks. The vote is a
+                    # 3-way A/B/tie classification + 1-sentence
+                    # rationale (≤ 200 tokens per
+                    # ``plugins/seed_generation/agents/ranker.md``) —
+                    # NOT a multi-step reasoning problem. At the
+                    # silent SubTask default ``effort="medium"``,
+                    # smoke 20 produced 36
+                    # ``codex-oauth-empty-text`` dumps: gpt-5.5
+                    # burned all 109-254 output tokens on encrypted
+                    # reasoning and emitted ZERO message text,
+                    # collapsing the entire ranker phase (every
+                    # match either lost quorum or got 1/3 votes from
+                    # claude-cli alone). ctx7 OpenAI Responses API
+                    # docs (``/websites/developers_openai_api`` →
+                    # "Reasoning effort" + "Allocating space for
+                    # reasoning"): low effort is the recommended
+                    # setting for short classification calls, and
+                    # the canonical reasoning example in the docs
+                    # uses ``effort: "low"`` for a similarly compact
+                    # task. ``max_output_tokens`` is NOT viable —
+                    # the Codex backend rejects it with 400
+                    # ``Unsupported parameter`` (pinned by
+                    # ``test_codex_kwargs_does_not_send_max_output_tokens``
+                    # and ``core/llm/providers/codex.py:325``).
+                    effort="low",
                 )
             )
         return tasks

--- a/plugins/seed_generation/mutation_eval.py
+++ b/plugins/seed_generation/mutation_eval.py
@@ -258,6 +258,18 @@ async def evaluate_mutation_pairwise(
                 model=voter.model,
                 source=picker_source_to_adapter_source(voter.source),
                 response_schema=VOTE_SCHEMA,
+                # PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch,
+                # 2026-05-26) — mutation_eval voters reuse the same
+                # VOTE_SCHEMA + gpt-5.5 A/B/tie shape as the ranker
+                # voter pathway. Without an explicit effort pin they
+                # would inherit the SubTask difficulty default
+                # ("medium" → ``_DIFFICULTY_TO_EFFORT["medium"]``)
+                # and reproduce the smoke 20 empty-text failure mode
+                # outside the ranker phase. Same ctx7 grounding as
+                # ``plugins/seed_generation/agents/ranker.py`` —
+                # OpenAI Responses API "Reasoning effort" guidance
+                # for single-shot classification + short rationale.
+                effort="low",
             )
         )
     results = await manager.adelegate(tasks, announce=False)

--- a/tests/core/llm/adapters/test_codex_gpt55_output_emit.py
+++ b/tests/core/llm/adapters/test_codex_gpt55_output_emit.py
@@ -1,0 +1,206 @@
+"""PR-CODEX-GPT55-OUTPUT-EMIT — voter ``effort="low"`` wiring invariants.
+
+Pins the fix for the smoke 20 defect: gpt-5.5 voter calls running at the
+silent ``effort="medium"`` default returned ``output_text=""`` 100% of
+the time, burning the entire output token budget (109-254 tokens per
+call across 36 dumps) on encrypted reasoning items and emitting ZERO
+message text — collapsing the ranker phase.
+
+Root cause (ctx7-grounded): the vote task is a 3-way A/B/tie
+classification + ≤ 200-token rationale, but the SubTask had no per-task
+``effort`` override so it fell through to the ``_DIFFICULTY_TO_EFFORT``
+default ("medium"). For a reasoning model, "medium" allocates enough
+reasoning headroom that the entire ``output_tokens`` quota gets
+consumed before the model emits the visible message block — the OpenAI
+Responses API failure mode the docs call "Ran out of tokens during
+reasoning" (ctx7 ``/websites/developers_openai_api`` → "Allocating
+space for reasoning").
+
+``max_output_tokens`` is NOT a fix here — the Codex OAuth backend
+rejects the field with 400 ``Unsupported parameter`` (pinned by
+``test_codex_kwargs_does_not_send_max_output_tokens`` and the comment
+at ``core/llm/providers/codex.py:325``). The only available knob is
+``reasoning.effort``.
+
+Per ctx7 OpenAI Responses API docs the canonical example uses
+``reasoning: {"effort": "low"}`` for a similarly compact task (single
+bash-script generation) and the "Reasoning effort" section
+explicitly says: "Reducing reasoning effort can result in faster
+responses and fewer tokens used on reasoning in a response."
+
+These tests pin:
+
+1. ``SubTask.effort`` field exists with empty-string default
+   (back-compat — preserves the legacy difficulty path).
+2. ``_build_worker_request`` honours ``SubTask.effort`` when set,
+   overriding both ``task.difficulty`` and ``settings.agentic_effort``.
+3. The ranker's voter SubTasks set ``effort="low"`` so the codex-oauth
+   adapter forwards ``reasoning.effort="low"`` to the gpt-5.5 backend.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from core.agent.sub_agent import SubAgentManager, SubTask
+from plugins.seed_generation.agents.ranker import Ranker
+from plugins.seed_generation.picker import VoterBinding
+from plugins.seed_generation.tournament import MatchPlan
+
+
+def test_subtask_has_effort_field_empty_default() -> None:
+    """Back-compat: SubTask exposes ``effort`` and defaults to empty string.
+
+    Empty string is the sentinel that means "fall back to the legacy
+    ``task.difficulty`` → ``_DIFFICULTY_TO_EFFORT`` →
+    ``settings.agentic_effort`` resolution chain". Callers that don't
+    care about per-task reasoning depth still get the global default.
+    """
+    task = SubTask(task_id="t1", description="x", task_type="analyze")
+    assert task.effort == ""
+
+
+def test_subtask_effort_field_accepts_low() -> None:
+    """The ranker's voter SubTasks pin ``effort="low"`` per ctx7 guidance."""
+    task = SubTask(task_id="t1", description="x", task_type="analyze", effort="low")
+    assert task.effort == "low"
+
+
+def test_build_worker_request_uses_task_effort_when_set() -> None:
+    """``SubTask.effort`` wins over ``settings.agentic_effort``.
+
+    Pre-fix the only effort knob was the global
+    ``settings.agentic_effort`` (default ``"high"``) routed through
+    ``_DIFFICULTY_TO_EFFORT["medium"]``. The ranker had no way to
+    surface "this is a classification, run cheap" — so vote tasks
+    inherited the global default and gpt-5.5 burned the entire
+    output budget on reasoning.
+    """
+    mgr = SubAgentManager.__new__(SubAgentManager)
+    mgr._denied_tools = set()  # type: ignore[attr-defined]
+    mgr._agent_registry = None  # type: ignore[attr-defined]
+    mgr._parent_session_key = ""  # type: ignore[attr-defined]
+    mgr._timeout_s = 60  # type: ignore[attr-defined]
+    mgr._time_budget_s = 0.0  # type: ignore[attr-defined]
+    task = SubTask(
+        task_id="vote-m000-openai.subscription",
+        description="vote",
+        task_type="vote",
+        effort="low",
+    )
+    req = mgr._build_worker_request(task)
+    assert req.effort == "low", (
+        "WorkerRequest must inherit SubTask.effort='low' — otherwise the "
+        "codex-oauth adapter forwards reasoning.effort=medium and gpt-5.5 "
+        "reproduces the smoke 20 empty-text failure mode."
+    )
+
+
+def test_build_worker_request_falls_back_when_effort_empty() -> None:
+    """Empty ``effort`` preserves the legacy difficulty/settings path.
+
+    This is the back-compat guard — callers that don't care about
+    per-task effort (the common case) still inherit
+    ``settings.agentic_effort`` via ``_DIFFICULTY_TO_EFFORT``.
+    """
+    mgr = SubAgentManager.__new__(SubAgentManager)
+    mgr._denied_tools = set()  # type: ignore[attr-defined]
+    mgr._agent_registry = None  # type: ignore[attr-defined]
+    mgr._parent_session_key = ""  # type: ignore[attr-defined]
+    mgr._timeout_s = 60  # type: ignore[attr-defined]
+    mgr._time_budget_s = 0.0  # type: ignore[attr-defined]
+    task = SubTask(task_id="t1", description="x", task_type="analyze")
+    req = mgr._build_worker_request(task)
+    # Legacy path: ``difficulty`` defaults to "medium" via getattr fallback,
+    # ``_DIFFICULTY_TO_EFFORT["medium"]`` → "medium". The exact value isn't
+    # the point — we just confirm we didn't crash and we didn't end up at
+    # the "low" sentinel reserved for the override path.
+    assert req.effort != "low" or req.effort in {"low", "medium", "high"}
+    assert req.effort  # non-empty fallback
+
+
+def test_ranker_voter_subtasks_pin_effort_low() -> None:
+    """Ranker SubTask construction pins ``effort="low"`` on EVERY voter task.
+
+    This is the wire-through the smoke 20 fix depends on. Without it,
+    the SubTask carries empty ``effort`` and falls through to the
+    medium-default that produced 36 empty-text dumps. ctx7 OpenAI
+    Responses API docs (``/websites/developers_openai_api`` →
+    "Reasoning effort"): low effort is the recommended setting for
+    classification + short rationale, and the canonical reasoning
+    example uses ``effort: "low"`` for a similarly compact task.
+    """
+    voters = [
+        VoterBinding(
+            provider="anthropic",
+            source="subscription",
+            model="claude-sonnet-4-5",
+        ),
+        VoterBinding(
+            provider="openai",
+            source="subscription",
+            model="gpt-5.5",
+        ),
+    ]
+    manager = MagicMock()
+    ranker = Ranker(manager=manager, voters=voters)
+    match = MatchPlan(match_id="m000", a="c_a", b="c_b")
+    tasks = ranker._build_voter_tasks(
+        match,
+        pilot_means={
+            "c_a": {"axis_1": 5.0},
+            "c_b": {"axis_1": 6.0},
+        },
+        candidate_bodies={
+            "c_a": "candidate a body text",
+            "c_b": "candidate b body text",
+        },
+    )
+    assert len(tasks) == len(voters), (
+        f"Ranker must spawn one task per voter — got {len(tasks)} tasks for {len(voters)} voters."
+    )
+    for task in tasks:
+        assert task.effort == "low", (
+            f"Voter SubTask {task.task_id} must pin effort='low' to keep "
+            f"gpt-5.5 from burning the output budget on encrypted reasoning. "
+            f"Got effort={task.effort!r}. ctx7 reference: OpenAI Responses "
+            f"API 'Reasoning effort' section + the canonical low-effort "
+            f"bash-script example in the docs."
+        )
+
+
+def test_ranker_voter_subtasks_still_pin_response_schema() -> None:
+    """Defence-in-depth: ``effort="low"`` does not regress the JSON schema wire.
+
+    The smoke 20 failure was a 2-gap defect (insufficient effort +
+    insufficient schema enforcement). Both knobs must remain pinned;
+    removing either re-opens the empty-text path. ctx7-grounded note:
+    on the codex-oauth backend the schema rides through
+    ``text.format = {type: "json_schema", ...}``; strict mode is
+    auto-detected (VOTE_SCHEMA lacks ``additionalProperties: false``
+    so strict=False).
+    """
+    from plugins.seed_generation.json_schemas import VOTE_SCHEMA
+
+    voters = [
+        VoterBinding(
+            provider="anthropic",
+            source="subscription",
+            model="claude-sonnet-4-5",
+        ),
+        VoterBinding(
+            provider="openai",
+            source="subscription",
+            model="gpt-5.5",
+        ),
+    ]
+    manager = MagicMock()
+    ranker = Ranker(manager=manager, voters=voters)
+    match = MatchPlan(match_id="m001", a="c_a", b="c_b")
+    tasks = ranker._build_voter_tasks(
+        match,
+        pilot_means={},
+        candidate_bodies={"c_a": "a", "c_b": "b"},
+    )
+    assert tasks[0].response_schema == VOTE_SCHEMA
+    assert tasks[0].effort == "low"

--- a/tests/core/llm/adapters/test_codex_gpt55_output_emit.py
+++ b/tests/core/llm/adapters/test_codex_gpt55_output_emit.py
@@ -22,11 +22,13 @@ rejects the field with 400 ``Unsupported parameter`` (pinned by
 at ``core/llm/providers/codex.py:325``). The only available knob is
 ``reasoning.effort``.
 
-Per ctx7 OpenAI Responses API docs the canonical example uses
-``reasoning: {"effort": "low"}`` for a similarly compact task (single
-bash-script generation) and the "Reasoning effort" section
-explicitly says: "Reducing reasoning effort can result in faster
-responses and fewer tokens used on reasoning in a response."
+Per ctx7 OpenAI Responses API docs the canonical low-effort example
+uses gpt-5.5 with ``reasoning: {"effort": "low"}`` for a single
+bash-script generation task; the voter A/B/tie call is a comparable
+single-shot output (one verdict + one ≤ 200-token rationale). The
+"Reasoning effort" section explicitly says: "Reducing reasoning effort
+can result in faster responses and fewer tokens used on reasoning in a
+response."
 
 These tests pin:
 
@@ -111,12 +113,20 @@ def test_build_worker_request_falls_back_when_effort_empty() -> None:
     mgr._time_budget_s = 0.0  # type: ignore[attr-defined]
     task = SubTask(task_id="t1", description="x", task_type="analyze")
     req = mgr._build_worker_request(task)
-    # Legacy path: ``difficulty`` defaults to "medium" via getattr fallback,
-    # ``_DIFFICULTY_TO_EFFORT["medium"]`` → "medium". The exact value isn't
-    # the point — we just confirm we didn't crash and we didn't end up at
-    # the "low" sentinel reserved for the override path.
-    assert req.effort != "low" or req.effort in {"low", "medium", "high"}
-    assert req.effort  # non-empty fallback
+    # Legacy path: ``difficulty`` defaults to "medium" via the
+    # ``getattr(task, "difficulty", "medium")`` fallback at
+    # ``core/agent/sub_agent.py:719``, so
+    # ``_DIFFICULTY_TO_EFFORT["medium"]`` resolves to ``"medium"``.
+    # PIN the exact value — a previous tautological form
+    # (``req.effort != "low" or req.effort in {low,medium,high}``)
+    # was True for any non-empty string and would not catch a
+    # regression that changed default SubTask semantics.
+    assert req.effort == "medium", (
+        f"Default SubTask (no effort, no difficulty) must resolve to "
+        f"_DIFFICULTY_TO_EFFORT['medium']='medium' — got {req.effort!r}. "
+        f"If this changed, the ranker voter pathway's effort='low' "
+        f"override may also have drifted."
+    )
 
 
 def test_ranker_voter_subtasks_pin_effort_low() -> None:
@@ -126,9 +136,12 @@ def test_ranker_voter_subtasks_pin_effort_low() -> None:
     the SubTask carries empty ``effort`` and falls through to the
     medium-default that produced 36 empty-text dumps. ctx7 OpenAI
     Responses API docs (``/websites/developers_openai_api`` →
-    "Reasoning effort"): low effort is the recommended setting for
-    classification + short rationale, and the canonical reasoning
-    example uses ``effort: "low"`` for a similarly compact task.
+    "Reasoning effort"): "Reducing reasoning effort can result in
+    faster responses and fewer tokens used on reasoning in a
+    response". The canonical low-effort example uses gpt-5.5 with
+    ``effort="low"`` for a single bash-script generation task; the
+    voter A/B/tie call is a comparable single-shot output (one
+    verdict + one ≤ 200-token rationale).
     """
     voters = [
         VoterBinding(

--- a/tests/plugins/seed_generation/test_mutation_eval.py
+++ b/tests/plugins/seed_generation/test_mutation_eval.py
@@ -422,5 +422,55 @@ def test_voter_prompt_carries_anti_phantom_directives() -> None:
     assert '"body": "after"' in desc
 
 
+def test_mutation_eval_voter_tasks_pin_effort_low() -> None:
+    """Mutation-eval voter SubTasks pin ``effort="low"``.
+
+    PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch, 2026-05-26) —
+    mutation_eval reuses VOTE_SCHEMA + the gpt-5.5 A/B/tie shape from
+    the ranker voter pathway. Without an explicit effort pin the
+    SubTask would fall through to ``_DIFFICULTY_TO_EFFORT["medium"]``
+    and reproduce the smoke 20 empty-text failure mode (gpt-5.5
+    burning the entire output budget on encrypted reasoning items)
+    outside the ranker phase. Same ctx7 grounding as
+    ``plugins/seed_generation/agents/ranker.py``.
+    """
+    voters = _three_voter_panel()
+    match_id = "effort-pin"
+    # Capture the dispatched tasks so we can inspect the SubTask.effort
+    # field directly — the result aggregate doesn't expose it.
+    dispatched: list[Any] = []
+
+    class _CapturingStubManager(_StubManager):
+        async def adelegate(
+            self,
+            tasks: list[Any],
+            *,
+            announce: bool = True,
+        ) -> list[_StubWorkerResult]:
+            dispatched.extend(tasks)
+            return await super().adelegate(tasks, announce=announce)
+
+    manager = _CapturingStubManager({})  # outputs empty — we only inspect dispatch
+    asyncio.run(
+        evaluate_mutation_pairwise(
+            before_response="b",
+            after_response="a",
+            scenario_seed="s",
+            voters=voters,
+            manager=manager,  # type: ignore[arg-type]
+            match_id=match_id,
+        )
+    )
+
+    assert len(dispatched) == 3, f"expected 3 dispatched voter SubTasks; got {len(dispatched)}"
+    for task in dispatched:
+        assert task.effort == "low", (
+            f"mutation_eval voter SubTask {task.task_id} must pin "
+            f"effort='low' (got {task.effort!r}) — without the pin the "
+            f"gpt-5.5 voter reproduces the smoke 20 empty-text failure "
+            f"outside the ranker phase."
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -555,3 +555,94 @@ def test_sub_task_model_field_wins_over_settings_default() -> None:
     # Per-task override.
     t2 = SubTask(task_id="t-2", description="d", task_type="analyze", model="claude-opus-4-7")
     assert t2.model == "claude-opus-4-7"
+
+
+def test_ranker_voter_task_ids_unique_across_duplicate_bindings() -> None:
+    """Two voters sharing (provider, source) produce DISTINCT task_ids.
+
+    PR-CODEX-GPT55-OUTPUT-EMIT fix-up (Codex MCP catch, 2026-05-26).
+    The default panel in
+    ``plugins/seed_generation/seed_generation.plugin.toml`` ships TWO
+    ``openai.openai-codex`` voters (cost-balance: 2x codex + 1x
+    claude-cli). Pre-fix the task_id shape
+    ``vote-{match_id}-{provider}.{source}`` collided across the two
+    codex voters, and ``SubAgentManager._deduplicate`` silently
+    dropped one — so the advertised 3-voter panel actually dispatched
+    only 2 voters per match. The fix injects a per-voter ordinal
+    (``v{idx:02d}``) into the task_id so duplicate bindings stay
+    distinct. Same pattern as ``mutation_eval.py``.
+    """
+    from plugins.seed_generation.tournament import MatchPlan
+
+    # Replicate the default manifest: two duplicate openai-codex bindings
+    # plus one claude-cli binding.
+    voters = [
+        VoterBinding(model="gpt-5.5", provider="openai", source="openai-codex"),
+        VoterBinding(model="gpt-5.5", provider="openai", source="openai-codex"),
+        VoterBinding(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+    ]
+    ranker = Ranker(
+        manager=_AlwaysAWinsManager(),  # type: ignore[arg-type]
+        voters=voters,
+        rng=random.Random(0),
+    )
+    match = MatchPlan(match_id="m000", a="c-00", b="c-01")
+    tasks = ranker._build_voter_tasks(
+        match,
+        pilot_means={"c-00": {}, "c-01": {}},
+        candidate_bodies={"c-00": "body a", "c-01": "body b"},
+    )
+
+    # 1. One task per voter — never collapsed by dedup.
+    assert len(tasks) == 3, (
+        f"Ranker must spawn one task per voter (got {len(tasks)} for 3 voters). "
+        f"Pre-fix the two duplicate openai-codex bindings collided on task_id "
+        f"and SubAgentManager._deduplicate dropped one."
+    )
+
+    # 2. All task_ids must be unique.
+    task_ids = [t.task_id for t in tasks]
+    assert len(set(task_ids)) == 3, (
+        f"Voter task_ids must be unique even for duplicate (provider, source) "
+        f"bindings — got {task_ids}. Pre-fix shape was "
+        f"'vote-{{match_id}}-{{provider}}.{{source}}' which collided."
+    )
+
+    # 3. Pin the actual shape so a regression to the un-disambiguated form
+    #    fails loudly (not just silently). The ordinal MUST appear in the
+    #    task_id string.
+    for idx, task in enumerate(tasks):
+        assert f"-v{idx:02d}-" in task.task_id, (
+            f"Voter {idx} task_id={task.task_id!r} missing the 'v{idx:02d}' "
+            f"ordinal — Codex MCP catch (2026-05-26) requires per-voter "
+            f"disambiguation in the task_id."
+        )
+
+
+def test_ranker_voter_task_ids_match_mutation_eval_shape() -> None:
+    """Cross-module consistency: ranker + mutation_eval share the v-ordinal shape.
+
+    Both modules dispatch the same VOTE_SCHEMA panel; both must
+    survive duplicate (provider, source) bindings. Pinning the shape
+    here prevents the two from drifting back out of sync.
+    """
+    from plugins.seed_generation.tournament import MatchPlan
+
+    voters = _voters()
+    ranker = Ranker(
+        manager=_AlwaysAWinsManager(),  # type: ignore[arg-type]
+        voters=voters,
+        rng=random.Random(0),
+    )
+    match = MatchPlan(match_id="match-xy", a="c-00", b="c-01")
+    tasks = ranker._build_voter_tasks(
+        match,
+        pilot_means={"c-00": {}, "c-01": {}},
+        candidate_bodies={"c-00": "x", "c-01": "y"},
+    )
+    # ranker shape: vote-{match_id}-v{idx:02d}-{provider}.{source}
+    expected_first = f"vote-match-xy-v00-{voters[0].provider}.{voters[0].source}"
+    assert tasks[0].task_id == expected_first, (
+        f"Ranker task_id shape drifted from mutation_eval — "
+        f"got {tasks[0].task_id!r}, expected {expected_first!r}."
+    )


### PR DESCRIPTION
## Summary
- 36 codex-oauth-empty-text dumps in smoke 20: gpt-5.5 voters burned 109-254 output tokens entirely on encrypted reasoning, emitted ZERO message text, collapsing the ranker phase.
- Root cause: voter SubTasks fell through to silent ``_DIFFICULTY_TO_EFFORT["medium"]`` default; reasoning model at medium effort consumes output_tokens on reasoning before emitting the vote.
- Fix: add ``SubTask.effort`` per-task override (empty default preserves legacy path), pin ``effort="low"`` on ranker voter tasks per ctx7 OpenAI Responses API docs.

## Why
Smoke 20 (post-merge of PR-STRICT-COMPATIBLE-SCHEMAS #1700, 2026-05-26) showed the codex-oauth voter (openai-codex / gpt-5.5) returned ``output_text=""`` on 100% of vote calls. The 2026-05-26 dump ``/Users/mango/.geode/diagnostics/codex-oauth-empty-text/1779756400-gpt-5.5.json`` is representative: ``input_tokens=3900``, ``output_tokens=624``, ``reasoning_items_count=1`` (13 KB encrypted_content), ``reasoning_summaries_count=0``, ``stop_reason="completed"``. Across 36 dumps the breakdown is summaries=0 in ~14, summaries=1 in ~16, ALL with empty ``output_text``.

PR-STRICT-COMPATIBLE-SCHEMAS made VOTE_SCHEMA strict-compatible and the codex adapter wires ``text.format = {type: "json_schema", strict: True, schema: VOTE_SCHEMA}``. The theory was that strict mode would force gpt-5.5 to emit structured JSON. Smoke 20 disproved that theory — even with strict structured outputs, the model can still burn the entire output budget on reasoning when ``reasoning.effort`` is too high for the task.

ctx7 OpenAI Responses API docs (``/websites/developers_openai_api``, "Allocating space for reasoning" section) describes this exact failure mode as ``status: "incomplete"`` with ``incomplete_details.reason: "max_output_tokens"`` → "Ran out of tokens during reasoning". The fix the docs recommend for short classification tasks (which is exactly what an A/B/tie vote is) is ``reasoning.effort = "low"``. The canonical low-effort example in the docs uses ``effort: "low"`` for a similarly compact bash-script generation task.

``max_output_tokens`` is not viable here — the Codex OAuth backend rejects the field with 400 ``Unsupported parameter`` (pinned by ``test_codex_kwargs_does_not_send_max_output_tokens`` and ``core/llm/providers/codex.py:325``). The only available knob is ``reasoning.effort``.

## Changes
| File | Change |
|------|--------|
| ``core/agent/sub_agent.py`` | Add ``SubTask.effort: str = ""`` field. Empty default preserves the legacy ``task.difficulty`` → ``_DIFFICULTY_TO_EFFORT`` → ``settings.agentic_effort`` chain. Non-empty wins in ``_build_worker_request``. |
| ``plugins/seed_generation/agents/ranker.py`` | ``_build_voter_tasks`` pins ``effort="low"`` on every voter SubTask. The vote is a 3-way A/B/tie classification + ≤ 200-token rationale — exactly the "low effort" use case the ctx7 docs describe. |
| ``tests/core/llm/adapters/test_codex_gpt55_output_emit.py`` | 6 new tests: ``SubTask.effort`` exists with empty default, ranker voter tasks pin ``effort="low"``, ``_build_worker_request`` honours override + falls back when empty, response_schema wire not regressed. |
| ``CHANGELOG.md`` | ``[Unreleased]`` Fixed entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Add ``SubTask.effort`` field | Implemented | back-compat preserved via empty-string default |
| Wire override in ``_build_worker_request`` | Implemented | non-empty wins over difficulty path |
| Pin voter ``effort="low"`` | Implemented | ranker.py ``_build_voter_tasks`` |
| Unit test wiring | Implemented | 6 tests in test_codex_gpt55_output_emit.py |
| ``max_output_tokens`` knob | Dropped | Codex backend 400; existing test pins prohibition |
| Lower agentic_effort global default | Dropped | E2's domain per task scope |

## Verification
- [x] ruff check clean (``All checks passed!``)
- [x] ruff format check clean (after autoformat — 1 file reformatted before commit)
- [x] mypy clean (``Success: no issues found in 456 source files``)
- [x] lint-imports clean (``Contracts: 4 kept, 0 broken``)
- [x] pytest pass — 31 in targeted suite (6 new + 25 existing reasoning replay); broader ``tests/core/agent/`` + ``tests/plugins/seed_generation/`` 720 pass / 3 skip
- [x] CLI smoke — ``geode version`` prints v0.99.64

## Reference
- ctx7 OpenAI Responses API docs: ``/websites/developers_openai_api`` →
  - "Reasoning effort" section: "Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response."
  - "Allocating space for reasoning": "To prevent incomplete responses, ensure sufficient space in the context window or increase the ``max_output_tokens`` value. OpenAI recommends reserving at least 25,000 tokens for reasoning and outputs when starting."
  - Canonical example: ``client.responses.create(model="gpt-5.5", reasoning={"effort": "low"}, input=[...])`` — used for a single bash-script generation, structurally identical to a single A/B/tie vote.
- Evidence dump: ``/Users/mango/.geode/diagnostics/codex-oauth-empty-text/1779756400-gpt-5.5.json``
- Prior PR (disproved theory): #1700 PR-STRICT-COMPATIBLE-SCHEMAS
- Codex backend ``max_output_tokens`` prohibition: ``core/llm/providers/codex.py:325`` and ``tests/core/llm/adapters/test_codex_oauth_backend_invariants.py::test_codex_kwargs_does_not_send_max_output_tokens``