### PR TITLE
fix(autoresearch): monotonic gen_tag counter to prevent same-commit collision (PR-GEN-COUNTER)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-GEN-COUNTER** — ``autoresearch.train._resolve_gen_tag`` no
+  longer collapses repeated audits at the same git commit into a
+  single synthetic ``autoresearch-{commit}`` gen_tag. The 2026-05-26
+  attribution sprint Phase A audit (§5.6) found that every audit at
+  one commit shared the same gen_tag, making cross-cycle attribution
+  decomposition impossible. Post-PR the resolver reads
+  ``~/.geode/self-improving-loop/sessions.jsonl``, finds rows whose
+  gen_tag starts with ``autoresearch-{commit}``, parses the optional
+  ``-gen{N}`` suffix, and emits ``autoresearch-{commit}-gen{N+1}``.
+  Legacy rows without a suffix count as ``gen0`` (next emission is
+  ``gen1``). The ``AUTORESEARCH_GEN_TAG`` operator override still
+  wins. Best-effort reads — malformed JSON / non-dict rows / OSError
+  during scan all fall through gracefully to ``gen1``. Pinned by 11
+  invariant tests in
+  ``tests/autoresearch/test_gen_tag_monotonic.py`` covering fresh
+  history, increments, legacy mixing, per-commit isolation, override
+  precedence, malformed-row tolerance, and OSError fallback.
+
 ### Added
 
 - **PR-WIRE-1** — Three new ``/self-improving`` REPL sub-actions wire

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -93,6 +93,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1529,17 +1530,101 @@ def _resolve_session_id() -> str:
     return f"{stamp}-{short}"
 
 
+_GEN_SUFFIX_RE = re.compile(r"-gen(\d+)$")
+
+
+def _next_gen_counter_for_commit(commit: str, sessions_path: Path | None = None) -> int:
+    """Return the next monotonic ``gen{N}`` counter for ``commit``.
+
+    PR-GEN-COUNTER (2026-05-26) — fix the attribution silent leak found
+    in the 2026-05-26 sprint Phase A audit (§5.6): pre-PR,
+    ``_resolve_gen_tag(commit)`` returned ``autoresearch-{commit}``
+    deterministically, so repeated audits at the same commit collapsed
+    onto the same gen_tag — every attribution row at that commit
+    looked like the same generation. This function reads
+    ``sessions.jsonl``, finds rows whose gen_tag starts with
+    ``autoresearch-{commit}``, parses the optional ``-gen{N}`` suffix,
+    and returns ``max(N) + 1``. Rows without the suffix (legacy
+    pre-PR format) count as ``gen0`` so the next is ``gen1``.
+
+    ``sessions_path`` parameter is for testability; default reads
+    ``SESSIONS_INDEX_PATH``.
+    """
+    target = sessions_path if sessions_path is not None else SESSIONS_INDEX_PATH
+    if not target.is_file():
+        return 1
+    max_n = 0
+    saw_commit = False
+    prefix = f"autoresearch-{commit}"
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                tag = row.get("gen_tag", "")
+                if not isinstance(tag, str) or not tag.startswith(prefix):
+                    continue
+                saw_commit = True
+                # Match either ``<prefix>`` (legacy = gen0 implied) or
+                # ``<prefix>-gen<N>`` (post-PR explicit counter).
+                suffix = tag[len(prefix) :]
+                if suffix == "":
+                    continue  # legacy gen0 — max_n stays at 0
+                m = _GEN_SUFFIX_RE.match(suffix)
+                if m:
+                    try:
+                        n = int(m.group(1))
+                    except ValueError:
+                        # Regex restricts to ``\d+`` so this cannot fire
+                        # in practice, but ``int`` *can* raise on
+                        # absurdly long digit strings. Treat as if the
+                        # row didn't match so the scan continues.
+                        continue
+                    max_n = max(max_n, n)
+    except OSError:
+        # Reading sessions.jsonl is best-effort — fall through to gen1.
+        return 1
+    if not saw_commit:
+        return 1
+    return max_n + 1
+
+
 def _resolve_gen_tag(commit: str) -> str:
     """Return the gen_tag for this audit.
 
     Honours ``AUTORESEARCH_GEN_TAG`` so a parent driver (e.g. seed-
     pipeline cycle) can label generations consistently across runs.
-    Default: ``autoresearch-<commit>``.
+    Default: ``autoresearch-<commit>-gen<N>`` where ``N`` is the next
+    monotonic counter for this commit's history in ``sessions.jsonl``.
+
+    PR-GEN-COUNTER (2026-05-26) — switched from ``autoresearch-{commit}``
+    (collision-prone) to ``autoresearch-{commit}-gen{N}`` so repeated
+    audits at the same commit don't collapse into one synthetic
+    generation. Legacy gen_tags in old sessions.jsonl (no ``-gen{N}``
+    suffix) are treated as ``gen0`` — the next emission is ``gen1``.
+
+    Concurrency: the counter scan + emission are NOT atomic. Two
+    overlapping ``_resolve_gen_tag`` calls (e.g. seed-gen cycle +
+    manual ``geode audit`` overlap) can both observe the same
+    ``max(N)`` and emit the same ``gen{N+1}``, since the session row
+    is appended only at run end. This is acceptable as a best-effort
+    counter — gen_tag uniqueness is NOT guaranteed under concurrency.
+    Operators who need strict uniqueness should pin the tag via
+    ``AUTORESEARCH_GEN_TAG`` from the parent driver. See Codex MCP
+    review (PR-GEN-COUNTER CONDITIONAL_PASS #2, 2026-05-26).
     """
     override = os.environ.get("AUTORESEARCH_GEN_TAG", "").strip()
     if override:
         return override
