### PR TITLE
feat(seed-gen): checkpoint ranker partial progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ functional change.
   throttle for the resulting burst. Pinned by
   ``tests/plugins/seed_generation/test_ranker.py`` invariants for
   concurrent match dispatch and post-gather Elo ordering.
+- **PR-RANKER-PARTIAL-CHECKPOINT** — seed-generation Ranker now writes
+  ``checkpoints/ranker.partial.json`` while match panels run. The
+  partial checkpoint stores the ordered Elo-applied match prefix
+  (``completed_match_ids``), ``partial_ratings``,
+  ``partial_outcomes_serialised``, and ``total_matches`` with atomic
+  temp-file replacement. Resume accepts the checkpoint only when it
+  matches the current match-plan prefix, restores ratings/outcomes,
+  and dispatches only the remaining matches. Pinned by checkpointer,
+  resume, and Ranker invariants for round-trip, stale-plan rejection,
+  final partial dump, and no replay of completed matches.
 
 ### Fixed
 

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -37,10 +37,13 @@ P-checklist application:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import random
+import time
 from copy import deepcopy
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from plugins.seed_generation.agents.base import (
@@ -57,7 +60,6 @@ from plugins.seed_generation.tournament import (
     MatchOutcome,
     MatchPlan,
     apply_match,
-    initial_ratings,
     majority_winner,
     plan_matches,
     top_k,
@@ -73,6 +75,8 @@ __all__ = ["Ranker"]
 
 _DEFAULT_RANKER_MODEL = "claude-opus-4-7"
 _TASK_TYPE = "seed-ranker-vote"
+_PARTIAL_CHECKPOINT_EVERY_MATCHES = 10
+_PARTIAL_CHECKPOINT_EVERY_SECONDS = 120.0
 
 _REQUIRED_VOTE_FIELDS = ("match_id", "winner", "rationale")
 _VALID_WINNER_LABELS = frozenset({"A", "B", "tie"})
@@ -91,6 +95,17 @@ _CANDIDATE_BODY_UNAVAILABLE = (
     'Treat this match as ambiguous — emit ``winner: "tie"`` and note '
     "the unavailability in your rationale.)"
 )
+
+
+def _serialise_match_outcome(outcome: MatchOutcome) -> dict[str, Any]:
+    return {
+        "match_id": outcome.match_id,
+        "a": outcome.a,
+        "b": outcome.b,
+        "winner": outcome.winner,
+        "votes": list(outcome.votes),
+        "voter_ids": list(outcome.voter_ids),
+    }
 
 
 class Ranker(BaseSeedAgent):
@@ -184,7 +199,6 @@ class Ranker(BaseSeedAgent):
         # well under any LLM context budget.
         candidate_bodies = self._read_candidate_bodies(state)
 
-        ratings = initial_ratings(candidate_ids)
         # CSP-8 (2026-05-22) — Proximity now emits clusters
         # (``state.similarity_clusters``) instead of a sparse pairwise
         # graph. Bracket seeding reverts to the legacy random-shuffle
@@ -192,14 +206,25 @@ class Ranker(BaseSeedAgent):
         # meta_reviewer + operator-readable state.json as a coverage
         # signal but does NOT feed the Elo bracket.
         match_plan = plan_matches(candidate_ids, rng=self._rng)
+        from plugins.seed_generation.resume import load_ranker_partial_resume
+
+        resume = load_ranker_partial_resume(
+            state.run_dir,
+            candidate_ids=candidate_ids,
+            match_plan=match_plan,
+        )
+        ratings = resume.ratings
         log.info(
-            "seed-generation ranker: %d candidates → %d matches × %d voters",
+            "seed-generation ranker: %d candidates → %d matches × %d voters "
+            "(resumed=%d pending=%d)",
             len(candidate_ids),
             len(match_plan),
             len(self._voters),
+            len(resume.completed_match_ids),
+            len(resume.pending_matches),
         )
 
-        outcomes: list[MatchOutcome] = []
+        outcomes: list[MatchOutcome] = list(resume.outcomes)
         # PR-SEEDS-HIRES (2026-05-26) — accumulate per-match details
         # (voter rationale + Elo before/after deltas) so the hub's
         # tournament page can render the full 3-voter panel breakdown
@@ -211,17 +236,40 @@ class Ranker(BaseSeedAgent):
         # expensive part is the voter panel call inside ``_play_match``;
         # the rating mutation must stay ordered by ``match_plan`` so the
         # same RNG seed still produces the same final Elo table.
-        match_results = await asyncio.gather(
-            *[
-                self._play_match(
-                    match,
-                    pilot_means=pilot_means,
-                    candidate_bodies=candidate_bodies,
+        result_queue: asyncio.Queue[
+            tuple[MatchPlan, tuple[MatchOutcome | None, dict[str, Any]]] | None
+        ] = asyncio.Queue()
+        checkpoint_task: asyncio.Task[None] | None = None
+        if state.run_dir is not None and resume.pending_matches:
+            checkpoint_task = asyncio.create_task(
+                self._partial_checkpoint_loop(
+                    run_dir=state.run_dir,
+                    match_plan=match_plan,
+                    result_queue=result_queue,
+                    base_completed_match_ids=list(resume.completed_match_ids),
+                    base_ratings=ratings,
+                    base_outcomes=outcomes,
+                    total_matches=len(match_plan),
                 )
-                for match in match_plan
-            ]
-        )
-        for match, (outcome, detail) in zip(match_plan, match_results, strict=True):
+            )
+        try:
+            match_results = await asyncio.gather(
+                *[
+                    self._play_match_with_checkpoint_report(
+                        match,
+                        pilot_means=pilot_means,
+                        candidate_bodies=candidate_bodies,
+                        result_queue=result_queue,
+                    )
+                    for match in resume.pending_matches
+                ]
+            )
+        finally:
+            if checkpoint_task is not None:
+                await result_queue.put(None)
+                with contextlib.suppress(Exception):
+                    await checkpoint_task
+        for match, (outcome, detail) in zip(resume.pending_matches, match_results, strict=True):
             elo_before = deepcopy(ratings)
             if outcome is None:
                 # Detail is still meaningful for quorum-lost matches —
@@ -285,6 +333,121 @@ class Ranker(BaseSeedAgent):
                 "survivors": survivors,
             },
         )
+
+    async def _play_match_with_checkpoint_report(
+        self,
+        match: MatchPlan,
+        *,
+        pilot_means: dict[str, dict[str, Any]],
+        candidate_bodies: dict[str, str],
+        result_queue: asyncio.Queue[
+            tuple[MatchPlan, tuple[MatchOutcome | None, dict[str, Any]]] | None
+        ],
+    ) -> tuple[MatchOutcome | None, dict[str, Any]]:
+        result = await self._play_match(
+            match,
+            pilot_means=pilot_means,
+            candidate_bodies=candidate_bodies,
+        )
+        await result_queue.put((match, result))
+        return result
+
+    async def _partial_checkpoint_loop(
+        self,
+        *,
+        run_dir: Path,
+        match_plan: list[MatchPlan],
+        result_queue: asyncio.Queue[
+            tuple[MatchPlan, tuple[MatchOutcome | None, dict[str, Any]]] | None
+        ],
+        base_completed_match_ids: list[str],
+        base_ratings: dict[str, float],
+        base_outcomes: list[MatchOutcome],
+        total_matches: int,
+    ) -> None:
+        """Persist the ordered Elo prefix while match panels run.
+
+        Match calls finish in arbitrary order, but the partial checkpoint
+        must only record the deterministic prefix that has been applied
+        to Elo in ``match_plan`` order.
+        """
+        from plugins.seed_generation.checkpointer import write_partial_ranker_checkpoint
+
+        ratings = dict(base_ratings)
+        outcomes = list(base_outcomes)
+        completed_ids = list(base_completed_match_ids)
+        completed_set = set(completed_ids)
+        pending_results: dict[str, tuple[MatchOutcome | None, dict[str, Any]]] = {}
+        next_idx = 0
+        while next_idx < len(match_plan) and match_plan[next_idx].match_id in completed_set:
+            next_idx += 1
+
+        last_dump_count = len(completed_ids)
+        last_dump_at = time.monotonic()
+        force_dump = False
+
+        while True:
+            timeout = max(
+                0.1,
+                _PARTIAL_CHECKPOINT_EVERY_SECONDS - (time.monotonic() - last_dump_at),
+            )
+            timed_out = False
+            try:
+                item = await asyncio.wait_for(result_queue.get(), timeout=timeout)
+            except TimeoutError:
+                timed_out = True
+                item = None
+                force_dump = True
+
+            if item is None and not timed_out:
+                force_dump = True
+            elif item is not None:
+                match, result = item
+                pending_results[match.match_id] = result
+
+            while next_idx < len(match_plan):
+                match = match_plan[next_idx]
+                if match.match_id in completed_set:
+                    next_idx += 1
+                    continue
+                if match.match_id not in pending_results:
+                    break
+                result = pending_results.pop(match.match_id)
+                outcome, _detail = result
+                completed_set.add(match.match_id)
+                completed_ids.append(match.match_id)
+                if outcome is not None:
+                    apply_match(ratings, outcome, k_factor=self._k_factor)
+                    outcomes.append(outcome)
+                next_idx += 1
+
+            due_by_count = (
+                len(completed_ids) - last_dump_count >= _PARTIAL_CHECKPOINT_EVERY_MATCHES
+            )
+            due_by_time = time.monotonic() - last_dump_at >= _PARTIAL_CHECKPOINT_EVERY_SECONDS
+            dirty = len(completed_ids) > last_dump_count
+            if dirty and (due_by_count or due_by_time or force_dump):
+                try:
+                    write_partial_ranker_checkpoint(
+                        run_dir,
+                        completed_match_ids=completed_ids,
+                        partial_ratings=ratings,
+                        partial_outcomes_serialised=[
+                            _serialise_match_outcome(outcome) for outcome in outcomes
+                        ],
+                        total_matches=total_matches,
+                    )
+                except OSError as exc:
+                    log.warning(
+                        "seed-generation ranker: partial checkpoint write failed — %s",
+                        exc,
+                    )
+                last_dump_count = len(completed_ids)
+                last_dump_at = time.monotonic()
+                force_dump = False
+
+            if item is None and not timed_out:
+                break
 
     def _read_candidate_bodies(self, state: PipelineState) -> dict[str, str]:
         """Read each candidate's seed .md body once, keyed by candidate id.

--- a/plugins/seed_generation/checkpointer.py
+++ b/plugins/seed_generation/checkpointer.py
@@ -42,15 +42,22 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "CHECKPOINT_SUBDIR",
+    "RANKER_PARTIAL_CHECKPOINT",
     "PhaseCheckpoint",
+    "RankerPartialCheckpoint",
     "list_completed_phases",
     "load_checkpoint",
+    "load_partial_ranker_checkpoint",
     "write_checkpoint",
+    "write_partial_ranker_checkpoint",
 ]
 
 
 CHECKPOINT_SUBDIR = "checkpoints"
 """Subdirectory under ``run_dir`` holding the per-phase JSON files."""
+
+RANKER_PARTIAL_CHECKPOINT = "ranker.partial.json"
+"""Mid-ranker checkpoint filename under ``<run_dir>/checkpoints``."""
 
 
 @dataclass(frozen=True)
@@ -92,6 +99,53 @@ class PhaseCheckpoint:
             duration_ms=float(payload.get("duration_ms", 0.0)),
             state_snapshot=dict(payload.get("state_snapshot", {})),
             error=payload.get("error"),
+        )
+
+
+@dataclass(frozen=True)
+class RankerPartialCheckpoint:
+    """Mid-phase Ranker checkpoint.
+
+    The Ranker dispatches match panels concurrently, but Elo mutation
+    remains ordered. This checkpoint records the ordered prefix that has
+    already been applied to ``partial_ratings`` so a resumed run can skip
+    those matches and continue from the same deterministic Elo state.
+    """
+
+    completed_match_ids: list[str]
+    partial_ratings: dict[str, float]
+    partial_outcomes_serialised: list[dict[str, Any]]
+    total_matches: int
+    last_checkpoint_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "completed_match_ids": self.completed_match_ids,
+            "partial_ratings": self.partial_ratings,
+            "partial_outcomes_serialised": self.partial_outcomes_serialised,
+            "total_matches": self.total_matches,
+            "last_checkpoint_at": self.last_checkpoint_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> RankerPartialCheckpoint:
+        completed_raw = payload.get("completed_match_ids", [])
+        ratings_raw = payload.get("partial_ratings", {})
+        outcomes_raw = payload.get("partial_outcomes_serialised", [])
+        if not isinstance(completed_raw, list):
+            completed_raw = []
+        if not isinstance(ratings_raw, dict):
+            ratings_raw = {}
+        if not isinstance(outcomes_raw, list):
+            outcomes_raw = []
+        return cls(
+            completed_match_ids=[str(item) for item in completed_raw],
+            partial_ratings={str(k): float(v) for k, v in ratings_raw.items()},
+            partial_outcomes_serialised=[
+                dict(item) for item in outcomes_raw if isinstance(item, dict)
+            ],
+            total_matches=int(payload.get("total_matches", 0)),
+            last_checkpoint_at=float(payload.get("last_checkpoint_at", 0.0)),
         )
 
 
@@ -147,6 +201,48 @@ def write_checkpoint(
     return target
 
 
+def write_partial_ranker_checkpoint(
+    run_dir: Path,
+    *,
+    completed_match_ids: list[str],
+    partial_ratings: dict[str, float],
+    partial_outcomes_serialised: list[dict[str, Any]],
+    total_matches: int,
+) -> Path:
+    """Write ``checkpoints/ranker.partial.json`` atomically."""
+    ck = RankerPartialCheckpoint(
+        completed_match_ids=list(completed_match_ids),
+        partial_ratings={str(k): float(v) for k, v in partial_ratings.items()},
+        partial_outcomes_serialised=[dict(item) for item in partial_outcomes_serialised],
+        total_matches=int(total_matches),
+        last_checkpoint_at=time.time(),
+    )
+    ck_dir = run_dir / CHECKPOINT_SUBDIR
+    ck_dir.mkdir(parents=True, exist_ok=True)
+    target = ck_dir / RANKER_PARTIAL_CHECKPOINT
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".ranker.partial.",
+        suffix=".tmp",
+        dir=str(ck_dir),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(ck.to_dict(), fh, ensure_ascii=False, indent=2, default=str)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except OSError as exc:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        log.warning(
+            "checkpointer: failed to write ranker partial checkpoint at %s — %s",
+            target,
+            exc,
+        )
+        raise
+    return target
+
+
 def load_checkpoint(run_dir: Path, phase: str) -> PhaseCheckpoint | None:
     """Load a single phase's checkpoint, return None when absent.
 
@@ -169,6 +265,25 @@ def load_checkpoint(run_dir: Path, phase: str) -> PhaseCheckpoint | None:
         return PhaseCheckpoint.from_dict(payload)
     except (KeyError, TypeError, ValueError) as exc:
         log.warning("checkpointer: %s checkpoint at %s malformed — %s", phase, target, exc)
+        return None
+
+
+def load_partial_ranker_checkpoint(run_dir: Path) -> RankerPartialCheckpoint | None:
+    """Load ``checkpoints/ranker.partial.json`` when present and valid."""
+    target = run_dir / CHECKPOINT_SUBDIR / RANKER_PARTIAL_CHECKPOINT
+    if not target.is_file():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("checkpointer: ranker partial checkpoint at %s unreadable — %s", target, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return RankerPartialCheckpoint.from_dict(payload)
+    except (TypeError, ValueError) as exc:
+        log.warning("checkpointer: ranker partial checkpoint at %s malformed — %s", target, exc)
         return None
 
 

--- a/plugins/seed_generation/resume.py
+++ b/plugins/seed_generation/resume.py
@@ -30,24 +30,29 @@ index than per-event JSONL).
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from plugins.seed_generation.checkpointer import (
     list_completed_phases,
     load_checkpoint,
+    load_partial_ranker_checkpoint,
 )
 from plugins.seed_generation.orchestrator import (
     _ITERATION_PHASE_ORDER,
     _PHASE_ORDER,
     PipelineState,
 )
+from plugins.seed_generation.tournament import MatchOutcome, MatchPlan, WinnerLabel, initial_ratings
 
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "RankerPartialResume",
     "ResumeError",
     "hydrate_state",
+    "load_ranker_partial_resume",
     "next_phase_to_run",
     "resolve_resume_target",
 ]
