### PR TITLE
feat(seed-gen): dedup ranker survivors post elo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ functional change.
   and dispatches only the remaining matches. Pinned by checkpointer,
   resume, and Ranker invariants for round-trip, stale-plan rejection,
   final partial dump, and no replay of completed matches.
+- **PR-RANKER-DEDUP-POST-ELO** — seed-generation now applies an
+  open-coscientist-aligned post-Ranker survivor dedup pass before
+  Evolver dispatch. Within each high-similarity survivor cluster,
+  GEODE keeps the best candidate by ``(elo_rating, sum(dim_means),
+  candidate_id)``, removes lower-ranked near-duplicates from
+  ``state.survivors``, and appends audit rows to
+  ``state.removed_duplicates``. Pinned by pure helper and Pipeline
+  invariants covering Elo priority, Pilot-score tie-breaks, survivor
+  filtering, and non-high / non-survivor preservation.
 
 ### Fixed
 

--- a/plugins/seed_generation/dedup.py
+++ b/plugins/seed_generation/dedup.py
@@ -1,0 +1,93 @@
+"""Post-Elo survivor deduplication for seed generation.
+
+The Proximity phase records semantic clusters before Pilot/Ranker have
+empirical signal. This module applies the open-coscientist pattern after
+Ranker: within each high-similarity survivor cluster, keep the strongest
+candidate by Elo, then aggregate Pilot score, then id.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["dedup_survivors_by_cluster"]
+
+
+def dedup_survivors_by_cluster(
+    survivors: list[str],
+    ratings: dict[str, float],
+    pilot_scores: dict[str, dict[str, Any]],
+    similarity_clusters: list[dict[str, Any]],
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Drop lower-ranked high-similarity survivors.
+
+    Returns ``(filtered_survivors, removed_rows)``. Survivor order is
+    preserved except for removed ids so Evolver still sees Ranker's
+    survivor ordering.
+    """
+    survivor_set = set(survivors)
+    removals: dict[str, dict[str, Any]] = {}
+    for cluster in similarity_clusters:
+        cluster_id = str(cluster.get("cluster_id", "?"))
+        topic = str(cluster.get("topic", ""))
+        entries = cluster.get("similar_hypotheses") or []
+        if not isinstance(entries, list):
+            continue
+
+        high_ids: list[str] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            cid = entry.get("candidate_id")
+            if (
+                isinstance(cid, str)
+                and cid in survivor_set
+                and entry.get("similarity_degree") == "high"
+            ):
+                high_ids.append(cid)
+        high_ids = list(dict.fromkeys(high_ids))
+        if len(high_ids) <= 1:
+            continue
+
+        keep = max(high_ids, key=lambda cid: _survivor_rank(cid, ratings, pilot_scores))
+        for cid in high_ids:
+            if cid == keep:
+                continue
+            removals[cid] = {
+                "candidate_id": cid,
+                "cluster_id": cluster_id,
+                "topic": topic,
+                "reason": "post_elo_high_similarity_duplicate",
+                "kept_instead": keep,
+                "elo_rating": float(ratings.get(cid, 0.0)),
+                "pilot_score_sum": _pilot_score_sum(cid, pilot_scores),
+            }
+
+    filtered = [cid for cid in survivors if cid not in removals]
+    return filtered, [removals[cid] for cid in survivors if cid in removals]
+
+
+def _survivor_rank(
+    candidate_id: str,
+    ratings: dict[str, float],
+    pilot_scores: dict[str, dict[str, Any]],
+) -> tuple[float, float, str]:
+    return (
+        float(ratings.get(candidate_id, 0.0)),
+        _pilot_score_sum(candidate_id, pilot_scores),
+        candidate_id,
+    )
+
+
+def _pilot_score_sum(candidate_id: str, pilot_scores: dict[str, dict[str, Any]]) -> float:
+    entry = pilot_scores.get(candidate_id, {})
+    means = entry.get("dim_means", {}) if isinstance(entry, dict) else {}
+    if not isinstance(means, dict):
+        return 0.0
+    total = 0.0
+    for value in means.values():
+        try:
+            total += float(value)
+        except (TypeError, ValueError):
+            continue
+    return total

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -618,10 +618,14 @@ class Pipeline:
                 # resume re-runs failed phases instead of pretending
                 # they completed.
                 if iteration == 0 and self.state.run_dir is not None and phase_result.success:
+                    if phase == "ranker":
+                        self._apply_post_elo_dedup()
                     self._record_checkpoint(
                         phase,
                         duration_ms=(time.time() - phase_started) * 1000.0,
                     )
+                elif phase == "ranker" and phase_result.success:
+                    self._apply_post_elo_dedup()
                 # PR-COSCI-1 (2026-05-21) — abort early when the
                 # candidates pool is empty after a phase that should
                 # have populated or filtered it. The check is scoped
