### PR TITLE
PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE (Sprint H1) — extend prefix allowlist to result.result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE (Sprint H1) — extend the
+  ``_CLI_INJECTION_PREFIX_RE`` allowlist (from
+  PR-TRANSIENT-CLI-INJECTION-PREFIX) to the ``event.type="result"``
+  scan branch in ``classify_transient_signal``. Smoke 22 evidence:
+  dump ``1779767762-claude-opus-4-7.json`` — LLM seed body landed
+  in ``event.type="result"`` ``result`` field carrying the phrase
+  ``"...the rate-limit warning as sufficient grounds for N=2..."``
+  and the pre-fix broad any-position transient regex matched it,
+  aborting ``gen-gen1-000`` even though the seed ``.md`` was
+  already written. The fix gates the ``result.result`` field (LLM-
+  authored aggregated final-assistant text) on the same prefix
+  allowlist as the ``assistant`` + ``content_block_delta``
+  branches; the ``result.error`` / ``result.message`` /
+  ``result.stderr`` fields keep the any-position scan since they
+  carry CLI/system error text, not LLM prose. Pinned by
+  ``test_classify_signal_smoke22_llm_prose_in_result_event_not_false_positive``
+  (verbatim reconstruction of the dump),
+  ``test_classify_signal_result_event_error_field_still_fires_any_position``
+  (CLI-error path regression guard), and
+  ``test_classify_signal_result_event_cli_injection_prefix_in_result_fires``
+  (CLI-injection prefix in result.result still fires correctly).
+
 ### Added
 
 - **PR-SELF-IMPROVING-P6 — autoresearch surface (5 sub-pages) +

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -748,6 +748,25 @@ def classify_transient_signal(
                     value = event.payload.get(key)
                     if not isinstance(value, str):
                         continue
+                    # PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE
+                    # (Sprint H1, 2026-05-26) — the ``result`` field
+                    # carries the LLM's aggregated final assistant
+                    # response (LLM-authored prose), not a CLI/system
+                    # error. Apply the same CLI-injection-prefix
+                    # allowlist as the ``assistant`` +
+                    # ``content_block_delta`` branches so LLM prose
+                    # with rate-limit vocabulary doesn't false-positive.
+                    # Smoke 22 incident: dump
+                    # ``1779767762-claude-opus-4-7.json`` — LLM seed
+                    # body in ``event/result.result`` matched
+                    # ``"rate-limit warning"`` and aborted
+                    # ``gen-gen1-000`` even though the seed .md was
+                    # already written. The ``error`` / ``message`` /
+                    # ``stderr`` fields are CLI-injected error text,
+                    # not LLM content, so they keep the any-position
+                    # scan.
+                    if key == "result" and not _CLI_INJECTION_PREFIX_RE.match(value):
+                        continue
                     match = CLAUDE_TRANSIENT_UPSTREAM_RE.search(value)
                     if match:
                         return TransientSignal(

--- a/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
+++ b/tests/plugins/petri_audit/test_claude_cli_transient_classifier.py
@@ -583,6 +583,88 @@ def test_classify_signal_assistant_event_exclamation_prefix_still_fires() -> Non
     assert signal.event_type == "assistant"
 
 
+def test_classify_signal_smoke22_llm_prose_in_result_event_not_false_positive() -> None:
+    """PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE (Sprint H1, 2026-05-26)
+    regression — smoke 22 evidence: dump
+    ``/Users/mango/.geode/diagnostics/claude-cli-transient/1779767762-claude-opus-4-7.json``.
+    LLM seed body landed in ``event.type="result"`` ``result`` field
+    (the aggregated final-assistant text) containing the phrase
+    ``"rate-limit warning"``. Pre-fix the broad transient regex matched
+    any-position in the ``result`` field, aborting ``gen-gen1-000``
+    even though the seed .md was already written.
+
+    The fix extends the same CLI-injection-prefix allowlist applied
+    to the ``assistant`` + ``content_block_delta`` branches to the
+    ``result.result`` field (LLM-authored prose), while preserving
+    any-position scans on ``result.error`` / ``result.message`` /
+    ``result.stderr`` (CLI-injected error text)."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    seed_body = (
+        "Wrote candidate seed describing the incident triage workflow. "
+        "The agent recognizes the operator-supplied context, the idempotent "
+        "refund tool, and the rate-limit warning as sufficient grounds for "
+        "N=2. Frontmatter includes target_dims and tags."
+    )
+    stdout = _make_stream_json([{"type": "result", "stop_reason": "end_turn", "result": seed_body}])
+    events = parse_stream_json_events(stdout)
+    signal = classify_transient_signal(stdout=stdout, stderr="", events=events)
+    assert signal is None, (
+        "smoke 22 false-positive regressed: LLM seed prose in result.result "
+        "matched the transient regex without the CLI-injection prefix gate"
+    )
+
+
+def test_classify_signal_result_event_error_field_still_fires_any_position() -> None:
+    """The ``result.error`` field is a CLI/system error message, not
+    LLM-authored prose. The fix must keep the any-position scan on this
+    field — only ``result.result`` (LLM aggregate) gets the prefix
+    allowlist. Regression guard for the Sprint H1 scope."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "result",
+                "error": "Upstream API responded with overloaded_error: server busy",
+                "result": "",
+            }
+        ]
+    )
+    signal = classify_transient_signal(
+        stdout="", stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.event_field == "error"
+
+
+def test_classify_signal_result_event_cli_injection_prefix_in_result_fires() -> None:
+    """When the ``result.result`` field DOES start with the CLI-injection
+    prefix (e.g. claude-cli wrote ``! Unexpected error...`` as the
+    aggregated final text because the model never emitted anything),
+    the prefix-allowlist gate lets the transient regex run and fires
+    normally. Mirror of the existing assistant-event coverage for the
+    result-event path."""
+    from plugins.petri_audit.claude_cli_provider import (
+        classify_transient_signal,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "result", "result": "! Unexpected error. Auto-retrying."}])
+    signal = classify_transient_signal(
+        stdout=stdout, stderr="", events=parse_stream_json_events(stdout)
+    )
+    assert signal is not None
+    assert signal.event_type == "result"
+    assert signal.event_field == "result"
+
+
 def test_classify_signal_content_block_delta_exclamation_prefix_still_fires() -> None:
     """Same prefix-allowlist guarantee for the streaming delta path —
     a CLI-injected error chunk that arrives as ``content_block_delta``


### PR DESCRIPTION
## Summary
- Extend the ``_CLI_INJECTION_PREFIX_RE`` allowlist (from PR-TRANSIENT-CLI-INJECTION-PREFIX) to the ``event.type="result"`` ``result`` field in ``classify_transient_signal``.
- Closes the gap that produced 1 false-positive in smoke 22 (gen-gen1-000 aborted via ``event/result.result`` matching ``"rate-limit warning"`` in LLM seed prose).
- ``result.error`` / ``result.message`` / ``result.stderr`` keep any-position scans (they carry CLI-injected error text, not LLM prose).

## Why
The original F1 fix (PR-TRANSIENT-CLI-INJECTION-PREFIX) gated the ``assistant`` + ``content_block_delta`` branches but missed the ``result`` event — which also surfaces the LLM's aggregated final assistant text in its ``result`` field. Smoke 22 dump ``1779767762-claude-opus-4-7.json``:

```
signal: source=event event_type=result event_field=result
matched: "...the operator-supplied context, the idempotent refund tool,
         and the rate-limit warning as sufficient grounds for N=2..."
```

The LLM wrote a CI-status seed body describing a rate-limit-themed audit scenario; the result-event scan matched ``"rate-limit warning"`` in the LLM's prose and aborted the sub-agent even though the seed ``.md`` was already written.

## Changes
| File | Change |
|------|--------|
| ``plugins/petri_audit/claude_cli_provider.py`` | In ``classify_transient_signal``'s ``event.type="result"`` branch, gate the ``result.result`` field on the same prefix allowlist as the assistant + content_block_delta branches. Other ``result`` fields (``error`` / ``message`` / ``stderr``) keep the any-position scan since they carry CLI-injected error text. |
| ``tests/plugins/petri_audit/test_claude_cli_transient_classifier.py`` | 3 new tests: smoke 22 verbatim regression, error-field any-position regression guard, CLI-injection prefix in result.result still fires. |
| ``CHANGELOG.md`` | ``[Unreleased] → ### Fixed`` entry. |

## Verification
- [x] ruff check clean
- [x] ruff format check clean
- [x] mypy clean (37 source files)
- [x] lint-imports clean
- [x] pytest tests/plugins/petri_audit/ — 577 passed, 35 skipped (3 new tests added)

## Reference
- Smoke 22 dump: ``/Users/mango/.geode/diagnostics/claude-cli-transient/1779767762-claude-opus-4-7.json``
- Prior F1 PR (assistant + content_block_delta gating): #1727 PR-TRANSIENT-CLI-INJECTION-PREFIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)