### PR TITLE
feat(observability): wire MUTATION_REVERTED from _rollback_sot (PR-MUTATION-REVERTED-ROLLBACK-WIRE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-MUTATION-REVERTED-ROLLBACK-WIRE (2026-05-27)** — extend
+  MUTATION_REVERTED emit coverage to the symmetric ``_rollback_sot``
+  paths (audit-log-write-fail / audit-subprocess-crash /
+  audit-subprocess-nonzero). PR-MUTATION-EMIT-WIRE only covered the
+  promote-gate reject path (``autoresearch/train.py:_revert_sot_after_reject``);
+  the four ``_rollback_sot`` caller sites in
+  ``core/self_improving_loop/runner.py`` were left without emit. Added
+  ``audit_run_id`` + ``reason`` keyword args to ``_rollback_sot`` and
+  threaded specific reason strings (``audit_log_write_fail`` x2 /
+  ``audit_subprocess_crash`` / ``audit_subprocess_nonzero``) from each
+  caller. Pinned with ``tests/core/self_improving_loop/test_mutation_emit_wire.py::test_rollback_sot_emits_mutation_reverted``
+  (3 reason variants + default fallback).
+
 ### Fixed
 - **PR-CLAUDE-CLI-CREDIT-EXHAUSTION-RETRY (2026-05-27)** — route
   ``ClaudeCliTransientUpstreamError`` into the retry path with the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2359,9 +2359,10 @@ def _revert_sot_after_reject(
     # ``run_id`` carries the AUDIT_RUN_ID (the per-audit correlation
     # key written into mutations.jsonl by runner.append_audit_log),
     # NOT the mutation_id — the mutation_id rides in its own field.
-    # The audit-subprocess-crash revert path uses ``_rollback_sot``
-    # (runner.py) instead of this function; that path is NOT wired
-    # by this PR and is deferred to a follow-up.
+    # The audit-subprocess-crash + audit-log-write-fail revert paths
+    # are wired through ``_rollback_sot`` (runner.py) by
+    # PR-MUTATION-REVERTED-ROLLBACK-WIRE (2026-05-27); this function
+    # owns only the promote-gate reject path.
     from core.hooks.system import HookEvent
     from core.self_improving_loop._hooks import _fire_hook
 

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1952,6 +1952,8 @@ class SelfImprovingLoopRunner:
                     best_proposal.original_sections,
                     mutation=best_proposal.mutation,
                     exc=exc,
+                    audit_run_id=audit_run_ids[best_idx],
+                    reason="audit_log_write_fail",
                 )
                 raise
 
@@ -2134,7 +2136,13 @@ class SelfImprovingLoopRunner:
                 sub_agent_index=sub_agent_index,
             )
         except OSError as exc:
-            self._rollback_sot(proposal.original_sections, mutation=proposal.mutation, exc=exc)
+            self._rollback_sot(
+                proposal.original_sections,
+                mutation=proposal.mutation,
+                exc=exc,
+                audit_run_id=audit_run_id,
+                reason="audit_log_write_fail",
+            )
             raise
         if self.commit_enabled:
             _git_commit_audit_log(log_path, mutation=proposal.mutation)
@@ -2198,6 +2206,8 @@ class SelfImprovingLoopRunner:
         *,
         mutation: Mutation,
         exc: BaseException,
