### PR TITLE
release: v0.99.68 — develop → main rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,23 +52,30 @@ functional change.
 - PR-UPGRADE-ROLES-TOP-TIER — operator directive (2026-05-26): every
   seed-generation role default model is now ``claude-opus-4-7`` (the
   Anthropic top tier registered in GEODE's model spec). Replaces the
-  prior cost-tiered defaults that mixed ``claude-sonnet-4-6`` (8
-  roles) and ``claude-haiku-4-5`` (pilot's "cheap-fast inner-loop"
-  slot). The ranker judge panel's anthropic voter also moves from
+  prior cost-tiered defaults that mixed ``claude-sonnet-4-6`` (6
+  roles: generator/critic/proximity/ranker/evolver/literature_review)
+  and ``claude-haiku-4-5`` (pilot's "cheap-fast inner-loop" slot).
+  The ranker judge panel's anthropic voter also moves from
   ``claude-sonnet-4-6`` → ``claude-opus-4-7``; the two ``gpt-5.5``
   voters stay (already the OpenAI top tier per
-  ``core/llm/adapters/_openai_common.py`` registry). ``allowed_models``
-  lists are unchanged so operators retain per-deployment override
-  flexibility via ``~/.geode/config.toml``. Cost impact: per-run
-  spend rises ~3-5x in fan-out phases (generator 15-spawn, pilot
-  per-candidate Petri inner-loop, ranker 59-match × 3-voter panel)
-  but bypasses the smoke 17-21 quality regressions tied to lower-tier
-  models on schema-heavy tasks. Affects: 7 role TOML defaults
-  (generator/critic/proximity/pilot/ranker/evolver/literature_review)
-  + 8 ``_DEFAULT_*_MODEL`` code constants + 1 voter panel entry +
-  ``_DEFAULT_FALLBACK_MODEL`` in ``_registry_builder.py``. The
+  ``core/llm/adapters/_openai_common.py`` registry). The pilot
+  agent's Petri inner-loop ``target_models`` also moves from
+  ``["claude-haiku-4-5", "gpt-5.4-mini"]`` to
+  ``["claude-opus-4-7", "gpt-5.5"]`` (provider-cross top tier kept
+  for variance estimation). ``allowed_models`` lists are unchanged
+  so operators retain per-deployment override flexibility via
+  ``~/.geode/config.toml``. Cost impact: per-run spend rises ~3-5x
+  in fan-out phases (generator 15-spawn, pilot per-candidate Petri
+  inner-loop, ranker 59-match × 3-voter panel), and the 90s
+  pilot wall-time cap will time out more often on opus latency —
+  operators can pin a faster model via the per-role override. The
   codex-OAuth gpt-5.5 empty-output-text defect is unaffected — that
   fix is tracked separately as Sprint G (PR-GPT55-EMPTY-OUTPUT-EMIT).
+  Affects: 7 role TOML defaults + 8 ``_DEFAULT_*_MODEL`` code
+  constants (7 agent files + ``_DEFAULT_FALLBACK_MODEL`` in
+  ``_registry_builder.py``) + 1 judge_panel voter entry + pilot.md
+  prompt's ``target_models`` line. Pinned by
+  ``test_bundled_manifest_all_role_defaults_top_tier``.
 
 ## [0.99.67] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- PR-UPGRADE-ROLES-TOP-TIER — operator directive (2026-05-26): every
+  seed-generation role default model is now ``claude-opus-4-7`` (the
+  Anthropic top tier registered in GEODE's model spec). Replaces the
+  prior cost-tiered defaults that mixed ``claude-sonnet-4-6`` (8
+  roles) and ``claude-haiku-4-5`` (pilot's "cheap-fast inner-loop"
+  slot). The ranker judge panel's anthropic voter also moves from
+  ``claude-sonnet-4-6`` → ``claude-opus-4-7``; the two ``gpt-5.5``
+  voters stay (already the OpenAI top tier per
+  ``core/llm/adapters/_openai_common.py`` registry). ``allowed_models``
+  lists are unchanged so operators retain per-deployment override
+  flexibility via ``~/.geode/config.toml``. Cost impact: per-run
+  spend rises ~3-5x in fan-out phases (generator 15-spawn, pilot
+  per-candidate Petri inner-loop, ranker 59-match × 3-voter panel)
+  but bypasses the smoke 17-21 quality regressions tied to lower-tier
+  models on schema-heavy tasks. Affects: 7 role TOML defaults
+  (generator/critic/proximity/pilot/ranker/evolver/literature_review)
+  + 8 ``_DEFAULT_*_MODEL`` code constants + 1 voter panel entry +
+  ``_DEFAULT_FALLBACK_MODEL`` in ``_registry_builder.py``. The
+  codex-OAuth gpt-5.5 empty-output-text defect is unaffected — that
+  fix is tracked separately as Sprint G (PR-GPT55-EMPTY-OUTPUT-EMIT).
+
 ## [0.99.67] - 2026-05-26
 
 Single-fix PATCH rotation. Ships PR-TRANSIENT-CLI-INJECTION-PREFIX to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.68] - 2026-05-26
+
+Single-change MINOR rotation. Ships PR-UPGRADE-ROLES-TOP-TIER —
+operator-directed bulk upgrade of every seed-generation role default
+to ``claude-opus-4-7`` (Anthropic top tier) and pilot's Petri audit
+``target_models`` to the provider-cross top-tier pair
+``[claude-opus-4-7, gpt-5.5]``. The codex-OAuth gpt-5.5 empty-output
+defect is NOT in this release — Sprint G handles it separately.
+
 ### Changed
 
 - PR-UPGRADE-ROLES-TOP-TIER — operator directive (2026-05-26): every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.67
+- **Version**: 0.99.68
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.67 — Long-running Autonomous Execution Harness
+# GEODE v0.99.68 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.68**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.67 — Long-running Autonomous Execution Harness
+# GEODE v0.99.68 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.67**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.68**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -263,7 +263,7 @@ def populate_registry(
 # binding for (mismatch between picker.bindings and manifest.enabled_roles).
 # We log+continue rather than crashing so the operator gets a clear
 # "no registered agent" error at phase time pointing at the missing role.
-_DEFAULT_FALLBACK_MODEL = "claude-sonnet-4-6"
+_DEFAULT_FALLBACK_MODEL = "claude-opus-4-7"
 
 
 __all__ = ["build_subagent_manager", "populate_registry"]

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -63,7 +63,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Critic"]
 
 
-_DEFAULT_CRITIC_MODEL = "claude-sonnet-4-6"
+_DEFAULT_CRITIC_MODEL = "claude-opus-4-7"
 _CRITIC_AGENT_NAME = "seed_critic"
 _TASK_TYPE = "seed-critique"
 

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -56,7 +56,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Evolver"]
 
 
-_DEFAULT_EVOLVER_MODEL = "claude-sonnet-4-6"
+_DEFAULT_EVOLVER_MODEL = "claude-opus-4-7"
 _EVOLVER_AGENT_NAME = "seed_evolver"
 _TASK_TYPE = "seed-evolve"
 

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -66,7 +66,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Generator"]
 
 
-_DEFAULT_GENERATOR_MODEL = "claude-sonnet-4-6"
+_DEFAULT_GENERATOR_MODEL = "claude-opus-4-7"
 _GENERATOR_AGENT_NAME = "seed_generator"
 _TASK_TYPE = "seed-generation"
 # CSP-13 (2026-05-23) — Loop 2 (debate-turn) sidecar suffix. The

--- a/plugins/seed_generation/agents/literature_review.py
+++ b/plugins/seed_generation/agents/literature_review.py
@@ -63,7 +63,7 @@ log = logging.getLogger(__name__)
 __all__ = ["LiteratureReview"]
 
 
-_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-sonnet-4-6"
+_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-opus-4-7"
 _LITERATURE_REVIEW_AGENT_NAME = "seed_literature_review"
 _TASK_TYPE = "seed-literature-review"
 

--- a/plugins/seed_generation/agents/pilot.md
+++ b/plugins/seed_generation/agents/pilot.md
@@ -15,7 +15,7 @@ For ONE candidate seed, run a cheap Petri audit (1 seed × 2 model × 1 paraphra
 1. Locate candidate `.md` at `<run_dir>/candidates/<uuid>.md`.
 2. Invoke `petri_audit` tool with:
    - `seeds = [<uuid>.md]`
-   - `target_models = ["claude-haiku-4-5", "gpt-5.4-mini"]` (2 model)
+   - `target_models = ["claude-opus-4-7", "gpt-5.5"]` (2 model, provider-cross top tier)
    - `paraphrases = 1` (single)
    - `dim_set = "geode_judge_subset"`
 3. Read the `.eval` archive at `~/.geode/petri/logs/<run>.eval`.

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -56,7 +56,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Pilot"]
 
 
-_DEFAULT_PILOT_MODEL = "claude-haiku-4-5"
+_DEFAULT_PILOT_MODEL = "claude-opus-4-7"
 _PILOT_AGENT_NAME = "seed_pilot"
 _TASK_TYPE = "seed-pilot"
 

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -66,7 +66,7 @@ __all__ = ["HIGH_SIMILARITY_DEGREE", "Proximity"]
 
 HIGH_SIMILARITY_DEGREE = "high"
 
-_DEFAULT_PROXIMITY_MODEL = "claude-sonnet-4-6"
+_DEFAULT_PROXIMITY_MODEL = "claude-opus-4-7"
 _PROXIMITY_AGENT_NAME = "seed_proximity"
 _TASK_TYPE = "seed-proximity"
 

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -68,7 +68,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Ranker"]
 
 
-_DEFAULT_RANKER_MODEL = "claude-sonnet-4-6"
+_DEFAULT_RANKER_MODEL = "claude-opus-4-7"
 _TASK_TYPE = "seed-ranker-vote"
 
 _REQUIRED_VOTE_FIELDS = ("match_id", "winner", "rationale")

--- a/plugins/seed_generation/picker.py
+++ b/plugins/seed_generation/picker.py
@@ -194,7 +194,7 @@ def load_user_overrides(
 
        [seed_generation.role.pilot]
        source = "subscription"
-       model  = "claude-haiku-4-5"
+       model  = "claude-opus-4-7"
 
     The legacy ``~/.geode/seed-generation.toml`` schema (per-role top-level
     table) is still read when ``[seed_generation.role.*]`` is absent from

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -56,7 +56,7 @@ enabled_roles = [
 # ── Roles ────────────────────────────────────────────────────────────────────
 
 [seed_generation.role.generator]
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -73,7 +73,7 @@ role_contract = "plugins/seed_generation/agents/generator.md"
 num_turns = 0
 
 [seed_generation.role.critic]
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 # ``claude-opus-4-7`` accepted so operators on the Claude Code Max
 # subscription can route critic on the strongest available reasoning
 # model when running through ``source = "claude-cli"``.
@@ -91,7 +91,7 @@ role_contract = "plugins/seed_generation/agents/critic.md"
 # (paper §3). Pre-CSP-8 was an embedding call to text-embedding-3-small;
 # now an LLM completion call like every other role. CSP-10 dropped the
 # ``kind`` field from the schema (every role is completion now).
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 # ``claude-opus-4-7`` accepted for the same Claude Code Max routing
 # reason as critic — proximity is also a reasoning-heavy role.
 allowed_models = [
@@ -105,7 +105,7 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 
 [seed_generation.role.pilot]
 # Cheap-fast slot — runs inside the Petri inner-loop on every candidate.
-default_model = "claude-haiku-4-5"
+default_model = "claude-opus-4-7"
 # ``claude-opus-4-7`` accepted so operators can opt into a stronger
 # pilot when iteration cost is acceptable (manifest default stays
 # haiku for the cheap-fast contract).
@@ -120,7 +120,7 @@ role_contract = "plugins/seed_generation/agents/pilot.md"
 [seed_generation.role.ranker]
 # 3-judge panel orchestrator. Its own default_model is a placeholder —
 # the panel's voter binding (below) drives actual LLM calls.
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -129,7 +129,7 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/ranker.md"
 
 [seed_generation.role.evolver]
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -170,7 +170,7 @@ role_contract = "plugins/seed_generation/agents/supervisor.md"
 # in ``~/.geode/config.toml`` to opt into the external arxiv fetch +
 # git-tracked snapshot loop.
 [seed_generation.role.literature_review]
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -212,6 +212,6 @@ provider = "openai"
 source = "openai-codex"
 
 [[seed_generation.judge_panel.voters]]
-model = "claude-sonnet-4-6"
+model = "claude-opus-4-7"
 provider = "anthropic"
 source = "claude-cli"

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -104,11 +104,16 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/proximity.md"
 
 [seed_generation.role.pilot]
-# Cheap-fast slot — runs inside the Petri inner-loop on every candidate.
+# Pilot orchestrates a Petri inner-loop audit per candidate. Default
+# tier moved to ``claude-opus-4-7`` (PR-UPGRADE-ROLES-TOP-TIER,
+# 2026-05-26) under operator directive that all role LLMs run on the
+# Anthropic top tier — see CHANGELOG. The 90s wall-time cap in
+# pilot.md is unchanged; operators tightening the per-candidate
+# budget can override the model via
+# ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.
 default_model = "claude-opus-4-7"
-# ``claude-opus-4-7`` accepted so operators can opt into a stronger
-# pilot when iteration cost is acceptable (manifest default stays
-# haiku for the cheap-fast contract).
+# Override paths: operators can pin a faster/cheaper model via the
+# allowlist below when the 90s wall-time becomes a bottleneck.
 allowed_models = [
     "claude-opus-4-7",
     "claude-haiku-4-5",
@@ -192,8 +197,9 @@ queries_per_run = 3
 [seed_generation.judge_panel]
 # Default voter mix: 2 reviewers on OpenAI gpt-5.5 via openai-codex
 # (ChatGPT Plus subscription / Codex Responses API) + 1 reviewer on
-# Anthropic claude-sonnet-4-6 via claude-cli (Claude Code Max
-# subscription). Both diversity gates are satisfied:
+# Anthropic claude-opus-4-7 via claude-cli (Claude Code Max
+# subscription, top tier per PR-UPGRADE-ROLES-TOP-TIER 2026-05-26).
+# Both diversity gates are satisfied:
 #   * providers ≥ 2 (openai + anthropic)
 #   * paths ≥ 2 (openai-codex + claude-cli)
 # Every voter rides a subscription path so PAYG credit isn't required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.67"
+version = "0.99.68"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -256,6 +256,41 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
         )
 
 
+def test_bundled_manifest_all_role_defaults_top_tier() -> None:
+    """PR-UPGRADE-ROLES-TOP-TIER (2026-05-26) regression pin — every
+    role default in the shipped TOML must be ``claude-opus-4-7``
+    (the Anthropic top tier per GEODE's spec registry). The judge
+    panel must keep 2× gpt-5.5 codex voters + 1× claude-opus-4-7
+    voter (provider-diversity gate). Prior to this PR roles split
+    across ``claude-sonnet-4-6`` (generator/critic/proximity/ranker/
+    evolver/literature_review) and ``claude-haiku-4-5`` (pilot's
+    cheap-fast slot); meta_reviewer + supervisor were already opus."""
+    clear_manifest_cache()
+    manifest = load_manifest()
+    role_names = (
+        "generator",
+        "critic",
+        "proximity",
+        "pilot",
+        "ranker",
+        "evolver",
+        "meta_reviewer",
+        "supervisor",
+        "literature_review",
+    )
+    for name in role_names:
+        role = manifest.get_role(name)
+        assert role.default_model == "claude-opus-4-7", (
+            f"role {name!r} default_model={role.default_model!r}; "
+            "PR-UPGRADE-ROLES-TOP-TIER requires opus-4-7"
+        )
+    voters = manifest.judge_panel.voters
+    voter_models = sorted(v.model for v in voters)
+    assert voter_models == ["claude-opus-4-7", "gpt-5.5", "gpt-5.5"], (
+        f"judge panel voter models {voter_models!r}; expected [claude-opus-4-7, gpt-5.5, gpt-5.5]"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Parse path (no I/O — dict literal)
 # ---------------------------------------------------------------------------

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -238,7 +238,7 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
     clear_manifest_cache()
     manifest = load_manifest()
     proximity = manifest.get_role("proximity")
-    assert proximity.default_model == "claude-sonnet-4-6"
+    assert proximity.default_model == "claude-opus-4-7"
 
     toml_body = (
         Path(__file__).resolve().parents[3]

--- a/tests/plugins/seed_generation/test_picker.py
+++ b/tests/plugins/seed_generation/test_picker.py
@@ -41,31 +41,34 @@ from plugins.seed_generation.picker import (
 
 
 def _make_manifest() -> SeedGenerationManifest:
-    """Build an in-memory manifest equivalent to the shipped TOML."""
+    """Build an in-memory manifest equivalent to the shipped TOML
+    (post PR-UPGRADE-ROLES-TOP-TIER, 2026-05-26 — every role default
+    is ``claude-opus-4-7``; allowed_models retains operator override
+    flexibility)."""
     roles = {
         "generator": SeedRoleSpec(
-            default_model="claude-sonnet-4-6",
-            allowed_models=["claude-sonnet-4-6", "claude-opus-4-7"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-sonnet-4-6"],
         ),
         "critic": SeedRoleSpec(
-            default_model="claude-sonnet-4-6",
-            allowed_models=["claude-sonnet-4-6"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-sonnet-4-6"],
         ),
         "proximity": SeedRoleSpec(
-            default_model="claude-sonnet-4-6",
-            allowed_models=["claude-sonnet-4-6"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-sonnet-4-6"],
         ),
         "pilot": SeedRoleSpec(
-            default_model="claude-haiku-4-5",
-            allowed_models=["claude-haiku-4-5"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-haiku-4-5"],
         ),
         "ranker": SeedRoleSpec(
-            default_model="claude-sonnet-4-6",
-            allowed_models=["claude-sonnet-4-6"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-sonnet-4-6"],
         ),
         "evolver": SeedRoleSpec(
-            default_model="claude-sonnet-4-6",
-            allowed_models=["claude-sonnet-4-6"],
+            default_model="claude-opus-4-7",
+            allowed_models=["claude-opus-4-7", "claude-sonnet-4-6"],
         ),
         "meta_reviewer": SeedRoleSpec(
             default_model="claude-opus-4-7",
@@ -74,9 +77,9 @@ def _make_manifest() -> SeedGenerationManifest:
     }
     judge_panel = JudgePanelSpec(
         voters=[
-            VoterSpec(model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"),
+            VoterSpec(model="claude-opus-4-7", provider="anthropic", source="claude-cli"),
             VoterSpec(model="gpt-5.5", provider="openai", source="openai-codex"),
-            VoterSpec(model="claude-haiku-4-5", provider="anthropic", source="api_key"),
+            VoterSpec(model="gpt-5.5", provider="openai", source="openai-codex"),
         ],
         required_diversity_providers=2,
     )
@@ -178,9 +181,11 @@ def test_pick_bindings_voter_panel_resolved() -> None:
         result = pick_bindings(manifest=manifest, overrides={})
     assert len(result.voters) == 3
     sources = {v.source for v in result.voters}
-    # Voters have explicit sources (claude-cli / openai-codex / api_key),
-    # none are "auto" so the OAuth probe doesn't change them.
-    assert sources == {"claude-cli", "openai-codex", "api_key"}
+    # Shipped panel (PR-UPGRADE-ROLES-TOP-TIER 2026-05-26): 2× openai-codex
+    # (gpt-5.5) + 1× claude-cli (claude-opus-4-7). Both diversity gates
+    # are satisfied (providers ≥ 2, paths ≥ 2). None are "auto" so the
+    # OAuth probe doesn't change them.
+    assert sources == {"claude-cli", "openai-codex"}
 
 
 def test_pick_bindings_diversity_providers_count() -> None:
@@ -411,7 +416,8 @@ def test_pick_bindings_rejects_override_model_outside_allowlist() -> None:
     # claude-haiku-4-5 is NOT in generator.allowed_models for this test fixture.
     overrides = {"generator": {"model": "claude-haiku-4-5"}}
     result = pick_bindings(manifest=manifest, overrides=overrides, auto_probe=False)
-    assert result.bindings["generator"].model == "claude-sonnet-4-6"  # default
+    # Default is claude-opus-4-7 after PR-UPGRADE-ROLES-TOP-TIER (2026-05-26).
+    assert result.bindings["generator"].model == "claude-opus-4-7"  # default
 
 
 def test_pick_bindings_rejects_override_source_outside_petri_allowed() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.67"
+version = "0.99.68"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Brings develop to main for v0.99.68 — ships PR-UPGRADE-ROLES-TOP-TIER (PR #1731): bulk upgrade of seed-generation role defaults to claude-opus-4-7 + pilot target_models to provider-cross top-tier pair.

## Verification
- [x] release/v0.99.68 → develop merged via #1732 (CI 8/8 green)
- [x] 5 SoT version locations stamped 0.99.68