### PR TITLE
fix(auth): resolve ChatGPT plan labels from JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ functional change.
 
 ### Fixed
 
+- **PR-FIX-CHATGPT-PLAN-HALLUCINATION** — ChatGPT OAuth plan display now
+  resolves the JWT ``chatgpt_plan_type`` slug into a product label
+  instead of leaking raw slugs or hard-coding Plus. ``chatgpt_plan_label``
+  maps known tiers (Free / Plus / Pro / Pro Lite / Team / Business /
+  Enterprise / Edu), preserves a generic ``ChatGPT subscription`` fallback,
+  and title-cases future unknown slugs. ``/login openai`` now emits
+  ``Plan: ChatGPT Pro Lite`` for ``prolite`` accounts, the ``/login``
+  dashboard renders OpenAI Codex plan bindings with the same label, and
+  the credential-source display no longer formats raw ``ChatGPT prolite``.
+  Generic docs, comments, hub chips, and tests now refer to ChatGPT
+  subscription / Codex subscription paths rather than pretending every
+  OAuth account is Plus. Pinned by
+  ``tests/core/auth/test_chatgpt_plan_label.py``,
+  ``tests/test_login_plan_binding.py``, and
+  ``tests/test_oauth_path_display.py``.
+
 - **PR-GEN-COUNTER** — ``autoresearch.train._resolve_gen_tag`` no
   longer collapses repeated audits at the same git commit into a
   single synthetic ``autoresearch-{commit}`` gen_tag. The 2026-05-26
@@ -19114,4 +19130,3 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 [0.7.0]: https://github.com/mangowhoiscloud/geode/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mangowhoiscloud/geode/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mangowhoiscloud/geode/releases/tag/v0.6.0
-

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -46,7 +46,7 @@ Same three-file structure borrowed from Karpathy autoresearch:
 - **`program.md`** — instructions to the agent. Humans modify this.
 
 The Karpathy 5-min wall-clock budget maps onto the audit budget
-(default ~5 min, capped by ChatGPT Plus quota / Anthropic API spend).
+(default ~5 min, capped by ChatGPT subscription quota / Anthropic API spend).
 The `val_bpb` metric maps onto AlphaEval fitness — a 17-dim weighted
 aggregate (5 critical + 12 auxiliary) plus a derived stability axis
 (1.0 total weight, **higher = better**), with 3 info dims tracked
