### PR TITLE
feat(self-improving-loop): surface clarity bundle — TARGET_KINDS doc + Pareto archive promote-gate integration (PR-SURFACE-CLARITY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,41 @@ functional change.
 
 ### Added
 
+- **PR-SURFACE-CLARITY** — Phase H bundle (TARGET-KIND-DOC +
+  PARETO-INTEGRATE) closing the 2026-05-26 attribution sprint Phase A
+  audit §5 and §5.7 follow-ups.
+  * **TARGET-KIND-DOC**: ``core/self_improving_loop/policies.py``
+    introduces the ``_READER_ONLY_KINDS`` frozenset listing the 7 SoT
+    surfaces wired in ``autoresearch.train.run_audit``'s STRICT-mode
+    env block (``tool_descriptions`` / ``style_guide`` /
+    ``provider_routing`` / ``cache_policy`` / ``heuristics`` /
+    ``in_context_slots`` / ``few_shot_pool``) but NOT in
+    ``TARGET_KINDS``. Comment block above ``TARGET_KINDS`` explains
+    the asymmetry as intentional ADR-013 phased rollout and points
+    operators at the fail-fast ``parse_mutation`` ValueError when a
+    mutator emits a reader-only kind. Pinned by 4 invariant tests in
+    ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+    (disjoint sets, fail-fast emission per kind, env-wiring parity,
+    size-7 sanity counter).
+  * **PARETO-INTEGRATE**: ``autoresearch.train.main`` now appends an
+    ``ArchiveEntry`` to ``BASELINE_ARCHIVE_PATH`` after the promote
+    decision is finalized (every cycle, accept + reject). The entry
+    carries full ``dim_means`` / ``dim_stderr`` plus ``promoted``
+    (bool) and ``reason`` (str) via ``ArchiveEntry.extra="allow"``
+    so downstream regret-analysis readers can compute the multi-axis
+    cost of rejecting mutation M. Gated by
+    ``[self_improving_loop.autoresearch] pareto_mode = true``
+    (operator opt-in; default off preserves backward-compat) AND
+    ``not args.dry_run`` (synthetic dim_means has no Pareto signal).
+    Wrapped in best-effort try/except — JSONL writer failure logs at
+    WARNING and the audit cycle continues, matching the existing
+    runner-side pareto wiring pattern (runner.py:1667-1673).
+    Pinned by 5 invariant tests in
+    ``tests/autoresearch/test_pareto_integrate_promote_gate.py``
+    (block presence, opt-in gating, ``promoted`` + ``reason`` field
+    join keys, single source of truth for the accept/reject bit,
+    best-effort error path).
+
 - **PR-MAX-GEN** — Outer-loop hardening: hard cap on total auto-trigger
   fires.
   * ``auto_trigger_mutator`` accepts a new ``max_generation: int = 0``

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2691,6 +2691,83 @@ def main() -> int:
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 
+    # PR-PARETO-INTEGRATE (2026-05-27) — multi-axis preservation. The
+    # 2026-05-26 attribution sprint Phase A audit (§5.7) found that
+    # ``pareto_archive.append_archive_entry`` was wired only inside
+    # ``runner.apply_group_proposals`` (sibling-group path, fitness scalar
+    # only) and never from ``train.py``'s promote gate. The promote gate
+    # is the *only* point where the full ``dim_means`` (multi-axis
+    # observation) crosses paths with the accept/reject decision — without
+    # archiving here, every rejected mutation's per-dim scores are lost
+    # the moment we move to the next cycle.
+    #
+    # Writes when:
+    #   1. ``[self_improving_loop.autoresearch] pareto_mode = true``
+    #      (operator opt-in; default off preserves backward-compat).
+    #   2. Not ``--dry-run`` (synthetic dim_means carries no Pareto signal).
+    #
+    # The entry uses ``extra="allow"`` to attach ``promoted`` + ``reason``
+    # so downstream readers can compute "regret" — what was rejected and
+    # by which gate? Cycle-wide multi-axis history is preserved regardless
+    # of the binary accept/reject outcome.
+    if not args.dry_run:
+        try:
+            from core.config.self_improving_loop import load_self_improving_loop_config
+
+            _sil_cfg = load_self_improving_loop_config()
+            if _sil_cfg.autoresearch.pareto_mode:
+                from core.paths import BASELINE_ARCHIVE_PATH
+                from core.self_improving_loop.pareto_archive import (
+                    ArchiveEntry,
+                    append_archive_entry,
+                )
+
+                _pareto_mid = (
+                    os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+                    or f"manual-{commit[:8]}-{int(started_at)}"
+                )
+                _pareto_audit_run_id = os.environ.get("GEODE_SIL_AUDIT_RUN_ID", "").strip()
+                _pareto_group_id = os.environ.get("GEODE_SIL_GROUP_ID", "").strip()
+                # ``promoted`` and ``reason`` rides on ArchiveEntry's
+                # ``extra="allow"`` — they're not core schema but
+                # downstream regret-analysis readers join on them.
+                # ``promoted_line`` is set in every promote branch
+                # (dry-run/--no-promote/--promote/auto). It starts with
+                # ``"true ("`` only when the baseline was actually
+                # promoted; ``"false ("`` covers rejection + dry-run
+                # synthetic + explicit no-promote. Derive boolean from
+                # that single source so all four branches agree.
+                _was_promoted = promoted_line.startswith("true")
+                # Codex MCP review (CONDITIONAL_PASS must-fix #1) — when
+                # the runner's apply_group_proposals fires sibling
+                # subprocesses, it ALSO writes pareto archive rows (with
+                # fitness scalar only, pre-audit). Adding train.py's
+                # post-audit row would duplicate the mutation_id key
+                # downstream readers join on. We tag with ``phase``
+                # (extra="allow") so the two writers coexist with
+                # distinguishable rows: runner = ``pre_audit_sibling``
+                # (fitness scalar, all N siblings), train = ``post_audit``
+                # (full dim_means + promoted decision, single outcome).
+                entry = ArchiveEntry(
+                    mutation_id=_pareto_mid,
+                    group_id=_pareto_group_id,
+                    audit_run_id=_pareto_audit_run_id,
+                    ts=time.time(),
+                    dim_means={k: float(v) for k, v in dim_means.items()},
+                    dim_stderr={k: float(v) for k, v in (dim_stderr or {}).items()},
+                    promoted=_was_promoted,
+                    reason=promoted_line,
+                    phase="post_audit",
+                )
+                append_archive_entry(entry, archive_path=BASELINE_ARCHIVE_PATH)
+        except Exception:
+            # Best-effort: archive append must not break the audit
+            # cycle. Failures land in train.py log but don't propagate.
+            log.warning(
+                "PR-PARETO-INTEGRATE: archive append failed (cycle continues)",
+                exc_info=True,
+            )
+
     # W2 (2026-05-25) + PR-AR-L6 (2026-05-26) — closed loop attribution.
     # Two paths:
     #

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -135,6 +135,23 @@ def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
 # 보존: ``GLOBAL_RETRIEVAL_POLICY_PATH`` 와 ``_KIND_TO_PATH`` 의 ``retrieval``
 # 매핑은 그대로 둠 — 미래 RAG 인프라 신설 시 별도 ADR 로 ``TARGET_KINDS``
 # 에 재추가 가능하도록 path-literal guard 유지.
+#
+# PR-TARGET-KIND-DOC (2026-05-27) — surface-clarity bundle. The 2026-05-26
+# attribution sprint Phase A audit (§5 mutation surface verification)
+# found an asymmetry: ``autoresearch.train.run_audit``'s env override
+# block (around line 868-903) wires STRICT-mode env vars for **13** SoT
+# files, but ``TARGET_KINDS`` below lists only **6 active** mutation
+# slots. The 7 difference is :data:`_READER_ONLY_KINDS` — reader-deployed
+# SoT surfaces that the audit subprocess consumes (read-only) but the
+# mutator cannot dispatch to. ADR-013 phased rollout intent: each
+# reader-only surface graduates in its own follow-up PR (matching the
+# ADR-012 M1/M2 precedent that opened ``skill_catalog`` and
+# ``agent_contract``). Mutator emitting a ``target_kind`` not in
+# ``TARGET_KINDS`` fails fast at ``parse_mutation`` (``runner.py:914``
+# ValueError) — fail-closed by design. The reader-only set is pinned
+# by ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+# so a future PR that promotes any of them must remove the entry
+# explicitly rather than silently expanding mutator dispatch.
 TARGET_KINDS: tuple[str, ...] = (
     "prompt",
     "tool_policy",
@@ -172,6 +189,29 @@ _KIND_TO_PATH: dict[str, Path] = {
 # M1+M2 (2026-05-21) — nested-schema kinds. ``load_policy`` /
 # ``write_policy`` 의 flat ↔ nested 변환 dispatch 분기 키.
 _NESTED_KINDS: frozenset[str] = frozenset({"skill_catalog", "agent_contract"})
+
+
+# PR-TARGET-KIND-DOC (2026-05-27) — reader-only SoT surfaces. These are
+# wired in ``autoresearch.train.run_audit``'s ``GEODE_*_OVERRIDE`` +
+# ``GEODE_*_STRICT`` env block (so the audit subprocess can read them
+# under operator-local overrides) but NOT in :data:`TARGET_KINDS` (so
+# the mutator can't dispatch to them). Each entry must graduate to
+# ``TARGET_KINDS`` via its own follow-up PR — phased rollout matches
+# the ADR-012 M1/M2 precedent. Frozen set so a future PR that adds an
+# entry to ``TARGET_KINDS`` *must* remove it here (the invariant test
+# in ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+# verifies the two sets are disjoint).
+_READER_ONLY_KINDS: frozenset[str] = frozenset(
+    {
+        "tool_descriptions",
+        "style_guide",
+        "provider_routing",
+        "cache_policy",
+        "heuristics",
+        "in_context_slots",
+        "few_shot_pool",
+    }
+)
 
 
 def is_valid_target_kind(kind: str) -> bool:

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1653,6 +1653,13 @@ class SelfImprovingLoopRunner:
                 _archive_appended = 0
                 _archive_failed = 0
                 for idx, proposal in enumerate(proposals):
+                    # PR-PARETO-INTEGRATE (2026-05-27) Codex MCP review
+                    # must-fix #1 — tag with ``phase="pre_audit_sibling"``
+                    # so this sibling row (fitness scalar, pre-audit) is
+                    # distinguishable from train.py's post-audit row
+                    # (full dim_means + promoted decision). Both writers
+                    # share the mutation_id join key but downstream
+                    # readers filter by phase.
                     entry = ArchiveEntry(
                         mutation_id=proposal.mutation.mutation_id,
                         group_id=group_id,
@@ -1660,6 +1667,7 @@ class SelfImprovingLoopRunner:
                         ts=time.time(),
                         dim_means={"fitness": float(fitness_values[idx])},
                         dim_stderr={},
+                        phase="pre_audit_sibling",
                     )
                     try:
                         append_archive_entry(entry, archive_path=BASELINE_ARCHIVE_PATH)

--- a/tests/autoresearch/test_pareto_integrate_promote_gate.py
+++ b/tests/autoresearch/test_pareto_integrate_promote_gate.py
@@ -1,0 +1,166 @@
+"""PR-PARETO-INTEGRATE (2026-05-27) — promote-gate Pareto archive wiring.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5.7)
+found that ``core.self_improving_loop.pareto_archive.append_archive_entry``
+was wired only inside ``runner.apply_group_proposals`` (sibling-group
+path, fitness scalar only). The promote gate in ``autoresearch.train.main``
+— the one site where full ``dim_means`` meets the accept/reject
+decision — never archived its observation. Every rejected mutation's
+per-dim scores vanished at cycle end, so regret analysis ("what was
+the multi-axis cost of rejecting mutation M?") was impossible.
+
+This PR adds an archive write inside ``main()`` after the promote
+decision is finalized, gated by:
+* ``[self_improving_loop.autoresearch] pareto_mode = true`` (operator
+  opt-in; default off preserves backward-compat).
+* Not ``--dry-run`` (synthetic dim_means has no Pareto signal).
+
+The entry rides ArchiveEntry's ``extra="allow"`` to attach
+``promoted`` (bool) + ``reason`` (str) so downstream regret-analysis
+readers can join on them.
+
+This file pins the wiring as opt-in (off by default), accept+reject
+parity (both write), dry-run skip, and the regret-analysis fields.
+The actual archive read/write/dominate-prune behavior is covered in
+``tests/core/self_improving_loop/test_pareto_archive.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_pareto_archive_write_lives_in_promote_gate() -> None:
+    """Static-source pin: the new archive-write block is in
+    ``autoresearch.train.main`` (not just inside the runner's group
+    path). Closes the §5.7 audit finding that the promote gate had no
+    archive integration."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    assert "PR-PARETO-INTEGRATE" in src, (
+        "PR-PARETO-INTEGRATE marker missing from autoresearch.train — "
+        "the promote-gate archive write block was removed or moved. "
+        "Either restore the wiring or update the §5.7 audit follow-up "
+        "documentation."
+    )
+    assert "append_archive_entry" in src, (
+        "autoresearch.train no longer references pareto_archive's "
+        "append_archive_entry — the promote-gate wiring is broken."
+    )
+
+
+def test_pareto_archive_block_gated_by_pareto_mode_and_dry_run() -> None:
+    """The archive write must be gated by BOTH ``pareto_mode`` opt-in
+    AND ``not args.dry_run``. Catches a refactor that loosens either
+    guard (which would write spurious archive rows or break the
+    dry-run no-cost invariant)."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Substring grep for the two guards. Brittle on rename, but that
+    # rename is exactly the case the audit asks us to surface.
+    assert "if not args.dry_run:" in src
+    assert "pareto_mode" in src
+
+
+def test_pareto_archive_entry_carries_promoted_and_reason() -> None:
+    """The ArchiveEntry constructed in train.py must pass ``promoted``
+    + ``reason`` so downstream regret-analysis readers can compute
+    "what was the multi-axis cost of rejecting mutation M?". Pin
+    these field names because they're the join keys."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Both kwargs must appear inside the PR-PARETO-INTEGRATE block.
+    # Substring presence is sufficient — the block is small.
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000  # safety fallback
+    block = src[pr_block_start:pr_block_end]
+    assert "promoted=" in block, (
+        "ArchiveEntry kwarg ``promoted`` missing in the PR-PARETO-"
+        "INTEGRATE block — regret analysis needs the accept/reject "
+        "bit to filter rejected mutations."
+    )
+    assert "reason=" in block, (
+        "ArchiveEntry kwarg ``reason`` missing — downstream readers "
+        "lose the human-readable promote_line context."
+    )
+
+
+def test_pareto_archive_promoted_derived_from_promoted_line() -> None:
+    """``promoted_line`` is set in every promote branch
+    (dry-run/--no-promote/--promote/auto). Deriving ``promoted`` from
+    its prefix (``"true"`` vs ``"false"``) keeps the four branches
+    agreeing without re-implementing the gate logic. Pin this so a
+    refactor that splits the derivation can't drift the boolean."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000
+    block = src[pr_block_start:pr_block_end]
+    assert 'promoted_line.startswith("true")' in block, (
+        "PR-PARETO-INTEGRATE block must derive ``promoted`` from "
+        '``promoted_line.startswith("true")`` so the four branches '
+        "(dry-run/--no-promote/--promote/auto) share one source of "
+        "truth for the accept/reject bit."
+    )
+
+
+def test_pareto_archive_phase_tag_distinguishes_pre_post_audit() -> None:
+    """Codex MCP review (CONDITIONAL_PASS must-fix #1) — when group
+    sampling fires runner.apply_group_proposals, BOTH runner-side
+    (per-sibling pre-audit fitness) AND train-side (post-audit full
+    dim_means) writers append to the archive on the same mutation_id.
+    The ``phase`` field (ArchiveEntry.extra="allow") distinguishes the
+    two so downstream readers don't read duplicate-key data as
+    conflicting.
+
+    Train-side: ``phase="post_audit"``. Runner-side:
+    ``phase="pre_audit_sibling"``. Pin both literals so a refactor
+    can't drift them apart and silently break the join."""
+    import inspect
+
+    from autoresearch import train as train_mod
+    from core.self_improving_loop import runner as runner_mod
+
+    train_src = inspect.getsource(train_mod)
+    runner_src = inspect.getsource(runner_mod)
+
+    assert 'phase="post_audit"' in train_src, (
+        'Train-side pareto archive entry must tag ``phase="post_audit"`` '
+        "to distinguish from runner-side sibling rows. Without this tag, "
+        "downstream readers see duplicate mutation_id rows with "
+        "conflicting dim_means shapes."
+    )
+    assert 'phase="pre_audit_sibling"' in runner_src, (
+        "Runner-side pareto archive entry must tag "
+        '``phase="pre_audit_sibling"`` so downstream readers can filter '
+        "to the per-sibling fitness-scalar pre-audit signal."
+    )
+
+
+def test_pareto_archive_failure_is_best_effort() -> None:
+    """An exception inside the archive-append block must NOT propagate
+    out of ``main()``. The audit cycle continues even if the JSONL
+    writer fails (matches the pattern from runner.apply_group_proposals's
+    existing pareto wiring at runner.py:1667-1673)."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000
+    block = src[pr_block_start:pr_block_end]
+    assert "except Exception:" in block, (
+        "PR-PARETO-INTEGRATE block must wrap the archive append in "
+        "try/except so a JSONL writer failure can't break the audit "
+        "cycle. The existing runner-side pareto wiring uses the same "
+        "best-effort pattern (runner.py:1667-1673)."
+    )

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -360,9 +360,7 @@ def test_max_generation_post_lock_recheck_blocks_overshoot(
     assert "post-lock re-check" in status.detail
 
 
-def test_max_generation_emits_hook_event(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_max_generation_emits_hook_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Codex MCP review #2 (FAIL must-fix #3) — direct emission test.
     When the cap fires, the registered HookSystem must receive a
     ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` event with

--- a/tests/core/self_improving_loop/test_target_kind_surface_doc.py
+++ b/tests/core/self_improving_loop/test_target_kind_surface_doc.py
@@ -1,0 +1,119 @@
+"""PR-TARGET-KIND-DOC (2026-05-27) — TARGET_KINDS vs _READER_ONLY_KINDS pin.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5
+mutation surface verification) found an asymmetry between the
+canonical ``TARGET_KINDS`` (6 active mutation slots) and
+``autoresearch.train.run_audit``'s env override block (13 STRICT-mode
+env vars for the 6 active + 1 deprecated + 7 reader-only).
+
+The asymmetry is **intentional** (ADR-013 phased rollout) but
+previously undocumented in code — a mutator emitting a target_kind
+like ``tool_descriptions`` (reader-deployed but not yet a mutation
+slot) would fail at ``parse_mutation``'s ValueError without any
+operator-visible signal that the surface is reader-only.
+
+This file pins:
+
+1. ``_READER_ONLY_KINDS`` is disjoint from ``TARGET_KINDS`` — no
+   accidental double-listing (which would make ``parse_mutation``
+   accept a kind that's also marked reader-only).
+2. Each reader-only kind, when emitted as a mutator response, fails
+   fast at ``parse_mutation`` with a clear ValueError. This is the
+   operator-visible signal that the surface isn't yet writable.
+3. The reader-only set matches the 7 surfaces with env wiring in
+   ``autoresearch/train.py:840-903`` (the audit-side override block).
+   A future PR that adds an env var without graduating the kind to
+   ``TARGET_KINDS`` or adding to ``_READER_ONLY_KINDS`` will fail
+   this test, forcing explicit triage.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_target_kinds_and_reader_only_are_disjoint() -> None:
+    """A kind can be EITHER mutator-dispatchable (in TARGET_KINDS) OR
+    reader-only (in _READER_ONLY_KINDS), never both. Catches a future
+    PR that accidentally double-lists a kind during a graduation."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS, TARGET_KINDS
+
+    overlap = set(TARGET_KINDS) & _READER_ONLY_KINDS
+    assert not overlap, (
+        f"TARGET_KINDS and _READER_ONLY_KINDS overlap on {overlap!r} — "
+        "a kind must be either active (in TARGET_KINDS) or reader-only, "
+        "never both. Check the ADR-013 graduation that introduced the "
+        "duplicate listing."
+    )
+
+
+def test_reader_only_kind_emit_fails_fast_at_parse_mutation() -> None:
+    """Operator-visible signal: mutator response carrying a reader-only
+    target_kind raises ValueError at ``parse_mutation``, not silently
+    succeeds. Iterates every entry in ``_READER_ONLY_KINDS`` so adding
+    a new entry automatically gains test coverage."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+    from core.self_improving_loop.runner import parse_mutation
+
+    for kind in _READER_ONLY_KINDS:
+        payload = json.dumps(
+            {
+                "target_section": "any",
+                "new_value": "any",
+                "rationale": "test",
+                "target_kind": kind,
+            }
+        )
+        with pytest.raises(ValueError, match=f"target_kind {kind!r}"):
+            parse_mutation(payload)
+
+
+def test_reader_only_kinds_match_env_override_block() -> None:
+    """Static-source pin: every kind in ``_READER_ONLY_KINDS`` must have
+    a corresponding ``GEODE_<KIND>_OVERRIDE`` env var set in
+    ``autoresearch/train.py:run_audit``'s override block (the audit-
+    side STRICT-mode wiring). Catches the future PR that adds env
+    wiring for a new SoT without listing it in ``_READER_ONLY_KINDS``.
+
+    Brittleness intent: substring check on the source file, same
+    rationale as ``tests/autoresearch/test_dry_run_no_attribution.py``
+    — a failing assertion forces explicit triage, which is exactly
+    what the doc comment in ``policies.py`` warns about.
+    """
+    import inspect
+
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Each kind in _READER_ONLY_KINDS must have its env var present.
+    # Convention: ``GEODE_{KIND.upper()}_OVERRIDE`` (matches the
+    # ``ADR-012 S0a/S0b`` wiring pattern train.py:840-903).
+    for kind in _READER_ONLY_KINDS:
+        env_var = f"GEODE_{kind.upper()}_OVERRIDE"
+        assert env_var in src, (
+            f"_READER_ONLY_KINDS contains {kind!r} but "
+            f"autoresearch/train.py has no {env_var} env wiring. "
+            "Either remove the kind from _READER_ONLY_KINDS (it's not "
+            "actually reader-deployed) or add the STRICT-mode env in "
+            "run_audit's override block."
+        )
+
+
+def test_reader_only_set_size_matches_audit_finding() -> None:
+    """Sanity counter — the 2026-05-26 Phase A audit found exactly 7
+    reader-only surfaces. If a future PR graduates one (moving it to
+    TARGET_KINDS) the size should drop; if a new surface lands the
+    size should grow. Either way the explicit count makes the change
+    impossible to miss in code review."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+
+    assert len(_READER_ONLY_KINDS) == 7, (
+        f"_READER_ONLY_KINDS has {len(_READER_ONLY_KINDS)} entries; the "
+        "2026-05-26 attribution sprint Phase A audit counted 7. "
+        "Update this assertion AND the policies.py doc comment if the "
+        "surface count legitimately changed."
+    )


### PR DESCRIPTION
## Summary

- Phase H bundle (`TARGET-KIND-DOC` + `PARETO-INTEGRATE`) — 2026-05-26 autoresearch attribution sprint §5/§5.7 audit findings 모두 closure.
- **TARGET-KIND-DOC**: `_READER_ONLY_KINDS` frozenset 신규 + comment block 으로 13-vs-6 surface asymmetry 의 ADR-013 phased rollout 의도 명시. mutator 가 reader-only kind emit 시 `parse_mutation` ValueError 로 fail-fast.
- **PARETO-INTEGRATE**: `autoresearch.train.main` 의 promote gate path 에 `BASELINE_ARCHIVE_PATH` 신규 append. full `dim_means` + `promoted`/`reason`/`phase` 보존 — accept + reject 모두 record. opt-in (`pareto_mode=true`), not-dry-run gate. runner-side sibling row 와 `phase` 로 distinguishable.

## Why

`.audit/diagnostics/attribution-grounding-2026-05-26.md` §5 + §5.7 audit findings:

- **§5**: 13 STRICT-mode env vars (`autoresearch/train.py:868-903`) vs 6 `TARGET_KINDS` (`core/self_improving_loop/policies.py:138-154`) 의 asymmetry 가 코드 내 미명시. mutator 가 `tool_descriptions` 등을 emit 하면 `parse_mutation` 가 raise 하지만 operator 가 "why?" 알 수 없음.
- **§5.7**: `pareto_archive.append_archive_entry` 가 promote gate path 에서 미호출. multi-axis fitness scalarization 손실. reject 된 mutation 의 per-dim score 가 cycle 종료 시 사라져 regret 분석 ("multi-axis cost of rejecting M") 불가능.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/policies.py` | `TARGET_KINDS` 위에 comment block (ADR-013 phased-rollout + fail-fast 메커니즘 설명). 모듈-level `_READER_ONLY_KINDS: frozenset[str]` 신규 (7 entries: tool_descriptions / style_guide / provider_routing / cache_policy / heuristics / in_context_slots / few_shot_pool). |
| `autoresearch/train.py` | `print(promoted_line)` 직후 ~50 line PR-PARETO-INTEGRATE block. `pareto_mode` + `not args.dry_run` gate. ArchiveEntry 에 full `dim_means` + `dim_stderr` + `promoted` (`promoted_line.startswith("true")` derived, 4-branch single source) + `reason` (promoted_line 그대로) + `phase="post_audit"`. best-effort try/except. |
| `core/self_improving_loop/runner.py` | 기존 `apply_group_proposals` 내부 sibling 행 write 에 `phase="pre_audit_sibling"` tag 추가. Codex MCP review must-fix #1 (duplicate mutation_id) 해결 — train-side 와 runner-side row 가 `phase` 로 distinguishable. |
| `tests/core/self_improving_loop/test_target_kind_surface_doc.py` | 신규. 4 invariant: disjoint (TARGET vs READER_ONLY), fail-fast (per kind), env-wiring parity, sanity size=7. |
| `tests/autoresearch/test_pareto_integrate_promote_gate.py` | 신규. 6 invariant: block 존재, opt-in gate, promoted+reason field, single source 4-branch derivation, phase tag distinguishing, best-effort error path. |
| `tests/core/self_improving_loop/test_auto_trigger_max_generation.py` | (side) develop main format drift auto-fix. 단순 single-line formatting. |
| `CHANGELOG.md` | `[Unreleased]` Added entry. |

## Verification

- [x] `geode-ci --fast` ALL GREEN (ruff/format/mypy/deptry/lint-imports/4 ratchets/bandit/prompt integrity).
- [x] `geode-ci --tests` — 10 new tests pass. 8399 total pass / 5 pre-existing failures (`test_m4_4_in_context_wiring` + `test_seed_eval_export` 4 — develop main 에서도 동일, 본 PR 무관).
- [x] Codex MCP review CONDITIONAL_PASS → 1 must-fix (duplicate Pareto archive rows in group mode) 해결 via `phase` tag.

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §5, §5.7
- 기존 pareto 인프라: `core/self_improving_loop/pareto_archive.py` + `runner.py:1646-1681`
- Sibling merged PRs: #1749, #1753, #1757, #1758, #1759, #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)