### PR TITLE
release: v0.99.71 — Sprint H closeout + backlog #99 cleanup bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.71] - 2026-05-26
+
+Sprint H closeout + backlog #99 cleanup. Bundles 4 PRs into one PATCH
+rotation: PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE (Sprint H1 — extends
+F1 prefix allowlist to the result-event scan branch),
+PR-VOTER-EFFORT-OVERRIDE-HATCH (per-voter ``reasoning.effort`` operator
+surface + config.toml loader + enum validator),
+PR-CODEX-MULTITURN-PHASE-PRESERVE (round-trip ``ResponseOutputMessage.phase``
+across Codex multi-turn replay, full E2E wire chain with checkpoint /
+resume preservation), and PR-SCHEMA-TYPE-DRIFT-INVARIANT (per-property
+JSON-Schema ``type`` drift invariants — backlog #99 Codex MCP retro-audit
+fold).
+
 ### Added
 
 - PR-SCHEMA-TYPE-DRIFT-INVARIANT (backlog #99, Codex MCP retro-audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.70
+- **Version**: 0.99.71
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 355 core + 58 plugins = 413
-- **Tests**: 6849 (+5 live)
+- **Modules**: 390 core + 68 plugins = 458
+- **Tests**: 8291 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.70 — Long-running Autonomous Execution Harness
+# GEODE v0.99.71 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.70**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.71**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.70 — Long-running Autonomous Execution Harness
+# GEODE v0.99.71 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.70**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.71**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.70"
+version = "0.99.71"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- v0.99.71 PATCH rotation bundling 4 PRs since v0.99.70 (Sprint H tail + backlog #99 Codex MCP retro-audit fold).
- Stamps 5 SoT locations + refreshes measured metrics (390 core + 68 plugins = 458 modules, 8291 tests).
- release → develop first (rotation pattern); develop → main follows as pass-through.

## Why

Develop is 4 PRs ahead of main and the `[Unreleased]` CHANGELOG section has accumulated all four entries. Roll them into a single tagged release so the CHANGELOG header carries the bundle's intent and main carries no `[Unreleased]` content (release discipline rule).

## Changes

| PR | Item | Type |
|----|------|------|
| #1740 | PR-TRANSIENT-CLI-INJECTION-RESULT-SCOPE (Sprint H1) — extend F1 `_CLI_INJECTION_PREFIX_RE` allowlist to the `event.type="result"` scan branch | Fixed |
| #1741 | PR-VOTER-EFFORT-OVERRIDE-HATCH — per-voter `reasoning.effort` operator surface; `VoterSpec.effort` + `VoterBinding.effort` + `_load_config_toml_voter_overrides` + OpenAI enum validator (Codex MCP HIGH + MEDIUM catch folds) | Added |
| #1742 | PR-CODEX-MULTITURN-PHASE-PRESERVE — round-trip `ResponseOutputMessage.phase` across Codex multi-turn replay; full E2E wire chain `translate_codex_response` → `AdapterCallResult.assistant_phase` → `AgenticResponse.assistant_phase` → `_assistant_msg["phase"]` → `build_codex_input`; survives `SessionCheckpoint.load()` resume cycle via metadata sidecar fold (Codex MCP HIGH catch) | Added |
| #1743 | PR-SCHEMA-TYPE-DRIFT-INVARIANT (backlog #99) — per-property JSON-Schema `type` drift invariants for 8 Loop-1 seed-generation roles + coverage guard | Added |

## Verification

- [x] ruff check clean (974 files)
- [x] ruff format --check clean
- [x] mypy clean (458 source files)
- [x] 5 SoT stamps consistent (pyproject.toml + CLAUDE.md + README.md + README.ko.md + CHANGELOG.md all show v0.99.71)
- [x] Module + test metrics refreshed (390 core + 68 plugins = 458, 8291 tests +5 live)

## Reference

- Rotation per CLAUDE.md §6 — release/* merges into develop first (CHANGELOG bump lands on develop so it never lags behind main), then develop → main is a straight pass-through.
- Bundles 4 already-CI-green merged PRs; no new functional change in this PR beyond the version stamp and CHANGELOG promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)