@@ -64,7 +64,7 @@ without spending budget.
 ## Quick start
 
 Requirements: `uv`, the GEODE `[audit]` extra (`inspect_ai`,
-`inspect_petri`), and either `~/.codex/auth.json` (ChatGPT Plus
+`inspect_petri`), and either `~/.codex/auth.json` (ChatGPT subscription
 OAuth) or `ANTHROPIC_API_KEY`.
 
 ```bash

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -119,7 +119,7 @@ cross-check `input_hallucination_mean` (lower = better) and
 `overrefusal_mean` (lower = better) — neither should regress
 meaningfully even when fitness improves.
 
-**Cost**: Stay within ChatGPT Plus quota / Anthropic API budget. One
+**Cost**: Stay within ChatGPT subscription quota / Anthropic API budget. One
 audit ≈ $0 (OAuth path) or ≈ $5–10 (Anthropic PAYG path).
 
 **Simplicity criterion**: When two runs land the same fitness, the

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -89,6 +89,111 @@ def _plan_type_from_token(token: str) -> str:
     return ""
 
 
+# PR-FIX-CHATGPT-PLAN-HALLUCINATION (2026-05-26) — display-label map for
+# the documented ``chatgpt_plan_type`` JWT claim values. Pre-fix the
+# GEODE codebase had "ChatGPT Plus" hard-coded in ~28 places regardless
+# of the operator's actual tier (verified incident: operator on
+# ``plan_type='prolite'`` saw "ChatGPT Plus" surfaced in CLI / hub
+# chip / docs / audit reports). The mapping below resolves the slug
+# the JWT issuer publishes into the human-readable plan name that
+# OpenAI uses in its own product UI. Unknown slugs round-trip as
+# ``"ChatGPT {Slug}"`` so a newly-launched tier still displays
+# something — instead of perpetuating the "Plus" hallucination.
+_CHATGPT_PLAN_LABELS: dict[str, str] = {
+    "free": "ChatGPT Free",
+    "plus": "ChatGPT Plus",
+    "pro": "ChatGPT Pro",
+    "prolite": "ChatGPT Pro Lite",
+    "team": "ChatGPT Team",
+    "business": "ChatGPT Business",
+    "enterprise": "ChatGPT Enterprise",
+    "edu": "ChatGPT Edu",
+}
+
+
+def chatgpt_plan_label(plan_type: str | None) -> str:
+    """Resolve a ``chatgpt_plan_type`` JWT claim slug to its display label.
+
+    Examples
+    --------
+    >>> chatgpt_plan_label("plus")
+    'ChatGPT Plus'
+    >>> chatgpt_plan_label("prolite")
+    'ChatGPT Pro Lite'
+    >>> chatgpt_plan_label("")
+    'ChatGPT subscription'
+    >>> chatgpt_plan_label("future-tier-2030")
+    'ChatGPT Future-Tier-2030'
+
+    Empty / None slugs surface a generic "ChatGPT subscription" label
+    (e.g. when no OAuth profile is signed-in yet, or build-time site
+    rendering without operator JWT). Unknown slugs title-case the slug
+    so a newly-launched tier still gets a reasonable display string
+    rather than dropping to "Plus".
+    """
+    normalised = (plan_type or "").strip().lower()
+    if not normalised:
+        return "ChatGPT subscription"
+    canonical = _CHATGPT_PLAN_LABELS.get(normalised)
+    if canonical:
+        return canonical
+    # Fallback: title-case the slug. Keep punctuation as-is so future
+    # tiers with hyphens / numbers (e.g. "plus-2030") survive.
+    return f"ChatGPT {normalised.title()}"
+
+
+def resolve_local_chatgpt_plan_label() -> str:
+    """Resolve the operator's *current* ChatGPT plan label from local JWTs.
+
+    Walks the two well-known token sources GEODE reads at runtime:
+
+    1. ``~/.codex/auth.json`` (external Codex CLI token — preferred,
+       this is what production smoke runs typically use).
+    2. GEODE profile store via :func:`reconcile_plan_tier_from_stored_jwt`
+       (in-process Plan registry).
+
+    Returns the human label from :func:`chatgpt_plan_label`. Falls back
+    to the generic "ChatGPT subscription" string when nothing is
+    readable — never raises, never blocks startup / build / CLI render.
+
+    Used by hub builders, login UX, and any other display layer that
+    needs the operator's actual plan name instead of the pre-fix
+    "Plus" hard-code.
+    """
+    # Source 1: external Codex CLI auth file (most common).
+    codex_auth = Path.home() / ".codex" / "auth.json"
+    try:
+        raw = codex_auth.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        token = (
+            payload.get("tokens", {}).get("id_token", "")
+            or payload.get("tokens", {}).get("access_token", "")
+            or ""
+        )
+        slug = _plan_type_from_token(token) if token else ""
+        if slug:
+            return chatgpt_plan_label(slug)
+    except (OSError, json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    # Source 2: GEODE-issued OAuth profile. Container not built
+    # (standalone CLI / pytest) → silently fall through to the generic
+    # label so callers never see an empty string.
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        from core.wiring.container import ensure_profile_store
+
+        store = ensure_profile_store()
+        profile = store.get(f"{_GEODE_OPENAI_PLAN_ID}:user")
+        token = (profile.key if profile else "") or ""
+        slug = _plan_type_from_token(token) if token else ""
+        if slug:
+            return chatgpt_plan_label(slug)
+
+    return chatgpt_plan_label("")
+
+
 def reconcile_plan_tier_from_stored_jwt() -> tuple[str, str] | None:
     """Re-decode the stored OpenAI OAuth JWT and sync ``subscription_tier``.
 
@@ -431,7 +536,7 @@ def login_openai() -> dict[str, Any]:
         provider=_PROVIDER_LABEL,
         account_id=account_id,
         email=email,
-        plan_type=plan_type or "unknown",
+        plan_type=chatgpt_plan_label(plan_type),
         # v0.52.2 — resolve the live SOT path each call (auth.toml since
         # v0.50.2). Pre-fix this displayed the legacy auth.json constant
         # while the actual write landed in auth.toml.

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -285,6 +285,10 @@ def _format_plan_binding(registry: Any, plan_id: str) -> str:
         return f"{plan_id} [muted](unbound)[/muted]"
     kind = plan.kind.value
     tier = getattr(plan, "subscription_tier", None)
+    if getattr(plan, "provider", "") == "openai-codex":
+        from core.auth.oauth_login import chatgpt_plan_label
+
+        tier = chatgpt_plan_label(tier)
     tier_suffix = f"·{tier}" if tier else ""
     display = getattr(plan, "display_name", "") or plan_id
     return f"[bold]{plan_id}[/bold] [muted]({kind}{tier_suffix} · {display})[/muted]"
@@ -321,7 +325,12 @@ def _login_show_status() -> None:
     if plans:
         for plan in plans:
             usage = registry.usage_for(plan.id)
-            tier_label = f" · {plan.subscription_tier}" if plan.subscription_tier else ""
+            subscription_tier = plan.subscription_tier
+            if getattr(plan, "provider", "") == "openai-codex":
+                from core.auth.oauth_login import chatgpt_plan_label
+
+                subscription_tier = chatgpt_plan_label(subscription_tier)
+            tier_label = f" · {subscription_tier}" if subscription_tier else ""
             quota_label = ""
             if plan.quota is not None:
                 remaining = usage.remaining_in_window(plan)
@@ -474,7 +483,7 @@ def _login_add_interactive(_args: str) -> None:
         (
             "subscription",
             "Subscription (GLM Coding Lite/Pro/Max · "
-            "ChatGPT Plus/Pro/Business/Enterprise · "
+            "ChatGPT Plus/Pro/Pro Lite/Team/Business/Enterprise/Edu · "
             "Claude Pro/Max ×5/Max ×20/Team)",
         ),
         ("payg", "Pay-as-you-go API key (Anthropic, OpenAI, GLM PAYG)"),
@@ -708,8 +717,9 @@ def _format_credential_source_label(provider: str, source: str) -> str:
             return "ChatGPT subscription (audit extra not installed)"
         if meta is None:
             return "(no Codex auth.json detected)"
-        plan = meta.get("plan_type") or "unknown plan"
-        return f"ChatGPT {plan}"
+        from core.auth.oauth_login import chatgpt_plan_label
+
+        return chatgpt_plan_label(meta.get("plan_type"))
     return source
 
 

--- a/core/orchestration/openai_api_lane.py
+++ b/core/orchestration/openai_api_lane.py
@@ -1,6 +1,6 @@
 """Module-level Lane for OpenAI API call concurrency (codex-oauth + payg).
 
-PR-OAUTH-API-LANES (2026-05-26) — covers ``openai-codex`` (ChatGPT Plus
+PR-OAUTH-API-LANES (2026-05-26) — covers ``openai-codex`` (ChatGPT
 subscription via Codex Responses API) and ``openai-payg`` (OpenAI
 API key). Both share the same per-account rate-limit bucket on
 OpenAI's server side; a single shared lane prevents a burst of
@@ -20,7 +20,7 @@ Why ``max_concurrent=4``
 
 Mid-range default selected from three reference points:
 
-1. **OpenAI Codex Responses API**: ChatGPT Plus subscription bucket
+1. **OpenAI Codex Responses API**: ChatGPT subscription bucket
    is documented to support ~500 RPM aggregate across all models
    (per the public Codex CLI roll-out post-2025-Q4). gpt-5.x voter
    calls average ~10s wallclock; 4 inflight × 10s = 0.4s/call

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -259,7 +259,7 @@
   },
   {
     "name": "manage_login",
-    "description": "Unified credentials/plans command — Plans + API keys + OAuth + routing in one tool. Use whenever the user says login/logout, sets up a subscription (GLM Coding Lite/Pro/Max, ChatGPT Plus/Pro/Business/Enterprise, Claude Pro/Max ×5/Max ×20/Team), changes credentials, asks about quota, switches active plan, or pastes an API key with intent. Mirrors the /login slash command (see `core.cli.commands.cmd_login`).",
+    "description": "Unified credentials/plans command — Plans + API keys + OAuth + routing in one tool. Use whenever the user says login/logout, sets up a subscription (GLM Coding Lite/Pro/Max, ChatGPT Plus/Pro/Pro Lite/Team/Business/Enterprise/Edu, Claude Pro/Max ×5/Max ×20/Team), changes credentials, asks about quota, switches active plan, or pastes an API key with intent. Mirrors the /login slash command (see `core.cli.commands.cmd_login`).",
     "category": "model",
     "cost_tier": "cheap",
     "input_schema": {

--- a/docs/architecture/autoresearch.md
+++ b/docs/architecture/autoresearch.md
@@ -235,7 +235,7 @@ ratchet 의 input 이 되는 경로:
 |---|---|
 | mutation 이 GEODE syntax 깨뜨림 | wrapper override JSON 의 schema 단순 (str→str dict). syntax break X. env 가 잘못되면 `core/agent/system_prompt.py` load 가 fail-closed 하므로 fitness 가 기본 wrapper 로 조용히 오염되지 않음. |
 | Generation drift (cumulative bias) | per-generation `results.tsv` + cross-axis ratchet (§5) + critical axis strict gate. |
-| Long-running loop 의 cost 폭주 | per-audit budget 5분 + self-improving-loop agent 의 timeout (program.md). ChatGPT Plus / Claude Max OAuth path = $0 per-token. |
+| Long-running loop 의 cost 폭주 | per-audit budget 5분 + self-improving-loop agent 의 timeout (program.md). ChatGPT subscription / Claude Max OAuth path = $0 per-token. |
 | Goodhart's law (rubric self-mutation) | AlphaEval rubric (`plugins/petri_audit/judge_dims/geode_judge_subset.yaml`) 는 program.md 의 CANNOT 항. seed pool (`plugins/petri_audit/seeds_safe10/`) 도 mutation 불가. |
 | 자기참조 loop (autoresearch 가 autoresearch 를 mutate) | mutation target 이 `WRAPPER_PROMPT_SECTIONS` dict 1 곳 — `autoresearch/` 디렉터리 자체 mutate 불가능 (program.md 의 in-scope file 4 개 외 X). |
 | Rejected hypothesis 의 information loss | `results.tsv` 의 discard row 가 다음 hypothesis 의 부정적 prior. agent context 에 결과 누적. |

--- a/docs/architecture/seed-generation-ui-decision.md
+++ b/docs/architecture/seed-generation-ui-decision.md
@@ -8,7 +8,7 @@
 GEODE 의 4 auth path:
 
 - **A**: local `claude` CLI (Claude subscription via macOS keychain) — `claude_code_provider`
-- **B**: local `codex` CLI (ChatGPT Plus OAuth, device-code) — `codex_provider`
+- **B**: local `codex` CLI (ChatGPT OAuth, device-code) — `codex_provider`
 - **C**: OpenAI PAYG (sk-…) — `openai-payg`
 - **D**: Anthropic PAYG (sk-ant-…) — `anthropic-payg-geode`
 
@@ -126,7 +126,7 @@ Source value 는 Petri 의 `[petri.source.<family>].allowed` 와 1:1 (anthropic 
 - **OpenAI `text-embedding-3-small`** ($0.02 / 1M tok), 1536-dim.
 - 다른 provider (Voyage, Cohere) 후순위 — 본 ADR 의 결정은 OpenAI 단일.
 - routing.toml 의 `[embedding]` section 으로 user override 가능 (별도 sub-PR 의 enhancement).
-- credential — OpenAI PAYG (sk-…) 만 사용. ChatGPT Plus OAuth 는 embeddings API 미지원.
+- credential — OpenAI PAYG (sk-…) 만 사용. ChatGPT OAuth 는 embeddings API 미지원.
 
 ### 2. 7-role × 4-path picker (TUI)
 
@@ -177,7 +177,7 @@ Production chat 은 sk-ant-PAYG 만 사용.
 활성화하시겠습니까? [y/N]:
 ```
 
-ChatGPT Plus subscription (B path) 도 동등 notice.
+ChatGPT subscription (B path) 도 동등 notice.
 
 ### 4. Cost preview (`geode audit-seeds quota`)
 

