### PR TITLE
fix(hub): repoint DOCS sidebar at real Next.js petri routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- PR-HUB-DOCS-LINK-FIX — the self-improving hub's DOCS sidebar pointed
+  at two Next.js routes that don't exist: ``/geode/docs/petri`` (no
+  ``overview`` suffix, returned 404) and ``/geode/docs/petri/dimensions``
+  (wrong slug, the real route is ``judge-dimensions``). Operator
+  surfaced the bug after the v0.99.71 production deploy. Rewrites both
+  in the four hub templates (``index.html.template`` + 3 autoresearch
+  ``.template`` + ``run.html.template``) and the 9 already-emitted
+  pages under ``docs/self-improving/``, plus the inspect_ai SPA
+  landing card at ``docs/self-improving/petri-bundle/landing.html``.
+  Pinned by new ``test_docs_petri_links_match_next_routes`` which
+  enumerates every ``/geode/docs/petri/<slug>`` href in the built HTML
+  and asserts ``slug ∈ {dir.name for dir in site/src/app/docs/petri/}``,
+  so a future Next.js rename or hub typo fails the gate before merge.
+
 ## [0.99.71] - 2026-05-26
 
 Sprint H closeout + backlog #99 cleanup. Bundles 4 PRs into one PATCH

--- a/docs/self-improving/autoresearch/baseline.html.template
+++ b/docs/self-improving/autoresearch/baseline.html.template
@@ -52,9 +52,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/autoresearch/baseline/index.html
+++ b/docs/self-improving/autoresearch/baseline/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -278,7 +278,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 09:31.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/index.html
+++ b/docs/self-improving/autoresearch/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -79,9 +79,9 @@
       <dt>auditor model</dt><dd><span class="chip claude">Claude Code</span> <code>claude-cli/claude-opus-4-7</code></dd>
       <dt>target model</dt><dd><span class="chip geode">GEODE</span> <code>geode/gpt-5.5</code></dd>
       <dt>judge model</dt><dd><span class="chip claude">Claude Code</span> <code>claude-cli/claude-sonnet-4-6</code></dd>
-      <dt>mutations.jsonl</dt><dd>3 rows &middot; <span class='muted'>2026-05-26 02:46</span></dd>
+      <dt>mutations.jsonl</dt><dd>3 rows &middot; <span class='muted'>2026-05-26 09:29</span></dd>
       <dt>results.tsv</dt><dd>3 rows &middot; <span class='muted'>—</span></dd>
-      <dt>policies/</dt><dd>4 files &middot; <span class='muted'>2026-05-26 02:46</span></dd>
+      <dt>policies/</dt><dd>4 files &middot; <span class='muted'>2026-05-26 09:29</span></dd>
       <dt>source</dt><dd><code>baseline.json</code></dd>
     </dl>
 
@@ -135,13 +135,13 @@
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>1 (current promoted) &middot; <span class='muted'>archive: 3 rows</span></td>
-          <td class="muted">2026-05-26 02:45</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/baseline/">open &rarr;</a></td>
         </tr>
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>3 rows</td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/mutations/">open &rarr;</a></td>
         </tr>
         <tr>
@@ -153,7 +153,7 @@
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/policies/">Policies</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>4 files</td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/policies/">open &rarr;</a></td>
         </tr>
       </tbody>
@@ -170,7 +170,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 09:31.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/index.html.template
+++ b/docs/self-improving/autoresearch/index.html.template
@@ -52,9 +52,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/autoresearch/mutations.html.template
+++ b/docs/self-improving/autoresearch/mutations.html.template
@@ -52,9 +52,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/autoresearch/mutations/index.html
+++ b/docs/self-improving/autoresearch/mutations/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -134,7 +134,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 09:31.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/policies.html.template
+++ b/docs/self-improving/autoresearch/policies.html.template
@@ -52,9 +52,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/autoresearch/policies/index.html
+++ b/docs/self-improving/autoresearch/policies/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -83,7 +83,7 @@
       <tbody>
         <tr>
           <td class="id"><code>decomposition.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="num">86 B</td>
           <td><span class="muted">—</span></td>
           <td><details>
