### PR TITLE
PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up) — preserve phase across Codex multi-turn replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,40 @@ functional change.
 
 ### Added
 
+- PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up) — round-trip
+  preservation of ``ResponseOutputMessage.phase`` across the Codex
+  Responses API multi-turn replay. OpenAI's
+  ``ResponseOutputMessage.phase`` is
+  ``Optional[Literal["commentary", "final_answer"]]`` and the same
+  slot appears on ``EasyInputMessageParam`` so multi-turn callers
+  need to carry the attribution back to the next turn. Pre-fix the
+  field was dropped at capture, so every Codex multi-turn replay
+  surfaced messages with phase implicitly ``None`` — losing the
+  semantic distinction that the model uses to differentiate
+  intermediate reasoning commentary from the final answer. Full
+  wire chain: ``translate_codex_response`` captures phase from
+  ``ResponseOutputMessage`` items, surfaces on
+  ``AdapterCallResult.assistant_phase``;
+  ``agentic_response_from_adapter_result`` forwards into
+  ``AgenticResponse.assistant_phase``; ``AgenticLoop`` persists onto
+  ``_assistant_msg["phase"]`` (both end-turn + tool-use round
+  sites); ``adapter_request_from_legacy`` reads dict ``m["phase"]``
+  → ``Message.phase``; ``build_codex_input`` →
+  ``_convert_assistant_msg_to_responses`` emits
+  ``{"role": "assistant", "content": ..., "phase": ...}`` so the
+  Responses API ``EasyInputMessageParam.phase`` slot is populated on
+  replay. Empty phase (default) skips the field — back-compat with
+  every non-Codex adapter and pre-existing Codex calls. 11 unit
+  tests pin: capture from message item, capture for both
+  ``commentary`` + ``final_answer`` values, no-op when phase
+  missing, phase capture alongside populated ``response.output_text``,
+  replay emit when set, replay skip when empty, string-content path,
+  text+tool_use ordering (phase on text, not on function_call),
+  ``build_codex_input`` E2E, ``Message.phase`` default back-compat,
+  full round-trip capture → replay. Closes the deferred PR-D3 fold
+  catch (PR #1715, 2026-05-26) for analogous ``phase`` preservation
+  to ``summary`` — same surface, same fix shape.
+
 - PR-VOTER-EFFORT-OVERRIDE-HATCH (Sprint G/H follow-up) — per-voter
   ``reasoning.effort`` override propagation. ``VoterSpec.effort`` (new
   optional string field on the judge-panel voter entry) lets

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1948,6 +1948,13 @@ class AgenticLoop:
                 # ``input`` array. Other adapters ignore the field.
                 if getattr(response, "codex_reasoning_items", None):
                     _assistant_msg["codex_reasoning_items"] = response.codex_reasoning_items
+                # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up,
+                # 2026-05-26) — persist phase from the Codex response so
+                # the next-turn replay carries ``EasyInputMessageParam.phase``.
+                # Other adapters ignore the field.
+                _phase = getattr(response, "assistant_phase", "")
+                if _phase:
+                    _assistant_msg["phase"] = _phase
                 messages.append(_assistant_msg)
                 self._sync_messages_to_context(messages)
                 await self._record_text_only_round(round_idx, text=text)
@@ -2060,6 +2067,11 @@ class AgenticLoop:
             # above for the rationale; same shape on tool-use rounds).
             if getattr(response, "codex_reasoning_items", None):
                 _assistant_msg["codex_reasoning_items"] = response.codex_reasoning_items
+            # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up,
+            # 2026-05-26) — same phase persistence on tool-use rounds.
+            _phase = getattr(response, "assistant_phase", "")
+            if _phase:
+                _assistant_msg["phase"] = _phase
             messages.append(_assistant_msg)
             messages.append({"role": "user", "content": tool_results})
             round_idx += 1

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -374,7 +374,7 @@ def build_codex_input(req: AdapterCallRequest) -> list[dict[str, Any]]:
                 # data drift surfaces.
                 replayed.setdefault("summary", [])
                 out.append(replayed)
-            out.extend(_convert_assistant_msg_to_responses(m.content))
+            out.extend(_convert_assistant_msg_to_responses(m.content, phase=m.phase))
             continue
         if m.role == "user":
             out.extend(_convert_user_msg_to_responses(m.content))
@@ -466,7 +466,11 @@ def _convert_user_msg_to_chat(content: Any) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _convert_assistant_msg_to_responses(content: Any) -> list[dict[str, Any]]:
+def _convert_assistant_msg_to_responses(
+    content: Any,
+    *,
+    phase: str = "",
+) -> list[dict[str, Any]]:
     """Anthropic assistant content → Responses API typed items.
 
     Splits text + tool_use into separate items (text becomes
@@ -474,13 +478,32 @@ def _convert_assistant_msg_to_responses(content: Any) -> list[dict[str, Any]]:
     ``{"type": "function_call", "call_id", "name", "arguments"}``) preserving
     the original ordering so the next-turn pairing with ``function_call_output``
     matches by ``call_id``.
+
+    ``phase`` (PR-CODEX-MULTITURN-PHASE-PRESERVE, Sprint H follow-up,
+    2026-05-26): when non-empty, attached to each text-bearing
+    ``{role: "assistant", ...}`` item so the OpenAI Responses API
+    ``EasyInputMessageParam.phase`` slot is populated. Empty (the
+    default) skips the field — back-compat with every non-Codex caller.
     """
     if isinstance(content, str):
-        return [{"role": "assistant", "content": content}]
+        out: dict[str, Any] = {"role": "assistant", "content": content}
+        if phase:
+            out["phase"] = phase
+        return [out]
     if not isinstance(content, list):
-        return [{"role": "assistant", "content": _stringify(content)}]
+        out = {"role": "assistant", "content": _stringify(content)}
+        if phase:
+            out["phase"] = phase
+        return [out]
     items: list[dict[str, Any]] = []
     text_parts: list[str] = []
+
+    def _emit_text_item() -> None:
+        out = {"role": "assistant", "content": "\n".join(text_parts)}
+        if phase:
+            out["phase"] = phase
+        items.append(out)
+
     for block in content:
         if not isinstance(block, dict):
             continue
@@ -489,7 +512,7 @@ def _convert_assistant_msg_to_responses(content: Any) -> list[dict[str, Any]]:
             text_parts.append(block.get("text", ""))
         elif btype == "tool_use":
             if text_parts:
-                items.append({"role": "assistant", "content": "\n".join(text_parts)})
+                _emit_text_item()
                 text_parts = []
             items.append(
                 {
@@ -500,8 +523,13 @@ def _convert_assistant_msg_to_responses(content: Any) -> list[dict[str, Any]]:
                 }
             )
     if text_parts:
-        items.append({"role": "assistant", "content": "\n".join(text_parts)})
-    return items if items else [{"role": "assistant", "content": ""}]
+        _emit_text_item()
+    if items:
+        return items
+    fallback = {"role": "assistant", "content": ""}
+    if phase:
+        fallback["phase"] = phase
+    return [fallback]
 
 
 def _convert_user_msg_to_responses(content: Any) -> list[dict[str, Any]]:
@@ -628,6 +656,15 @@ def translate_codex_response(
     # carry a message item, reconstruct the text from the
     # SSE-delivered ``output_text`` content blocks.
     fallback_text_parts: list[str] = []
+    # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up, 2026-05-26)
+    # — capture per-response ``phase`` attribution from the Codex
+    # message item. ``ResponseOutputMessage.phase`` is
+    # ``Optional[Literal["commentary", "final_answer"]]`` and appears
+    # symmetrically on ``EasyInputMessageParam`` so the replay path
+    # can carry the semantic attribution. Multiple message items per
+    # response are rare; LAST one wins (matches the last-message-wins
+    # shape of ``response.output_text``).
+    assistant_phase: str = ""
     for item in items_source:
         itype = getattr(item, "type", "") if not isinstance(item, dict) else item.get("type", "")
         if itype == "message" and not text:
@@ -651,6 +688,13 @@ def translate_codex_response(
                     refusal_text = _attr_or_key(block, "refusal") or ""
                     if refusal_text:
                         fallback_text_parts.append(refusal_text)
+        if itype == "message":
+            # Capture phase regardless of whether ``text`` was already
+            # populated by ``response.output_text`` — phase lives on
+            # the item, not on the aggregated text accessor.
+            phase_value = _attr_or_key(item, "phase")
+            if isinstance(phase_value, str) and phase_value:
+                assistant_phase = phase_value
         if itype == "function_call":
             # Codex backend assigns ``call_id`` as the durable identifier — the
             # ``function_call_output`` reply on the next turn MUST reference
@@ -712,6 +756,7 @@ def translate_codex_response(
         raw_response=response,
         reasoning_items=tuple(reasoning_items),
         reasoning_summaries=tuple(reasoning_summaries),
+        assistant_phase=assistant_phase,
     )
 
 

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -87,6 +87,15 @@ class Message:
     content: str | list[dict[str, Any]]
     tool_use_id: str | None = None
     codex_reasoning_items: tuple[dict[str, Any], ...] = ()
+    # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up, 2026-05-26)
+    # — per-message phase attribution captured from the prior Codex
+    # turn. OpenAI Responses API's ``ResponseOutputMessage`` carries
+    # ``phase: Literal["commentary", "final_answer"]``; that field
+    # appears symmetrically on ``EasyInputMessageParam`` so the
+    # adapter can replay the semantic attribution to the next turn.
+    # Empty string = no phase (skip the field on output dict).
+    # Codex adapter is the only producer; other adapters leave empty.
+    phase: str = ""
 
 
 @dataclass(frozen=True)
@@ -187,6 +196,17 @@ class AdapterCallResult:
     raw_response: Any = None
     reasoning_items: tuple[dict[str, Any], ...] = ()
     reasoning_summaries: tuple[str, ...] = ()
+    # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up, 2026-05-26)
+    # — per-response phase attribution from the Codex Responses API
+    # ``ResponseOutputMessage.phase`` field
+    # (Literal["commentary", "final_answer"]). Captured by
+    # ``translate_codex_response`` from the SSE-accumulated message
+    # item. Empty string when the response had no phase set or the
+    # adapter isn't Codex. The legacy bridge forwards this into
+    # :attr:`core.llm.agentic_response.AgenticResponse.assistant_phase`
+    # so the AgenticLoop can persist it on the next-turn message dict
+    # for multi-turn replay.
+    assistant_phase: str = ""
     # PR-V (2026-05-24, spec doc §3) — sessionId emitted by claude-cli's
     # ``system.init`` event (paperclip ``parse.ts:30``). Callers persist
     # this so the next turn can resume the same backend session via

--- a/core/llm/adapters/translation.py
+++ b/core/llm/adapters/translation.py
@@ -67,16 +67,27 @@ def build_adapter_request(
         # legacy ``inject_reasoning_replay`` walker depends on (Codex MCP
         # A2 BLOCKER 3).
         reasoning_items: tuple[dict[str, Any], ...] = ()
+        phase: str = ""
         if role == "assistant":
             raw = m.get("codex_reasoning_items")
             if isinstance(raw, list):
                 reasoning_items = tuple(item for item in raw if isinstance(item, dict))
+            # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up,
+            # 2026-05-26) — forward the per-message phase attribution
+            # the AgenticLoop persisted from a prior Codex response so
+            # multi-turn replay carries the
+            # ``Literal["commentary", "final_answer"]`` semantic to the
+            # next ``EasyInputMessageParam.phase``.
+            phase_raw = m.get("phase")
+            if isinstance(phase_raw, str):
+                phase = phase_raw
         adapter_messages.append(
             Message(
                 role=role,
                 content=content,
                 tool_use_id=tool_use_id,
                 codex_reasoning_items=reasoning_items,
+                phase=phase,
             )
         )
     adapter_tools: list[ToolSpec] = [
@@ -152,6 +163,7 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
         usage=usage,
         codex_reasoning_items=codex_reasoning_items,
         reasoning_summaries=reasoning_summaries,
+        assistant_phase=result.assistant_phase,
     )
 
 

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -98,6 +98,16 @@ class AgenticResponse:
     # ``thinking`` content blocks. ``None`` when the call produced no
     # reasoning summary; never set by GLM/OpenAI Chat Completions.
     reasoning_summaries: list[str] | None = None
+    # PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up, 2026-05-26)
+    # — assistant phase attribution from
+    # ``ResponseOutputMessage.phase`` (Codex Responses API). Captured
+    # by ``translate_codex_response``, forwarded via
+    # ``agentic_response_from_adapter_result``; AgenticLoop persists
+    # to the next-turn message dict so multi-turn replay carries the
+    # ``Literal["commentary", "final_answer"]`` attribution to the
+    # next ``EasyInputMessageParam.phase``. Empty string for non-Codex
+    # adapters and for Codex responses with no phase set.
+    assistant_phase: str = ""
 
 
 def inject_reasoning_replay(

--- a/core/memory/session_manager.py
+++ b/core/memory/session_manager.py
@@ -398,9 +398,40 @@ def _extract_message_fields(msg: dict[str, Any]) -> dict[str, Any]:
     finish_reason: str | None = finish_reason_raw if isinstance(finish_reason_raw, str) else None
 
     metadata_raw = msg.get("metadata")
+    # PR-CODEX-MULTITURN-PHASE-PRESERVE fold (Sprint H follow-up,
+    # 2026-05-26, Codex MCP HIGH catch) — fold the Codex sidecar keys
+    # (``phase`` from ResponseOutputMessage attribution, and the
+    # pre-existing ``codex_reasoning_items`` encrypted-reasoning replay
+    # blobs) into ``metadata`` so a checkpoint/resume cycle preserves
+    # them. The docstring already promised "unknown keys are folded
+    # into metadata so nothing is lost" but the implementation only
+    # ever read ``msg["metadata"]`` — the sidecar keys were silently
+    # dropped on resume. ``_row_to_message`` mirrors this back so the
+    # round-trip is symmetric.
+    sidecar: dict[str, Any] = {}
+    phase_raw = msg.get("phase")
+    if isinstance(phase_raw, str) and phase_raw:
+        sidecar["phase"] = phase_raw
+    reasoning_items_raw = msg.get("codex_reasoning_items")
+    if isinstance(reasoning_items_raw, (list, tuple)) and reasoning_items_raw:
+        sidecar["codex_reasoning_items"] = list(reasoning_items_raw)
+
+    merged_metadata: dict[str, Any] | list[Any] | None
+    if sidecar:
+        if isinstance(metadata_raw, dict):
+            merged_metadata = {**metadata_raw, **sidecar}
+        elif metadata_raw is None:
+            merged_metadata = sidecar
+        else:
+            # Non-dict metadata (e.g. legacy list) — wrap so sidecar
+            # keys still persist alongside the original payload.
+            merged_metadata = {"_metadata": metadata_raw, **sidecar}
+    else:
+        merged_metadata = metadata_raw if isinstance(metadata_raw, (dict, list)) else None
+
     metadata_json: str | None = (
-        json.dumps(metadata_raw, ensure_ascii=False)
-        if isinstance(metadata_raw, (dict, list)) and metadata_raw
+        json.dumps(merged_metadata, ensure_ascii=False)
+        if isinstance(merged_metadata, (dict, list)) and merged_metadata
         else None
     )
 
@@ -921,6 +952,18 @@ class SessionManager:
                 msg["metadata"] = json.loads(row[10])
             except json.JSONDecodeError:
                 msg["metadata"] = row[10]
+        # PR-CODEX-MULTITURN-PHASE-PRESERVE fold (Sprint H follow-up,
+        # 2026-05-26) — un-fold the Codex sidecar keys (``phase``,
+        # ``codex_reasoning_items``) that ``_extract_message_fields``
+        # stashed into ``metadata`` on the way in. Without this
+        # mirror the checkpoint/resume cycle silently drops the
+        # phase semantic and the encrypted-reasoning replay blobs,
+        # breaking multi-turn continuity on Codex gpt-5.x.
+        metadata = msg.get("metadata")
+        if isinstance(metadata, dict):
+            for sidecar_key in ("phase", "codex_reasoning_items"):
+                if sidecar_key in metadata:
+                    msg[sidecar_key] = metadata[sidecar_key]
         return msg
 
     def close(self) -> None:

--- a/tests/core/llm/adapters/test_codex_multiturn_phase_preserve.py
+++ b/tests/core/llm/adapters/test_codex_multiturn_phase_preserve.py
@@ -1,0 +1,179 @@
+"""PR-CODEX-MULTITURN-PHASE-PRESERVE (Sprint H follow-up, 2026-05-26)
+— round-trip preservation of ``ResponseOutputMessage.phase`` across
+the Codex Responses API multi-turn replay.
+
+OpenAI Responses API's ``ResponseOutputMessage.phase`` is
+``Optional[Literal["commentary", "final_answer"]]``. The same slot
+appears on ``EasyInputMessageParam`` (request input), so multi-turn
+replay needs to carry the attribution through:
+
+  capture (translate_codex_response)
+  → AdapterCallResult.assistant_phase
+  → AgenticResponse.assistant_phase (agentic_response_from_adapter_result)
+  → AgenticLoop persists ``_assistant_msg["phase"]``
+  → adapter_request_from_legacy reads dict m["phase"] → Message.phase
+  → build_codex_input → _convert_assistant_msg_to_responses
+    emits ``{"role": "assistant", ..., "phase": ...}``
+
+Tests pin each link of the chain.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.llm.adapters._openai_common import (
+    _convert_assistant_msg_to_responses,
+    build_codex_input,
+    translate_codex_response,
+)
+from core.llm.adapters.base import AdapterCallRequest, Message
+
+
+def _empty_response() -> SimpleNamespace:
+    return SimpleNamespace(output_text="", output=[], status="completed", usage=None)
+
+
+def _message_item(text: str, *, phase: str | None = None) -> SimpleNamespace:
+    block = SimpleNamespace(type="output_text", text=text)
+    return SimpleNamespace(type="message", role="assistant", content=[block], phase=phase)
+
+
+def test_translate_codex_response_captures_phase_from_message_item() -> None:
+    """When the Codex response carries a message item with
+    ``phase="commentary"``, that attribution lands on
+    ``AdapterCallResult.assistant_phase``."""
+    msg = _message_item("intermediate thought", phase="commentary")
+    result = translate_codex_response(_empty_response(), accumulated_items=[msg])
+    assert result.text == "intermediate thought"
+    assert result.assistant_phase == "commentary"
+
+
+def test_translate_codex_response_captures_final_answer_phase() -> None:
+    """Same invariant for the ``final_answer`` value."""
+    msg = _message_item("the answer is 42", phase="final_answer")
+    result = translate_codex_response(_empty_response(), accumulated_items=[msg])
+    assert result.assistant_phase == "final_answer"
+
+
+def test_translate_codex_response_empty_phase_when_message_has_no_phase() -> None:
+    """No-op guarantee — message items without ``phase`` produce an
+    empty string (back-compat with non-phase-aware responses)."""
+    msg = _message_item("vanilla response", phase=None)
+    result = translate_codex_response(_empty_response(), accumulated_items=[msg])
+    assert result.assistant_phase == ""
+
+
+def test_translate_codex_response_phase_capture_alongside_populated_text() -> None:
+    """Phase capture must work even when ``response.output_text`` was
+    already populated by the SDK (no SSE-fallback needed). The phase
+    lives on the message item, not on the aggregated text accessor."""
+    response = SimpleNamespace(
+        output_text="server-aggregated", output=[], status="completed", usage=None
+    )
+    msg = _message_item("ignored — text already set", phase="final_answer")
+    result = translate_codex_response(response, accumulated_items=[msg])
+    assert result.text == "server-aggregated"
+    assert result.assistant_phase == "final_answer"
+
+
+def test_convert_assistant_msg_emits_phase_when_set() -> None:
+    """The replay path emits ``phase`` on the output dict when the
+    caller passes ``phase="commentary"``. Empty (default) skips the
+    field — back-compat with every non-Codex caller."""
+    items = _convert_assistant_msg_to_responses(
+        [{"type": "text", "text": "hello"}], phase="commentary"
+    )
+    assert len(items) == 1
+    assert items[0] == {"role": "assistant", "content": "hello", "phase": "commentary"}
+
+
+def test_convert_assistant_msg_empty_phase_omits_field() -> None:
+    """Empty phase string must not add the field to the output dict."""
+    items = _convert_assistant_msg_to_responses([{"type": "text", "text": "hello"}], phase="")
+    assert items[0] == {"role": "assistant", "content": "hello"}
+    assert "phase" not in items[0]
+
+
+def test_convert_assistant_msg_string_content_with_phase() -> None:
+    """String-shape content path also honours phase."""
+    items = _convert_assistant_msg_to_responses("plain string", phase="final_answer")
+    assert items == [{"role": "assistant", "content": "plain string", "phase": "final_answer"}]
+
+
+def test_convert_assistant_msg_text_plus_tool_use_attaches_phase_to_text() -> None:
+    """When content has text+tool_use blocks, ``phase`` attaches to
+    every text item; tool_use items don't carry phase (server-side
+    they're function_calls, no semantic phase)."""
+    content = [
+        {"type": "text", "text": "I'll search."},
+        {"type": "tool_use", "id": "call_1", "name": "search", "input": {"q": "x"}},
+    ]
+    items = _convert_assistant_msg_to_responses(content, phase="commentary")
+    # First item is the text with phase
+    assert items[0] == {
+        "role": "assistant",
+        "content": "I'll search.",
+        "phase": "commentary",
+    }
+    # Second item is function_call — no phase
+    assert items[1]["type"] == "function_call"
+    assert "phase" not in items[1]
+
+
+def test_build_codex_input_forwards_phase_from_message() -> None:
+    """End-to-end through ``build_codex_input``: a Message with
+    ``phase="final_answer"`` flows into the codex input array as
+    ``{role: "assistant", phase: "final_answer", ...}``."""
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        messages=(
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello back", phase="commentary"),
+            Message(role="user", content="follow-up"),
+        ),
+        system_prompt="you are helpful",
+    )
+    items = build_codex_input(req)
+    # First user message
+    assert items[0] == {"role": "user", "content": "hi"}
+    # Assistant message with phase
+    assert items[1] == {
+        "role": "assistant",
+        "content": "hello back",
+        "phase": "commentary",
+    }
+    # Second user message
+    assert items[2] == {"role": "user", "content": "follow-up"}
+
+
+def test_message_phase_default_empty_for_backcompat() -> None:
+    """Existing call sites that construct ``Message(role, content, ...)``
+    without ``phase`` get the back-compat empty string default."""
+    m = Message(role="assistant", content="hi")
+    assert m.phase == ""
+
+
+def test_round_trip_phase_capture_to_replay() -> None:
+    """Full round-trip — phase captured from a Codex response item
+    survives back into the next-turn codex input."""
+    # Turn 1 simulated capture:
+    msg_item = _message_item("first answer", phase="final_answer")
+    result = translate_codex_response(_empty_response(), accumulated_items=[msg_item])
+    assert result.assistant_phase == "final_answer"
+
+    # AgenticLoop would persist this as _assistant_msg["phase"] in the
+    # next-turn messages list. Simulate that via translation:
+    next_turn_msg = Message(role="assistant", content=result.text, phase=result.assistant_phase)
+
+    # Turn 2 build_codex_input replay:
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        messages=(Message(role="user", content="prev?"), next_turn_msg),
+    )
+    items = build_codex_input(req)
+    assert items[1] == {
+        "role": "assistant",
+        "content": "first answer",
+        "phase": "final_answer",
+    }

--- a/tests/core/llm/adapters/test_codex_multiturn_phase_preserve.py
+++ b/tests/core/llm/adapters/test_codex_multiturn_phase_preserve.py
@@ -154,6 +154,52 @@ def test_message_phase_default_empty_for_backcompat() -> None:
     assert m.phase == ""
 
 
+def test_phase_survives_checkpoint_resume_cycle(tmp_path) -> None:
+    """Codex MCP HIGH catch fold — ``_assistant_msg["phase"]`` must
+    survive the SQLite checkpoint/resume cycle. Pre-fold the session
+    manager's ``_extract_message_fields`` dropped the sidecar key on
+    the way IN (documented but not implemented), so resume saw
+    ``phase`` implicitly empty and the next-turn replay lost the
+    attribution. The fix folds Codex sidecar keys (``phase`` +
+    ``codex_reasoning_items``) into ``metadata`` at extract time and
+    un-folds them at ``_row_to_message``."""
+    from core.memory.session_manager import _extract_message_fields
+
+    # Extract phase as a top-level msg key
+    extracted = _extract_message_fields(
+        {"role": "assistant", "content": "first answer", "phase": "final_answer"}
+    )
+    # Phase should be folded into metadata (JSON-serialised at the column)
+    import json as _json
+
+    assert extracted["metadata"] is not None
+    parsed_meta = _json.loads(extracted["metadata"])
+    assert parsed_meta["phase"] == "final_answer"
+
+
+def test_codex_reasoning_items_also_survive_checkpoint(tmp_path) -> None:
+    """Same fold also rescues ``codex_reasoning_items`` which had been
+    silently dropped pre-fold (parallel bug surfaced by the same
+    Codex MCP review)."""
+    from core.memory.session_manager import _extract_message_fields
+
+    items = [{"type": "reasoning", "encrypted_content": "ENC_A", "summary": []}]
+    extracted = _extract_message_fields(
+        {
+            "role": "assistant",
+            "content": "answer",
+            "codex_reasoning_items": items,
+            "phase": "commentary",
+        }
+    )
+    import json as _json
+
+    assert extracted["metadata"] is not None
+    parsed_meta = _json.loads(extracted["metadata"])
+    assert parsed_meta["phase"] == "commentary"
+    assert parsed_meta["codex_reasoning_items"] == items
+
+
 def test_round_trip_phase_capture_to_replay() -> None:
     """Full round-trip — phase captured from a Codex response item
     survives back into the next-turn codex input."""


### PR DESCRIPTION
## Summary
- Capture ``ResponseOutputMessage.phase`` (``commentary``/``final_answer``) from Codex responses and replay through ``EasyInputMessageParam.phase`` on next turn.
- Full wire chain end-to-end: adapter capture → AdapterCallResult → AgenticResponse → AgenticLoop persistence → Message → build_codex_input replay.
- Closes the deferred PR-D3 fold catch (PR #1715) for phase preservation analogous to summary preservation.

## Why
OpenAI Responses API's ``ResponseOutputMessage.phase`` is ``Optional[Literal["commentary", "final_answer"]]`` and the same slot appears symmetrically on ``EasyInputMessageParam`` (request input). Multi-turn Codex replay needs to carry this attribution back to the next turn so the model retains the semantic distinction between intermediate commentary and the final answer.

Pre-fix the field was dropped at capture time, so every Codex multi-turn replay surfaced messages with phase implicitly ``None`` — losing the distinction the model uses to differentiate intermediate reasoning commentary from the final answer in the conversation history.

## Changes
| File | Change |
|------|--------|
| ``core/llm/adapters/base.py`` | Add ``Message.phase: str = ""`` + ``AdapterCallResult.assistant_phase: str = ""`` |
| ``core/llm/adapters/_openai_common.py`` | ``translate_codex_response`` captures phase from message items. ``_convert_assistant_msg_to_responses`` accepts ``phase`` kwarg and emits ``{"role": "assistant", ..., "phase": ...}`` when set. ``build_codex_input`` forwards ``m.phase`` to the converter. |
| ``core/llm/agentic_response.py`` | Add ``AgenticResponse.assistant_phase: str = ""`` |
| ``core/llm/adapters/translation.py`` | ``agentic_response_from_adapter_result`` forwards ``result.assistant_phase``. ``adapter_request_from_legacy`` reads dict ``m["phase"]`` → ``Message.phase``. |
| ``core/agent/loop/agent_loop.py`` | Both ``_assistant_msg`` construction sites (end-turn round + tool-use round) persist ``response.assistant_phase`` onto the dict if non-empty. |
| ``tests/core/llm/adapters/test_codex_multiturn_phase_preserve.py`` | 11 new tests pin every link of the chain. |
| ``CHANGELOG.md`` | ``[Unreleased] → ### Added`` entry. |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (458 source files)
- [x] lint-imports clean
- [x] pytest tests/core/llm/adapters/ tests/test_agentic_loop.py tests/plugins/seed_generation/ — 879 passed, 3 skipped

## Reference
- ctx7 OpenAI Responses API docs — ``ResponseOutputMessage.phase`` + ``EasyInputMessageParam.phase`` symmetric slot definitions verified locally via SDK introspection.
- PR-D3 fold deferred catch: PR #1715 "PR-CODEX-MULTITURN-SUMMARY-PRESERVE" (the original sister fix for ``summary`` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)