--- a/docs/architecture/self-improving-loop-resume-decision.md
+++ b/docs/architecture/self-improving-loop-resume-decision.md
@@ -1,7 +1,7 @@
 # ADR — Outer-Loop Checkpoint + Resume on Credential Rollout
 
 > **Status**: Accepted (2026-05-19)
-> **Scope**: GEODE self-improving-loop (autoresearch + seed-generation). When a subscription credential (Claude Code OAuth, ChatGPT Plus OAuth) hits its quota mid-run, the operator must be able to swap accounts and **resume from the last completed unit of work** without re-spending budget on already-finished generations / candidates / matches.
+> **Scope**: GEODE self-improving-loop (autoresearch + seed-generation). When a subscription credential (Claude Code OAuth, ChatGPT OAuth) hits its quota mid-run, the operator must be able to swap accounts and **resume from the last completed unit of work** without re-spending budget on already-finished generations / candidates / matches.
 
 ## Context
 

--- a/docs/design/self-improving-autoresearch-visual-spec.md
+++ b/docs/design/self-improving-autoresearch-visual-spec.md
@@ -452,7 +452,7 @@ Per master DESIGN.md §3, each of `auditor_model` / `target_model` / `judge_mode
 ```html
 <dl class="status-grid">
   <dt>auditor</dt>
-  <dd><span class="chip codex">Codex Plus</span> <code>codex/gpt-5-codex-high</code></dd>
+  <dd><span class="chip codex">Codex</span> <code>codex/gpt-5-codex-high</code></dd>
   <dt>target</dt>
   <dd><span class="chip claude">Claude Code</span> <code>claude-cli/claude-opus-4-7</code></dd>
   <dt>judge</dt>

--- a/docs/design/self-improving-hub-system.md
+++ b/docs/design/self-improving-hub-system.md
@@ -65,7 +65,7 @@ Visitors range from operators (daily status check) to external readers (PR demo)
 |---|---|---|
 | `.chip.payg` | `#f1f3f5` / `#4a5260` | `anthropic/` or `openai/` prefix — PAYG API billing |
 | `.chip.claude` | `#efe7fb` / `#5a2ca0` | `claude-cli/` prefix — Claude Code Max OAuth |
-| `.chip.codex` | `#d1e7dd` / `#0a3622` | `codex/` or `openai-codex/` prefix — ChatGPT Plus OAuth |
+| `.chip.codex` | `#d1e7dd` / `#0a3622` | `codex/` or `openai-codex/` prefix — ChatGPT OAuth |
 | `.chip.geode` | `#cfe2ff` / `#052c65` | `geode/` prefix — self-target wrapper |
 
 ### Surface Buckets (3 only)
@@ -306,7 +306,7 @@ When citing data that may change, anchor to source with version:
 | Mutation row schema | W4 | `core/self_improving_loop/runner.py:81` ApplyRecord |
 | Fitness axes count | 4 (dim / ux / admire / bench) | ADR-012 §Decision.2 amendment |
 | Hub surface count | 3 (petri / seedgen / autoresearch) | This DESIGN.md |
-| Harness chip count | 4 (PAYG / Claude Code / Codex Plus / GEODE) | This DESIGN.md §3 |
+| Harness chip count | 4 (PAYG / Claude Code / Codex / GEODE) | This DESIGN.md §3 |
 
 If any of these change, the master DESIGN.md schema_version bumps + every sibling per-page doc that cites it must re-stamp `last_updated`.
 

--- a/docs/design/self-improving-hub-visual-spec.md
+++ b/docs/design/self-improving-hub-visual-spec.md
@@ -483,7 +483,7 @@ Indent = `padding-left: 24px;` (`1.5rem`). The prefix glyph is U+2514 `└` foll
 |---|---|---|
 | `.chip.payg`   | `PAYG`        | `anthropic/…`, `openai/…` (raw provider API key billing) |
 | `.chip.claude` | `Claude Code` | `claude-cli/…` (Claude Code Max OAuth) |
-| `.chip.codex`  | `Codex Plus`  | `codex/…`, `openai-codex/…` (ChatGPT Plus OAuth) |
+| `.chip.codex`  | `Codex`  | `codex/…`, `openai-codex/…` (ChatGPT OAuth) |
 | `.chip.geode`  | `GEODE`       | `geode/…` (self-target wrapper) |
 
 Frontend agent does **not** localize chip text. Always English. Always exactly as above.
@@ -622,7 +622,7 @@ The middle dot is U+00B7 (`·`), surrounded by single spaces.
   <p>Harness chip legend:
     <span class="chip payg">PAYG</span>API key billing ·
     <span class="chip claude">Claude Code</span>Max OAuth ·
-    <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth ·
+    <span class="chip codex">Codex</span>ChatGPT OAuth ·
     <span class="chip geode">GEODE</span>self-target wrapper.
   </p>
   <p>Repo: <a href="https://github.com/mangowhoiscloud/geode"><code>github.com/mangowhoiscloud/geode</code></a></p>
@@ -656,7 +656,7 @@ If any placeholder cannot be resolved at build time → CI fails. **No silent de
 
 ### 8.4 Anchor invariant
 
-The legend paragraph must contain all four chips in the exact order `PAYG · Claude Code · Codex Plus
+The legend paragraph must contain all four chips in the exact order `PAYG · Claude Code · Codex
 · GEODE`. This order is fixed so visitors building muscle memory across pages always see chips in
 the same slot. Per-page DESIGN.md `verification_checklist` test asserts this order via regex.
 

--- a/docs/design/self-improving-hub.md
+++ b/docs/design/self-improving-hub.md
@@ -147,7 +147,7 @@ GEODE
 ```
 Source: docs/self-improving/ (mirrors docs/petri-bundle/ post-relocation).
 Built by .github/workflows/pages.yml on every main push.
-Harness chip legend: PAYG · Claude Code · Codex Plus · GEODE.
+Harness chip legend: PAYG · Claude Code · Codex · GEODE.
 Repo: github.com/mangowhoiscloud/geode
 ```
 

--- a/docs/design/self-improving-seed-generation-conversations.md
+++ b/docs/design/self-improving-seed-generation-conversations.md
@@ -44,7 +44,7 @@ All three files ship in the bundle via `bundle_sync._sync_subagents`
 |--------|--------|
 | `task_id` | dir name; links to `/agent/<task_id>/` |
 | `phase` | `session.json:metadata.phase` (fallback: task_id prefix) |
-| `model` | harness chip (Claude Code / Codex Plus / PAYG / GEODE) + raw model code |
+| `model` | harness chip (Claude Code / Codex / PAYG / GEODE) + raw model code |
 | `turns` | count of `user_message` + `assistant_message` events |
 | `cost` | `Σ session_end.total_cost` |
 | `duration` | `Σ session_end.duration_s` |

--- a/docs/design/self-improving-seed-generation-visual-spec.md
+++ b/docs/design/self-improving-seed-generation-visual-spec.md
@@ -390,7 +390,7 @@ When a future run records per-phase mutator overrides (`state.json.mutator_by_ph
 <div class="mutator-banner mutator-banner--split">
   <span class="label">Mutator</span>
   <span class="role-label">gen</span> <span class="chip claude">Claude Code</span> <code>claude-cli/claude-opus-4-7</code>
