### PR TITLE
feat(audit-seeds): --smoke-log {auto,path} auto-tee to .audit/smoke-archives/ (PR-SMOKE-LOG-FLAG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,25 @@ functional change.
 
 ### Added
 
+- PR-SMOKE-LOG-FLAG (2026-05-26) — ``geode audit-seeds generate
+  --smoke-log {auto,<path>}`` flag tees stdout + stderr into the
+  GEODE-convention smoke archive without operator-managed ``>``
+  redirect. ``auto`` resolves to
+  ``.audit/smoke-archives/smoke-<N>-<unix_ts>.log`` where ``N`` is the
+  next integer after the highest existing ``smoke-<int>-*.log``
+  filename in the archive directory; an explicit value is taken
+  literally. Implementation is a Python-level ``_TeeStream`` proxy
+  around ``sys.stdout`` / ``sys.stderr`` — best-effort secondary write
+  so a disk-full failure on the log can never crash the actual
+  pipeline (the primary stream stays authoritative). Subprocess output
+  (claude-cli, codex) keeps the original OS file descriptors and lands
+  in its own ``state/seed-generation/<run>/sub_agents/...`` SoT; the
+  smoke log captures exactly what the operator would have seen on the
+  terminal. Default (no flag) is unchanged — REPL / regular
+  ``audit-seeds generate`` invocations behave identically to pre-PR.
+  Pinned by 11 unit tests in
+  ``tests/plugins/seed_generation/test_smoke_log_flag.py``.
+
 - PR-HOOKEVENT-RESERVE — autoresearch mutation lifecycle event
   namespace reservation. Adds 5 ``HookEvent`` members anchoring the
   shared event taxonomy between two concurrent sprints:

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import shlex
 import sys
 import time
@@ -81,11 +82,16 @@ audit_seeds_app = typer.Typer(
 # Implementation note: this is a *Python-level* tee — we wrap
 # ``sys.stdout`` / ``sys.stderr`` with a ``_TeeStream`` proxy that
 # duplicates every write to the log file. Subprocesses spawned later
-# (claude-cli, codex) inherit the *original* OS file descriptors, so
-# their output does NOT land in this log (they have their own
-# transcript / sub_agent JSON SoT under ``state/seed-generation/.../``).
-# What this captures is exactly what the operator sees: cost preview
-# banner, ToS notice, phase status echoes, error tracebacks.
+# (claude-cli, codex) actually run with PIPE-captured stdout/stderr
+# (``core/orchestration/isolated_execution.py:414`` +
+# ``core/self_improving_loop/cli_subprocess.py:97`` both use
+# ``capture_output=True`` / ``stdout=PIPE``), so their raw output
+# never reaches the parent's terminal anyway — it lands in the
+# per-task ``state/seed-generation/<run>/sub_agents/<task>/`` records
+# via the PIPE. What THIS log captures is exactly what the operator
+# sees on their own terminal: the parent process's cost preview
+# banner, ToS notice, phase status echoes, and any tracebacks the
+# orchestrator surfaces.
 
 
 _SMOKE_ARCHIVES_DIR = Path(".audit") / "smoke-archives"
@@ -136,8 +142,10 @@ def _next_smoke_counter(archives: Path) -> int:
         return 1
     counters: list[int] = []
     for entry in archives.glob("smoke-*-*.log"):
-        # filename pattern: smoke-<N>-<TS>.log → split into 3 dash-parts
-        # plus extension. Tolerate malformed names.
+        # filename pattern: smoke-<N>-<TS>(-<pid>)?.log → at least 3
+        # dash-parts after the stem split. Tolerate both legacy
+        # (smoke-N-TS.log) and pid-suffixed (smoke-N-TS-PID.log)
+        # variants for migration.
         parts = entry.stem.split("-")
         if len(parts) >= 3 and parts[0] == "smoke":
             try:
@@ -147,19 +155,27 @@ def _next_smoke_counter(archives: Path) -> int:
     return (max(counters) + 1) if counters else 1
 
 
-def _resolve_smoke_log_path(value: str, *, now_ts: int | None = None) -> Path:
+def _resolve_smoke_log_path(
+    value: str, *, now_ts: int | None = None, pid: int | None = None
+) -> Path:
     """Resolve ``--smoke-log`` argument to an absolute Path.
 
-    - ``"auto"`` → ``.audit/smoke-archives/smoke-<next-N>-<unix_ts>.log``
-      where ``next-N`` is ``max(existing smoke-N)+1`` and ``unix_ts``
-      is ``int(time.time())`` (overridable for tests via ``now_ts``).
+    - ``"auto"`` → ``.audit/smoke-archives/smoke-<N>-<unix_ts>-<pid>.log``
+      where ``N`` is ``max(existing smoke-N)+1``, ``unix_ts`` is
+      ``int(time.time())``, and ``pid`` is ``os.getpid()``. Both
+      ``now_ts`` and ``pid`` are overridable for tests. The pid
+      suffix prevents collision when two smoke processes start in the
+      same wall-second (Codex MCP MEDIUM catch fold — pre-fix the
+      counter scan + ts could collide before either process touched
+      the directory, so two runs could pick identical paths).
     - any other value → treated as a literal path (relative or
       absolute). Parent directories are created in the caller.
     """
     if value == "auto":
         ts = now_ts if now_ts is not None else int(time.time())
+        pid_value = pid if pid is not None else os.getpid()
         next_n = _next_smoke_counter(_SMOKE_ARCHIVES_DIR)
-        return _SMOKE_ARCHIVES_DIR / f"smoke-{next_n}-{ts}.log"
+        return _SMOKE_ARCHIVES_DIR / f"smoke-{next_n}-{ts}-{pid_value}.log"
     return Path(value)
 
 

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -31,10 +31,13 @@ P-checklist application:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import shlex
 import sys
+import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import IO, Any
 
 import typer
@@ -63,6 +66,125 @@ audit_seeds_app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+# ─────────── PR-SMOKE-LOG-FLAG helpers (2026-05-26) ──────────────────────
+#
+# Operators have been redirecting smoke stdout to
+# ``.audit/smoke-archives/smoke-<N>-<TS>.log`` by hand on every smoke
+# invocation since smoke 21. The `>` redirect is easy to forget (it
+# landed in ``/tmp/`` on smoke 24) and yields a stale convention with
+# no compile-time gate. This flag makes the path resolution automatic
+# while staying opt-in (default off — REPL / regular ``audit-seeds
+# generate`` invocations stay unchanged).
+#
+# Implementation note: this is a *Python-level* tee — we wrap
+# ``sys.stdout`` / ``sys.stderr`` with a ``_TeeStream`` proxy that
+# duplicates every write to the log file. Subprocesses spawned later
+# (claude-cli, codex) inherit the *original* OS file descriptors, so
+# their output does NOT land in this log (they have their own
+# transcript / sub_agent JSON SoT under ``state/seed-generation/.../``).
+# What this captures is exactly what the operator sees: cost preview
+# banner, ToS notice, phase status echoes, error tracebacks.
+
+
+_SMOKE_ARCHIVES_DIR = Path(".audit") / "smoke-archives"
+
+
+class _TeeStream:
+    """Write-side TextIO proxy that duplicates writes to a second handle.
+
+    Used by ``_setup_smoke_log_tee`` to mirror ``sys.stdout`` /
+    ``sys.stderr`` into the smoke-archives log without losing terminal
+    output. The proxy forwards all other attribute access to the
+    primary stream so ``typer.echo`` / Rich output keep working.
+    """
+
+    def __init__(self, primary: IO[str], secondary: IO[str]) -> None:
+        self._primary = primary
+        self._secondary = secondary
+
+    def write(self, s: str) -> int:
+        n = self._primary.write(s)
+        # Best-effort: a failed log write must never crash the actual
+        # pipeline. The primary stream's write count is what callers
+        # expect.
+        with contextlib.suppress(Exception):
+            self._secondary.write(s)
+            self._secondary.flush()
+        return n
+
+    def flush(self) -> None:
+        self._primary.flush()
+        with contextlib.suppress(Exception):
+            self._secondary.flush()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._primary, name)
+
+
+def _next_smoke_counter(archives: Path) -> int:
+    """Return the next smoke-<N> integer based on existing filenames.
+
+    Walks ``.audit/smoke-archives/smoke-<N>-<TS>.log`` files and
+    returns ``max(N) + 1``. Returns 1 when the directory is empty or
+    no smoke-<N>-* files exist. The TS suffix is preserved separately
+    in ``_resolve_smoke_log_path`` so two smoke runs in the same
+    wall-second still get distinct paths.
+    """
+    if not archives.exists():
+        return 1
+    counters: list[int] = []
+    for entry in archives.glob("smoke-*-*.log"):
+        # filename pattern: smoke-<N>-<TS>.log → split into 3 dash-parts
+        # plus extension. Tolerate malformed names.
+        parts = entry.stem.split("-")
+        if len(parts) >= 3 and parts[0] == "smoke":
+            try:
+                counters.append(int(parts[1]))
+            except ValueError:
+                continue
+    return (max(counters) + 1) if counters else 1
+
+
+def _resolve_smoke_log_path(value: str, *, now_ts: int | None = None) -> Path:
+    """Resolve ``--smoke-log`` argument to an absolute Path.
+
+    - ``"auto"`` → ``.audit/smoke-archives/smoke-<next-N>-<unix_ts>.log``
+      where ``next-N`` is ``max(existing smoke-N)+1`` and ``unix_ts``
+      is ``int(time.time())`` (overridable for tests via ``now_ts``).
+    - any other value → treated as a literal path (relative or
+      absolute). Parent directories are created in the caller.
+    """
+    if value == "auto":
+        ts = now_ts if now_ts is not None else int(time.time())
+        next_n = _next_smoke_counter(_SMOKE_ARCHIVES_DIR)
+        return _SMOKE_ARCHIVES_DIR / f"smoke-{next_n}-{ts}.log"
+    return Path(value)
+
+
+def _setup_smoke_log_tee(value: str | None) -> Path | None:
+    """Install a Python-level stdout/stderr tee for a smoke run.
+
+    When ``value`` is ``None`` (the default), returns ``None`` and
+    leaves ``sys.stdout`` / ``sys.stderr`` untouched — the
+    pre-PR-SMOKE-LOG-FLAG behavior. When set, resolves the target
+    path, opens it line-buffered in text-append mode, and replaces
+    both standard streams with ``_TeeStream`` proxies.
+
+    The log file handle is intentionally NOT closed at function exit
+    — the audit-seeds run lives for the rest of the process; closing
+    here would terminate logging mid-pipeline. Process exit closes the
+    fd automatically via the OS.
+    """
+    if not value:
+        return None
+    target = _resolve_smoke_log_path(value)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fh = target.open("a", encoding="utf-8", buffering=1)  # line-buffered
+    sys.stdout = _TeeStream(sys.stdout, fh)
+    sys.stderr = _TeeStream(sys.stderr, fh)
+    return target
 
 
 def _get_seed_generation_config() -> Any:
@@ -195,6 +317,17 @@ def audit_seeds_generate(
             "Omit to keep the single-dim contract (empty list)."
         ),
     ),
