### PR TITLE
release: v0.99.66 — develop → main rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.66] - 2026-05-26
+
+Seed-generation ranker-phase robustness rotation. 2 PR fixing two
+independent smoke-20 defects: gpt-5.5 voter calls returning empty
+`output_text` 100% of the time (E1 — fixed by `effort="low"` pin
+based on ctx7 OpenAI Responses API docs grounding), and ~13%-rate
+generator sub-agent silent partial-writes (E2 — fixed by structural
+`enable_goal_decomposition=False` for sub-agents plus defence-in-depth
+`decomposition_result_leak` outcome detection). Both surfaced when
+smoke 20 ranker collapsed (quorum lost on every match). The two fixes
+are unrelated in code path but symbiotic at the system level: without
+E1 the ranker has no codex voters, without E2 the ranker has missing
+candidates to vote on. v0.99.66 ships both alongside the pre-existing
+voter task_id collision fix that E1 surfaced.
+
 ### Fixed
 
 - PR-GENERATOR-PLAN-LEAK-FIX — seed generator silent partial-write defect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- PR-GENERATOR-PLAN-LEAK-FIX — seed generator silent partial-write defect
+  (smoke 20, 2/15 generator sub-agents reported `success=true` but wrote
+  no candidate `.md` file). Root cause: the supervisor-built per-task
+  description contained natural English connectors (` and `, ` then `)
+  that tripped `core.agent.plan._has_compound_indicators`, so
+  `decompose_async` fired with the decomposer system prompt inside the
+  sub-agent worker; claude-cli cached that prompt under the sub-agent's
+  session_id; `_persist_session_id` stamped it as the resume target;
+  the next `_call_llm` turn (now carrying the *generator* system prompt)
+  was dispatched with `resume_session_id` set, which makes
+  `build_subprocess_stdin` skip the system block on the rationale that
+  it's already cached. The model resumed the decomposer conversation
+  and emitted a `DecompositionResult`-shape JSON instead of calling
+  `seed_debate_turn` / `write_file`. Fix is two-layered:
+  (1) **structural** — `core.agent.worker._run_agentic` now constructs
+  the sub-agent `AgenticLoop` with `enable_goal_decomposition=False`
+  (sub-agents are specialised executors; the parent already decomposed);
+  (2) **defence-in-depth** — `_resolve_worker_outcome` downgrades
+  `success=True` to `False` when the loop's text is a planner-shape
+  JSON (all three `is_compound` / `goals` / `reasoning` keys with their
+  canonical types), surfacing the defect class explicitly via a
+  `decomposition_result_leak` summary cause instead of letting a
+  phantom seed slip past the IPC boundary.
+
 ## [0.99.64] - 2026-05-26
 
 Cognitive-loop + Hermes + adapter-robustness rotation. 5 PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.65
+- **Version**: 0.99.66
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.65 — Long-running Autonomous Execution Harness
+# GEODE v0.99.66 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.65**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.65 — Long-running Autonomous Execution Harness
+# GEODE v0.99.66 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.65**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -411,6 +411,34 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         # preserves legacy free-form text responses for callers that
         # didn't declare a schema (REPL, gateway, ad-hoc CLI).
         response_schema=request.response_schema,