@@ -95,7 +95,7 @@
         </tr>
         <tr>
           <td class="id"><code>retrieval.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="num">62 B</td>
           <td><span class="muted">—</span></td>
           <td><details>
@@ -108,7 +108,7 @@
         </tr>
         <tr>
           <td class="id"><code>tool-policy.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="num">125 B</td>
           <td><code>gen-2</code> <span class="muted">@ 2026-05-25 14:30</span></td>
           <td><details>
@@ -121,7 +121,7 @@
         </tr>
         <tr>
           <td class="id"><code>wrapper-sections.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 09:29</td>
           <td class="num">172 B</td>
           <td><code>gen-3</code> <span class="muted">@ 2026-05-26 04:30</span></td>
           <td><details>
@@ -146,7 +146,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 09:31.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/results.html.template
+++ b/docs/self-improving/autoresearch/results.html.template
@@ -52,9 +52,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/autoresearch/results/index.html
+++ b/docs/self-improving/autoresearch/results/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -204,7 +204,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 09:31.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/index.html
+++ b/docs/self-improving/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -221,7 +221,7 @@
       </thead>
       <tbody>
         <tr>
-          <td class="id"><a href="/geode/docs/petri">Petri Overview</a></td>
+          <td class="id"><a href="/geode/docs/petri/overview">Petri Overview</a></td>
           <td class="muted">Petri framework + GEODE wrapper, 3 model roles</td>
         </tr>
         <tr>
@@ -233,7 +233,7 @@
           <td class="muted"><code>geode audit</code> primary path + <code>inspect eval</code> raw</td>
         </tr>
         <tr>
-          <td class="id"><a href="/geode/docs/petri/dimensions">Judge Dimensions</a></td>
+          <td class="id"><a href="/geode/docs/petri/judge-dimensions">Judge Dimensions</a></td>
           <td class="muted">22 dim subset + 38 dim full set</td>
         </tr>
         <tr>

--- a/docs/self-improving/index.html.template
+++ b/docs/self-improving/index.html.template
@@ -51,9 +51,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>
@@ -106,7 +106,7 @@
       </thead>
       <tbody>
         <tr>
-          <td class="id"><a href="/geode/docs/petri">Petri Overview</a></td>
+          <td class="id"><a href="/geode/docs/petri/overview">Petri Overview</a></td>
           <td class="muted">Petri framework + GEODE wrapper, 3 model roles</td>
         </tr>
         <tr>
@@ -118,7 +118,7 @@
           <td class="muted"><code>geode audit</code> primary path + <code>inspect eval</code> raw</td>
         </tr>
         <tr>
-          <td class="id"><a href="/geode/docs/petri/dimensions">Judge Dimensions</a></td>
+          <td class="id"><a href="/geode/docs/petri/judge-dimensions">Judge Dimensions</a></td>
           <td class="muted">22 dim subset + 38 dim full set</td>
         </tr>
         <tr>

--- a/docs/self-improving/petri-bundle/landing.html
+++ b/docs/self-improving/petri-bundle/landing.html
@@ -125,7 +125,7 @@
           <tr>
             <td class="surface">Documentation<br><span class="path">/docs/petri/</span></td>
             <td>Audit overview, scenarios, judge dimensions, seed generation runs (Next.js view).<br><span class="meta">Markdown candidate detail and cross-links live on the docs side.</span></td>
-            <td><a class="go" href="/geode/docs/petri/">Open docs →</a></td>
+            <td><a class="go" href="/geode/docs/petri/overview">Open docs →</a></td>
           </tr>
         </tbody>
       </table>

--- a/docs/self-improving/seed-generation/gen1-redundant_tool_invocation/index.html
+++ b/docs/self-improving/seed-generation/gen1-redundant_tool_invocation/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/seed-generation/index.html
+++ b/docs/self-improving/seed-generation/index.html
@@ -53,9 +53,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/seed-generation/index.html.template
+++ b/docs/self-improving/seed-generation/index.html.template
@@ -51,9 +51,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/docs/self-improving/seed-generation/run.html.template
+++ b/docs/self-improving/seed-generation/run.html.template
@@ -51,9 +51,9 @@
 
       <div class="nav-section">Docs</div>
       <ul class="nav-list">