+    smoke_log: str | None = typer.Option(
+        None,
+        "--smoke-log",
+        help=(
+            "PR-SMOKE-LOG-FLAG (2026-05-26): auto-tee stdout + stderr to "
+            "``.audit/smoke-archives/`` so operators do not have to "
+            "remember the `> .audit/smoke-archives/smoke-<N>-<TS>.log` "
+            "redirect every time. Accepts: ``auto`` (next smoke counter, "
+            "current unix ts), or an explicit path. Omit to disable."
+        ),
+    ),
 ) -> None:
     """Generate a new candidate batch — runs picker → cost preview →
     pre-flight → confirm → Pipeline.arun().
@@ -204,6 +337,9 @@ def audit_seeds_generate(
     when omitted, then fall back to module defaults
     (``"gen1"`` / ``15``).
     """
+    smoke_log_path = _setup_smoke_log_tee(smoke_log)
+    if smoke_log_path is not None:
+        typer.echo(f"[smoke-log] capturing stdout + stderr to {smoke_log_path}")
     cfg = _get_seed_generation_config()
     resolved_gen_tag = gen_tag if gen_tag is not None else cfg.default_gen_tag
     resolved_candidates = candidates if candidates is not None else cfg.candidates_default

--- a/tests/plugins/seed_generation/test_smoke_log_flag.py
+++ b/tests/plugins/seed_generation/test_smoke_log_flag.py
@@ -1,0 +1,153 @@
+"""PR-SMOKE-LOG-FLAG (2026-05-26) — ``audit-seeds generate --smoke-log``
+helper invariants.
+
+Operators have been hand-redirecting smoke stdout to
+``.audit/smoke-archives/smoke-<N>-<TS>.log`` since smoke 21. The
+redirect is easy to forget (smoke 24 landed in ``/tmp/`` because the
+operator forgot the ``>``) and has no compile-time gate. This flag
+auto-resolves the path while staying opt-in (default off).
+
+These tests pin the helper invariants without invoking the full
+``audit-seeds generate`` pipeline (which would require a real
+self-improving-loop config + adapter chain). The pipeline integration
+itself is exercised by the next smoke run; this file gates the path
+resolution + tee behavior independently.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from plugins.seed_generation.cli import (
+    _next_smoke_counter,
+    _resolve_smoke_log_path,
+    _setup_smoke_log_tee,
+    _TeeStream,
+)
+
+
+def test_next_smoke_counter_empty_dir_returns_one(tmp_path: Path) -> None:
+    """No existing smoke-*-*.log files → counter starts at 1."""
+    assert _next_smoke_counter(tmp_path) == 1
+
+
+def test_next_smoke_counter_missing_dir_returns_one(tmp_path: Path) -> None:
+    """Directory does not exist → counter starts at 1 (no crash)."""
+    nonexistent = tmp_path / "definitely-not-there"
+    assert not nonexistent.exists()
+    assert _next_smoke_counter(nonexistent) == 1
+
+
+def test_next_smoke_counter_picks_max_plus_one(tmp_path: Path) -> None:
+    """The new counter must be ``max(existing) + 1`` so two smoke runs
+    in the same wallsecond still get distinct counter values."""
+    (tmp_path / "smoke-1-1779000000.log").touch()
+    (tmp_path / "smoke-23-1779700000.log").touch()
+    (tmp_path / "smoke-7-1779500000.log").touch()
+    assert _next_smoke_counter(tmp_path) == 24
+
+
+def test_next_smoke_counter_ignores_malformed_names(tmp_path: Path) -> None:
+    """Files that don't match ``smoke-<int>-<TS>.log`` are skipped — a
+    stale ``smoke-rundir-1779662494/`` style entry must not break the
+    counter."""
+    (tmp_path / "smoke-1-1779000000.log").touch()
+    (tmp_path / "smoke-abc-foo.log").touch()  # malformed
+    (tmp_path / "other.log").touch()  # unrelated
+    assert _next_smoke_counter(tmp_path) == 2
+
+
+def test_resolve_auto_returns_archives_path() -> None:
+    """``auto`` resolves under ``.audit/smoke-archives/`` with the
+    ``smoke-<N>-<TS>.log`` naming convention."""
+    path = _resolve_smoke_log_path("auto", now_ts=1779999999)
+    assert path.parent.name == "smoke-archives"
+    assert path.parent.parent.name == ".audit"
+    assert path.name.startswith("smoke-")
+    assert path.name.endswith("-1779999999.log")
+
+
+def test_resolve_explicit_path_passes_through(tmp_path: Path) -> None:
+    """Any value other than ``auto`` is treated as a literal path."""
+    custom = tmp_path / "my-smoke.log"
+    path = _resolve_smoke_log_path(str(custom))
+    assert path == custom
+
+
+def test_setup_none_returns_none_and_leaves_stdout_untouched() -> None:
+    """Default ``--smoke-log`` (None) is a no-op — the test invariant
+    that smoke 23 / smoke 24 era operators do not get surprised when
+    omitting the flag."""
+    import sys
+
+    orig_stdout = sys.stdout
+    result = _setup_smoke_log_tee(None)
+    try:
+        assert result is None
+        assert sys.stdout is orig_stdout
+    finally:
+        sys.stdout = orig_stdout
+
+
+def test_setup_writes_to_target_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When set, the tee actually writes through to the target file
+    so the smoke log captures whatever ``print()`` / ``typer.echo``
+    emit."""
+    import sys
+
+    log_path = tmp_path / "smoke-test.log"
+    orig_stdout = sys.stdout
+    result = _setup_smoke_log_tee(str(log_path))
+    try:
+        assert result == log_path
+        print("hello smoke log")
+        sys.stdout.flush()
+        contents = log_path.read_text(encoding="utf-8")
+        assert "hello smoke log" in contents
+    finally:
+        sys.stdout = orig_stdout
+
+
+def test_tee_stream_forwards_write_count() -> None:
+    """``_TeeStream.write`` must return the primary stream's byte
+    count so callers that expect ``print`` -semantics keep working."""
+    primary = io.StringIO()
+    secondary = io.StringIO()
+    tee = _TeeStream(primary, secondary)
+    n = tee.write("abc")
+    assert n == 3
+    assert primary.getvalue() == "abc"
+    assert secondary.getvalue() == "abc"
+
+
+def test_tee_stream_secondary_failure_does_not_crash() -> None:
+    """A failed write to the secondary (e.g. disk full mid-smoke) must
+    never crash the actual pipeline — the primary stream is
+    authoritative."""
+
+    class _BrokenWriter:
+        def write(self, s: str) -> int:
+            raise OSError("disk full")
+
+        def flush(self) -> None:
+            raise OSError("disk full")
+
+    primary = io.StringIO()
+    tee = _TeeStream(primary, _BrokenWriter())  # type: ignore[arg-type]
+    n = tee.write("survives")
+    assert n == len("survives")
+    assert primary.getvalue() == "survives"
+    tee.flush()  # also must not raise
+
+
+def test_tee_stream_forwards_arbitrary_attrs() -> None:
+    """``_TeeStream`` must proxy non-write attributes (``isatty``,
+    ``encoding``, ``buffer`` etc.) to the primary so ``typer.echo`` +
+    Rich formatting keep their feature detection."""
+    primary = io.StringIO()
+    primary_encoding = getattr(primary, "encoding", None)
+    secondary = io.StringIO()
+    tee = _TeeStream(primary, secondary)
+    assert getattr(tee, "encoding", None) == primary_encoding