-    return f"autoresearch-{commit}"
+    counter = _next_gen_counter_for_commit(commit)
+    return f"autoresearch-{commit}-gen{counter}"
 
 
 def _append_session_index(

--- a/tests/autoresearch/test_gen_tag_monotonic.py
+++ b/tests/autoresearch/test_gen_tag_monotonic.py
@@ -1,0 +1,196 @@
+"""PR-GEN-COUNTER (2026-05-26) — monotonic gen_tag counter pin.
+
+Closes the silent leak surfaced in the 2026-05-26 autoresearch
+attribution sprint Phase A audit (§5.6):
+
+* Pre-PR ``_resolve_gen_tag(commit)`` returned ``autoresearch-{commit}``
+  deterministically — same commit + repeated audits = same gen_tag.
+* Attribution rows at that commit collapsed into one synthetic
+  generation; outer-loop diagnostics couldn't decompose cross-cycle
+  signal.
+
+Post-PR ``_resolve_gen_tag`` returns ``autoresearch-{commit}-gen{N}``
+where N is read from sessions.jsonl history and incremented. This
+file pins:
+
+1. Fresh history (no sessions.jsonl) → first call returns ``gen1``.
+2. History with ``gen3`` for this commit → next call returns ``gen4``.
+3. Legacy history (no ``-gen{N}`` suffix) → treated as ``gen0``,
+   next call returns ``gen1``.
+4. ``AUTORESEARCH_GEN_TAG`` operator override still wins (counter
+   ignored).
+5. Different commit's prior history doesn't bleed (per-commit
+   isolation).
+6. Malformed JSONL rows are skipped gracefully (one bad row
+   doesn't abort).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_session(
+    path: Path,
+    *,
+    gen_tag: str,
+    session_id: str = "session-x",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "session_id": session_id,
+        "gen_tag": gen_tag,
+        "component": "autoresearch",
+        "started_at": 0.0,
+        "ended_at": 1.0,
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+def test_fresh_history_returns_gen1(tmp_path: Path) -> None:
+    """No sessions.jsonl yet → first gen_tag emission is gen1."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=tmp_path / "missing.jsonl")
+    assert n == 1
+
+
+def test_history_with_existing_gen_n_increments(tmp_path: Path) -> None:
+    """history has gen1 + gen3 for this commit → next is gen4."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen1")
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen3")
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 4
+
+
+def test_legacy_no_suffix_treated_as_gen0_so_next_is_gen1(tmp_path: Path) -> None:
+    """Pre-PR rows had ``autoresearch-{commit}`` with no ``-gen{N}``
+    suffix — those count as gen0; next emission is gen1."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-abc1234")  # legacy
+    _write_session(sessions, gen_tag="autoresearch-abc1234")  # legacy dup
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 1
+
+
+def test_legacy_mixed_with_gen_n(tmp_path: Path) -> None:
+    """Mix of legacy (no suffix) + ``-gen{N}`` rows → max(N) + 1
+    ignores the legacy ones."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-abc1234")  # legacy → gen0
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen2")
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen5")
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 6
+
+
+def test_other_commit_does_not_bleed(tmp_path: Path) -> None:
+    """sessions.jsonl has gen5 for *other* commit → our commit's
+    counter stays at gen1 (per-commit isolation)."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-other7890-gen5")
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 1
+
+
+def test_operator_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTORESEARCH_GEN_TAG env override skips the counter entirely —
+    operator pins the tag for cross-process consistency."""
+    from autoresearch.train import _resolve_gen_tag
+
+    monkeypatch.setenv("AUTORESEARCH_GEN_TAG", "custom-pinned-tag-v3")
+
+    assert _resolve_gen_tag("abc1234") == "custom-pinned-tag-v3"
+
+
+def test_resolve_emits_gen_n_format_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without override and with empty history → emits
+    ``autoresearch-{commit}-gen1`` (post-PR shape)."""
+    from autoresearch import train as train_mod
+
+    monkeypatch.delenv("AUTORESEARCH_GEN_TAG", raising=False)
+    monkeypatch.setattr(train_mod, "SESSIONS_INDEX_PATH", tmp_path / "missing.jsonl")
+
+    tag = train_mod._resolve_gen_tag("abc1234")
+    assert tag == "autoresearch-abc1234-gen1"
+
+
+def test_resolve_increments_with_real_history(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end pin: writing one gen1 row + calling _resolve_gen_tag
+    returns gen2 — the SESSIONS_INDEX_PATH lookup actually wires the
+    counter into the resolver, not just into the private helper."""
+    from autoresearch import train as train_mod
+
+    monkeypatch.delenv("AUTORESEARCH_GEN_TAG", raising=False)
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen1")
+    monkeypatch.setattr(train_mod, "SESSIONS_INDEX_PATH", sessions)
+
+    tag = train_mod._resolve_gen_tag("abc1234")
+    assert tag == "autoresearch-abc1234-gen2"
+
+
+def test_malformed_json_row_skipped_gracefully(tmp_path: Path) -> None:
+    """One malformed JSON line in the middle of sessions.jsonl must
+    not abort the scan — the good rows around it should still be
+    parsed."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen1")
+    with sessions.open("a", encoding="utf-8") as fh:
+        fh.write("{ this is not valid JSON\n")
+        fh.write("\n")  # blank line
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen3")
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 4
+
+
+def test_non_dict_row_skipped(tmp_path: Path) -> None:
+    """JSON arrays / scalars in sessions.jsonl (shouldn't happen, but
+    defensive) are skipped without aborting."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    sessions.write_text('[1, 2, 3]\n"just a string"\n', encoding="utf-8")
+    _write_session(sessions, gen_tag="autoresearch-abc1234-gen2")
+
+    n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 3
+
+
+def test_oserror_during_read_returns_gen1(tmp_path: Path) -> None:
+    """Permission error / IO failure during read → fall through to
+    gen1 (best-effort). The audit cycle should never crash because
+    sessions.jsonl is unreadable."""
+    from autoresearch.train import _next_gen_counter_for_commit
+
+    sessions = tmp_path / "sessions.jsonl"
+    sessions.write_text("dummy\n", encoding="utf-8")
+
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        n = _next_gen_counter_for_commit("abc1234", sessions_path=sessions)
+    assert n == 1

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1568,18 +1568,32 @@ def test_resolve_gen_tag_honors_env_override(monkeypatch: pytest.MonkeyPatch) ->
     assert _resolve_gen_tag("a1b2c3d") == "seed-generation-gen1"
 
 
-def test_resolve_gen_tag_default_includes_commit(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Unset env falls back to ``autoresearch-<commit>``."""
+def test_resolve_gen_tag_default_includes_commit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unset env falls back to ``autoresearch-<commit>-gen<N>``.
+
+    PR-GEN-COUNTER (2026-05-26) — the resolver now appends a monotonic
+    ``-gen{N}`` counter derived from sessions.jsonl history. With no
+    history, the first emission is ``gen1``."""
+    from autoresearch import train as train_mod
+
     monkeypatch.delenv("AUTORESEARCH_GEN_TAG", raising=False)
-    assert _resolve_gen_tag("a1b2c3d") == "autoresearch-a1b2c3d"
+    monkeypatch.setattr(train_mod, "SESSIONS_INDEX_PATH", tmp_path / "missing.jsonl")
+    assert _resolve_gen_tag("a1b2c3d") == "autoresearch-a1b2c3d-gen1"
 
 
 def test_resolve_gen_tag_treats_whitespace_as_unset(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Whitespace-only env value is treated as unset."""
