### PR TITLE
docs(self-improving-loop): downgrade DAPO/GRPO to 'inspired by' + remove unverified EXAONE citation (PR-ATTR-INSPIRED-BY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,36 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-ATTR-INSPIRED-BY** — self-improving loop's group-sampling
+  selection layer docstrings + plan doc + config docstrings
+  downgraded from "DAPO Dynamic Sampling + GRPO advantage
+  normalization + EXAONE 4.5 zero-variance filter" (which overstated
+  the relationship) to **"DAPO-inspired variance gate +
+  GRPO-inspired group-relative scoring — not policy optimization, no
+  parameter update, no gradient"**. Removes the mis-citation of
+  EXAONE 4.5 (arXiv 2604.08644) verified during the 2026-05-26
+  attribution sprint Phase A audit: that paper is the EXAONE 4.5
+  vision-language model technical report from LG AI Research and
+  contains no variance filter / Dynamic Sampling / RL-training
+  content. Touched files: `core/self_improving_loop/runner.py`
+  (5 docstrings + 1 prompt-template line),
+  `core/config/self_improving_loop.py` (group_size +
+  group_variance_threshold knobs),
+  `core/self_improving_loop/credit_assignment.py` (module
+  docstring), `docs/plans/2026-05-25-baseline-fitness-rl-grounding.md`
+  (D5 row + frontier table + section 4.2 + reference list).
+  No deterministic code-path change. One runtime-facing string did
+  change — the mutator LLM prompt template line in
+  `runner.py:_MUTATION_CONTRACT_SUFFIX` mentions the variance gate
+  in its sibling-uniqueness instruction, reworded from "DAPO Dynamic
+  Sampling variance filter" to "DAPO-inspired variance gate" so the
+  mutator's understanding stays consistent with the docstrings.
+  No test invalidation. Historical `CHANGELOG.md` entries for past
+  releases that mentioned the prior framing are intentionally left
+  unchanged (Keep a Changelog: released entries are immutable).
+
 ### Added
 
 - PR-SMOKE-LOG-FLAG (2026-05-26) — ``geode audit-seeds generate

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -238,35 +238,38 @@ class AutoresearchConfig(BaseModel):
     """In-process mutator runner binding. Consumed by
     :func:`core.self_improving_loop.runner._default_llm_call`."""
 
-    # P1-revised (2026-05-25) — GSPO/DAPO + EXAONE variance filter 의 selection
-    # layer 만 inference-time 으로 채택. 본 sprint plan:
-    # ``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md``.
+    # P1-revised (2026-05-25) — DAPO-inspired variance gate + GRPO-inspired
+    # group-relative scoring 의 *selection* layer 만 inference-time 으로 채택.
+    # **Not policy optimization; no parameter update; no gradient.** 본 sprint
+    # plan: ``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md``.
     group_size: Annotated[int, Field(ge=1, le=8)] = 1
     """Number of sibling mutations to propose+audit per self-improving cycle.
 
     - ``1`` (default): legacy (1+1)-ES + previous-baseline 비교. group sampling
       disabled, backward-compat 보존.
     - ``2`` (MVP): N=2 sibling parallel mutator call + sequential audit + group
-      mean/std → DAPO Dynamic Sampling 의 variance filter + advantage
-      normalization. P1-revised 의 시작값.
-    - ``4`` (full): frontier-aligned (DeepSeek-R1 GRPO N=8, Promptbreeder
-      pop=50 의 cost-trimmed 변형). audit cost 4x 부담.
+      mean/std → DAPO-inspired variance gate + GRPO-inspired z-score ranking.
+      P1-revised 의 시작값.
+    - ``4`` (full): frontier-inspired (GRPO uses N=8 for *training* — here we
+      use it for *selection* only, cost-trimmed). audit cost 4x 부담.
 
     cost 영향 — N 배 audit cost (subscription source 는 quota window 안에서
     무료, ``core/llm/audit_lane.py`` OL-P2 audit_lane=1 으로 sequential 강제).
     """
 
     group_variance_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.01
