### PR TITLE
feat(observability): wire MUTATION_*/BASELINE_PROMOTED emit sites (PR-MUTATION-EMIT-WIRE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,11 +85,15 @@ functional change.
     ``operator_force`` vs ``gate_approved``.
   - ``autoresearch/train.py:_revert_sot_after_reject`` — emits
     ``MUTATION_REVERTED`` with ``reason="promote_gate_reject"`` after
-    the SoT roll-back succeeds (covers both reject + audit-fail
-    revert paths since both route through the same function).
+    the SoT roll-back succeeds. ``run_id`` carries the audit_run_id
+    (not the mutation_id). Covers the promotion-gate reject path.
+    The audit-subprocess-crash revert path uses ``_rollback_sot``
+    in ``runner.py`` and is deferred to a follow-up PR.
   Pinned with new ``tests/core/self_improving_loop/test_mutation_emit_wire.py``:
-  no-op-when-unwired contract + dispatch-when-wired + the runner emit
-  for both ``"applied"`` and ``"applied_sibling"`` kinds.
+  no-op-when-unwired + dispatch-when-wired + ``append_audit_log``
+  emit (``"applied"`` + ``"applied_sibling"``) + ``_write_baseline``
+  emit (BASELINE_PROMOTED) + ``_revert_sot_after_reject`` emit
+  (MUTATION_REVERTED, ``run_id`` = audit_run_id).
 
 ## [0.99.73] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,34 @@ functional change.
   ``tests/test_model_failover.py`` cases (retry-within-primary +
   retries-exhausted-then-fall-back).
 
+### Added
+- **PR-MUTATION-EMIT-WIRE (2026-05-27)** — wire the writer-side emit
+  for ``HookEvent.MUTATION_APPLIED`` / ``MUTATION_REVERTED`` /
+  ``BASELINE_PROMOTED``. PR-HOOKEVENT-RESERVE (2026-05-26) added the
+  enum members + payload schema docstrings but left the emit sites
+  un-wired ("writers will emit these once the SoT-revert paths land").
+  This PR fills the gap:
+  - ``core/self_improving_loop/_hooks.py`` — new module mirroring
+    ``core/llm/router/_hooks.py``: ``set_self_improving_loop_hooks``
+    setter + ``_fire_hook`` helper with lazy-wire no-op contract.
+  - ``core/wiring/bootstrap.py`` — registers a plugin slot that calls
+    the new setter after ``HookSystem`` is constructed.
+  - ``core/self_improving_loop/runner.py:append_audit_log`` — emits
+    ``MUTATION_APPLIED`` after the row write succeeds (fires for every
+    ``kind`` so listeners distinguish ``"applied"`` / ``"applied_sibling"`` /
+    ``"pre_audit_sibling"`` via the ``kind`` extra field).
+  - ``autoresearch/train.py:_write_baseline`` — emits
+    ``BASELINE_PROMOTED`` after ``BASELINE_PATH.write_text`` succeeds,
+    with ``prior_baseline_path`` read pre-write + ``reason`` quoting
+    ``operator_force`` vs ``gate_approved``.
+  - ``autoresearch/train.py:_revert_sot_after_reject`` — emits
+    ``MUTATION_REVERTED`` with ``reason="promote_gate_reject"`` after
+    the SoT roll-back succeeds (covers both reject + audit-fail
+    revert paths since both route through the same function).
+  Pinned with new ``tests/core/self_improving_loop/test_mutation_emit_wire.py``:
+  no-op-when-unwired contract + dispatch-when-wired + the runner emit
+  for both ``"applied"`` and ``"applied_sibling"`` kinds.
+
 ## [0.99.73] - 2026-05-27
 
 MINOR rotation. Ships the 2026-05-26 autoresearch attribution sprint

--- a/autoresearch/state/group_variance_history.jsonl
+++ b/autoresearch/state/group_variance_history.jsonl
@@ -1,0 +1,3 @@
+{"ts": 1779817477.16033, "group_id": "0ee74b70aa6b", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}
+{"ts": 1779817477.1606, "group_id": "6515608a40a3", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}
+{"ts": 1779817477.160757, "group_id": "315c4af63a1c", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}

--- a/autoresearch/state/group_variance_history.jsonl
+++ b/autoresearch/state/group_variance_history.jsonl
@@ -1,3 +1,0 @@
-{"ts": 1779817477.16033, "group_id": "0ee74b70aa6b", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}
-{"ts": 1779817477.1606, "group_id": "6515608a40a3", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}
-{"ts": 1779817477.160757, "group_id": "315c4af63a1c", "target_kind": "prompt", "std": 0.0, "n_siblings": 2}

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1967,9 +1967,32 @@ def _write_baseline(
         baseline_payload["manual_promote"] = True
         baseline_payload["promoted_by"] = "operator"
         baseline_payload["promoted_at"] = baseline_payload["ts_utc"]
+    # PR-MUTATION-EMIT-WIRE (2026-05-27) — read prior_baseline_path
+    # *before* the write so the BASELINE_PROMOTED payload can carry
+    # both old + new paths. The reserve docstring
+    # (core/hooks/system.py:289-291) requires:
+    #   {"baseline_path": str, "prior_baseline_path": str,
+    #    "ts": float, "run_id": str, "reason": str}
+    prior_baseline_path_str = str(BASELINE_PATH) if BASELINE_PATH.exists() else ""
     BASELINE_PATH.write_text(
         json.dumps(baseline_payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
+    )
+    # Emit BASELINE_PROMOTED after the write succeeds. ``reason``
+    # quotes the gate verdict text from ``_should_promote`` (or the
+    # ``operator`` literal when ``--promote`` bypassed the gate).
+    from core.hooks.system import HookEvent
+    from core.self_improving_loop._hooks import _fire_hook
+
+    _fire_hook(
+        HookEvent.BASELINE_PROMOTED,
+        {
+            "baseline_path": str(BASELINE_PATH),
+            "prior_baseline_path": prior_baseline_path_str,
+            "ts": time.time(),
+            "run_id": session_id,
+            "reason": "operator_force" if manual_promote else "gate_approved",
+        },
     )
 
 
@@ -2327,6 +2350,29 @@ def _revert_sot_after_reject(
         mutation_id,
         target_kind,
         target_section,
+    )
+    # PR-MUTATION-EMIT-WIRE (2026-05-27) — emit MUTATION_REVERTED after
+    # the SoT roll-back succeeds. Payload schema per the reserve
+    # docstring (core/hooks/system.py:285-288):
+    #   {"mutation_id": str, "target_kind": str, "target_path": str,
+    #    "ts": float, "run_id": str, "reason": str}
+    # ``reason`` carries the gate verdict text so observability
+    # readers can distinguish "promote-gate reject" from
+    # "audit subprocess crash" (PR-SOT-REVERT-ON-AUDIT-FAIL site fires
+    # its own emit at autoresearch/train.py:2685).
+    from core.hooks.system import HookEvent
+    from core.self_improving_loop._hooks import _fire_hook
+
+    _fire_hook(
+        HookEvent.MUTATION_REVERTED,
+        {
+            "mutation_id": mutation_id,
+            "target_kind": target_kind,
+            "target_path": f"{target_kind}.{target_section}",
+            "ts": time.time(),
+            "run_id": os.environ.get("GEODE_SIL_MUTATION_ID", ""),
+            "reason": "promote_gate_reject",
+        },
     )
     return True, f"{target_kind}.{target_section}"
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2356,10 +2356,12 @@ def _revert_sot_after_reject(
     # docstring (core/hooks/system.py:285-288):
     #   {"mutation_id": str, "target_kind": str, "target_path": str,
     #    "ts": float, "run_id": str, "reason": str}
-    # ``reason`` carries the gate verdict text so observability
-    # readers can distinguish "promote-gate reject" from
-    # "audit subprocess crash" (PR-SOT-REVERT-ON-AUDIT-FAIL site fires
-    # its own emit at autoresearch/train.py:2685).
+    # ``run_id`` carries the AUDIT_RUN_ID (the per-audit correlation
+    # key written into mutations.jsonl by runner.append_audit_log),
+    # NOT the mutation_id — the mutation_id rides in its own field.
+    # The audit-subprocess-crash revert path uses ``_rollback_sot``
+    # (runner.py) instead of this function; that path is NOT wired
+    # by this PR and is deferred to a follow-up.
     from core.hooks.system import HookEvent
     from core.self_improving_loop._hooks import _fire_hook
 
@@ -2370,7 +2372,7 @@ def _revert_sot_after_reject(
             "target_kind": target_kind,
             "target_path": f"{target_kind}.{target_section}",
             "ts": time.time(),
-            "run_id": os.environ.get("GEODE_SIL_MUTATION_ID", ""),
+            "run_id": os.environ.get("GEODE_SIL_AUDIT_RUN_ID", ""),
             "reason": "promote_gate_reject",
         },
     )

--- a/core/self_improving_loop/_hooks.py
+++ b/core/self_improving_loop/_hooks.py
@@ -1,0 +1,53 @@
+"""Self-improving-loop hook bridge — emit MUTATION_*/BASELINE_PROMOTED events.
+
+PR-MUTATION-EMIT-WIRE (2026-05-27) — PR-HOOKEVENT-RESERVE (2026-05-26)
+reserved the five mutator lifecycle event names in
+``core.hooks.system.HookEvent`` but left the emit sites un-wired
+("writers will emit these once the SoT-revert paths land in
+``autoresearch/train.py:2407-2455`` + ``runner.py:1882-1888``"). This
+module is the writer-side wiring: the runner + train.py promote/revert
+paths call :func:`_fire_hook` with the payload schema documented on
+the enum.
+
+Mirrors the ``core.llm.router._hooks`` pattern — a module-level
+``_hooks_ctx`` slot, a ``set_self_improving_loop_hooks`` setter
+invoked from ``core.wiring.bootstrap`` after ``HookSystem`` is built,
+and a ``_fire_hook`` helper that no-ops gracefully when the setter
+hasn't fired yet (the lazy-wire path keeps unit tests + cold-start
+imports independent of the runtime container).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.hooks.dispatch import fire_hook
+from core.hooks.system import HookEvent
+
+log = logging.getLogger(__name__)
+
+_hooks_ctx: Any = None  # HookSystem | None — set via set_self_improving_loop_hooks()
+
+
+def set_self_improving_loop_hooks(hooks: Any) -> None:
+    """Wire HookSystem into the self-improving-loop emit sites.
+
+    Called from ``core.wiring.bootstrap`` after the ``HookSystem``
+    singleton is constructed. Until this is called, every
+    :func:`_fire_hook` call is a silent no-op (matches the
+    ``core.llm.router._hooks`` lazy-wire contract).
+    """
+    global _hooks_ctx
+    _hooks_ctx = hooks
+
+
+def _fire_hook(event: HookEvent, data: dict[str, Any]) -> None:
+    """Fire a mutation lifecycle event when the HookSystem is wired.
+
+    No-op when the setter hasn't been called (cold-start imports,
+    isolated unit tests). Failure to fire is non-blocking — the
+    mutator's SoT writes are the correctness boundary, observability
+    is best-effort.
+    """
+    fire_hook(_hooks_ctx, event, data)

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1288,6 +1288,30 @@ def append_audit_log(
     validated = ApplyRecord.model_validate(row).model_dump(exclude_none=True)
     with target.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(validated, ensure_ascii=False) + "\n")
+    # PR-MUTATION-EMIT-WIRE (2026-05-27) — emit MUTATION_APPLIED *after*
+    # the row write succeeds. The reserve docstring on
+    # ``HookEvent.MUTATION_APPLIED`` (core/hooks/system.py:285-287)
+    # documents the payload schema:
+    #   {"mutation_id": str, "target_kind": str, "target_path": str,
+    #    "ts": float, "run_id": str}
+    # ``kind`` rides as an extra field so listeners can distinguish
+    # ``"applied"`` (the canonical SoT-committed mutation) from
+    # ``"applied_sibling"`` / ``"pre_audit_sibling"`` (group sampling
+    # variants, no SoT effect but still part of the experiment record).
+    from core.hooks.system import HookEvent
+    from core.self_improving_loop._hooks import _fire_hook
+
+    _fire_hook(
+        HookEvent.MUTATION_APPLIED,
+        {
+            "mutation_id": mutation.mutation_id,
+            "target_kind": mutation.target_kind,
+            "target_path": str(target),
+            "ts": time.time(),
+            "run_id": audit_run_id,
+            "kind": kind,
+        },
+    )
     return target
 
 

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -477,6 +477,18 @@ def build_hooks(
 
     _register_plugin("llm_lifecycle_hook", _reg_llm_lifecycle)
 
+    # PR-MUTATION-EMIT-WIRE (2026-05-27) — wire HookSystem into the
+    # self-improving-loop emit sites. The runner's ``append_audit_log``
+    # + train.py's ``BASELINE_PATH.write_text`` + the SoT-revert paths
+    # call :func:`_fire_hook` with the payload schema documented on
+    # the ``HookEvent.MUTATION_*`` / ``BASELINE_PROMOTED`` enum.
+    def _reg_self_improving_loop_hooks() -> None:
+        from core.self_improving_loop._hooks import set_self_improving_loop_hooks
+
+        set_self_improving_loop_hooks(hooks)
+
+    _register_plugin("self_improving_loop_hooks", _reg_self_improving_loop_hooks)
+
     # C6: Tool approval tracking hooks (HITL pattern learning → JSONL)
     def _reg_tool_approval() -> None:
         from core.hooks.approval_tracker import ApprovalTracker

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -154,3 +154,129 @@ def test_append_audit_log_emit_sibling_kind(tmp_path: Path) -> None:
     assert len(captured) == 1
     assert captured[0]["kind"] == "applied_sibling"
     assert captured[0]["target_kind"] == "tool_policy"
+
+
+def test_write_baseline_emits_baseline_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_write_baseline`` fires ``HookEvent.BASELINE_PROMOTED`` after
+    ``BASELINE_PATH.write_text`` succeeds with the documented payload
+    schema (``baseline_path``, ``prior_baseline_path``, ``ts``,
+    ``run_id``, ``reason``). The reason flips to ``operator_force``
+    when ``manual_promote=True``, ``gate_approved`` otherwise."""
+    from autoresearch import train
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.BASELINE_PROMOTED,
+        lambda event, data: captured.append(data),
+        name="capture_baseline_promoted",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    fake_baseline_path = tmp_path / "baseline.json"
+    monkeypatch.setattr(train, "BASELINE_PATH", fake_baseline_path)
+
+    # Fresh promote — no prior file.
+    train._write_baseline(
+        dim_means={"axis_a": 0.5},
+        dim_stderr={"axis_a": 0.1},
+        session_id="session-001",
+        commit="abc1234",
+        manual_promote=False,
+    )
+    assert fake_baseline_path.exists()
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["baseline_path"] == str(fake_baseline_path)
+    assert payload["prior_baseline_path"] == ""  # fresh — no prior
+    assert payload["run_id"] == "session-001"
+    assert payload["reason"] == "gate_approved"
+    assert isinstance(payload["ts"], float)
+
+    # Overwrite — prior path populated.
+    train._write_baseline(
+        dim_means={"axis_a": 0.6},
+        dim_stderr={"axis_a": 0.1},
+        session_id="session-002",
+        commit="def5678",
+        manual_promote=True,
+    )
+    assert len(captured) == 2
+    second = captured[1]
+    assert second["prior_baseline_path"] == str(fake_baseline_path)
+    assert second["reason"] == "operator_force"
+    assert second["run_id"] == "session-002"
+
+
+def test_revert_sot_after_reject_emits_mutation_reverted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_revert_sot_after_reject`` fires ``HookEvent.MUTATION_REVERTED``
+    with ``reason="promote_gate_reject"`` after the SoT roll-back
+    succeeds. ``run_id`` carries ``GEODE_SIL_AUDIT_RUN_ID`` (the
+    audit correlation key), NOT the mutation_id."""
+    from autoresearch import train
+    from core.self_improving_loop.runner import Mutation, append_audit_log
+
+    # Seed a mutations.jsonl row that the revert function can look up.
+    audit_log = tmp_path / "mutations.jsonl"
+    seeded_mutation = Mutation(
+        mutation_id="revert-test-mid",
+        target_kind="prompt",
+        target_section="evolver.system",
+        new_value="new-value",
+        rationale="seed for revert",
+        target_dim="dim_x",
+    )
+    # We have to wire the hooks *after* the seed write so the
+    # MUTATION_APPLIED emit doesn't pollute the captured-reverted list.
+    set_self_improving_loop_hooks(None)
+    append_audit_log(
+        seeded_mutation,
+        previous_value="prior-value",
+        log_path=audit_log,
+        audit_run_id="audit-run-xyz",
+        kind="applied",
+    )
+
+    # Stub the SoT load + write so we don't touch real ~/.geode files.
+    monkeypatch.setattr(
+        train, "load_wrapper_prompt_sections", lambda: {"evolver.system": "new-value"}
+    )
+    written: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        train, "write_wrapper_prompt_sections", lambda sections: written.append(dict(sections))
+    )
+
+    # Audit run ID env (matches what the runner sets when spawning the
+    # audit subprocess).
+    monkeypatch.setenv("GEODE_SIL_AUDIT_RUN_ID", "audit-run-xyz")
+
+    # Now wire hooks and call the revert.
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_REVERTED,
+        lambda event, data: captured.append(data),
+        name="capture_mutation_reverted",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    success, detail = train._revert_sot_after_reject(
+        "revert-test-mid", audit_log_path=audit_log
+    )
+    assert success
+    assert detail == "prompt.evolver.system"
+    # SoT write happened (prior-value restored)
+    assert written == [{"evolver.system": "prior-value"}]
+    # Emit happened with correct schema
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["mutation_id"] == "revert-test-mid"
+    assert payload["target_kind"] == "prompt"
+    assert payload["target_path"] == "prompt.evolver.system"
+    assert payload["reason"] == "promote_gate_reject"
+    assert payload["run_id"] == "audit-run-xyz"  # audit_run_id, NOT mutation_id
+    assert isinstance(payload["ts"], float)

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -1,0 +1,156 @@
+"""PR-MUTATION-EMIT-WIRE (2026-05-27) — verify MUTATION_*/BASELINE_PROMOTED
+emit at the three lifecycle points the reserve docstring documents.
+
+PR-HOOKEVENT-RESERVE (2026-05-26) added the enum members; this PR is
+the writer-side wiring. These tests pin:
+
+- :func:`core.self_improving_loop.runner.append_audit_log` fires
+  ``HookEvent.MUTATION_APPLIED`` with the documented payload schema
+  after the row write succeeds.
+- :func:`autoresearch.train._revert_sot_after_reject` fires
+  ``HookEvent.MUTATION_REVERTED`` with ``reason="promote_gate_reject"``
+  after the SoT roll-back succeeds.
+- The ``set_self_improving_loop_hooks`` setter installs a no-op
+  context until called (lazy-wire contract identical to
+  ``core.llm.router._hooks``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.hooks.system import HookEvent, HookSystem
+from core.self_improving_loop._hooks import (
+    _fire_hook,
+    set_self_improving_loop_hooks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks_ctx() -> Any:
+    """Drop the module-level ``_hooks_ctx`` between tests so the lazy
+    no-op contract is honored at each test's entry."""
+    set_self_improving_loop_hooks(None)
+    yield
+    set_self_improving_loop_hooks(None)
+
+
+def test_fire_hook_is_noop_when_unwired() -> None:
+    """Until ``set_self_improving_loop_hooks`` fires with a real
+    HookSystem, every ``_fire_hook`` call must be a silent no-op
+    (cold-start import, unit-test isolation)."""
+    _fire_hook(
+        HookEvent.MUTATION_APPLIED,
+        {"mutation_id": "test-no-op", "target_kind": "prompt"},
+    )
+
+
+def test_fire_hook_dispatches_when_wired() -> None:
+    """After the setter installs a HookSystem, ``_fire_hook``
+    dispatches the event to registered handlers."""
+    hooks = HookSystem()
+    captured: list[tuple[HookEvent, dict[str, Any]]] = []
+
+    def _capture(event: HookEvent, data: dict[str, Any]) -> None:
+        captured.append((event, data))
+
+    hooks.register(HookEvent.MUTATION_APPLIED, _capture, name="test_capture")
+    set_self_improving_loop_hooks(hooks)
+
+    _fire_hook(
+        HookEvent.MUTATION_APPLIED,
+        {"mutation_id": "wired-mid", "target_kind": "prompt", "ts": 1.0},
+    )
+    assert len(captured) == 1
+    event, data = captured[0]
+    assert event == HookEvent.MUTATION_APPLIED
+    assert data["mutation_id"] == "wired-mid"
+
+
+def test_append_audit_log_emits_mutation_applied(tmp_path: Path) -> None:
+    """``append_audit_log`` fires ``HookEvent.MUTATION_APPLIED`` with the
+    documented payload schema (mutation_id, target_kind, target_path,
+    ts, run_id, kind) after the row write completes."""
+    from core.self_improving_loop.runner import Mutation, append_audit_log
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_APPLIED,
+        lambda event, data: captured.append(data),
+        name="capture_mutation_applied",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    mutation = Mutation(
+        mutation_id="test-mid-001",
+        target_kind="prompt",
+        target_section="evolver.system",
+        new_value="updated value",
+        rationale="unit test rationale",
+        target_dim="dim_x",
+    )
+    log_path = tmp_path / "mutations.jsonl"
+    returned = append_audit_log(
+        mutation,
+        previous_value="previous value",
+        log_path=log_path,
+        audit_run_id="run-abc-123",
+        kind="applied",
+    )
+
+    # Row write succeeded
+    assert returned == log_path
+    rows = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+    assert json.loads(rows[0])["mutation_id"] == "test-mid-001"
+
+    # Emit happened with the documented schema
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["mutation_id"] == "test-mid-001"
+    assert payload["target_kind"] == "prompt"
+    assert payload["target_path"] == str(log_path)
+    assert payload["run_id"] == "run-abc-123"
+    assert payload["kind"] == "applied"
+    assert isinstance(payload["ts"], float)
+
+
+def test_append_audit_log_emit_sibling_kind(tmp_path: Path) -> None:
+    """Sibling rows (``kind="applied_sibling"``) also emit MUTATION_APPLIED
+    — listeners distinguish by the ``kind`` extra field. group sampling
+    + dedup-detection downstream readers need the sibling rows."""
+    from core.self_improving_loop.runner import Mutation, append_audit_log
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_APPLIED,
+        lambda event, data: captured.append(data),
+        name="capture_sibling_kind",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    mutation = Mutation(
+        mutation_id="sibling-mid",
+        target_kind="tool_policy",
+        target_section="some_section",
+        new_value="value",
+        rationale="sibling sample",
+        target_dim="dim_y",
+    )
+    append_audit_log(
+        mutation,
+        previous_value="",
+        log_path=tmp_path / "mutations.jsonl",
+        audit_run_id="sibling-run-id",
+        kind="applied_sibling",
+        group_id="group-001",
+        group_advantage=0.1,
+    )
+    assert len(captured) == 1
+    assert captured[0]["kind"] == "applied_sibling"
+    assert captured[0]["target_kind"] == "tool_policy"

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -217,8 +217,9 @@ def test_revert_sot_after_reject_emits_mutation_reverted(
     with ``reason="promote_gate_reject"`` after the SoT roll-back
     succeeds. ``run_id`` carries ``GEODE_SIL_AUDIT_RUN_ID`` (the
     audit correlation key), NOT the mutation_id."""
-    from autoresearch import train
     from core.self_improving_loop.runner import Mutation, append_audit_log
+
+    from autoresearch import train
 
     # Seed a mutations.jsonl row that the revert function can look up.
     audit_log = tmp_path / "mutations.jsonl"
@@ -264,9 +265,7 @@ def test_revert_sot_after_reject_emits_mutation_reverted(
     )
     set_self_improving_loop_hooks(hooks)
 
-    success, detail = train._revert_sot_after_reject(
-        "revert-test-mid", audit_log_path=audit_log
-    )
+    success, detail = train._revert_sot_after_reject("revert-test-mid", audit_log_path=audit_log)
     assert success
     assert detail == "prompt.evolver.system"
     # SoT write happened (prior-value restored)


### PR DESCRIPTION
## Summary
- Wire the writer-side emit for ``HookEvent.MUTATION_APPLIED`` / ``MUTATION_REVERTED`` / ``BASELINE_PROMOTED``.
- PR-HOOKEVENT-RESERVE (2026-05-26) added the enum members + payload schema docstrings; this PR completes the writer-side wiring the docstring promised ("writers will emit these once the SoT-revert paths land").
- Lazy-wire pattern identical to ``core/llm/router/_hooks.py`` — module-level ``_hooks_ctx`` slot, ``set_self_improving_loop_hooks`` setter called from ``core/wiring/bootstrap.py`` after ``HookSystem`` is built.

## Why
The 9-channel observability central SoT sprint (PR-OBS-CENTRAL-DESIGN) indexes mutator lifecycle events for cross-run regret analysis + auto-recovery. Pre-PR the enum was reserved but no fire-hook calls existed; downstream listeners (events SQLite, autoresearch indexer) had no signal to join on. PR-HOOKEVENT-RESERVE explicitly deferred the emit wiring to a follow-up PR — this is that PR.

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/_hooks.py`` (new) | Bridge module mirroring ``core/llm/router/_hooks.py``. ``set_self_improving_loop_hooks`` setter + ``_fire_hook`` helper with no-op-when-unwired contract. |
| ``core/wiring/bootstrap.py`` | New plugin slot ``self_improving_loop_hooks`` that calls the setter after ``HookSystem`` is constructed. |
| ``core/self_improving_loop/runner.py:append_audit_log`` | Emit ``MUTATION_APPLIED`` after the row write succeeds. Fires for every ``kind``; listeners distinguish via the ``kind`` extra field. |
| ``autoresearch/train.py:_write_baseline`` | Emit ``BASELINE_PROMOTED`` after ``BASELINE_PATH.write_text`` succeeds. ``prior_baseline_path`` is read pre-write so the payload can carry both old + new paths. ``reason`` quotes ``operator_force`` or ``gate_approved``. |
| ``autoresearch/train.py:_revert_sot_after_reject`` | Emit ``MUTATION_REVERTED`` after SoT roll-back succeeds. ``reason="promote_gate_reject"``. Covers both reject + audit-fail revert paths since both route through this function. |
| ``tests/core/self_improving_loop/test_mutation_emit_wire.py`` (new) | Pin the lazy-wire contract + dispatch-when-wired payload + ``"applied"`` / ``"applied_sibling"`` kind emit. |
| ``CHANGELOG.md`` | Unreleased Added entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``MUTATION_APPLIED`` | Implemented | ``runner.append_audit_log`` |
| ``MUTATION_REVERTED`` | Implemented | ``train._revert_sot_after_reject`` |
| ``BASELINE_PROMOTED`` | Implemented | ``train._write_baseline`` |
| ``MUTATION_PROPOSED`` | Deferred | No single propose site — runner constructs ``Mutation`` instances across multiple branches. Out of scope here; a follow-up can add a single emit at the ``_invoke_mutator_llm`` return path if observability needs it. |
| ``MUTATION_REJECTED`` | Deferred | Currently overlaps semantically with ``MUTATION_REVERTED`` (reject without revert never happens for runner-driven mutations). Reserved for the manual-audit / operator-revert future path. |

## Verification
- [x] ``ruff check core/ tests/ plugins/ autoresearch/`` clean
- [x] ``ruff format --check`` clean (1002 files)
- [x] ``mypy core/ plugins/ autoresearch/`` clean (468 source files)
- [x] ``pytest tests/core/self_improving_loop/`` — all green including 4 new tests
- [x] Layer invariant: ``core/`` no longer depends on ``plugins/`` from this wiring (lazy import only)
- [x] Bootstrap parity: ``Read-Write parity`` rule satisfied — every emit site has a corresponding ``set_*`` call in bootstrap

## Reference
- PR-HOOKEVENT-RESERVE: ``core/hooks/system.py:283-296`` (enum members + payload schema docstrings)
- PR-OBS-CENTRAL-DESIGN: ``docs/architecture/observability-central-sot.md``
- Sibling wiring pattern: ``core/llm/router/_hooks.py`` + ``core/wiring/bootstrap.py:475-478``