### PR TITLE
fix(self-improving-loop): rollback SoT when audit subprocess crashes or exits non-zero (PR-SOT-REVERT-ON-AUDIT-FAIL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-SOT-REVERT-ON-AUDIT-FAIL** — self-improving loop closed-loop
+  silent leak #2: `SelfImprovingLoopRunner._invoke_autoresearch` now
+  checks the audit subprocess's `returncode` and rolls the canonical
+  SoT back to `proposal.original_sections` when the subprocess
+  crashes (Exception) or exits non-zero. Without this, a crashed
+  audit left the SoT mutated and the baseline unchanged, giving the
+  next cycle no signal to attribute the regression to. `_rollback_sot`'s
+  `exc` parameter type is widened from `OSError` to `BaseException`
+  so the synthesized `RuntimeError` for non-zero exit codes type-checks.
+  `apply_proposal` (the singleton group_size=1 path) now forwards
+  `proposal.original_sections` to the invoker. Pinned by 7 invariant
+  tests covering returncode=0 (no rollback), non-zero rollback,
+  Exception rollback, None-guard backward-compat, and the widened exc type.
+
 ## [0.99.71] - 2026-05-26
 
 Sprint H closeout + backlog #99 cleanup. Bundles 4 PRs into one PATCH

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1881,10 +1881,16 @@ class SelfImprovingLoopRunner:
             _git_commit_audit_log(log_path, mutation=proposal.mutation)
         if self.rerun_enabled:
             repo_root = log_path.resolve().parents[1]
+            # PR-SOT-REVERT-ON-AUDIT-FAIL (2026-05-26) — forward
+            # ``proposal.original_sections`` so _invoke_autoresearch can
+            # rollback the canonical SoT if the audit subprocess crashes
+            # or exits non-zero. Without this, a crashed audit leaves
+            # the SoT mutated and the baseline unchanged — silent leak.
             self._invoke_autoresearch(
                 repo_root,
                 audit_run_id=audit_run_id,
                 mutation=proposal.mutation,
+                original_sections=proposal.original_sections,
             )
         self._append_self_improving_loop_index(proposal.mutation, previous_value)
         return proposal.mutation
@@ -1931,17 +1937,29 @@ class SelfImprovingLoopRunner:
         original_sections: dict[str, str],
         *,
         mutation: Mutation,
-        exc: OSError,
+        exc: BaseException,
     ) -> None:
         """Restore the SoT to ``original_sections`` after a post-apply failure.
 
-        G5b.fix3 — invoked from ``run_once`` when
+        G5b.fix3 — original use: invoked from ``run_once`` when
         :func:`append_audit_log` raises ``OSError`` *after*
         :func:`apply_mutation` has already written the new sections to
         disk. The SoT must be rolled back to the pre-mutation state so
         the loop never persists a mutation that has no audit-log row;
         otherwise the git-as-optimiser ledger and the live state would
         diverge silently.
+
+        PR-SOT-REVERT-ON-AUDIT-FAIL (2026-05-26) — extended use: also
+        invoked from :meth:`_invoke_autoresearch` when the post-commit
+        audit subprocess raises (caught as ``Exception``) or exits
+        non-zero (synthesized as ``RuntimeError`` carrying the exit
+        code). ``exc`` type is widened from ``OSError`` to
+        ``BaseException`` so the synthesized RuntimeError type-checks —
+        but the in-process catch boundary in
+        :meth:`_invoke_autoresearch` is ``Exception``, so
+        KeyboardInterrupt / SystemExit still propagate without
+        triggering rollback. The log message is structural; the exact
+        exception type lands in the formatted output.
 
         Rollback failure is itself logged but never raised in place of
         the original ``exc`` — the caller already has the more useful
@@ -1984,6 +2002,7 @@ class SelfImprovingLoopRunner:
         *,
         audit_run_id: str = "",
         mutation: Mutation | None = None,
+        original_sections: dict[str, str] | None = None,
     ) -> None:
         """Wrap the autoresearch subprocess so tests can override.
 
