### PR TITLE
release: v0.99.74 — operations sprint + mutator feedback bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.74] - 2026-05-27
+
+> PATCH rotation bundling the 2026-05-27 operations sprint:
+> claude-cli credit-exhaustion retry (auto-bridges a 5h pool refresh
+> via the paperclip QUOTA_BACKOFF schedule), aggressive LaneQueue
+> raise to cap 50 across every workload + global lane, and
+> observability completion — every reserved MUTATION_*/BASELINE_PROMOTED
+> HookEvent (PR-HOOKEVENT-RESERVE 2026-05-26) now has live emit-site
+> coverage including the audit-fail / audit-log-write-fail revert
+> paths.
+
 ### Added
 - **PR-MUTATION-REVERTED-ROLLBACK-WIRE (2026-05-27)** — extend
   MUTATION_REVERTED emit coverage to the symmetric ``_rollback_sot``
@@ -108,6 +119,34 @@ functional change.
   emit (``"applied"`` + ``"applied_sibling"``) + ``_write_baseline``
   emit (BASELINE_PROMOTED) + ``_revert_sot_after_reject`` emit
   (MUTATION_REVERTED, ``run_id`` = audit_run_id).
+
+### Changed
+- **PR-LANE-CAP-50 (2026-05-27)** — raise every lane / queue
+  concurrency default to 50. Operator decision after the smoke 24
+  evolver phase 5/5 credit-exhaustion pattern + PR-LANE-CAP-AGGRESSIVE
+  (claude=4 / openai=16 / anthropic=8) didn't bridge the
+  Anthropic Max OAuth 5h pool refresh.
+  - ``core/orchestration/lane_queue.py``: ``DEFAULT_MAX_CONCURRENT``
+    4 → 50.
+  - ``core/wiring/container.py``: ``DEFAULT_GLOBAL_CONCURRENCY`` 8 →
+    50, ``DEFAULT_SEED_PIPELINE_CONCURRENCY`` 4 → 50. Gateway lane
+    intentionally unchanged at 4.
+  - Per-adapter lanes raised in lockstep: ``DEFAULT_CLAUDE_CLI_LANE_MAX``
+    4 → 50, ``DEFAULT_OPENAI_API_LANE_MAX`` 16 → 50,
+    ``DEFAULT_ANTHROPIC_API_LANE_MAX`` 8 → 50,
+    ``DEFAULT_CODEX_CLI_LANE_MAX`` 2 → 50.
+  - ``plugins/seed_generation/agents/ranker.py``:
+    ``DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`` 8 → 50 (matches the
+    per-adapter lane ceiling so cap 50 is equilibrium).
+  - The OpenClaw hierarchy invariant ``max(workload_lane) <=
+    max(global_lane)`` is preserved at the new 50/50 ceiling.
+- **PR-LANE-CAP-DOCS-CLEANUP (2026-05-27)** — refresh 5 stale
+  docstring / decision-doc references that still cited
+  ``max_concurrent=16`` (pilot.py, evolver.py, critic.py,
+  seed-generation-decision.md) or ``max_concurrent=2``
+  (oauth_usage.py) to reference the ``DEFAULT_*_CONCURRENCY``
+  constants with their post-PR-LANE-CAP-50 value (currently 50).
+  Docstring-only — no code semantics shift.
 
 ## [0.99.73] - 2026-05-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.73
+- **Version**: 0.99.74
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 390 core + 68 plugins = 458
-- **Tests**: 8291 (+5 live)
+- **Modules**: 393 core + 69 plugins = 462
+- **Tests**: 8485 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.73 — Long-running Autonomous Execution Harness
+# GEODE v0.99.74 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.73**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.74**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.73 — Long-running Autonomous Execution Harness
+# GEODE v0.99.74 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.73**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.74**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.73"
+version = "0.99.74"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.73"
+version = "0.99.74"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.74 rotation bundling the 2026-05-27 operations sprint + the mutator feedback bundle (PR #1779).
- Operations: claude-cli credit-exhaustion retry, LaneQueue cap 50, MUTATION_*/BASELINE_PROMOTED emit completion.
- Mutator: per-dim credit + (kind × dim) matrix feedback into prompt, difflib dedup guard, tool_descriptions graduation to TARGET_KINDS.

## Verification
- [x] geode-ci --fast ALL GREEN
- [x] pytest tests/core/self_improving_loop/ 486 passed
- [x] Codex MCP review APPROVED (4 paths converge on same SoT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)