### PR TITLE
fix(runner): correct parents[N] in repo_root + raise budget cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,39 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-RUNNER-REPO-ROOT-FIX (2026-05-27)** — repair the off-by-one
+  ``parents[N]`` arithmetic at three call sites in
+  ``core/self_improving_loop/runner.py`` (the
+  ``_git_commit_audit_log`` git operations and both
+  ``_invoke_autoresearch`` repo_root computations). PR-G5b
+  (2026-05-20) moved the audit log from
+  ``<repo>/state/mutations.jsonl`` to
+  ``<repo>/autoresearch/state/mutations.jsonl`` but the three
+  ``parents[1]`` derivations were not updated, so they resolved to
+  ``<repo>/autoresearch`` instead of the repo root. Latent because
+  unit tests mock the subprocess and live runs went through
+  ``geode audit-seeds generate`` / ``autoresearch/train.py``
+  directly; surfaces as ``[Errno 2] No such file or directory:
+  '<repo>/autoresearch/autoresearch/train.py'`` on the first real
+  ``SelfImprovingLoopRunner.run_once()`` with ``rerun_enabled=True``.
+  All three sites now use ``parents[2]``. Pinned by
+  ``tests/test_runner_repo_root_invariant.py`` (three assertions:
+  filesystem invariant, negative invariant on ``parents[1]``, and
+  source-level regex to fail-fast on a future regression).
+
+### Changed
+- **Self-improving loop config** —
+  ``[self_improving_loop.autoresearch] budget_minutes`` upper bound
+  raised from 60 to 600 minutes
+  (``core/config/self_improving_loop.py``). The 60-minute cap dated
+  from Pattern B's initial subscription-only scope; production
+  audits with multi-seed re-measurement (8+ seeds × judge+auditor
+  + claude-cli OAuth handshakes) routinely need 90-180 minutes.
+  Operators were forced to inline-edit the pydantic constraint to
+  exceed the cap. Lower bound (1 minute) and default (5 minutes)
+  unchanged.
+
 ### Added
 - **PR-MUTATION-PROPOSED-WIRE (2026-05-27)** — emit
   ``HookEvent.MUTATION_PROPOSED`` at

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -223,7 +223,7 @@ class AutoresearchConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    budget_minutes: Annotated[int, Field(ge=1, le=60)] = 5
+    budget_minutes: Annotated[int, Field(ge=1, le=600)] = 5
 
     # Step J-b.1 — role sub-fields (the SoT relocation).
     target: PetriRoleConfig = Field(default_factory=PetriRoleConfig)

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1403,7 +1403,12 @@ def _git_commit_audit_log(
     argv without running real git.
     """
     try:
-        repo_root = log_path.resolve().parents[1]
+        # parents[2] = repo root. ``log_path`` is
+        # ``<repo>/autoresearch/state/mutations.jsonl``; parents[1]
+        # resolves to ``<repo>/autoresearch`` which is *inside* the git
+        # tree but is not the repo root and would silently rebase git
+        # operations against a non-canonical cwd.
+        repo_root = log_path.resolve().parents[2]
         subprocess.run(  # noqa: S603  # nosec B603 — argv = audit-log path
             ["git", "add", str(log_path)],  # noqa: S607  # nosec B607 — git in PATH
             cwd=str(repo_root),
@@ -1895,7 +1900,9 @@ class SelfImprovingLoopRunner:
                 audit_run_id = _mint_audit_run_id()
                 audit_run_ids.append(audit_run_id)
 
-                repo_root = (self.audit_log_path or MUTATION_AUDIT_LOG_PATH).resolve().parents[1]
+                # parents[2] = repo root (see apply_proposal note above —
+                # MUTATION_AUDIT_LOG_PATH = <repo>/autoresearch/state/mutations.jsonl).
+                repo_root = (self.audit_log_path or MUTATION_AUDIT_LOG_PATH).resolve().parents[2]
 
                 proc = _run_autoresearch_subprocess(
                     repo_root=repo_root,
@@ -2271,7 +2278,11 @@ class SelfImprovingLoopRunner:
         if self.commit_enabled:
             _git_commit_audit_log(log_path, mutation=proposal.mutation)
         if self.rerun_enabled:
-            repo_root = log_path.resolve().parents[1]
+            # MUTATION_AUDIT_LOG_PATH lives at <repo>/autoresearch/state/mutations.jsonl,
+            # so parents[2] is the repo root. parents[1] would point at
+            # <repo>/autoresearch and spawn `uv run python autoresearch/train.py`
+            # with cwd=autoresearch → ENOENT on autoresearch/autoresearch/train.py.
+            repo_root = log_path.resolve().parents[2]
             # PR-SOT-REVERT-ON-AUDIT-FAIL (2026-05-26) — forward
             # ``proposal.original_sections`` so _invoke_autoresearch can
             # rollback the canonical SoT if the audit subprocess crashes

--- a/tests/test_runner_repo_root_invariant.py
+++ b/tests/test_runner_repo_root_invariant.py
@@ -1,0 +1,99 @@
+"""Regression pin for the ``repo_root`` computation used by
+
+``SelfImprovingLoopRunner.apply_proposal`` and
+``apply_group_proposals`` when they invoke the autoresearch
+re-audit subprocess.
+
+Both call sites derive ``repo_root`` from
+``MUTATION_AUDIT_LOG_PATH.resolve().parents[N]`` and then pass it as
+``cwd`` to ``_run_autoresearch_subprocess``. The argv inside that
+subprocess is ``["uv", "run", "python", "autoresearch/train.py"]``,
+so the cwd MUST be the repo root — otherwise the relative path
+resolves to ``<wrong-root>/autoresearch/train.py`` and the
+subprocess exits with ``[Errno 2]`` before any audit work happens.
+
+Latent bug history: PR-G5b (2026-05-20) moved the audit log from
+``<repo>/state/mutations.jsonl`` to
+``<repo>/autoresearch/state/mutations.jsonl``. The ``parents[1]``
+arithmetic at the two call sites was not updated and the bug
+slept because (a) tests mocked the subprocess and (b) live runs
+went through ``geode audit-seeds generate`` / ``train.py`` directly
+rather than the inner-loop runner. This test fails on a regression
+by asserting the resolved repo root actually contains
+``autoresearch/train.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.paths import MUTATION_AUDIT_LOG_PATH
+
+
+@pytest.fixture
+def audit_log_path() -> Path:
+    return Path(MUTATION_AUDIT_LOG_PATH)
+
+
+def test_mutation_audit_log_lives_two_levels_below_repo_root(
+    audit_log_path: Path,
+) -> None:
+    """``parents[2]`` of the audit log path is the repo root.
+
+    Pin: ``MUTATION_AUDIT_LOG_PATH`` =
+    ``<repo>/autoresearch/state/mutations.jsonl`` → ``parents[2]``
+    is the directory containing ``autoresearch/train.py``.
+    """
+    repo_root = audit_log_path.resolve().parents[2]
+    assert (repo_root / "autoresearch" / "train.py").is_file(), (
+        f"repo_root={repo_root!r} does not contain autoresearch/train.py — "
+        f"the parents[2] offset is wrong or the audit log path moved again."
+    )
+
+
+def test_parents_one_is_not_repo_root(
+    audit_log_path: Path,
+) -> None:
+    """``parents[1]`` points at ``autoresearch/`` not the repo root.
+
+    Direct negative pin: if some future refactor flips back to
+    ``parents[1]``, the subprocess argv ``autoresearch/train.py``
+    against this cwd resolves to ``autoresearch/autoresearch/train.py``
+    which does not exist. This test asserts that exact non-existence
+    so the wrong cwd cannot silently pass.
+    """
+    wrong_root = audit_log_path.resolve().parents[1]
+    wrong_path = wrong_root / "autoresearch" / "train.py"
+    assert not wrong_path.exists(), (
+        f"Unexpected: {wrong_path!r} exists — runner.py's parents[2] arithmetic "
+        f"was chosen against parents[1] precisely because parents[1] "
+        f"resolves to the autoresearch/ subdirectory, not the repo root."
+    )
+
+
+def test_runner_apply_proposal_uses_correct_parents_offset() -> None:
+    """The two ``parents[N]`` call sites in ``runner.py`` must use ``parents[2]``.
+
+    Source-level pin: greps the runner module so a regression to
+    ``parents[1]`` on either call site fails before any subprocess
+    spawn. Catches the off-by-one bug introduced after PR-G5b
+    moved the audit log under ``autoresearch/state/``.
+    """
+    from core.self_improving_loop import runner
+
+    source = Path(runner.__file__).read_text(encoding="utf-8")
+    # Both call sites should now read parents[2]; parents[1] must not
+    # appear in any repo_root computation downstream of MUTATION_AUDIT_LOG_PATH
+    # / self.audit_log_path / log_path. We guard with a substring scan rather
+    # than AST parsing because the patterns are unambiguous and the file is
+    # already line-stable here.
+    forbidden = [
+        "log_path.resolve().parents[1]",
+        "MUTATION_AUDIT_LOG_PATH).resolve().parents[1]",
+    ]
+    for needle in forbidden:
+        assert needle not in source, (
+            f"runner.py still contains {needle!r} — re-introducing the "
+            f"off-by-one bug. Replace with parents[2]."
+        )


### PR DESCRIPTION
## Summary
- Correct off-by-one `parents[N]` arithmetic at 3 callsites in `core/self_improving_loop/runner.py` — `parents[1]` was pointing at `<repo>/autoresearch` instead of the repo root after PR-G5b moved the audit log under `autoresearch/state/`
- Raise `[self_improving_loop.autoresearch] budget_minutes` pydantic upper bound from 60 to 600 to accommodate Pattern B subscription-mode audits that need 90-180 min for multi-seed re-measurement
- Add 3-assertion regression pin (`tests/test_runner_repo_root_invariant.py`) to fail-fast on any future `parents[1]` re-introduction

## Why
First surfaced as `[Errno 2] No such file or directory: '<repo>/autoresearch/autoresearch/train.py'` when `SelfImprovingLoopRunner.run_once(rerun_enabled=True)` was invoked for the first real closed-loop validation cycle (`baseline → mutation → re-audit → promote/revert`). The path doubling happened because the runner's subprocess argv `["uv", "run", "python", "autoresearch/train.py"]` was joined with cwd=`<repo>/autoresearch` (wrong root) instead of `<repo>` (correct root).

Latent because (a) unit tests mock the audit subprocess and (b) all prior live runs went through `geode audit-seeds generate` / direct `autoresearch/train.py` invocation, never through the inner-loop runner's `_invoke_autoresearch`. The second blocker (60-min budget cap) was hit immediately after — operators legitimately need longer budgets for multi-seed audits and were forced to inline-edit the pydantic constraint.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | 3 callsites: `parents[1]` → `parents[2]` (`_git_commit_audit_log`, `apply_proposal` rerun branch, `apply_group_proposals` sibling rerun). Comments added explaining why parents[2]. |
| `core/config/self_improving_loop.py` | `budget_minutes` pydantic `Field(ge=1, le=60)` → `Field(ge=1, le=600)`. Default (5) and lower bound (1) unchanged. |
| `tests/test_runner_repo_root_invariant.py` | New: 3 assertions — (a) filesystem invariant (`parents[2]` contains `autoresearch/train.py`), (b) negative invariant (`parents[1]` does NOT), (c) source-level regex to fail-fast on `parents[1]` re-introduction. |
| `CHANGELOG.md` | Add PR-RUNNER-REPO-ROOT-FIX entry under `[Unreleased]` (Fixed + Changed). |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 1001 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 463 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_runner_repo_root_invariant.py tests/test_self_improving_loop_config.py tests/test_autoresearch_train.py tests/test_policy_mutation.py tests/test_self_improving_minimal_2.py` — passes
- [ ] Full E2E (live closed-loop cycle 1) — will re-attempt after merge + rebuild

## Reference
- Original PR-G5b (2026-05-20) moved `mutations.jsonl` under `autoresearch/state/`
- Surfaced 2026-05-27 during first real `run_once(rerun_enabled=True, rerun_dry_run=False)` invocation
