### PR TITLE
fix(audit): bootstrap LLM adapters in audit subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-AUDIT-ADAPTER-BOOTSTRAP-FIX (2026-05-27)** — call
+  ``core.llm.adapters.registry.bootstrap_builtins()`` inside
+  ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``
+  before constructing ``AgenticLoop``. The inspect-ai audit
+  subprocess (``uv run inspect eval inspect_petri/audit``) does not
+  go through ``core.wiring.container._build_llm_adapters`` — the
+  parent's wiring bootstrap path — so the subprocess's adapter
+  registry was empty (``Known pairs: []``) and every target
+  ``generate`` call failed with
+  ``AdapterNotFoundError: provider='openai' source='payg'``.
+  Latent because no unit test exercised the audit subprocess
+  end-to-end with a live target; surfaced during the first real
+  ``SelfImprovingLoopRunner.run_once(rerun_enabled=True,
+  rerun_dry_run=False)`` invocation, where target inference happened
+  zero times across 8 seeds × 5 max_turns × 5 samples and every
+  ``dim_means`` returned ``inspect_petri`` placeholder values —
+  rendering the autoresearch fitness signal a fake-success surface
+  that would have driven the promote/revert gate on bogus data.
+  Mirrors the equivalent fix at ``core/agent/worker.py:817-823`` for
+  the sub-agent worker subprocess (identical wiring gap). Pinned by
+  ``tests/test_geode_target_adapter_bootstrap.py`` (3 assertions:
+  source-level pin, idempotency contract, codex-oauth + claude-cli
+  registration after bootstrap).
 - **PR-RUNNER-REPO-ROOT-FIX (2026-05-27)** — repair the off-by-one
   ``parents[N]`` arithmetic at three call sites in
   ``core/self_improving_loop/runner.py`` (the

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -282,7 +282,20 @@ async def _default_geode_runner(
     #
     # ``disable_settings_drift`` is True iff the caller explicitly pinned
     # a target model — see N6-followup priority docstring above.
+    # The inspect-ai audit subprocess (``uv run inspect eval inspect_petri/audit``)
+    # does not go through ``core.wiring.container._build_llm_adapters``, the
+    # parent's bootstrap path. Without an explicit ``bootstrap_builtins()``
+    # here the registry is empty (``Known pairs: []``) and every target
+    # ``generate`` call inside this runner fails with
+    # ``AdapterNotFoundError: provider='openai' source='payg'``. Mirrors the
+    # ``core/agent/worker.py:817-823`` pattern for the sub-agent worker
+    # subprocess, which has the identical wiring gap. Idempotent — safe to
+    # re-call when the parent already populated the registry.
+    from core.llm.adapters.registry import bootstrap_builtins
+
     from core.llm.adapters import infer_provider_from_model
+
+    bootstrap_builtins()
 
     loop = AgenticLoop(
         ctx,

--- a/tests/test_geode_target_adapter_bootstrap.py
+++ b/tests/test_geode_target_adapter_bootstrap.py
@@ -1,0 +1,140 @@
+"""Regression pin for ``plugins/petri_audit/targets/geode_target.py``'s
+adapter-registry bootstrap.
+
+The inspect-ai audit subprocess (``uv run inspect eval inspect_petri/audit``)
+does not go through ``core.wiring.container._build_llm_adapters``, the
+parent's wiring bootstrap path. Without an explicit ``bootstrap_builtins()``
+call before constructing ``AgenticLoop`` inside ``_default_geode_runner``,
+the audit subprocess's adapter registry stays empty and every target
+``generate(messages, ...)`` call inside the runner fails with
+``AdapterNotFoundError: provider='openai' source='payg'. Known pairs: []``.
+
+Latent until 2026-05-27 because no test exercised the audit subprocess
+end-to-end with a real target invocation. Surfaced when
+``SelfImprovingLoopRunner.run_once(rerun_enabled=True, rerun_dry_run=False)``
+was driven for the first real closed-loop validation cycle: target
+inference happened 0 times across 8 seeds × 5 max_turns × 5 samples;
+all dim_means returned ``inspect_petri`` default values, making the
+fitness signal that drives the autoresearch promote/revert gate a
+fake-success surface.
+
+Mirrors the equivalent fix at ``core/agent/worker.py:817-823`` for the
+sub-agent worker subprocess, which has the identical wiring gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_default_geode_runner_calls_bootstrap_builtins() -> None:
+    """Source-level pin: the runner module references ``bootstrap_builtins``.
+
+    Greps ``plugins/petri_audit/targets/geode_target.py`` for the
+    ``bootstrap_builtins`` symbol so a future refactor that drops the
+    call (e.g. import rearrangement, function extraction) fails the
+    test before the audit subprocess fake-success regression re-lands.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    assert "bootstrap_builtins" in source, (
+        "geode_target.py no longer references bootstrap_builtins(); the "
+        "audit subprocess will revert to AdapterNotFoundError on the next "
+        "live audit. Re-add the call before AgenticLoop construction in "
+        "_default_geode_runner — see worker.py:817 for the pattern."
+    )
+    assert "bootstrap_builtins()" in source, (
+        "bootstrap_builtins must be CALLED (not merely imported) inside "
+        "_default_geode_runner. The audit subprocess's wiring container "
+        "is the parent's, not this one's — registry stays empty without "
+        "an explicit call."
+    )
+
+
+def test_bootstrap_builtins_is_idempotent_so_double_call_is_safe() -> None:
+    """``bootstrap_builtins`` is safe to call when the registry is populated.
+
+    The fix in ``_default_geode_runner`` calls ``bootstrap_builtins()``
+    unconditionally on every runner entry, on the assumption the call is
+    cheap and idempotent. This test pins that assumption so a future
+    refactor that makes the call expensive (e.g. by changing it from
+    "skip-if-registered" to "fail-if-registered") doesn't silently
+    introduce a hot-path crash.
+    """
+    from core.llm.adapters.registry import (
+        _REGISTRY,
+        _reset_for_test,
+        bootstrap_builtins,
+        list_adapters,
+    )
+
+    try:
+        _reset_for_test()
+        assert len(_REGISTRY) == 0, "registry not cleared by _reset_for_test"
+
+        bootstrap_builtins()
+        first_pass = list_adapters()
+        assert len(first_pass) > 0, (
+            "bootstrap_builtins did not register any adapters; the audit "
+            "subprocess will still see Known pairs=[]."
+        )
+
+        bootstrap_builtins()  # idempotent — no raise
+        second_pass = list_adapters()
+        assert second_pass == first_pass, (
+            "second bootstrap_builtins() call changed the registry. The "
+            "runner expects calling the function on a populated registry "
+            "to be a no-op."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()  # restore for any downstream tests
+
+
+def test_bootstrap_registers_codex_oauth_for_petri_target() -> None:
+    """The ``codex-oauth`` adapter (backs Petri ``target`` source) must be registered.
+
+    ``config.toml`` pins ``[self_improving_loop.petri.target] source =
+    "openai-codex"`` — a Petri-surface alias that
+    ``plugins/petri_audit/models.py`` routes to the canonical
+    ``codex-oauth`` adapter inside the GEODE registry.
+    ``_default_geode_runner`` resolves the source via
+    ``resolve_for(provider, source)`` inside ``AgenticLoop``. If the
+    canonical adapter is not registered after ``bootstrap_builtins()``,
+    the lookup falls back to ``source='payg'`` and triggers
+    ``AdapterNotFoundError`` (the fake-success path that motivated this
+    PR). Pin the registration so a future ``bootstrap_builtins``
+    refactor that drops the codex-oauth import is caught here.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        list_adapters,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        names = {a.name for a in list_adapters()}
+        # Canonical adapter name (registered by CodexOAuthAdapter) — the
+        # Petri-surface ``openai-codex`` alias resolves through this.
+        assert "codex-oauth" in names, (
+            f"codex-oauth adapter missing after bootstrap. Registered: "
+            f"{sorted(names)!r}. The Petri target inference will fail."
+        )
+        # Also pin claude-cli (auditor + judge source) so a regression
+        # that drops either bootstrap surfaces in a single test rather
+        # than as a remote AdapterNotFoundError during a live audit.
+        assert "claude-cli" in names, (
+            f"claude-cli adapter missing after bootstrap. Registered: "
+            f"{sorted(names)!r}. The Petri auditor + judge will fail."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()


### PR DESCRIPTION
## Summary
- Call `bootstrap_builtins()` inside `plugins/petri_audit/targets/geode_target.py:_default_geode_runner` so the inspect-ai audit subprocess populates its adapter registry before `AgenticLoop.resolve_for(provider, source)` is invoked.
- Add regression pin (`tests/test_geode_target_adapter_bootstrap.py`) — source-level reference, idempotency, `codex-oauth` + `claude-cli` post-bootstrap presence.

## Why
First surfaced during the first real closed-loop validation cycle (`SelfImprovingLoopRunner.run_once(rerun_enabled=True, rerun_dry_run=False)`). Inspect-ai trace logs (`~/Library/Application Support/inspect_ai/traces/trace-*.log`) showed **57 `AdapterNotFoundError` retries** in both the baseline and post-mutation audits with the signature `provider='openai' source='payg'. Known pairs: []` — the registry was completely empty in the audit subprocess.

Mechanism: `uv run inspect eval inspect_petri/audit` spawns a Python subprocess that imports `plugins/petri_audit/targets/geode_target.py` but **never goes through `core.wiring.container._build_llm_adapters`** — the parent process's wiring bootstrap path. Without an explicit call inside the runner, the subprocess's `_REGISTRY` stayed at `{}` and every target `generate(messages, ...)` call short-circuited before any LLM round-trip. Result: target inference happened **zero times across 8 seeds × 5 max_turns × 5 samples**, and every `dim_means` value returned was an `inspect_petri` placeholder. The autoresearch promote/revert gate would have been driven on entirely fake fitness data.

Mirrors the **identical** wiring gap and the **identical** fix already in place at `core/agent/worker.py:817-823` for the sub-agent worker subprocess (PR comment: *"the worker subprocess does not go through `core.wiring.container._build_llm_adapters` (the parent's wiring bootstrap), so without an explicit `bootstrap_builtins()` here the worker's registry is empty and every sub-agent call crashes with `AdapterNotFoundError: Known pairs: []`."*).

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/targets/geode_target.py` | Add `from core.llm.adapters.registry import bootstrap_builtins; bootstrap_builtins()` inside `_default_geode_runner`, immediately before `AgenticLoop(...)` construction. Idempotent; safe to call on every runner entry. |
| `tests/test_geode_target_adapter_bootstrap.py` | New file — three assertions: (a) source-level greppable reference to `bootstrap_builtins`, (b) idempotency contract (double-call leaves registry unchanged), (c) post-bootstrap registry contains both `codex-oauth` (Petri target backing) and `claude-cli` (auditor + judge source). |
| `CHANGELOG.md` | Add PR-AUDIT-ADAPTER-BOOTSTRAP-FIX entry under `[Unreleased]`. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check` — already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 463 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_geode_target_adapter_bootstrap.py` — 3 passed
- [ ] Live E2E (real closed-loop cycle with actual target inference) — will run after merge + rebuild

## Reference
- Audit trace evidence: `~/Library/Application Support/inspect_ai/traces/trace-39622.log.gz` (baseline run, 57 AdapterNotFoundError) + `trace-96727.log` (cycle 1 retry, identical signature).
- Sibling fix precedent: `core/agent/worker.py:817-823` (PR #1572 / MAINPATH-1 follow-up).
