### PR TITLE
feat(seed-gen): parallelize ranker match dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-RANKER-PARALLEL** — seed-generation Ranker now dispatches all
+  independent tournament matches with ``asyncio.gather`` and applies
+  Elo updates afterward in the original ``match_plan`` order. This
+  preserves deterministic final ratings / survivor selection for a
+  fixed RNG seed while allowing the voter-panel LLM calls to overlap;
+  the provider lanes introduced by PR-OAUTH-API-LANES remain the
+  throttle for the resulting burst. Pinned by
+  ``tests/plugins/seed_generation/test_ranker.py`` invariants for
+  concurrent match dispatch and post-gather Elo ordering.
+
 ### Fixed
 
 - **PR-GEN-COUNTER** — ``autoresearch.train._resolve_gen_tag`` no
@@ -19114,4 +19126,3 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 [0.7.0]: https://github.com/mangowhoiscloud/geode/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mangowhoiscloud/geode/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mangowhoiscloud/geode/releases/tag/v0.6.0
-

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -36,6 +36,7 @@ P-checklist application:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import random
@@ -205,13 +206,23 @@ class Ranker(BaseSeedAgent):
         # per match. ``state.elo_ratings`` only carries the FINAL ratings;
         # this list carries the per-match trace.
         match_details: list[dict[str, Any]] = []
-        for match in match_plan:
+        # PR-RANKER-PARALLEL (2026-05-26) — dispatch every independent
+        # match concurrently, then apply Elo sequentially below. The
+        # expensive part is the voter panel call inside ``_play_match``;
+        # the rating mutation must stay ordered by ``match_plan`` so the
+        # same RNG seed still produces the same final Elo table.
+        match_results = await asyncio.gather(
+            *[
+                self._play_match(
+                    match,
+                    pilot_means=pilot_means,
+                    candidate_bodies=candidate_bodies,
+                )
+                for match in match_plan
+            ]
+        )
+        for match, (outcome, detail) in zip(match_plan, match_results, strict=True):
             elo_before = deepcopy(ratings)
-            outcome, detail = await self._play_match(
-                match,
-                pilot_means=pilot_means,
-                candidate_bodies=candidate_bodies,
-            )
             if outcome is None:
                 # Detail is still meaningful for quorum-lost matches —
                 # surface the partial voter responses in the hub.

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -173,6 +173,37 @@ class _MostFailManager:
         return results
 
 
+class _DelayedAlwaysAWinsManager:
+    """All voters say A wins, with a sleep that exposes match concurrency."""
+
+    def __init__(self) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.active = 0
+        self.max_active = 0
+        self.started_match_ids: list[str] = []
+        self.finished_match_ids: list[str] = []
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        self.received_tasks.extend(tasks)
+        match_id = str(tasks[0].args["match_id"]) if tasks else "unknown"
+        self.started_match_ids.append(match_id)
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.01)
+        self.active -= 1
+        self.finished_match_ids.append(match_id)
+        return [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output=_good_vote(t.args["match_id"], winner="A"),
+                duration_ms=10.0,
+            )
+            for t in tasks
+        ]
+
+
 def test_ranker_requires_two_voters() -> None:
     with pytest.raises(ValueError, match=r"requires"):
         Ranker(manager=_AlwaysAWinsManager(), voters=[_voters()[0]])  # type: ignore[arg-type]
@@ -228,6 +259,62 @@ def test_ranker_dispatches_3_voters_per_match() -> None:
     asyncio.run(ranker.aexecute(state))
     # Each match has 3 voters; total tasks = 3 * match_count
     assert len(manager.received_tasks) % 3 == 0
