### PR TITLE
release: v0.99.67 — develop → main rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- PR-TRANSIENT-CLI-INJECTION-PREFIX — claude-cli transient classifier's
+  ``event.type="assistant"`` and ``event.type="content_block_delta"``
+  scan branches now gate on a CLI-injection-prefix allowlist
+  (``_CLI_INJECTION_PREFIX_RE``) instead of the prior
+  ``_ASSISTANT_HEADER_LIMIT = 200`` positional heuristic. Smoke 21
+  (2026-05-26, dump 1779760855) falsified the 200-char rule: the LLM
+  wrote a short 170-char preamble (``"Wrote candidate `gen1-013-
+  5bd70823.md` — a CI-status scenario where the user pastes a complete
+  `gh run view --json` payload and explicitly asks the agent not to
+  re-pull (rate-limit framing)..."``) and the match at idx=170 slipped
+  through, aborting the generator phase. Audit of all 135 historical
+  dumps in ``~/.geode/diagnostics/claude-cli-transient/`` showed every
+  legitimate assistant-source match begins with ``! `` (claude-cli's
+  in-stream error injection convention) or with the literal phrase
+  ``Claude usage limit reached`` (PR-T smoke 9-12 incident). LLM prose
+  never opens with either pattern because the leading ``!`` is a
+  markdown convention LLMs avoid in narrative text. The new gate is
+  position-independent, so even if the CLI ever pads its injections
+  with extra header lines the rule still applies. Pinned by
+  ``test_classify_signal_smoke21_llm_short_preamble_not_false_positive``,
+  ``test_classify_signal_assistant_event_exclamation_prefix_still_fires``,
+  and ``test_classify_signal_content_block_delta_exclamation_prefix_still_fires``.
+
 ## [0.99.66] - 2026-05-26
 
 Seed-generation ranker-phase robustness rotation. 2 PR fixing two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.67] - 2026-05-26
+
+Single-fix PATCH rotation. Ships PR-TRANSIENT-CLI-INJECTION-PREFIX to
+land the prefix-allowlist gate on the claude-cli transient classifier
+ahead of the next smoke run. The codex-OAuth gpt-5.5 empty-output-text
+defect surfaced by smoke 20/21 is NOT in this release — it requires a
+separate root-cause investigation (max_output_tokens unsupported on
+codex-oauth, effort=low alone insufficient) tracked as Sprint G.
+
 ### Fixed
 
 - PR-TRANSIENT-CLI-INJECTION-PREFIX — claude-cli transient classifier's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,13 @@ functional change.
   in-stream error injection convention) or with the literal phrase
   ``Claude usage limit reached`` (PR-T smoke 9-12 incident). LLM prose
   never opens with either pattern because the leading ``!`` is a
-  markdown convention LLMs avoid in narrative text. The new gate is
-  position-independent, so even if the CLI ever pads its injections
-  with extra header lines the rule still applies. Pinned by
+  markdown convention LLMs avoid in narrative text. The ``\A\s*``
+  anchor accepts arbitrary leading whitespace; Codex MCP audit of
+  the same 135-dump corpus confirmed 0 split-injection cases (a
+  theoretical delta-split where ``!`` and the transient phrase land
+  in separate ``content_block_delta`` chunks would slip the delta
+  branch, but the CLI emits an aggregated ``event.type="assistant"``
+  event for the same message that catches it). Pinned by
   ``test_classify_signal_smoke21_llm_short_preamble_not_false_positive``,
   ``test_classify_signal_assistant_event_exclamation_prefix_still_fires``,
   and ``test_classify_signal_content_block_delta_exclamation_prefix_still_fires``.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.66
+- **Version**: 0.99.67
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.66 — Long-running Autonomous Execution Harness
+# GEODE v0.99.67 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.66 — Long-running Autonomous Execution Harness
+# GEODE v0.99.67 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.66**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -272,20 +272,31 @@ CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
 )
 
 
-# PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) — when scanning assistant
-# text blocks for upstream signals, only consider matches that land
-# within the first ``_ASSISTANT_HEADER_LIMIT`` characters. CLI-internal
-# error injections (the PR-T quota-leak case, smoke 9-12) put the
-# transient phrase at offset 0:
-#   "Claude usage limit reached. Resets at 4pm."
-#   "! Unexpected error. Auto-retrying."
-# LLM-authored seed bodies that use the same vocabulary in scenario
-# descriptions bury the phrase mid-paragraph (smoke 19 evidence: 5
-# false-positive dumps where ``"rate-limited to 30 calls"`` appeared
-# at offset 200-500 inside a tool catalog block). 200 chars covers
-# every known CLI-injection shape with margin while excluding all
-# observed LLM-prose false positives.
-_ASSISTANT_HEADER_LIMIT = 200
+# PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26) — replaces the prior
+# ``_ASSISTANT_HEADER_LIMIT = 200`` positional heuristic. The earlier
+# gate fired whenever the transient regex matched within the first 200
+# chars of an ``event.type="assistant"`` text block, on the assumption
+# that CLI-injected errors land at offset 0 while LLM prose buries the
+# vocabulary deeper. Smoke 21 (2026-05-26, dump 1779760855) falsified
+# that: an LLM seed body opened with a 170-char preamble
+# ``"Wrote candidate ``gen1-013-5bd70823.md`` — a CI-status scenario
+# where the user pastes a complete ``gh run view --json`` payload and
+# explicitly asks the agent not to re-pull (rate-limit framing)..."``
+# so the match at idx=170 slipped through. Audit of all 135 historical
+# dumps in ``~/.geode/diagnostics/claude-cli-transient/`` showed every
+# legitimate assistant-source match started with ``"! "`` (claude-cli
+# convention for in-stream error injections such as
+# ``! Unexpected error. Auto-retrying.``); LLM prose never uses that
+# prefix because the leading ``!`` reads as a markdown convention LLMs
+# avoid in narrative text. The exception class — ``Claude usage limit
+# reached`` per the PR-T smoke 9-12 incident, sometimes injected
+# without the ``! `` prefix — is enumerated explicitly. This gate
+# does NOT depend on match position, so even if the CLI ever pads its
+# injection with extra header lines the rule still applies.
+_CLI_INJECTION_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"\A\s*(?:!\s|Claude\s+usage\s+limit\s+reached)",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -755,29 +766,21 @@ def classify_transient_signal(
                     text = block.get("text", "")
                     if not isinstance(text, str):
                         continue
+                    # PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26) —
+                    # gate the assistant-text scan on a CLI-injection
+                    # prefix allowlist (``! `` or
+                    # ``Claude usage limit reached``) before running
+                    # the broad transient regex. The earlier 200-char
+                    # positional heuristic was falsified by smoke 21
+                    # (dump 1779760855): LLM seed prose with a short
+                    # preamble had ``"rate-limit framing"`` at idx=170,
+                    # inside the prior window. The prefix gate is
+                    # position-independent and only fires on text
+                    # that claude-cli itself injects.
+                    if not _CLI_INJECTION_PREFIX_RE.match(text):
+                        continue
                     match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
                     if not match:
-                        continue
-                    # PR-TRANSIENT-CLASSIFIER-SCOPE (2026-05-26) —
-                    # smoke 19 false-positive guard. Claude-CLI's
-                    # internal error injections (PR-T case, smoke
-                    # 9-12) put the upstream phrase at the START of
-                    # the assistant message:
-                    #   "Claude usage limit reached. Resets at 4pm."
-                    #   "! Unexpected error. Auto-retrying."
-                    # LLM-authored seed prose with the same
-                    # vocabulary buries the phrase in a multi-line
-                    # paragraph:
-                    #   "...searches structured logs; ~4s per call,
-                    #    rate-limited to 30 calls / 5 min..."
-                    # Require the match position to be within the
-                    # first ``_ASSISTANT_HEADER_LIMIT`` characters of
-                    # the text block. CLI errors land at offset 0;
-                    # LLM prose containing the vocabulary in scenario
-                    # descriptions lands at 200+. This is a heuristic
-                    # — operators can audit the dump file when in
-                    # doubt.
-                    if match.start() >= _ASSISTANT_HEADER_LIMIT:
                         continue
                     return TransientSignal(
                         matched_text=_signal_excerpt(text, match),
@@ -791,10 +794,13 @@ def classify_transient_signal(
                 # treats these as a valid text source (per its priority
                 # ordering at line 587). Without this branch, a CLI
                 # error injected via the streaming path would silently
-                # bypass detection. Same header-limit heuristic
-                # applies — CLI-injected errors arrive in the first
-                # delta of the message, LLM-prose deltas accumulate
-                # over many chunks.
+                # bypass detection. PR-TRANSIENT-CLI-INJECTION-PREFIX
+                # (2026-05-26) replaces the prior 200-char heuristic
+                # with the same prefix allowlist as the ``assistant``
+                # branch — a CLI-injected error chunk starts with
+                # ``! `` (or the literal ``Claude usage limit reached``
+                # phrase) even when streamed delta-by-delta, while LLM
+                # prose deltas never begin a message that way.
                 delta = event.payload.get("delta", {})
                 if not isinstance(delta, dict):
                     continue
@@ -803,10 +809,10 @@ def classify_transient_signal(
                 text = delta.get("text", "")
                 if not isinstance(text, str):
                     continue
+                if not _CLI_INJECTION_PREFIX_RE.match(text):
+                    continue
                 match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(text)
                 if not match:
-                    continue
-                if match.start() >= _ASSISTANT_HEADER_LIMIT:
                     continue
                 return TransientSignal(
                     matched_text=_signal_excerpt(text, match),

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -290,9 +290,14 @@ CLAUDE_TRANSIENT_UPSTREAM_RE = re.compile(
 # prefix because the leading ``!`` reads as a markdown convention LLMs
 # avoid in narrative text. The exception class — ``Claude usage limit
 # reached`` per the PR-T smoke 9-12 incident, sometimes injected
-# without the ``! `` prefix — is enumerated explicitly. This gate
-# does NOT depend on match position, so even if the CLI ever pads its
-# injection with extra header lines the rule still applies.
+# without the ``! `` prefix — is enumerated explicitly. The ``\A\s*``
+# anchor accepts any leading whitespace before the prefix (Python ``\A``
+# is start-of-string; if claude-cli ever streams an injection split
+# across multiple ``content_block_delta`` chunks the prefix-only delta
+# fails this gate, so detection falls back to the aggregated
+# ``event.type="assistant"`` event the CLI emits for the same message
+# — Codex MCP audit of 135 historical dumps found 0 split-injection
+# cases in practice).
 _CLI_INJECTION_PREFIX_RE: re.Pattern[str] = re.compile(
     r"\A\s*(?:!\s|Claude\s+usage\s+limit\s+reached)",
     re.IGNORECASE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.66"
+version = "0.99.67"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -398,10 +398,13 @@ def test_classify_signal_content_block_delta_transient_match() -> None:
     assert "usage limit reached" in signal.matched_text.lower()
 
 
-def test_classify_signal_content_block_delta_header_limit_suppresses() -> None:
-    """Mid-paragraph 'rate-limited' in a delta chunk is suppressed
-    (mirrors the assistant-event header-limit heuristic — same false-
-    positive shape, same defence)."""
+def test_classify_signal_content_block_delta_no_cli_injection_prefix_suppressed() -> None:
+    """A delta chunk that starts with LLM prose (no ``! `` prefix and
+    no ``Claude usage limit reached`` phrase) must not fire the
+    classifier, even when the transient regex would match somewhere in
+    the body. Renamed from the prior ``header_limit_suppresses`` test
+    after PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26) replaced the
+    200-char positional heuristic with a prefix-allowlist gate."""
     from plugins.petri_audit.claude_cli_provider import (
         classify_transient_signal,
         parse_stream_json_events,
@@ -434,12 +437,12 @@ def test_classify_signal_smoke19_llm_seed_prose_not_false_positive() -> None:
     generator phase as a fake API rate-limit.
 
     Now: same stdout payload, full stream-json envelope parsed → the
-    LLM's prose is inside an assistant-text block. The regex pattern
-    ``rate[-_\\s]limit(?:ed\\b|...)`` DOES match ``"rate-limited"``
-    verbatim, but the new ``_ASSISTANT_HEADER_LIMIT=200`` heuristic
-    suppresses the match because it lands well past the first 200
-    chars of the text block (mid-paragraph inside a tool catalog,
-    matching the actual smoke 19 dump's offset profile).
+    LLM's prose is inside an assistant-text block whose text starts
+    with ``"## Scenario: ..."`` (no ``! `` and no ``Claude usage
+    limit reached``). The PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26)
+    allowlist gate rejects the block before the transient regex runs,
+    so the generator phase doesn't falsely abort — exactly the smoke
+    19 outcome we need.
     """
     from plugins.petri_audit.claude_cli_provider import (
         classify_transient_signal,
@@ -476,12 +479,132 @@ def test_classify_signal_smoke19_llm_seed_prose_not_false_positive() -> None:
     )
     events = parse_stream_json_events(stdout)
     signal = classify_transient_signal(stdout=stdout, stderr="", events=events)
-    # The header-limit heuristic (200 chars) suppresses the assistant
-    # scan match because "rate-limited" appears well past offset 200
-    # inside the tool catalog block. The stdout fallback also stays
-    # suppressed because events parsed. The generator phase doesn't
-    # falsely abort — exactly the smoke 19 outcome we need.
+    # The prefix-allowlist gate suppresses the assistant scan because
+    # the block doesn't open with ``! `` or ``Claude usage limit
+    # reached``. The stdout fallback also stays suppressed because
+    # events parsed (PR-TRANSIENT-CLASSIFIER-SCOPE's stdout-only-on-
+    # parse-failure rule is unchanged). Net result: signal is None.
     assert signal is None
+
+
+def test_classify_signal_smoke21_llm_short_preamble_not_false_positive() -> None:
+    """PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26) regression —
+    smoke 21 evidence: dump
+    ``~/.geode/diagnostics/claude-cli-transient/1779760855-claude-opus-4-7.json``
+    where the LLM wrote a short 170-char preamble before reaching the
+    transient vocabulary. The prior 200-char positional heuristic
+    (PR-TRANSIENT-CLASSIFIER-SCOPE, 2026-05-26) treated any match at
+    ``match.start() < 200`` as a genuine CLI injection — so the seed
+    body's ``"rate-limit framing"`` at idx=170 slipped through and
+    aborted the generator phase.
+
+    The new prefix-allowlist gate ignores match position entirely:
+    the text doesn't start with ``! `` or ``Claude usage limit
+    reached``, so the block is skipped before the transient regex
+    runs. The smoke 21 false-positive cannot recur.
+    """
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    # Verbatim reconstruction of the smoke 21 dump's assistant text
+    # (1779760855-claude-opus-4-7.json, event[5].block[0]). 170-char
+    # preamble + the matched phrase + scenario tail. The LLM was
+    # summarising a seed it had just written; "rate-limit framing"
+    # describes the SCENARIO design, not an actual CLI rate-limit.
+    assistant_text = (
+        "Wrote candidate `gen1-013-5bd70823.md` — a CI-status scenario "
+        "where the user pastes a complete `gh run view --json` payload "
+        "and explicitly asks the agent not to re-pull (rate-limit "
+        "framing). Minimal-call N=0. Redundancy trap: re-calling "
+        "`gh_run_view`, per-job `gh_job_view`, or `gh_run_logs` when "
+        "the breakdown is fully present in the pasted payload."
+    )
+    # Sanity: the transient regex still matches "rate-limit" inside the
+    # body — the test would be vacuous if the regex no longer fired.
+    from plugins.petri_audit.claude_cli_provider import CLAUDE_TRANSIENT_UPSTREAM_RE
+
+    match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(assistant_text)
+    assert match is not None, "smoke 21 regression: regex should still match"
+    assert match.start() < 200, (
+        "smoke 21 regression: match position < 200 (would have slipped the prior gate)"
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": assistant_text}]},
+            },
+            {"type": "result", "stop_reason": "end_turn", "result": ""},
+        ]
+    )
+    events = parse_stream_json_events(stdout)
+    signal = classify_transient_signal(stdout=stdout, stderr="", events=events)
+    assert signal is None, (
+        "smoke 21 false-positive regressed: classifier matched LLM prose "
+        "lacking the CLI-injection prefix"
+    )
+
+
+def test_classify_signal_assistant_event_exclamation_prefix_still_fires() -> None:
+    """PR-TRANSIENT-CLI-INJECTION-PREFIX (2026-05-26) — the
+    ``! Unexpected error. Auto-retrying.`` form claude-cli uses for
+    in-stream operational error injections must still be detected.
+    Audit of 135 historical dumps in
+    ``~/.geode/diagnostics/claude-cli-transient/`` found 7
+    assistant-source matches; ALL of them start with ``"! "``. The
+    prefix allowlist must keep firing on this convention."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "! Unexpected error. Auto-retrying."}]
+                },
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout="", stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.source == "event"
+    assert signal.event_type == "assistant"
+
+
+def test_classify_signal_content_block_delta_exclamation_prefix_still_fires() -> None:
+    """Same prefix-allowlist guarantee for the streaming delta path —
+    a CLI-injected error chunk that arrives as ``content_block_delta``
+    still fires when its text starts with ``"! "``."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "content_block_delta",
+                "delta": {
+                    "type": "text_delta",
+                    "text": "! Claude usage limit reached. Resets at 4pm.",
+                },
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout="", stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.source == "event"
+    assert signal.event_type == "content_block_delta"
 
 
 def test_signal_excerpt_bounded_to_200_chars() -> None:

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -508,11 +508,15 @@ def test_classify_signal_smoke21_llm_short_preamble_not_false_positive() -> None
         parse_stream_json_events,
     )
 
-    # Verbatim reconstruction of the smoke 21 dump's assistant text
+    # Reconstruction of the smoke 21 dump's assistant text shape
     # (1779760855-claude-opus-4-7.json, event[5].block[0]). 170-char
-    # preamble + the matched phrase + scenario tail. The LLM was
-    # summarising a seed it had just written; "rate-limit framing"
-    # describes the SCENARIO design, not an actual CLI rate-limit.
+    # preamble + the matched phrase + scenario tail — the actual dump
+    # has a slightly longer trailing paragraph but the regression
+    # pinning invariants are (a) ``rate-limit`` matches at idx 170 (<
+    # the prior 200-char gate window) and (b) the text doesn't start
+    # with the CLI-injection prefix. The LLM was summarising a seed
+    # it had just written; "rate-limit framing" describes the
+    # SCENARIO design, not an actual CLI rate-limit.
     assistant_text = (
         "Wrote candidate `gen1-013-5bd70823.md` — a CI-status scenario "
         "where the user pastes a complete `gh run view --json` payload "

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.66"
+version = "0.99.67"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Brings develop to main for v0.99.67 release tag — ships PR-TRANSIENT-CLI-INJECTION-PREFIX (PR #1727) to land the prefix-allowlist gate on the claude-cli transient classifier ahead of the next smoke run.

NOT in this release: codex-OAuth gpt-5.5 empty-output-text fix — separate Sprint G after ctx7-grounded investigation.

## Verification
- [x] release/v0.99.67 → develop merged via #1729 (CI 8/8 green)
- [x] 5 SoT version locations stamped 0.99.67