### PR TITLE
release: v0.99.66 — seed-gen ranker-phase robustness (E1 + E2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.66] - 2026-05-26
+
+Seed-generation ranker-phase robustness rotation. 2 PR fixing two
+independent smoke-20 defects: gpt-5.5 voter calls returning empty
+`output_text` 100% of the time (E1 — fixed by `effort="low"` pin
+based on ctx7 OpenAI Responses API docs grounding), and ~13%-rate
+generator sub-agent silent partial-writes (E2 — fixed by structural
+`enable_goal_decomposition=False` for sub-agents plus defence-in-depth
+`decomposition_result_leak` outcome detection). Both surfaced when
+smoke 20 ranker collapsed (quorum lost on every match). The two fixes
+are unrelated in code path but symbiotic at the system level: without
+E1 the ranker has no codex voters, without E2 the ranker has missing
+candidates to vote on. v0.99.66 ships both alongside the pre-existing
+voter task_id collision fix that E1 surfaced.
+
 ### Fixed
 
 - PR-GENERATOR-PLAN-LEAK-FIX — seed generator silent partial-write defect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.65
+- **Version**: 0.99.66
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.65 — Long-running Autonomous Execution Harness
+# GEODE v0.99.66 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.65**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.65 — Long-running Autonomous Execution Harness
+# GEODE v0.99.66 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.65**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.65"
+version = "0.99.66"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.65"
+version = "0.99.66"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bumps version 0.99.65 → 0.99.66 across 5 SoT files (pyproject.toml + CLAUDE.md + README.md + README.ko.md + CHANGELOG.md) plus uv.lock.
- Ships PR-CODEX-GPT55-OUTPUT-EMIT (E1, #1719) + PR-GENERATOR-PLAN-LEAK-FIX (E2, #1721) — both already merged into develop and now stamped into a release.

## Verification
- [x] CHANGELOG `[Unreleased] → [0.99.66] - 2026-05-26` migration
- [x] 5 version locations consistent (grep -nH '0.99.66')
- [x] uv.lock geode-agent version row updated to 0.99.66
- [x] base branch is develop (release rotates into develop first, then develop → main per gitflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)