### PR TITLE
release: v0.99.72 — PR-SEEDS-HIRES + attribution sprint Phase A bundle (→ develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.72] - 2026-05-26
+
+MINOR rotation. Ships PR-SEEDS-HIRES P1+P2+P3 — operator directive
+2026-05-26 to lift seed-generation hub to extreme resolution (every
+agent conversation, every procedure, active runs + current step,
+per-candidate phase evolution, every ranker match outcome). Plus
+the attribution sprint Phase A bundle: PR-GEN-COUNTER, PR-WIRE-1,
+PR-ATTR-INSPIRED-BY, PR-SMOKE-LOG-FLAG, PR-HOOKEVENT-RESERVE,
+PR-SOT-REVERT-ON-REJECT, PR-SOT-REVERT-ON-AUDIT-FAIL, and the
+ranker-parallel-lanes change. See section entries below.
+
 ### Changed
 
 - **PR-RANKER-PARALLEL** — seed-generation Ranker now dispatches all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.71
+- **Version**: 0.99.72
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.71 — Long-running Autonomous Execution Harness
+# GEODE v0.99.72 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.71**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.72**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.71 — Long-running Autonomous Execution Harness
+# GEODE v0.99.72 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.71**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.72**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.71"
+version = "0.99.72"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.71"
+version = "0.99.72"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
MINOR rotation. CHANGELOG promotion + version stamp 5 SoT locations.

## Verification
- [x] ruff check core/ tests/ plugins/ scripts/ — clean
- [x] mypy plugins/seed_generation/ + scripts/build_self_improving_hub.py — clean
- [x] pytest tests/test_self_improving_hub_e2e.py — 45/45
- [x] Local CI gates simulated (GitHub Actions outage workaround per operator approval)

Bundles: PR-SEEDS-HIRES P1+P2+P3, PR-GEN-COUNTER, PR-WIRE-1, PR-ATTR-INSPIRED-BY, PR-SMOKE-LOG-FLAG, PR-HOOKEVENT-RESERVE, PR-SOT-REVERT-ON-REJECT, PR-SOT-REVERT-ON-AUDIT-FAIL, ranker-parallel-with-lanes.