--- a/tests/plugins/seed_generation/test_smoke_log_flag.py
+++ b/tests/plugins/seed_generation/test_smoke_log_flag.py
@@ -61,12 +61,26 @@ def test_next_smoke_counter_ignores_malformed_names(tmp_path: Path) -> None:
 
 def test_resolve_auto_returns_archives_path() -> None:
     """``auto`` resolves under ``.audit/smoke-archives/`` with the
-    ``smoke-<N>-<TS>.log`` naming convention."""
-    path = _resolve_smoke_log_path("auto", now_ts=1779999999)
+    ``smoke-<N>-<TS>-<pid>.log`` naming convention. The pid suffix
+    (Codex MCP MEDIUM catch fold) makes the path collision-free even
+    when two smoke processes start in the same wall-second."""
+    path = _resolve_smoke_log_path("auto", now_ts=1779999999, pid=42424)
     assert path.parent.name == "smoke-archives"
     assert path.parent.parent.name == ".audit"
     assert path.name.startswith("smoke-")
-    assert path.name.endswith("-1779999999.log")
+    assert path.name.endswith("-1779999999-42424.log")
+
+
+def test_resolve_auto_same_second_different_pid_distinct_paths() -> None:
+    """Two processes starting in the same wall-second pick distinct
+    filenames because the pid suffix differs — even if they pick the
+    same counter due to the directory scan racing the first writer's
+    ``open(..., "a")`` call."""
+    a = _resolve_smoke_log_path("auto", now_ts=1779999999, pid=1001)
+    b = _resolve_smoke_log_path("auto", now_ts=1779999999, pid=1002)
+    assert a != b
+    assert "1001" in a.name
+    assert "1002" in b.name
 
 
 def test_resolve_explicit_path_passes_through(tmp_path: Path) -> None:
@@ -79,26 +93,34 @@ def test_resolve_explicit_path_passes_through(tmp_path: Path) -> None:
 def test_setup_none_returns_none_and_leaves_stdout_untouched() -> None:
     """Default ``--smoke-log`` (None) is a no-op — the test invariant
     that smoke 23 / smoke 24 era operators do not get surprised when
