### PR TITLE
feat(self-improving-loop): variance gate adaptive threshold + resample budget (PR-ALGO-DEPTH)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,12 @@ autoresearch/state/*
 # append, dominated entry prune lineage 보존. silent-ignored writer 회피
 # (PR-G5b #1350 precedent).
 !autoresearch/state/baseline_archive.jsonl
+# PR-VAR-ADAPTIVE (2026-05-27) — historical group-std samples for the
+# percentile-based variance gate. Same git-tracked invariant as
+# mutations.jsonl / baseline_archive.jsonl. Without this negation the
+# percentile threshold would silently lose history under the broad
+# ``autoresearch/state/*`` ignore — exactly the PR-G5b #1350 incident.
+!autoresearch/state/group_variance_history.jsonl
 # PR-RATCHET-1 (2026-05-21) — 5 mutation-target JSONs (wrapper-sections /
 # tool-policy / decomposition / retrieval / reflection) moved in-repo
 # from ~/.geode/self-improving-loop/ so `git diff` shows the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-VAR-ADAPTIVE + PR-RESAMPLE-BUDGET** — Phase F bundle of the
+  2026-05-26 attribution sprint (selection-gate algorithm depth).
+  * **PR-VAR-ADAPTIVE**: percentile-based ``group_variance_threshold``
+    resolver. New config knobs ``group_variance_threshold_mode:
+    Literal["fixed", "percentile"] = "fixed"``,
+    ``group_variance_history_window: int = 30``,
+    ``group_variance_percentile: float = 0.05``. New SoT
+    ``autoresearch/state/group_variance_history.jsonl`` (git-tracked
+    via ``.gitignore`` negation, PR-G5b precedent). New
+    ``append_group_variance_history`` writer (called from
+    ``apply_group_proposals`` after every group sampling cycle,
+    regardless of accept/reject) + ``resolve_group_variance_threshold``
+    reader. Per-kind filter + below-window fallback to fixed value.
+    Closes the 2026-05-26 sprint Phase A audit's "fitness-scale
+    drift" concern.
+  * **PR-RESAMPLE-BUDGET**: optional retry-on-low-variance.
+    ``max_group_resamples: int = 0`` (ge=0, le=10) + flag
+    ``resample_on_low_variance: bool = False``. When both enabled and
+    ``_compute_group_advantage`` returns ``filtered_low_variance``,
+    ``apply_group_proposals`` cleans up sibling temp files and
+    recursively calls ``self.propose_group(N)`` + retry, bounded by
+    the budget. Default knob values preserve legacy "filtered →
+    cycle skip" behaviour. DAPO frontier equivalent:
+    ``max_num_gen_batches`` informative-batch retention. Pinned by
+    11 invariant tests in
+    ``tests/core/self_improving_loop/test_variance_adaptive_and_resample.py``.
+
 ### Changed
 
 - PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raise the per-adapter lane

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -267,10 +267,65 @@ class AutoresearchConfig(BaseModel):
     *selection* gate, separate concern).
 
     Default 0.01 is a placeholder — no externally-verified production value
-    is currently grounded for this knob. ``baseline.json`` history (N≥30
-    cycle) 누적 후 percentile-based (5th percentile 미만 filter) 로 adapt
-    권장 (PR-VAR-ADAPTIVE follow-up). ``group_size`` 가 1 이면 무시.
+    is currently grounded for this knob. PR-VAR-ADAPTIVE (2026-05-27)
+    closes the follow-up with the ``group_variance_threshold_mode`` /
+    ``group_variance_history_window`` / ``group_variance_percentile``
+    knobs below. When ``mode="percentile"`` and the history has ≥window
+    entries, this fixed value is ignored in favour of the percentile.
     """
+
+    group_variance_threshold_mode: Literal["fixed", "percentile"] = "fixed"
+    """PR-VAR-ADAPTIVE (2026-05-27) — variance gate threshold source.
+
+    - ``"fixed"`` (default, backward-compat): use
+      ``group_variance_threshold`` as the hard floor regardless of
+      observed history. Legacy behaviour preserved.
+    - ``"percentile"``: read
+      ``autoresearch/state/group_variance_history.jsonl`` (git-tracked),
+      filter to the most recent ``group_variance_history_window``
+      entries for the active ``target_kind`` (when available — else
+      pooled across kinds), and use the ``group_variance_percentile``
+      th-percentile std as the threshold. When the history has fewer
+      than the window count, falls back to the fixed value so an
+      operator can enable the mode without bootstrapping a synthetic
+      history. Closes the 2026-05-26 attribution sprint Phase A
+      audit's "fitness-scale drift" concern — operators changing
+      fitness_margin_floor or weight schemas no longer need to
+      manually re-tune the variance threshold.
+    """
+
+    group_variance_history_window: Annotated[int, Field(ge=5, le=1000)] = 30
+    """PR-VAR-ADAPTIVE (2026-05-27) — number of history entries to use
+    when computing the percentile threshold. Default 30 ≈ 25 day window
+    at min_interval=20h. Below the window count the percentile mode
+    falls back to ``group_variance_threshold`` (fixed). Range floor of
+    5 ensures the percentile has enough samples to be meaningful;
+    ceiling of 1000 caps memory + read latency."""
+
+    group_variance_percentile: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.05
+    """PR-VAR-ADAPTIVE (2026-05-27) — which percentile of historical
+    group std becomes the threshold. ``0.05`` = 5th percentile (skip
+    only the bottom 5% of historical variance, i.e. the truly
+    low-signal groups). Higher values (e.g. ``0.10``) are more
+    aggressive at filtering. Must be in ``(0.0, 1.0)`` — exact 0 / 1
+    are degenerate."""
+
+    max_group_resamples: Annotated[int, Field(ge=0, le=10)] = 0
+    """PR-RESAMPLE-BUDGET (2026-05-27) — number of additional group
+    proposals to attempt when ``_compute_group_advantage`` returns
+    ``filtered_low_variance``. ``0`` (default) preserves legacy
+    behaviour (one shot, low-variance group → cycle skip). Non-zero
+    enables a retry loop bounded by this budget. DAPO frontier
+    equivalent: ``max_num_gen_batches`` — informative-batch
+    retention. Each retry costs N audit subprocesses, so the
+    operator-facing knob is bounded at 10."""
+
+    resample_on_low_variance: bool = False
+    """PR-RESAMPLE-BUDGET (2026-05-27) — must be True for
+    ``max_group_resamples`` to take effect. Separate flag (vs reading
+    ``max_group_resamples > 0`` directly) so an operator can pre-set
+    the budget but keep the feature disabled until A/B data validates
+    it. Default False preserves backward-compat."""
 
     pareto_mode: bool = False
     """P2-revised (2026-05-25) — Pareto archive + Dynamic Reward Weighting

--- a/core/paths.py
+++ b/core/paths.py
@@ -337,6 +337,13 @@ MUTATION_AUDIT_LOG_PATH = _AUTORESEARCH_STATE_DIR / "mutations.jsonl"
 # Append-only, mutation 의 17-dim fitness vector 보존. AlphaEvolve
 # evolutionary DB + DGM lineage archive 의 frontier 패턴 차용.
 BASELINE_ARCHIVE_PATH = _AUTORESEARCH_STATE_DIR / "baseline_archive.jsonl"
+# PR-VAR-ADAPTIVE (2026-05-27) — historical group-std samples for the
+# percentile-based variance gate threshold. Append-only JSONL row per
+# group sampling cycle. Same git-tracked + .gitignore-negation pattern
+# as ``mutations.jsonl`` and ``baseline_archive.jsonl`` (PR-G5b
+# precedent — writer destination must be tracked or the archive
+# silently disappears under the broad ``autoresearch/state/*`` ignore).
+GROUP_VARIANCE_HISTORY_PATH = _AUTORESEARCH_STATE_DIR / "group_variance_history.jsonl"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
 # (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -37,6 +37,7 @@ Test strategy:
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 import logging
@@ -66,9 +67,11 @@ __all__ = [
     "RunnerContext",
     "SelfImprovingLoopRunner",
     "_compute_group_advantage",
+    "append_group_variance_history",
     "apply_mutation",
     "build_runner_context",
     "parse_mutation",
+    "resolve_group_variance_threshold",
 ]
 
 
@@ -1061,6 +1064,119 @@ def _parse_fitness_from_subprocess_stdout(
     )
 
 
+def append_group_variance_history(
+    *,
+    group_id: str,
+    target_kind: str,
+    std: float,
+    n_siblings: int,
+    history_path: Path | None = None,
+) -> bool:
+    """Append one row to ``group_variance_history.jsonl``.
+
+    PR-VAR-ADAPTIVE (2026-05-27) — feeds the percentile resolver.
+    Every group-sampling cycle (regardless of accept/reject) appends
+    its observed std so the threshold can adapt to fitness-scale
+    drift without operator intervention.
+
+    Best-effort: any OSError (parent missing, disk full) logs at
+    WARNING and returns False. Callers ignore the return value
+    because telemetry failure must not break the mutator loop.
+    """
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    target = history_path if history_path is not None else GROUP_VARIANCE_HISTORY_PATH
+    row = {
+        "ts": time.time(),
+        "group_id": group_id,
+        "target_kind": target_kind,
+        "std": float(std),
+        "n_siblings": int(n_siblings),
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        log.warning("self-improving-loop: variance history append failed: %s", exc)
+        return False
+    return True
+
+
+def resolve_group_variance_threshold(
+    cfg_autoresearch: Any,
+    *,
+    target_kind: str | None = None,
+    history_path: Path | None = None,
+) -> tuple[float, str]:
+    """Resolve the variance gate threshold for the upcoming cycle.
+
+    PR-VAR-ADAPTIVE (2026-05-27) — when
+    ``group_variance_threshold_mode == "percentile"`` and the history
+    file contains at least ``group_variance_history_window`` entries
+    matching ``target_kind`` (or pooled across kinds when
+    ``target_kind`` is None), returns the corresponding percentile of
+    historical ``std`` values. Otherwise returns the legacy fixed
+    ``group_variance_threshold`` value.
+
+    Returns ``(threshold, source)`` where ``source`` is ``"fixed"`` or
+    ``"percentile"`` so callers can log which path fired (useful for
+    operators watching the adaptive knob converge on a stable value).
+
+    Best-effort: missing file / malformed rows / read OSError all
+    fall through to the fixed value (legacy behaviour preserved).
+    """
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    fixed = float(cfg_autoresearch.group_variance_threshold)
+    if getattr(cfg_autoresearch, "group_variance_threshold_mode", "fixed") != "percentile":
+        return fixed, "fixed"
+
+    window = int(getattr(cfg_autoresearch, "group_variance_history_window", 30))
+    percentile = float(getattr(cfg_autoresearch, "group_variance_percentile", 0.05))
+
+    target = history_path if history_path is not None else GROUP_VARIANCE_HISTORY_PATH
+    if not target.is_file():
+        return fixed, "fixed"
+
+    matched_stds: list[float] = []
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if target_kind is not None and row.get("target_kind") != target_kind:
+                    continue
+                raw_std = row.get("std")
+                if isinstance(raw_std, int | float):
+                    matched_stds.append(float(raw_std))
+    except OSError:
+        log.warning("self-improving-loop: variance history read failed", exc_info=True)
+        return fixed, "fixed"
+
+    if len(matched_stds) < window:
+        return fixed, "fixed"
+
+    # Take the most recent ``window`` entries (history is append-only
+    # so file order == chronological).
+    recent = matched_stds[-window:]
+    recent_sorted = sorted(recent)
+    # Linear-interpolation percentile (matches numpy.quantile default).
+    pos = percentile * (len(recent_sorted) - 1)
+    lo_idx = int(pos)
+    hi_idx = min(lo_idx + 1, len(recent_sorted) - 1)
+    frac = pos - lo_idx
+    interpolated = recent_sorted[lo_idx] * (1 - frac) + recent_sorted[hi_idx] * frac
+    return interpolated, "percentile"
+
+
 def _compute_group_advantage(
     fitness_values: list[float],
     threshold: float,
@@ -1488,6 +1604,7 @@ class SelfImprovingLoopRunner:
         *,
         swarm_id: str = "",
         sub_agent_index: int | None = None,
+        _resample_attempt: int = 0,
     ) -> Mutation | None:
         """P1-revised (2026-05-25) — apply N sibling proposals → audit →
         variance gate → group-relative scoring → top-1 commit.
@@ -1527,6 +1644,21 @@ class SelfImprovingLoopRunner:
         Requires ``rerun_enabled=True`` — group advantage 가 real fitness
         에 의존하므로 audit 가 실제로 fire 되어야 함.
         """
+        # PR-VAR-ADAPTIVE (2026-05-27) Codex MCP review must-fix #1 —
+        # enforce homogeneous ``target_kind`` across siblings BEFORE
+        # any audit cost or rerun-enabled gate. The variance signal is
+        # only meaningful when N siblings touch the same SoT surface
+        # (different surfaces have different std scales, so mixing
+        # collapses the percentile resolver's per-kind filter).
+        if proposals:
+            _kinds = {p.mutation.target_kind for p in proposals}
+            if len(_kinds) > 1:
+                raise ValueError(
+                    f"apply_group_proposals requires homogeneous target_kind "
+                    f"across siblings (variance signal is per-kind, see "
+                    f"PR-VAR-ADAPTIVE); got {_kinds!r}"
+                )
+
         if len(proposals) == 1:
             return self.apply_proposal(
                 proposals[0],
@@ -1559,7 +1691,26 @@ class SelfImprovingLoopRunner:
         from core.config.self_improving_loop import load_self_improving_loop_config
 
         cfg = load_self_improving_loop_config()
-        threshold = cfg.autoresearch.group_variance_threshold
+        # PR-VAR-ADAPTIVE (2026-05-27) — variance gate threshold resolved
+        # via ``resolve_group_variance_threshold``. When
+        # ``group_variance_threshold_mode == "percentile"`` and the
+        # history has >= window entries for this target_kind, the
+        # threshold adapts to fitness-scale drift; otherwise falls
+        # through to the legacy fixed value. ``threshold_source`` is
+        # logged so operators can verify the adaptive knob is firing.
+        # Homogeneous ``target_kind`` is already enforced at function
+        # entry above (PR-VAR-ADAPTIVE Codex MCP review must-fix #1).
+        _resolve_kind = proposals[0].mutation.target_kind if proposals else None
+        # Codex MCP review must-fix #2 — threshold is re-resolved on each
+        # ``_resample_attempt`` (the recursive call re-enters this
+        # function), which means a resample sees the just-appended std
+        # of the failed attempt. This is intentional: each retry is a
+        # fresh selection cycle and the threshold should reflect the
+        # latest percentile. To freeze across retries, an operator
+        # would set ``mode="fixed"`` (which ignores history entirely).
+        threshold, threshold_source = resolve_group_variance_threshold(
+            cfg.autoresearch, target_kind=_resolve_kind
+        )
         mutator_temp = settings.temperature_self_improving_mutation
 
         # Codex MCP review #5 (2026-05-25) — temperature guard 를 N audit 비용
@@ -1620,12 +1771,68 @@ class SelfImprovingLoopRunner:
                 mutator_temperature=mutator_temp,
             )
 
+            # PR-VAR-ADAPTIVE (2026-05-27) — append the observed group
+            # std to the history file (best-effort; failure logs WARNING
+            # but doesn't break the cycle). The resolver above reads
+            # this on the *next* cycle to compute the percentile
+            # threshold, so the gate self-adapts to fitness-scale drift.
+            # We log regardless of filtered/ok status — both are valid
+            # variance signals to learn from.
+            if len(fitness_values) >= 2:
+                _mean = sum(fitness_values) / len(fitness_values)
+                _observed_std = (
+                    sum((v - _mean) ** 2 for v in fitness_values) / len(fitness_values)
+                ) ** 0.5
+                append_group_variance_history(
+                    group_id=group_id,
+                    target_kind=_resolve_kind or "",
+                    std=_observed_std,
+                    n_siblings=len(fitness_values),
+                )
+
             if status == "filtered_low_variance":
+                # PR-RESAMPLE-BUDGET (2026-05-27) — when
+                # ``resample_on_low_variance=True`` and we haven't
+                # exhausted ``max_group_resamples``, propose a fresh
+                # sibling group and retry the audit. DAPO frontier
+                # equivalent: ``max_num_gen_batches`` informative-batch
+                # retention. The default config (budget=0, flag=False)
+                # preserves the legacy "filtered → cycle skip" behaviour.
+                _max_resamples = (
+                    int(cfg.autoresearch.max_group_resamples)
+                    if cfg.autoresearch.resample_on_low_variance
+                    else 0
+                )
+                if _resample_attempt < _max_resamples:
+                    log.info(
+                        "self-improving-loop: group %s filtered (low variance, "
+                        "std < %s, source=%s). resample attempt %d/%d.",
+                        group_id,
+                        threshold,
+                        threshold_source,
+                        _resample_attempt + 1,
+                        _max_resamples,
+                    )
+                    # Cleanup sibling temp files of this attempt before
+                    # recursing — the new attempt will create its own.
+                    for sibling_path in sibling_sot_paths:
+                        with contextlib.suppress(OSError):
+                            sibling_path.unlink(missing_ok=True)
+                    new_proposals = self.propose_group(len(proposals))
+                    return self.apply_group_proposals(
+                        new_proposals,
+                        swarm_id=swarm_id,
+                        sub_agent_index=sub_agent_index,
+                        _resample_attempt=_resample_attempt + 1,
+                    )
                 log.info(
                     "self-improving-loop: group %s filtered (low variance, "
-                    "std < %s). cycle skipped, no SoT commit.",
+                    "std < %s, source=%s). cycle skipped, no SoT commit "
+                    "(after %d resample attempt(s)).",
                     group_id,
                     threshold,
+                    threshold_source,
+                    _resample_attempt,
                 )
                 return None
             if status != "ok" or advantages is None:

--- a/tests/core/self_improving_loop/test_variance_adaptive_and_resample.py
+++ b/tests/core/self_improving_loop/test_variance_adaptive_and_resample.py
@@ -1,0 +1,441 @@
+"""PR-VAR-ADAPTIVE + PR-RESAMPLE-BUDGET (2026-05-27) — Phase F bundle.
+
+Two complementary algorithm-depth additions to the
+``apply_group_proposals`` selection layer:
+
+**PR-VAR-ADAPTIVE** — replaces the hardcoded
+``group_variance_threshold = 0.01`` with an optional percentile-based
+resolver that reads ``group_variance_history.jsonl`` and returns the
+configured percentile of recent observed std values. Closes the
+2026-05-26 attribution sprint Phase A audit (§4.3 follow-up): the
+fixed threshold drifts silently when fitness-scale changes (e.g., new
+DIM_WEIGHTS rotation, anchor_confidence_mode toggle).
+
+**PR-RESAMPLE-BUDGET** — when ``filtered_low_variance`` fires, the
+default behaviour is "cycle skip" (no SoT commit, no retry). With
+``resample_on_low_variance=True`` and ``max_group_resamples > 0``,
+the runner now proposes a fresh sibling group and retries the audit
+up to the budget. DAPO frontier equivalent: ``max_num_gen_batches``
+informative-batch retention.
+
+This file pins:
+
+* Variance history append (best-effort writer, all rows recorded).
+* Percentile resolver — fixed-mode default, percentile-mode below /
+  at / above window, per-kind filter, malformed-row graceful skip,
+  OSError fallback to fixed.
+* Threshold resolution wires into ``apply_group_proposals`` (verified
+  via patched ``_compute_group_advantage``).
+* Resample retry — fires only when both knobs enabled, recurses with
+  ``_resample_attempt`` increment, respects budget, falls through to
+  cycle skip on exhaustion.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_variance_row(
+    path: Path,
+    *,
+    std: float,
+    target_kind: str = "prompt",
+    group_id: str | None = None,
+    n_siblings: int = 2,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, Any] = {
+        "ts": time.time(),
+        "group_id": group_id or "g",
+        "target_kind": target_kind,
+        "std": float(std),
+        "n_siblings": int(n_siblings),
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# append_group_variance_history
+# ---------------------------------------------------------------------------
+
+
+def test_append_variance_history_creates_file_and_appends(tmp_path: Path) -> None:
+    from core.self_improving_loop.runner import append_group_variance_history
+
+    history = tmp_path / "variance.jsonl"
+    ok = append_group_variance_history(
+        group_id="g1",
+        target_kind="prompt",
+        std=0.07,
+        n_siblings=2,
+        history_path=history,
+    )
+    assert ok is True
+    assert history.is_file()
+    row = json.loads(history.read_text().strip())
+    assert row["std"] == 0.07
+    assert row["target_kind"] == "prompt"
+    assert row["n_siblings"] == 2
+    assert row["group_id"] == "g1"
+
+
+def test_append_variance_history_failure_returns_false(tmp_path: Path) -> None:
+    """OSError on write must not propagate — caller ignores the return
+    value so telemetry failure can't break the mutator cycle."""
+    from core.self_improving_loop.runner import append_group_variance_history
+
+    history = tmp_path / "variance.jsonl"
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        ok = append_group_variance_history(
+            group_id="g1",
+            target_kind="prompt",
+            std=0.07,
+            n_siblings=2,
+            history_path=history,
+        )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_group_variance_threshold
+# ---------------------------------------------------------------------------
+
+
+class _FakeAutoresearchCfg:
+    """Minimal stand-in for ``AutoresearchConfig`` so tests don't
+    have to construct the full pydantic model."""
+
+    def __init__(
+        self,
+        *,
+        mode: str = "fixed",
+        fixed: float = 0.01,
+        window: int = 30,
+        percentile: float = 0.05,
+    ) -> None:
+        self.group_variance_threshold = fixed
+        self.group_variance_threshold_mode = mode
+        self.group_variance_history_window = window
+        self.group_variance_percentile = percentile
+
+
+def test_resolver_fixed_mode_returns_fixed(tmp_path: Path) -> None:
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    cfg = _FakeAutoresearchCfg(mode="fixed", fixed=0.02)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, history_path=tmp_path / "missing.jsonl"
+    )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+def test_resolver_percentile_mode_fallback_when_history_short(tmp_path: Path) -> None:
+    """Percentile mode with history shorter than the window falls back
+    to the fixed value — operators can enable the knob without manually
+    bootstrapping a synthetic history."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 5 rows but window=30 → fallback.
+    for _ in range(5):
+        _write_variance_row(history, std=0.1)
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+def test_resolver_percentile_mode_computes_percentile_when_window_met(tmp_path: Path) -> None:
+    """Percentile mode with sufficient history returns the configured
+    percentile of recent std values."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 30 rows, std=1..30, target_kind=prompt
+    for i in range(1, 31):
+        _write_variance_row(history, std=float(i))
+
+    # 5th percentile of [1..30] ≈ 1 + 0.05 * 29 = 2.45
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30, percentile=0.05)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    assert source == "percentile"
+    assert abs(threshold - 2.45) < 0.01
+
+
+def test_resolver_percentile_filters_by_target_kind(tmp_path: Path) -> None:
+    """Per-kind percentile — when ``target_kind`` is provided, only
+    matching rows count toward the window."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 30 prompt rows + 30 tool_policy rows. Asking for tool_policy
+    # should ignore prompt rows.
+    for _ in range(30):
+        _write_variance_row(history, std=0.01, target_kind="prompt")
+    for _ in range(30):
+        _write_variance_row(history, std=5.0, target_kind="tool_policy")
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold_prompt, _ = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    threshold_tool, _ = resolve_group_variance_threshold(
+        cfg, target_kind="tool_policy", history_path=history
+    )
+    # prompt std all 0.01 → percentile ≈ 0.01
+    assert abs(threshold_prompt - 0.01) < 0.001
+    # tool_policy std all 5.0 → percentile ≈ 5.0
+    assert abs(threshold_tool - 5.0) < 0.001
+
+
+def test_resolver_handles_malformed_rows(tmp_path: Path) -> None:
+    """Malformed JSON / non-dict / missing std → skipped silently. The
+    scan must not abort on one bad row."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # Mix valid + malformed
+    _write_variance_row(history, std=0.1)
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+        fh.write("\n")
+        fh.write("[1, 2, 3]\n")
+        fh.write('{"missing_std_field": true}\n')
+    for _ in range(30):
+        _write_variance_row(history, std=0.5)
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    # 31 valid rows total, take last 30 → all std=0.5 → percentile=0.5
+    assert source == "percentile"
+    assert abs(threshold - 0.5) < 0.001
+
+
+def test_resolver_oserror_falls_back_to_fixed(tmp_path: Path) -> None:
+    """Read failure (permission denied / disk error) → fall through to
+    fixed value. The mutator cycle never crashes because the history
+    file is unreadable."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    history.write_text("dummy\n")
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    with patch.object(Path, "open", side_effect=OSError("permission denied")):
+        threshold, source = resolve_group_variance_threshold(
+            cfg, target_kind="prompt", history_path=history
+        )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# Config schema invariants
+# ---------------------------------------------------------------------------
+
+
+def test_config_schema_defaults_preserve_legacy_behaviour() -> None:
+    """The new knobs MUST default to the legacy single-shot fixed-
+    threshold behaviour so existing operators see no change unless
+    they opt-in."""
+    from core.config.self_improving_loop import AutoresearchConfig
+
+    cfg = AutoresearchConfig()
+    assert cfg.group_variance_threshold_mode == "fixed"
+    assert cfg.group_variance_history_window == 30
+    assert cfg.group_variance_percentile == 0.05
+    assert cfg.max_group_resamples == 0
+    assert cfg.resample_on_low_variance is False
+
+
+def test_config_schema_validation_bounds() -> None:
+    """Pydantic Field bounds should reject out-of-range values so an
+    operator can't misconfigure into an unreachable threshold."""
+    from core.config.self_improving_loop import AutoresearchConfig
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_history_window=4)  # ge=5
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_percentile=0.0)  # gt=0
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_percentile=1.0)  # lt=1
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(max_group_resamples=11)  # le=10
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(max_group_resamples=-1)  # ge=0
+
+
+# ---------------------------------------------------------------------------
+# Gitignore invariant — variance history must be tracked
+# ---------------------------------------------------------------------------
+
+
+def test_apply_group_proposals_rejects_mixed_target_kinds() -> None:
+    """Codex MCP review must-fix #1 — apply_group_proposals raises
+    when sibling proposals span multiple target_kinds. The variance
+    signal is only meaningful within a single SoT surface."""
+    from core.self_improving_loop.runner import (
+        Mutation,
+        Proposal,
+        SelfImprovingLoopRunner,
+    )
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    p1 = Proposal(
+        mutation=Mutation(
+            target_section="role",
+            new_value="x",
+            rationale="y",
+            target_kind="prompt",
+        ),
+        target_sections={"role": "orig"},
+        original_sections={"role": "orig"},
+    )
+    p2 = Proposal(
+        mutation=Mutation(
+            target_section="rule",
+            new_value="x",
+            rationale="y",
+            target_kind="tool_policy",
+        ),
+        target_sections={"rule": "orig"},
+        original_sections={"rule": "orig"},
+    )
+
+    with pytest.raises(ValueError, match="homogeneous target_kind"):
+        runner.apply_group_proposals([p1, p2])
+
+
+def test_apply_group_proposals_resample_recurses_then_skips() -> None:
+    """Codex MCP review must-fix #3 — direct apply_group_proposals
+    test that exercises the resample budget. Mocks
+    _run_autoresearch_subprocess to always return zero-variance
+    fitness, mocks self.propose_group to return identical sibling
+    sets, then asserts the function recursed ``max_group_resamples``
+    times before falling through to ``None`` (cycle skip)."""
+    from unittest.mock import MagicMock
+
+    from core.self_improving_loop.runner import (
+        Mutation,
+        Proposal,
+        SelfImprovingLoopRunner,
+    )
+
+    def _make_proposal() -> Proposal:
+        return Proposal(
+            mutation=Mutation(
+                target_section="role",
+                new_value="x",
+                rationale="y",
+                target_kind="prompt",
+            ),
+            target_sections={"role": "orig"},
+            original_sections={"role": "orig"},
+        )
+
+    proposals = [_make_proposal(), _make_proposal()]
+
+    # ``rerun_enabled=True`` + ``rerun_dry_run=False`` is required by
+    # apply_group_proposals's safety gates (group sampling needs real
+    # audit fitness to compute variance). The subprocess + parse are
+    # mocked below so no real audit cost is incurred.
+    runner = SelfImprovingLoopRunner(rerun_enabled=True, rerun_dry_run=False)
+    # Force resample knobs on at the runtime read site.
+    fake_cfg = MagicMock()
+    fake_cfg.autoresearch.group_variance_threshold = 0.1
+    fake_cfg.autoresearch.group_variance_threshold_mode = "fixed"
+    fake_cfg.autoresearch.max_group_resamples = 2
+    fake_cfg.autoresearch.resample_on_low_variance = True
+
+    propose_calls: list[int] = []
+
+    def fake_propose_group(self_: object, n: int) -> list[Proposal]:
+        # Patched as a method on SelfImprovingLoopRunner → first arg is
+        # the bound ``self`` (the runner instance). We don't use it,
+        # just bounce N back as the proposal count.
+        propose_calls.append(n)
+        return [_make_proposal() for _ in range(n)]
+
+    # _apply_sibling_in_memory_with_value writes a temp file; mock to
+    # return a stable triple so the cleanup loop has something to unlink.
+    def fake_apply_sibling(proposal: Proposal):  # type: ignore[no-untyped-def]
+        return ({"role": "x"}, "orig", Path("/tmp/nonexistent"))  # noqa: S108
+
+    # Fake the subprocess to return zero-variance fitness so
+    # _compute_group_advantage returns ``filtered_low_variance``.
+    fake_proc = MagicMock(stdout="audit_fitness=0.5\n")
+
+    # The runner imports load_self_improving_loop_config lazily inside
+    # apply_group_proposals, so patch the source module symbol (not the
+    # runner-local re-export, which doesn't exist at module load time).
+    with (
+        patch(
+            "core.config.self_improving_loop.load_self_improving_loop_config",
+            return_value=fake_cfg,
+        ),
+        patch(
+            "core.self_improving_loop.runner._apply_sibling_in_memory_with_value",
+            side_effect=fake_apply_sibling,
+        ),
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            return_value=fake_proc,
+        ),
+        patch(
+            "core.self_improving_loop.runner._parse_fitness_from_subprocess_stdout",
+            return_value=0.5,
+        ),
+        patch.object(SelfImprovingLoopRunner, "propose_group", fake_propose_group),
+    ):
+        result = runner.apply_group_proposals(proposals)
+
+    # All siblings score 0.5 → std=0 < threshold 0.1 → filtered.
+    # Budget=2 → 2 retries before skip → propose_group invoked twice.
+    assert result is None
+    assert len(propose_calls) == 2
+    assert propose_calls == [2, 2]
+
+
+def test_variance_history_path_not_gitignored() -> None:
+    """PR-G5b precedent — writer destination must be git-tracked, or
+    the archive silently disappears under the broad
+    ``autoresearch/state/*`` ignore."""
+    # Use git check-ignore -v to inspect which rule matched. Exit code:
+    #   0 = ignored, 1 = not ignored, other = error.
+    import shutil
+    import subprocess
+
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    git = shutil.which("git") or "git"
+    result = subprocess.run(  # noqa: S603
+        [git, "check-ignore", "-v", str(GROUP_VARIANCE_HISTORY_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        # Ignored — must have matched the negation, not the broad rule.
+        assert "!autoresearch/state/group_variance_history.jsonl" in result.stdout, (
+            f"group_variance_history.jsonl is git-ignored without "
+            f"hitting the explicit negation rule. "
+            f"stdout={result.stdout!r}"
+        )
+    # returncode==1 means not ignored at all → OK.


### PR DESCRIPTION
## Summary

- Phase F bundle (`PR-VAR-ADAPTIVE` + `PR-RESAMPLE-BUDGET`) — 2026-05-26 attribution sprint 의 algorithm-depth follow-up closure.
- **VAR-ADAPTIVE**: `group_variance_threshold` 의 percentile-based resolver. 신규 git-tracked SoT `autoresearch/state/group_variance_history.jsonl` 에 group std history 기록. 4개 config knob (`mode`, `history_window`, `percentile` + 기존 `group_variance_threshold` 가 fallback).
- **RESAMPLE-BUDGET**: `filtered_low_variance` 시 retry. config: `max_group_resamples: int = 0` + `resample_on_low_variance: bool = False`. enable 시 `propose_group(N)` 재호출하고 `_resample_attempt+1` 로 재귀.
- Codex MCP CONDITIONAL_PASS → 3 must-fix 모두 적용 (homogeneous target_kind 강제, re-resolution 의미 명시, 직접 apply_group_proposals 테스트).

## Why

2026-05-26 sprint Phase A audit + 사용자 backlog Plan §F:

- **VAR-ADAPTIVE motivation** (§4.3 follow-up): fixed threshold 0.01 은 `DIM_WEIGHTS` rotation 또는 `anchor_confidence_mode` toggle 시 fitness scale drift 와 정합 안됨. 운영자가 매번 manual 튜닝.
- **RESAMPLE-BUDGET motivation**: low-variance group 발생 시 N audit subprocess (cost) 가 buried. DAPO frontier 가 `max_num_gen_batches` 로 informative-batch retention 적용 — selection layer 에 동일 idea 적용.

## Changes

| File | Change |
|------|--------|
| `core/config/self_improving_loop.py` | 5 신규 knob: `group_variance_threshold_mode: Literal["fixed", "percentile"] = "fixed"`, `group_variance_history_window: int = 30 (ge=5, le=1000)`, `group_variance_percentile: float = 0.05 (gt=0, lt=1)`, `max_group_resamples: int = 0 (ge=0, le=10)`, `resample_on_low_variance: bool = False`. 모든 default 가 legacy behaviour 보존. |
| `core/paths.py` | `GROUP_VARIANCE_HISTORY_PATH` constant. |
| `.gitignore` | `!autoresearch/state/group_variance_history.jsonl` negation (PR-G5b precedent — silent-ignored writer 회피). |
| `core/self_improving_loop/runner.py` | `append_group_variance_history(...)` 신규 writer. `resolve_group_variance_threshold(cfg, *, target_kind, history_path)` 신규 reader (linear-interpolation percentile, per-kind filter, OSError fallback). `apply_group_proposals` 에 (a) 함수 entry homogeneous target_kind enforcement (Codex review #1), (b) threshold resolver wiring, (c) group std 후 history append, (d) filtered_low_variance branch 에서 budget 시 `propose_group` 재호출 + 재귀. `contextlib.suppress(OSError)` 사용 (ruff SIM105). |
| `tests/core/self_improving_loop/test_variance_adaptive_and_resample.py` | 신규. 13 invariant: writer (file+OSError) / resolver (fixed/percentile-fallback/percentile-met/per-kind/malformed/OSError) / config schema (defaults + Pydantic bounds) / apply_group_proposals (mixed kind reject + resample 재귀+cleanup) / gitignore negation parity. |
| `CHANGELOG.md` | `[Unreleased]` Added entry. |

## Verification

- [x] `geode-ci --fast` ALL GREEN.
- [x] `uv run pytest tests/core/self_improving_loop/test_variance_adaptive_and_resample.py -q` — 13/13 pass.
- [x] Codex MCP review CONDITIONAL_PASS → 3 must-fix applied (homogeneous target_kind, re-resolution semantic doc, behavioral apply_group_proposals tests).

## Reference

- Sprint diagnostics: `.audit/diagnostics/attribution-grounding-2026-05-26.md` §4.3
- Frontier inspiration: DAPO arXiv 2503.14476 § Dynamic Sampling + max_num_gen_batches (concept-level, not formula citation — see `[[feedback-inspired-by-attribution]]`)
- Sibling merged PRs: #1749, #1753, #1757, #1758, #1759, #1768, #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)