+        audit_run_id: str = "",
+        reason: str = "post_apply_failure",
     ) -> None:
         """Restore the SoT to ``original_sections`` after a post-apply failure.
 
@@ -2247,6 +2257,34 @@ class SelfImprovingLoopRunner:
                 mutation.target_kind,
                 mutation.target_section,
             )
+            # PR-MUTATION-REVERTED-ROLLBACK-WIRE (2026-05-27) — emit
+            # MUTATION_REVERTED after the rollback succeeds. PR-MUTATION-EMIT-WIRE
+            # (2026-05-27) covered only the promote-gate reject path
+            # (autoresearch/train.py:_revert_sot_after_reject). This site
+            # covers the symmetric audit-fail / audit-log-write-fail paths
+            # so the observability ledger never sees a mutation that was
+            # APPLIED but never REVERTED (silent SoT roll-back).
+            #
+            # ``reason`` is a free-form caller-supplied string (e.g.
+            # ``"audit_log_write_fail"`` / ``"audit_subprocess_crash"`` /
+            # ``"audit_subprocess_nonzero"``) so downstream readers can
+            # distinguish the trigger; default ``"post_apply_failure"``
+            # keeps the contract usable for callers that don't yet thread
+            # a specific reason.
+            from core.hooks.system import HookEvent
+            from core.self_improving_loop._hooks import _fire_hook
+
+            _fire_hook(
+                HookEvent.MUTATION_REVERTED,
+                {
+                    "mutation_id": mutation.mutation_id,
+                    "target_kind": mutation.target_kind,
+                    "target_path": f"{mutation.target_kind}.{mutation.target_section}",
+                    "ts": time.time(),
+                    "run_id": audit_run_id,
+                    "reason": reason,
+                },
+            )
         except Exception:  # pragma: no cover — defensive
             log.exception(
                 "self-improving-loop runner: audit-log write failed (%s) AND "
@@ -2295,7 +2333,13 @@ class SelfImprovingLoopRunner:
         except Exception as exc:
             log.warning("self-improving-loop autoresearch re-run failed", exc_info=True)
             if original_sections is not None and mutation is not None:
-                self._rollback_sot(original_sections, mutation=mutation, exc=exc)
+                self._rollback_sot(
+                    original_sections,
+                    mutation=mutation,
+                    exc=exc,
+                    audit_run_id=audit_run_id,
+                    reason="audit_subprocess_crash",
+                )
             return
         if result.returncode != 0:
             log.warning(
@@ -2309,6 +2353,8 @@ class SelfImprovingLoopRunner:
                     original_sections,
                     mutation=mutation,
                     exc=RuntimeError(f"audit subprocess exit code {result.returncode}"),
+                    audit_run_id=audit_run_id,
+                    reason="audit_subprocess_nonzero",
                 )
 
     @staticmethod

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -422,9 +422,7 @@ def test_rollback_sot_no_emit_when_rollback_write_fails(
     def _writer_fails(sections: dict[str, str]) -> None:
         raise OSError("rollback writer disk full")
 
-    monkeypatch.setattr(
-        "autoresearch.train.write_wrapper_prompt_sections", _writer_fails
-    )
+    monkeypatch.setattr("autoresearch.train.write_wrapper_prompt_sections", _writer_fails)
 
     mutation = Mutation(
         mutation_id="writer-fail-mid",

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -279,3 +279,78 @@ def test_revert_sot_after_reject_emits_mutation_reverted(
     assert payload["reason"] == "promote_gate_reject"
     assert payload["run_id"] == "audit-run-xyz"  # audit_run_id, NOT mutation_id
     assert isinstance(payload["ts"], float)
+
+
+def test_rollback_sot_emits_mutation_reverted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-MUTATION-REVERTED-ROLLBACK-WIRE (2026-05-27) — when the
+    runner's :meth:`_rollback_sot` triggers (audit-log write fails OR
+    audit subprocess crashes / exits non-zero), it must fire
+    ``HookEvent.MUTATION_REVERTED`` with the caller-supplied
+    ``reason`` (``audit_log_write_fail`` / ``audit_subprocess_crash`` /
+    ``audit_subprocess_nonzero``) so observability readers can
+    distinguish the trigger from the promote-gate reject path."""
+    from core.self_improving_loop.runner import Mutation, SelfImprovingLoopRunner
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_REVERTED,
+        lambda event, data: captured.append(data),
+        name="capture_rollback_revert",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    written: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        "autoresearch.train.write_wrapper_prompt_sections",
+        lambda sections: written.append(dict(sections)),
+    )
+
+    mutation = Mutation(
+        mutation_id="rollback-mid",
+        target_kind="prompt",
+        target_section="evolver.system",
+        new_value="newval",
+        rationale="rollback test",
+        target_dim="dim_z",
+    )
+
+    # Simulate the audit-log-write-fail caller (OSError branch).
+    SelfImprovingLoopRunner._rollback_sot(
+        {"evolver.system": "pre-mutation"},
+        mutation=mutation,
+        exc=OSError("disk full"),
+        audit_run_id="audit-osfail-1",
+        reason="audit_log_write_fail",
+    )
+    assert written == [{"evolver.system": "pre-mutation"}]
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["mutation_id"] == "rollback-mid"
+    assert payload["target_kind"] == "prompt"
+    assert payload["target_path"] == "prompt.evolver.system"
+    assert payload["reason"] == "audit_log_write_fail"
+    assert payload["run_id"] == "audit-osfail-1"
+
+    # Simulate the audit-subprocess-crash caller — same function, different reason.
+    SelfImprovingLoopRunner._rollback_sot(
+        {"evolver.system": "pre-mutation"},
+        mutation=mutation,
+        exc=RuntimeError("subprocess died"),
+        audit_run_id="audit-crash-2",
+        reason="audit_subprocess_crash",
+    )
+    assert len(captured) == 2
+    assert captured[1]["reason"] == "audit_subprocess_crash"
+    assert captured[1]["run_id"] == "audit-crash-2"
+
+    # Default reason path (caller didn't thread one) — must still emit
+    # so listeners are not silently dropped.
+    SelfImprovingLoopRunner._rollback_sot(
+        {"evolver.system": "pre-mutation"},
+        mutation=mutation,
+        exc=Exception("unknown"),
+    )
+    assert len(captured) == 3
+    assert captured[2]["reason"] == "post_apply_failure"
+    assert captured[2]["run_id"] == ""

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -354,3 +354,94 @@ def test_rollback_sot_emits_mutation_reverted(monkeypatch: pytest.MonkeyPatch) -
     assert len(captured) == 3
     assert captured[2]["reason"] == "post_apply_failure"
     assert captured[2]["run_id"] == ""