+
+
+def test_ranker_dispatches_matches_concurrently() -> None:
+    """PR-RANKER-PARALLEL — independent matches are fanned out together."""
+    state = _state_with_candidates(5)
+    manager = _DelayedAlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+    assert result.success
+    assert manager.max_active > 1, (
+        "Ranker should dispatch multiple match panels concurrently; "
+        f"observed max_active={manager.max_active}"
+    )
+    assert len(manager.started_match_ids) == len(manager.finished_match_ids)
+
+
+def test_ranker_applies_elo_after_parallel_dispatch_in_match_plan_order() -> None:
+    """Elo remains deterministic even when match calls complete asynchronously."""
+    from plugins.seed_generation.tournament import (
+        MatchOutcome,
+        apply_match,
+        initial_ratings,
+        plan_matches,
+    )
+
+    seed = 42
+    state = _state_with_candidates(4)
+    manager = _DelayedAlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(seed),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+
+    candidate_ids = [c["id"] for c in state.candidates]
+    expected = initial_ratings(candidate_ids)
+    voter_ids = tuple(f"{v.provider}.{v.source}" for v in _voters())
+    for match in plan_matches(candidate_ids, rng=random.Random(seed)):
+        apply_match(
+            expected,
+            MatchOutcome(
+                match_id=match.match_id,
+                a=match.a,
+                b=match.b,
+                winner="A",
+                votes=("A", "A", "A"),
+                voter_ids=voter_ids,
+            ),
+        )
+    assert result.output["elo_ratings"] == expected
+    assert manager.max_active > 1
 
 
 def test_ranker_split_votes_become_ties() -> None:

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import random
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from core.agent.sub_agent import SubResult, SubTask
@@ -266,7 +266,7 @@ def test_ranker_dispatches_matches_concurrently() -> None:
     state = _state_with_candidates(5)
     manager = _DelayedAlwaysAWinsManager()
     ranker = Ranker(
-        manager=manager,  # type: ignore[arg-type]
+        manager=cast(Any, manager),
         voters=_voters(),
         rng=random.Random(0),
     )
@@ -292,7 +292,7 @@ def test_ranker_applies_elo_after_parallel_dispatch_in_match_plan_order() -> Non
     state = _state_with_candidates(4)
     manager = _DelayedAlwaysAWinsManager()
     ranker = Ranker(
-        manager=manager,  # type: ignore[arg-type]
+        manager=cast(Any, manager),
         voters=_voters(),
         rng=random.Random(seed),
     )


### PR DESCRIPTION
## Summary

Parallelizes independent seed-generation ranker matches with `asyncio.gather`, while preserving deterministic tournament semantics by applying Elo updates afterward in the original `match_plan` order.

## Why

Ranker match panels are independent LLM calls. Dispatching them sequentially leaves provider lane capacity idle after PR-OAUTH-API-LANES introduced lane-level throttling. The ranker can now overlap match evaluation and rely on the existing provider lanes as the burst throttle.

## Changes

- Dispatches all ranker `_play_match` tasks concurrently with `asyncio.gather`.
- Applies match outcomes and Elo transitions sequentially after gather using `zip(..., strict=True)` over the original match plan.
- Adds regression tests for concurrent dispatch and post-gather deterministic Elo ordering.
- Updates `CHANGELOG.md` under `[Unreleased]`.

## GAP Audit

- Determinism: final ratings remain tied to `match_plan` order, not completion order.
- Throttling: no local semaphore was added in Ranker; provider lanes remain the single throttling layer.
- Resume/checkpoint behavior: unchanged in this PR and left for PR-RANKER-PARTIAL-CHECKPOINT.

## Verification

- `uv run pytest tests/plugins/seed_generation/test_ranker.py -q` -> 22 passed
- `uv run ruff check plugins/seed_generation/agents/ranker.py tests/plugins/seed_generation/test_ranker.py` -> passed
- `uv run pytest tests/plugins/seed_generation/test_ranker.py tests/plugins/seed_generation/test_tournament.py tests/plugins/seed_generation/test_orchestrator.py tests/plugins/seed_generation/test_voter_effort_override.py tests/core/orchestration/test_openai_api_lane.py tests/core/orchestration/test_anthropic_api_lane.py -q` -> 102 passed
- `uv run mypy plugins/seed_generation/agents/ranker.py` -> passed
- `git diff --check` -> passed

Live tests were not run.