-  <span class="role-label">critic</span> <span class="chip codex">Codex Plus</span> <code>codex/gpt-5.5</code>
+  <span class="role-label">critic</span> <span class="chip codex">Codex</span> <code>codex/gpt-5.5</code>
   <!-- one inline group per phase override -->
 </div>
 ```
@@ -1226,7 +1226,7 @@ Frontend agent self-verifies before PR:
 ### 17.3 Both pages
 
 - [ ] Page weighs < 80 KB gzipped (index typically ~10 KB, per-run ~30 KB; the 80 KB ceiling absorbs the heatmap)
-- [ ] All chips present + use locked vocabulary (`PAYG` / `Claude Code` / `Codex Plus` / `GEODE`)
+- [ ] All chips present + use locked vocabulary (`PAYG` / `Claude Code` / `Codex` / `GEODE`)
 - [ ] Same sidebar HTML structure as hub (only `.active` location changes)
 - [ ] HTML validates (W3C); CSS validates (no parse errors)
 - [ ] Lighthouse a11y score ≥ 95

--- a/docs/plans/2026-05-22-self-improving-roadmap.md
+++ b/docs/plans/2026-05-22-self-improving-roadmap.md
@@ -89,7 +89,7 @@ OL-A1 의 cron-fired runner 는 기존 mutator entry-point 의 `_default_llm_cal
 | `api_key` (default) | `call_with_failover` → `resolve_agentic_adapter(provider)` — `_ADAPTER_MAP` 의 4 entry (anthropic / openai / glm / openai-codex) | Anthropic PAYG (ANTHROPIC_API_KEY) / OpenAI PAYG (OPENAI_API_KEY) / GLM PAYG / **OpenAI subscription via OAuth** (`~/.codex/auth.json` — `CodexAgenticAdapter` 가 HTTP 로 chatgpt.com/backend-api/codex 호출) | API key env var 또는 OAuth token file 존재 |
 | `auto` | 동상 (model id 로 `infer_provider_from_model` 자동 매핑) | 동상 | 동상 |
 | `claude-cli` | `cli_subprocess.invoke_claude_cli` — `claude --print --output-format text --append-system-prompt <SYS> <USER>` subprocess | Claude Code Max **subscription** (CLI 의 OAuth) | (a) `claude` binary on `$PATH` (b) Claude Code CLI 가 로그인 상태 (c) TTY-less 환경에서 `--print` 모드 작동 (subprocess.run 의 `stdin=` 기본 안전) |
-| `openai-codex` (subprocess form) | `cli_subprocess.invoke_codex_cli` — `codex exec --skip-git-repo-check <combined>` subprocess | ChatGPT Plus/Pro **subscription** (CLI 의 OAuth) | (a) `codex` binary on `$PATH` (b) Codex CLI 가 로그인 상태 (c) `--skip-git-repo-check` flag 로 worktree 외부 실행 허용 |
+| `openai-codex` (subprocess form) | `cli_subprocess.invoke_codex_cli` — `codex exec --skip-git-repo-check <combined>` subprocess | ChatGPT Plus/Pro/Pro Lite/Team/Business/Enterprise **subscription** (CLI 의 OAuth) | (a) `codex` binary on `$PATH` (b) Codex CLI 가 로그인 상태 (c) `--skip-git-repo-check` flag 로 worktree 외부 실행 허용 |
 
 **Cron 환경의 검증 포인트 (OL-A1 구현 시 필수 테스트)**
 

--- a/docs/self-improving/autoresearch/baseline.html.template
+++ b/docs/self-improving/autoresearch/baseline.html.template
@@ -79,7 +79,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/baseline/index.html
+++ b/docs/self-improving/autoresearch/baseline/index.html
@@ -274,11 +274,11 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 14:35.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/index.html
+++ b/docs/self-improving/autoresearch/index.html
@@ -79,9 +79,9 @@
       <dt>auditor model</dt><dd><span class="chip claude">Claude Code</span> <code>claude-cli/claude-opus-4-7</code></dd>
       <dt>target model</dt><dd><span class="chip geode">GEODE</span> <code>geode/gpt-5.5</code></dd>
       <dt>judge model</dt><dd><span class="chip claude">Claude Code</span> <code>claude-cli/claude-sonnet-4-6</code></dd>
-      <dt>mutations.jsonl</dt><dd>3 rows &middot; <span class='muted'>2026-05-26 02:46</span></dd>
+      <dt>mutations.jsonl</dt><dd>3 rows &middot; <span class='muted'>2026-05-26 12:31</span></dd>
       <dt>results.tsv</dt><dd>3 rows &middot; <span class='muted'>—</span></dd>
-      <dt>policies/</dt><dd>4 files &middot; <span class='muted'>2026-05-26 02:46</span></dd>
+      <dt>policies/</dt><dd>4 files &middot; <span class='muted'>2026-05-26 12:31</span></dd>
       <dt>source</dt><dd><code>baseline.json</code></dd>
     </dl>
 
@@ -135,13 +135,13 @@
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>1 (current promoted) &middot; <span class='muted'>archive: 3 rows</span></td>
-          <td class="muted">2026-05-26 02:45</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/baseline/">open &rarr;</a></td>
         </tr>
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>3 rows</td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/mutations/">open &rarr;</a></td>
         </tr>
         <tr>
@@ -153,7 +153,7 @@
         <tr>
           <td class="id"><a href="/geode/self-improving/autoresearch/policies/">Policies</a> <span class="bucket autoresearch">autoresearch</span></td>
           <td>4 files</td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="id"><a href="/geode/self-improving/autoresearch/policies/">open &rarr;</a></td>
         </tr>
       </tbody>
@@ -166,11 +166,11 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 14:35.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/index.html.template
+++ b/docs/self-improving/autoresearch/index.html.template
@@ -113,7 +113,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/mutations.html.template
+++ b/docs/self-improving/autoresearch/mutations.html.template
@@ -103,7 +103,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/mutations/index.html
+++ b/docs/self-improving/autoresearch/mutations/index.html
@@ -130,11 +130,11 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 14:35.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/policies.html.template
+++ b/docs/self-improving/autoresearch/policies.html.template
@@ -91,7 +91,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/policies/index.html
+++ b/docs/self-improving/autoresearch/policies/index.html
@@ -83,7 +83,7 @@
       <tbody>
         <tr>
           <td class="id"><code>decomposition.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="num">86 B</td>
           <td><span class="muted">—</span></td>
           <td><details>
@@ -95,7 +95,7 @@
         </tr>
         <tr>
           <td class="id"><code>retrieval.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="num">62 B</td>
           <td><span class="muted">—</span></td>
           <td><details>
@@ -108,7 +108,7 @@
         </tr>
         <tr>
           <td class="id"><code>tool-policy.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="num">125 B</td>
           <td><code>gen-2</code> <span class="muted">@ 2026-05-25 14:30</span></td>
           <td><details>
@@ -121,7 +121,7 @@
         </tr>
         <tr>
           <td class="id"><code>wrapper-sections.json</code> <span class="bucket autoresearch">autoresearch</span></td>
-          <td class="muted">2026-05-26 02:46</td>
+          <td class="muted">2026-05-26 12:31</td>
           <td class="num">172 B</td>
           <td><code>gen-3</code> <span class="muted">@ 2026-05-26 04:30</span></td>
           <td><details>
@@ -142,11 +142,11 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 14:35.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/autoresearch/results.html.template
+++ b/docs/self-improving/autoresearch/results.html.template
@@ -95,7 +95,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/results/index.html
+++ b/docs/self-improving/autoresearch/results/index.html
@@ -200,11 +200,11 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.65</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 03:28.
+        Rendered against GEODE <code>v0.99.71</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-26 14:35.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/index.html
+++ b/docs/self-improving/index.html
@@ -67,7 +67,7 @@
 
   <main class="content">
     <h1 class="page-title">GEODE Self-Improving Hub</h1>
-    <p class="page-sub">Anthropic Petri (inspect_ai) audit, self-improving-loop seed-generation, and autoresearch closed-loop. Three surfaces, one publish bundle. Each row shows the model used and the billing harness (PAYG = API key, Claude Code = Max OAuth, Codex Plus = ChatGPT Plus OAuth, GEODE = self-target wrapper).</p>
+    <p class="page-sub">Anthropic Petri (inspect_ai) audit, self-improving-loop seed-generation, and autoresearch closed-loop. Three surfaces, one publish bundle. Each row shows the model used and the billing harness (PAYG = API key, Claude Code = Max OAuth, Codex = ChatGPT OAuth, GEODE = self-target wrapper).</p>
 
     <div class="warning" role="status">Autoresearch baseline is stale &mdash; rendering from <code>baseline.json.outdated-20260522</code>. No live <code>baseline.json</code> present in <code>autoresearch/state/</code>.</div>
 
@@ -250,7 +250,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/index.html.template
+++ b/docs/self-improving/index.html.template
@@ -65,7 +65,7 @@
 
   <main class="content">
     <h1 class="page-title">GEODE Self-Improving Hub</h1>
-    <p class="page-sub">Anthropic Petri (inspect_ai) audit, self-improving-loop seed-generation, and autoresearch closed-loop. Three surfaces, one publish bundle. Each row shows the model used and the billing harness (PAYG = API key, Claude Code = Max OAuth, Codex Plus = ChatGPT Plus OAuth, GEODE = self-target wrapper).</p>
+    <p class="page-sub">Anthropic Petri (inspect_ai) audit, self-improving-loop seed-generation, and autoresearch closed-loop. Three surfaces, one publish bundle. Each row shows the model used and the billing harness (PAYG = API key, Claude Code = Max OAuth, Codex = ChatGPT OAuth, GEODE = self-target wrapper).</p>
 
 {{ stale_baseline_warning }}
 