-        <li><a href="/geode/docs/petri">Petri overview</a></li>
+        <li><a href="/geode/docs/petri/overview">Petri overview</a></li>
         <li><a href="/geode/docs/petri/run">Run an audit</a></li>
-        <li><a href="/geode/docs/petri/dimensions">Judge dimensions</a></li>
+        <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a></li>
       </ul>
 
       <div class="nav-section">Meta</div>

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -293,6 +293,33 @@ def test_every_href_is_basepath_safe(built_html: str) -> None:
         assert href.startswith("/geode/"), f"href {href!r} missing /geode/ basePath prefix"
 
 
+def test_docs_petri_links_match_next_routes(built_html: str) -> None:
+    """Every ``/geode/docs/petri/<slug>`` link in the hub must point at an
+    existing Next.js route under ``site/src/app/docs/petri/<slug>/page.tsx``.
+    Otherwise the live site returns 404 even though the local preview path
+    looks valid. Caught after PR-SELF-IMPROVING-P5 shipped with stale slugs
+    (``/petri`` → 404 instead of ``/petri/overview``; ``/petri/dimensions`` →
+    404 instead of ``/petri/judge-dimensions``).
+    """
+    routes_root = REPO_ROOT / "site" / "src" / "app" / "docs" / "petri"
+    assert routes_root.is_dir(), f"Next.js docs/petri/ routes dir missing at {routes_root}"
+    valid_slugs = {
+        p.name for p in routes_root.iterdir() if p.is_dir() and (p / "page.tsx").is_file()
+    }
+    bad: list[str] = []
+    for href in _collect_hrefs(built_html):
+        m = re.match(r"^/geode/docs/petri/([^/?#]+)/?$", href)
+        if not m:
+            continue
+        slug = m.group(1)
+        if slug not in valid_slugs:
+            bad.append(href)
+    assert not bad, (
+        f"links point at non-existent Next.js routes: {bad}. "
+        f"Valid slugs under site/src/app/docs/petri/: {sorted(valid_slugs)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 6. Version stamp
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.70"
+version = "0.99.71"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- DOCS sidebar links `/geode/docs/petri` (404) and `/geode/docs/petri/dimensions` (404) repointed at the actual Next.js routes `overview` and `judge-dimensions`
- New E2E `test_docs_petri_links_match_next_routes` enumerates every `/geode/docs/petri/<slug>` href and asserts it matches a real `site/src/app/docs/petri/<slug>/page.tsx` directory

## Why
After v0.99.71 production deploy, operator clicked DOCS sidebar (Petri overview / Judge dimensions) and got 404. The hub builder was emitting URLs that didn't exist in the Next.js docs site. Local preview hid it earlier because we never had the Next.js routes mounted under the same server.

## Changes
| File | Change |
|------|--------|
| `docs/self-improving/index.html.template` + 3 autoresearch templates + `seed-generation/run.html.template` | `/petri` → `/petri/overview`; `/petri/dimensions` → `/petri/judge-dimensions` |
| 9 emitted pages under `docs/self-improving/` | same rewrite |
| `docs/self-improving/petri-bundle/landing.html` | "Open docs →" card likewise repointed |
| `tests/test_self_improving_hub_e2e.py` | new `test_docs_petri_links_match_next_routes` — asserts every emitted `/geode/docs/petri/<slug>` slug is a real Next.js route directory |
| `CHANGELOG.md` | Unreleased entry |
| `uv.lock` | passive `0.99.70 → 0.99.71` sync after develop release |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] pytest tests/test_self_improving_hub_e2e.py — **31/31** (was 30/30; +1 new pin)
- [x] All 6 Next.js routes (`bundle / judge-dimensions / overview / run / scenarios / seeds`) verified to exist as `page.tsx` directories