@@ -1991,17 +2010,46 @@ class SelfImprovingLoopRunner:
         mutation_id + expected_dim to the subprocess env so the
         attribution row written after the audit carries the same
         cross-ref keys as the apply row.
+
+        PR-SOT-REVERT-ON-AUDIT-FAIL (2026-05-26) — when the subprocess
+        crashes (Exception) or exits non-zero (returncode != 0), the
+        canonical SoT mutation this audit was supposed to validate is
+        rolled back via :meth:`_rollback_sot`. Without rollback a
+        crashed audit leaves the SoT mutated and the baseline
+        unchanged — the next cycle has no signal to attribute the
+        regression to.
+
+        ``original_sections`` is the pre-mutation SoT
+        (``proposal.original_sections``). When ``None`` (callers that
+        didn't migrate, or mutation is None), rollback is skipped and
+        the legacy graceful-log behaviour is preserved.
         """
         try:
-            _run_autoresearch_subprocess(
+            result = _run_autoresearch_subprocess(
                 repo_root=repo_root,
                 dry_run=self.rerun_dry_run,
                 audit_run_id=audit_run_id,
                 mutation_id=mutation.mutation_id if mutation is not None else "",
                 expected_dim=mutation.expected_dim if mutation is not None else None,
             )
-        except Exception:  # pragma: no cover — defensive
+        except Exception as exc:
             log.warning("self-improving-loop autoresearch re-run failed", exc_info=True)
+            if original_sections is not None and mutation is not None:
+                self._rollback_sot(original_sections, mutation=mutation, exc=exc)
+            return
+        if result.returncode != 0:
+            log.warning(
+                "self-improving-loop autoresearch re-run exited non-zero "
+                "(returncode=%d); stderr tail: %s",
+                result.returncode,
+                (result.stderr or "")[-500:],
+            )
+            if original_sections is not None and mutation is not None:
+                self._rollback_sot(
+                    original_sections,
+                    mutation=mutation,
+                    exc=RuntimeError(f"audit subprocess exit code {result.returncode}"),
+                )
 
     @staticmethod
     def _append_self_improving_loop_index(mutation: Mutation, previous_value: str) -> None:

--- a/tests/core/self_improving_loop/test_invoke_autoresearch_rollback.py
+++ b/tests/core/self_improving_loop/test_invoke_autoresearch_rollback.py
@@ -1,0 +1,373 @@
+"""PR-SOT-REVERT-ON-AUDIT-FAIL (2026-05-26) — SoT rollback when
+post-commit audit subprocess crashes or exits non-zero.
+
+Closes the second silent leak from the 2026-05-26 autoresearch
+attribution/wiring sprint Phase A audit (Section 5.2):
+
+* ``SelfImprovingLoopRunner.apply_proposal`` (runner.py:1865) writes
+  the mutation to the canonical SoT.
+* ``_invoke_autoresearch`` (runner.py:1981-2004 pre-PR) spawned the
+  audit subprocess but did not check ``returncode`` and only logged
+  on Exception — never called ``_rollback_sot``.
+* Result: a crashed audit left the SoT mutated and the baseline
+  unchanged. The next cycle had no signal to attribute the
+  regression to.
+
+This file pins three behaviours:
+
+1. ``_invoke_autoresearch`` calls ``_rollback_sot`` when the
+   subprocess returns a non-zero ``returncode`` (and
+   ``original_sections`` was forwarded).
+2. ``_invoke_autoresearch`` calls ``_rollback_sot`` when the
+   subprocess raises any Exception.
+3. ``_invoke_autoresearch`` does NOT call ``_rollback_sot`` when the
+   subprocess succeeds (returncode 0) — pinning we don't regress the
+   happy path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from core.self_improving_loop.runner import Mutation, SelfImprovingLoopRunner
+
+
+def _make_runner(tmp_path: Path) -> SelfImprovingLoopRunner:
+    """Build a minimally-wired runner instance for unit testing."""
+    return SelfImprovingLoopRunner(
+        llm_call=lambda system, user: (
+            '{"target_section": "role", "new_value": "x", "rationale": "y"}'
+        ),
+        rerun_enabled=True,
+        commit_enabled=False,
+        audit_log_path=tmp_path / "mutations.jsonl",
+    )
+
+
+def _make_mutation() -> Mutation:
+    return Mutation(
+        target_section="role",
+        new_value="mutated-value",
+        rationale="test mutation",
+        target_kind="prompt",
+        mutation_id="mut-test-1",
+    )
+
+
+def _completed_process(returncode: int, stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["uv", "run", "python", "autoresearch/train.py"],
+        returncode=returncode,
+        stdout="",
+        stderr=stderr,
+    )
+
+
+def test_audit_subprocess_returncode_zero_does_not_rollback(tmp_path: Path) -> None:
+    """Happy path — when the audit subprocess exits 0, the canonical
+    SoT mutation stays in place (no rollback) because the audit has
+    accepted or rejected via its own promote-gate path and any
+    rejection-side revert is handled in train.py (PR-SOT-REVERT-ON-REJECT)."""
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+    original_sections = {"role": "pre-mutation"}
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed_process(returncode=0)
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id="run-1",
+            mutation=mutation,
+            original_sections=original_sections,
+        )
+
+    assert rollback_calls == []
+
+
+def test_audit_subprocess_nonzero_returncode_triggers_rollback(tmp_path: Path) -> None:
+    """When the audit subprocess exits non-zero, rollback is called
+    with the original_sections + mutation + a RuntimeError carrying
+    the exit code in its message."""
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+    original_sections = {"role": "pre-mutation"}
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed_process(returncode=2, stderr="something went wrong")
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id="run-1",
+            mutation=mutation,
+            original_sections=original_sections,
+        )
+
+    assert len(rollback_calls) == 1
+    args, kwargs = rollback_calls[0]
+    # First positional arg: original_sections
+    assert args == (original_sections,)
+    assert kwargs["mutation"] is mutation
+    assert isinstance(kwargs["exc"], RuntimeError)
+    assert "exit code 2" in str(kwargs["exc"])
+
+
+def test_audit_subprocess_exception_triggers_rollback(tmp_path: Path) -> None:
+    """When the subprocess invocation itself raises (e.g. OSError on
+    fork failure, timeout), rollback is called with the captured
+    exception."""
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+    original_sections = {"role": "pre-mutation"}
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise OSError("simulated fork failure")
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id="run-1",
+            mutation=mutation,
+            original_sections=original_sections,
+        )
+
+    assert len(rollback_calls) == 1
+    args, kwargs = rollback_calls[0]
+    assert args == (original_sections,)
+    assert isinstance(kwargs["exc"], OSError)
+    assert "simulated fork failure" in str(kwargs["exc"])
+
+
+def test_rollback_skipped_when_original_sections_not_forwarded(tmp_path: Path) -> None:
+    """Backward-compat: when ``original_sections`` is None (a caller
+    that didn't migrate to the new signature), the legacy graceful-
+    log behaviour is preserved — no rollback call, no crash."""
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed_process(returncode=99)
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id="run-1",
+            mutation=mutation,
+            original_sections=None,
+        )
+
+    assert rollback_calls == []
+
+
+def test_rollback_skipped_when_mutation_is_none(tmp_path: Path) -> None:
+    """Defensive — when mutation is None we cannot meaningfully rollback
+    (don't know which SoT to restore), so the legacy log-only behaviour
+    is preserved."""
+    runner = _make_runner(tmp_path)
+    original_sections = {"role": "pre-mutation"}
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("fail")
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id="run-1",
+            mutation=None,
+            original_sections=original_sections,
+        )
+
+    assert rollback_calls == []
+
+
+def test_rollback_sot_accepts_runtimerror_after_pr(tmp_path: Path) -> None:
+    """Pin: the ``exc`` parameter type widening from OSError to
+    BaseException — _rollback_sot must accept any exception subclass
+    so the audit-fail rollback path (RuntimeError) works at type
+    check time. Smoke-runs the static dispatch."""
+    mutation = _make_mutation()
+    original_sections = {"role": "pre-mutation"}
+
+    write_calls: list[Any] = []
+
+    def fake_write_wrapper(sections: dict[str, str]) -> None:
+        write_calls.append(sections)
+
+    with patch("autoresearch.train.write_wrapper_prompt_sections", fake_write_wrapper):
+        # RuntimeError used to fail mypy on the OSError-typed parameter;
+        # post-PR this is accepted.
+        SelfImprovingLoopRunner._rollback_sot(
+            original_sections,
+            mutation=mutation,
+            exc=RuntimeError("audit subprocess exit code 2"),
+        )
+
+    assert write_calls == [original_sections]
+
+
+def test_apply_proposal_forwards_original_sections_and_rolls_back_on_nonzero(
+    tmp_path: Path,
+) -> None:
+    """End-to-end pin: when ``apply_proposal`` is called with a
+    runner-driven cycle (``rerun_enabled=True``) and the audit
+    subprocess exits non-zero, the canonical SoT is restored from
+    ``proposal.original_sections``. This pins the entire wiring chain:
+    apply_proposal → _invoke_autoresearch → _rollback_sot → write
+    back the pre-mutation sections.
+
+    Codex MCP review #2 (CONDITIONAL_PASS, must-fix #1) — the unit
+    tests above patch ``_rollback_sot`` so they don't prove the
+    actual restoration. This test patches the *writers* instead so
+    the rollback path's actual SoT write is observed."""
+    from core.self_improving_loop.runner import Proposal
+
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+    original_sections = {"role": "ORIGINAL", "shell_caution": "untouched"}
+
+    proposal = Proposal(
+        mutation=mutation,
+        target_sections=dict(original_sections),
+        original_sections=dict(original_sections),
+    )
+
+    # Track the SoT state via writer/reader patches.
+    sot_state = dict(original_sections)
+
+    def fake_load_wrapper() -> dict[str, str]:
+        return dict(sot_state)
+
+    def fake_write_wrapper(sections: dict[str, str]) -> None:
+        sot_state.clear()
+        sot_state.update(sections)
+
+    def failing_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed_process(returncode=2, stderr="audit crashed")
+
+    with (
+        patch("autoresearch.train.load_wrapper_prompt_sections", fake_load_wrapper),
+        patch("autoresearch.train.write_wrapper_prompt_sections", fake_write_wrapper),
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            failing_subprocess,
+        ),
+        # Skip the git commit step (commit_enabled=False already, but
+        # be explicit about not invoking git in test).
+        patch(
+            "core.self_improving_loop.runner._git_commit_audit_log",
+            lambda *a, **kw: None,
+        ),
+    ):
+        result = runner.apply_proposal(proposal)
+
+    # apply_proposal returns the mutation regardless — the rollback
+    # is silent (logged but not raised).
+    assert result is mutation
+    # CRITICAL invariant: SoT was first mutated by apply_mutation then
+    # restored by the rollback path. End state must equal the
+    # pre-mutation original_sections.
+    assert sot_state == original_sections
+    assert sot_state["role"] == "ORIGINAL"
+
+
+@pytest.mark.parametrize("returncode", [1, 2, 124, 137])
+def test_rollback_triggers_across_failure_returncodes(tmp_path: Path, returncode: int) -> None:
+    """Pin that any non-zero returncode triggers rollback — not just
+    a magic value. Covers timeout (124), OOM kill (137), and generic
+    failures (1, 2)."""
+    runner = _make_runner(tmp_path)
+    mutation = _make_mutation()
+    original_sections = {"role": "pre-mutation"}
+
+    rollback_calls: list[Any] = []
+
+    def fake_subprocess(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed_process(returncode=returncode)
+
+    with (
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            fake_subprocess,
+        ),
+        patch.object(
+            SelfImprovingLoopRunner,
+            "_rollback_sot",
+            staticmethod(lambda *a, **kw: rollback_calls.append((a, kw))),
+        ),
+    ):
+        runner._invoke_autoresearch(
+            tmp_path,
+            audit_run_id=f"run-rc{returncode}",
+            mutation=mutation,
+            original_sections=original_sections,
+        )
+
+    assert len(rollback_calls) == 1
+    _, kwargs = rollback_calls[0]
+    assert f"exit code {returncode}" in str(kwargs["exc"])