@@ -135,7 +135,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/seed-generation/gen1-redundant_tool_invocation/index.html
+++ b/docs/self-improving/seed-generation/gen1-redundant_tool_invocation/index.html
@@ -291,7 +291,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/seed-generation/index.html
+++ b/docs/self-improving/seed-generation/index.html
@@ -136,7 +136,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/seed-generation/index.html.template
+++ b/docs/self-improving/seed-generation/index.html.template
@@ -125,7 +125,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/self-improving/seed-generation/run.html.template
+++ b/docs/self-improving/seed-generation/run.html.template
@@ -174,7 +174,7 @@
       <p>Harness chip legend:
         <span class="chip payg">PAYG</span>API key billing &middot;
         <span class="chip claude">Claude Code</span>Max OAuth &middot;
-        <span class="chip codex">Codex Plus</span>ChatGPT Plus OAuth &middot;
+        <span class="chip codex">Codex</span>ChatGPT OAuth &middot;
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">

--- a/docs/visualizations/autoresearch-comparison.md
+++ b/docs/visualizations/autoresearch-comparison.md
@@ -28,7 +28,7 @@
 |---|---|---|---|
 | **Domain** | GPT pre-training | LLM alignment auditing | GEODE's stated research goal is improving its own agent harness, not training a GPT |
 | **Mutation target** | model architecture / hyperparams / optimizer (Muon + AdamW) inside `train.py` | `WRAPPER_PROMPT_SECTIONS` dict + audit-runner hyperparameters (`BUDGET_MINUTES`, `TARGET_MODEL`, `JUDGE_MODEL`, `USE_OAUTH`, `SEED_LIMIT`, …) | wrapper-prompt sections are the only thing that can change agent behaviour without re-training the LLM |
-| **Workload** | one full GPT training run on a single GPU | one `geode audit` subprocess invocation (~5 min wall-clock) consuming ChatGPT Plus / Anthropic quota | matches GEODE's deployment reality |
+| **Workload** | one full GPT training run on a single GPU | one `geode audit` subprocess invocation (~5 min wall-clock) consuming ChatGPT subscription / Anthropic quota | matches GEODE's deployment reality |
 | **Metric** | `val_bpb` (validation bits-per-byte, lower better, vocab-size-independent) | AlphaEval fitness scalar — 17-dim weighted aggregate + stability axis, higher better | val_bpb is irrelevant for an agent harness; AlphaEval rubric is the agent-safety SoT |
 | **Optimiser** | Muon + AdamW gradient descent | none — it's a discrete prompt-mutation loop, not differentiable | wrapper-prompt sections are text, not weights |
 | **Promote signal** | val_bpb decreased | `decide_promote` rule: `raw_fitness_gain > max(prior_stderr, 0.05)` + every critical dim within `baseline_stderr + critical_margin` | statistical significance threshold under judge-LLM noise |

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -196,7 +196,7 @@ queries_per_run = 3
 
 [seed_generation.judge_panel]
 # Default voter mix: 2 reviewers on OpenAI gpt-5.5 via openai-codex
-# (ChatGPT Plus subscription / Codex Responses API) + 1 reviewer on
+# (ChatGPT subscription / Codex Responses API) + 1 reviewer on
 # Anthropic claude-opus-4-7 via claude-cli (Claude Code Max
 # subscription, top tier per PR-UPGRADE-ROLES-TOP-TIER 2026-05-26).
 # Both diversity gates are satisfied:

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -141,8 +141,8 @@ HARNESS_MAP: dict[str, tuple[str, str]] = {
     "anthropic": ("payg", "PAYG"),
     "openai": ("payg", "PAYG"),
     "claude-cli": ("claude", "Claude Code"),
-    "codex": ("codex", "Codex Plus"),
-    "openai-codex": ("codex", "Codex Plus"),
+    "codex": ("codex", "Codex"),
+    "openai-codex": ("codex", "Codex"),
     "geode": ("geode", "GEODE"),
 }
 

