### PR TITLE
feat(self-improving-loop): outer-loop hardening — max_generation cap + promote stamp + dry-run attribution pin (PR-OUTER-LOOP-HARDENING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,62 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-MAX-GEN** — Outer-loop hardening: hard cap on total auto-trigger
+  fires.
+  * ``auto_trigger_mutator`` accepts a new ``max_generation: int = 0``
+    parameter. When non-zero, ``count_fired_generations`` reads
+    ``~/.geode/self-improving-loop/auto_trigger_history.jsonl`` and
+    blocks the next fire with state ``max_generation_reached`` (detail
+    ``current/max``) when the count is at or above the cap.
+  * The cap is checked BEFORE the lockfile acquisition (saturated
+    history doesn't consume the lock) AND AFTER (post-lock re-check
+    mirrors the existing ``is_min_interval_satisfied`` pattern so two
+    parallel callers can't both overshoot).
+  * Production wiring: new ``[self_improving_loop.scheduler]
+    max_generation`` config knob (default ``0`` = unlimited, max
+    ``100_000``). ``register_auto_trigger`` forwards the knob through
+    the scheduler callback. ``core/wiring/automation.py`` passes it
+    from ``load_self_improving_loop_config().scheduler.max_generation``.
+  * New HookEvent ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED``
+    reserved in ``core/hooks/system.py`` (same payload schema as
+    sibling auto-trigger events).
+  * Closes the 2026-05-26 autoresearch attribution sprint Phase A audit
+    (§5.6) finding that ``auto_trigger_mutator`` had only the
+    ``min_interval_minutes`` floor and no hard cap. Pinned by 12
+    invariant tests in
+    ``tests/core/self_improving_loop/test_auto_trigger_max_generation.py``
+    covering count helper edge cases, pre-lock cap, post-lock cap
+    recheck, production wiring forwarding, and HookEvent reservation.
+
+### Changed
+
+- **PR-PROMOTE-STAMP** — ``autoresearch.train._write_baseline``
+  accepts a new ``manual_promote: bool = False`` parameter. When
+  ``True``, the function stamps the baseline.json payload with three
+  additive top-level fields: ``manual_promote: true``,
+  ``promoted_by: "operator"``, ``promoted_at: <ts_utc>``. The
+  ``--promote`` operator override path in ``main()`` passes
+  ``manual_promote=True``. The auto-promote path keeps the default,
+  preserving backward-compat on baseline shape. Closes the audit
+  finding (§5.5) that downstream readers couldn't distinguish
+  operator-forced from gate-approved promotions. Pinned by 4
+  invariant tests in ``tests/autoresearch/test_promote_stamp.py``.
+
 ### Fixed
+
+- **PR-DRY-RUN-NO-ATTR (pin only)** — The 2026-05-26 attribution
+  sprint Phase A audit flagged the risk of ``--dry-run`` cycles
+  writing synthetic ``fitness_delta=0`` attribution rows to
+  ``mutations.jsonl``. Verification during the sprint confirmed the
+  skip guard ``_attribution_should_write = not args.dry_run`` was
+  ALREADY in place at ``autoresearch/train.py:2692`` (post-PR-AR-L6).
+  No code change in this commit — added 2 static-source invariant
+  tests in ``tests/autoresearch/test_dry_run_no_attribution.py`` that
+  fail loudly if a future refactor strips the guard. Brittle by
+  design — the cost of false alarms is far below the cost of the
+  silent leak re-opening.
 
 - **PR-GEN-COUNTER** — ``autoresearch.train._resolve_gen_tag`` no
   longer collapses repeated audits at the same git commit into a

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1882,6 +1882,14 @@ def _write_baseline(
     bench_stderr: dict[str, float] | None = None,
     bench_sample_count: dict[str, int] | None = None,
     bench_rubric_version: str = "",
+    # PR-PROMOTE-STAMP (2026-05-26) — when the operator forces promotion
+    # via ``--promote`` instead of going through the ``_should_promote``
+    # gate, stamp the baseline.json with a ``manual_promote`` marker so
+    # later readers can distinguish operator-forced from gate-approved
+    # promotions. Default ``False`` preserves the legacy stamp-free
+    # auto-promote shape — callers that omit the flag produce identical
+    # baselines to pre-PR.
+    manual_promote: bool = False,
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -1949,6 +1957,16 @@ def _write_baseline(
         "raw": raw_payload,
         "axes": axes_payload,
     }
+    # PR-PROMOTE-STAMP (2026-05-26) — operator-forced promotion via
+    # ``--promote`` stamps the baseline so audit-trail readers (e.g.
+    # ``/self-improving status``, observability indexer) can tell that
+    # the value was bypass-promoted, not gate-approved. Closes the
+    # silent-equivalence ambiguity flagged in the 2026-05-26 sprint
+    # Phase A audit (§5.5 ``baseline.json`` promoted SoT discussion).
+    if manual_promote:
+        baseline_payload["manual_promote"] = True
+        baseline_payload["promoted_by"] = "operator"
+        baseline_payload["promoted_at"] = baseline_payload["ts_utc"]
     BASELINE_PATH.write_text(
         json.dumps(baseline_payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -2603,7 +2621,12 @@ def main() -> int:
     elif args.no_promote:
         promoted_line = "false (--no-promote)"
     elif args.promote:
-        _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
+        # PR-PROMOTE-STAMP (2026-05-26) — operator-forced promotion
+        # bypasses ``_should_promote``. Stamp the baseline.json with
+        # ``manual_promote: true`` + ``promoted_by`` + ``promoted_at``
+        # so downstream readers can tell this baseline was approved
+        # by operator override, not by the auto-promote gate.
+        _write_baseline(dim_means, dim_stderr, manual_promote=True, **_baseline_provenance)
         promoted_line = "true (--promote, manual override)"
     else:
         # PR-3 of petri-schema-v2 (2026-05-23) — surface the v2

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -486,10 +486,12 @@ class SchedulerConfig(BaseModel):
     expression. Suggested production value: ``100`` (covers ~25 days
     at min_interval=360 = 6h). Closes 2026-05-26 attribution sprint
     Phase A audit (§5.6) — runaway auto-trigger no-stop-condition
-    leak. Cap is best-effort (no post-lock recheck under concurrent
-    callers); operators needing strict uniqueness should also use a
-    cron expression that fires less frequently than
-    ``min_interval_minutes``."""
+    leak. The cap is checked both pre-lock (skips no-op lock acquire
+    when the history is already saturated) and post-lock (catches the
+    race where two parallel callers both observed count=N-1 before
+    either appended). Operators needing strict uniqueness across
+    independent host processes should also pick a cron expression
+    that fires less frequently than ``min_interval_minutes``."""
 
 
 class SelfImprovingLoopConfig(BaseModel):

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -476,6 +476,21 @@ class SchedulerConfig(BaseModel):
     *back-to-back* runs. Must satisfy ``min_interval_minutes <= cron
     period`` for the schedule to actually fire."""
 
+    max_generation: Annotated[int, Field(ge=0, le=100_000)] = 0
+    """PR-MAX-GEN (2026-05-26) — hard cap on total ``fired`` rows in
+    ``~/.geode/self-improving-loop/auto_trigger_history.jsonl``. When
+    the cap is reached the trigger returns ``max_generation_reached``
+    without invoking the mutator runner. ``0`` (default) preserves
+    legacy unbounded behaviour — recommended only for operators who
+    set ``min_interval_minutes`` aggressively and trust the cron
+    expression. Suggested production value: ``100`` (covers ~25 days
+    at min_interval=360 = 6h). Closes 2026-05-26 attribution sprint
+    Phase A audit (§5.6) — runaway auto-trigger no-stop-condition
+    leak. Cap is best-effort (no post-lock recheck under concurrent
+    callers); operators needing strict uniqueness should also use a
+    cron expression that fires less frequently than
+    ``min_interval_minutes``."""
+
 
 class SelfImprovingLoopConfig(BaseModel):
     """Top-level [self_improving_loop.*] config root.

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -237,6 +237,13 @@ class HookEvent(Enum):
     SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED = "self_improving_auto_trigger_interval_blocked"
     SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR = "self_improving_auto_trigger_runner_error"
     SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR = "self_improving_auto_trigger_parse_error"
+    # PR-MAX-GEN (2026-05-26) — emitted when the auto-trigger hits the
+    # ``max_generation`` cap in ``~/.geode/self-improving-loop/auto_trigger_history.jsonl``.
+    # Same ``{trigger_id, ts, detail}`` payload schema; ``detail`` carries
+    # ``"current/max"`` (e.g. ``"100/100"``).
+    SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED = (
+        "self_improving_auto_trigger_max_generation_reached"
+    )
 
     # Wall-clock budget hand-off (PR-CL-BUDGET, 2026-05-23). Replaces the
     # prior turn hard-cap with a 2h time-cap + automatic T-10min hand-off.

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -99,9 +99,9 @@ STATE_TO_HOOK_EVENT: dict[str, str] = {
     "interval_blocked": "SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED",
     "runner_error": "SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR",
     "parse_error": "SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR",
-    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent not yet
-    # reserved (see follow-up HookEvent stub PR); ``_emit_state_event``
-    # graceful-skips the missing event name, so telemetry stays opt-in.
+    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent reserved
+    # in ``core/hooks/system.py`` alongside the sibling auto-trigger
+    # events; same ``{trigger_id, ts, detail}`` payload schema.
     "max_generation_reached": "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED",
 }
 """Maps terminal :class:`AutoTriggerStatus.state` → HookEvent enum name.

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -54,6 +54,7 @@ __all__ = [
     "acquire_auto_trigger_lock",
     "append_history_entry",
     "auto_trigger_mutator",
+    "count_fired_generations",
     "is_min_interval_satisfied",
     "read_last_run_timestamp",
     "register_auto_trigger",
@@ -98,6 +99,10 @@ STATE_TO_HOOK_EVENT: dict[str, str] = {
     "interval_blocked": "SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED",
     "runner_error": "SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR",
     "parse_error": "SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR",
+    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent not yet
+    # reserved (see follow-up HookEvent stub PR); ``_emit_state_event``
+    # graceful-skips the missing event name, so telemetry stays opt-in.
+    "max_generation_reached": "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED",
 }
 """Maps terminal :class:`AutoTriggerStatus.state` → HookEvent enum name.
 
@@ -114,7 +119,7 @@ SoT for "trigger was registered or skipped"."""
 class AutoTriggerStatus:
     """Return shape from :func:`auto_trigger_mutator`.
 
-    Six terminal states:
+    Seven terminal states:
 
     * ``fired`` — runner.run_once completed; ``mutation`` carries the
       Mutation summary (target_section + new_value len), timestamp
@@ -129,6 +134,10 @@ class AutoTriggerStatus:
       (mutation parse / validation); ``error`` carries the message.
       Treated separately from ``runner_error`` so telemetry can
       distinguish "LLM produced garbage" from "infra crashed".
+    * ``max_generation_reached`` — PR-MAX-GEN (2026-05-26):
+      ``max_generation`` was set non-zero and the auto-trigger
+      history already contains that many ``fired`` rows. Hard stop
+      on unbounded firing. ``detail`` carries ``current/max``.
     """
 
     state: str
@@ -220,6 +229,44 @@ def is_min_interval_satisfied(
     current = now if now is not None else time.time()
     elapsed_minutes = (current - last_run) / 60.0
     return elapsed_minutes >= min_interval_minutes
+
+
+def count_fired_generations(history_path: Path | None = None) -> int:
+    """Count ``state="fired"`` rows in the auto-trigger history log.
+
+    PR-MAX-GEN (2026-05-26) — Phase A audit (§5.6) found that
+    ``auto_trigger_mutator`` had no max-generation gate, only the
+    ``min_interval_minutes`` floor. With min_interval=60 and cron fires
+    every hour, a misconfigured operator could accumulate hundreds of
+    fired generations without any hard stop. This counter is the data
+    feed for the new ``max_generation`` gate.
+
+    Best-effort read — missing file / malformed JSON / non-dict rows
+    are all skipped silently. The audit log is append-only so future-
+    proof: each call re-counts (no in-memory cache invalidation).
+
+    Returns 0 when the history log is absent (fresh repo / never fired).
+    """
+    target = history_path if history_path is not None else AUTO_TRIGGER_HISTORY_PATH
+    if not target.is_file():
+        return 0
+    n = 0
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("state") == "fired":
+                    n += 1
+    except OSError:
+        log.warning("auto_trigger: history read failed", exc_info=True)
+        return n
+    return n
 
 
 def append_history_entry(
@@ -314,6 +361,7 @@ def auto_trigger_mutator(
     *,
     enabled: bool,
     min_interval_minutes: int,
+    max_generation: int = 0,
     runner_factory: Callable[[], Any] | None = None,
     lock_path: Path | None = None,
     timestamp_path: Path | None = None,
@@ -321,7 +369,7 @@ def auto_trigger_mutator(
     hooks: Any = None,
     now: float | None = None,
 ) -> AutoTriggerStatus:
-    """One mutator firing — guarded by lockfile + min-interval.
+    """One mutator firing — guarded by lockfile + min-interval + max-generation.
 
     Args:
         enabled: Defensive gate. When False, return ``disabled``
@@ -329,6 +377,11 @@ def auto_trigger_mutator(
             registering the trigger in this case; this is belt+suspenders.
         min_interval_minutes: Floor between successful firings (see
             :class:`SchedulerConfig.min_interval_minutes`).
+        max_generation: PR-MAX-GEN (2026-05-26) — hard cap on total
+            ``fired`` rows in the history log. When non-zero and the
+            current count is at or above the cap, return
+            ``max_generation_reached`` without firing. ``0`` (default)
+            disables the cap — legacy unbounded behaviour preserved.
         runner_factory: Zero-arg callable returning an object with
             ``run_once() -> Mutation`` method. Defaults to
             :class:`SelfImprovingLoopRunner` constructed with no args.
@@ -352,6 +405,21 @@ def auto_trigger_mutator(
         # ``disabled`` is the only state that skips telemetry + history
         # (see STATE_TO_HOOK_EVENT docstring for rationale).
         return AutoTriggerStatus(state="disabled")
+
+    # PR-MAX-GEN (2026-05-26) — generation cap. Evaluated BEFORE the
+    # interval gate so a misconfigured cron with min_interval=0 still
+    # hits the cap, and BEFORE the lock so a saturated history doesn't
+    # consume the lock for a no-op fire. ``0`` means unlimited.
+    if max_generation > 0:
+        fired_count = count_fired_generations(history_path=history_path)
+        if fired_count >= max_generation:
+            return _finalize_status(
+                "max_generation_reached",
+                f"{fired_count}/{max_generation}",
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
+            )
 
     if not is_min_interval_satisfied(
         min_interval_minutes=min_interval_minutes,
@@ -394,6 +462,24 @@ def auto_trigger_mutator(
                 history_path=history_path,
                 ts=ts_now,
             )
+
+        # PR-MAX-GEN (2026-05-26) Codex MCP must-fix #2 — re-check the
+        # generation cap AFTER acquiring the lock for the same reason
+        # the interval check does: two parallel callers can both read
+        # the pre-lock count as N-1, both proceed to fire, and overshoot
+        # the cap by 1. The post-lock recheck reads the freshly-written
+        # history (the previous holder appends + releases atomically) so
+        # the second caller sees count=N and blocks cleanly.
+        if max_generation > 0:
+            fired_count = count_fired_generations(history_path=history_path)
+            if fired_count >= max_generation:
+                return _finalize_status(
+                    "max_generation_reached",
+                    f"{fired_count}/{max_generation} (post-lock re-check)",
+                    hooks=hooks,
+                    history_path=history_path,
+                    ts=ts_now,
+                )
 
         # Codex MCP catch (PR-OL-A1 fix-up): runner construction itself
         # can raise (lazy import failure, runner __init__ side-effects).
@@ -460,6 +546,7 @@ def register_auto_trigger(
     enabled: bool,
     cron: str,
     min_interval_minutes: int,
+    max_generation: int = 0,
     runner_factory: Callable[[], Any] | None = None,
     hooks: Any = None,
 ) -> bool:
@@ -469,12 +556,17 @@ def register_auto_trigger(
     needs to call. Returns True when the trigger was registered, False
     when ``enabled=False`` (so the wiring layer can log the skip).
 
-    The callback closes over ``min_interval_minutes`` + ``runner_factory``
-    + ``hooks`` so the scheduler's bare ``callback(data)`` invocation
-    forwards into :func:`auto_trigger_mutator` with the right config
-    and telemetry sink. The callback swallows every exception (logs at
-    WARNING) — `TriggerManager`'s own error isolation is the second
-    layer of defense.
+    The callback closes over ``min_interval_minutes`` +
+    ``max_generation`` + ``runner_factory`` + ``hooks`` so the
+    scheduler's bare ``callback(data)`` invocation forwards into
+    :func:`auto_trigger_mutator` with the right config and telemetry
+    sink. The callback swallows every exception (logs at WARNING) —
+    `TriggerManager`'s own error isolation is the second layer of
+    defense.
+
+    PR-MAX-GEN (2026-05-26) — added ``max_generation`` so the wiring
+    layer can pass the scheduler config knob through to the mutator
+    cap gate. Default ``0`` preserves legacy unbounded behaviour.
     """
     if not enabled:
         log.info("auto_trigger: [self_improving_loop.scheduler] enabled=False; skip register")
@@ -487,6 +579,7 @@ def register_auto_trigger(
             status = auto_trigger_mutator(
                 enabled=True,
                 min_interval_minutes=min_interval_minutes,
+                max_generation=max_generation,
                 runner_factory=runner_factory,
                 hooks=hooks,
             )

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -114,6 +114,12 @@ def build_automation(
             enabled=sil_cfg.scheduler.enabled,
             cron=sil_cfg.scheduler.cron,
             min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
+            # PR-MAX-GEN (2026-05-26) — production wiring for the
+            # generation cap. ``0`` (config default) preserves legacy
+            # unbounded behaviour. Operators set a non-zero cap in
+            # ~/.geode/config.toml under [self_improving_loop.scheduler]
+            # max_generation = N.
+            max_generation=sil_cfg.scheduler.max_generation,
             hooks=hooks,
         )
     except Exception:

--- a/tests/autoresearch/test_dry_run_no_attribution.py
+++ b/tests/autoresearch/test_dry_run_no_attribution.py
@@ -1,0 +1,54 @@
+"""PR-DRY-RUN-NO-ATTR (2026-05-26) — pin existing dry-run attribution skip.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5.6,
+item #7) flagged the risk of ``--dry-run`` runs writing synthetic
+``fitness_delta=0`` attribution rows to ``mutations.jsonl`` — a
+noise-accumulation surface for downstream credit-assignment readers.
+
+Current state (post-PR-AR-L6, already in develop main as of 2026-05-26):
+``autoresearch/train.py:2692`` guards attribution writes with
+``_attribution_should_write = not args.dry_run``. The skip is real.
+
+This PR doesn't change behaviour — it adds an invariant test so the
+skip cannot regress silently. The 2026-05-26 sprint discovered the
+ALREADY-IMPLEMENTED state during Phase A; pinning it here prevents
+the leak from re-opening if a future PR strips the guard.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_attribution_write_guarded_by_not_dry_run() -> None:
+    """Static pin: the substring ``_attribution_should_write = not args.dry_run``
+    must remain in ``autoresearch.train.main``. Any future refactor that
+    removes the guard will break this assertion, forcing the author to
+    re-prove the skip semantics rather than silently regressing.
+
+    Brittleness is intentional — the alternative (full subprocess
+    integration test of train.py with mocked Petri output) would be
+    orders of magnitude slower and equally string-matchy at the
+    assertion level."""
+    from autoresearch import train as train_mod
+
+    source = inspect.getsource(train_mod)
+    assert "_attribution_should_write = not args.dry_run" in source, (
+        "PR-DRY-RUN-NO-ATTR invariant violated — the dry-run attribution "
+        "skip guard at train.py around line 2692 has been removed. "
+        "Re-add or document the new skip mechanism."
+    )
+
+
+def test_attribution_block_skips_when_should_write_false() -> None:
+    """Static pin: the attribution write block must be conditional on
+    ``_attribution_should_write`` (not unconditional). Catches the
+    refactor where someone moves the write out of the if-guard."""
+    from autoresearch import train as train_mod
+
+    source = inspect.getsource(train_mod)
+    assert "if _attribution_should_write:" in source, (
+        "PR-DRY-RUN-NO-ATTR invariant violated — the conditional guard "
+        "around the attribution write block at train.py is missing. "
+        "The write must remain gated by _attribution_should_write."
+    )

--- a/tests/autoresearch/test_promote_stamp.py
+++ b/tests/autoresearch/test_promote_stamp.py
@@ -1,0 +1,155 @@
+"""PR-PROMOTE-STAMP (2026-05-26) — ``--promote`` flag baseline stamp pin.
+
+Closes the audit finding from the 2026-05-26 autoresearch attribution
+sprint Phase A audit (§5.5): the ``--promote`` operator override
+bypassed ``_should_promote`` but wrote an *identical-shape*
+baseline.json — downstream readers couldn't tell whether the value
+came from operator force or from the auto-promote gate.
+
+Post-PR, ``_write_baseline(manual_promote=True)`` stamps the
+baseline.json with three new top-level fields:
+
+* ``manual_promote: true``
+* ``promoted_by: "operator"``
+* ``promoted_at: <ts_utc>``
+
+Auto-promote callers omit ``manual_promote`` → flag stays out of
+the file → backward-compat preserved.
+
+This file pins:
+
+1. Default ``manual_promote=False`` → baseline.json has NO ``manual_promote``
+   field (legacy shape preserved).
+2. ``manual_promote=True`` → all three stamp fields present.
+3. ``promoted_at`` equals ``ts_utc`` (single timestamp source).
+4. The rest of the baseline payload (raw/axes/schema_version/...) is
+   identical between the two modes — stamp is additive only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _common_kwargs() -> dict[str, object]:
+    return {
+        "session_id": "test-session",
+        "commit": "abc1234",
+        "sample_count": {"output_quality": 5},
+        "measurement_modality": {"output_quality": "judge_llm"},
+    }
+
+
+def test_default_baseline_has_no_manual_promote_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-promote path (default ``manual_promote=False``) writes the
+    legacy v2-schema baseline shape WITHOUT the stamp fields. This
+    pins backward-compat for callers that omit the new flag."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert "manual_promote" not in payload
+    assert "promoted_by" not in payload
+    assert "promoted_at" not in payload
+    # Sanity — the rest of the v2 shape is intact.
+    assert payload["schema_version"] == 2
+    assert payload["session_id"] == "test-session"
+    assert payload["commit"] == "abc1234"
+
+
+def test_manual_promote_stamps_baseline_with_three_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``manual_promote=True`` → baseline.json gets all three stamp
+    fields. Downstream reader sees ``manual_promote: true`` and knows
+    the value came from operator override, not gate approval."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert payload["manual_promote"] is True
+    assert payload["promoted_by"] == "operator"
+    assert "promoted_at" in payload
+
+
+def test_manual_promote_promoted_at_equals_ts_utc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``promoted_at`` and ``ts_utc`` share the same timestamp source —
+    no drift between when the baseline was *written* and when it was
+    *promoted* (they're the same event in the manual-promote path)."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert payload["promoted_at"] == payload["ts_utc"]
+
+
+def test_manual_promote_additive_only_rest_of_payload_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stamp is additive: every other field in the baseline payload
+    must be identical between ``manual_promote=False`` and
+    ``manual_promote=True``. Catches accidental shape drift."""
+    from autoresearch import train as train_mod
+
+    auto_path = tmp_path / "auto.json"
+    manual_path = tmp_path / "manual.json"
+
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", auto_path)
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        **_common_kwargs(),
+    )
+
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", manual_path)
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    auto = json.loads(auto_path.read_text(encoding="utf-8"))
+    manual = json.loads(manual_path.read_text(encoding="utf-8"))
+
+    # Strip stamp + ts_utc/promoted_at (those can differ by milliseconds
+    # between the two _write_baseline calls if the clock ticks).
+    for stamp in ("manual_promote", "promoted_by", "promoted_at"):
+        manual.pop(stamp, None)
+    auto.pop("ts_utc", None)
+    manual.pop("ts_utc", None)
+
+    assert auto == manual

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -1,0 +1,379 @@
+"""PR-MAX-GEN (2026-05-26) — auto_trigger max_generation cap.
+
+Closes the audit finding from the 2026-05-26 autoresearch attribution
+sprint Phase A (§5.6): ``auto_trigger_mutator`` only enforced a
+``min_interval_minutes`` floor and had no hard cap on total fired
+generations. A misconfigured operator could accumulate hundreds of
+fires without any stop condition.
+
+This file pins:
+
+1. ``count_fired_generations`` correctly counts only ``state="fired"``
+   rows (other states like ``interval_blocked`` ignored).
+2. Empty / missing history file → count = 0.
+3. ``max_generation=0`` (default) preserves legacy unbounded behaviour.
+4. ``max_generation=N`` blocks the (N+1)-th fire with state
+   ``max_generation_reached``.
+5. The cap check fires BEFORE the lock acquisition (so a saturated
+   history doesn't consume the lock for a no-op).
+6. Malformed / non-dict / OSError reads degrade gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_history_row(
+    path: Path,
+    *,
+    state: str,
+    ts: float | None = None,
+    detail: str = "",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, Any] = {
+        "ts": ts if ts is not None else time.time(),
+        "state": state,
+        "detail": detail,
+        "trigger_id": "self_improving_loop_auto_trigger",
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# count_fired_generations
+# ---------------------------------------------------------------------------
+
+
+def test_count_fired_generations_missing_file_returns_zero(tmp_path: Path) -> None:
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    assert count_fired_generations(history_path=tmp_path / "missing.jsonl") == 0
+
+
+def test_count_fired_generations_only_counts_fired_state(tmp_path: Path) -> None:
+    """``interval_blocked`` / ``lock_busy`` / ``runner_error`` etc. are
+    history rows too — they must NOT contribute to the fire count."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="interval_blocked")
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="lock_busy")
+    _write_history_row(history, state="runner_error")
+    _write_history_row(history, state="parse_error")
+    _write_history_row(history, state="fired")
+
+    assert count_fired_generations(history_path=history) == 3
+
+
+def test_count_fired_generations_skips_malformed_rows(tmp_path: Path) -> None:
+    """Best-effort — malformed JSON / non-dict rows / blank lines all
+    skipped silently without aborting the scan."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+        fh.write("\n")  # blank
+        fh.write("[1, 2, 3]\n")  # non-dict
+    _write_history_row(history, state="fired")
+
+    assert count_fired_generations(history_path=history) == 2
+
+
+def test_count_fired_generations_oserror_returns_partial(tmp_path: Path) -> None:
+    """OSError mid-read returns the count accumulated so far (best-effort)."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    history.write_text("dummy\n", encoding="utf-8")
+
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        n = count_fired_generations(history_path=history)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# auto_trigger_mutator — max_generation gate behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_max_generation_zero_means_unlimited(tmp_path: Path) -> None:
+    """``max_generation=0`` (default) → legacy unbounded behaviour: even
+    with 100 prior fires the next call still proceeds past the cap
+    check (it may still hit lock/interval/runner gates, but the cap
+    itself doesn't block)."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(100):
+        _write_history_row(history, state="fired")
+
+    fake_runner_calls: list[None] = []
+
+    class _FakeRunner:
+        def run_once(self) -> object:
+            fake_runner_calls.append(None)
+
+            class _Mut:
+                target_section = "role"
+
+            return _Mut()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=0,  # unlimited
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "fired"
+    assert len(fake_runner_calls) == 1
+
+
+def test_max_generation_blocks_when_history_at_cap(tmp_path: Path) -> None:
+    """``max_generation=3`` + history already has 3 fired rows → next
+    call returns ``max_generation_reached`` without invoking runner."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(3):
+        _write_history_row(history, state="fired")
+
+    runner_calls: list[None] = []
+
+    class _FakeRunner:
+        def run_once(self) -> object:  # pragma: no cover — must not fire
+            runner_calls.append(None)
+            return object()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "3/3" in status.detail
+    assert runner_calls == []
+
+
+def test_max_generation_blocks_when_history_above_cap(tmp_path: Path) -> None:
+    """Pre-existing history with 5 fires + cap=3 → still blocked. The
+    ``>=`` comparison ensures the cap can't be re-entered after the
+    operator raises and lowers it."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(5):
+        _write_history_row(history, state="fired")
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("must not be called")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "5/3" in status.detail
+
+
+def test_max_generation_allows_when_below_cap(tmp_path: Path) -> None:
+    """``max_generation=3`` + history has 2 fired rows → next call
+    proceeds (only 2 of 3 used)."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="fired")
+
+    class _FakeRunner:
+        def run_once(self) -> object:
+            class _Mut:
+                target_section = "role"
+
+            return _Mut()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "fired"
+
+
+def test_max_generation_cap_evaluated_before_lock(tmp_path: Path) -> None:
+    """The cap check must fire BEFORE the lock acquisition, otherwise a
+    saturated history would still consume + release the lock on every
+    cron tick (lock cost wasted)."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(2):
+        _write_history_row(history, state="fired")
+
+    lock_acquire_calls: list[None] = []
+
+    def fake_acquire(lock_path: Path | None = None) -> int | None:
+        lock_acquire_calls.append(None)  # pragma: no cover — must not be reached
+        return 1
+
+    with patch.object(mod, "acquire_auto_trigger_lock", fake_acquire):
+        status = mod.auto_trigger_mutator(
+            enabled=True,
+            min_interval_minutes=0,
+            max_generation=2,
+            runner_factory=lambda: object(),  # would crash if reached
+            lock_path=tmp_path / "lock",
+            timestamp_path=tmp_path / "ts.txt",
+            history_path=history,
+        )
+
+    assert status.state == "max_generation_reached"
+    assert lock_acquire_calls == []
+
+
+def test_register_auto_trigger_forwards_max_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex MCP review #1 (FAIL must-fix #1) — pin that
+    ``register_auto_trigger`` actually forwards ``max_generation``
+    into the scheduler callback. Without this wiring, the new
+    config knob was a dead parameter."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    forwarded: dict[str, Any] = {}
+
+    def fake_mutator(**kwargs: Any) -> mod.AutoTriggerStatus:
+        forwarded.update(kwargs)
+        return mod.AutoTriggerStatus(state="fired")
+
+    monkeypatch.setattr(mod, "auto_trigger_mutator", fake_mutator)
+
+    class _FakeTM:
+        def __init__(self) -> None:
+            self.registered: list[Any] = []
+
+        def register(self, cfg: Any) -> None:
+            self.registered.append(cfg)
+
+    tm = _FakeTM()
+    result = mod.register_auto_trigger(
+        tm,
+        enabled=True,
+        cron="0 * * * *",
+        min_interval_minutes=60,
+        max_generation=42,
+        runner_factory=lambda: object(),
+        hooks=None,
+    )
+
+    assert result is True
+    assert len(tm.registered) == 1
+    # Invoke the registered callback to verify the forwarded knob.
+    tm.registered[0].callback({})
+    assert forwarded["max_generation"] == 42
+
+
+def test_max_generation_hook_event_reserved() -> None:
+    """Codex MCP review #1 (FAIL must-fix #3) — pin that the new
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` HookEvent
+    is reserved in ``core/hooks/system.py``. Without this the
+    ``STATE_TO_HOOK_EVENT`` mapping references a nonexistent enum
+    name and ``_emit_state_event`` silently skips telemetry."""
+    from core.hooks import HookEvent
+
+    assert hasattr(HookEvent, "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED")
+    assert (
+        HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED.value
+        == "self_improving_auto_trigger_max_generation_reached"
+    )
+
+
+def test_max_generation_post_lock_recheck_blocks_overshoot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #1 (FAIL must-fix #2) — pin that the post-lock
+    cap re-check exists. Simulates the race: pre-lock count is below
+    cap, but by the time the lock is acquired another process has
+    bumped the count to/above cap. Without re-check both would fire."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    # Pre-lock state: 2 fires, cap=3 → pre-lock check allows.
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="fired")
+
+    # When the lock acquisition is requested, simulate that ANOTHER
+    # process appended a fire between our pre-lock count and our
+    # lock-acquire. We mutate the history file mid-flight.
+    real_acquire = mod.acquire_auto_trigger_lock
+
+    def fake_acquire(lock_path: Path | None = None) -> int | None:
+        _write_history_row(history, state="fired")  # race: cap now reached
+        return real_acquire(lock_path=lock_path)
+
+    monkeypatch.setattr(mod, "acquire_auto_trigger_lock", fake_acquire)
+
+    status = mod.auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("post-lock re-check should have blocked")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "post-lock re-check" in status.detail
+
+
+def test_max_generation_disabled_state_short_circuits_before_cap(tmp_path: Path) -> None:
+    """``enabled=False`` short-circuits BEFORE the cap check — disabled
+    is a defensive guard that never touches disk."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(5):
+        _write_history_row(history, state="fired")
+
+    status = auto_trigger_mutator(
+        enabled=False,
+        min_interval_minutes=0,
+        max_generation=2,
+        history_path=history,
+    )
+
+    assert status.state == "disabled"

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -360,6 +360,52 @@ def test_max_generation_post_lock_recheck_blocks_overshoot(
     assert "post-lock re-check" in status.detail
 
 
+def test_max_generation_emits_hook_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #2 (FAIL must-fix #3) — direct emission test.
+    When the cap fires, the registered HookSystem must receive a
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` event with
+    the ``{trigger_id, ts, detail}`` payload. Pins the wiring from
+    ``_finalize_status`` → ``_emit_state_event`` →
+    ``STATE_TO_HOOK_EVENT[max_generation_reached]`` → ``HookEvent``."""
+    from core.hooks import HookEvent
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(3):
+        _write_history_row(history, state="fired")
+
+    captured: list[tuple[HookEvent, dict[str, Any]]] = []
+
+    class _FakeHooks:
+        def trigger(self, event: HookEvent, payload: dict[str, Any]) -> None:
+            captured.append((event, payload))
+
+    status = mod.auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("runner must not fire")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+        hooks=_FakeHooks(),
+    )
+
+    assert status.state == "max_generation_reached"
+    # Hook system received the cap-reached event with the canonical
+    # auto-trigger payload schema.
+    assert len(captured) == 1
+    event, payload = captured[0]
+    assert event is HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED
+    assert payload["trigger_id"] == mod.AUTO_TRIGGER_TRIGGER_ID
+    assert "ts" in payload
+    assert "3/3" in payload["detail"]
+
+
 def test_max_generation_disabled_state_short_circuits_before_cap(tmp_path: Path) -> None:
     """``enabled=False`` short-circuits BEFORE the cap check — disabled
     is a defensive guard that never touches disk."""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -19,8 +19,9 @@ class TestHookEvent:
         # lives here.
         # Tally: +6 PR-2 cognitive + 5 OL-A1.5 auto-trigger
         # + 3 PR-CL-BUDGET handoff + 5 PR-HOOKEVENT-RESERVE (mutation /
-        # baseline lifecycle).
-        assert len(HookEvent) == 79
+        # baseline lifecycle) + 1 PR-MAX-GEN
+        # (SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED).
+        assert len(HookEvent) == 80
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_STARTED.value == "pipeline_start"

--- a/tests/test_ol_a15_telemetry.py
+++ b/tests/test_ol_a15_telemetry.py
@@ -62,7 +62,9 @@ class _CapturingHooks:
 # ---------------------------------------------------------------------------
 
 
-def test_hook_event_has_five_auto_trigger_variants() -> None:
+def test_hook_event_has_auto_trigger_variants() -> None:
+    """PR-MAX-GEN (2026-05-26) added a sixth auto-trigger variant:
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED``."""
     from core.hooks import HookEvent
 
     assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_FIRED.value == "self_improving_auto_trigger_fired"
@@ -78,10 +80,15 @@ def test_hook_event_has_five_auto_trigger_variants() -> None:
     assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR.value == (
         "self_improving_auto_trigger_parse_error"
     )
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED.value == (
+        "self_improving_auto_trigger_max_generation_reached"
+    )
 
 
-def test_state_to_hook_event_map_covers_five_states_only() -> None:
-    """`disabled` is intentionally absent — see module docstring."""
+def test_state_to_hook_event_map_covers_terminal_states() -> None:
+    """`disabled` is intentionally absent — see module docstring.
+    PR-MAX-GEN (2026-05-26) added ``max_generation_reached`` for the
+    generation-cap state, bringing the map to six entries."""
     from core.self_improving_loop.auto_trigger import STATE_TO_HOOK_EVENT
 
     assert set(STATE_TO_HOOK_EVENT) == {
@@ -90,6 +97,7 @@ def test_state_to_hook_event_map_covers_five_states_only() -> None:
         "interval_blocked",
         "runner_error",
         "parse_error",
+        "max_generation_reached",
     }
     assert "disabled" not in STATE_TO_HOOK_EVENT
 


### PR DESCRIPTION
## Summary

- Phase E (outer-loop hardening) 3 sprint items bundled per "PR 단위 크게 가져가도 좋아" instruction.
- **PR-MAX-GEN** — auto_trigger hard cap on total fires (pre/post-lock check) + config knob + production wiring + HookEvent reservation.
- **PR-PROMOTE-STAMP** — `--promote` 강제 promotion 시 baseline.json 에 manual_promote stamp.
- **PR-DRY-RUN-NO-ATTR (pin only)** — 기존 skip guard 의 invariant test 추가.

## Why

2026-05-26 autoresearch attribution sprint Phase A audit (`.audit/diagnostics/attribution-grounding-2026-05-26.md`) findings:

- §5.6: auto_trigger_mutator 가 `min_interval_minutes` floor 만 존재하고 hard cap 없음 → misconfigured cron 시 hundreds-of-fires.
- §5.5: `--promote` 가 auto-promote 와 identical-shape baseline.json 만 write → downstream reader 가 origin 구분 불가.
- §5.6 item #7: `--dry-run` 시 synthetic `fitness_delta=0` attribution row 가 mutations.jsonl 에 누적될 risk. (검증 결과 skip guard 이미 implemented; invariant test 만 추가)

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/auto_trigger.py` | 신규 `count_fired_generations` helper. `auto_trigger_mutator` 에 `max_generation: int = 0` param. Pre-lock + post-lock cap check. `register_auto_trigger` signature 에 `max_generation` 추가. `STATE_TO_HOOK_EVENT` 에 `max_generation_reached` 추가. |
| `core/config/self_improving_loop.py` | `SchedulerConfig.max_generation: Annotated[int, Field(ge=0, le=100_000)] = 0` 신규 knob. 상세 docstring (pre/post-lock 동작 명시). |
| `core/wiring/automation.py` | `register_auto_trigger(... max_generation=sil_cfg.scheduler.max_generation ...)` production wiring. |
| `core/hooks/system.py` | `SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED` HookEvent 예약. |
| `autoresearch/train.py` | `_write_baseline` 에 `manual_promote: bool = False` param. `True` 시 baseline.json 에 3 stamp field 추가. `args.promote` branch 에서 `manual_promote=True` 전달. |
| `tests/core/self_improving_loop/test_auto_trigger_max_generation.py` | 신규. 13 invariant test (helper edge cases + pre/post-lock cap + production wiring + HookEvent reserve + direct emission). |
| `tests/autoresearch/test_promote_stamp.py` | 신규. 4 invariant test (default no-stamp + stamp 3-field + promoted_at parity + additive-only). |
| `tests/autoresearch/test_dry_run_no_attribution.py` | 신규. 2 static-source invariant test (기존 skip guard regression 방어). |
| `tests/test_hooks.py` | `len(HookEvent) == 79` → `80` (PR-MAX-GEN 으로 1 증가). |
| `tests/test_ol_a15_telemetry.py` | `STATE_TO_HOOK_EVENT` 의 5 entry 가정 → 6 entry (`max_generation_reached` 포함). 사이드 enum variant 어서션도 동기화. |
| `CHANGELOG.md` | `[Unreleased]` Added/Changed/Fixed entries. Develop backmerge 의 ranker / ChatGPT-plan PR entry 들과 interleave. |

## Verification

- [x] `geode-ci --fast` ALL GREEN (ruff/format/mypy/deptry/lint-imports/4 ratchets/bandit/prompt integrity)
- [x] `geode-ci --tests` — 19 new tests pass. 8389 total pass / 5 pre-existing failures (`test_m4_4_in_context_wiring` + `test_seed_eval_export` 4) — develop main 에서도 동일, 본 PR 무관.
- [x] Codex MCP review **(2 iterations)** — 1st FAIL → 3 must-fix 모두 적용 (production wiring + post-lock recheck + HookEvent reservation); 2nd FAIL → 3 must-fix 모두 적용 (stale test sync + stale docs cleanup + direct emission test).

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §5.5, §5.6
- Sibling merged PRs: #1749 SOT-REVERT-ON-REJECT, #1753 SOT-REVERT-ON-AUDIT-FAIL, #1757 ATTR-INSPIRED-BY, #1758 WIRE-1, #1759 GEN-COUNTER
- Develop backmerge (#1764/#1765) — no code overlap with this PR's territory

🤖 Generated with [Claude Code](https://claude.com/claude-code)