### PR TITLE
fix(self-improving-loop): revert SoT when promote gate rejects mutation (PR-SOT-REVERT-ON-REJECT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-SOT-REVERT-ON-REJECT** — self-improving loop closed-loop silent
+  leak: when the runner-driven audit (`GEODE_SIL_MUTATION_ID` env set)
+  triggers `_should_promote=False`, the SoT is now reverted to its
+  pre-mutation state instead of leaving the rejected mutation as
+  permanent state. `autoresearch.train._revert_sot_after_reject` walks
+  `mutations.jsonl` for the apply row's `previous_value` and dispatches
+  through `load_wrapper_prompt_sections`/`write_wrapper_prompt_sections`
+  (prompt kind) or `policies.load_policy`/`policies.write_policy`
+  (policy kinds). Insertion case (`previous_value=""`) deletes the key
+  instead of writing back an empty string. Manual audits (no SIL env)
+  remain unchanged — operator-driven mutations accumulate by design.
+  Pinned by 9 invariant tests in `tests/autoresearch/test_sot_revert_on_reject.py`.
+
 ## [0.99.71] - 2026-05-26
 
 Sprint H closeout + backlog #99 cleanup. Bundles 4 PRs into one PATCH

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2119,6 +2119,102 @@ def _should_promote(
     )
 
 
+def _revert_sot_after_reject(
+    mutation_id: str,
+    *,
+    audit_log_path: Path | None = None,
+) -> tuple[bool, str]:
+    """Restore the target_section to its pre-mutation ``previous_value``
+    after the promotion gate rejects a runner-driven mutation.
+
+    PR-SOT-REVERT-ON-REJECT (2026-05-26). When the audit was triggered
+    by ``SelfImprovingLoopRunner`` (``GEODE_SIL_MUTATION_ID`` env set)
+    and :func:`_should_promote` returned ``False``, the SoT must be
+    rolled back; otherwise rejected mutations accumulate as permanent
+    state and the loop's regression-cause attribution becomes
+    undecomposable across cycles.
+
+    Lookup walks ``mutations.jsonl`` for the latest apply row matching
+    ``mutation_id`` (apply rows are written by ``runner.append_audit_log``
+    BEFORE the audit subprocess is invoked, so the row is always present
+    when the runner-driven path reaches this code).
+
+    Manual audits (no ``GEODE_SIL_MUTATION_ID`` env) are not handled by
+    this function — operator-driven mutations accumulate by design and
+    only an explicit ``geode self-improving revert`` would unwind them.
+
+    Returns ``(success, detail)``. Failure cases (mutation row missing,
+    file I/O error) log a WARNING and return ``(False, reason)`` so the
+    caller can surface the leak status in the audit's promoted_line.
+    """
+    from core.self_improving_loop.mutations_reader import iter_mutations
+    from core.self_improving_loop.policies import load_policy, write_policy
+    from core.self_improving_loop.runner import ApplyRecord
+
+    apply_row: ApplyRecord | None = None
+    # iter_mutations yields in file order (append-only); keep the LAST
+    # match so a re-applied mutation_id (rare; mutator should mint a
+    # fresh id) reverts to the most recent previous_value.
+    for row in iter_mutations(audit_log_path, kinds={"applied"}):
+        if isinstance(row, ApplyRecord) and row.mutation_id == mutation_id:
+            apply_row = row
+
+    if apply_row is None:
+        log.warning(
+            "SoT revert skipped — mutation_id %r not found in mutations.jsonl",
+            mutation_id,
+        )
+        return False, f"mutation_id {mutation_id!r} not found"
+
+    target_kind = apply_row.target_kind
+    target_section = apply_row.target_section
+    previous_value = apply_row.previous_value
+
+    # Insertion-vs-replacement parity: ``apply_mutation`` (runner.py:949-994)
+    # records ``previous_value = sections.get(target_section, "")``, so an
+    # empty previous_value can mean either (a) the section was absent
+    # before the mutation (insertion) or (b) it was present but empty
+    # (legitimate empty value). The symmetric revert deletes the key
+    # when previous_value is empty — otherwise the rejected mutation
+    # leaves a residual empty-string section, defeating the leak fix.
+    # Trade-off: a genuine empty-to-non-empty replacement reverts to
+    # absent rather than empty. Acceptable because the SoT schemas
+    # treat absent and empty-string equivalently at read time (both
+    # fall through to the section's bootstrap default).
+    try:
+        if target_kind == "prompt":
+            current = load_wrapper_prompt_sections()
+            if previous_value == "":
+                current.pop(target_section, None)
+            else:
+                current[target_section] = previous_value
+            write_wrapper_prompt_sections(current)
+        else:
+            current = load_policy(target_kind)
+            if previous_value == "":
+                current.pop(target_section, None)
+            else:
+                current[target_section] = previous_value
+            write_policy(target_kind, current)
+    except Exception as exc:
+        log.warning(
+            "SoT revert failed for mutation %s (kind=%s section=%s): %s",
+            mutation_id,
+            target_kind,
+            target_section,
+            exc,
+        )
+        return False, f"write failed ({type(exc).__name__})"
+
+    log.info(
+        "SoT reverted for rejected mutation %s (kind=%s section=%s)",
+        mutation_id,
+        target_kind,
+        target_section,
+    )
+    return True, f"{target_kind}.{target_section}"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -2452,6 +2548,25 @@ def main() -> int:
         )
         if ok:
             _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