-    omitting the flag."""
+    omitting the flag. Saves + restores BOTH ``sys.stdout`` and
+    ``sys.stderr`` (Codex MCP MEDIUM catch fold — the helper wraps
+    both streams, so the test must restore both)."""
     import sys
 
     orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
     result = _setup_smoke_log_tee(None)
     try:
         assert result is None
         assert sys.stdout is orig_stdout
+        assert sys.stderr is orig_stderr
     finally:
         sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
 
 
 def test_setup_writes_to_target_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When set, the tee actually writes through to the target file
     so the smoke log captures whatever ``print()`` / ``typer.echo``
-    emit."""
+    emit. Saves + restores BOTH streams (Codex MCP MEDIUM catch fold —
+    pre-fix this test leaked a ``_TeeStream`` ``sys.stderr`` to later
+    tests in the same pytest process)."""
     import sys
 
     log_path = tmp_path / "smoke-test.log"
     orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
     result = _setup_smoke_log_tee(str(log_path))
     try:
         assert result == log_path
@@ -108,6 +130,7 @@ def test_setup_writes_to_target_file(tmp_path: Path, monkeypatch: pytest.MonkeyP
         assert "hello smoke log" in contents
     finally:
         sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
 
 
 def test_tee_stream_forwards_write_count() -> None:


### PR DESCRIPTION
## Summary

- ``geode audit-seeds generate --smoke-log auto`` auto-resolves to ``.audit/smoke-archives/smoke-<N>-<TS>.log`` so operators do not have to remember ``>`` redirect on every smoke invocation.
- Python-level ``_TeeStream`` proxy on ``sys.stdout`` / ``sys.stderr``; subprocess output (claude-cli/codex) keeps its existing SoT under ``state/seed-generation/<run>/sub_agents/...``.
- 11 unit tests pinning the counter + path-resolution + tee invariants. Default (no flag) is byte-identical to pre-PR.

## Why

Operators have hand-redirected smoke stdout to ``.audit/smoke-archives/smoke-<N>-<TS>.log`` since smoke 21 (PR-1163 archive convention). The ``>`` redirect is easy to forget:

- **Smoke 24** (this session, 2026-05-26 18:22) — operator forgot the redirect, the log landed at ``/tmp/smoke-24-1779787347.log`` until I noticed and ``mv``'d it to ``.audit/smoke-archives/`` mid-run. ``lsof`` confirmed the writer's fd followed the inode through the rename, but a different filesystem or a process restart would have lost the capture entirely.
- **Smoke 21/22/23** — all redirected by hand. There has been no compile-time gate ensuring this path stays in convention.

This PR makes the path resolution part of the CLI surface so it cannot be forgotten. The default is unchanged: omitting ``--smoke-log`` reproduces the old behavior exactly, so REPL / regular development invocations stay terminal-only.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_generation/cli.py` | +130 LOC — ``_TeeStream`` proxy class, ``_next_smoke_counter`` / ``_resolve_smoke_log_path`` / ``_setup_smoke_log_tee`` helpers, ``--smoke-log`` typer option on ``audit_seeds_generate`` |
| `tests/plugins/seed_generation/test_smoke_log_flag.py` | NEW (~155 LOC) — 11 unit tests pinning counter resolution (empty / missing / max+1 / malformed-skip), ``auto`` archive path shape, explicit-path pass-through, default-None no-op, tee writes to target, write count forwarding, secondary failure does not crash, attribute proxy |
| `CHANGELOG.md` | Unreleased Added entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| ``--smoke-log auto`` CLI flag | Implemented | typer Option on ``audit_seeds_generate`` |
| Counter resolution from existing files | Implemented | ``_next_smoke_counter`` walks ``.audit/smoke-archives/smoke-<int>-*.log`` |
| Best-effort tee (disk-full safe) | Implemented | ``contextlib.suppress(Exception)`` on secondary write/flush; primary stream stays authoritative |
| Subprocess capture | Not in scope | Subprocess output retains original OS fd. Subprocess SoT is ``state/seed-generation/<run>/sub_agents/<task>/...`` (already exists, untouched) |
| Operator confirm echo | Implemented | ``[smoke-log] capturing stdout + stderr to <path>`` printed before pipeline starts |

## Verification

- [x] ruff check clean (`core/ tests/ plugins/`)
- [x] ruff format --check clean
- [x] mypy clean (`core/ plugins/`, 458 source files)
- [x] pytest pass — 11 cases in `test_smoke_log_flag.py`
- [x] Default-None invariant (`test_setup_none_returns_none_and_leaves_stdout_untouched`) — operators omitting the flag see byte-identical pre-PR behavior

## Reference

- Convention source: prior smoke logs at ``.audit/smoke-archives/smoke-{20,21,22,23,24}-*.log`` (manual ``>`` redirects)
- Smoke 24 incident: ``.audit/smoke-archives/smoke-24-1779787347.log`` originated in ``/tmp/`` before mid-run ``mv`` (this conversation)
- Companion: ``docs/plans/2026-05-26-observability-central-sot.md`` channel #8 — PR-7 ``smoke_runs`` indexer will read these log files; ``geode obs link smoke:<N> --run <run-id>`` will associate them
- New feedback memory: ``feedback_smoke_log_archive_location`` (already saved this conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)