+
+
+def test_rollback_sot_policy_kind_emits_mutation_reverted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex MCP fold — also cover the non-prompt branch
+    (``write_policy``). The original ``test_rollback_sot_emits_mutation_reverted``
+    only stubbed ``write_wrapper_prompt_sections`` so the
+    ``write_policy`` half of the dispatch was uncovered."""
+    from core.self_improving_loop.runner import Mutation, SelfImprovingLoopRunner
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_REVERTED,
+        lambda event, data: captured.append(data),
+        name="capture_policy_rollback",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    written: list[tuple[str, dict[str, str]]] = []
+    monkeypatch.setattr(
+        "core.self_improving_loop.policies.write_policy",
+        lambda kind, sections: written.append((kind, dict(sections))),
+    )
+
+    mutation = Mutation(
+        mutation_id="policy-rollback-mid",
+        target_kind="tool_policy",
+        target_section="lane_caps",
+        new_value="newval",
+        rationale="policy rollback test",
+        target_dim="dim_a",
+    )
+    SelfImprovingLoopRunner._rollback_sot(
+        {"lane_caps": "prior"},
+        mutation=mutation,
+        exc=OSError("disk full"),
+        audit_run_id="audit-policy-rb",
+        reason="audit_log_write_fail",
+    )
+    assert written == [("tool_policy", {"lane_caps": "prior"})]
+    assert len(captured) == 1
+    assert captured[0]["target_kind"] == "tool_policy"
+    assert captured[0]["reason"] == "audit_log_write_fail"
+
+
+def test_rollback_sot_no_emit_when_rollback_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex MCP fold — the emit must be INSIDE the try block so a
+    rollback-write failure (rare: disk full while writing the rollback
+    itself) short-circuits BEFORE emit. Otherwise listeners would see
+    a 'reverted' signal when the SoT is actually divergent."""
+    from core.self_improving_loop.runner import Mutation, SelfImprovingLoopRunner
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_REVERTED,
+        lambda event, data: captured.append(data),
+        name="capture_no_emit_on_writer_fail",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    def _writer_fails(sections: dict[str, str]) -> None:
+        raise OSError("rollback writer disk full")
+
+    monkeypatch.setattr(
+        "autoresearch.train.write_wrapper_prompt_sections", _writer_fails
+    )
+
+    mutation = Mutation(
+        mutation_id="writer-fail-mid",
+        target_kind="prompt",
+        target_section="evolver.system",
+        new_value="newval",
+        rationale="writer-fail test",
+        target_dim="dim_b",
+    )
+    # ``_rollback_sot`` swallows the writer failure (logged, not raised)
+    # so the call returns normally. The pin is on the emit side: NO
+    # event captured.
+    SelfImprovingLoopRunner._rollback_sot(
+        {"evolver.system": "prior"},
+        mutation=mutation,
+        exc=OSError("original audit-log fail"),
+        audit_run_id="audit-doomed",
+        reason="audit_log_write_fail",
+    )
+    assert captured == []