+        else:
+            # PR-SOT-REVERT-ON-REJECT (2026-05-26) — when the audit was
+            # triggered by the mutator runner (GEODE_SIL_MUTATION_ID
+            # set) and the promotion gate rejected the mutation, revert
+            # the SoT so the loop doesn't accumulate rejected mutations
+            # as permanent state. Manual audits (no mutation_id env)
+            # intentionally accumulate operator-side changes; they are
+            # not auto-reverted (operator must use an explicit revert
+            # command). The detail string is appended to ``reason`` so
+            # the audit's printed ``baseline_promoted:`` line surfaces
+            # whether the leak prevention fired and the outcome.
+            _sil_mid_for_revert = os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+            if _sil_mid_for_revert:
+                revert_ok, revert_detail = _revert_sot_after_reject(_sil_mid_for_revert)
+                reason = (
+                    f"{reason}; SoT reverted ({revert_detail})"
+                    if revert_ok
+                    else f"{reason}; SoT revert FAILED ({revert_detail})"
+                )
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2147,17 +2147,34 @@ def _revert_sot_after_reject(
     file I/O error) log a WARNING and return ``(False, reason)`` so the
     caller can surface the leak status in the audit's promoted_line.
     """
+    from typing import cast
+
     from core.self_improving_loop.mutations_reader import iter_mutations
     from core.self_improving_loop.policies import load_policy, write_policy
     from core.self_improving_loop.runner import ApplyRecord
 
+    # Note on type narrowing: ``iter_mutations(kinds={"applied"})``
+    # filters at the reader's discriminator (mutations_reader._parse_row)
+    # so every yielded row is an ApplyRecord. We avoid ``isinstance``
+    # because under pytest-cov import instrumentation the ApplyRecord
+    # class identity can drift between writer-side (mutations_reader's
+    # module-cached import) and reader-side (our function-local import),
+    # making isinstance False even when the row is structurally
+    # identical (CI failure on PR #1749 first attempt, 2026-05-26).
+    # ``cast`` gives mypy the narrowing without a runtime identity check.
     apply_row: ApplyRecord | None = None
+    target_kind = ""
+    target_section = ""
+    previous_value = ""
     # iter_mutations yields in file order (append-only); keep the LAST
     # match so a re-applied mutation_id (rare; mutator should mint a
     # fresh id) reverts to the most recent previous_value.
     for row in iter_mutations(audit_log_path, kinds={"applied"}):
-        if isinstance(row, ApplyRecord) and row.mutation_id == mutation_id:
-            apply_row = row
+        if row.mutation_id == mutation_id:
+            apply_row = cast(ApplyRecord, row)
+            target_kind = apply_row.target_kind
+            target_section = apply_row.target_section
+            previous_value = apply_row.previous_value
 
     if apply_row is None:
         log.warning(
@@ -2165,10 +2182,6 @@ def _revert_sot_after_reject(
             mutation_id,
         )
         return False, f"mutation_id {mutation_id!r} not found"
-
-    target_kind = apply_row.target_kind
-    target_section = apply_row.target_section
-    previous_value = apply_row.previous_value
 
     # Insertion-vs-replacement parity: ``apply_mutation`` (runner.py:949-994)
     # records ``previous_value = sections.get(target_section, "")``, so an

--- a/tests/autoresearch/test_sot_revert_on_reject.py
+++ b/tests/autoresearch/test_sot_revert_on_reject.py
@@ -1,0 +1,359 @@
+"""PR-SOT-REVERT-ON-REJECT (2026-05-26) — SoT revert on rejected mutation.
+
+Closes a CRITICAL silent leak surfaced in the 2026-05-26 autoresearch
+attribution/wiring sprint Phase A audit:
+
+* ``SelfImprovingLoopRunner.apply_proposal`` (runner.py:1865) writes the
+  mutated section to the canonical SoT BEFORE the audit subprocess runs.
+* ``autoresearch.train.main`` (train.py:2453) used to call
+  ``_write_baseline`` only when ``_should_promote`` returned ``True`` —
+  the ``False`` branch had no else clause, so the SoT remained mutated
+  even though the baseline was unchanged.
+* Result: every rejected mutation accumulated as permanent SoT state,
+  next-cycle baseline scoring ran against the stacked SoT, and
+  regression-cause attribution became undecomposable.
+
+This file pins two parts of the fix:
+
+1. ``_revert_sot_after_reject`` correctly looks up the apply row by
+   ``mutation_id`` and restores the previous_value to the SoT — for
+   both ``prompt`` (wrapper-sections SoT) and policy kinds (policies.py
+   SoT files).
+2. The ``main()`` promote gate calls the revert only when
+   ``GEODE_SIL_MUTATION_ID`` is set (runner-driven cycle), not on
+   manual audits (operator-driven accumulation is intentional).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _write_apply_row(
+    log_path: Path,
+    *,
+    mutation_id: str,
+    target_kind: str,
+    target_section: str,
+    previous_value: str,
+    new_value: str = "mutated",
+) -> None:
+    """Append one apply row to a mutations.jsonl fixture."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "ts": time.time(),
+        "kind": "applied",
+        "mutation_id": mutation_id,
+        "target_kind": target_kind,
+        "target_section": target_section,
+        "previous_value": previous_value,
+        "new_value": new_value,
+    }
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+def test_revert_returns_false_when_mutation_id_missing(tmp_path: Path) -> None:
+    """Empty mutations.jsonl → (False, 'not found') without raising."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    empty_log = tmp_path / "mutations.jsonl"
+    empty_log.touch()
+
+    ok, detail = _revert_sot_after_reject("mut-absent", audit_log_path=empty_log)
+
+    assert ok is False
+    assert "not found" in detail
+
+
+def test_revert_returns_false_when_log_file_absent(tmp_path: Path) -> None:
+    """Missing mutations.jsonl is graceful (iter_mutations yields empty)."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    nonexistent_log = tmp_path / "does-not-exist.jsonl"
+
+    ok, detail = _revert_sot_after_reject("mut-x", audit_log_path=nonexistent_log)
+
+    assert ok is False
+    assert "not found" in detail
+
+
+def test_revert_restores_prompt_kind_via_wrapper_sections(tmp_path: Path) -> None:
+    """``prompt`` kind dispatches through wrapper-sections SoT helpers."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    from autoresearch import train as train_module
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="mut-prompt-1",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="original-role-prose",
+        new_value="mutated-role-prose",
+    )
+
+    # Patch the wrapper-sections helpers to capture revert behaviour
+    # without touching the operator's real ``~/.geode`` SoT.
+    current_state = {"role": "mutated-role-prose", "shell_caution": "untouched"}
+
+    def fake_load() -> dict[str, str]:
+        return dict(current_state)
+
+    def fake_write(sections: dict[str, str]) -> None:
+        current_state.clear()
+        current_state.update(sections)
+
+    with (
+        patch.object(train_module, "load_wrapper_prompt_sections", fake_load),
+        patch.object(train_module, "write_wrapper_prompt_sections", fake_write),
+    ):
+        ok, detail = _revert_sot_after_reject("mut-prompt-1", audit_log_path=log_path)
+
+    assert ok is True
+    assert detail == "prompt.role"
+    assert current_state["role"] == "original-role-prose"
+    # Symmetric branch parity — non-target section must be preserved.
+    assert current_state["shell_caution"] == "untouched"
+
+
+def test_revert_restores_policy_kind_via_policies_helpers(tmp_path: Path) -> None:
+    """Non-prompt kinds dispatch through ``policies.load_policy`` /
+    ``policies.write_policy``."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="mut-tool-policy-1",
+        target_kind="tool_policy",
+        target_section="prefer_grep",
+        previous_value="true",
+        new_value="false",
+    )
+
+    current_state: dict[str, str] = {"prefer_grep": "false", "other_key": "kept"}
+
+    def fake_load(kind: str) -> dict[str, str]:
+        assert kind == "tool_policy"
+        return dict(current_state)
+
+    captured: dict[str, dict[str, str]] = {}
+
+    def fake_write(kind: str, sections: dict[str, str]) -> Path:
+        captured["kind"] = kind  # type: ignore[assignment]
+        captured["sections"] = sections
+        current_state.clear()
+        current_state.update(sections)
+        return tmp_path / f"{kind}.json"
+
+    with (
+        patch("core.self_improving_loop.policies.load_policy", fake_load),
+        patch("core.self_improving_loop.policies.write_policy", fake_write),
+    ):
+        ok, detail = _revert_sot_after_reject("mut-tool-policy-1", audit_log_path=log_path)
+
+    assert ok is True
+    assert detail == "tool_policy.prefer_grep"
+    assert captured["kind"] == "tool_policy"  # type: ignore[comparison-overlap]
+    assert captured["sections"]["prefer_grep"] == "true"
+    assert captured["sections"]["other_key"] == "kept"
+
+
+def test_revert_picks_latest_apply_row_on_duplicate_mutation_id(tmp_path: Path) -> None:
+    """When mutations.jsonl has multiple apply rows with the same
+    mutation_id (rare; mutator should mint fresh IDs), revert restores
+    the LATEST previous_value so the newest mutation is the one
+    unwound."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    from autoresearch import train as train_module
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="dup-mid",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="oldest-prev",
+        new_value="first-mut",
+    )
+    _write_apply_row(
+        log_path,
+        mutation_id="dup-mid",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="newest-prev",
+        new_value="second-mut",
+    )
+
+    current_state = {"role": "second-mut"}
+
+    def fake_load() -> dict[str, str]:
+        return dict(current_state)
+
+    def fake_write(sections: dict[str, str]) -> None:
+        current_state.clear()
+        current_state.update(sections)
+
+    with (
+        patch.object(train_module, "load_wrapper_prompt_sections", fake_load),
+        patch.object(train_module, "write_wrapper_prompt_sections", fake_write),
+    ):
+        ok, detail = _revert_sot_after_reject("dup-mid", audit_log_path=log_path)
+
+    assert ok is True
+    assert current_state["role"] == "newest-prev"
+
+
+def test_revert_returns_false_when_writer_raises(tmp_path: Path) -> None:
+    """Writer OSError must not bubble — caller surfaces the leak status
+    in the audit's promoted_line, never crashes the audit."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    from autoresearch import train as train_module
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="mut-fail",
+        target_kind="prompt",
+        target_section="role",
+        previous_value="orig",
+        new_value="new",
+    )
+
+    def fake_load() -> dict[str, str]:
+        return {"role": "new"}
+
+    def fake_write(sections: dict[str, str]) -> None:
+        raise OSError("disk full")
+
+    with (
+        patch.object(train_module, "load_wrapper_prompt_sections", fake_load),
+        patch.object(train_module, "write_wrapper_prompt_sections", fake_write),
+    ):
+        ok, detail = _revert_sot_after_reject("mut-fail", audit_log_path=log_path)
+
+    assert ok is False
+    assert "write failed" in detail
+    assert "OSError" in detail
+
+
+def test_only_kind_applied_is_considered_not_applied_sibling(tmp_path: Path) -> None:
+    """``applied_sibling`` rows (group sampling's non-best) must NOT be
+    used as revert targets — those mutations were never committed to the
+    canonical SoT (sibling-only temp file via
+    ``policies.write_sibling_in_memory``)."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    log_path = tmp_path / "mutations.jsonl"
+    # Write a sibling-only row first (must be ignored)
+    row = {
+        "ts": time.time(),
+        "kind": "applied_sibling",
+        "mutation_id": "sibling-only-mid",
+        "target_kind": "prompt",
+        "target_section": "role",
+        "previous_value": "this-should-not-revert",
+        "new_value": "sibling-mut",
+    }
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+    ok, detail = _revert_sot_after_reject("sibling-only-mid", audit_log_path=log_path)
+
+    # iter_mutations is called with kinds={"applied"} so the sibling row
+    # is filtered out. Result: row not found.
+    assert ok is False
+    assert "not found" in detail
+
+
+def test_revert_deletes_section_when_previous_value_empty(tmp_path: Path) -> None:
+    """Insertion-case symmetry — ``apply_mutation`` records
+    ``previous_value=""`` when the target_section was absent before
+    the mutation (runner.py:978, :991). Revert must DELETE the
+    inserted key, not write back an empty string, or the rejected
+    insertion leaves a residual empty-string section in the SoT."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    from autoresearch import train as train_module
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="mut-insert-1",
+        target_kind="prompt",
+        target_section="newly_inserted",
+        previous_value="",  # insertion: section was absent before
+        new_value="inserted-content",
+    )
+
+    current_state = {
+        "role": "kept",
+        "newly_inserted": "inserted-content",  # mutator just added this
+    }
+
+    def fake_load() -> dict[str, str]:
+        return dict(current_state)
+
+    def fake_write(sections: dict[str, str]) -> None:
+        current_state.clear()
+        current_state.update(sections)
+
+    with (
+        patch.object(train_module, "load_wrapper_prompt_sections", fake_load),
+        patch.object(train_module, "write_wrapper_prompt_sections", fake_write),
+    ):
+        ok, _ = _revert_sot_after_reject("mut-insert-1", audit_log_path=log_path)
+
+    assert ok is True
+    # Key must be REMOVED, not present with empty value.
+    assert "newly_inserted" not in current_state
+    assert current_state["role"] == "kept"
+
+
+def test_revert_deletes_inserted_policy_kind_section(tmp_path: Path) -> None:
+    """Same insertion semantics for non-prompt kinds — ``write_policy``
+    must receive a sections dict without the inserted key."""
+    from autoresearch.train import _revert_sot_after_reject
+
+    log_path = tmp_path / "mutations.jsonl"
+    _write_apply_row(
+        log_path,
+        mutation_id="mut-insert-policy",
+        target_kind="tool_policy",
+        target_section="newly_added_rule",
+        previous_value="",
+        new_value="prefer-fd",
+    )
+
+    current_state: dict[str, str] = {
+        "existing_key": "keep",
+        "newly_added_rule": "prefer-fd",
+    }
+
+    captured: dict[str, dict[str, str]] = {}
+
+    def fake_load(kind: str) -> dict[str, str]:
+        return dict(current_state)
+
+    def fake_write(kind: str, sections: dict[str, str]) -> Path:
+        captured["sections"] = sections
+        current_state.clear()
+        current_state.update(sections)
+        return tmp_path / f"{kind}.json"
+
+    with (
+        patch("core.self_improving_loop.policies.load_policy", fake_load),
+        patch("core.self_improving_loop.policies.write_policy", fake_write),
+    ):
+        ok, _ = _revert_sot_after_reject("mut-insert-policy", audit_log_path=log_path)
+
+    assert ok is True
+    assert "newly_added_rule" not in captured["sections"]
+    assert captured["sections"]["existing_key"] == "keep"


### PR DESCRIPTION
## Summary

- 자율 학습 loop 의 CRITICAL silent leak 차단 — runner 가 mutation 을 canonical SoT 에 write 한 뒤 audit 의 `_should_promote` 가 reject 해도 SoT 가 그대로 남던 누수 fix.
- `_revert_sot_after_reject` helper 추가 + `train.py:2453` else 분기에서 호출 (runner-driven cycle 시).
- 9 invariant test 로 insertion/replacement/duplicate-id/IOError 등 모든 분기 pin.

## Why

2026-05-26 autoresearch attribution/wiring sprint 의 Phase A audit (`.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.1) 에서 확인된 silent leak:

```
runner.apply_proposal (runner.py:1865)
  → apply_mutation writes target_section's new_value to canonical SoT
  → append_audit_log writes apply row to mutations.jsonl
  → _invoke_autoresearch spawns audit subprocess

train.main (train.py:2453, BEFORE this PR):
  if ok:
      _write_baseline(...)
  # ← NO else branch; SoT remained mutated when ok=False
```

cycle 누적 시 rejected mutation 들이 SoT 에 stack → next-cycle baseline scoring 이 stacked SoT 에 대해 평가 → regression 원인 decomposition 불가. 메모리 `[[feedback_latest_vs_promoted_sot]]` 의 "stale evidence 영원히 누적" 패턴이 SoT 차원에서도 발생.

## Changes

| File | Change |
|------|--------|
| `autoresearch/train.py` | Added `_revert_sot_after_reject(mutation_id, *, audit_log_path)` helper (~75 lines after `_should_promote`). Walks `mutations.jsonl` for the latest apply row matching `mutation_id`, restores `previous_value` via `load/write_wrapper_prompt_sections` (prompt kind) or `policies.load_policy`/`write_policy` (policy kinds). Insertion case (`previous_value=""`) deletes the inserted key instead of writing empty string. |
| `autoresearch/train.py` | `main()` auto-promote else branch (~15 lines) — when `_should_promote` returns False AND `GEODE_SIL_MUTATION_ID` env is set (runner-driven cycle), calls `_revert_sot_after_reject` and appends revert status to `reason` so the printed `baseline_promoted:` line surfaces leak prevention outcome. Manual audits (no SIL env) intentionally skip — operator-driven accumulation is by design. |
| `tests/autoresearch/test_sot_revert_on_reject.py` | New file, 9 invariants: missing mutation_id, missing log file, prompt-kind revert, policy-kind revert, duplicate-mutation_id (latest wins), writer OSError graceful, `applied_sibling` rows excluded, insertion-case deletes key (prompt + policy kinds). |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry. |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy core/ plugins/ autoresearch/` clean (464 source files)
- [x] `uv run pytest tests/autoresearch/ -q -m "not live"` pass (~390 tests including 9 new)
- [x] `uv run lint-imports` 4/4 architecture contracts kept
- [x] Codex MCP review CONDITIONAL_PASS → all 3 must-fix applied (insertion key-pop semantics, slop test replaced, CHANGELOG entry)

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` (in `attribution-grounding-check` worktree)
- CLAUDE.md "Writer destination tracked" rule precedent: PR-G5b #1350 (2026-05-20) — `autoresearch/state/mutations.jsonl` silently gitignored incident
- Next in sprint: PR-SOT-REVERT-ON-AUDIT-FAIL (subprocess returncode check + `_rollback_sot` on audit subprocess crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)