### PR DESCRIPTION
## Summary

- 자율 학습 loop 의 두 번째 silent leak 차단 — runner 가 mutation 을 canonical SoT 에 write 한 뒤 audit subprocess 가 crash 하거나 returncode != 0 으로 exit 했을 때 SoT 가 그대로 남던 누수 fix.
- `_invoke_autoresearch` 가 subprocess returncode 검사 + Exception 발생 시 `_rollback_sot` 호출 (forward 된 `original_sections` 가 있을 때).
- 11 invariant test 로 returncode 0/non-zero/Exception/None-guard/parametric returncode/end-to-end apply_proposal 까지 모든 branch pin.

## Why

PR #1749 (PR-SOT-REVERT-ON-REJECT) 가 `_should_promote=False` 인 reject path 를 train.py-side 에서 차단했지만, **subprocess 자체가 crash 하거나 non-zero exit 하는 별개의 실패 surface** 가 무방어 상태였음. 즉:

- subprocess returncode != 0 → `_run_autoresearch_subprocess` 는 `check=False` 라 raise 안 함 → `_invoke_autoresearch` 는 None return 받고 무시
- subprocess Exception (fork failure, timeout, OOM kill) → `_invoke_autoresearch` 는 `except Exception` 으로 catch 후 단순 log.warning, `_rollback_sot` 미호출