@@ -739,6 +743,41 @@ class Pipeline:
         # don't re-cluster (evolved candidates are deduped by the
         # Evolver's anti-convergence Jaccard guard, CSP-6).
         return True
+
+    def _apply_post_elo_dedup(self) -> None:
+        """Filter high-similarity survivor clusters after Ranker.
+
+        Proximity records semantic clusters before Pilot/Ranker have
+        score signal. This post-Elo pass mirrors open-coscientist's
+        high-similarity dedup rule, but uses GEODE's survivor ids, Elo
+        ratings, and Pilot dim means.
+        """
+        from plugins.seed_generation.dedup import dedup_survivors_by_cluster
+
+        if not self.state.survivors or not self.state.similarity_clusters:
+            return
+        filtered, removed = dedup_survivors_by_cluster(
+            survivors=list(self.state.survivors),
+            ratings=dict(self.state.elo_ratings),
+            pilot_scores=dict(self.state.pilot_scores),
+            similarity_clusters=list(self.state.similarity_clusters),
+        )
+        if not removed:
+            return
+        self.state.survivors = filtered
+        self.state.removed_duplicates.extend(removed)
+        log.info(
+            "seed-generation post-Elo dedup: removed %d high-similarity survivors",
+            len(removed),
+        )
+        _emit_orchestrator_event(
+            "post_elo_dedup_finished",
+            payload={
+                "removed": len(removed),
+                "survivors_before": len(filtered) + len(removed),
+                "survivors_after": len(filtered),
+            },
+        )
 
     def _append_session_index(self, *, started_at: float, ended_at: float) -> None:
         """Append one row to ``~/.geode/self-improving-loop/sessions.jsonl``.

--- a/tests/plugins/seed_generation/test_dedup.py
+++ b/tests/plugins/seed_generation/test_dedup.py
@@ -1,0 +1,85 @@
+"""Tests for post-Elo seed survivor deduplication."""
+
+from __future__ import annotations
+
+from plugins.seed_generation.dedup import dedup_survivors_by_cluster
+
+
+def test_dedup_survivors_keeps_best_high_similarity_by_elo() -> None:
+    filtered, removed = dedup_survivors_by_cluster(
+        survivors=["c-low", "c-best", "c-other"],
+        ratings={"c-low": 990.0, "c-best": 1030.0, "c-other": 1000.0},
+        pilot_scores={
+            "c-low": {"dim_means": {"dim_01": 0.9}},
+            "c-best": {"dim_means": {"dim_01": 0.1}},
+        },
+        similarity_clusters=[
+            {
+                "cluster_id": "cluster-a",
+                "topic": "same mechanism",
+                "similar_hypotheses": [
+                    {"candidate_id": "c-low", "similarity_degree": "high"},
+                    {"candidate_id": "c-best", "similarity_degree": "high"},
+                    {"candidate_id": "c-other", "similarity_degree": "medium"},
+                ],
+            }
+        ],
+    )
+
+    assert filtered == ["c-best", "c-other"]
+    assert removed == [
+        {
+            "candidate_id": "c-low",
+            "cluster_id": "cluster-a",
+            "topic": "same mechanism",
+            "reason": "post_elo_high_similarity_duplicate",
+            "kept_instead": "c-best",
+            "elo_rating": 990.0,
+            "pilot_score_sum": 0.9,
+        }
+    ]
+
+
+def test_dedup_survivors_uses_pilot_sum_as_tiebreaker() -> None:
+    filtered, removed = dedup_survivors_by_cluster(
+        survivors=["c-a", "c-b"],
+        ratings={"c-a": 1000.0, "c-b": 1000.0},
+        pilot_scores={
+            "c-a": {"dim_means": {"dim_01": 0.3, "dim_02": 0.2}},
+            "c-b": {"dim_means": {"dim_01": 0.6}},
+        },
+        similarity_clusters=[
+            {
+                "cluster_id": "cluster-a",
+                "similar_hypotheses": [
+                    {"candidate_id": "c-a", "similarity_degree": "high"},
+                    {"candidate_id": "c-b", "similarity_degree": "high"},
+                ],
+            }
+        ],
+    )
+
+    assert filtered == ["c-b"]
+    assert removed[0]["candidate_id"] == "c-a"
+    assert removed[0]["kept_instead"] == "c-b"
+
+
+def test_dedup_survivors_ignores_non_survivors_and_non_high_entries() -> None:
+    filtered, removed = dedup_survivors_by_cluster(
+        survivors=["c-a", "c-b"],
+        ratings={"c-a": 1000.0, "c-b": 990.0, "c-c": 1200.0},
+        pilot_scores={},
+        similarity_clusters=[
+            {
+                "cluster_id": "cluster-a",
+                "similar_hypotheses": [
+                    {"candidate_id": "c-a", "similarity_degree": "medium"},
+                    {"candidate_id": "c-b", "similarity_degree": "low"},
+                    {"candidate_id": "c-c", "similarity_degree": "high"},
+                ],
+            }
+        ],
+    )
+
+    assert filtered == ["c-a", "c-b"]
+    assert removed == []

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -398,6 +398,33 @@ def test_record_checkpoint_writes_per_phase_files(tmp_path) -> None:
     assert "meta_reviewer" in meta_review_ck["state_snapshot"]["completed_phases"]
 
 
+def test_pipeline_applies_post_elo_dedup_before_evolver() -> None:
+    state = PipelineState(run_id="t-dedup", target_dim="x", gen_tag="gen2")
+    state.survivors = ["c-a", "c-b", "c-c"]
+    state.elo_ratings = {"c-a": 1000.0, "c-b": 1040.0, "c-c": 990.0}
+    state.pilot_scores = {
+        "c-a": {"dim_means": {"dim_01": 0.9}},
+        "c-b": {"dim_means": {"dim_01": 0.1}},
+    }
+    state.similarity_clusters = [
+        {
+            "cluster_id": "cluster-a",
+            "topic": "same failure mode",
+            "similar_hypotheses": [
+                {"candidate_id": "c-a", "similarity_degree": "high"},
+                {"candidate_id": "c-b", "similarity_degree": "high"},
+                {"candidate_id": "c-c", "similarity_degree": "low"},
+            ],
+        }
+    ]
+
+    Pipeline(state, PipelineRegistry())._apply_post_elo_dedup()
+
+    assert state.survivors == ["c-b", "c-c"]
+    assert state.removed_duplicates[-1]["candidate_id"] == "c-a"
+    assert state.removed_duplicates[-1]["kept_instead"] == "c-b"
+
+
 class _SoftFailAgent(BaseSeedAgent):
     """Agent that returns ``status="error"`` without raising — mirrors
     smoke 17 proximity phase (LLM emitted non-JSON narrative, the


### PR DESCRIPTION
## Summary

Adds an open-coscientist-aligned post-Ranker survivor dedup pass. After Ranker computes Elo survivors, GEODE now uses prior Proximity clusters plus Elo and Pilot scores to remove lower-ranked high-similarity survivors before Evolver dispatch.

## Why

Proximity clustering happens before Pilot and Ranker have empirical quality signals. This pass keeps Proximity's semantic cluster signal but waits until after Elo so the dedup decision can keep the strongest survivor instead of relying on the pre-ranker cluster shape alone.

## Changes

- Adds `plugins.seed_generation.dedup.dedup_survivors_by_cluster`.
- Keeps the best high-similarity survivor per cluster by `(elo_rating, sum(dim_means), candidate_id)`.
- Preserves survivor order except for removed ids so Evolver still sees Ranker's ordering.
- Applies the pass immediately after successful Ranker phases, before Evolver and before the iteration-0 ranker checkpoint snapshot.
- Appends audit rows to `state.removed_duplicates` with `kept_instead`, Elo, Pilot score sum, cluster id/topic, and reason.
- Updates `CHANGELOG.md` under `[Unreleased]`.

## GAP Audit

- Stacked on #1761 / `feature/ranker-parallel`; retarget to `develop` after #1761 lands.
- This PR is independent of #1762 partial checkpointing and does not include that branch's changes.
- Non-high entries and non-survivor cluster members are ignored, so this cannot expand or reorder the survivor set.

## Verification

- `uv run pytest tests/plugins/seed_generation/test_dedup.py tests/plugins/seed_generation/test_orchestrator.py tests/plugins/seed_generation/test_ranker.py tests/plugins/seed_generation/test_evolver.py -q` -> 63 passed
- `uv run ruff check plugins/seed_generation/dedup.py plugins/seed_generation/orchestrator.py tests/plugins/seed_generation/test_dedup.py tests/plugins/seed_generation/test_orchestrator.py` -> passed
- `uv run mypy plugins/seed_generation/dedup.py plugins/seed_generation/orchestrator.py` -> passed
- `uv run pytest tests/plugins/seed_generation/test_dedup.py tests/plugins/seed_generation/test_ranker.py tests/plugins/seed_generation/test_tournament.py tests/plugins/seed_generation/test_orchestrator.py tests/plugins/seed_generation/test_iteration_loop.py tests/plugins/seed_generation/test_resume.py tests/plugins/seed_generation/test_state_offload.py tests/plugins/seed_generation/test_meta_reviewer.py tests/plugins/seed_generation/test_evolver.py -q` -> 148 passed
- `git diff --check` -> passed

Live smoke was not run.