### PR TITLE
chore: promote develop to main (v0.99.73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,12 @@ autoresearch/state/*
 # append, dominated entry prune lineage 보존. silent-ignored writer 회피
 # (PR-G5b #1350 precedent).
 !autoresearch/state/baseline_archive.jsonl
+# PR-VAR-ADAPTIVE (2026-05-27) — historical group-std samples for the
+# percentile-based variance gate. Same git-tracked invariant as
+# mutations.jsonl / baseline_archive.jsonl. Without this negation the
+# percentile threshold would silently lose history under the broad
+# ``autoresearch/state/*`` ignore — exactly the PR-G5b #1350 incident.
+!autoresearch/state/group_variance_history.jsonl
 # PR-RATCHET-1 (2026-05-21) — 5 mutation-target JSONs (wrapper-sections /
 # tool-policy / decomposition / retrieval / reflection) moved in-repo
 # from ~/.geode/self-improving-loop/ so `git diff` shows the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.73] - 2026-05-27
+
+MINOR rotation. Ships the 2026-05-26 autoresearch attribution sprint
+Phase A audit's three remaining bundles: outer-loop hardening
+(PR-OUTER-LOOP-HARDENING — max_generation cap + promote_stamp +
+dry-run attribution invariant pin), surface clarity
+(PR-SURFACE-CLARITY — TARGET_KINDS reader-only documentation +
+Pareto archive promote-gate integration), and selection-gate
+algorithm depth (PR-ALGO-DEPTH — percentile-based variance
+threshold + resample budget). Plus PR-LANE-CAP-AGGRESSIVE from
+develop. See section entries below.
+
 ### Added
 
 - **PR-VAR-ADAPTIVE + PR-RESAMPLE-BUDGET** — Phase F bundle of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,41 @@ functional change.
 
 ### Added
 
+- **PR-SURFACE-CLARITY** — Phase H bundle (TARGET-KIND-DOC +
+  PARETO-INTEGRATE) closing the 2026-05-26 attribution sprint Phase A
+  audit §5 and §5.7 follow-ups.
+  * **TARGET-KIND-DOC**: ``core/self_improving_loop/policies.py``
+    introduces the ``_READER_ONLY_KINDS`` frozenset listing the 7 SoT
+    surfaces wired in ``autoresearch.train.run_audit``'s STRICT-mode
+    env block (``tool_descriptions`` / ``style_guide`` /
+    ``provider_routing`` / ``cache_policy`` / ``heuristics`` /
+    ``in_context_slots`` / ``few_shot_pool``) but NOT in
+    ``TARGET_KINDS``. Comment block above ``TARGET_KINDS`` explains
+    the asymmetry as intentional ADR-013 phased rollout and points
+    operators at the fail-fast ``parse_mutation`` ValueError when a
+    mutator emits a reader-only kind. Pinned by 4 invariant tests in
+    ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+    (disjoint sets, fail-fast emission per kind, env-wiring parity,
+    size-7 sanity counter).
+  * **PARETO-INTEGRATE**: ``autoresearch.train.main`` now appends an
+    ``ArchiveEntry`` to ``BASELINE_ARCHIVE_PATH`` after the promote
+    decision is finalized (every cycle, accept + reject). The entry
+    carries full ``dim_means`` / ``dim_stderr`` plus ``promoted``
+    (bool) and ``reason`` (str) via ``ArchiveEntry.extra="allow"``
+    so downstream regret-analysis readers can compute the multi-axis
+    cost of rejecting mutation M. Gated by
+    ``[self_improving_loop.autoresearch] pareto_mode = true``
+    (operator opt-in; default off preserves backward-compat) AND
+    ``not args.dry_run`` (synthetic dim_means has no Pareto signal).
+    Wrapped in best-effort try/except — JSONL writer failure logs at
+    WARNING and the audit cycle continues, matching the existing
+    runner-side pareto wiring pattern (runner.py:1667-1673).
+    Pinned by 5 invariant tests in
+    ``tests/autoresearch/test_pareto_integrate_promote_gate.py``
+    (block presence, opt-in gating, ``promoted`` + ``reason`` field
+    join keys, single source of truth for the accept/reject bit,
+    best-effort error path).
+
 - **PR-MAX-GEN** — Outer-loop hardening: hard cap on total auto-trigger
   fires.
   * ``auto_trigger_mutator`` accepts a new ``max_generation: int = 0``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,62 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-MAX-GEN** — Outer-loop hardening: hard cap on total auto-trigger
+  fires.
+  * ``auto_trigger_mutator`` accepts a new ``max_generation: int = 0``
+    parameter. When non-zero, ``count_fired_generations`` reads
+    ``~/.geode/self-improving-loop/auto_trigger_history.jsonl`` and
+    blocks the next fire with state ``max_generation_reached`` (detail
+    ``current/max``) when the count is at or above the cap.
+  * The cap is checked BEFORE the lockfile acquisition (saturated
+    history doesn't consume the lock) AND AFTER (post-lock re-check
+    mirrors the existing ``is_min_interval_satisfied`` pattern so two
+    parallel callers can't both overshoot).
+  * Production wiring: new ``[self_improving_loop.scheduler]
+    max_generation`` config knob (default ``0`` = unlimited, max
+    ``100_000``). ``register_auto_trigger`` forwards the knob through
+    the scheduler callback. ``core/wiring/automation.py`` passes it
+    from ``load_self_improving_loop_config().scheduler.max_generation``.
+  * New HookEvent ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED``
+    reserved in ``core/hooks/system.py`` (same payload schema as
+    sibling auto-trigger events).
+  * Closes the 2026-05-26 autoresearch attribution sprint Phase A audit
+    (§5.6) finding that ``auto_trigger_mutator`` had only the
+    ``min_interval_minutes`` floor and no hard cap. Pinned by 12
+    invariant tests in
+    ``tests/core/self_improving_loop/test_auto_trigger_max_generation.py``
+    covering count helper edge cases, pre-lock cap, post-lock cap
+    recheck, production wiring forwarding, and HookEvent reservation.
+
+### Changed
+
+- **PR-PROMOTE-STAMP** — ``autoresearch.train._write_baseline``
+  accepts a new ``manual_promote: bool = False`` parameter. When
+  ``True``, the function stamps the baseline.json payload with three
+  additive top-level fields: ``manual_promote: true``,
+  ``promoted_by: "operator"``, ``promoted_at: <ts_utc>``. The
+  ``--promote`` operator override path in ``main()`` passes
+  ``manual_promote=True``. The auto-promote path keeps the default,
+  preserving backward-compat on baseline shape. Closes the audit
+  finding (§5.5) that downstream readers couldn't distinguish
+  operator-forced from gate-approved promotions. Pinned by 4
+  invariant tests in ``tests/autoresearch/test_promote_stamp.py``.
+
 ### Fixed
+
+- **PR-DRY-RUN-NO-ATTR (pin only)** — The 2026-05-26 attribution
+  sprint Phase A audit flagged the risk of ``--dry-run`` cycles
+  writing synthetic ``fitness_delta=0`` attribution rows to
+  ``mutations.jsonl``. Verification during the sprint confirmed the
+  skip guard ``_attribution_should_write = not args.dry_run`` was
+  ALREADY in place at ``autoresearch/train.py:2692`` (post-PR-AR-L6).
+  No code change in this commit — added 2 static-source invariant
+  tests in ``tests/autoresearch/test_dry_run_no_attribution.py`` that
+  fail loudly if a future refactor strips the guard. Brittle by
+  design — the cost of false alarms is far below the cost of the
+  silent leak re-opening.
 
 - **PR-GEN-COUNTER** — ``autoresearch.train._resolve_gen_tag`` no
   longer collapses repeated audits at the same git commit into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raise the per-adapter lane
+  concurrency caps + lane timeouts + add a phase-local semaphore on
+  the ranker's ``asyncio.gather`` match-dispatch. Pre-raise the
+  conservative defaults (claude_cli=2, openai_api=4, anthropic_api=4,
+  Lane.timeout_s=300) left the documented per-account RPM budgets
+  ~95% idle while PR-RANKER-PARALLEL's 59-match Loop 1 burst queued
+  100+ voter calls behind 4-slot caps, pushing tail latency past the
+  5-minute lane timeout. New defaults match documented OpenAI Codex
+  Responses (500 RPM) + Anthropic tier 1 (50 RPM) ceilings:
+  - ``DEFAULT_CLAUDE_CLI_LANE_MAX``: 2 → **4** (Max OAuth burst floor)
+  - ``DEFAULT_OPENAI_API_LANE_MAX``: 4 → **16** (500 RPM / 10-15s call)
+  - ``DEFAULT_ANTHROPIC_API_LANE_MAX``: 4 → **8** (50 RPM / 60-70s call)
+  - ``*_LANE_TIMEOUT_S``: 300s → **7200s (2h)** (gather burst tail)
+  Adds ``DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 8`` + env override
+  ``GEODE_RANKER_MAX_INFLIGHT_MATCHES`` so the phase-local
+  ``asyncio.Semaphore(8)`` bounds the gather "in-flight" task count
+  (8 matches × 3 voters = 24 tasks max), matching the per-lane
+  ceiling exactly. Operator overrides (``GEODE_CLAUDE_CLI_LANE_MAX``,
+  ``GEODE_OPENAI_API_LANE_MAX``, ``GEODE_ANTHROPIC_API_LANE_MAX``,
+  ``GEODE_RANKER_MAX_INFLIGHT_MATCHES``) stay the recommended tuning
+  knob for tier upgrades / debug runs. Pinned by 6 new ranker
+  semaphore unit tests + 2 updated lane default-value tests.
+
 ## [0.99.72] - 2026-05-26
 
 MINOR rotation. Ships PR-SEEDS-HIRES P1+P2+P3 — operator directive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-VAR-ADAPTIVE + PR-RESAMPLE-BUDGET** — Phase F bundle of the
+  2026-05-26 attribution sprint (selection-gate algorithm depth).
+  * **PR-VAR-ADAPTIVE**: percentile-based ``group_variance_threshold``
+    resolver. New config knobs ``group_variance_threshold_mode:
+    Literal["fixed", "percentile"] = "fixed"``,
+    ``group_variance_history_window: int = 30``,
+    ``group_variance_percentile: float = 0.05``. New SoT
+    ``autoresearch/state/group_variance_history.jsonl`` (git-tracked
+    via ``.gitignore`` negation, PR-G5b precedent). New
+    ``append_group_variance_history`` writer (called from
+    ``apply_group_proposals`` after every group sampling cycle,
+    regardless of accept/reject) + ``resolve_group_variance_threshold``
+    reader. Per-kind filter + below-window fallback to fixed value.
+    Closes the 2026-05-26 sprint Phase A audit's "fitness-scale
+    drift" concern.
+  * **PR-RESAMPLE-BUDGET**: optional retry-on-low-variance.
+    ``max_group_resamples: int = 0`` (ge=0, le=10) + flag
+    ``resample_on_low_variance: bool = False``. When both enabled and
+    ``_compute_group_advantage`` returns ``filtered_low_variance``,
+    ``apply_group_proposals`` cleans up sibling temp files and
+    recursively calls ``self.propose_group(N)`` + retry, bounded by
+    the budget. Default knob values preserve legacy "filtered →
+    cycle skip" behaviour. DAPO frontier equivalent:
+    ``max_num_gen_batches`` informative-batch retention. Pinned by
+    11 invariant tests in
+    ``tests/core/self_improving_loop/test_variance_adaptive_and_resample.py``.
+
 ### Changed
 
 - PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raise the per-adapter lane

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.72
+- **Version**: 0.99.73
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.72 — Long-running Autonomous Execution Harness
+# GEODE v0.99.73 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.72**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.73**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.72 — Long-running Autonomous Execution Harness
+# GEODE v0.99.73 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.72**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.73**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1882,6 +1882,14 @@ def _write_baseline(
     bench_stderr: dict[str, float] | None = None,
     bench_sample_count: dict[str, int] | None = None,
     bench_rubric_version: str = "",
+    # PR-PROMOTE-STAMP (2026-05-26) — when the operator forces promotion
+    # via ``--promote`` instead of going through the ``_should_promote``
+    # gate, stamp the baseline.json with a ``manual_promote`` marker so
+    # later readers can distinguish operator-forced from gate-approved
+    # promotions. Default ``False`` preserves the legacy stamp-free
+    # auto-promote shape — callers that omit the flag produce identical
+    # baselines to pre-PR.
+    manual_promote: bool = False,
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -1949,6 +1957,16 @@ def _write_baseline(
         "raw": raw_payload,
         "axes": axes_payload,
     }
+    # PR-PROMOTE-STAMP (2026-05-26) — operator-forced promotion via
+    # ``--promote`` stamps the baseline so audit-trail readers (e.g.
+    # ``/self-improving status``, observability indexer) can tell that
+    # the value was bypass-promoted, not gate-approved. Closes the
+    # silent-equivalence ambiguity flagged in the 2026-05-26 sprint
+    # Phase A audit (§5.5 ``baseline.json`` promoted SoT discussion).
+    if manual_promote:
+        baseline_payload["manual_promote"] = True
+        baseline_payload["promoted_by"] = "operator"
+        baseline_payload["promoted_at"] = baseline_payload["ts_utc"]
     BASELINE_PATH.write_text(
         json.dumps(baseline_payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -2603,7 +2621,12 @@ def main() -> int:
     elif args.no_promote:
         promoted_line = "false (--no-promote)"
     elif args.promote:
-        _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
+        # PR-PROMOTE-STAMP (2026-05-26) — operator-forced promotion
+        # bypasses ``_should_promote``. Stamp the baseline.json with
+        # ``manual_promote: true`` + ``promoted_by`` + ``promoted_at``
+        # so downstream readers can tell this baseline was approved
+        # by operator override, not by the auto-promote gate.
+        _write_baseline(dim_means, dim_stderr, manual_promote=True, **_baseline_provenance)
         promoted_line = "true (--promote, manual override)"
     else:
         # PR-3 of petri-schema-v2 (2026-05-23) — surface the v2

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2691,6 +2691,83 @@ def main() -> int:
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 
+    # PR-PARETO-INTEGRATE (2026-05-27) — multi-axis preservation. The
+    # 2026-05-26 attribution sprint Phase A audit (§5.7) found that
+    # ``pareto_archive.append_archive_entry`` was wired only inside
+    # ``runner.apply_group_proposals`` (sibling-group path, fitness scalar
+    # only) and never from ``train.py``'s promote gate. The promote gate
+    # is the *only* point where the full ``dim_means`` (multi-axis
+    # observation) crosses paths with the accept/reject decision — without
+    # archiving here, every rejected mutation's per-dim scores are lost
+    # the moment we move to the next cycle.
+    #
+    # Writes when:
+    #   1. ``[self_improving_loop.autoresearch] pareto_mode = true``
+    #      (operator opt-in; default off preserves backward-compat).
+    #   2. Not ``--dry-run`` (synthetic dim_means carries no Pareto signal).
+    #
+    # The entry uses ``extra="allow"`` to attach ``promoted`` + ``reason``
+    # so downstream readers can compute "regret" — what was rejected and
+    # by which gate? Cycle-wide multi-axis history is preserved regardless
+    # of the binary accept/reject outcome.
+    if not args.dry_run:
+        try:
+            from core.config.self_improving_loop import load_self_improving_loop_config
+
+            _sil_cfg = load_self_improving_loop_config()
+            if _sil_cfg.autoresearch.pareto_mode:
+                from core.paths import BASELINE_ARCHIVE_PATH
+                from core.self_improving_loop.pareto_archive import (
+                    ArchiveEntry,
+                    append_archive_entry,
+                )
+
+                _pareto_mid = (
+                    os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+                    or f"manual-{commit[:8]}-{int(started_at)}"
+                )
+                _pareto_audit_run_id = os.environ.get("GEODE_SIL_AUDIT_RUN_ID", "").strip()
+                _pareto_group_id = os.environ.get("GEODE_SIL_GROUP_ID", "").strip()
+                # ``promoted`` and ``reason`` rides on ArchiveEntry's
+                # ``extra="allow"`` — they're not core schema but
+                # downstream regret-analysis readers join on them.
+                # ``promoted_line`` is set in every promote branch
+                # (dry-run/--no-promote/--promote/auto). It starts with
+                # ``"true ("`` only when the baseline was actually
+                # promoted; ``"false ("`` covers rejection + dry-run
+                # synthetic + explicit no-promote. Derive boolean from
+                # that single source so all four branches agree.
+                _was_promoted = promoted_line.startswith("true")
+                # Codex MCP review (CONDITIONAL_PASS must-fix #1) — when
+                # the runner's apply_group_proposals fires sibling
+                # subprocesses, it ALSO writes pareto archive rows (with
+                # fitness scalar only, pre-audit). Adding train.py's
+                # post-audit row would duplicate the mutation_id key
+                # downstream readers join on. We tag with ``phase``
+                # (extra="allow") so the two writers coexist with
+                # distinguishable rows: runner = ``pre_audit_sibling``
+                # (fitness scalar, all N siblings), train = ``post_audit``
+                # (full dim_means + promoted decision, single outcome).
+                entry = ArchiveEntry(
+                    mutation_id=_pareto_mid,
+                    group_id=_pareto_group_id,
+                    audit_run_id=_pareto_audit_run_id,
+                    ts=time.time(),
+                    dim_means={k: float(v) for k, v in dim_means.items()},
+                    dim_stderr={k: float(v) for k, v in (dim_stderr or {}).items()},
+                    promoted=_was_promoted,
+                    reason=promoted_line,
+                    phase="post_audit",
+                )
+                append_archive_entry(entry, archive_path=BASELINE_ARCHIVE_PATH)
+        except Exception:
+            # Best-effort: archive append must not break the audit
+            # cycle. Failures land in train.py log but don't propagate.
+            log.warning(
+                "PR-PARETO-INTEGRATE: archive append failed (cycle continues)",
+                exc_info=True,
+            )
+
     # W2 (2026-05-25) + PR-AR-L6 (2026-05-26) — closed loop attribution.
     # Two paths:
     #

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -267,10 +267,65 @@ class AutoresearchConfig(BaseModel):
     *selection* gate, separate concern).
 
     Default 0.01 is a placeholder — no externally-verified production value
-    is currently grounded for this knob. ``baseline.json`` history (N≥30
-    cycle) 누적 후 percentile-based (5th percentile 미만 filter) 로 adapt
-    권장 (PR-VAR-ADAPTIVE follow-up). ``group_size`` 가 1 이면 무시.
+    is currently grounded for this knob. PR-VAR-ADAPTIVE (2026-05-27)
+    closes the follow-up with the ``group_variance_threshold_mode`` /
+    ``group_variance_history_window`` / ``group_variance_percentile``
+    knobs below. When ``mode="percentile"`` and the history has ≥window
+    entries, this fixed value is ignored in favour of the percentile.
     """
+
+    group_variance_threshold_mode: Literal["fixed", "percentile"] = "fixed"
+    """PR-VAR-ADAPTIVE (2026-05-27) — variance gate threshold source.
+
+    - ``"fixed"`` (default, backward-compat): use
+      ``group_variance_threshold`` as the hard floor regardless of
+      observed history. Legacy behaviour preserved.
+    - ``"percentile"``: read
+      ``autoresearch/state/group_variance_history.jsonl`` (git-tracked),
+      filter to the most recent ``group_variance_history_window``
+      entries for the active ``target_kind`` (when available — else
+      pooled across kinds), and use the ``group_variance_percentile``
+      th-percentile std as the threshold. When the history has fewer
+      than the window count, falls back to the fixed value so an
+      operator can enable the mode without bootstrapping a synthetic
+      history. Closes the 2026-05-26 attribution sprint Phase A
+      audit's "fitness-scale drift" concern — operators changing
+      fitness_margin_floor or weight schemas no longer need to
+      manually re-tune the variance threshold.
+    """
+
+    group_variance_history_window: Annotated[int, Field(ge=5, le=1000)] = 30
+    """PR-VAR-ADAPTIVE (2026-05-27) — number of history entries to use
+    when computing the percentile threshold. Default 30 ≈ 25 day window
+    at min_interval=20h. Below the window count the percentile mode
+    falls back to ``group_variance_threshold`` (fixed). Range floor of
+    5 ensures the percentile has enough samples to be meaningful;
+    ceiling of 1000 caps memory + read latency."""
+
+    group_variance_percentile: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.05
+    """PR-VAR-ADAPTIVE (2026-05-27) — which percentile of historical
+    group std becomes the threshold. ``0.05`` = 5th percentile (skip
+    only the bottom 5% of historical variance, i.e. the truly
+    low-signal groups). Higher values (e.g. ``0.10``) are more
+    aggressive at filtering. Must be in ``(0.0, 1.0)`` — exact 0 / 1
+    are degenerate."""
+
+    max_group_resamples: Annotated[int, Field(ge=0, le=10)] = 0
+    """PR-RESAMPLE-BUDGET (2026-05-27) — number of additional group
+    proposals to attempt when ``_compute_group_advantage`` returns
+    ``filtered_low_variance``. ``0`` (default) preserves legacy
+    behaviour (one shot, low-variance group → cycle skip). Non-zero
+    enables a retry loop bounded by this budget. DAPO frontier
+    equivalent: ``max_num_gen_batches`` — informative-batch
+    retention. Each retry costs N audit subprocesses, so the
+    operator-facing knob is bounded at 10."""
+
+    resample_on_low_variance: bool = False
+    """PR-RESAMPLE-BUDGET (2026-05-27) — must be True for
+    ``max_group_resamples`` to take effect. Separate flag (vs reading
+    ``max_group_resamples > 0`` directly) so an operator can pre-set
+    the budget but keep the feature disabled until A/B data validates
+    it. Default False preserves backward-compat."""
 
     pareto_mode: bool = False
     """P2-revised (2026-05-25) — Pareto archive + Dynamic Reward Weighting

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -486,10 +486,12 @@ class SchedulerConfig(BaseModel):
     expression. Suggested production value: ``100`` (covers ~25 days
     at min_interval=360 = 6h). Closes 2026-05-26 attribution sprint
     Phase A audit (§5.6) — runaway auto-trigger no-stop-condition
-    leak. Cap is best-effort (no post-lock recheck under concurrent
-    callers); operators needing strict uniqueness should also use a
-    cron expression that fires less frequently than
-    ``min_interval_minutes``."""
+    leak. The cap is checked both pre-lock (skips no-op lock acquire
+    when the history is already saturated) and post-lock (catches the
+    race where two parallel callers both observed count=N-1 before
+    either appended). Operators needing strict uniqueness across
+    independent host processes should also pick a cron expression
+    that fires less frequently than ``min_interval_minutes``."""
 
 
 class SelfImprovingLoopConfig(BaseModel):

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -476,6 +476,21 @@ class SchedulerConfig(BaseModel):
     *back-to-back* runs. Must satisfy ``min_interval_minutes <= cron
     period`` for the schedule to actually fire."""
 
+    max_generation: Annotated[int, Field(ge=0, le=100_000)] = 0
+    """PR-MAX-GEN (2026-05-26) — hard cap on total ``fired`` rows in
+    ``~/.geode/self-improving-loop/auto_trigger_history.jsonl``. When
+    the cap is reached the trigger returns ``max_generation_reached``
+    without invoking the mutator runner. ``0`` (default) preserves
+    legacy unbounded behaviour — recommended only for operators who
+    set ``min_interval_minutes`` aggressively and trust the cron
+    expression. Suggested production value: ``100`` (covers ~25 days
+    at min_interval=360 = 6h). Closes 2026-05-26 attribution sprint
+    Phase A audit (§5.6) — runaway auto-trigger no-stop-condition
+    leak. Cap is best-effort (no post-lock recheck under concurrent
+    callers); operators needing strict uniqueness should also use a
+    cron expression that fires less frequently than
+    ``min_interval_minutes``."""
+
 
 class SelfImprovingLoopConfig(BaseModel):
     """Top-level [self_improving_loop.*] config root.

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -237,6 +237,13 @@ class HookEvent(Enum):
     SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED = "self_improving_auto_trigger_interval_blocked"
     SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR = "self_improving_auto_trigger_runner_error"
     SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR = "self_improving_auto_trigger_parse_error"
+    # PR-MAX-GEN (2026-05-26) — emitted when the auto-trigger hits the
+    # ``max_generation`` cap in ``~/.geode/self-improving-loop/auto_trigger_history.jsonl``.
+    # Same ``{trigger_id, ts, detail}`` payload schema; ``detail`` carries
+    # ``"current/max"`` (e.g. ``"100/100"``).
+    SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED = (
+        "self_improving_auto_trigger_max_generation_reached"
+    )
 
     # Wall-clock budget hand-off (PR-CL-BUDGET, 2026-05-23). Replaces the
     # prior turn hard-cap with a 2h time-cap + automatic T-10min hand-off.

--- a/core/orchestration/anthropic_api_lane.py
+++ b/core/orchestration/anthropic_api_lane.py
@@ -80,16 +80,24 @@ ANTHROPIC_API_LANE_NAME = "anthropic-api"
 ANTHROPIC_API_LANE_MAX_ENV = "GEODE_ANTHROPIC_API_LANE_MAX"
 """Operator override for :data:`DEFAULT_ANTHROPIC_API_LANE_MAX`."""
 
-DEFAULT_ANTHROPIC_API_LANE_MAX = 4
-"""Default concurrent Anthropic API calls (oauth + payg pooled).
+DEFAULT_ANTHROPIC_API_LANE_MAX = 8
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 4 to 8.
 
-See module docstring for the three-point rationale (Anthropic tier 1
-50 RPM, claude_cli_lane + audit_lane co-existence, PR-RANKER-PARALLEL
-match-burst headroom)."""
+Anthropic tier 1 documents 50 RPM aggregate per account. Voter calls
+land in 60-70s wallclock each → steady-state ~0.86 inflight per cap
+slot, so cap 8 = ~7 RPM steady state, well under the 50 RPM
+ceiling. The ranker.py panel uses claude-cli (subprocess, gated by
+``claude_cli_lane``) for the anthropic voter, NOT direct API, so the
+8-slot cap here exists to cover hybrid panels and the autoresearch
+mutator's direct API path; it is the natural pair to
+``claude_cli_lane`` raised to 4 in the same PR.
 
-ANTHROPIC_API_LANE_TIMEOUT_S = 300.0
-"""5 minutes — survives a queued slow call but surfaces a genuinely
-stuck call to operators."""
+Operator override via :data:`ANTHROPIC_API_LANE_MAX_ENV` for
+enterprise tiers with higher per-account RPM budgets."""
+
+ANTHROPIC_API_LANE_TIMEOUT_S = 7200.0
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to
+7200s (2h). Same rationale as the sibling lanes."""
 
 
 _ANTHROPIC_API_LANE: Lane | None = None

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -119,17 +119,40 @@ silently fall back to the default — the lane should never harden into
 "no slots" mid-run because of a typo.
 """
 
-DEFAULT_CLAUDE_CLI_LANE_MAX = 2
-"""One slot below the documented 3-4 burst limiter floor so the
-operator's host Claude Code session occupies the spare slot without
-crossing the 429 threshold. See the module docstring for the full
-rationale."""
+DEFAULT_CLAUDE_CLI_LANE_MAX = 4
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 2 to 4.
 
-CLAUDE_CLI_LANE_TIMEOUT_S = 300.0
-"""5 minutes. A legitimate ``claude --print`` for mutator-sized prompts
-finishes in seconds-to-tens-of-seconds; an inspect_ai eval call may
-take a minute or two. The lane wait should outlast a queued slow
-call but not so long that a genuinely-stuck subprocess hides the
+Documented Claude Code burst-limiter floor is 3-4 slots per 5h pool.
+Operator's host Claude Code session occupies 1 slot; the remaining 3
+go to ranker / mutator / audit-spawned sub-agents. Pre-raise the
+ranker's ``asyncio.gather`` burst (`ranker.py:256`) queued all
+voter-side claude-cli calls behind 2-slot cap → 89 × 70s = ~104min
+worst-case lane queue wait, well past the (also raised) 7200s
+timeout. The new cap matches the documented public floor exactly,
+with the host slot accounted for, so a long-running smoke (Loop 1
+ranker with 59 matches × 1 anthropic voter = 59 claude-cli forks) no
+longer creates a queue depth deeper than the 5h pool can sustain.
+
+Operator override via :data:`CLAUDE_CLI_LANE_MAX_ENV` for Max20x tier
+operators with larger 5h pools (5-6) or single-account audit hosts
+that need to push to the documented 4-slot ceiling without host-
+session contention."""
+
+CLAUDE_CLI_LANE_TIMEOUT_S = 7200.0
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to
+7200s (2h). Pre-raise the ranker's parallel match-burst could send
+the last-queued voter to a 60-100min wait, well past 5min — the lane
+would fall through to "timeout" and surface a `TimeoutError` even
+though the subprocess itself was perfectly healthy. The 2h timeout
+covers the worst-case Loop 1 ranker (59 matches × ~70s/voter / cap 4
+= ~17min steady state, with retries up to ~1h). A genuinely-stuck
+subprocess still surfaces — just on a 2h boundary instead of 5min.
+
+Pre-raise rationale (retained for context): A legitimate
+``claude --print`` for mutator-sized prompts finishes in
+seconds-to-tens-of-seconds; an inspect_ai eval call may take a minute
+or two. The lane wait should outlast a queued slow call but not so
+long that a genuinely-stuck subprocess hides the
 problem from operators."""
 
 

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -26,28 +26,42 @@ lane is too restrictive for non-Claude-CLI traffic (API-billed
 Anthropic / OpenAI completions). The two flows need separate caps,
 which is why this lane sits alongside ``global`` rather than under it.
 
-Why ``max_concurrent=2``
-========================
+Why ``max_concurrent=4`` (PR-LANE-CAP-AGGRESSIVE, 2026-05-27)
+============================================================
 
-One slot below the public burst-limiter floor of 3, leaving room for
-the operator's host Claude Code session to occupy 1 slot without
-hitting the 429 threshold. Two stacked rationales:
+Raised from 2 (PR-RANKER-PARALLEL conservative default) to 4 per
+operator decision "공격적으로 늘려" + the measured PR-RANKER-PARALLEL
+burst evidence (Loop 1: 59 matches × 1 anthropic voter = 59
+``claude --print`` forks queued behind the prior cap-2 ceiling, tail
+latency past 5min).
 
-1. **Burst limiter headroom**: host session (≈1 in-flight) + 2
-   ``claude --print`` sub-agents = 3 total = burst-limit floor. A 4th
-   would race the limiter and start drawing 429 + Retry-After.
-2. **Conservative until Phase 3**: paperclip's OAuth-usage polling
-   (Phase 3) would let us raise the cap on tiers with larger 5h
-   token pools. Until then we ship the safe lower bound and let
-   operators tune via environment override
-   (:data:`CLAUDE_CLI_LANE_MAX_ENV`).
+**Burst-limiter reality**: Claude Code's documented sub-agent burst
+floor is 3-4 *exclusive of* the operator's host session — the host's
+own OAuth claim does NOT consume a sub-agent slot. So cap 4 = 4
+``claude --print`` sub-agents running concurrently against the
+shared 5h pool, with the host's interactive session as a separate
+budget line item. The two share the same 5h pool *token total* but
+their inflight counts are independent.
+
+**Aggressive headroom trade-off**: Cap 4 sits at the upper edge of
+the documented floor. Two stacked watch-outs:
+
+1. **Pool exhaustion still possible** — the 5h pool's *token*
+   budget is a separate ceiling. Smoke 25 (2026-05-26) hit
+   ``model_action_required`` after ~2h of sustained sub-agent
+   traffic. Cap-raise alone doesn't prevent that; the pool must
+   refresh before resume.
+2. **Host session contention**: if the operator's interactive
+   session is mid-multi-turn while a smoke runs at cap 4, the
+   shared 5h pool drains faster. Operators on Max20x tier with
+   larger pools may raise via :data:`CLAUDE_CLI_LANE_MAX_ENV`;
+   operators on lower tiers may lower to 2-3.
 
 **Pre-flight measurement gap**: [[project_lanequeue_handoff_2026_05_22]]
-calls for a one-time measurement of the operator's actual burst
-threshold before Phase 2. Live measurement requires network access to
-the operator's OAuth bucket which CSP-sprint sessions don't have, so
-this PR ships the conservative public-doc-grounded cap (2) and
-exposes the override for post-deploy tuning.
+called for a one-time measurement of the actual burst threshold.
+The PR-LANE-CAP-AGGRESSIVE raise rests on smoke-24-25 empirical
+data (cap 2 demonstrably idle ~95% of the 5h pool RPM budget)
+rather than the original public-doc grounding.
 
 Why module-level (not LaneQueue-registered)
 ===========================================

--- a/core/orchestration/openai_api_lane.py
+++ b/core/orchestration/openai_api_lane.py
@@ -75,15 +75,32 @@ OPENAI_API_LANE_NAME = "openai-api"
 OPENAI_API_LANE_MAX_ENV = "GEODE_OPENAI_API_LANE_MAX"
 """Operator override for :data:`DEFAULT_OPENAI_API_LANE_MAX`."""
 
-DEFAULT_OPENAI_API_LANE_MAX = 4
-"""Default concurrent OpenAI API calls (codex-oauth + payg pooled).
+DEFAULT_OPENAI_API_LANE_MAX = 16
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 4 to 16.
 
-See module docstring for the three-point rationale (OpenAI Codex
-Responses API 500 RPM bucket, codex_cli_lane co-existence,
-PR-RANKER-PARALLEL match-burst headroom)."""
+OpenAI Codex Responses API documents a 500 RPM aggregate per ChatGPT
+subscription bucket (verified against operator's ``prolite`` plan via
+the JWT's ``rate_limit`` claim window). Voter calls land in 10-15s
+wallclock each, so steady-state throughput = ``60s / call * cap``.
+At cap 16 that's ~64-96 RPM — well under the 500 RPM ceiling, even
+counting the codex_cli_lane (2 slots) + audit_lane (1 slot) running
+concurrently. Pre-raise the cap 4 only used ~24 RPM of the available
+500 budget; the burst from PR-RANKER-PARALLEL (2 × 59 codex voters
+inside ``asyncio.gather``) would queue 110+ calls behind the 4-slot
+cap → 1700s+ tail latency.
 
-OPENAI_API_LANE_TIMEOUT_S = 300.0
-"""5 minutes — same rationale as the Anthropic API lane."""
+Operator override via :data:`OPENAI_API_LANE_MAX_ENV` for tier
+upgrades or downgrades; the env stays the recommended tuning knob,
+the new default is a sane aggressive ceiling for the documented
+prolite/pro/enterprise tiers."""
+
+OPENAI_API_LANE_TIMEOUT_S = 7200.0
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to
+7200s (2h). Same rationale as ``claude_cli_lane`` — the parallel
+ranker burst can push the last-queued voter well past 5min even
+under the new 16-cap if a single 429 cascades. 2h matches the
+ranker phase's hard time budget; a genuinely-stuck call still
+surfaces at the 2h boundary."""
 
 
 _OPENAI_API_LANE: Lane | None = None

--- a/core/paths.py
+++ b/core/paths.py
@@ -337,6 +337,13 @@ MUTATION_AUDIT_LOG_PATH = _AUTORESEARCH_STATE_DIR / "mutations.jsonl"
 # Append-only, mutation 의 17-dim fitness vector 보존. AlphaEvolve
 # evolutionary DB + DGM lineage archive 의 frontier 패턴 차용.
 BASELINE_ARCHIVE_PATH = _AUTORESEARCH_STATE_DIR / "baseline_archive.jsonl"
+# PR-VAR-ADAPTIVE (2026-05-27) — historical group-std samples for the
+# percentile-based variance gate threshold. Append-only JSONL row per
+# group sampling cycle. Same git-tracked + .gitignore-negation pattern
+# as ``mutations.jsonl`` and ``baseline_archive.jsonl`` (PR-G5b
+# precedent — writer destination must be tracked or the archive
+# silently disappears under the broad ``autoresearch/state/*`` ignore).
+GROUP_VARIANCE_HISTORY_PATH = _AUTORESEARCH_STATE_DIR / "group_variance_history.jsonl"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
 # (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -99,9 +99,9 @@ STATE_TO_HOOK_EVENT: dict[str, str] = {
     "interval_blocked": "SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED",
     "runner_error": "SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR",
     "parse_error": "SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR",
-    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent not yet
-    # reserved (see follow-up HookEvent stub PR); ``_emit_state_event``
-    # graceful-skips the missing event name, so telemetry stays opt-in.
+    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent reserved
+    # in ``core/hooks/system.py`` alongside the sibling auto-trigger
+    # events; same ``{trigger_id, ts, detail}`` payload schema.
     "max_generation_reached": "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED",
 }
 """Maps terminal :class:`AutoTriggerStatus.state` → HookEvent enum name.

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -54,6 +54,7 @@ __all__ = [
     "acquire_auto_trigger_lock",
     "append_history_entry",
     "auto_trigger_mutator",
+    "count_fired_generations",
     "is_min_interval_satisfied",
     "read_last_run_timestamp",
     "register_auto_trigger",
@@ -98,6 +99,10 @@ STATE_TO_HOOK_EVENT: dict[str, str] = {
     "interval_blocked": "SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED",
     "runner_error": "SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR",
     "parse_error": "SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR",
+    # PR-MAX-GEN (2026-05-26) — generation cap state. HookEvent not yet
+    # reserved (see follow-up HookEvent stub PR); ``_emit_state_event``
+    # graceful-skips the missing event name, so telemetry stays opt-in.
+    "max_generation_reached": "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED",
 }
 """Maps terminal :class:`AutoTriggerStatus.state` → HookEvent enum name.
 
@@ -114,7 +119,7 @@ SoT for "trigger was registered or skipped"."""
 class AutoTriggerStatus:
     """Return shape from :func:`auto_trigger_mutator`.
 
-    Six terminal states:
+    Seven terminal states:
 
     * ``fired`` — runner.run_once completed; ``mutation`` carries the
       Mutation summary (target_section + new_value len), timestamp
@@ -129,6 +134,10 @@ class AutoTriggerStatus:
       (mutation parse / validation); ``error`` carries the message.
       Treated separately from ``runner_error`` so telemetry can
       distinguish "LLM produced garbage" from "infra crashed".
+    * ``max_generation_reached`` — PR-MAX-GEN (2026-05-26):
+      ``max_generation`` was set non-zero and the auto-trigger
+      history already contains that many ``fired`` rows. Hard stop
+      on unbounded firing. ``detail`` carries ``current/max``.
     """
 
     state: str
@@ -220,6 +229,44 @@ def is_min_interval_satisfied(
     current = now if now is not None else time.time()
     elapsed_minutes = (current - last_run) / 60.0
     return elapsed_minutes >= min_interval_minutes
+
+
+def count_fired_generations(history_path: Path | None = None) -> int:
+    """Count ``state="fired"`` rows in the auto-trigger history log.
+
+    PR-MAX-GEN (2026-05-26) — Phase A audit (§5.6) found that
+    ``auto_trigger_mutator`` had no max-generation gate, only the
+    ``min_interval_minutes`` floor. With min_interval=60 and cron fires
+    every hour, a misconfigured operator could accumulate hundreds of
+    fired generations without any hard stop. This counter is the data
+    feed for the new ``max_generation`` gate.
+
+    Best-effort read — missing file / malformed JSON / non-dict rows
+    are all skipped silently. The audit log is append-only so future-
+    proof: each call re-counts (no in-memory cache invalidation).
+
+    Returns 0 when the history log is absent (fresh repo / never fired).
+    """
+    target = history_path if history_path is not None else AUTO_TRIGGER_HISTORY_PATH
+    if not target.is_file():
+        return 0
+    n = 0
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("state") == "fired":
+                    n += 1
+    except OSError:
+        log.warning("auto_trigger: history read failed", exc_info=True)
+        return n
+    return n
 
 
 def append_history_entry(
@@ -314,6 +361,7 @@ def auto_trigger_mutator(
     *,
     enabled: bool,
     min_interval_minutes: int,
+    max_generation: int = 0,
     runner_factory: Callable[[], Any] | None = None,
     lock_path: Path | None = None,
     timestamp_path: Path | None = None,
@@ -321,7 +369,7 @@ def auto_trigger_mutator(
     hooks: Any = None,
     now: float | None = None,
 ) -> AutoTriggerStatus:
-    """One mutator firing — guarded by lockfile + min-interval.
+    """One mutator firing — guarded by lockfile + min-interval + max-generation.
 
     Args:
         enabled: Defensive gate. When False, return ``disabled``
@@ -329,6 +377,11 @@ def auto_trigger_mutator(
             registering the trigger in this case; this is belt+suspenders.
         min_interval_minutes: Floor between successful firings (see
             :class:`SchedulerConfig.min_interval_minutes`).
+        max_generation: PR-MAX-GEN (2026-05-26) — hard cap on total
+            ``fired`` rows in the history log. When non-zero and the
+            current count is at or above the cap, return
+            ``max_generation_reached`` without firing. ``0`` (default)
+            disables the cap — legacy unbounded behaviour preserved.
         runner_factory: Zero-arg callable returning an object with
             ``run_once() -> Mutation`` method. Defaults to
             :class:`SelfImprovingLoopRunner` constructed with no args.
@@ -352,6 +405,21 @@ def auto_trigger_mutator(
         # ``disabled`` is the only state that skips telemetry + history
         # (see STATE_TO_HOOK_EVENT docstring for rationale).
         return AutoTriggerStatus(state="disabled")
+
+    # PR-MAX-GEN (2026-05-26) — generation cap. Evaluated BEFORE the
+    # interval gate so a misconfigured cron with min_interval=0 still
+    # hits the cap, and BEFORE the lock so a saturated history doesn't
+    # consume the lock for a no-op fire. ``0`` means unlimited.
+    if max_generation > 0:
+        fired_count = count_fired_generations(history_path=history_path)
+        if fired_count >= max_generation:
+            return _finalize_status(
+                "max_generation_reached",
+                f"{fired_count}/{max_generation}",
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
+            )
 
     if not is_min_interval_satisfied(
         min_interval_minutes=min_interval_minutes,
@@ -394,6 +462,24 @@ def auto_trigger_mutator(
                 history_path=history_path,
                 ts=ts_now,
             )
+
+        # PR-MAX-GEN (2026-05-26) Codex MCP must-fix #2 — re-check the
+        # generation cap AFTER acquiring the lock for the same reason
+        # the interval check does: two parallel callers can both read
+        # the pre-lock count as N-1, both proceed to fire, and overshoot
+        # the cap by 1. The post-lock recheck reads the freshly-written
+        # history (the previous holder appends + releases atomically) so
+        # the second caller sees count=N and blocks cleanly.
+        if max_generation > 0:
+            fired_count = count_fired_generations(history_path=history_path)
+            if fired_count >= max_generation:
+                return _finalize_status(
+                    "max_generation_reached",
+                    f"{fired_count}/{max_generation} (post-lock re-check)",
+                    hooks=hooks,
+                    history_path=history_path,
+                    ts=ts_now,
+                )
 
         # Codex MCP catch (PR-OL-A1 fix-up): runner construction itself
         # can raise (lazy import failure, runner __init__ side-effects).
@@ -460,6 +546,7 @@ def register_auto_trigger(
     enabled: bool,
     cron: str,
     min_interval_minutes: int,
+    max_generation: int = 0,
     runner_factory: Callable[[], Any] | None = None,
     hooks: Any = None,
 ) -> bool:
@@ -469,12 +556,17 @@ def register_auto_trigger(
     needs to call. Returns True when the trigger was registered, False
     when ``enabled=False`` (so the wiring layer can log the skip).
 
-    The callback closes over ``min_interval_minutes`` + ``runner_factory``
-    + ``hooks`` so the scheduler's bare ``callback(data)`` invocation
-    forwards into :func:`auto_trigger_mutator` with the right config
-    and telemetry sink. The callback swallows every exception (logs at
-    WARNING) — `TriggerManager`'s own error isolation is the second
-    layer of defense.
+    The callback closes over ``min_interval_minutes`` +
+    ``max_generation`` + ``runner_factory`` + ``hooks`` so the
+    scheduler's bare ``callback(data)`` invocation forwards into
+    :func:`auto_trigger_mutator` with the right config and telemetry
+    sink. The callback swallows every exception (logs at WARNING) —
+    `TriggerManager`'s own error isolation is the second layer of
+    defense.
+
+    PR-MAX-GEN (2026-05-26) — added ``max_generation`` so the wiring
+    layer can pass the scheduler config knob through to the mutator
+    cap gate. Default ``0`` preserves legacy unbounded behaviour.
     """
     if not enabled:
         log.info("auto_trigger: [self_improving_loop.scheduler] enabled=False; skip register")
@@ -487,6 +579,7 @@ def register_auto_trigger(
             status = auto_trigger_mutator(
                 enabled=True,
                 min_interval_minutes=min_interval_minutes,
+                max_generation=max_generation,
                 runner_factory=runner_factory,
                 hooks=hooks,
             )

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -135,6 +135,23 @@ def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
 # 보존: ``GLOBAL_RETRIEVAL_POLICY_PATH`` 와 ``_KIND_TO_PATH`` 의 ``retrieval``
 # 매핑은 그대로 둠 — 미래 RAG 인프라 신설 시 별도 ADR 로 ``TARGET_KINDS``
 # 에 재추가 가능하도록 path-literal guard 유지.
+#
+# PR-TARGET-KIND-DOC (2026-05-27) — surface-clarity bundle. The 2026-05-26
+# attribution sprint Phase A audit (§5 mutation surface verification)
+# found an asymmetry: ``autoresearch.train.run_audit``'s env override
+# block (around line 868-903) wires STRICT-mode env vars for **13** SoT
+# files, but ``TARGET_KINDS`` below lists only **6 active** mutation
+# slots. The 7 difference is :data:`_READER_ONLY_KINDS` — reader-deployed
+# SoT surfaces that the audit subprocess consumes (read-only) but the
+# mutator cannot dispatch to. ADR-013 phased rollout intent: each
+# reader-only surface graduates in its own follow-up PR (matching the
+# ADR-012 M1/M2 precedent that opened ``skill_catalog`` and
+# ``agent_contract``). Mutator emitting a ``target_kind`` not in
+# ``TARGET_KINDS`` fails fast at ``parse_mutation`` (``runner.py:914``
+# ValueError) — fail-closed by design. The reader-only set is pinned
+# by ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+# so a future PR that promotes any of them must remove the entry
+# explicitly rather than silently expanding mutator dispatch.
 TARGET_KINDS: tuple[str, ...] = (
     "prompt",
     "tool_policy",
@@ -172,6 +189,29 @@ _KIND_TO_PATH: dict[str, Path] = {
 # M1+M2 (2026-05-21) — nested-schema kinds. ``load_policy`` /
 # ``write_policy`` 의 flat ↔ nested 변환 dispatch 분기 키.
 _NESTED_KINDS: frozenset[str] = frozenset({"skill_catalog", "agent_contract"})
+
+
+# PR-TARGET-KIND-DOC (2026-05-27) — reader-only SoT surfaces. These are
+# wired in ``autoresearch.train.run_audit``'s ``GEODE_*_OVERRIDE`` +
+# ``GEODE_*_STRICT`` env block (so the audit subprocess can read them
+# under operator-local overrides) but NOT in :data:`TARGET_KINDS` (so
+# the mutator can't dispatch to them). Each entry must graduate to
+# ``TARGET_KINDS`` via its own follow-up PR — phased rollout matches
+# the ADR-012 M1/M2 precedent. Frozen set so a future PR that adds an
+# entry to ``TARGET_KINDS`` *must* remove it here (the invariant test
+# in ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
+# verifies the two sets are disjoint).
+_READER_ONLY_KINDS: frozenset[str] = frozenset(
+    {
+        "tool_descriptions",
+        "style_guide",
+        "provider_routing",
+        "cache_policy",
+        "heuristics",
+        "in_context_slots",
+        "few_shot_pool",
+    }
+)
 
 
 def is_valid_target_kind(kind: str) -> bool:

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -37,6 +37,7 @@ Test strategy:
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 import logging
@@ -66,9 +67,11 @@ __all__ = [
     "RunnerContext",
     "SelfImprovingLoopRunner",
     "_compute_group_advantage",
+    "append_group_variance_history",
     "apply_mutation",
     "build_runner_context",
     "parse_mutation",
+    "resolve_group_variance_threshold",
 ]
 
 
@@ -1061,6 +1064,119 @@ def _parse_fitness_from_subprocess_stdout(
     )
 
 
+def append_group_variance_history(
+    *,
+    group_id: str,
+    target_kind: str,
+    std: float,
+    n_siblings: int,
+    history_path: Path | None = None,
+) -> bool:
+    """Append one row to ``group_variance_history.jsonl``.
+
+    PR-VAR-ADAPTIVE (2026-05-27) — feeds the percentile resolver.
+    Every group-sampling cycle (regardless of accept/reject) appends
+    its observed std so the threshold can adapt to fitness-scale
+    drift without operator intervention.
+
+    Best-effort: any OSError (parent missing, disk full) logs at
+    WARNING and returns False. Callers ignore the return value
+    because telemetry failure must not break the mutator loop.
+    """
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    target = history_path if history_path is not None else GROUP_VARIANCE_HISTORY_PATH
+    row = {
+        "ts": time.time(),
+        "group_id": group_id,
+        "target_kind": target_kind,
+        "std": float(std),
+        "n_siblings": int(n_siblings),
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        log.warning("self-improving-loop: variance history append failed: %s", exc)
+        return False
+    return True
+
+
+def resolve_group_variance_threshold(
+    cfg_autoresearch: Any,
+    *,
+    target_kind: str | None = None,
+    history_path: Path | None = None,
+) -> tuple[float, str]:
+    """Resolve the variance gate threshold for the upcoming cycle.
+
+    PR-VAR-ADAPTIVE (2026-05-27) — when
+    ``group_variance_threshold_mode == "percentile"`` and the history
+    file contains at least ``group_variance_history_window`` entries
+    matching ``target_kind`` (or pooled across kinds when
+    ``target_kind`` is None), returns the corresponding percentile of
+    historical ``std`` values. Otherwise returns the legacy fixed
+    ``group_variance_threshold`` value.
+
+    Returns ``(threshold, source)`` where ``source`` is ``"fixed"`` or
+    ``"percentile"`` so callers can log which path fired (useful for
+    operators watching the adaptive knob converge on a stable value).
+
+    Best-effort: missing file / malformed rows / read OSError all
+    fall through to the fixed value (legacy behaviour preserved).
+    """
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    fixed = float(cfg_autoresearch.group_variance_threshold)
+    if getattr(cfg_autoresearch, "group_variance_threshold_mode", "fixed") != "percentile":
+        return fixed, "fixed"
+
+    window = int(getattr(cfg_autoresearch, "group_variance_history_window", 30))
+    percentile = float(getattr(cfg_autoresearch, "group_variance_percentile", 0.05))
+
+    target = history_path if history_path is not None else GROUP_VARIANCE_HISTORY_PATH
+    if not target.is_file():
+        return fixed, "fixed"
+
+    matched_stds: list[float] = []
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if target_kind is not None and row.get("target_kind") != target_kind:
+                    continue
+                raw_std = row.get("std")
+                if isinstance(raw_std, int | float):
+                    matched_stds.append(float(raw_std))
+    except OSError:
+        log.warning("self-improving-loop: variance history read failed", exc_info=True)
+        return fixed, "fixed"
+
+    if len(matched_stds) < window:
+        return fixed, "fixed"
+
+    # Take the most recent ``window`` entries (history is append-only
+    # so file order == chronological).
+    recent = matched_stds[-window:]
+    recent_sorted = sorted(recent)
+    # Linear-interpolation percentile (matches numpy.quantile default).
+    pos = percentile * (len(recent_sorted) - 1)
+    lo_idx = int(pos)
+    hi_idx = min(lo_idx + 1, len(recent_sorted) - 1)
+    frac = pos - lo_idx
+    interpolated = recent_sorted[lo_idx] * (1 - frac) + recent_sorted[hi_idx] * frac
+    return interpolated, "percentile"
+
+
 def _compute_group_advantage(
     fitness_values: list[float],
     threshold: float,
@@ -1488,6 +1604,7 @@ class SelfImprovingLoopRunner:
         *,
         swarm_id: str = "",
         sub_agent_index: int | None = None,
+        _resample_attempt: int = 0,
     ) -> Mutation | None:
         """P1-revised (2026-05-25) — apply N sibling proposals → audit →
         variance gate → group-relative scoring → top-1 commit.
@@ -1527,6 +1644,21 @@ class SelfImprovingLoopRunner:
         Requires ``rerun_enabled=True`` — group advantage 가 real fitness
         에 의존하므로 audit 가 실제로 fire 되어야 함.
         """
+        # PR-VAR-ADAPTIVE (2026-05-27) Codex MCP review must-fix #1 —
+        # enforce homogeneous ``target_kind`` across siblings BEFORE
+        # any audit cost or rerun-enabled gate. The variance signal is
+        # only meaningful when N siblings touch the same SoT surface
+        # (different surfaces have different std scales, so mixing
+        # collapses the percentile resolver's per-kind filter).
+        if proposals:
+            _kinds = {p.mutation.target_kind for p in proposals}
+            if len(_kinds) > 1:
+                raise ValueError(
+                    f"apply_group_proposals requires homogeneous target_kind "
+                    f"across siblings (variance signal is per-kind, see "
+                    f"PR-VAR-ADAPTIVE); got {_kinds!r}"
+                )
+
         if len(proposals) == 1:
             return self.apply_proposal(
                 proposals[0],
@@ -1559,7 +1691,26 @@ class SelfImprovingLoopRunner:
         from core.config.self_improving_loop import load_self_improving_loop_config
 
         cfg = load_self_improving_loop_config()
-        threshold = cfg.autoresearch.group_variance_threshold
+        # PR-VAR-ADAPTIVE (2026-05-27) — variance gate threshold resolved
+        # via ``resolve_group_variance_threshold``. When
+        # ``group_variance_threshold_mode == "percentile"`` and the
+        # history has >= window entries for this target_kind, the
+        # threshold adapts to fitness-scale drift; otherwise falls
+        # through to the legacy fixed value. ``threshold_source`` is
+        # logged so operators can verify the adaptive knob is firing.
+        # Homogeneous ``target_kind`` is already enforced at function
+        # entry above (PR-VAR-ADAPTIVE Codex MCP review must-fix #1).
+        _resolve_kind = proposals[0].mutation.target_kind if proposals else None
+        # Codex MCP review must-fix #2 — threshold is re-resolved on each
+        # ``_resample_attempt`` (the recursive call re-enters this
+        # function), which means a resample sees the just-appended std
+        # of the failed attempt. This is intentional: each retry is a
+        # fresh selection cycle and the threshold should reflect the
+        # latest percentile. To freeze across retries, an operator
+        # would set ``mode="fixed"`` (which ignores history entirely).
+        threshold, threshold_source = resolve_group_variance_threshold(
+            cfg.autoresearch, target_kind=_resolve_kind
+        )
         mutator_temp = settings.temperature_self_improving_mutation
 
         # Codex MCP review #5 (2026-05-25) — temperature guard 를 N audit 비용
@@ -1620,12 +1771,68 @@ class SelfImprovingLoopRunner:
                 mutator_temperature=mutator_temp,
             )
 
+            # PR-VAR-ADAPTIVE (2026-05-27) — append the observed group
+            # std to the history file (best-effort; failure logs WARNING
+            # but doesn't break the cycle). The resolver above reads
+            # this on the *next* cycle to compute the percentile
+            # threshold, so the gate self-adapts to fitness-scale drift.
+            # We log regardless of filtered/ok status — both are valid
+            # variance signals to learn from.
+            if len(fitness_values) >= 2:
+                _mean = sum(fitness_values) / len(fitness_values)
+                _observed_std = (
+                    sum((v - _mean) ** 2 for v in fitness_values) / len(fitness_values)
+                ) ** 0.5
+                append_group_variance_history(
+                    group_id=group_id,
+                    target_kind=_resolve_kind or "",
+                    std=_observed_std,
+                    n_siblings=len(fitness_values),
+                )
+
             if status == "filtered_low_variance":
+                # PR-RESAMPLE-BUDGET (2026-05-27) — when
+                # ``resample_on_low_variance=True`` and we haven't
+                # exhausted ``max_group_resamples``, propose a fresh
+                # sibling group and retry the audit. DAPO frontier
+                # equivalent: ``max_num_gen_batches`` informative-batch
+                # retention. The default config (budget=0, flag=False)
+                # preserves the legacy "filtered → cycle skip" behaviour.
+                _max_resamples = (
+                    int(cfg.autoresearch.max_group_resamples)
+                    if cfg.autoresearch.resample_on_low_variance
+                    else 0
+                )
+                if _resample_attempt < _max_resamples:
+                    log.info(
+                        "self-improving-loop: group %s filtered (low variance, "
+                        "std < %s, source=%s). resample attempt %d/%d.",
+                        group_id,
+                        threshold,
+                        threshold_source,
+                        _resample_attempt + 1,
+                        _max_resamples,
+                    )
+                    # Cleanup sibling temp files of this attempt before
+                    # recursing — the new attempt will create its own.
+                    for sibling_path in sibling_sot_paths:
+                        with contextlib.suppress(OSError):
+                            sibling_path.unlink(missing_ok=True)
+                    new_proposals = self.propose_group(len(proposals))
+                    return self.apply_group_proposals(
+                        new_proposals,
+                        swarm_id=swarm_id,
+                        sub_agent_index=sub_agent_index,
+                        _resample_attempt=_resample_attempt + 1,
+                    )
                 log.info(
                     "self-improving-loop: group %s filtered (low variance, "
-                    "std < %s). cycle skipped, no SoT commit.",
+                    "std < %s, source=%s). cycle skipped, no SoT commit "
+                    "(after %d resample attempt(s)).",
                     group_id,
                     threshold,
+                    threshold_source,
+                    _resample_attempt,
                 )
                 return None
             if status != "ok" or advantages is None:

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1653,6 +1653,13 @@ class SelfImprovingLoopRunner:
                 _archive_appended = 0
                 _archive_failed = 0
                 for idx, proposal in enumerate(proposals):
+                    # PR-PARETO-INTEGRATE (2026-05-27) Codex MCP review
+                    # must-fix #1 — tag with ``phase="pre_audit_sibling"``
+                    # so this sibling row (fitness scalar, pre-audit) is
+                    # distinguishable from train.py's post-audit row
+                    # (full dim_means + promoted decision). Both writers
+                    # share the mutation_id join key but downstream
+                    # readers filter by phase.
                     entry = ArchiveEntry(
                         mutation_id=proposal.mutation.mutation_id,
                         group_id=group_id,
@@ -1660,6 +1667,7 @@ class SelfImprovingLoopRunner:
                         ts=time.time(),
                         dim_means={"fitness": float(fitness_values[idx])},
                         dim_stderr={},
+                        phase="pre_audit_sibling",
                     )
                     try:
                         append_archive_entry(entry, archive_path=BASELINE_ARCHIVE_PATH)

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -114,6 +114,12 @@ def build_automation(
             enabled=sil_cfg.scheduler.enabled,
             cron=sil_cfg.scheduler.cron,
             min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
+            # PR-MAX-GEN (2026-05-26) — production wiring for the
+            # generation cap. ``0`` (config default) preserves legacy
+            # unbounded behaviour. Operators set a non-zero cap in
+            # ~/.geode/config.toml under [self_improving_loop.scheduler]
+            # max_generation = N.
+            max_generation=sil_cfg.scheduler.max_generation,
             hooks=hooks,
         )
     except Exception:

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -1127,9 +1127,10 @@ def register() -> None:
             # PR-LQ-Phase2 (2026-05-22) — share the
             # claude-cli-subagent lane with the self-improving-loop
             # mutator path so the host OAuth bucket sees at most
-            # ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (=2) concurrent
-            # ``claude --print`` subprocesses. The lane runs the
-            # blocking semaphore wait in a worker thread so the
+            # ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (raised to 4 in
+            # PR-LANE-CAP-AGGRESSIVE 2026-05-27 from the prior =2)
+            # concurrent ``claude --print`` subprocesses. The lane runs
+            # the blocking semaphore wait in a worker thread so the
             # event loop is not pinned while queued.
             from core.orchestration.claude_cli_lane import acquire_claude_cli_lane_async
 

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -111,15 +111,24 @@ def _serialise_match_outcome(outcome: MatchOutcome) -> dict[str, Any]:
 # PR-LANE-CAP-AGGRESSIVE (2026-05-27) — phase-local concurrency cap for
 # the ranker's ``asyncio.gather`` match-dispatch burst. The cap exists
 # *on top* of the per-adapter lanes (claude_cli=4 / openai_api=16 /
-# anthropic_api=8) to bound the gather submission queue depth — each
-# match spawns 3 voter sub-agents (~1 claude-cli + 2 codex), so cap 8
-# matches = 8 claude-cli + 16 codex inflight, exactly the per-lane
-# ceiling. Pre-cap a 59-match Loop 1 burst would push 177 task objects
+# anthropic_api=8) to bound the gather submission queue depth.
+#
+# Concurrency budget (default 3-voter panel = 2 codex + 1 claude-cli):
+#   8 matches inflight * 3 voters = 24 voter tasks
+#     - claude-cli tasks: 8 (1 per match) — exceeds claude_cli_lane=4;
+#       4 wait in lane queue, 4 inflight
+#     - codex tasks: 16 (2 per match) — exactly openai_api_lane=16
+#   Net: codex saturates its lane; claude-cli runs at 100% utilisation
+#   with a depth-4 lane wait queue. Cap 8 is the equilibrium where
+#   neither lane is starved and neither is severely backlogged.
+#
+# Pre-cap a 59-match Loop 1 burst would push 177 task objects
 # into ``asyncio.wait`` queues simultaneously; the lanes throttle the
 # subprocess/API side but the awaiting task list itself becomes a
-# memory + scheduler tax. Cap 8 keeps gather "in-flight" at
-# ``cap * voter_count`` = ``8 * 3 = 24`` tasks, with the rest serialised
-# behind the semaphore acquire.
+# memory + scheduler tax. Cap 8 keeps gather "in-flight" at 24 tasks,
+# with the rest serialised behind the semaphore acquire — operator
+# can raise via :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` if the lane
+# caps are also raised proportionally.
 DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 8
 """Operator default = 8 simultaneous match dispatches inside
 ``asyncio.gather``. See :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` for

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -108,6 +108,51 @@ def _serialise_match_outcome(outcome: MatchOutcome) -> dict[str, Any]:
     }
 
 
+# PR-LANE-CAP-AGGRESSIVE (2026-05-27) — phase-local concurrency cap for
+# the ranker's ``asyncio.gather`` match-dispatch burst. The cap exists
+# *on top* of the per-adapter lanes (claude_cli=4 / openai_api=16 /
+# anthropic_api=8) to bound the gather submission queue depth — each
+# match spawns 3 voter sub-agents (~1 claude-cli + 2 codex), so cap 8
+# matches = 8 claude-cli + 16 codex inflight, exactly the per-lane
+# ceiling. Pre-cap a 59-match Loop 1 burst would push 177 task objects
+# into ``asyncio.wait`` queues simultaneously; the lanes throttle the
+# subprocess/API side but the awaiting task list itself becomes a
+# memory + scheduler tax. Cap 8 keeps gather "in-flight" at
+# ``cap * voter_count`` = ``8 * 3 = 24`` tasks, with the rest serialised
+# behind the semaphore acquire.
+DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 8
+"""Operator default = 8 simultaneous match dispatches inside
+``asyncio.gather``. See :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` for
+runtime override."""
+
+RANKER_MAX_INFLIGHT_MATCHES_ENV = "GEODE_RANKER_MAX_INFLIGHT_MATCHES"
+"""Operator override — raise / lower the phase-local cap. Invalid
+values silently fall back to the default (lane should never harden
+into "no slots" from a typo)."""
+
+
+def resolve_ranker_max_inflight_matches() -> int:
+    """Resolve the effective phase-local match-dispatch cap.
+
+    Defaults to :data:`DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`; honours
+    :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` as a positive integer.
+    Non-positive / non-integer overrides fall back silently — the cap
+    must never harden into 0 mid-run from a typo.
+    """
+    import os
+
+    raw = os.environ.get(RANKER_MAX_INFLIGHT_MATCHES_ENV, "").strip()
+    if not raw:
+        return DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+    if parsed <= 0:
+        return DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+    return parsed
+
+
 class Ranker(BaseSeedAgent):
     """Elo tournament orchestrator with 3-voter judge panel.
 
@@ -253,16 +298,27 @@ class Ranker(BaseSeedAgent):
                 )
             )
         try:
-            match_results = await asyncio.gather(
-                *[
-                    self._play_match_with_checkpoint_report(
+            # PR-LANE-CAP-AGGRESSIVE (2026-05-27) — wrap each
+            # ``_play_match_with_checkpoint_report`` in a phase-local
+            # semaphore acquire so the gather submission queue depth
+            # never exceeds :data:`DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`.
+            # The per-adapter lanes (claude_cli_lane=4 / openai_api_lane=16)
+            # already throttle the downstream subprocess/API calls; this
+            # cap keeps the gather "in-flight" task count from balloon-
+            # ing past the lane ceiling on a 59-match Loop 1 burst.
+            match_semaphore = asyncio.Semaphore(resolve_ranker_max_inflight_matches())
+
+            async def _bounded_play(match: MatchPlan) -> tuple[MatchOutcome | None, dict[str, Any]]:
+                async with match_semaphore:
+                    return await self._play_match_with_checkpoint_report(
                         match,
                         pilot_means=pilot_means,
                         candidate_bodies=candidate_bodies,
                         result_queue=result_queue,
                     )
-                    for match in resume.pending_matches
-                ]
+
+            match_results = await asyncio.gather(
+                *[_bounded_play(match) for match in resume.pending_matches]
             )
         finally:
             if checkpoint_task is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.72"
+version = "0.99.73"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/autoresearch/test_dry_run_no_attribution.py
+++ b/tests/autoresearch/test_dry_run_no_attribution.py
@@ -1,0 +1,54 @@
+"""PR-DRY-RUN-NO-ATTR (2026-05-26) — pin existing dry-run attribution skip.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5.6,
+item #7) flagged the risk of ``--dry-run`` runs writing synthetic
+``fitness_delta=0`` attribution rows to ``mutations.jsonl`` — a
+noise-accumulation surface for downstream credit-assignment readers.
+
+Current state (post-PR-AR-L6, already in develop main as of 2026-05-26):
+``autoresearch/train.py:2692`` guards attribution writes with
+``_attribution_should_write = not args.dry_run``. The skip is real.
+
+This PR doesn't change behaviour — it adds an invariant test so the
+skip cannot regress silently. The 2026-05-26 sprint discovered the
+ALREADY-IMPLEMENTED state during Phase A; pinning it here prevents
+the leak from re-opening if a future PR strips the guard.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_attribution_write_guarded_by_not_dry_run() -> None:
+    """Static pin: the substring ``_attribution_should_write = not args.dry_run``
+    must remain in ``autoresearch.train.main``. Any future refactor that
+    removes the guard will break this assertion, forcing the author to
+    re-prove the skip semantics rather than silently regressing.
+
+    Brittleness is intentional — the alternative (full subprocess
+    integration test of train.py with mocked Petri output) would be
+    orders of magnitude slower and equally string-matchy at the
+    assertion level."""
+    from autoresearch import train as train_mod
+
+    source = inspect.getsource(train_mod)
+    assert "_attribution_should_write = not args.dry_run" in source, (
+        "PR-DRY-RUN-NO-ATTR invariant violated — the dry-run attribution "
+        "skip guard at train.py around line 2692 has been removed. "
+        "Re-add or document the new skip mechanism."
+    )
+
+
+def test_attribution_block_skips_when_should_write_false() -> None:
+    """Static pin: the attribution write block must be conditional on
+    ``_attribution_should_write`` (not unconditional). Catches the
+    refactor where someone moves the write out of the if-guard."""
+    from autoresearch import train as train_mod
+
+    source = inspect.getsource(train_mod)
+    assert "if _attribution_should_write:" in source, (
+        "PR-DRY-RUN-NO-ATTR invariant violated — the conditional guard "
+        "around the attribution write block at train.py is missing. "
+        "The write must remain gated by _attribution_should_write."
+    )

--- a/tests/autoresearch/test_pareto_integrate_promote_gate.py
+++ b/tests/autoresearch/test_pareto_integrate_promote_gate.py
@@ -1,0 +1,166 @@
+"""PR-PARETO-INTEGRATE (2026-05-27) — promote-gate Pareto archive wiring.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5.7)
+found that ``core.self_improving_loop.pareto_archive.append_archive_entry``
+was wired only inside ``runner.apply_group_proposals`` (sibling-group
+path, fitness scalar only). The promote gate in ``autoresearch.train.main``
+— the one site where full ``dim_means`` meets the accept/reject
+decision — never archived its observation. Every rejected mutation's
+per-dim scores vanished at cycle end, so regret analysis ("what was
+the multi-axis cost of rejecting mutation M?") was impossible.
+
+This PR adds an archive write inside ``main()`` after the promote
+decision is finalized, gated by:
+* ``[self_improving_loop.autoresearch] pareto_mode = true`` (operator
+  opt-in; default off preserves backward-compat).
+* Not ``--dry-run`` (synthetic dim_means has no Pareto signal).
+
+The entry rides ArchiveEntry's ``extra="allow"`` to attach
+``promoted`` (bool) + ``reason`` (str) so downstream regret-analysis
+readers can join on them.
+
+This file pins the wiring as opt-in (off by default), accept+reject
+parity (both write), dry-run skip, and the regret-analysis fields.
+The actual archive read/write/dominate-prune behavior is covered in
+``tests/core/self_improving_loop/test_pareto_archive.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_pareto_archive_write_lives_in_promote_gate() -> None:
+    """Static-source pin: the new archive-write block is in
+    ``autoresearch.train.main`` (not just inside the runner's group
+    path). Closes the §5.7 audit finding that the promote gate had no
+    archive integration."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    assert "PR-PARETO-INTEGRATE" in src, (
+        "PR-PARETO-INTEGRATE marker missing from autoresearch.train — "
+        "the promote-gate archive write block was removed or moved. "
+        "Either restore the wiring or update the §5.7 audit follow-up "
+        "documentation."
+    )
+    assert "append_archive_entry" in src, (
+        "autoresearch.train no longer references pareto_archive's "
+        "append_archive_entry — the promote-gate wiring is broken."
+    )
+
+
+def test_pareto_archive_block_gated_by_pareto_mode_and_dry_run() -> None:
+    """The archive write must be gated by BOTH ``pareto_mode`` opt-in
+    AND ``not args.dry_run``. Catches a refactor that loosens either
+    guard (which would write spurious archive rows or break the
+    dry-run no-cost invariant)."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Substring grep for the two guards. Brittle on rename, but that
+    # rename is exactly the case the audit asks us to surface.
+    assert "if not args.dry_run:" in src
+    assert "pareto_mode" in src
+
+
+def test_pareto_archive_entry_carries_promoted_and_reason() -> None:
+    """The ArchiveEntry constructed in train.py must pass ``promoted``
+    + ``reason`` so downstream regret-analysis readers can compute
+    "what was the multi-axis cost of rejecting mutation M?". Pin
+    these field names because they're the join keys."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Both kwargs must appear inside the PR-PARETO-INTEGRATE block.
+    # Substring presence is sufficient — the block is small.
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000  # safety fallback
+    block = src[pr_block_start:pr_block_end]
+    assert "promoted=" in block, (
+        "ArchiveEntry kwarg ``promoted`` missing in the PR-PARETO-"
+        "INTEGRATE block — regret analysis needs the accept/reject "
+        "bit to filter rejected mutations."
+    )
+    assert "reason=" in block, (
+        "ArchiveEntry kwarg ``reason`` missing — downstream readers "
+        "lose the human-readable promote_line context."
+    )
+
+
+def test_pareto_archive_promoted_derived_from_promoted_line() -> None:
+    """``promoted_line`` is set in every promote branch
+    (dry-run/--no-promote/--promote/auto). Deriving ``promoted`` from
+    its prefix (``"true"`` vs ``"false"``) keeps the four branches
+    agreeing without re-implementing the gate logic. Pin this so a
+    refactor that splits the derivation can't drift the boolean."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000
+    block = src[pr_block_start:pr_block_end]
+    assert 'promoted_line.startswith("true")' in block, (
+        "PR-PARETO-INTEGRATE block must derive ``promoted`` from "
+        '``promoted_line.startswith("true")`` so the four branches '
+        "(dry-run/--no-promote/--promote/auto) share one source of "
+        "truth for the accept/reject bit."
+    )
+
+
+def test_pareto_archive_phase_tag_distinguishes_pre_post_audit() -> None:
+    """Codex MCP review (CONDITIONAL_PASS must-fix #1) — when group
+    sampling fires runner.apply_group_proposals, BOTH runner-side
+    (per-sibling pre-audit fitness) AND train-side (post-audit full
+    dim_means) writers append to the archive on the same mutation_id.
+    The ``phase`` field (ArchiveEntry.extra="allow") distinguishes the
+    two so downstream readers don't read duplicate-key data as
+    conflicting.
+
+    Train-side: ``phase="post_audit"``. Runner-side:
+    ``phase="pre_audit_sibling"``. Pin both literals so a refactor
+    can't drift them apart and silently break the join."""
+    import inspect
+
+    from autoresearch import train as train_mod
+    from core.self_improving_loop import runner as runner_mod
+
+    train_src = inspect.getsource(train_mod)
+    runner_src = inspect.getsource(runner_mod)
+
+    assert 'phase="post_audit"' in train_src, (
+        'Train-side pareto archive entry must tag ``phase="post_audit"`` '
+        "to distinguish from runner-side sibling rows. Without this tag, "
+        "downstream readers see duplicate mutation_id rows with "
+        "conflicting dim_means shapes."
+    )
+    assert 'phase="pre_audit_sibling"' in runner_src, (
+        "Runner-side pareto archive entry must tag "
+        '``phase="pre_audit_sibling"`` so downstream readers can filter '
+        "to the per-sibling fitness-scalar pre-audit signal."
+    )
+
+
+def test_pareto_archive_failure_is_best_effort() -> None:
+    """An exception inside the archive-append block must NOT propagate
+    out of ``main()``. The audit cycle continues even if the JSONL
+    writer fails (matches the pattern from runner.apply_group_proposals's
+    existing pareto wiring at runner.py:1667-1673)."""
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    pr_block_start = src.find("PR-PARETO-INTEGRATE")
+    pr_block_end = src.find("# W2 (2026-05-25)", pr_block_start)
+    if pr_block_end < 0:
+        pr_block_end = pr_block_start + 4000
+    block = src[pr_block_start:pr_block_end]
+    assert "except Exception:" in block, (
+        "PR-PARETO-INTEGRATE block must wrap the archive append in "
+        "try/except so a JSONL writer failure can't break the audit "
+        "cycle. The existing runner-side pareto wiring uses the same "
+        "best-effort pattern (runner.py:1667-1673)."
+    )

--- a/tests/autoresearch/test_promote_stamp.py
+++ b/tests/autoresearch/test_promote_stamp.py
@@ -1,0 +1,155 @@
+"""PR-PROMOTE-STAMP (2026-05-26) — ``--promote`` flag baseline stamp pin.
+
+Closes the audit finding from the 2026-05-26 autoresearch attribution
+sprint Phase A audit (§5.5): the ``--promote`` operator override
+bypassed ``_should_promote`` but wrote an *identical-shape*
+baseline.json — downstream readers couldn't tell whether the value
+came from operator force or from the auto-promote gate.
+
+Post-PR, ``_write_baseline(manual_promote=True)`` stamps the
+baseline.json with three new top-level fields:
+
+* ``manual_promote: true``
+* ``promoted_by: "operator"``
+* ``promoted_at: <ts_utc>``
+
+Auto-promote callers omit ``manual_promote`` → flag stays out of
+the file → backward-compat preserved.
+
+This file pins:
+
+1. Default ``manual_promote=False`` → baseline.json has NO ``manual_promote``
+   field (legacy shape preserved).
+2. ``manual_promote=True`` → all three stamp fields present.
+3. ``promoted_at`` equals ``ts_utc`` (single timestamp source).
+4. The rest of the baseline payload (raw/axes/schema_version/...) is
+   identical between the two modes — stamp is additive only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _common_kwargs() -> dict[str, object]:
+    return {
+        "session_id": "test-session",
+        "commit": "abc1234",
+        "sample_count": {"output_quality": 5},
+        "measurement_modality": {"output_quality": "judge_llm"},
+    }
+
+
+def test_default_baseline_has_no_manual_promote_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-promote path (default ``manual_promote=False``) writes the
+    legacy v2-schema baseline shape WITHOUT the stamp fields. This
+    pins backward-compat for callers that omit the new flag."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert "manual_promote" not in payload
+    assert "promoted_by" not in payload
+    assert "promoted_at" not in payload
+    # Sanity — the rest of the v2 shape is intact.
+    assert payload["schema_version"] == 2
+    assert payload["session_id"] == "test-session"
+    assert payload["commit"] == "abc1234"
+
+
+def test_manual_promote_stamps_baseline_with_three_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``manual_promote=True`` → baseline.json gets all three stamp
+    fields. Downstream reader sees ``manual_promote: true`` and knows
+    the value came from operator override, not gate approval."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert payload["manual_promote"] is True
+    assert payload["promoted_by"] == "operator"
+    assert "promoted_at" in payload
+
+
+def test_manual_promote_promoted_at_equals_ts_utc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``promoted_at`` and ``ts_utc`` share the same timestamp source —
+    no drift between when the baseline was *written* and when it was
+    *promoted* (they're the same event in the manual-promote path)."""
+    from autoresearch import train as train_mod
+
+    baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", baseline_path)
+
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert payload["promoted_at"] == payload["ts_utc"]
+
+
+def test_manual_promote_additive_only_rest_of_payload_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stamp is additive: every other field in the baseline payload
+    must be identical between ``manual_promote=False`` and
+    ``manual_promote=True``. Catches accidental shape drift."""
+    from autoresearch import train as train_mod
+
+    auto_path = tmp_path / "auto.json"
+    manual_path = tmp_path / "manual.json"
+
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", auto_path)
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        **_common_kwargs(),
+    )
+
+    monkeypatch.setattr(train_mod, "BASELINE_PATH", manual_path)
+    train_mod._write_baseline(
+        {"output_quality": 0.8},
+        {"output_quality": 0.05},
+        manual_promote=True,
+        **_common_kwargs(),
+    )
+
+    auto = json.loads(auto_path.read_text(encoding="utf-8"))
+    manual = json.loads(manual_path.read_text(encoding="utf-8"))
+
+    # Strip stamp + ts_utc/promoted_at (those can differ by milliseconds
+    # between the two _write_baseline calls if the clock ticks).
+    for stamp in ("manual_promote", "promoted_by", "promoted_at"):
+        manual.pop(stamp, None)
+    auto.pop("ts_utc", None)
+    manual.pop("ts_utc", None)
+
+    assert auto == manual

--- a/tests/core/orchestration/test_anthropic_api_lane.py
+++ b/tests/core/orchestration/test_anthropic_api_lane.py
@@ -33,12 +33,16 @@ def _reset_lane() -> None:
     reset_anthropic_api_lane_for_tests()
 
 
-def test_default_max_concurrent_is_four() -> None:
-    """Default capacity 4 — see module docstring's three-point
-    rationale (Anthropic tier 1 50 RPM, claude_cli_lane co-existence,
-    PR-RANKER-PARALLEL match-burst headroom)."""
-    assert DEFAULT_ANTHROPIC_API_LANE_MAX == 4
-    assert resolve_anthropic_api_lane_max() == 4
+def test_default_max_concurrent_is_eight() -> None:
+    """Default capacity 8 — PR-LANE-CAP-AGGRESSIVE (2026-05-27) raised
+    from 4 to 8. Anthropic tier 1 documents 50 RPM aggregate per
+    account; voter calls land in 60-70s wallclock each → steady-state
+    ~0.86 inflight per cap slot, so cap 8 = ~7 RPM steady state, well
+    under the 50 RPM ceiling. Pre-raise the cap-4 only used ~3 RPM
+    of the available 50, leaving 47 RPM idle while the ranker burst
+    queued behind a tight cap."""
+    assert DEFAULT_ANTHROPIC_API_LANE_MAX == 8
+    assert resolve_anthropic_api_lane_max() == 8
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/orchestration/test_openai_api_lane.py
+++ b/tests/core/orchestration/test_openai_api_lane.py
@@ -30,11 +30,16 @@ def _reset_lane() -> None:
     reset_openai_api_lane_for_tests()
 
 
-def test_default_max_concurrent_is_four() -> None:
-    """See module docstring — OpenAI Codex Responses API 500 RPM
-    bucket leaves substantial headroom for 4 concurrent calls."""
-    assert DEFAULT_OPENAI_API_LANE_MAX == 4
-    assert resolve_openai_api_lane_max() == 4
+def test_default_max_concurrent_is_sixteen() -> None:
+    """Default capacity 16 — PR-LANE-CAP-AGGRESSIVE (2026-05-27)
+    raised from 4 to 16. OpenAI Codex Responses API documents a 500
+    RPM aggregate per ChatGPT subscription bucket; voter calls land
+    in 10-15s wallclock each, so steady-state throughput at cap 16
+    is ~64-96 RPM — well under the 500 RPM ceiling. Pre-raise the
+    cap-4 wasted ~95% of the available budget while the ranker's
+    asyncio.gather burst queued 110+ calls behind it."""
+    assert DEFAULT_OPENAI_API_LANE_MAX == 16
+    assert resolve_openai_api_lane_max() == 16
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -1,0 +1,379 @@
+"""PR-MAX-GEN (2026-05-26) — auto_trigger max_generation cap.
+
+Closes the audit finding from the 2026-05-26 autoresearch attribution
+sprint Phase A (§5.6): ``auto_trigger_mutator`` only enforced a
+``min_interval_minutes`` floor and had no hard cap on total fired
+generations. A misconfigured operator could accumulate hundreds of
+fires without any stop condition.
+
+This file pins:
+
+1. ``count_fired_generations`` correctly counts only ``state="fired"``
+   rows (other states like ``interval_blocked`` ignored).
+2. Empty / missing history file → count = 0.
+3. ``max_generation=0`` (default) preserves legacy unbounded behaviour.
+4. ``max_generation=N`` blocks the (N+1)-th fire with state
+   ``max_generation_reached``.
+5. The cap check fires BEFORE the lock acquisition (so a saturated
+   history doesn't consume the lock for a no-op).
+6. Malformed / non-dict / OSError reads degrade gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_history_row(
+    path: Path,
+    *,
+    state: str,
+    ts: float | None = None,
+    detail: str = "",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, Any] = {
+        "ts": ts if ts is not None else time.time(),
+        "state": state,
+        "detail": detail,
+        "trigger_id": "self_improving_loop_auto_trigger",
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# count_fired_generations
+# ---------------------------------------------------------------------------
+
+
+def test_count_fired_generations_missing_file_returns_zero(tmp_path: Path) -> None:
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    assert count_fired_generations(history_path=tmp_path / "missing.jsonl") == 0
+
+
+def test_count_fired_generations_only_counts_fired_state(tmp_path: Path) -> None:
+    """``interval_blocked`` / ``lock_busy`` / ``runner_error`` etc. are
+    history rows too — they must NOT contribute to the fire count."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="interval_blocked")
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="lock_busy")
+    _write_history_row(history, state="runner_error")
+    _write_history_row(history, state="parse_error")
+    _write_history_row(history, state="fired")
+
+    assert count_fired_generations(history_path=history) == 3
+
+
+def test_count_fired_generations_skips_malformed_rows(tmp_path: Path) -> None:
+    """Best-effort — malformed JSON / non-dict rows / blank lines all
+    skipped silently without aborting the scan."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+        fh.write("\n")  # blank
+        fh.write("[1, 2, 3]\n")  # non-dict
+    _write_history_row(history, state="fired")
+
+    assert count_fired_generations(history_path=history) == 2
+
+
+def test_count_fired_generations_oserror_returns_partial(tmp_path: Path) -> None:
+    """OSError mid-read returns the count accumulated so far (best-effort)."""
+    from core.self_improving_loop.auto_trigger import count_fired_generations
+
+    history = tmp_path / "history.jsonl"
+    history.write_text("dummy\n", encoding="utf-8")
+
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        n = count_fired_generations(history_path=history)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# auto_trigger_mutator — max_generation gate behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_max_generation_zero_means_unlimited(tmp_path: Path) -> None:
+    """``max_generation=0`` (default) → legacy unbounded behaviour: even
+    with 100 prior fires the next call still proceeds past the cap
+    check (it may still hit lock/interval/runner gates, but the cap
+    itself doesn't block)."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(100):
+        _write_history_row(history, state="fired")
+
+    fake_runner_calls: list[None] = []
+
+    class _FakeRunner:
+        def run_once(self) -> object:
+            fake_runner_calls.append(None)
+
+            class _Mut:
+                target_section = "role"
+
+            return _Mut()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=0,  # unlimited
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "fired"
+    assert len(fake_runner_calls) == 1
+
+
+def test_max_generation_blocks_when_history_at_cap(tmp_path: Path) -> None:
+    """``max_generation=3`` + history already has 3 fired rows → next
+    call returns ``max_generation_reached`` without invoking runner."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(3):
+        _write_history_row(history, state="fired")
+
+    runner_calls: list[None] = []
+
+    class _FakeRunner:
+        def run_once(self) -> object:  # pragma: no cover — must not fire
+            runner_calls.append(None)
+            return object()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "3/3" in status.detail
+    assert runner_calls == []
+
+
+def test_max_generation_blocks_when_history_above_cap(tmp_path: Path) -> None:
+    """Pre-existing history with 5 fires + cap=3 → still blocked. The
+    ``>=`` comparison ensures the cap can't be re-entered after the
+    operator raises and lowers it."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(5):
+        _write_history_row(history, state="fired")
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("must not be called")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "5/3" in status.detail
+
+
+def test_max_generation_allows_when_below_cap(tmp_path: Path) -> None:
+    """``max_generation=3`` + history has 2 fired rows → next call
+    proceeds (only 2 of 3 used)."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="fired")
+
+    class _FakeRunner:
+        def run_once(self) -> object:
+            class _Mut:
+                target_section = "role"
+
+            return _Mut()
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "fired"
+
+
+def test_max_generation_cap_evaluated_before_lock(tmp_path: Path) -> None:
+    """The cap check must fire BEFORE the lock acquisition, otherwise a
+    saturated history would still consume + release the lock on every
+    cron tick (lock cost wasted)."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(2):
+        _write_history_row(history, state="fired")
+
+    lock_acquire_calls: list[None] = []
+
+    def fake_acquire(lock_path: Path | None = None) -> int | None:
+        lock_acquire_calls.append(None)  # pragma: no cover — must not be reached
+        return 1
+
+    with patch.object(mod, "acquire_auto_trigger_lock", fake_acquire):
+        status = mod.auto_trigger_mutator(
+            enabled=True,
+            min_interval_minutes=0,
+            max_generation=2,
+            runner_factory=lambda: object(),  # would crash if reached
+            lock_path=tmp_path / "lock",
+            timestamp_path=tmp_path / "ts.txt",
+            history_path=history,
+        )
+
+    assert status.state == "max_generation_reached"
+    assert lock_acquire_calls == []
+
+
+def test_register_auto_trigger_forwards_max_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex MCP review #1 (FAIL must-fix #1) — pin that
+    ``register_auto_trigger`` actually forwards ``max_generation``
+    into the scheduler callback. Without this wiring, the new
+    config knob was a dead parameter."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    forwarded: dict[str, Any] = {}
+
+    def fake_mutator(**kwargs: Any) -> mod.AutoTriggerStatus:
+        forwarded.update(kwargs)
+        return mod.AutoTriggerStatus(state="fired")
+
+    monkeypatch.setattr(mod, "auto_trigger_mutator", fake_mutator)
+
+    class _FakeTM:
+        def __init__(self) -> None:
+            self.registered: list[Any] = []
+
+        def register(self, cfg: Any) -> None:
+            self.registered.append(cfg)
+
+    tm = _FakeTM()
+    result = mod.register_auto_trigger(
+        tm,
+        enabled=True,
+        cron="0 * * * *",
+        min_interval_minutes=60,
+        max_generation=42,
+        runner_factory=lambda: object(),
+        hooks=None,
+    )
+
+    assert result is True
+    assert len(tm.registered) == 1
+    # Invoke the registered callback to verify the forwarded knob.
+    tm.registered[0].callback({})
+    assert forwarded["max_generation"] == 42
+
+
+def test_max_generation_hook_event_reserved() -> None:
+    """Codex MCP review #1 (FAIL must-fix #3) — pin that the new
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` HookEvent
+    is reserved in ``core/hooks/system.py``. Without this the
+    ``STATE_TO_HOOK_EVENT`` mapping references a nonexistent enum
+    name and ``_emit_state_event`` silently skips telemetry."""
+    from core.hooks import HookEvent
+
+    assert hasattr(HookEvent, "SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED")
+    assert (
+        HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED.value
+        == "self_improving_auto_trigger_max_generation_reached"
+    )
+
+
+def test_max_generation_post_lock_recheck_blocks_overshoot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #1 (FAIL must-fix #2) — pin that the post-lock
+    cap re-check exists. Simulates the race: pre-lock count is below
+    cap, but by the time the lock is acquired another process has
+    bumped the count to/above cap. Without re-check both would fire."""
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    # Pre-lock state: 2 fires, cap=3 → pre-lock check allows.
+    _write_history_row(history, state="fired")
+    _write_history_row(history, state="fired")
+
+    # When the lock acquisition is requested, simulate that ANOTHER
+    # process appended a fire between our pre-lock count and our
+    # lock-acquire. We mutate the history file mid-flight.
+    real_acquire = mod.acquire_auto_trigger_lock
+
+    def fake_acquire(lock_path: Path | None = None) -> int | None:
+        _write_history_row(history, state="fired")  # race: cap now reached
+        return real_acquire(lock_path=lock_path)
+
+    monkeypatch.setattr(mod, "acquire_auto_trigger_lock", fake_acquire)
+
+    status = mod.auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("post-lock re-check should have blocked")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+    )
+
+    assert status.state == "max_generation_reached"
+    assert "post-lock re-check" in status.detail
+
+
+def test_max_generation_disabled_state_short_circuits_before_cap(tmp_path: Path) -> None:
+    """``enabled=False`` short-circuits BEFORE the cap check — disabled
+    is a defensive guard that never touches disk."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(5):
+        _write_history_row(history, state="fired")
+
+    status = auto_trigger_mutator(
+        enabled=False,
+        min_interval_minutes=0,
+        max_generation=2,
+        history_path=history,
+    )
+
+    assert status.state == "disabled"

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -360,9 +360,7 @@ def test_max_generation_post_lock_recheck_blocks_overshoot(
     assert "post-lock re-check" in status.detail
 
 
-def test_max_generation_emits_hook_event(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_max_generation_emits_hook_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Codex MCP review #2 (FAIL must-fix #3) — direct emission test.
     When the cap fires, the registered HookSystem must receive a
     ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` event with

--- a/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
+++ b/tests/core/self_improving_loop/test_auto_trigger_max_generation.py
@@ -360,6 +360,52 @@ def test_max_generation_post_lock_recheck_blocks_overshoot(
     assert "post-lock re-check" in status.detail
 
 
+def test_max_generation_emits_hook_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #2 (FAIL must-fix #3) — direct emission test.
+    When the cap fires, the registered HookSystem must receive a
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED`` event with
+    the ``{trigger_id, ts, detail}`` payload. Pins the wiring from
+    ``_finalize_status`` → ``_emit_state_event`` →
+    ``STATE_TO_HOOK_EVENT[max_generation_reached]`` → ``HookEvent``."""
+    from core.hooks import HookEvent
+    from core.self_improving_loop import auto_trigger as mod
+
+    history = tmp_path / "history.jsonl"
+    for _ in range(3):
+        _write_history_row(history, state="fired")
+
+    captured: list[tuple[HookEvent, dict[str, Any]]] = []
+
+    class _FakeHooks:
+        def trigger(self, event: HookEvent, payload: dict[str, Any]) -> None:
+            captured.append((event, payload))
+
+    status = mod.auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=0,
+        max_generation=3,
+        runner_factory=lambda: (_ for _ in ()).throw(  # pragma: no cover
+            AssertionError("runner must not fire")
+        ),
+        lock_path=tmp_path / "lock",
+        timestamp_path=tmp_path / "ts.txt",
+        history_path=history,
+        hooks=_FakeHooks(),
+    )
+
+    assert status.state == "max_generation_reached"
+    # Hook system received the cap-reached event with the canonical
+    # auto-trigger payload schema.
+    assert len(captured) == 1
+    event, payload = captured[0]
+    assert event is HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED
+    assert payload["trigger_id"] == mod.AUTO_TRIGGER_TRIGGER_ID
+    assert "ts" in payload
+    assert "3/3" in payload["detail"]
+
+
 def test_max_generation_disabled_state_short_circuits_before_cap(tmp_path: Path) -> None:
     """``enabled=False`` short-circuits BEFORE the cap check — disabled
     is a defensive guard that never touches disk."""

--- a/tests/core/self_improving_loop/test_target_kind_surface_doc.py
+++ b/tests/core/self_improving_loop/test_target_kind_surface_doc.py
@@ -1,0 +1,119 @@
+"""PR-TARGET-KIND-DOC (2026-05-27) — TARGET_KINDS vs _READER_ONLY_KINDS pin.
+
+The 2026-05-26 autoresearch attribution sprint Phase A audit (§5
+mutation surface verification) found an asymmetry between the
+canonical ``TARGET_KINDS`` (6 active mutation slots) and
+``autoresearch.train.run_audit``'s env override block (13 STRICT-mode
+env vars for the 6 active + 1 deprecated + 7 reader-only).
+
+The asymmetry is **intentional** (ADR-013 phased rollout) but
+previously undocumented in code — a mutator emitting a target_kind
+like ``tool_descriptions`` (reader-deployed but not yet a mutation
+slot) would fail at ``parse_mutation``'s ValueError without any
+operator-visible signal that the surface is reader-only.
+
+This file pins:
+
+1. ``_READER_ONLY_KINDS`` is disjoint from ``TARGET_KINDS`` — no
+   accidental double-listing (which would make ``parse_mutation``
+   accept a kind that's also marked reader-only).
+2. Each reader-only kind, when emitted as a mutator response, fails
+   fast at ``parse_mutation`` with a clear ValueError. This is the
+   operator-visible signal that the surface isn't yet writable.
+3. The reader-only set matches the 7 surfaces with env wiring in
+   ``autoresearch/train.py:840-903`` (the audit-side override block).
+   A future PR that adds an env var without graduating the kind to
+   ``TARGET_KINDS`` or adding to ``_READER_ONLY_KINDS`` will fail
+   this test, forcing explicit triage.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_target_kinds_and_reader_only_are_disjoint() -> None:
+    """A kind can be EITHER mutator-dispatchable (in TARGET_KINDS) OR
+    reader-only (in _READER_ONLY_KINDS), never both. Catches a future
+    PR that accidentally double-lists a kind during a graduation."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS, TARGET_KINDS
+
+    overlap = set(TARGET_KINDS) & _READER_ONLY_KINDS
+    assert not overlap, (
+        f"TARGET_KINDS and _READER_ONLY_KINDS overlap on {overlap!r} — "
+        "a kind must be either active (in TARGET_KINDS) or reader-only, "
+        "never both. Check the ADR-013 graduation that introduced the "
+        "duplicate listing."
+    )
+
+
+def test_reader_only_kind_emit_fails_fast_at_parse_mutation() -> None:
+    """Operator-visible signal: mutator response carrying a reader-only
+    target_kind raises ValueError at ``parse_mutation``, not silently
+    succeeds. Iterates every entry in ``_READER_ONLY_KINDS`` so adding
+    a new entry automatically gains test coverage."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+    from core.self_improving_loop.runner import parse_mutation
+
+    for kind in _READER_ONLY_KINDS:
+        payload = json.dumps(
+            {
+                "target_section": "any",
+                "new_value": "any",
+                "rationale": "test",
+                "target_kind": kind,
+            }
+        )
+        with pytest.raises(ValueError, match=f"target_kind {kind!r}"):
+            parse_mutation(payload)
+
+
+def test_reader_only_kinds_match_env_override_block() -> None:
+    """Static-source pin: every kind in ``_READER_ONLY_KINDS`` must have
+    a corresponding ``GEODE_<KIND>_OVERRIDE`` env var set in
+    ``autoresearch/train.py:run_audit``'s override block (the audit-
+    side STRICT-mode wiring). Catches the future PR that adds env
+    wiring for a new SoT without listing it in ``_READER_ONLY_KINDS``.
+
+    Brittleness intent: substring check on the source file, same
+    rationale as ``tests/autoresearch/test_dry_run_no_attribution.py``
+    — a failing assertion forces explicit triage, which is exactly
+    what the doc comment in ``policies.py`` warns about.
+    """
+    import inspect
+
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+
+    from autoresearch import train as train_mod
+
+    src = inspect.getsource(train_mod)
+    # Each kind in _READER_ONLY_KINDS must have its env var present.
+    # Convention: ``GEODE_{KIND.upper()}_OVERRIDE`` (matches the
+    # ``ADR-012 S0a/S0b`` wiring pattern train.py:840-903).
+    for kind in _READER_ONLY_KINDS:
+        env_var = f"GEODE_{kind.upper()}_OVERRIDE"
+        assert env_var in src, (
+            f"_READER_ONLY_KINDS contains {kind!r} but "
+            f"autoresearch/train.py has no {env_var} env wiring. "
+            "Either remove the kind from _READER_ONLY_KINDS (it's not "
+            "actually reader-deployed) or add the STRICT-mode env in "
+            "run_audit's override block."
+        )
+
+
+def test_reader_only_set_size_matches_audit_finding() -> None:
+    """Sanity counter — the 2026-05-26 Phase A audit found exactly 7
+    reader-only surfaces. If a future PR graduates one (moving it to
+    TARGET_KINDS) the size should drop; if a new surface lands the
+    size should grow. Either way the explicit count makes the change
+    impossible to miss in code review."""
+    from core.self_improving_loop.policies import _READER_ONLY_KINDS
+
+    assert len(_READER_ONLY_KINDS) == 7, (
+        f"_READER_ONLY_KINDS has {len(_READER_ONLY_KINDS)} entries; the "
+        "2026-05-26 attribution sprint Phase A audit counted 7. "
+        "Update this assertion AND the policies.py doc comment if the "
+        "surface count legitimately changed."
+    )

--- a/tests/core/self_improving_loop/test_variance_adaptive_and_resample.py
+++ b/tests/core/self_improving_loop/test_variance_adaptive_and_resample.py
@@ -1,0 +1,441 @@
+"""PR-VAR-ADAPTIVE + PR-RESAMPLE-BUDGET (2026-05-27) — Phase F bundle.
+
+Two complementary algorithm-depth additions to the
+``apply_group_proposals`` selection layer:
+
+**PR-VAR-ADAPTIVE** — replaces the hardcoded
+``group_variance_threshold = 0.01`` with an optional percentile-based
+resolver that reads ``group_variance_history.jsonl`` and returns the
+configured percentile of recent observed std values. Closes the
+2026-05-26 attribution sprint Phase A audit (§4.3 follow-up): the
+fixed threshold drifts silently when fitness-scale changes (e.g., new
+DIM_WEIGHTS rotation, anchor_confidence_mode toggle).
+
+**PR-RESAMPLE-BUDGET** — when ``filtered_low_variance`` fires, the
+default behaviour is "cycle skip" (no SoT commit, no retry). With
+``resample_on_low_variance=True`` and ``max_group_resamples > 0``,
+the runner now proposes a fresh sibling group and retries the audit
+up to the budget. DAPO frontier equivalent: ``max_num_gen_batches``
+informative-batch retention.
+
+This file pins:
+
+* Variance history append (best-effort writer, all rows recorded).
+* Percentile resolver — fixed-mode default, percentile-mode below /
+  at / above window, per-kind filter, malformed-row graceful skip,
+  OSError fallback to fixed.
+* Threshold resolution wires into ``apply_group_proposals`` (verified
+  via patched ``_compute_group_advantage``).
+* Resample retry — fires only when both knobs enabled, recurses with
+  ``_resample_attempt`` increment, respects budget, falls through to
+  cycle skip on exhaustion.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_variance_row(
+    path: Path,
+    *,
+    std: float,
+    target_kind: str = "prompt",
+    group_id: str | None = None,
+    n_siblings: int = 2,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, Any] = {
+        "ts": time.time(),
+        "group_id": group_id or "g",
+        "target_kind": target_kind,
+        "std": float(std),
+        "n_siblings": int(n_siblings),
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# append_group_variance_history
+# ---------------------------------------------------------------------------
+
+
+def test_append_variance_history_creates_file_and_appends(tmp_path: Path) -> None:
+    from core.self_improving_loop.runner import append_group_variance_history
+
+    history = tmp_path / "variance.jsonl"
+    ok = append_group_variance_history(
+        group_id="g1",
+        target_kind="prompt",
+        std=0.07,
+        n_siblings=2,
+        history_path=history,
+    )
+    assert ok is True
+    assert history.is_file()
+    row = json.loads(history.read_text().strip())
+    assert row["std"] == 0.07
+    assert row["target_kind"] == "prompt"
+    assert row["n_siblings"] == 2
+    assert row["group_id"] == "g1"
+
+
+def test_append_variance_history_failure_returns_false(tmp_path: Path) -> None:
+    """OSError on write must not propagate — caller ignores the return
+    value so telemetry failure can't break the mutator cycle."""
+    from core.self_improving_loop.runner import append_group_variance_history
+
+    history = tmp_path / "variance.jsonl"
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        ok = append_group_variance_history(
+            group_id="g1",
+            target_kind="prompt",
+            std=0.07,
+            n_siblings=2,
+            history_path=history,
+        )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_group_variance_threshold
+# ---------------------------------------------------------------------------
+
+
+class _FakeAutoresearchCfg:
+    """Minimal stand-in for ``AutoresearchConfig`` so tests don't
+    have to construct the full pydantic model."""
+
+    def __init__(
+        self,
+        *,
+        mode: str = "fixed",
+        fixed: float = 0.01,
+        window: int = 30,
+        percentile: float = 0.05,
+    ) -> None:
+        self.group_variance_threshold = fixed
+        self.group_variance_threshold_mode = mode
+        self.group_variance_history_window = window
+        self.group_variance_percentile = percentile
+
+
+def test_resolver_fixed_mode_returns_fixed(tmp_path: Path) -> None:
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    cfg = _FakeAutoresearchCfg(mode="fixed", fixed=0.02)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, history_path=tmp_path / "missing.jsonl"
+    )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+def test_resolver_percentile_mode_fallback_when_history_short(tmp_path: Path) -> None:
+    """Percentile mode with history shorter than the window falls back
+    to the fixed value — operators can enable the knob without manually
+    bootstrapping a synthetic history."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 5 rows but window=30 → fallback.
+    for _ in range(5):
+        _write_variance_row(history, std=0.1)
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+def test_resolver_percentile_mode_computes_percentile_when_window_met(tmp_path: Path) -> None:
+    """Percentile mode with sufficient history returns the configured
+    percentile of recent std values."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 30 rows, std=1..30, target_kind=prompt
+    for i in range(1, 31):
+        _write_variance_row(history, std=float(i))
+
+    # 5th percentile of [1..30] ≈ 1 + 0.05 * 29 = 2.45
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30, percentile=0.05)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    assert source == "percentile"
+    assert abs(threshold - 2.45) < 0.01
+
+
+def test_resolver_percentile_filters_by_target_kind(tmp_path: Path) -> None:
+    """Per-kind percentile — when ``target_kind`` is provided, only
+    matching rows count toward the window."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # 30 prompt rows + 30 tool_policy rows. Asking for tool_policy
+    # should ignore prompt rows.
+    for _ in range(30):
+        _write_variance_row(history, std=0.01, target_kind="prompt")
+    for _ in range(30):
+        _write_variance_row(history, std=5.0, target_kind="tool_policy")
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold_prompt, _ = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    threshold_tool, _ = resolve_group_variance_threshold(
+        cfg, target_kind="tool_policy", history_path=history
+    )
+    # prompt std all 0.01 → percentile ≈ 0.01
+    assert abs(threshold_prompt - 0.01) < 0.001
+    # tool_policy std all 5.0 → percentile ≈ 5.0
+    assert abs(threshold_tool - 5.0) < 0.001
+
+
+def test_resolver_handles_malformed_rows(tmp_path: Path) -> None:
+    """Malformed JSON / non-dict / missing std → skipped silently. The
+    scan must not abort on one bad row."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    # Mix valid + malformed
+    _write_variance_row(history, std=0.1)
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+        fh.write("\n")
+        fh.write("[1, 2, 3]\n")
+        fh.write('{"missing_std_field": true}\n')
+    for _ in range(30):
+        _write_variance_row(history, std=0.5)
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    threshold, source = resolve_group_variance_threshold(
+        cfg, target_kind="prompt", history_path=history
+    )
+    # 31 valid rows total, take last 30 → all std=0.5 → percentile=0.5
+    assert source == "percentile"
+    assert abs(threshold - 0.5) < 0.001
+
+
+def test_resolver_oserror_falls_back_to_fixed(tmp_path: Path) -> None:
+    """Read failure (permission denied / disk error) → fall through to
+    fixed value. The mutator cycle never crashes because the history
+    file is unreadable."""
+    from core.self_improving_loop.runner import resolve_group_variance_threshold
+
+    history = tmp_path / "variance.jsonl"
+    history.write_text("dummy\n")
+
+    cfg = _FakeAutoresearchCfg(mode="percentile", fixed=0.02, window=30)
+    with patch.object(Path, "open", side_effect=OSError("permission denied")):
+        threshold, source = resolve_group_variance_threshold(
+            cfg, target_kind="prompt", history_path=history
+        )
+    assert threshold == 0.02
+    assert source == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# Config schema invariants
+# ---------------------------------------------------------------------------
+
+
+def test_config_schema_defaults_preserve_legacy_behaviour() -> None:
+    """The new knobs MUST default to the legacy single-shot fixed-
+    threshold behaviour so existing operators see no change unless
+    they opt-in."""
+    from core.config.self_improving_loop import AutoresearchConfig
+
+    cfg = AutoresearchConfig()
+    assert cfg.group_variance_threshold_mode == "fixed"
+    assert cfg.group_variance_history_window == 30
+    assert cfg.group_variance_percentile == 0.05
+    assert cfg.max_group_resamples == 0
+    assert cfg.resample_on_low_variance is False
+
+
+def test_config_schema_validation_bounds() -> None:
+    """Pydantic Field bounds should reject out-of-range values so an
+    operator can't misconfigure into an unreachable threshold."""
+    from core.config.self_improving_loop import AutoresearchConfig
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_history_window=4)  # ge=5
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_percentile=0.0)  # gt=0
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(group_variance_percentile=1.0)  # lt=1
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(max_group_resamples=11)  # le=10
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(max_group_resamples=-1)  # ge=0
+
+
+# ---------------------------------------------------------------------------
+# Gitignore invariant — variance history must be tracked
+# ---------------------------------------------------------------------------
+
+
+def test_apply_group_proposals_rejects_mixed_target_kinds() -> None:
+    """Codex MCP review must-fix #1 — apply_group_proposals raises
+    when sibling proposals span multiple target_kinds. The variance
+    signal is only meaningful within a single SoT surface."""
+    from core.self_improving_loop.runner import (
+        Mutation,
+        Proposal,
+        SelfImprovingLoopRunner,
+    )
+
+    runner = SelfImprovingLoopRunner(rerun_enabled=False)
+    p1 = Proposal(
+        mutation=Mutation(
+            target_section="role",
+            new_value="x",
+            rationale="y",
+            target_kind="prompt",
+        ),
+        target_sections={"role": "orig"},
+        original_sections={"role": "orig"},
+    )
+    p2 = Proposal(
+        mutation=Mutation(
+            target_section="rule",
+            new_value="x",
+            rationale="y",
+            target_kind="tool_policy",
+        ),
+        target_sections={"rule": "orig"},
+        original_sections={"rule": "orig"},
+    )
+
+    with pytest.raises(ValueError, match="homogeneous target_kind"):
+        runner.apply_group_proposals([p1, p2])
+
+
+def test_apply_group_proposals_resample_recurses_then_skips() -> None:
+    """Codex MCP review must-fix #3 — direct apply_group_proposals
+    test that exercises the resample budget. Mocks
+    _run_autoresearch_subprocess to always return zero-variance
+    fitness, mocks self.propose_group to return identical sibling
+    sets, then asserts the function recursed ``max_group_resamples``
+    times before falling through to ``None`` (cycle skip)."""
+    from unittest.mock import MagicMock
+
+    from core.self_improving_loop.runner import (
+        Mutation,
+        Proposal,
+        SelfImprovingLoopRunner,
+    )
+
+    def _make_proposal() -> Proposal:
+        return Proposal(
+            mutation=Mutation(
+                target_section="role",
+                new_value="x",
+                rationale="y",
+                target_kind="prompt",
+            ),
+            target_sections={"role": "orig"},
+            original_sections={"role": "orig"},
+        )
+
+    proposals = [_make_proposal(), _make_proposal()]
+
+    # ``rerun_enabled=True`` + ``rerun_dry_run=False`` is required by
+    # apply_group_proposals's safety gates (group sampling needs real
+    # audit fitness to compute variance). The subprocess + parse are
+    # mocked below so no real audit cost is incurred.
+    runner = SelfImprovingLoopRunner(rerun_enabled=True, rerun_dry_run=False)
+    # Force resample knobs on at the runtime read site.
+    fake_cfg = MagicMock()
+    fake_cfg.autoresearch.group_variance_threshold = 0.1
+    fake_cfg.autoresearch.group_variance_threshold_mode = "fixed"
+    fake_cfg.autoresearch.max_group_resamples = 2
+    fake_cfg.autoresearch.resample_on_low_variance = True
+
+    propose_calls: list[int] = []
+
+    def fake_propose_group(self_: object, n: int) -> list[Proposal]:
+        # Patched as a method on SelfImprovingLoopRunner → first arg is
+        # the bound ``self`` (the runner instance). We don't use it,
+        # just bounce N back as the proposal count.
+        propose_calls.append(n)
+        return [_make_proposal() for _ in range(n)]
+
+    # _apply_sibling_in_memory_with_value writes a temp file; mock to
+    # return a stable triple so the cleanup loop has something to unlink.
+    def fake_apply_sibling(proposal: Proposal):  # type: ignore[no-untyped-def]
+        return ({"role": "x"}, "orig", Path("/tmp/nonexistent"))  # noqa: S108
+
+    # Fake the subprocess to return zero-variance fitness so
+    # _compute_group_advantage returns ``filtered_low_variance``.
+    fake_proc = MagicMock(stdout="audit_fitness=0.5\n")
+
+    # The runner imports load_self_improving_loop_config lazily inside
+    # apply_group_proposals, so patch the source module symbol (not the
+    # runner-local re-export, which doesn't exist at module load time).
+    with (
+        patch(
+            "core.config.self_improving_loop.load_self_improving_loop_config",
+            return_value=fake_cfg,
+        ),
+        patch(
+            "core.self_improving_loop.runner._apply_sibling_in_memory_with_value",
+            side_effect=fake_apply_sibling,
+        ),
+        patch(
+            "core.self_improving_loop.runner._run_autoresearch_subprocess",
+            return_value=fake_proc,
+        ),
+        patch(
+            "core.self_improving_loop.runner._parse_fitness_from_subprocess_stdout",
+            return_value=0.5,
+        ),
+        patch.object(SelfImprovingLoopRunner, "propose_group", fake_propose_group),
+    ):
+        result = runner.apply_group_proposals(proposals)
+
+    # All siblings score 0.5 → std=0 < threshold 0.1 → filtered.
+    # Budget=2 → 2 retries before skip → propose_group invoked twice.
+    assert result is None
+    assert len(propose_calls) == 2
+    assert propose_calls == [2, 2]
+
+
+def test_variance_history_path_not_gitignored() -> None:
+    """PR-G5b precedent — writer destination must be git-tracked, or
+    the archive silently disappears under the broad
+    ``autoresearch/state/*`` ignore."""
+    # Use git check-ignore -v to inspect which rule matched. Exit code:
+    #   0 = ignored, 1 = not ignored, other = error.
+    import shutil
+    import subprocess
+
+    from core.paths import GROUP_VARIANCE_HISTORY_PATH
+
+    git = shutil.which("git") or "git"
+    result = subprocess.run(  # noqa: S603
+        [git, "check-ignore", "-v", str(GROUP_VARIANCE_HISTORY_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        # Ignored — must have matched the negation, not the broad rule.
+        assert "!autoresearch/state/group_variance_history.jsonl" in result.stdout, (
+            f"group_variance_history.jsonl is git-ignored without "
+            f"hitting the explicit negation rule. "
+            f"stdout={result.stdout!r}"
+        )
+    # returncode==1 means not ignored at all → OK.

--- a/tests/plugins/seed_generation/test_ranker_semaphore.py
+++ b/tests/plugins/seed_generation/test_ranker_semaphore.py
@@ -1,0 +1,61 @@
+"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — ranker phase-local semaphore invariants.
+
+The ranker wraps each ``asyncio.gather`` task in a phase-local
+``asyncio.Semaphore`` so the gather submission queue depth never
+exceeds the per-adapter lane ceiling. These tests pin the
+resolver (``resolve_ranker_max_inflight_matches``) + env override
++ default value. The integration with the gather call itself is
+covered by the existing ``test_ranker.py::test_ranker_dispatches_matches_concurrently``
+test, which observes start timestamps under the semaphore.
+"""
+
+from __future__ import annotations
+
+import pytest
+from plugins.seed_generation.agents.ranker import (
+    DEFAULT_RANKER_MAX_INFLIGHT_MATCHES,
+    RANKER_MAX_INFLIGHT_MATCHES_ENV,
+    resolve_ranker_max_inflight_matches,
+)
+
+
+def test_default_is_eight() -> None:
+    """The default cap is 8, matching the per-adapter lane ceiling
+    (claude_cli=4 voter * 1 + openai_api=16 voter * 2 = 24 inflight =
+    8 matches * 3 voters)."""
+    assert DEFAULT_RANKER_MAX_INFLIGHT_MATCHES == 8
+    assert resolve_ranker_max_inflight_matches() == 8
+
+
+def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RANKER_MAX_INFLIGHT_MATCHES_ENV, "12")
+    assert resolve_ranker_max_inflight_matches() == 12
+
+
+def test_env_override_empty_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RANKER_MAX_INFLIGHT_MATCHES_ENV, "")
+    assert resolve_ranker_max_inflight_matches() == DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+
+
+def test_env_override_non_integer_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Typos must NEVER harden into "no inflight matches" — the lane
+    falls back to the safe default so the operator's smoke run keeps
+    progressing instead of jamming on a malformed env var."""
+    monkeypatch.setenv(RANKER_MAX_INFLIGHT_MATCHES_ENV, "not-a-number")
+    assert resolve_ranker_max_inflight_matches() == DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+
+
+def test_env_override_zero_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """0 / negative override → fall back. Zero would lock the gather
+    (Semaphore(0) means no one acquires); negatives are nonsensical."""
+    for value in ("0", "-3", "-1"):
+        monkeypatch.setenv(RANKER_MAX_INFLIGHT_MATCHES_ENV, value)
+        assert resolve_ranker_max_inflight_matches() == DEFAULT_RANKER_MAX_INFLIGHT_MATCHES
+
+
+def test_env_override_large_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator may set this very high to disable phase-local
+    throttling (rely on lane caps only). 1000 = effectively unbounded
+    for the 59-match smoke."""
+    monkeypatch.setenv(RANKER_MAX_INFLIGHT_MATCHES_ENV, "1000")
+    assert resolve_ranker_max_inflight_matches() == 1000

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -19,8 +19,9 @@ class TestHookEvent:
         # lives here.
         # Tally: +6 PR-2 cognitive + 5 OL-A1.5 auto-trigger
         # + 3 PR-CL-BUDGET handoff + 5 PR-HOOKEVENT-RESERVE (mutation /
-        # baseline lifecycle).
-        assert len(HookEvent) == 79
+        # baseline lifecycle) + 1 PR-MAX-GEN
+        # (SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED).
+        assert len(HookEvent) == 80
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_STARTED.value == "pipeline_start"

--- a/tests/test_ol_a15_telemetry.py
+++ b/tests/test_ol_a15_telemetry.py
@@ -62,7 +62,9 @@ class _CapturingHooks:
 # ---------------------------------------------------------------------------
 
 
-def test_hook_event_has_five_auto_trigger_variants() -> None:
+def test_hook_event_has_auto_trigger_variants() -> None:
+    """PR-MAX-GEN (2026-05-26) added a sixth auto-trigger variant:
+    ``SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED``."""
     from core.hooks import HookEvent
 
     assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_FIRED.value == "self_improving_auto_trigger_fired"
@@ -78,10 +80,15 @@ def test_hook_event_has_five_auto_trigger_variants() -> None:
     assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR.value == (
         "self_improving_auto_trigger_parse_error"
     )
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_MAX_GENERATION_REACHED.value == (
+        "self_improving_auto_trigger_max_generation_reached"
+    )
 
 
-def test_state_to_hook_event_map_covers_five_states_only() -> None:
-    """`disabled` is intentionally absent — see module docstring."""
+def test_state_to_hook_event_map_covers_terminal_states() -> None:
+    """`disabled` is intentionally absent — see module docstring.
+    PR-MAX-GEN (2026-05-26) added ``max_generation_reached`` for the
+    generation-cap state, bringing the map to six entries."""
     from core.self_improving_loop.auto_trigger import STATE_TO_HOOK_EVENT
 
     assert set(STATE_TO_HOOK_EVENT) == {
@@ -90,6 +97,7 @@ def test_state_to_hook_event_map_covers_five_states_only() -> None:
         "interval_blocked",
         "runner_error",
         "parse_error",
+        "max_generation_reached",
     }
     assert "disabled" not in STATE_TO_HOOK_EVENT
 


### PR DESCRIPTION
## Summary

- Develop → main rotation for v0.99.73 release.
- Promotes the 4 attribution-sprint bundles merged on develop since v0.99.72: PR-OUTER-LOOP-HARDENING (#1768) + PR-LANE-CAP-AGGRESSIVE (#1769) + PR-SURFACE-CLARITY (#1770) + PR-ALGO-DEPTH (#1773) + release stamp #1774.

## Verification

- [x] develop ⊇ main verified via `git log origin/develop..origin/main` (empty).
- [x] Version stamp + CHANGELOG already landed on develop via release/v0.99.73 PR (#1774).
- [x] Local `geode-ci --fast` ALL GREEN on the release branch before #1774 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)