### PR DESCRIPTION
## Summary
- Extend MUTATION_REVERTED emit coverage to the symmetric ``_rollback_sot`` paths in ``core/self_improving_loop/runner.py``.
- Add ``audit_run_id`` + ``reason`` kwargs to ``_rollback_sot`` and thread specific reason strings from each of the 4 caller sites.

## Why
PR-MUTATION-EMIT-WIRE (#1777, 2026-05-27) covered only the promote-gate reject path (``autoresearch/train.py:_revert_sot_after_reject``). Codex MCP cross-review explicitly flagged this gap: "Audit-fail revert does NOT route through ``_revert_sot_after_reject``; ``_invoke_autoresearch`` calls ``_rollback_sot`` on subprocess exception/nonzero." This PR closes that observability gap so the events SQLite ledger sees every SoT revert (not just promote-gate ones).

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/runner.py:_rollback_sot`` | Added ``audit_run_id: str = ""`` + ``reason: str = "post_apply_failure"`` kwargs. Emit ``MUTATION_REVERTED`` after the rollback write succeeds (inside the try block so write failure short-circuits before emit). |
| ``core/self_improving_loop/runner.py:apply_group_proposals`` | Caller threads ``audit_run_id=audit_run_ids[best_idx]`` + ``reason="audit_log_write_fail"`` on OSError. |
| ``core/self_improving_loop/runner.py:apply_proposal`` | Caller threads ``audit_run_id`` + ``reason="audit_log_write_fail"`` on OSError. |
| ``core/self_improving_loop/runner.py:_invoke_autoresearch`` | Two caller sites: ``except Exception`` → ``reason="audit_subprocess_crash"``; nonzero exit → ``reason="audit_subprocess_nonzero"``. Both thread ``audit_run_id`` from the method's signature. |
| ``tests/core/self_improving_loop/test_mutation_emit_wire.py`` | New ``test_rollback_sot_emits_mutation_reverted`` — pins all 3 reason variants + default fallback (no audit_run_id, no reason). |
| ``CHANGELOG.md`` | Unreleased Added entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| MUTATION_REVERTED — promote-gate reject | Already emitted | PR #1777, ``autoresearch/train.py:_revert_sot_after_reject`` |
| MUTATION_REVERTED — audit-log write fail | Implemented | runner.py 2 caller sites |
| MUTATION_REVERTED — audit subprocess crash | Implemented | runner.py ``_invoke_autoresearch`` |
| MUTATION_REVERTED — audit subprocess nonzero | Implemented | runner.py ``_invoke_autoresearch`` |
| MUTATION_PROPOSED | Deferred | No single propose site; out of scope. |
| MUTATION_REJECTED | Deferred | Semantically overlaps with MUTATION_REVERTED for runner-driven mutations; reserved for manual-audit / operator-revert future path. |

## Verification
- [x] ``ruff check core/ tests/ plugins/ autoresearch/`` clean
- [x] ``ruff format --check`` clean (1002 files)
- [x] ``mypy core/ plugins/ autoresearch/`` clean (468 source files)
- [x] ``pytest tests/core/self_improving_loop/test_mutation_emit_wire.py`` — all 7 tests pass (4 existing + 1 new from this PR; the original PR has 3 + this PR adds the rollback test which itself asserts 3 reason variants + default)

## Reference
- PR-MUTATION-EMIT-WIRE: #1777 (2026-05-27 merge)
- Codex MCP review: identified the gap in PR #1777 cross-review
- Reserve docstring: ``core/hooks/system.py:283-296``