### PR TITLE
release: v0.99.67 — claude-cli transient classifier prefix-allowlist (F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.67] - 2026-05-26
+
+Single-fix PATCH rotation. Ships PR-TRANSIENT-CLI-INJECTION-PREFIX to
+land the prefix-allowlist gate on the claude-cli transient classifier
+ahead of the next smoke run. The codex-OAuth gpt-5.5 empty-output-text
+defect surfaced by smoke 20/21 is NOT in this release — it requires a
+separate root-cause investigation (max_output_tokens unsupported on
+codex-oauth, effort=low alone insufficient) tracked as Sprint G.
+
 ### Fixed
 
 - PR-TRANSIENT-CLI-INJECTION-PREFIX — claude-cli transient classifier's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.66
+- **Version**: 0.99.67
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.66 — Long-running Autonomous Execution Harness
+# GEODE v0.99.67 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.66 — Long-running Autonomous Execution Harness
+# GEODE v0.99.67 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.66"
+version = "0.99.67"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.66"
+version = "0.99.67"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bumps version 0.99.66 → 0.99.67 across 5 SoT files + uv.lock.
- Ships PR-TRANSIENT-CLI-INJECTION-PREFIX (PR #1727, merged into develop @ 1d8f28a1).
- NOT in this release: codex-OAuth gpt-5.5 empty-output-text fix — separate Sprint G.

## Verification
- [x] CHANGELOG ``[Unreleased] → [0.99.67] - 2026-05-26`` migration
- [x] 5 version locations stamped 0.99.67 (pyproject.toml, CLAUDE.md, README.md, README.ko.md, CHANGELOG.md)
- [x] uv.lock geode-agent version row updated
- [x] base = develop (release rotates into develop first per gitflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)