+    """Whitespace-only env value is treated as unset, so the resolver
+    falls back to ``autoresearch-<commit>-gen<N>`` (post PR-GEN-COUNTER
+    shape, gen1 for fresh history)."""
+    from autoresearch import train as train_mod
+
     monkeypatch.setenv("AUTORESEARCH_GEN_TAG", "   ")
-    assert _resolve_gen_tag("xyz") == "autoresearch-xyz"
+    monkeypatch.setattr(train_mod, "SESSIONS_INDEX_PATH", tmp_path / "missing.jsonl")
+    assert _resolve_gen_tag("xyz") == "autoresearch-xyz-gen1"
 
 
 def test_append_session_index_writes_jsonl_row(


### PR DESCRIPTION
## Summary

- ``_resolve_gen_tag(commit)`` 가 같은 commit 반복 호출 시 동일 gen_tag 를 emit 하던 silent leak fix.
- 신규 helper ``_next_gen_counter_for_commit(commit)`` 가 ``sessions.jsonl`` history 에서 ``-gen{N}`` suffix 찾아 N+1 emit.
- 11 신규 invariant test + 2 stale resolver test 갱신.

## Why

2026-05-26 autoresearch attribution sprint Phase A audit (`.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.6) 의 silent leak:

- pre-PR: `_resolve_gen_tag(commit)` 는 deterministic 하게 `autoresearch-{commit}` 반환
- 같은 commit 에서 반복 audit 호출 시 같은 gen_tag → attribution row 들이 모두 같은 generation 으로 보임
- cross-cycle attribution decomposition 불가

post-PR: `autoresearch-{commit}-gen{N+1}` — sessions.jsonl 의 history 에서 N 을 도출. operator override (`AUTORESEARCH_GEN_TAG` env) 는 그대로 wins. legacy rows (no suffix) 는 gen0 으로 취급.

## Changes

| File | Change |
|------|--------|
| `autoresearch/train.py` | `import re` 추가. 모듈-level `_GEN_SUFFIX_RE = re.compile(r"-gen(\d+)$")` 추가. 신규 `_next_gen_counter_for_commit(commit, sessions_path=None) -> int` helper. `_resolve_gen_tag(commit)` rewritten. 모든 error path (missing file / malformed JSON / non-dict row / OSError / ValueError on huge digit string) 가 graceful fall-through 로 gen1 반환. Concurrency 가 best-effort 임을 docstring 에 명시 (Codex MCP review #2). |
| `tests/autoresearch/test_gen_tag_monotonic.py` | 신규. 11 invariant test: fresh history → gen1, gen1+gen3 → gen4, legacy-only → gen1, legacy mixed with gen → max+1, per-commit isolation, operator env override precedence, real-history end-to-end wiring through `_resolve_gen_tag`, malformed JSON skip, non-dict row skip, OSError fallback. |
| `tests/test_autoresearch_train.py` | 2 stale resolver test 갱신 — `_resolve_gen_tag` 의 default output 이 `autoresearch-{commit}` → `autoresearch-{commit}-gen1` 로 변경됨에 맞춤 (Codex MCP review #1). |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry. |

## Verification

- [x] `geode-ci --fast` ALL GREEN
- [x] `uv run pytest tests/autoresearch/test_gen_tag_monotonic.py tests/test_autoresearch_train.py::test_resolve_gen_tag_*` 14 pass
- [x] Codex MCP review CONDITIONAL_PASS → 3 must-fix 적용 (stale test, concurrency doc, ValueError guard)
- [x] `uv run mypy autoresearch/` clean

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.6
- Memory: [[feedback-sot-revert-on-reject]] (같은 SoT silent leak 카테고리)
- Sibling merged PRs: #1749, #1753, #1757, #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)