+        # PR-GENERATOR-PLAN-LEAK-FIX (2026-05-26) — disable goal
+        # decomposition for sub-agents. Sub-agents are specialised
+        # executors driven by an AgentDefinition + supervisor-built
+        # task description; the parent orchestrator already performed
+        # whatever decomposition was needed. Leaving it on caused a
+        # silent partial-write defect (smoke 20, 2/15 generator spawns):
+        # the per-task description contained natural English
+        # connectors ("frontmatter fields ... AND tags",
+        # "call ``seed_debate_turn`` ... then turn=2") that tripped
+        # ``_has_compound_indicators`` → ``decompose_async`` fired with
+        # the decomposer system prompt → claude-cli cached that prompt
+        # under the sub-agent's session_id → ``_persist_session_id``
+        # stamped it as the resume target → the next ``_call_llm``
+        # turn (now carrying the *generator* system prompt) was
+        # dispatched with ``resume_session_id`` set, which makes
+        # ``build_subprocess_stdin`` SKIP the system prompt block
+        # ("already cached"). claude-cli resumed the decomposer
+        # conversation, the model stayed in decomposition mode, and
+        # emitted a ``DecompositionResult``-shape JSON instead of
+        # calling ``seed_debate_turn`` / ``write_file``. Worker
+        # reported ``success=True`` (non-empty text, no error,
+        # ``termination_reason="unknown"``) but no seed markdown was
+        # written; downstream ranker hit FileNotFoundError and the
+        # PR-VOTER-PROMPT-ANTI-PHANTOM UNAVAILABLE sentinel kicked in.
+        # Evidence: ``state/seed-generation/gen1-redundant_tool_invocation/
+        # sub_agents/gen-gen1-000-fe17d6c5/result.json`` — output is a
+        # verbatim ``DecompositionResult`` JSON.
+        enable_goal_decomposition=False,
     )
 
     # 7. Build prompt
@@ -670,6 +698,56 @@ def _build_schema_retry_prompt(
     )
 
 
+# PR-GENERATOR-PLAN-LEAK-FIX (2026-05-26) — defence-in-depth detector
+# for the ``DecompositionResult``-shape JSON leak documented at the
+# ``enable_goal_decomposition=False`` site above. The structural fix is
+# in ``_run_agentic`` (no decomposer call → no cached prompt to resume
+# from); this helper is the last safety net before a ``success=True``
+# row with a planner-shape body slips past into the orchestrator. The
+# three-key shape (``is_compound`` bool + ``goals`` list + ``reasoning``
+# string) matches ``core.agent.plan.DecompositionResult`` *exactly* —
+# no real sub-agent role emits that triple (seed_generator writes
+# markdown via ``write_file``; ranker / critic / proximity emit role
+# schemas with ``candidate_id`` / ``score`` / ``reason`` keys).
+_DECOMPOSITION_RESULT_KEYS: frozenset[str] = frozenset({"is_compound", "goals", "reasoning"})
+
+
+def _looks_like_decomposition_result(text: str) -> bool:
+    """Return True iff ``text``'s last balanced JSON object is a planner
+    ``DecompositionResult`` echo (the leak documented at the
+    ``enable_goal_decomposition=False`` worker call site).
+
+    Conservative: requires the parsed object to be a ``dict`` containing
+    ALL THREE planner keys with their canonical types (``is_compound``
+    bool + ``goals`` list + ``reasoning`` string). Single-key overlaps
+    (e.g. a role schema happening to include ``reasoning``) do not
+    match.
+    """
+    if not text or not text.strip():
+        return False
+    # Local import to keep ``worker.py``'s module-level import surface
+    # small (the IPC entry point should bootstrap without dragging in
+    # the SubAgentManager).
+    from core.agent.sub_agent import _last_balanced_json_object
+
+    candidate = _last_balanced_json_object(text)
+    if candidate is None:
+        return False
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    if not _DECOMPOSITION_RESULT_KEYS.issubset(parsed.keys()):
+        return False
+    return (
+        isinstance(parsed.get("is_compound"), bool)
+        and isinstance(parsed.get("goals"), list)
+        and isinstance(parsed.get("reasoning"), str)
+    )
+
+
 def _resolve_worker_outcome(
     agentic_result: AgenticResult | None,
 ) -> tuple[bool, str, str]:
@@ -685,6 +763,18 @@ def _resolve_worker_outcome(
 
     success = bool(text) and not error and termination_reason not in _FAILURE_TERMINATION_REASONS
 
+    # PR-GENERATOR-PLAN-LEAK-FIX (2026-05-26) — defence-in-depth: even
+    # when the loop reports a clean termination with non-empty text, a
+    # ``DecompositionResult``-shape body means the sub-agent never
+    # executed its role tools (no ``seed_debate_turn`` / ``write_file``
+    # for a generator; no schema-keyed output for evaluator roles).
+    # Downgrade to ``success=False`` so the parent surfaces the defect
+    # in the timeline instead of accepting a phantom seed.
+    plan_leak = False
+    if success and _looks_like_decomposition_result(text):
+        success = False
+        plan_leak = True
+
     # Summary surfaces the actual failure cause when ``success`` is False so
     # parent timeline rows ("Tool returned: ...") explain WHY the sub-agent
     # produced no usable output instead of echoing the fallback UI string.
@@ -697,6 +787,10 @@ def _resolve_worker_outcome(
             cause_bits.append(error)
         if termination_reason and termination_reason != "unknown":
             cause_bits.append(f"termination_reason={termination_reason}")
+        if plan_leak:
+            cause_bits.append(
+                "decomposition_result_leak (planner JSON emitted instead of tool calls)"
+            )
 
     if cause_bits:
         summary = "Sub-agent failed: " + "; ".join(cause_bits)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.65"
+version = "0.99.66"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_generator_plan_leak.py
+++ b/tests/plugins/seed_generation/test_generator_plan_leak.py
@@ -1,0 +1,289 @@
+"""Tests for PR-GENERATOR-PLAN-LEAK-FIX (2026-05-26).
+
+Smoke 20 surfaced a silent partial-write defect in the seed generator:
+2 of 15 sub-agent spawns reported ``success=true`` but never wrote
+the candidate ``.md`` file. Their ``output`` was instead a verbatim
+``core.agent.plan.DecompositionResult`` JSON object — the goal
+decomposer's schema. Root cause: the generator's per-task description
+contained natural-language compound connectors (``" and "``, ``" then "``)
+that tripped ``core.agent.plan._has_compound_indicators``, the worker's
+``AgenticLoop`` ran ``decompose_async`` with the decomposer system
+prompt, claude-cli cached that prompt under the sub-agent's session_id,
+and the next ``_call_llm`` turn resumed the decomposer conversation
+(``build_subprocess_stdin`` skips the system block when
+``resume_session_id`` is set) — so the model stayed in decomposition
+mode and emitted a planner JSON instead of calling tools.
+
+This file pins two regression invariants:
+
+1. **Structural fix** — ``core.agent.worker._run_agentic`` constructs the
+   sub-agent ``AgenticLoop`` with ``enable_goal_decomposition=False``.
+   Sub-agents are specialised executors; the parent orchestrator already
+   decomposed.
+2. **Defence-in-depth** — ``_resolve_worker_outcome`` downgrades
+   ``success=True`` to ``False`` when the loop's text is a
+   ``DecompositionResult``-shape JSON (last balanced object has the
+   three planner keys with their canonical types).
+
+Evidence file:
+``state/seed-generation/gen1-redundant_tool_invocation/sub_agents/gen-gen1-000-fe17d6c5/result.json``
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from core.agent.loop.models import AgenticResult
+from core.agent.plan import _has_compound_indicators
+from core.agent.worker import (
+    _looks_like_decomposition_result,
+    _resolve_worker_outcome,
+)
+
+# ---------------------------------------------------------------------------
+# Invariant 1: ``_has_compound_indicators`` tripped on the supervisor-built
+# generator description. Pin the trigger so a future indicator-list edit
+# doesn't accidentally un-document the failure surface.
+# ---------------------------------------------------------------------------
+
+
+def test_real_generator_description_trips_compound_indicators() -> None:
+    """The actual generator per-candidate description (smoke 20 shape)
+    contains ``" and "`` / ``" then "`` connectors that fire the
+    decomposer heuristic. This is why ``enable_goal_decomposition=False``
+    must hold for sub-agents — without it, the decomposer LLM call
+    pollutes the claude-cli session cache and the next turn resumes the
+    decomposer prompt instead of the role prompt.
+    """
+    # Distilled from ``plugins/seed_generation/agents/generator.py::_build_description``
+    # (kept short so the trigger is obvious; the production string is
+    # longer and contains MORE connectors).
+    description = (
+        "Generate ONE Petri audit seed targeting dim 'redundant_tool_invocation'. "
+        "Generation tag: gen1. Candidate id: gen1-000-fe17d6c5. "
+        "Write the seed markdown to: /tmp/x.md. "
+        "No existing pool provided; generate from scratch. "
+        "See your system prompt for the full contract — frontmatter fields "
+        "(incl. 'target_dims' AND 'tags: [\"x\", \"geode_specific\"]'), "
+        "body length, realism criterion, and forbidden patterns.\n\n"
+        "## Debate budget (CSP-13)\n"
+        "Follow the system prompt's protocol: call seed_debate_turn once per "
+        "turn (sequentially — call turn=1 first, then turn=2, …)."
+    )
+    assert _has_compound_indicators(description) is True, (
+        "Generator description must trip the decomposer heuristic — "
+        "if this ever changes, the structural fix below is moot and "
+        "the test catalogue is stale."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: worker constructs ``AgenticLoop`` with
+# ``enable_goal_decomposition=False`` (structural fix).
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerDisablesGoalDecomposition:
+    """Pin the kwarg the worker passes to ``AgenticLoop``. Mirrors the
+    ``TestSubAgentReasoningWiring`` pattern in ``tests/test_worker.py``
+    (capture kwargs via a side_effect stub).
+    """
+
+    def test_run_agentic_passes_enable_goal_decomposition_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        captured: dict = {}
+
+        def _fake_loop(*args, **kwargs):
+            captured.update(kwargs)
+            mock_loop = MagicMock()
+            mock_loop.arun = AsyncMock(
+                return_value=AgenticResult(
+                    text="ok",
+                    tool_calls=[],
+                    rounds=1,
+                    error=None,
+                    termination_reason="unknown",
+                )
+            )
+            return mock_loop
+
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", side_effect=_fake_loop),
+        ):
+            from core.agent.worker import WorkerRequest, _run_agentic
+
+            request = WorkerRequest(
+                task_id="leak-fix-test",
+                description="placeholder",
+            )
+            _run_agentic(request)
+
+        assert captured.get("enable_goal_decomposition") is False, (
+            "Worker must construct sub-agent AgenticLoop with "
+            "enable_goal_decomposition=False so the decomposer LLM call "
+            "does not pollute claude-cli's session cache. See "
+            "PR-GENERATOR-PLAN-LEAK-FIX worker.py call site."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3: ``_looks_like_decomposition_result`` correctly classifies
+# planner-shape JSON (defence-in-depth detector).
+# ---------------------------------------------------------------------------
+
+
+# Verbatim from smoke 20 evidence file (gen-gen1-000-fe17d6c5/result.json).
+_SMOKE_20_LEAK_OUTPUT_FENCELESS = json.dumps(
+    {
+        "is_compound": True,
+        "goals": [
+            {
+                "id": "step_1",
+                "description": "Record one debate turn to draft the seed",
+                "tool_name": "seed_debate_turn",
+                "tool_args": {"target_dim": "redundant_tool_invocation"},
+                "depends_on": [],
+            },
+            {
+                "id": "step_2",
+                "description": "Write the finalized seed markdown",
+                "tool_name": "write_file",
+                "tool_args": {"path": "/var/tmp/x.md", "content": ""},  # noqa: S108 — fixture data
+                "depends_on": ["step_1"],
+            },
+        ],
+        "reasoning": (
+            "Generating one Petri audit seed requires (1) a debate turn "
+            "and (2) writing the markdown."
+        ),
+    }
+)
+
+
+# Verbatim shape from smoke 20 second failure (gen-gen1-003-0905b491).
+_SMOKE_20_LEAK_OUTPUT_FENCED = (
+    "```json\n"
+    + json.dumps(
+        {
+            "is_compound": False,
+            "goals": [],
+            "reasoning": (
+                "Single write_file call writes the seed markdown to the "
+                "specified output path. No pool to query, no dependent steps."
+            ),
+        }
+    )
+    + "\n```"
+)
+
+
+class TestLooksLikeDecompositionResult:
+    def test_smoke_20_evidence_fenceless_matches(self) -> None:
+        assert _looks_like_decomposition_result(_SMOKE_20_LEAK_OUTPUT_FENCELESS) is True
+
+    def test_smoke_20_evidence_fenced_matches(self) -> None:
+        assert _looks_like_decomposition_result(_SMOKE_20_LEAK_OUTPUT_FENCED) is True
+
+    def test_role_schema_output_does_not_match(self) -> None:
+        """A legitimate evaluator-role JSON (ranker schema) shares no keys
+        with ``DecompositionResult`` and must NOT be flagged.
+        """
+        ranker_output = json.dumps(
+            {
+                "candidate_id": "gen1-000-abc",
+                "score": 7.2,
+                "reason": "high discrimination on the target dim",
+            }
+        )
+        assert _looks_like_decomposition_result(ranker_output) is False
+
+    def test_partial_overlap_does_not_match(self) -> None:
+        """Output with ``reasoning`` only (chain-of-thought style) doesn't
+        match — all three keys are required.
+        """
+        cot_output = json.dumps(
+            {
+                "reasoning": "I will write the file now.",
+                "candidate_id": "gen1-000-abc",
+            }
+        )
+        assert _looks_like_decomposition_result(cot_output) is False
+
+    def test_prose_only_does_not_match(self) -> None:
+        assert _looks_like_decomposition_result("I will now write the seed.") is False
+
+    def test_empty_string_does_not_match(self) -> None:
+        assert _looks_like_decomposition_result("") is False
+        assert _looks_like_decomposition_result("   \n\n  ") is False
+
+    def test_wrong_types_does_not_match(self) -> None:
+        """All three keys present but with wrong types — must NOT match
+        (e.g. ``goals`` as a string instead of a list).
+        """
+        wrong_types = json.dumps(
+            {
+                "is_compound": "true",  # str, not bool
+                "goals": [],
+                "reasoning": "x",
+            }
+        )
+        assert _looks_like_decomposition_result(wrong_types) is False
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4: ``_resolve_worker_outcome`` downgrades success → failure
+# when the loop's text is a planner-shape leak.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWorkerOutcomePlanLeak:
+    def test_plan_leak_text_downgrades_success(self) -> None:
+        result = AgenticResult(
+            text=_SMOKE_20_LEAK_OUTPUT_FENCELESS,
+            tool_calls=[],
+            rounds=1,
+            error=None,
+            termination_reason="unknown",
+        )
+        success, summary, text = _resolve_worker_outcome(result)
+        assert success is False, (
+            "Planner-shape body must downgrade success — otherwise the "
+            "phantom-seed defect slips past the IPC boundary."
+        )
+        assert "decomposition_result_leak" in summary
+        # Text is preserved verbatim so the parent timeline still has
+        # the leak content for post-mortem.
+        assert text == _SMOKE_20_LEAK_OUTPUT_FENCELESS
+
+    def test_role_schema_output_keeps_success(self) -> None:
+        """Legitimate role JSON keeps ``success=True``."""
+        ranker_text = json.dumps({"candidate_id": "gen1-000-abc", "score": 7.2, "reason": "ok"})
+        result = AgenticResult(
+            text=ranker_text,
+            tool_calls=[],
+            rounds=1,
+            error=None,
+            termination_reason="unknown",
+        )
+        success, _, _ = _resolve_worker_outcome(result)
+        assert success is True
+
+    def test_plan_leak_with_fenced_json_downgrades_success(self) -> None:
+        result = AgenticResult(
+            text=_SMOKE_20_LEAK_OUTPUT_FENCED,
+            tool_calls=[],
+            rounds=1,
+            error=None,
+            termination_reason="unknown",
+        )
+        success, summary, _ = _resolve_worker_outcome(result)
+        assert success is False
+        assert "decomposition_result_leak" in summary

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.65"
+version = "0.99.66"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Brings develop to main for v0.99.66 release tag — ships PR-CODEX-GPT55-OUTPUT-EMIT (E1, #1719) + PR-GENERATOR-PLAN-LEAK-FIX (E2, #1721) onto main so the editable-installed CLI picks up both fixes.

## Verification
- [x] release/v0.99.66 → develop merged via #1725 (CI 8/8 green)
- [x] 5 SoT version locations stamped 0.99.66