@@ -55,6 +60,16 @@ __all__ = [
 
 class ResumeError(RuntimeError):
     """Raised when the run directory can't be resumed (missing / corrupt)."""
+
+
+@dataclass(frozen=True)
+class RankerPartialResume:
+    """Ranker resume cursor derived from ``ranker.partial.json``."""
+
+    completed_match_ids: tuple[str, ...]
+    ratings: dict[str, float]
+    outcomes: list[MatchOutcome]
+    pending_matches: list[MatchPlan]
 
 
 def next_phase_to_run(run_dir: Path) -> str | None:
@@ -159,6 +174,65 @@ def resolve_resume_target(run_dir: Path) -> tuple[PipelineState, str | None]:
     return state, next_phase
 
 
+def load_ranker_partial_resume(
+    run_dir: Path | None,
+    *,
+    candidate_ids: list[str],
+    match_plan: list[MatchPlan],
+) -> RankerPartialResume:
+    """Return Ranker ratings/outcomes/pending plan after partial resume.
+
+    The partial checkpoint is only accepted when its completed ids form
+    an ordered prefix of the current ``match_plan`` and ``total_matches``
+    still matches. This avoids replaying a checkpoint created for a
+    different candidate set or RNG schedule.
+    """
+    fresh = RankerPartialResume(
+        completed_match_ids=(),
+        ratings=initial_ratings(candidate_ids),
+        outcomes=[],
+        pending_matches=list(match_plan),
+    )
+    if run_dir is None:
+        return fresh
+    ck = load_partial_ranker_checkpoint(run_dir)
+    if ck is None:
+        return fresh
+    if ck.total_matches != len(match_plan):
+        log.warning(
+            "seed-generation resume: ignoring ranker partial checkpoint "
+            "(total_matches=%d, current_plan=%d)",
+            ck.total_matches,
+            len(match_plan),
+        )
+        return fresh
+
+    completed_ids = list(ck.completed_match_ids)
+    expected_prefix = [match.match_id for match in match_plan[: len(completed_ids)]]
+    if completed_ids != expected_prefix:
+        log.warning(
+            "seed-generation resume: ignoring ranker partial checkpoint "
+            "because completed_match_ids are not the current match-plan prefix",
+        )
+        return fresh
+
+    outcomes = _deserialize_ranker_outcomes(ck.partial_outcomes_serialised)
+    pending = [match for match in match_plan if match.match_id not in set(completed_ids)]
+    ratings = initial_ratings(candidate_ids)
+    ratings.update({cid: rating for cid, rating in ck.partial_ratings.items() if cid in ratings})
+    log.info(
+        "seed-generation resume: ranker partial checkpoint restored %d/%d matches",
+        len(completed_ids),
+        len(match_plan),
+    )
+    return RankerPartialResume(
+        completed_match_ids=tuple(completed_ids),
+        ratings=ratings,
+        outcomes=outcomes,
+        pending_matches=pending,
+    )
+
+
 def _path_or_none(value: Any) -> Path | None:
     if value in (None, ""):
         return None
@@ -171,6 +245,29 @@ def _dict_or_none(value: Any) -> dict[str, float] | None:
     if not isinstance(value, dict):
         return None
     return {str(k): float(v) for k, v in value.items()}
+
+
+def _deserialize_ranker_outcomes(payloads: list[dict[str, Any]]) -> list[MatchOutcome]:
+    outcomes: list[MatchOutcome] = []
+    valid_winners = {"A", "B", "tie"}
+    for payload in payloads:
+        winner = payload.get("winner")
+        if winner not in valid_winners:
+            continue
+        winner_label = cast(WinnerLabel, winner)
+        votes = tuple(cast(WinnerLabel, v) for v in payload.get("votes", []) if v in valid_winners)
+        voter_ids = tuple(str(v) for v in payload.get("voter_ids", []))
+        outcomes.append(
+            MatchOutcome(
+                match_id=str(payload.get("match_id", "")),
+                a=str(payload.get("a", "")),
+                b=str(payload.get("b", "")),
+                winner=winner_label,
+                votes=votes,
+                voter_ids=voter_ids,
+            )
+        )
+    return outcomes
 
 
 # Re-export _ITERATION_PHASE_ORDER for tests that assert symmetry with

--- a/tests/plugins/seed_generation/test_checkpointer.py
+++ b/tests/plugins/seed_generation/test_checkpointer.py
@@ -13,10 +13,13 @@ from pathlib import Path
 import pytest
 from plugins.seed_generation.checkpointer import (
     CHECKPOINT_SUBDIR,
+    RANKER_PARTIAL_CHECKPOINT,
     PhaseCheckpoint,
     list_completed_phases,
     load_checkpoint,
+    load_partial_ranker_checkpoint,
     write_checkpoint,
+    write_partial_ranker_checkpoint,
 )
 
 
@@ -137,3 +140,29 @@ def test_list_completed_phases_skips_non_json_files(tmp_path: Path) -> None:
 
 def test_list_completed_phases_empty_dir(tmp_path: Path) -> None:
     assert list_completed_phases(tmp_path) == []
+
+
+def test_write_partial_ranker_checkpoint_round_trip(tmp_path: Path) -> None:
+    target = write_partial_ranker_checkpoint(
+        tmp_path,
+        completed_match_ids=["m000", "m001"],
+        partial_ratings={"c-1": 1016.0, "c-2": 984.0},
+        partial_outcomes_serialised=[
+            {
+                "match_id": "m000",
+                "a": "c-1",
+                "b": "c-2",
+                "winner": "A",
+                "votes": ["A", "A", "tie"],
+                "voter_ids": ["v1", "v2", "v3"],
+            }
+        ],
+        total_matches=5,
+    )
+    assert target == tmp_path / CHECKPOINT_SUBDIR / RANKER_PARTIAL_CHECKPOINT
+    ck = load_partial_ranker_checkpoint(tmp_path)
+    assert ck is not None
+    assert ck.completed_match_ids == ["m000", "m001"]
+    assert ck.partial_ratings == {"c-1": 1016.0, "c-2": 984.0}
+    assert ck.partial_outcomes_serialised[0]["match_id"] == "m000"
+    assert ck.total_matches == 5

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -317,6 +317,103 @@ def test_ranker_applies_elo_after_parallel_dispatch_in_match_plan_order() -> Non
     assert manager.max_active > 1
 
 
+def test_ranker_writes_partial_checkpoint(tmp_path: Any) -> None:
+    """PR-RANKER-PARTIAL-CHECKPOINT — final prefix is resumable."""
+    from plugins.seed_generation.checkpointer import load_partial_ranker_checkpoint
+    from plugins.seed_generation.tournament import plan_matches
+
+    seed = 7
+    state = _state_with_candidates(5)
+    state.run_dir = tmp_path
+    manager = _DelayedAlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,
+        voters=_voters(),
+        rng=random.Random(seed),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+
+    assert result.success
+    ck = load_partial_ranker_checkpoint(tmp_path)
+    assert ck is not None
+    expected_plan = plan_matches([c["id"] for c in state.candidates], rng=random.Random(seed))
+    assert ck.total_matches == len(expected_plan)
+    assert ck.completed_match_ids == [match.match_id for match in expected_plan]
+    assert ck.partial_ratings == result.output["elo_ratings"]
+
+
+def test_ranker_resumes_from_partial_checkpoint_without_replaying_completed_match(
+    tmp_path: Any,
+) -> None:
+    """A partial checkpoint skips the already-applied match prefix."""
+    from plugins.seed_generation.checkpointer import write_partial_ranker_checkpoint
+    from plugins.seed_generation.tournament import (
+        MatchOutcome,
+        apply_match,
+        initial_ratings,
+        plan_matches,
+    )
+
+    seed = 11
+    state = _state_with_candidates(4)
+    state.run_dir = tmp_path
+    candidate_ids = [c["id"] for c in state.candidates]
+    match_plan = plan_matches(candidate_ids, rng=random.Random(seed))
+    first = match_plan[0]
+    voter_ids = tuple(f"{v.provider}.{v.source}" for v in _voters())
+    first_outcome = MatchOutcome(
+        match_id=first.match_id,
+        a=first.a,
+        b=first.b,
+        winner="A",
+        votes=("A", "A", "A"),
+        voter_ids=voter_ids,
+    )
+    partial_ratings = initial_ratings(candidate_ids)
+    apply_match(partial_ratings, first_outcome)
+    write_partial_ranker_checkpoint(
+        tmp_path,
+        completed_match_ids=[first.match_id],
+        partial_ratings=partial_ratings,
+        partial_outcomes_serialised=[
+            {
+                "match_id": first_outcome.match_id,
+                "a": first_outcome.a,
+                "b": first_outcome.b,
+                "winner": first_outcome.winner,
+                "votes": list(first_outcome.votes),
+                "voter_ids": list(first_outcome.voter_ids),
+            }
+        ],
+        total_matches=len(match_plan),
+    )
+
+    manager = _DelayedAlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(seed),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+
+    expected = initial_ratings(candidate_ids)
+    for match in match_plan:
+        apply_match(
+            expected,
+            MatchOutcome(
+                match_id=match.match_id,
+                a=match.a,
+                b=match.b,
+                winner="A",
+                votes=("A", "A", "A"),
+                voter_ids=voter_ids,
+            ),
+        )
+    assert result.output["elo_ratings"] == expected
+    assert first.match_id not in manager.started_match_ids
+    assert set(manager.started_match_ids) == {match.match_id for match in match_plan[1:]}
+
+
 def test_ranker_split_votes_become_ties() -> None:
     state = _state_with_candidates(3)
     manager = _SplitVotesManager()

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -234,7 +234,7 @@ def test_ranker_produces_elo_ratings_and_survivors() -> None:
     state = _state_with_candidates(4)
     manager = _AlwaysAWinsManager()
     ranker = Ranker(
-        manager=manager,  # type: ignore[arg-type]
+        manager=cast(Any, manager),
         voters=_voters(),
         rng=random.Random(42),
     )
@@ -327,7 +327,7 @@ def test_ranker_writes_partial_checkpoint(tmp_path: Any) -> None:
     state.run_dir = tmp_path
     manager = _DelayedAlwaysAWinsManager()
     ranker = Ranker(
-        manager=manager,
+        manager=cast(Any, manager),
         voters=_voters(),
         rng=random.Random(seed),
     )
@@ -390,7 +390,7 @@ def test_ranker_resumes_from_partial_checkpoint_without_replaying_completed_matc
 
     manager = _DelayedAlwaysAWinsManager()
     ranker = Ranker(
-        manager=manager,  # type: ignore[arg-type]
+        manager=cast(Any, manager),
         voters=_voters(),
         rng=random.Random(seed),
     )

--- a/tests/plugins/seed_generation/test_resume.py
+++ b/tests/plugins/seed_generation/test_resume.py
@@ -7,6 +7,7 @@ PR-CHECKPOINT-RESUME-TIMEBUDGET (2026-05-25, S5) — pin the hydration
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from plugins.seed_generation.orchestrator import _PHASE_ORDER
 from plugins.seed_generation.resume import (
     ResumeError,
     hydrate_state,
+    load_ranker_partial_resume,
     next_phase_to_run,
     resolve_resume_target,
 )
@@ -222,3 +224,80 @@ def test_resolve_resume_target_returns_state_and_phase(tmp_path: Path) -> None:
     state, next_phase = resolve_resume_target(tmp_path)
     assert state.run_id == "gen1-broken_tool_use"
     assert next_phase == "literature_review"
+
+
+def test_load_ranker_partial_resume_filters_completed_prefix(tmp_path: Path) -> None:
+    from plugins.seed_generation.checkpointer import write_partial_ranker_checkpoint
+    from plugins.seed_generation.tournament import (
+        MatchOutcome,
+        apply_match,
+        initial_ratings,
+        plan_matches,
+    )
+
+    candidate_ids = ["c-1", "c-2", "c-3", "c-4"]
+    match_plan = plan_matches(candidate_ids, rng=random.Random(3))
+    first = match_plan[0]
+    outcome = MatchOutcome(
+        match_id=first.match_id,
+        a=first.a,
+        b=first.b,
+        winner="A",
+        votes=("A", "A", "tie"),
+        voter_ids=("v1", "v2", "v3"),
+    )
+    ratings = initial_ratings(candidate_ids)
+    apply_match(ratings, outcome)
+    write_partial_ranker_checkpoint(
+        tmp_path,
+        completed_match_ids=[first.match_id],
+        partial_ratings=ratings,
+        partial_outcomes_serialised=[
+            {
+                "match_id": outcome.match_id,
+                "a": outcome.a,
+                "b": outcome.b,
+                "winner": outcome.winner,
+                "votes": list(outcome.votes),
+                "voter_ids": list(outcome.voter_ids),
+            }
+        ],
+        total_matches=len(match_plan),
+    )
+
+    resume = load_ranker_partial_resume(
+        tmp_path,
+        candidate_ids=candidate_ids,
+        match_plan=match_plan,
+    )
+    assert resume.completed_match_ids == (first.match_id,)
+    assert resume.ratings == ratings
+    assert [match.match_id for match in resume.pending_matches] == [
+        match.match_id for match in match_plan[1:]
+    ]
+    assert len(resume.outcomes) == 1
+    assert resume.outcomes[0].match_id == first.match_id
+
+
+def test_load_ranker_partial_resume_ignores_non_prefix_checkpoint(tmp_path: Path) -> None:
+    from plugins.seed_generation.checkpointer import write_partial_ranker_checkpoint
+    from plugins.seed_generation.tournament import initial_ratings, plan_matches
+
+    candidate_ids = ["c-1", "c-2", "c-3", "c-4"]
+    match_plan = plan_matches(candidate_ids, rng=random.Random(3))
+    write_partial_ranker_checkpoint(
+        tmp_path,
+        completed_match_ids=[match_plan[1].match_id],
+        partial_ratings={"c-1": 1200.0},
+        partial_outcomes_serialised=[],
+        total_matches=len(match_plan),
+    )
+
+    resume = load_ranker_partial_resume(
+        tmp_path,
+        candidate_ids=candidate_ids,
+        match_plan=match_plan,
+    )
+    assert resume.completed_match_ids == ()
+    assert resume.ratings == initial_ratings(candidate_ids)
+    assert resume.pending_matches == match_plan


### PR DESCRIPTION
## Summary

Adds mid-phase Ranker partial checkpointing on top of the parallel match dispatch branch. The Ranker now writes `checkpoints/ranker.partial.json` while match panels run, and resume restores the ordered Elo-applied prefix before dispatching only the remaining matches.

## Why

After ranker match dispatch became parallel, the phase can still run long enough that losing the process mid-ranker would waste completed match work. The partial checkpoint gives `audit-seeds resume` a deterministic cursor inside the ranker phase without changing final Elo semantics.

## Changes

- Adds `RankerPartialCheckpoint` plus atomic `write_partial_ranker_checkpoint` / `load_partial_ranker_checkpoint` helpers.
- Adds `load_ranker_partial_resume`, which validates `total_matches` and requires completed ids to match the current `match_plan` prefix before restoring ratings/outcomes.
- Adds a dedicated Ranker checkpoint coroutine that consumes completed match results, applies only the ordered Elo prefix, and dumps every 10 matches or 120s, with a final forced dump.
- Keeps Elo mutation deterministic in `match_plan` order and skips replaying matches already present in the partial checkpoint.
- Updates `CHANGELOG.md` under `[Unreleased]`.

## GAP Audit

- Stacked on #1761 / `feature/ranker-parallel`; this PR should be retargeted to `develop` after #1761 lands.
- Checkpoint resume accepts only ordered-prefix checkpoints. Non-prefix or stale-plan files are ignored to avoid corrupting deterministic Elo state.
- The partial checkpoint restores ratings/outcomes for correctness and `elo_log.tsv`; it does not attempt to reconstruct rich per-voter `tournament_matches.json` details for matches completed before an interruption.

## Verification

- `uv run pytest tests/plugins/seed_generation/test_checkpointer.py tests/plugins/seed_generation/test_resume.py tests/plugins/seed_generation/test_ranker.py -q` -> 46 passed
- `uv run ruff check plugins/seed_generation/checkpointer.py plugins/seed_generation/resume.py plugins/seed_generation/agents/ranker.py tests/plugins/seed_generation/test_checkpointer.py tests/plugins/seed_generation/test_resume.py tests/plugins/seed_generation/test_ranker.py` -> passed
- `uv run mypy plugins/seed_generation/checkpointer.py plugins/seed_generation/resume.py plugins/seed_generation/agents/ranker.py` -> passed
- `uv run pytest tests/plugins/seed_generation/test_ranker.py tests/plugins/seed_generation/test_tournament.py tests/plugins/seed_generation/test_orchestrator.py tests/plugins/seed_generation/test_resume.py tests/plugins/seed_generation/test_checkpointer.py tests/plugins/seed_generation/test_seed_bundle_sync.py -q` -> 104 passed
- `git diff --check` -> passed

Live smoke was not run.