-    """DAPO Dynamic Sampling / EXAONE 4.5 zero-variance filter 의 threshold ε.
+    """DAPO-inspired variance gate threshold ε.
 
     N sibling mutation 의 fitness std 가 이 값 미만이면 group 폐기 (cycle skip
-    + log). variance filter 의 의도: 모든 sibling 이 비슷한 결과를 내면 학습
-    signal 0 → 무신호 cycle 의 audit cost 낭비 회피 (DAPO reported wall-clock
-    25% 절약).
+    + log). gate 의 의도: 모든 sibling 이 비슷한 결과를 내면 selection signal
+    0 → 무신호 cycle 의 audit cost 낭비 회피 (DAPO paper reports wall-clock
+    25% saving when applied as a *training* filter — here we use it as a
+    *selection* gate, separate concern).
 
-    EXAONE production value 미공개로 0.01 default. ``baseline.json`` history
-    (N≥30 cycle) 누적 후 percentile-based (5th percentile 미만 filter) 로
-    adapt 권장. ``group_size`` 가 1 이면 무시.
+    Default 0.01 is a placeholder — no externally-verified production value
+    is currently grounded for this knob. ``baseline.json`` history (N≥30
+    cycle) 누적 후 percentile-based (5th percentile 미만 filter) 로 adapt
+    권장 (PR-VAR-ADAPTIVE follow-up). ``group_size`` 가 1 이면 무시.
     """
 
     pareto_mode: bool = False

--- a/core/self_improving_loop/credit_assignment.py
+++ b/core/self_improving_loop/credit_assignment.py
@@ -17,7 +17,8 @@ group_advantage 가 어느 dim 에 attributable 한가?" 는 추적 불가.
 유지. 후속 caller (CLI 또는 operator dashboard) 가 결과를 visualise.
 
 Frontier reference: Quality-Diversity (Mouret & Clune 2015) 의
-behavior-characterization mapping + DAPO/GRPO 의 advantage decomposition.
+behavior-characterization mapping + GRPO-inspired group-relative
+advantage decomposition (formula only; no policy update).
 """
 
 from __future__ import annotations

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -488,7 +488,7 @@ _MUTATION_CONTRACT_SUFFIX = (
     "part of a sibling group (``group_size > 1``), each sibling MUST target a "
     "meaningfully different section or strategy. Repeating the same "
     "``target_section`` + ``new_value`` across siblings collapses group "
-    "variance to zero, trips the DAPO Dynamic Sampling variance filter, and "
+    "variance to zero, trips the DAPO-inspired variance gate, and "
     "the entire cycle's audit cost is discarded (see plan "
     "``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md`` §6).\n"
     "- Respond with a single JSON object — NO surrounding prose, NO code fences.\n"
@@ -1067,18 +1067,36 @@ def _compute_group_advantage(
     *,
     mutator_temperature: float,
 ) -> tuple[list[float] | None, str]:
-    """P1-revised (2026-05-25) — DAPO Dynamic Sampling + GRPO advantage normalization.
+    """P1-revised (2026-05-25) — DAPO-inspired variance gate + GRPO-inspired group-relative scoring.
+
+    **Not policy optimization; no parameter update; no gradient.** This is
+    an *inference-time* candidate-selection heuristic — N sibling
+    mutations are audited in parallel, low-signal groups (std < ε) are
+    skipped, and the remaining group's z-score is used to pick top-1
+    for canonical SoT commit.
 
     Plan: ``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md`` §4.1.
 
-    Frontier source: DAPO (ByteDance/Tsinghua arXiv 2503.14476) 의 Dynamic
-    Sampling — group reward variance ≈ 0 batch 폐기. EXAONE 4.5 (LG, arXiv
-    2604.08644) 의 zero-variance filter production 검증. GRPO (DeepSeek R1
-    arXiv 2402.03300) 의 advantage whitening.
+    Frontier inspiration (concept reference only — abstract-level
+    descriptions verified via WebFetch 2026-05-26; specific formulas
+    are NOT formally cited here because the PDF full-text was not
+    full-text-audited for this sprint; do not re-claim any specific
+    DAPO/GRPO result as "exact" without re-verifying against the PDF):
 
-    Returns (advantages, status):
-    - status="ok" + advantages = z-score whitening if group std > threshold
-    - status="filtered_low_variance" + advantages=None if std < threshold
+    - DAPO (ByteDance/Tsinghua, arXiv 2503.14476). Abstract introduces
+      "Decoupled Clip and Dynamic Sampling Policy Optimization". The
+      idea of skipping low-signal sampling groups is what GEODE
+      borrows for *selection-time* filtering — distinct from DAPO's
+      *training-time* use.
+    - GRPO (DeepSeekMath, arXiv 2402.03300). Abstract describes GRPO
+      as a PPO variant using group-relative scoring. GEODE uses
+      group-relative z-score ranking as a *selection* score for
+      top-1 sibling mutation commit — distinct from GRPO's use as a
+      policy-update advantage.
+
+    Returns (scores, status):
+    - status="ok" + scores = z-score ranking if group std > threshold
+    - status="filtered_low_variance" + scores=None if std < threshold
       → caller cycle skip (audit cost wasted 회피)
     - status="group_too_small" if N < 2 (legacy group_size=1 mode 는 caller
       가 본 helper 호출 안 함, 본 분기는 invariant test 용)
@@ -1419,9 +1437,10 @@ class SelfImprovingLoopRunner:
     def propose_group(self, n: int) -> list[Proposal]:
         """P1-revised (2026-05-25) — propose N sibling Mutations in parallel.
 
-        Frontier source: GRPO (DeepSeek R1) 의 group sampling + Promptbreeder
-        의 multi-prompt 동시 평가. plan ``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md``
-        §4.3 MVP scope.
+        Frontier inspiration: GRPO-inspired group sampling (DeepSeekMath
+        arXiv 2402.03300 — borrows the N-sibling-parallel idea, not the
+        policy-update gradient) + Promptbreeder 의 multi-prompt 동시 평가.
+        plan ``docs/plans/2026-05-25-baseline-fitness-rl-grounding.md`` §4.3 MVP scope.
 
         Each sibling shares the same baseline state (same system + user
         prompt). Stochasticity comes from ``Settings.temperature_self_improving_mutation``
@@ -1471,12 +1490,13 @@ class SelfImprovingLoopRunner:
         sub_agent_index: int | None = None,
     ) -> Mutation | None:
         """P1-revised (2026-05-25) — apply N sibling proposals → audit →
-        variance filter → advantage normalization → top-1 commit.
+        variance gate → group-relative scoring → top-1 commit.
 
-        Frontier source: DAPO Dynamic Sampling (variance filter) + GRPO
-        whitening (advantage normalization) + EXAONE 4.5 zero-variance
-        filter (production threshold). plan §4.3 + §5 (W3 env propagation
-        infra 재활용).
+        Frontier inspiration: DAPO-inspired variance gate (arXiv 2503.14476;
+        skip low-signal groups) + GRPO-inspired whitening (DeepSeekMath
+        arXiv 2402.03300; z-score ranking, used here as a *selection*
+        score, not a policy-update advantage). plan §4.3 + §5 (W3 env
+        propagation infra 재활용).
 
         Steps:
 
@@ -1900,8 +1920,9 @@ class SelfImprovingLoopRunner:
         - ``group_size=1`` (default, legacy): :meth:`propose` +
           :meth:`apply_proposal` 그대로 (single mutation, REINFORCE-style)
         - ``group_size>=2``: :meth:`propose_group` +
-          :meth:`apply_group_proposals` (DAPO Dynamic Sampling + GRPO
-          advantage normalization + variance filter top-1 commit)
+          :meth:`apply_group_proposals` (DAPO-inspired variance gate +
+          GRPO-inspired score whitening, mutation-selection only — not
+          policy gradient / not RL training)
 
         Variance filter trigger 시 ``None`` 반환 (cycle skip, no SoT
         commit). legacy mode 는 항상 ``Mutation`` 반환.

--- a/docs/plans/2026-05-25-baseline-fitness-rl-grounding.md
+++ b/docs/plans/2026-05-25-baseline-fitness-rl-grounding.md
@@ -33,7 +33,7 @@ GEODE 의 self-improving loop = RL 의 *policy gradient on non-Markovian environ
 | **D2** | scenario_realism → seed-gen feedback channel (mutator 분리). admirable / disappointing / needs_attention → self-improving loop baseline (B) 의 input |
 | **D3** | B (fitness) 식 fix 먼저, 가지치기 그 다음 |
 | **D4** | PSM (geode-scoring PSM Engine analyst_confidence multiplier) 거부 |
-| **D5** | P1-revised (GSPO/DAPO + EXAONE variance filter) 채택. P2-P5 후속 |
+| **D5** | P1-revised (DAPO-inspired variance gate + GRPO-inspired score whitening) 채택 — *selection layer only, no policy gradient*. P2-P5 후속 |
 
 ## 4. P1-revised 적용 plan
 
@@ -41,11 +41,11 @@ GEODE 의 self-improving loop = RL 의 *policy gradient on non-Markovian environ
 
 GEODE 의 mutator = Anthropic/OpenAI API endpoint, weight frozen. → frontier RL 의 learning layer (gradient descent, ratio clipping, KL penalty) 적용 X. **selection layer 3개만**:
 
-| 채택 | 출처 | GEODE 적용 |
+| 채택 (selection-only) | 출처 (inspired by) | GEODE 적용 |
 |---|---|---|
-| **Group baseline** | GRPO (DeepSeek R1) | N mutation → μ = mean(fitness) |
-| **Advantage normalization (whitening)** | GRPO | Â_i = (fitness_i - μ) / (σ + ε) |
-| **Variance filter (Dynamic Sampling)** | DAPO + EXAONE 4.5 zero-variance filter | σ < ε_var 면 group 폐기 |
+| **Group baseline** | GRPO-inspired (DeepSeekMath arXiv 2402.03300; GRPO uses it as policy-update baseline, we use it as selection baseline) | N mutation → μ = mean(fitness) |
+| **Score whitening (z-score)** | GRPO-inspired (same source; formula reused as selection-time ranking, not as policy gradient term) | score_i = (fitness_i - μ) / (σ + ε) |
+| **Variance gate** | DAPO-inspired (arXiv 2503.14476 *Dynamic Sampling* — applied at training time there, here at selection time) | σ < ε_var 면 group 폐기 |
 
 ### 4.2 DAPO 4 technique 중 본 sprint 채택
 
@@ -61,7 +61,7 @@ GEODE 의 mutator = Anthropic/OpenAI API endpoint, weight frozen. → frontier R
 | 항목 | 결정 | 비고 |
 |---|---|---|
 | group size N | **2** | config knob `[self_improving_loop.autoresearch] group_size`. 1=disabled, 2=MVP, 4=full |
-| variance threshold ε_var | **0.01** | config knob. EXAONE production value 미공개 → history 누적 (N≥30 cycle) 후 percentile-based 로 adapt |
+| variance threshold ε_var | **0.01** | config knob. Placeholder default — no externally-verified production value grounded for this knob. history 누적 (N≥30 cycle) 후 percentile-based 로 adapt (PR-VAR-ADAPTIVE follow-up) |
 | sibling SoT 처리 | **in-memory** | disk write 없음. audit subprocess spawn 시 env (W3 인프라) 로 SoT path propagate. 채택된 1개만 disk commit |
 | mutations.jsonl `kind` 확장 | `applied` (선택됨) + `applied_sibling` (선택 안 됨) + 기존 `attribution` | group_id field 추가 |
 | 폐기 시 동작 | cycle skip + log | 안전 default. 후속에 mutator 재시도 with higher temperature 옵션 |
@@ -100,8 +100,8 @@ GEODE 의 mutator = Anthropic/OpenAI API endpoint, weight frozen. → frontier R
 
 ```
 GEODE self-improving-loop 의 baseline RL grounding PR (P1-revised) diff 를 검증해줘.
-group baseline + advantage normalization + variance filter (DAPO Dynamic Sampling) 가
-frontier 의 selection layer 만 채택했는지 + weight 학습 layer (PPO ratio clip, KL penalty,
+group baseline + score whitening + variance gate (DAPO-inspired Dynamic Sampling, GRPO-inspired
+whitening) 가 frontier 의 selection layer 만 채택했는지 + weight 학습 layer (PPO ratio clip, KL penalty,
 gradient descent) 가 포함되지 않았는지 cross-check.
 
 특히 다음 anti-deception 패턴 확인:
@@ -188,10 +188,17 @@ gradient descent) 가 포함되지 않았는지 cross-check.
   - [[feedback-post-implementation-verification]] — RFC 작성 전 코드 검증 필수
   - [[feedback-codex-mcp-verification]] — §7 Codex MCP 검증
   - [[feedback-dual-sot-drift-invariant]] — sibling in-memory variant 의 drift 방지
-- Frontier:
-  - [DAPO arXiv 2503.14476](https://arxiv.org/html/2503.14476v1) — Dynamic Sampling 의 정확한 식
-  - [GRPO DeepSeekMath arXiv 2402.03300](https://arxiv.org/abs/2402.03300) — group baseline + advantage whitening
-  - [GSPO Qwen3 arXiv 2507.18071](https://arxiv.org/pdf/2507.18071) — sequence-level (GEODE 사상 정합)
-  - [EXAONE 4.5 arXiv 2604.08644](https://arxiv.org/html/2604.08644v1) — zero-variance filter production
+- Frontier inspiration (referenced for ideas, not formula citations
+  — verify against PDFs before quoting any specific formula):
+  - [DAPO arXiv 2503.14476](https://arxiv.org/html/2503.14476v1) — Dynamic Sampling concept (applied here at *selection* time, not as a training-time gradient filter)
+  - [GRPO DeepSeekMath arXiv 2402.03300](https://arxiv.org/abs/2402.03300) — group baseline + advantage whitening (formula reused as *selection* score, not as policy gradient term)
+  - [GSPO Qwen3 arXiv 2507.18071](https://arxiv.org/pdf/2507.18071) — sequence-level RL training (referenced for sequence-vs-token granularity discussion only; GEODE is not RL training)
   - [Solar Pro 3 SnapPO arXiv 2601.07022](https://arxiv.org/pdf/2601.07022) — cyclic producer-consumer (P5 후속)
   - [Dynamic Reward Weighting TACL '26 arXiv 2509.11452](https://arxiv.org/abs/2509.11452) — MORL P2-revised
+- Removed reference (2026-05-26 Phase A audit): EXAONE 4.5 arXiv
+  2604.08644 was previously cited as "zero-variance filter
+  production" grounding. WebFetch verification confirmed that paper
+  is the EXAONE 4.5 vision-language-model technical report (LG AI
+  Research) and contains no variance filter / Dynamic Sampling /
+  RL-training content. Citation removed to prevent fake-frontier
+  alignment from accumulating.

--- a/docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md
+++ b/docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md
@@ -7,7 +7,7 @@
 
 ## 1. Background
 
-PR-5 #1641 merge 후 self-improving loop 가 N=2 group sampling + variance filter + GRPO whitening 으로 single-trajectory variance 해소. 단 **multi-dim 신호의 scalarization 손실** 잔존:
+PR-5 #1641 merge 후 self-improving loop 가 N=2 group sampling + DAPO-inspired variance gate + GRPO-inspired z-score whitening (selection-only) 으로 single-trajectory variance 해소. 단 **multi-dim 신호의 scalarization 손실** 잔존:
 
 - 현재 fitness = weighted sum of 17 dims (`autoresearch/train.py:DIM_WEIGHTS`), 즉 *linear scalarization*
 - 알려진 한계: concave Pareto front 의 일부 구간 영원히 도달 불가 (Das & Dennis 1997)

--- a/docs/plans/2026-05-25-seed-gen-selection-layer-alignment.md
+++ b/docs/plans/2026-05-25-seed-gen-selection-layer-alignment.md
@@ -11,7 +11,7 @@ selection layer 가 develop 에 5 PR 으로 누적 머지된 상태:
 
 | PR | 모듈 | 핵심 신호 추가 |
 |----|------|---------------|
-| #1641 P1-revised | `runner._compute_group_advantage` + `propose_group(N)` | DAPO variance filter + GRPO whitening |
+| #1641 P1-revised | `runner._compute_group_advantage` + `propose_group(N)` | DAPO-inspired variance gate + GRPO-inspired z-score whitening (selection-only) |
 | #1645 P2-revised | `core/self_improving_loop/pareto_archive.py` | Pareto front per dim (`baseline_archive.jsonl`) |
 | #1648 P3-revised | `core/self_improving_loop/anchor_confidence.py` (ANCHOR_DIMS_POSITIVE/NEGATIVE) | anchor confidence multiplier `[0.7, 1.0]` |
 | #1650 P4 | `core/self_improving_loop/swarm_scaffolding.py` | sub-agent fan-out + mean/median/max aggregation |


### PR DESCRIPTION
## Summary

- DAPO + GRPO 의 인용 표현을 "implemented" → "inspired by" 로 다운그레이드 (selection layer only, no policy gradient 명시).
- EXAONE 4.5 (arXiv 2604.08644) 의 "zero-variance filter production 검증" 인용 완전 삭제 — 해당 paper 는 VLM 기술 보고서로 variance filter 내용 없음 (Phase A WebFetch 검증).
- 7 파일 docstring/comment 변경. 1 runtime 문자열 (mutator prompt template) 변경 (DAPO Dynamic Sampling → DAPO-inspired variance gate). deterministic code-path 변경 없음.

## Why

2026-05-26 autoresearch attribution sprint Phase A audit (`.audit/diagnostics/attribution-grounding-2026-05-26.md` §1) WebFetch 검증 결과:

- **arXiv 2604.08644** = LG AI Research EXAONE 4.5 VLM (vision-language model) tech report. 문서 이해 + extended context model. **NO** zero-variance filter / Dynamic Sampling / group-sampling variance filter for RL training.
- 이전 GEODE 코드의 "EXAONE 4.5 의 zero-variance filter production 검증" 인용은 fabricated grounding.
- `config/self_improving_loop.py:267` 의 "EXAONE production value 미공개" 자기모순 문구가 신호.

동시에 DAPO + GRPO 의 인용 표현도 정직화:
- 기존: "DAPO Dynamic Sampling + GRPO advantage normalization" (implemented 어조)
- 정정: "DAPO-inspired variance gate + GRPO-inspired group-relative scoring — not policy optimization, no parameter update, no gradient" (inspired-by + 명시적 부정문)
- 이유: GEODE 의 selection-time heuristic 은 DAPO/GRPO 의 training-time policy update 와 다른 것 — 차용한 것은 *idea*, 적용 layer 다름.

CLAUDE.md "Refactoring Deception Prevention" + 신규 [[feedback_inspired_by_attribution]] memory 의 frontier algorithm citation 룰.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | 5 docstring (`_compute_group_advantage`, `propose_group`, `apply_group_proposals`, `run_once`) + 1 prompt template line (`_MUTATION_CONTRACT_SUFFIX`) downgrade to inspired-by, explicit "not policy optimization, no parameter update, no gradient" 명시. |
| `core/config/self_improving_loop.py` | `group_size` + `group_variance_threshold` knob docstring 정정. 자기모순 "EXAONE production value 미공개" → "no externally-verified production value is currently grounded" 명시. |
| `core/self_improving_loop/credit_assignment.py` | 모듈 docstring "DAPO/GRPO 의 advantage decomposition" → "GRPO-inspired group-relative advantage decomposition (formula only; no policy update)". |
| `docs/plans/2026-05-25-baseline-fitness-rl-grounding.md` | D5 decision row + frontier table §4.1 + §4.3 ε_var rationale + §7 Codex MCP prompt + references list. **explicit "Removed reference (2026-05-26 Phase A audit)" 명시** — 향후 EXAONE 재인용 방지. |
| `docs/plans/2026-05-25-seed-gen-selection-layer-alignment.md` | 자매 sprint plan, "DAPO variance filter + GRPO whitening" → "DAPO-inspired variance gate + GRPO-inspired z-score whitening (selection-only)". |
| `docs/plans/2026-05-25-p2-pareto-archive-dynamic-reward-weighting.md` | 동일 자매 plan, 같은 정정. |
| `CHANGELOG.md` | `[Unreleased]` Changed entry. 과거 release entry 들 (EXAONE 인용 포함된 v0.99.x)은 의도적으로 미수정 (Keep a Changelog spec: released entries immutable). |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` clean
- [x] `uv run ruff format --check` clean (982 files)
- [x] `uv run mypy core/ plugins/ autoresearch/` clean (464 source files)
- [x] `uv run pytest tests/core/self_improving_loop/` 405 pass (behaviour unchanged — pure docstring/comment + 1 prompt-template wording)
- [x] Codex MCP review CONDITIONAL_PASS → 3 must-fix 적용 (formula attribution 약화, CHANGELOG 표현 수정 prompt template 노출 명시, sibling plan doc 정합)
- [x] EXAONE keyword `core/`, `autoresearch/`, `plugins/` 에서 0개 (final grep)

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §1.1 (EXAONE verification), §6.2 (PR-ATTR-2 decision = DELETE)
- WebFetch evidence: arXiv 2604.08644 abstract "vision-language model" + "document-understanding focus" — no variance / dynamic sampling / RL training mention
- Sibling PRs in sprint: #1749 PR-SOT-REVERT-ON-REJECT, #1753 PR-SOT-REVERT-ON-AUDIT-FAIL (both in CI queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)