--- a/tests/core/auth/test_chatgpt_plan_label.py
+++ b/tests/core/auth/test_chatgpt_plan_label.py
@@ -1,0 +1,192 @@
+"""PR-FIX-CHATGPT-PLAN-HALLUCINATION (2026-05-26) — chatgpt_plan_label invariants.
+
+Pre-fix the GEODE codebase had "ChatGPT Plus" hard-coded in ~28 places
+regardless of the operator's actual subscription tier. Verified
+incident: operator on JWT claim ``chatgpt_plan_type='prolite'`` (the
+Pro Lite tier) saw "ChatGPT Plus" surfaced in CLI / hub chip / docs /
+audit reports. This file pins the dynamic-resolution behaviour so a
+future drift can't re-hardcode a single tier.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from core.auth.oauth_login import (
+    _decode_jwt_claims,
+    _plan_type_from_token,
+    chatgpt_plan_label,
+    resolve_local_chatgpt_plan_label,
+)
+
+
+class TestChatgptPlanLabel:
+    """Slug → display label resolver — covers documented + future tiers."""
+
+    @pytest.mark.parametrize(
+        "slug,expected",
+        [
+            ("free", "ChatGPT Free"),
+            ("plus", "ChatGPT Plus"),
+            ("pro", "ChatGPT Pro"),
+            ("prolite", "ChatGPT Pro Lite"),
+            ("team", "ChatGPT Team"),
+            ("business", "ChatGPT Business"),
+            ("enterprise", "ChatGPT Enterprise"),
+            ("edu", "ChatGPT Edu"),
+        ],
+    )
+    def test_known_slugs(self, slug: str, expected: str) -> None:
+        assert chatgpt_plan_label(slug) == expected
+
+    def test_empty_slug_returns_generic_label(self) -> None:
+        """No JWT signed in / build-time site render → generic label, never empty."""
+        assert chatgpt_plan_label("") == "ChatGPT subscription"
+
+    def test_unknown_slug_title_cases_and_prefixes(self) -> None:
+        """Future-launched tier → ``ChatGPT {Title-Case}`` so display still works."""
+        assert chatgpt_plan_label("future-tier-2030") == "ChatGPT Future-Tier-2030"
+
+    def test_case_insensitive_slug_lookup(self) -> None:
+        """JWT issuer occasionally serves variants — case folds at the boundary."""
+        assert chatgpt_plan_label("PLUS") == "ChatGPT Plus"
+        assert chatgpt_plan_label("ProLite") == "ChatGPT Pro Lite"
+
+    def test_whitespace_slug_treated_as_empty(self) -> None:
+        """Defensive — JWT claim might be whitespace-only on partial decode."""
+        assert chatgpt_plan_label("   ") == "ChatGPT subscription"
+
+    def test_none_safe(self) -> None:
+        """Callers passing ``None`` (e.g. typed as ``str | None`` upstream)
+        must not crash."""
+        assert chatgpt_plan_label(None) == "ChatGPT subscription"
+
+
+class TestPlanTypeFromToken:
+    """JWT-extraction edge cases. The decode helper itself is tested via
+    ``_decode_jwt_claims``; this wraps the slug-extract step."""
+
+    def test_empty_token(self) -> None:
+        assert _plan_type_from_token("") == ""
+
+    def test_malformed_token_returns_empty(self) -> None:
+        """Malformed JWT (not three dot-separated segments) returns empty
+        slug — defensive so the caller's :func:`chatgpt_plan_label` falls
+        through to ``"ChatGPT subscription"``."""
+        assert _plan_type_from_token("not-a-real-jwt") == ""
+
+    def test_jwt_without_openai_auth_claim(self) -> None:
+        """Token decoded but missing the ``https://api.openai.com/auth``
+        nested claim → empty slug."""
+        # Build a minimal JWT-shaped string with a payload that has NO
+        # openai.com/auth claim.
+        import base64
+
+        payload = {"sub": "user-123"}
+        encoded_payload = (
+            base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        )
+        fake_token = f"header.{encoded_payload}.signature"
+        assert _plan_type_from_token(fake_token) == ""
+
+    def test_jwt_with_plan_type_extracted(self) -> None:
+        """Round-trip: build a JWT-shaped string with ``chatgpt_plan_type``
+        in the OpenAI auth claim → extract returns the slug."""
+        import base64
+
+        payload = {
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "prolite",
+            }
+        }
+        encoded_payload = (
+            base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        )
+        fake_token = f"header.{encoded_payload}.signature"
+        assert _plan_type_from_token(fake_token) == "prolite"
+
+
+class TestDecodeJwtClaims:
+    """JWT payload decoder — base64url padding edge cases."""
+
+    def test_unpadded_payload(self) -> None:
+        """JWT payloads omit trailing ``=`` — decoder must re-pad."""
+        import base64
+
+        payload = {"foo": "bar"}
+        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        # Force unpadded (rstrip already did, but assert no padding remains)
+        assert "=" not in raw
+        token = f"hdr.{raw}.sig"
+        assert _decode_jwt_claims(token) == payload
+
+    def test_empty_token_returns_empty_dict(self) -> None:
+        assert _decode_jwt_claims("") == {}
+
+    def test_single_segment_token(self) -> None:
+        assert _decode_jwt_claims("only-one-segment") == {}
+
+
+class TestResolveLocalLabel:
+    """Live resolution from disk — covers both Codex CLI auth.json and
+    GEODE profile store paths. Uses monkeypatch + tmp_path to keep the
+    test deterministic (operator's actual JWT remains untouched)."""
+
+    def test_falls_back_to_generic_when_no_token_anywhere(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No codex auth file + no GEODE profile → generic label."""
+        # Re-route HOME so the real ~/.codex/auth.json isn't read
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Hard-fail the profile store import so source-2 falls through
+        import core.wiring.container
+
+        monkeypatch.setattr(
+            core.wiring.container,
+            "ensure_profile_store",
+            lambda: (_ for _ in ()).throw(RuntimeError("test: container disabled")),
+        )
+        assert resolve_local_chatgpt_plan_label() == "ChatGPT subscription"
+
+    def test_reads_codex_cli_auth_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Synthetic codex auth.json with prolite plan → resolved label."""
+        import base64
+
+        payload = {
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "prolite",
+            }
+        }
+        encoded = (
+            base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        )
+        fake_token = f"hdr.{encoded}.sig"
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text(
+            json.dumps({"tokens": {"id_token": fake_token}}), encoding="utf-8"
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert resolve_local_chatgpt_plan_label() == "ChatGPT Pro Lite"
+
+    def test_malformed_codex_auth_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Malformed auth.json must not crash, must fall through to source-2
+        (and from there to generic when container is disabled)."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("not json at all", encoding="utf-8")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import core.wiring.container
+
+        monkeypatch.setattr(
+            core.wiring.container,
+            "ensure_profile_store",
+            lambda: (_ for _ in ()).throw(RuntimeError("test: container disabled")),
+        )
+        assert resolve_local_chatgpt_plan_label() == "ChatGPT subscription"

--- a/tests/test_agentic_response.py
+++ b/tests/test_agentic_response.py
@@ -255,7 +255,7 @@ class TestNormalizeOpenAIResponses:
         result = normalize_openai_responses(resp)
         assert result.content == []
         # v0.53.3 — empty output no longer drops usage; usage is preserved
-        # as zeros even when output is empty (the Codex Plus
+        # as zeros even when output is empty (the Codex
         # ``Completed.output``-omitted edge case).
         assert result.usage.input_tokens == 0
         assert result.usage.output_tokens == 0

--- a/tests/test_codex_multiturn_reasoning.py
+++ b/tests/test_codex_multiturn_reasoning.py
@@ -1,4 +1,4 @@
-"""R1 — Codex Plus multi-turn encrypted reasoning round-trip invariants.
+"""R1 — Codex multi-turn encrypted reasoning round-trip invariants.
 
 Pinned 2026-04-28 against the 3-codebase consensus pattern (Hermes
 ``agent/codex_responses_adapter.py:228-246, 720-738`` + OpenClaw

--- a/tests/test_codex_responses_shape.py
+++ b/tests/test_codex_responses_shape.py
@@ -132,7 +132,7 @@ def _capture_codex_kwargs(
 
 def test_tools_are_forwarded_to_codex(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pre-fix bug: tools list was silently dropped — function calling broken
-    on Codex Plus. Post-fix: must appear in stream() kwargs in Responses API
+    on Codex. Post-fix: must appear in stream() kwargs in Responses API
     flat-tool format ({type, name, description, parameters})."""
     tools = [
         {

--- a/tests/test_config_effort_knob.py
+++ b/tests/test_config_effort_knob.py
@@ -6,7 +6,7 @@ Verifies:
   2. ``_apply_model`` from the picker persists effort + model to
      ``.geode/config.toml`` (durable layer), not just ``.env``.
   3. PAYG ``openai.py`` adapter sends ``store=False`` (parity with
-     Codex Plus, R3-mini follow-up).
+     Codex, R3-mini follow-up).
 """
 
 from __future__ import annotations
@@ -104,7 +104,7 @@ class TestPickerPersistence:
 class TestPaygStoreFalse:
     def test_store_false_in_openai_kwargs(self) -> None:
         """Source-pin: the PAYG adapter must send ``store=False`` so it
-        matches Codex Plus and avoids server-side response retention."""
+        matches Codex and avoids server-side response retention."""
         from core.llm.providers import openai as openai_mod
 
         src = inspect.getsource(openai_mod)
@@ -112,7 +112,7 @@ class TestPaygStoreFalse:
 
     def test_codex_plus_still_uses_store_false(self) -> None:
         """Regression guard — extracting the shared replay walker
-        in v0.60.0 must not have dropped Codex Plus's store=False."""
+        in v0.60.0 must not have dropped Codex.s store=False."""
         from core.llm.providers import codex as codex_mod
 
         src = inspect.getsource(codex_mod)

--- a/tests/test_credential_breadcrumb_cross_provider.py
+++ b/tests/test_credential_breadcrumb_cross_provider.py
@@ -2,7 +2,7 @@
 
 The v0.52.1 incident: GLM was exhausted (1113 Insufficient balance) but
 the LLM only saw rejection details for GLM profiles. The user had
-already registered Codex Plus OAuth and an Anthropic API key, but the
+already registered Codex OAuth and an Anthropic API key, but the
 breadcrumb did not mention them, so the model could not suggest
 ``/model gpt-5.4-mini`` as recovery.
 

--- a/tests/test_d1_provider_closure.py
+++ b/tests/test_d1_provider_closure.py
@@ -59,7 +59,7 @@ def test_petri_role_source_accepts_claude_cli() -> None:
 
 
 def test_petri_role_source_accepts_openai_codex() -> None:
-    """``source = "openai-codex"`` 수락 (ChatGPT Plus OAuth)."""
+    """``source = "openai-codex"`` 수락 (ChatGPT OAuth)."""
     p = PetriRoleConfig(source="openai-codex")
     assert p.source == "openai-codex"
 

--- a/tests/test_e2e_live_reasoning_depth.py
+++ b/tests/test_e2e_live_reasoning_depth.py
@@ -7,7 +7,7 @@ None of these tests run by default (`@pytest.mark.live`); run with:
     uv run pytest tests/test_e2e_live_reasoning_depth.py -v -m live
 
 Coverage:
-  - R1 (v0.55.0): Codex Plus ``encrypted_content`` round-trip.
+  - R1 (v0.55.0): Codex ``encrypted_content`` round-trip.
   - R2 (v0.58.0): GLM ``thinking`` field + ``reasoning_content`` extraction.
   - R3-mini (v0.60.0): PAYG OpenAI ``include`` + ``summary="auto"``.
   - R4-mini (v0.56.0): Anthropic adaptive-thinking ``effort=xhigh`` on Opus 4.7.
@@ -209,7 +209,7 @@ class TestGlmThinkingLive:
 
 
 # ---------------------------------------------------------------------------
-# R1 + R6 — Codex Plus encrypted reasoning (subscription path)
+# R1 + R6 — Codex encrypted reasoning (subscription path)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_effort_picker.py
+++ b/tests/test_effort_picker.py
@@ -10,7 +10,7 @@ Pinned 2026-04-28 against:
     (low/medium/high/max/xhigh; xhigh is Opus 4.7-only)
   - OpenAI Responses effort enum: openai-python `shared/reasoning_effort.py`
     (none/minimal/low/medium/high/xhigh)
-  - Codex Plus enum: codex-rs `protocol/src/openai_models.rs:43-51`
+  - Codex enum: codex-rs `protocol/src/openai_models.rs:43-51`
     (None/Minimal/Low/Medium/High/XHigh)
   - GLM thinking enum: docs.z.ai/guides/capabilities/thinking-mode
     (binary enabled/disabled)

--- a/tests/test_glm_thinking_r2.py
+++ b/tests/test_glm_thinking_r2.py
@@ -165,7 +165,7 @@ class TestGlmAdapterSendsThinkingField:
     def test_clear_thinking_default_preserves_history(self) -> None:
         """``clear_thinking=False`` keeps prior-turn ``reasoning_content``
         in the model's context — matches R1's multi-turn-reasoning-
-        preservation goal on Codex Plus."""
+        preservation goal on Codex."""
         from core.llm.providers import glm as glm_mod
 
         with open(glm_mod.__file__, encoding="utf-8") as f:

--- a/tests/test_html_output_guard.py
+++ b/tests/test_html_output_guard.py
@@ -173,7 +173,7 @@ def test_guard_present_for_codex() -> None:
     from core.agent.system_prompt import _build_model_card
 
     _build_model_card.cache_clear()
-    # Codex Plus model id from CODEX_PRIMARY
+    # Codex model id from CODEX_PRIMARY
     card = _build_model_card("gpt-5.3-codex")
     # Codex routes through OpenAI provider in _resolve_provider; check the
     # guard fires.  If the resolver renames codex models later this test

--- a/tests/test_login_plan_binding.py
+++ b/tests/test_login_plan_binding.py
@@ -40,11 +40,13 @@ class _FakePlan:
         kind: str,
         display_name: str,
         subscription_tier: str | None = None,
+        provider: str = "glm",
     ) -> None:
         self.id = id
         self.kind = _FakePlanKind(kind)
         self.display_name = display_name
         self.subscription_tier = subscription_tier
+        self.provider = provider
 
 
 class _FakeRegistry:
@@ -93,6 +95,26 @@ def test_format_plan_binding_no_subscription_tier() -> None:
     assert "openai-payg" in out
     assert "payg" in out
     assert "OpenAI (PAYG)" in out
+
+
+def test_format_plan_binding_resolves_chatgpt_plan_slug() -> None:
+    """OpenAI Codex plan tiers are stored as JWT slugs but rendered as labels."""
+    from core.cli.commands.login import _format_plan_binding
+
+    registry = _FakeRegistry(
+        {
+            "openai-codex-geode": _FakePlan(
+                id="openai-codex-geode",
+                kind="oauth_borrowed",
+                display_name="OpenAI Codex (GEODE OAuth)",
+                subscription_tier="prolite",
+                provider="openai-codex",
+            )
+        }
+    )
+    out = _format_plan_binding(registry, "openai-codex-geode")
+    assert "ChatGPT Pro Lite" in out
+    assert "prolite" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_login_providers.py
+++ b/tests/test_login_providers.py
@@ -3,7 +3,7 @@
 Pre-fix the equivalence map (``openai ↔ openai-codex``,
 ``glm ↔ glm-coding``) lived only in ``core.llm.registry``; users saw the
 ``provider`` label in ``/login`` / ``/model`` and had no way to discover
-that a Codex Plus token and an OpenAI PAYG key both serve a ``gpt-5.x``
+that a Codex token and an OpenAI PAYG key both serve a ``gpt-5.x``
 request, or that a GLM Coding key shadows the PAYG endpoint.
 
 Contracts pinned here:

--- a/tests/test_model_forced_method.py
+++ b/tests/test_model_forced_method.py
@@ -2,7 +2,7 @@
 
 Pre-fix ``settings.forced_login_method = {"openai": "apikey"}`` silently
 re-sorted the plan chain in ``_apply_forced_login_method`` so a user
-selecting ``gpt-5.5`` expecting Codex Plus quietly ended up on PAYG.
+selecting ``gpt-5.5`` expecting Codex quietly ended up on PAYG.
 The picker now surfaces the override with a ``(forced: <method>)``
 suffix in both the interactive and non-tty list views, mirroring the
 M5 ``(login required)`` badge.

--- a/tests/test_oauth_path_display.py
+++ b/tests/test_oauth_path_display.py
@@ -65,3 +65,17 @@ def test_oauth_success_uses_auth_store_path() -> None:
         "Legacy ``stored_at=str(AUTH_STORE_PATH)`` regression detected — "
         "this displayed auth.json while writing to auth.toml (B1)."
     )
+
+
+def test_oauth_success_uses_chatgpt_plan_label() -> None:
+    """The login success line must render JWT plan slugs as product labels.
+
+    Pre-fix ``/login openai`` printed raw ``Plan: prolite`` for a Pro Lite
+    account. The UI event should receive the display label instead.
+    """
+    src = inspect.getsource(_oauth)
+    success_call = src.find("emit_oauth_login_success(")
+    assert success_call >= 0
+    block = src[success_call : success_call + 500]
+    assert "chatgpt_plan_label(plan_type)" in block
+    assert "plan_type=plan_type or" not in block

--- a/tests/test_provider_switching.py
+++ b/tests/test_provider_switching.py
@@ -1,6 +1,6 @@
 """v0.52.5 — Provider switching E2E (3C2 cross-provider + 2 within-provider).
 
-GEODE supports 3 providers (OpenAI Codex Plus OAuth, Anthropic API key,
+GEODE supports 3 providers (OpenAI Codex OAuth, Anthropic API key,
 GLM Coding Plan/PAYG) and 2 within-provider Plan switches (Codex↔PAYG,
 Coding↔PAYG). v0.52.4 introduced plan-aware routing with kind-priority
 sort, so the routing-policy test suite already covers the *first*
@@ -10,10 +10,10 @@ endpoint, or A's credentials into B's call?
 
 5 paths covered:
 
-  Path A — Codex Plus OAuth → Anthropic API key  (cross-provider)
-  Path B — Codex Plus OAuth → GLM Coding Plan    (cross-provider)
+  Path A — Codex OAuth → Anthropic API key  (cross-provider)
+  Path B — Codex OAuth → GLM Coding Plan    (cross-provider)
   Path C — Anthropic        → GLM                (cross-provider)
-  Path D — Codex Plus OAuth → OpenAI PAYG        (within-provider Plan)
+  Path D — Codex OAuth → OpenAI PAYG        (within-provider Plan)
   Path E — GLM Coding       → GLM PAYG           (within-provider Plan)
 
 Each path asserts five contracts:
@@ -205,16 +205,16 @@ def isolated_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 # ---------------------------------------------------------------------------
-# Path A — Codex Plus OAuth → Anthropic API key (cross-provider)
+# Path A — Codex OAuth → Anthropic API key (cross-provider)
 # ---------------------------------------------------------------------------
 
 
 def test_path_a_codex_oauth_to_anthropic_apikey(isolated_auth) -> None:
-    """User on Codex Plus does ``/model claude-opus-4-7`` → Anthropic API."""
+    """User on Codex subscription does ``/model claude-opus-4-7`` → Anthropic API."""
     _register_codex_oauth()
     _register_anthropic_payg()
 
-    # Origin: gpt-5.5 routes to Codex Plus.
+    # Origin: gpt-5.5 routes to Codex.
     origin = resolve_routing("gpt-5.5")
     assert origin is not None
     assert origin.plan.provider == "openai-codex"
@@ -231,7 +231,7 @@ def test_path_a_codex_oauth_to_anthropic_apikey(isolated_auth) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Path B — Codex Plus OAuth → GLM Coding Plan (cross-provider)
+# Path B — Codex OAuth → GLM Coding Plan (cross-provider)
 # ---------------------------------------------------------------------------
 
 
@@ -273,12 +273,12 @@ def test_path_c_anthropic_to_glm(isolated_auth) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Path D — Codex Plus OAuth → OpenAI PAYG (within-provider Plan switch)
+# Path D — Codex OAuth → OpenAI PAYG (within-provider Plan switch)
 # ---------------------------------------------------------------------------
 
 
 def test_path_d_codex_oauth_to_openai_payg_within_provider(isolated_auth) -> None:
-    """Both Plans registered. Default routing prefers Codex Plus (OAuth) for
+    """Both Plans registered. Default routing prefers Codex (OAuth) for
     gpt-5.4 per kind-priority. After ``/login route gpt-5.4 openai-payg``
     explicit override the same model must route to PAYG."""
     _register_codex_oauth()

--- a/tests/test_r3_mini_payg_reasoning.py
+++ b/tests/test_r3_mini_payg_reasoning.py
@@ -5,7 +5,7 @@ Pinned 2026-04-28 against:
   - openai-python ``responses/response_create_params.py:70-74``
     (``reasoning.encrypted_content`` semantics under ``store=False``)
   - openai-python ``responses/response_includable.py`` (include enum)
-  - Codex Plus parity: ``core/llm/providers/codex.py:347-348``
+  - Codex parity: ``core/llm/providers/codex.py:347-348``
 
 Verifies:
   1. ``_is_payg_reasoning_model`` gates gpt-5.x + o-series only.

--- a/tests/test_reasoning_summary_r6.py
+++ b/tests/test_reasoning_summary_r6.py
@@ -11,7 +11,7 @@ spinner. R6 implements this in GEODE at per-reasoning-item granularity
 Three invariants:
 
   1. ``normalize_openai_responses`` extracts ``reasoning.summary[].text``
-     into ``AgenticResponse.reasoning_summaries`` (Codex Plus path).
+     into ``AgenticResponse.reasoning_summaries`` (Codex path).
      Captures both the full reasoning-with-encrypted-content case and
      the summary-only fallback.
 
@@ -49,7 +49,7 @@ def _make_reasoning_item(*, encrypted: str | None, summary_texts: list[str]) -> 
 
 
 class TestCodexReasoningSummaryExtraction:
-    """Sidecar populated from Codex Plus ``reasoning.summary[].text``."""
+    """Sidecar populated from Codex ``reasoning.summary[].text``."""
 
     def test_extracts_summary_with_encrypted_blob(self) -> None:
         resp = MagicMock()

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -54,7 +54,7 @@ def test_plan_kind_priority_subscription_first() -> None:
 
 def test_openai_equivalence_class_pairs_with_codex() -> None:
     """openai and openai-codex must share an equivalence class so a
-    Codex Plus OAuth plan is considered when the user requests gpt-5.x."""
+    Codex OAuth plan is considered when the user requests gpt-5.x."""
     eq = equivalent_providers("openai")
     assert "openai-codex" in eq
     assert "openai" in eq
@@ -76,7 +76,7 @@ def test_unrelated_provider_is_singleton() -> None:
 
 
 def _seed_two_plans(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Plan, Plan]:
-    """Helper: register both an OAuth Codex Plus plan and a PAYG OpenAI
+    """Helper: register both an OAuth Codex plan and a PAYG OpenAI
     plan, each with an available profile. Returns (subscription_plan,
     payg_plan)."""
     monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
@@ -133,7 +133,7 @@ def _seed_two_plans(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Pl
 def test_resolve_routing_prefers_oauth_over_payg(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Both plans registered, no explicit /login route — Codex Plus must win.
+    """Both plans registered, no explicit /login route — Codex must win.
     This is the v0.52.1-incident-defining contract: a user who paid for
     Plus must not be billed PAYG for the same model."""
     sub_plan, _ = _seed_two_plans(monkeypatch, tmp_path)
@@ -269,7 +269,7 @@ def test_route_provider_returns_routed_provider_when_plan_found(
         id="openai-codex-geode",
         provider="openai-codex",
         kind=PlanKind.OAUTH_BORROWED,
-        display_name="OpenAI Codex Plus",
+        display_name="OpenAI Codex",
         base_url="https://chatgpt.com/backend-api/codex",
     )
     fake_target = type(

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -19,7 +19,7 @@ documented in ``docs/design/self-improving-hub-system.md`` +
 3. **Section contract** — 4 main sections (Petri Audit / Seed Generation
    / Autoresearch / Documentation) each render with expected columns.
 4. **Harness chip mapping** — every model prefix resolves to the
-   correct chip class (PAYG / Claude Code / Codex Plus / GEODE).
+   correct chip class (PAYG / Claude Code / Codex / GEODE).
 5. **URL safety** — every ``href`` starts with ``/geode/`` (no missing
    basePath) or is an external ``https://``.
 6. **Version stamp** — ``pyproject.toml`` version is interpolated into


### PR DESCRIPTION
## Summary
- Resolve ChatGPT OAuth `chatgpt_plan_type` JWT slugs into display labels instead of leaking raw slugs or assuming Plus.
- Wire the label into `/login openai`, `/login` plan/profile display, and credential-source status.
- Sweep user-facing/docs/test wording from fixed Plus wording to ChatGPT subscription / Codex subscription where applicable.

## Why
A Pro Lite account reports `chatgpt_plan_type=prolite`, but GEODE surfaces previously rendered raw `prolite` in login success output and still described many OpenAI OAuth paths as ChatGPT Plus. That made plan display misleading for Pro Lite, Pro, Team, Business, Enterprise, and Edu users.

## Changes
| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | Added `chatgpt_plan_label()` and local JWT label resolution; `/login openai` success emits a product label. |
| `core/cli/commands/login.py` | Renders OpenAI Codex plan bindings and credential-source labels through the ChatGPT label resolver. |
| `tests/core/auth/test_chatgpt_plan_label.py` | Adds slug mapping, JWT decode, fallback, and local auth resolution invariants. |
| `tests/test_login_plan_binding.py` | Pins OpenAI Codex plan bindings rendering `prolite` as `ChatGPT Pro Lite`. |
| `tests/test_oauth_path_display.py` | Pins login success wiring through `chatgpt_plan_label()`. |
| docs/tests/templates | Replaced fixed Plus wording with subscription/Codex wording where the path is not Plus-specific. |
| `CHANGELOG.md` | Records the fix under `[Unreleased]`. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Raw JWT plan slug display | Fixed | `/login openai` now emits `ChatGPT Pro Lite` for `prolite`. |
| `/login` plan binding display | Fixed | OpenAI Codex `subscription_tier` slugs are label-resolved. |
| Fixed Plus wording outside historical docs | Fixed | Current UI/docs/test wording now uses subscription/Codex wording unless Plus is the actual tier under test. |

## Verification
- `uv run pytest tests/core/auth/test_chatgpt_plan_label.py tests/test_login_plan_binding.py tests/test_oauth_path_display.py -q`
- `uv run pytest tests/test_login_plan_binding.py tests/test_oauth_path_display.py tests/core/auth/test_chatgpt_plan_label.py tests/test_oauth_login.py tests/test_provider_switching.py tests/test_routing_policy.py tests/test_codex_responses_shape.py tests/test_codex_request_shape.py tests/test_provider_label_consistency.py -q`
- `uv run pytest tests/test_agentic_response.py tests/test_codex_multiturn_reasoning.py tests/test_config_effort_knob.py tests/test_credential_breadcrumb_cross_provider.py tests/test_d1_provider_closure.py tests/test_effort_picker.py tests/test_glm_thinking_r2.py tests/test_html_output_guard.py tests/test_login_providers.py tests/test_model_forced_method.py tests/test_r3_mini_payg_reasoning.py tests/test_reasoning_summary_r6.py tests/test_self_improving_hub_e2e.py -q`
- `uv run ruff check core/auth/oauth_login.py core/cli/commands/login.py core/orchestration/openai_api_lane.py scripts/build_self_improving_hub.py tests/test_agentic_response.py tests/test_codex_multiturn_reasoning.py tests/test_codex_responses_shape.py tests/test_config_effort_knob.py tests/test_credential_breadcrumb_cross_provider.py tests/test_d1_provider_closure.py tests/test_e2e_live_reasoning_depth.py tests/test_effort_picker.py tests/test_glm_thinking_r2.py tests/test_html_output_guard.py tests/test_login_plan_binding.py tests/test_login_providers.py tests/test_model_forced_method.py tests/test_oauth_path_display.py tests/test_provider_switching.py tests/test_r3_mini_payg_reasoning.py tests/test_reasoning_summary_r6.py tests/test_routing_policy.py tests/test_self_improving_hub_e2e.py tests/core/auth/test_chatgpt_plan_label.py`
- `uv run mypy core/auth/oauth_login.py core/cli/commands/login.py`
- `git diff --check`

Live tests were not run.