### PR TITLE
feat(observability): emit MUTATION_PROPOSED at propose() (PR-MUTATION-PROPOSED-WIRE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-MUTATION-PROPOSED-WIRE (2026-05-27)** — emit
+  ``HookEvent.MUTATION_PROPOSED`` at
+  ``core/self_improving_loop/runner.py:propose`` after the LLM parse
+  + dedup gate + kind-aware SoT load all succeed, but BEFORE any
+  apply / audit. Closes the last remaining ``MUTATION_*`` emit gap
+  identified during the 2026-05-27 self-improving-loop observability
+  alignment audit (MUTATION_REJECTED stays deferred — semantic overlap
+  with MUTATION_REVERTED for runner-driven mutations). ``run_id`` is
+  empty in the payload because ``audit_run_id`` is minted later in
+  ``apply_proposal`` / ``apply_group_proposals``; listeners that need
+  to correlate proposed → applied join on ``mutation_id``. ``propose``
+  is the single entry point for single + group + swarm modes (group /
+  swarm call ``self.propose()`` internally), so this single emit-site
+  covers all three.
+
 ## [0.99.74] - 2026-05-27
 
 > PATCH rotation bundling the 2026-05-27 operations sprint:

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1670,6 +1670,27 @@ class SelfImprovingLoopRunner:
             raw_fitness = getattr(snapshot, "fitness", None)
             if isinstance(raw_fitness, int | float):
                 baseline_fitness = float(raw_fitness)
+        # PR-MUTATION-PROPOSED-WIRE (2026-05-27) — emit MUTATION_PROPOSED
+        # after the proposal has been built (LLM parse + dedup gate + SoT
+        # load all succeeded) but BEFORE any apply / audit. Payload schema
+        # per the reserve docstring (core/hooks/system.py:285-287). No
+        # ``run_id`` available here — the audit_run_id is minted later in
+        # apply_proposal / apply_group_proposals via :func:`_mint_audit_run_id`.
+        # Listeners that need to correlate proposed → applied join on
+        # ``mutation_id`` instead.
+        from core.hooks.system import HookEvent
+        from core.self_improving_loop._hooks import _fire_hook
+
+        _fire_hook(
+            HookEvent.MUTATION_PROPOSED,
+            {
+                "mutation_id": mutation.mutation_id,
+                "target_kind": mutation.target_kind,
+                "target_path": f"{mutation.target_kind}.{mutation.target_section}",
+                "ts": time.time(),
+                "run_id": "",
+            },
+        )
         return Proposal(
             mutation=mutation,
             target_sections=target_sections,

--- a/tests/core/self_improving_loop/test_mutation_emit_wire.py
+++ b/tests/core/self_improving_loop/test_mutation_emit_wire.py
@@ -401,6 +401,63 @@ def test_rollback_sot_policy_kind_emits_mutation_reverted(
     assert captured[0]["reason"] == "audit_log_write_fail"
 
 
+def test_propose_emits_mutation_proposed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-MUTATION-PROPOSED-WIRE (2026-05-27) —
+    :meth:`SelfImprovingLoopRunner.propose` emits ``MUTATION_PROPOSED``
+    after the proposal is built (LLM parse + dedup gate + SoT load
+    succeeded) but BEFORE any apply. Payload uses the same schema as
+    the other MUTATION_* variants; ``run_id`` is empty because the
+    audit_run_id is minted later in apply_proposal."""
+    import json
+
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    hooks = HookSystem()
+    captured: list[dict[str, Any]] = []
+    hooks.register(
+        HookEvent.MUTATION_PROPOSED,
+        lambda event, data: captured.append(data),
+        name="capture_mutation_proposed",
+    )
+    set_self_improving_loop_hooks(hooks)
+
+    # Stub the LLM call + context build so we don't hit real models or files.
+    canned_response = json.dumps(
+        {
+            "mutation_id": "proposed-mid",
+            "target_kind": "prompt",
+            "target_section": "evolver.system",
+            "new_value": "new prompt body",
+            "rationale": "test propose emit",
+            "target_dim": "dim_x",
+            "expected_dim": "dim_x",
+        }
+    )
+
+    def _stub_llm(system: str, user: str) -> str:
+        return canned_response
+
+    from core.self_improving_loop import runner as runner_mod
+
+    stub_ctx = runner_mod.RunnerContext(
+        current_sections={"evolver.system": "old prompt"},
+        current_policies={"prompt": {"evolver.system": "old prompt"}},
+    )
+    monkeypatch.setattr(runner_mod, "build_runner_context", lambda: stub_ctx)
+
+    sil = SelfImprovingLoopRunner(llm_call=_stub_llm)
+    proposal = sil.propose()
+
+    assert proposal.mutation.mutation_id == "proposed-mid"
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["mutation_id"] == "proposed-mid"
+    assert payload["target_kind"] == "prompt"
+    assert payload["target_path"] == "prompt.evolver.system"
+    assert payload["run_id"] == ""  # not minted yet at propose time
+    assert isinstance(payload["ts"], float)
+
+
 def test_rollback_sot_no_emit_when_rollback_write_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Wire ``HookEvent.MUTATION_PROPOSED`` emit at ``runner.propose()`` — the last MUTATION_* emit gap identified during the 2026-05-27 SIL observability alignment audit.
- Single emit-site covers single + group + swarm modes (group/swarm route through ``self.propose()``).

## Why
PR-HOOKEVENT-RESERVE (2026-05-26) reserved 5 MUTATION_*/BASELINE_PROMOTED events. The wire-up landed across PR #1777 (APPLIED + REVERTED + BASELINE_PROMOTED) and PR #1780 (REVERTED audit-fail paths). The 2026-05-27 SIL observability alignment audit flagged ``MUTATION_PROPOSED`` as the remaining true gap (``MUTATION_REJECTED`` is intentionally deferred — semantic overlap with REVERTED for runner-driven mutations).

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/runner.py:propose`` | Emit ``MUTATION_PROPOSED`` after LLM parse + dedup gate + kind-aware SoT load succeed; before ``return Proposal(...)``. ``run_id=""`` (audit_run_id is minted later by ``apply_proposal``). |
| ``tests/core/self_improving_loop/test_mutation_emit_wire.py`` | New ``test_propose_emits_mutation_proposed`` stubs LLM + ``RunnerContext`` to isolate the emit. |
| ``CHANGELOG.md`` | Unreleased Added entry. |

## GAP Audit
| Event | Status | Notes |
|-------|--------|-------|
| MUTATION_PROPOSED | Implemented (this PR) | ``runner.propose()`` |
| MUTATION_APPLIED | Already wired | PR #1777 |
| MUTATION_REVERTED | Already wired | PR #1777 + #1780 (4 reason variants) |
| BASELINE_PROMOTED | Already wired | PR #1777 |
| MUTATION_REJECTED | Deferred | Semantic overlap with REVERTED for runner-driven mutations; reserved for manual-audit / operator-revert path |
| SELF_IMPROVING_AUTO_TRIGGER_* (6) | Already wired (dynamic dispatch via ``auto_trigger._emit_state_event``) | Was a false negative in the initial audit |

## Verification
- [x] ``ruff check core/ tests/ plugins/ autoresearch/`` clean
- [x] ``ruff format --check`` clean (1006 files)
- [x] ``mypy core/ plugins/`` clean (463 source files)
- [x] ``pytest tests/core/self_improving_loop/test_mutation_emit_wire.py`` — all 10 tests pass (9 prior + 1 new)

## Reference
- 2026-05-27 SIL observability alignment audit (this session)
- PR-MUTATION-EMIT-WIRE: #1777
- PR-MUTATION-REVERTED-ROLLBACK-WIRE: #1780
- Reserve docstring: ``core/hooks/system.py:283-296``