### PR TITLE
docs: refresh stale lane cap references to PR-LANE-CAP-50 constants

### DIFF
--- a/core/llm/oauth_usage.py
+++ b/core/llm/oauth_usage.py
@@ -13,13 +13,13 @@ Why this exists
 
 The :class:`Lane` introduced in Phase 2
 (:mod:`core.orchestration.claude_cli_lane`) caps concurrent
-``claude --print`` fan-out at ``max_concurrent=2`` — one slot below
-the documented 3-4 burst-limiter floor. That cap is necessary but
-not sufficient: the 5-hour token bucket can be 90 % drained while
-the burst limiter is fully reset, and the next acquire would burn
-the last few percent for marginal value. paperclip solves this by
-polling ``/api/oauth/usage`` before each spawn and backing off when
-``five_hour.utilization >= 0.8``.
+``claude --print`` fan-out at ``DEFAULT_CLAUDE_CLI_LANE_MAX``
+(currently 50, raised from 2 by PR-LANE-CAP-50 2026-05-27). That cap
+is necessary but not sufficient: the 5-hour token bucket can be 90 %
+drained while the burst limiter is fully reset, and the next acquire
+would burn the last few percent for marginal value. paperclip solves
+this by polling ``/api/oauth/usage`` before each spawn and backing
+off when ``five_hour.utilization >= 0.8``.
 
 Path notes
 ==========

--- a/docs/architecture/seed-generation-decision.md
+++ b/docs/architecture/seed-generation-decision.md
@@ -23,7 +23,7 @@ AI co-scientist paper 의 6-agent topology (Generation / Reflection / Ranking / 
 |---|---|---|
 | Token budget guard | soft warning at $0.50 / sub-agent (cumulative), hard kill at $2.00 | 무인 진화 시 runaway 회피. config 가능 (`SEED_PIPELINE_BUDGET_SOFT_USD` / `_HARD_USD` env). |
 | Pipeline run budget cap | soft $0.30 / gen, hard $1.00 / gen | tournament 60 match × 3 judge × ~$0.02 = ~$3.6 의 worst-case 제어. config 가능. |
-| Concurrency Lane | `seed-generation` Lane, `max_concurrent=16` (기본 `global` Lane 의 max=8 별도) | 15-20 candidate parallel + tournament match 의 wall-time 감소 |
+| Concurrency Lane | `seed-generation` Lane, `DEFAULT_SEED_PIPELINE_CONCURRENCY` (currently 50, raised from 16 by PR-LANE-CAP-50 2026-05-27); shares ceiling with `global` Lane (`DEFAULT_GLOBAL_CONCURRENCY` also 50) | 50 candidate parallel + tournament match 의 wall-time 감소, per-adapter lanes 50 도 동일 ceiling |
 | Sub-agent recursion depth | `max_depth=1` (현 SubAgentManager 기본) | parent AgenticLoop central supervisor. 6-phase 모두 표현 가능 |
 | Bootstrap (첫 generation) | `baseline=None` → cross-axis gate 비활성, simple weighted sum 반환 | baseline 측정 자체가 첫 gen 의 결과. ADR-002 §5 참조 |
 

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -96,7 +96,8 @@ class Critic(BaseSeedAgent):
     (~200 token completion per critique). Fan-out lets the 15-candidate
     Generation batch be reviewed in roughly the same wall-time as one
     sequential critique, gated only by the ``seed-generation`` Lane
-    (max_concurrent=16, see ``core/wiring/container.py``).
+    (``DEFAULT_SEED_PIPELINE_CONCURRENCY``, currently 50 — see
+    ``core/wiring/container.py``).
     """
 
     def __init__(

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -113,7 +113,8 @@ class Evolver(BaseSeedAgent):
     information needed — the Critic feedback is per-candidate, the
     Pilot dim_means are per-candidate). Fan-out keeps the K=5
     evolution batch within one rollout's wall-time, gated by the
-    ``seed-generation`` Lane (max_concurrent=16).
+    ``seed-generation`` Lane (``DEFAULT_SEED_PIPELINE_CONCURRENCY``,
+    currently 50).
     """
 
     def __init__(

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -80,8 +80,9 @@ class Pilot(BaseSeedAgent):
     information needed). Pilot is the most expensive per-call phase
     (~1 Petri audit per candidate, 2 target models × 1 paraphrase), so
     fan-out matters: a 10-survivor batch runs in roughly one rollout's
-    wall-time, gated by the ``seed-generation`` Lane (max_concurrent=16,
-    see ``core/wiring/container.py``).
+    wall-time, gated by the ``seed-generation`` Lane
+    (``DEFAULT_SEED_PIPELINE_CONCURRENCY``, currently 50 — see
+    ``core/wiring/container.py``).
     """
 
     def __init__(

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.72"
+version = "0.99.73"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Docstring-only sweep: 5 sites still cited the pre-PR-LANE-CAP-50 lane cap values (``max_concurrent=2``, ``max_concurrent=16``, ``global max=8``). Refreshed to reference the actual ``DEFAULT_*_CONCURRENCY`` constants with their current (50) value.

## Why
PR-LANE-CAP-50 (2026-05-27, merged in #1772) raised every lane / queue concurrency default to 50 but the per-agent docstring rationales kept the pre-PR math. Stale docstrings violate the CHANGELOG/PR-body parity invariant (every adjective grep-provable) — a future reader following the doc would wire mental capacity planning against numbers that contradict the constants.

## Changes
| File | Change |
|------|--------|
| ``plugins/seed_generation/agents/pilot.py`` | ``max_concurrent=16`` → ``DEFAULT_SEED_PIPELINE_CONCURRENCY, currently 50`` |
| ``plugins/seed_generation/agents/evolver.py`` | Same — ``max_concurrent=16`` reference refreshed |
| ``plugins/seed_generation/agents/critic.py`` | Same — ``max_concurrent=16`` reference refreshed |
| ``docs/architecture/seed-generation-decision.md`` | Decision table ``max=16 / global max=8`` → ``DEFAULT_SEED_PIPELINE_CONCURRENCY (50) / DEFAULT_GLOBAL_CONCURRENCY (50)`` |
| ``core/llm/oauth_usage.py`` | Module docstring ``max_concurrent=2`` → ``DEFAULT_CLAUDE_CLI_LANE_MAX, currently 50`` |

## Verification
- [x] ``ruff check`` clean
- [x] ``ruff format --check`` clean
- [x] ``mypy`` clean (461 source files)
- [x] Grep verification: no remaining ``max_concurrent=2/4/16`` or ``claude_cli=2`` / ``openai_api=16`` literals in ``core/`` / ``plugins/`` / ``autoresearch/`` / ``docs/``
- [x] No code semantics change (docstring-only)

## Reference
- PR-LANE-CAP-50: #1772 (2026-05-27)
- Pre-PR docstring values predated the cap raise; this PR brings them in lockstep with the live constants.