### PR TITLE
fix(tests): repair 4 develop-main test failures from PR #1779

### DIFF
--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -230,7 +230,9 @@ def test_adr_cites_train_py_dim_weights_location() -> None:
 
 def test_active_slots_registered_as_mutation_targets() -> None:
     """S0d (2026-05-21) — retrieval deprecated; M1 — skill_catalog 추가;
-    M2 (2026-05-21) — agent_contract 추가 → 6 active slot."""
+    M2 (2026-05-21) — agent_contract 추가; PR-TOOL-DESCRIPTIONS-MUTATE
+    (2026-05-27, #1779) — tool_descriptions graduated from reader-only
+    to active mutation target → 7 active slot."""
     import importlib
 
     mod = importlib.import_module("core.self_improving_loop.policies")
@@ -238,12 +240,15 @@ def test_active_slots_registered_as_mutation_targets() -> None:
     expected = {
         "prompt",
         "tool_policy",
+        "tool_descriptions",
         "decomposition",
         "reflection",
         "skill_catalog",
         "agent_contract",
     }
-    assert target_kinds == expected, f"TARGET_KINDS 는 {expected} (post-M2). got={target_kinds}"
+    assert target_kinds == expected, (
+        f"TARGET_KINDS 는 {expected} (post-tool_descriptions). got={target_kinds}"
+    )
     assert "retrieval" not in target_kinds, "retrieval 은 S0d 이후 deprecate 유지"
 
 

--- a/tests/test_e1_mutation_cost_ledger.py
+++ b/tests/test_e1_mutation_cost_ledger.py
@@ -239,6 +239,8 @@ def test_propose_populates_cost_from_sidecar(
     mock_ctx.current_sections = {"# Setup": "current setup content"}
     mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
     mock_ctx.target_dim = ""
+    mock_ctx.mutator_feedback_block = ""
+    mock_ctx.recent_applies_for_dedup = ()
     monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
     monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")
 
@@ -285,6 +287,8 @@ def test_propose_clears_last_call_before_invocation(
     mock_ctx.current_sections = {"# Setup": "current setup content"}
     mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
     mock_ctx.target_dim = ""
+    mock_ctx.mutator_feedback_block = ""
+    mock_ctx.recent_applies_for_dedup = ()
     monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
     monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")
 

--- a/tests/test_e1_mutation_cost_ledger.py
+++ b/tests/test_e1_mutation_cost_ledger.py
@@ -159,6 +159,18 @@ def _build_propose_runner(
     mock_ctx.current_sections = {"# Setup": "current setup content"}
     mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
     mock_ctx.target_dim = ""
+    # PR-FIX-DEVELOP-TEST-BREAKAGE (2026-05-27) — PR-MUTATOR-HISTORY-FEEDBACK
+    # (#1779) added a new ``ctx.mutator_feedback_block`` block read in
+    # ``_build_user_prompt``. Pre-PR the MagicMock auto-returned a
+    # MagicMock for the missing attr → ``"\n\n".join(blocks)`` failed
+    # with "expected str instance, MagicMock found". Set explicitly to
+    # empty string so the falsy guard at
+    # ``runner.py:_build_user_prompt`` skips appending.
+    mock_ctx.mutator_feedback_block = ""
+    # PR-MUTATOR-DEDUP-GUARD (#1779) — also reads
+    # ``ctx.recent_applies_for_dedup`` to gate the dedup guard. Empty
+    # tuple → guard skipped (legacy behaviour).
+    mock_ctx.recent_applies_for_dedup = ()
     monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
     # apply 가 disk 안 건드리도록 path mock
     monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")


### PR DESCRIPTION
## Summary
- Repair 4 pre-existing test failures on develop that landed via PR #1779 (mutator-feedback-bundle).
- All 4 are tests-only edits — no production code change.

## Why
PR #1779 (mutator-feedback-bundle, merged 2026-05-27) introduced two breaking changes that weren't reflected in tests:
1. **TARGET_KINDS** grew from 6 → 7 members (added ``tool_descriptions`` via PR-TOOL-DESCRIPTIONS-MUTATE) but the ADR-012 surface-tier test's expected set stayed at 6.
2. **``ctx.mutator_feedback_block``** field added to RunnerContext + read in ``_build_user_prompt``. The 3 ``test_e1_mutation_cost_ledger`` test fixtures use ``MagicMock()`` for the ctx, so the missing attr auto-returned a MagicMock → ``"\n\n".join(blocks)`` failed with ``"expected str instance, MagicMock found"``.

This caused 4 CI failures on every PR opened after #1779 merged, including PR #1783 (PR-MUTATION-PROPOSED-WIRE) which had to be admin-merged.

## Changes
| File | Change |
|------|--------|
| ``tests/test_adr_012_surface_tiers.py`` | ``test_active_slots_registered_as_mutation_targets``: expected set ``{prompt, tool_policy, decomposition, reflection, skill_catalog, agent_contract}`` → adds ``tool_descriptions`` (7 members). |
| ``tests/test_e1_mutation_cost_ledger.py`` | 3 MagicMock fixtures: set ``mock_ctx.mutator_feedback_block = ""`` + ``mock_ctx.recent_applies_for_dedup = ()`` so the falsy guards in ``_build_user_prompt`` skip the new feedback block append. |

## Verification
- [x] ``ruff check core/ tests/ plugins/`` clean
- [x] ``ruff format --check`` clean
- [x] ``mypy core/ plugins/`` clean
- [x] ``pytest tests/test_adr_012_surface_tiers.py tests/test_e1_mutation_cost_ledger.py`` — all 34 tests green (3 prior failures now pass)

## Reference
- PR #1779: feat(self-improving-loop): mutator history feedback + dedup guard + tool_descriptions graduation
- Failure cascade caught by PR #1783 CI