두 경우 모두 canonical SoT 는 mutation 이 적용된 상태로 남고 baseline 은 미갱신 → next-cycle baseline scoring 이 stacked SoT 에 대해 평가 → regression 원인 decompose 불가.

Sprint Phase A audit `.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.2 + §5.5b 명시.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | `_invoke_autoresearch` 에 `original_sections: dict[str, str] \| None = None` parameter 추가. `_run_autoresearch_subprocess` 호출 결과의 `returncode != 0` 검사 + Exception 처리 모두에서 `_rollback_sot` 호출 (조건: `original_sections is not None and mutation is not None`). Backward-compat: 둘 중 하나라도 None 이면 legacy log-only 동작 유지. |
| `core/self_improving_loop/runner.py` | `_rollback_sot` 의 `exc` parameter type 을 `OSError` → `BaseException` 으로 확장. 합성된 `RuntimeError(f"audit subprocess exit code {N}")` 가 type-check 통과하도록. `_invoke_autoresearch` 의 in-process catch boundary 가 `Exception` 인 점 docstring 에 명시. |
| `core/self_improving_loop/runner.py` | `apply_proposal` 가 `_invoke_autoresearch` 호출 시 `proposal.original_sections` forward. |
| `tests/core/self_improving_loop/test_invoke_autoresearch_rollback.py` | 신규. 11 invariant: returncode=0 happy path / non-zero rollback / Exception rollback / None original_sections backward-compat / None mutation defensive guard / widened exc 수용 / parametric returncode [1, 2, 124, 137] / **end-to-end apply_proposal → _invoke_autoresearch → _rollback_sot → SoT 복원 wiring 체인** (writer patch). |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry. |

## Verification

- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run ruff format --check` clean (907 files)
- [x] `uv run mypy core/` clean (390 source files)
- [x] `uv run pytest tests/core/self_improving_loop/test_invoke_autoresearch_rollback.py tests/test_policy_mutation.py` 40 pass (11 new + 29 existing)
- [x] `uv run lint-imports` 4/4 architecture contracts kept
- [x] Codex MCP review CONDITIONAL_PASS → 2 must-fix 적용 (end-to-end test 추가 + uv.lock churn 제거)

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.2, §5.5b (in `attribution-grounding-check` worktree)
- Sibling PR (already merged or in CI): #1749 PR-SOT-REVERT-ON-REJECT — handles `_should_promote=False` orthogonal case
- Group N>1 path: `apply_group_proposals` (`runner.py:1581`) audits sibling temp SoTs BEFORE canonical commit, so this PR's `apply_proposal` (singleton group_size=1) scope is correct — no missed canonical-SoT failure surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)