### PR TITLE
fix(claude-cli): retry credit-exhaustion transients with QUOTA_BACKOFF (PR-CLAUDE-CLI-CREDIT-EXHAUSTION-RETRY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CLAUDE-CLI-CREDIT-EXHAUSTION-RETRY (2026-05-27)** — route
+  ``ClaudeCliTransientUpstreamError`` into the retry path with the
+  paperclip QUOTA_BACKOFF schedule (2m / 10m / 30m / 2h) so a
+  claude-cli 5h pool refresh window can be bridged automatically.
+  Pre-PR the bare ``except Exception`` branch in
+  ``core/llm/router/calls/_failover.py:136`` skipped the exception to
+  the next model after a single attempt; the SDK ``RETRYABLE_ERRORS``
+  tuple cannot include the plugin-imported exception (layer
+  violation + plugin-as-optional-dep). Smoke 24 surfaced this as 5/5
+  evolver phases hard-failing within 30s after 3 attempts each, even
+  though manual ``audit-seeds resume`` succeeded ~20 min later once
+  the Anthropic Max OAuth pool replenished. Pinned with two new
+  ``tests/test_model_failover.py`` cases (retry-within-primary +
+  retries-exhausted-then-fall-back).
+
 ## [0.99.73] - 2026-05-27
 
 MINOR rotation. Ships the 2026-05-26 autoresearch attribution sprint

--- a/core/llm/router/calls/_failover.py
+++ b/core/llm/router/calls/_failover.py
@@ -134,6 +134,58 @@ async def call_with_failover(
                 if attempt < _max_retries - 1:
                     await _asyncio.sleep(wait)
             except Exception as exc:
+                # PR-CLAUDE-CLI-CREDIT-EXHAUSTION-RETRY (2026-05-27) —
+                # ``ClaudeCliTransientUpstreamError`` lives under
+                # ``plugins/petri_audit`` so the core router cannot put
+                # it in ``_RETRYABLE_ERRORS`` (layer violation +
+                # plugin-as-optional-dep). Detect via lazy isinstance
+                # gate; treat as retryable with the long QUOTA backoff
+                # schedule (2m / 10m / 30m / 2h — paperclip
+                # heartbeat.ts:217-226). The shorter exponential
+                # ``_RETRYABLE_ERRORS`` schedule (max ~30s) cannot
+                # bridge an Anthropic 5h pool refresh window; smoke 24
+                # surfaced this as all 5 evolver phases hard-failing
+                # within 30s after 3 attempts each, even though manual
+                # ``resume`` succeeded ~20 min later once the pool
+                # replenished.
+                try:
+                    from plugins.petri_audit.claude_cli_provider import (
+                        ClaudeCliTransientUpstreamError,
+                    )
+
+                    is_claude_cli_transient = isinstance(exc, ClaudeCliTransientUpstreamError)
+                except ImportError:
+                    is_claude_cli_transient = False
+
+                if is_claude_cli_transient:
+                    from core.llm.claude_cli_errors import QUOTA_BACKOFF_SECONDS
+
+                    last_error = exc
+                    schedule_idx = min(attempt, len(QUOTA_BACKOFF_SECONDS) - 1)
+                    wait = QUOTA_BACKOFF_SECONDS[schedule_idx]
+                    _elapsed = time.monotonic() - _t0_failover
+                    log.info(
+                        "Failover: model=%s attempt=%d/%d claude-cli transient "
+                        "(credit/pool exhaustion), retrying in %.0fs (quota schedule)",
+                        current_model,
+                        attempt + 1,
+                        _max_retries,
+                        wait,
+                    )
+                    _fire_hook(
+                        HookEvent.LLM_CALL_RETRIED,
+                        {
+                            "model": current_model,
+                            "attempt": attempt + 1,
+                            "max_retries": _max_retries,
+                            "delay_s": wait,
+                            "elapsed_s": _elapsed,
+                            "error_type": type(exc).__name__,
+                        },
+                    )
+                    if attempt < _max_retries - 1:
+                        await _asyncio.sleep(wait)
+                    continue
                 # Unexpected error: log and move on to next model
                 last_error = exc
                 log.debug(

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -375,6 +375,56 @@ class TestCallWithFailover:
 
         assert sleeps == [QUOTA_BACKOFF_SECONDS[0], QUOTA_BACKOFF_SECONDS[1]]
 
+    def test_claude_cli_transient_clips_to_final_quota_tier(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """When ``max_retries`` exceeds ``len(QUOTA_BACKOFF_SECONDS)``,
+        every attempt past the schedule's tail repeats the final
+        ``7200.0`` (2h) wait — :func:`call_with_failover` uses
+        ``min(attempt, len(schedule) - 1)`` to clip, matching paperclip
+        heartbeat.ts:217-226 ("MAX_ATTEMPTS = 4, then surrender or
+        repeat 2h"). Without this clip a 5-attempt loop would
+        ``IndexError`` on attempt 4."""
+        from plugins.petri_audit.claude_cli_provider import (
+            ClaudeCliTransientUpstreamError,
+            TransientSignal,
+        )
+
+        from core.llm.claude_cli_errors import QUOTA_BACKOFF_SECONDS
+
+        signal = TransientSignal(matched_text="claude usage limit reached", source="event")
+        transient_err = ClaudeCliTransientUpstreamError(
+            "claude-cli upstream transient (quota, persistent)", signal=signal
+        )
+
+        async def call_fn(model: str) -> None:
+            raise transient_err
+
+        sleeps: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        monkeypatch.setattr("asyncio.sleep", _fake_sleep)
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY],  # single-model chain → no fallback
+                call_fn,
+                max_retries=6,  # exceeds len(QUOTA_BACKOFF_SECONDS) == 4
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is None
+        assert used_model is None
+        # 5 sleeps fired (between attempts 1→2 through 5→6); the final
+        # 2 entries clip to the schedule tail (7200.0).
+        assert sleeps == [
+            QUOTA_BACKOFF_SECONDS[0],
+            QUOTA_BACKOFF_SECONDS[1],
+            QUOTA_BACKOFF_SECONDS[2],
+            QUOTA_BACKOFF_SECONDS[3],
+            QUOTA_BACKOFF_SECONDS[3],  # clipped: attempt=4 → schedule[3]
+        ]
+
     def test_claude_cli_transient_exhausts_then_falls_back(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         """When the transient never resolves on the primary model,
         the loop exhausts ``max_retries`` then falls through to the

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -312,6 +312,106 @@ class TestCallWithFailover:
         assert response is mock_response
         assert used_model == ANTHROPIC_SECONDARY
 
+    def test_claude_cli_transient_retries_within_same_model(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """PR-CLAUDE-CLI-CREDIT-EXHAUSTION-RETRY (2026-05-27) —
+        ``ClaudeCliTransientUpstreamError`` must be retried on the
+        same model (not fall through to the next model in the chain).
+
+        Pre-PR the bare ``except Exception`` branch immediately broke
+        the retry loop on this exception (smoke 24: 5/5 evolver
+        phases hard-failed within 30s after 3 attempts). Post-PR the
+        plugin-imported exception routes into a quota-class retry
+        with the long QUOTA_BACKOFF schedule.
+
+        Asserts:
+        - All ``max_retries`` attempts run on the primary model
+          (i.e. the exception was treated as retryable, not as a
+          chain-skip signal).
+        - The retry uses the QUOTA_BACKOFF schedule (we patch
+          ``asyncio.sleep`` to a no-op and capture the wait values).
+        - Eventually returns success when the transient resolves
+          (mirrors a pool refresh).
+        """
+        from plugins.petri_audit.claude_cli_provider import (
+            ClaudeCliTransientUpstreamError,
+            TransientSignal,
+        )
+
+        signal = TransientSignal(matched_text="! Unexpected error. Auto-retrying.", source="event")
+        transient_err = ClaudeCliTransientUpstreamError(
+            "claude-cli upstream transient (pool exhausted)", signal=signal
+        )
+        mock_response = MagicMock()
+        call_count = {"n": 0}
+
+        async def call_fn(model: str) -> MagicMock:
+            call_count["n"] += 1
+            # Fail the first 2 attempts on primary; succeed on the 3rd.
+            if call_count["n"] < 3:
+                raise transient_err
+            return mock_response
+
+        sleeps: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        monkeypatch.setattr("asyncio.sleep", _fake_sleep)
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=3,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_PRIMARY  # retried within primary, no chain skip
+        assert call_count["n"] == 3
+        # Two sleeps fired (between attempts 1→2 and 2→3); both match the
+        # paperclip QUOTA_BACKOFF schedule (2m / 10m / 30m / 2h).
+        from core.llm.claude_cli_errors import QUOTA_BACKOFF_SECONDS
+
+        assert sleeps == [QUOTA_BACKOFF_SECONDS[0], QUOTA_BACKOFF_SECONDS[1]]
+
+    def test_claude_cli_transient_exhausts_then_falls_back(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """When the transient never resolves on the primary model,
+        the loop exhausts ``max_retries`` then falls through to the
+        next model in the chain. Mirrors the model-chain semantics
+        the SDK ``RETRYABLE_ERRORS`` branch already provides."""
+        from plugins.petri_audit.claude_cli_provider import (
+            ClaudeCliTransientUpstreamError,
+            TransientSignal,
+        )
+
+        signal = TransientSignal(matched_text="claude usage limit reached", source="event")
+        transient_err = ClaudeCliTransientUpstreamError(
+            "claude-cli upstream transient (quota)", signal=signal
+        )
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            if model == ANTHROPIC_PRIMARY:
+                raise transient_err
+            return mock_response
+
+        async def _fake_sleep(delay: float) -> None:
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", _fake_sleep)
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+
 
 # ---------------------------------------------------------------------------
 # Fallback chain configuration

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -383,12 +383,11 @@ class TestCallWithFailover:
         heartbeat.ts:217-226 ("MAX_ATTEMPTS = 4, then surrender or
         repeat 2h"). Without this clip a 5-attempt loop would
         ``IndexError`` on attempt 4."""
+        from core.llm.claude_cli_errors import QUOTA_BACKOFF_SECONDS
         from plugins.petri_audit.claude_cli_provider import (
             ClaudeCliTransientUpstreamError,
             TransientSignal,
         )
-
-        from core.llm.claude_cli_errors import QUOTA_BACKOFF_SECONDS
 
         signal = TransientSignal(matched_text="claude usage limit reached", source="event")
         transient_err = ClaudeCliTransientUpstreamError(


### PR DESCRIPTION
## Summary
- Route ``ClaudeCliTransientUpstreamError`` into the retry path with the paperclip QUOTA_BACKOFF schedule (2m / 10m / 30m / 2h) so a claude-cli 5h-pool refresh window can be bridged automatically.
- Pre-PR the bare ``except Exception`` branch in ``_failover.py:136`` skipped the plugin-imported exception to the next model after one attempt (single-model chain → hard fail).

## Why
Smoke 24 (v0.99.71) surfaced 5/5 evolver phases hard-failing within 30s after 3 attempts each, with the exact ``"! Unexpected error. Auto-retrying."`` claude-cli stream-json signature. Operator-triggered ``audit-seeds resume`` ~20 min later succeeded once the Anthropic Max OAuth pool replenished — proving the failure was upstream pool exhaustion, not a code bug.

Root cause: ``ClaudeCliTransientUpstreamError`` lives under ``plugins/petri_audit/claude_cli_provider.py`` so the core router cannot put it in ``_RETRYABLE_ERRORS`` (layer violation + plugin-as-optional-dep). With the current SDK-only ``_RETRYABLE_ERRORS`` it fell through to ``except Exception`` → ``break`` → chain skip on attempt 1, total retry budget ~0s. The shorter exponential schedule (max ~30s) cannot bridge a multi-minute pool refresh anyway.

## Changes
| File | Change |
|------|--------|
| ``core/llm/router/calls/_failover.py`` | Lazy isinstance gate above the catch-all ``except Exception`` — detects ``ClaudeCliTransientUpstreamError``, retries on the same model with ``QUOTA_BACKOFF_SECONDS[attempt]`` schedule, fires ``LLM_CALL_RETRIED`` hook with the quota schedule's delay. Falls back to next model only after ``max_retries`` exhausted (model-chain semantics intact). |
| ``tests/test_model_failover.py`` | Two new cases: ``test_claude_cli_transient_retries_within_same_model`` (3 attempts on primary with QUOTA_BACKOFF sleeps, success on attempt 3) and ``test_claude_cli_transient_exhausts_then_falls_back`` (exhausted retries → secondary). |
| ``CHANGELOG.md`` | Unreleased Fixed entry. |

## Verification
- [x] ``ruff check core/ tests/ plugins/`` clean
- [x] ``ruff format --check`` clean (994 files)
- [x] ``mypy core/ plugins/`` clean (461 source files)
- [x] ``pytest tests/test_model_failover.py tests/core/llm/ tests/test_worker.py`` — all green (402 passed)
- [x] Layer invariant: lazy isinstance gate keeps ``core/`` independent of ``plugins/petri_audit`` (same pattern already used in ``core/llm/errors.py:classify_llm_error``)

## Reference
- Smoke 24 archive: ``.audit/smoke-archives/smoke-24-1779787347.log``
- Diagnostic dumps: ``~/.geode/diagnostics/claude-cli-transient/1779814687-claude-opus-4-7.json`` (matches ``"! Unexpected error. Auto-retrying."`` signature)
- Memory: ``feedback_claude_cli_credit_exhaustion.md`` (Anthropic 5h pool refresh pattern, ~20 min observation)
- Paperclip schedule source: ``~/workspace/paperclip/packages/adapters/claude-local/src/server/heartbeat.ts:217-226`` (4-tier quota backoff)