### PR TITLE
fix(audit): route target (provider, source) through get_binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-AUDIT-TARGET-SOURCE-WIRE (2026-05-27)** — route the audit
+  subprocess's target ``(provider, source)`` resolution through
+  ``plugins/petri_audit/registry.get_binding("target", model=...)``
+  in ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``,
+  then pass the resolved ``source`` to ``AgenticLoop(..., source=...)``.
+  Previously the runner constructed ``AgenticLoop`` with only the
+  ``provider`` kwarg and silently inherited the default
+  ``source="payg"``, so the operator's
+  ``[self_improving_loop.petri.target] source`` /
+  ``[petri.target] source`` setting was ignored. On Pattern B
+  (subscription-only with ``fallback_to_payg=false``) every target
+  ``generate`` call surfaced as
+  ``OpenAIPaygAdapter: OPENAI_API_KEY not set`` even with the
+  ``codex-oauth`` source explicitly configured. The fix uses the
+  same resolver the manual ``geode audit`` CLI consults, so the three
+  source categories — PAYG (``openai-payg`` / ``anthropic-payg``),
+  subscription OAuth (``claude-cli`` / ``codex-oauth`` /
+  ``anthropic-oauth``), and local CLI (``codex-cli``) — all reach
+  ``AgenticLoop`` as the operator configured them. Pinned by
+  ``tests/test_geode_target_source_wiring.py`` (8 assertions:
+  source-level paren-balanced scan for ``source=`` kwarg,
+  ``get_binding`` reference, six parametrised category × source
+  checks for adapter registration post-bootstrap).
 - **PR-AUDIT-ADAPTER-BOOTSTRAP-FIX (2026-05-27)** — call
   ``core.llm.adapters.registry.bootstrap_builtins()`` inside
   ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -297,12 +297,47 @@ async def _default_geode_runner(
 
     bootstrap_builtins()
 
+    # PR-AUDIT-TARGET-SOURCE-WIRE (2026-05-27) — resolve the (provider,
+    # source) pair through ``get_binding("target", ...)`` so the audit
+    # subprocess's adapter selection honours the operator's
+    # ``[self_improving_loop.petri.target] source`` / ``[petri.target]
+    # source`` settings instead of falling through to AgenticLoop's
+    # default ``source="payg"`` and then failing with
+    # ``OPENAI_API_KEY not set`` on subscription-only environments
+    # (Pattern B). ``get_binding`` returns the same source the manual
+    # ``geode audit`` CLI resolves, so the audit subprocess + manual
+    # audit + autoresearch closed-loop now share one source SoT.
+    resolved_provider = infer_provider_from_model(model) if model else "anthropic"
+    resolved_source = ""
+    if model:
+        try:
+            from plugins.petri_audit.registry import get_binding
+
+            binding = get_binding("target", model=model)
+            resolved_provider = binding.provider
+            resolved_source = binding.source
+        except Exception:
+            # get_binding can raise if the model is not in the role
+            # manifest's allowed_models list (manual override / custom
+            # model). Fall through to provider inference + AgenticLoop
+            # default source — preserves legacy behaviour for callers
+            # that have not migrated their config to the [petri.target]
+            # section yet. Logged at DEBUG so production noise stays
+            # quiet but post-mortems can trace the fallback.
+            log.debug(
+                "geode_target: get_binding('target', model=%s) failed; "
+                "falling back to inferred provider + default source",
+                model,
+                exc_info=True,
+            )
+
     loop = AgenticLoop(
         ctx,
         executor,
         system_suffix=system_text,
         model=model,
-        provider=infer_provider_from_model(model) if model else "anthropic",
+        provider=resolved_provider,
+        source=resolved_source,
         disable_settings_drift=(model is not None),
     )
     log.debug(

--- a/tests/test_geode_target_source_wiring.py
+++ b/tests/test_geode_target_source_wiring.py
@@ -1,0 +1,139 @@
+"""Regression pin for ``geode_target._default_geode_runner``'s source
+wiring into ``AgenticLoop``.
+
+The audit subprocess invokes the GEODE target through
+``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``.
+Until 2026-05-27 the runner passed only ``provider=...`` to
+``AgenticLoop`` and silently inherited the default ``source="payg"``,
+so the operator's ``[self_improving_loop.petri.target] source`` /
+``[petri.target] source`` setting was ignored. On Pattern B
+(subscription-only, ``fallback_to_payg=false``) this surfaced as
+``OpenAIPaygAdapter: OPENAI_API_KEY not set`` for every target call —
+indistinguishable from a real adapter-missing error in the trace.
+
+The fix routes the (provider, source) pair through
+``plugins/petri_audit/registry.get_binding("target", model=...)``, the
+same resolver the manual ``geode audit`` CLI uses, so the three
+source categories (PAYG / subscription / local-cli) all reach
+``AgenticLoop`` exactly as the operator configured them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_default_geode_runner_passes_source_argument() -> None:
+    """Source-level pin: AgenticLoop is constructed with a ``source=`` kwarg.
+
+    Greps ``plugins/petri_audit/targets/geode_target.py`` for the
+    ``source=`` keyword inside the ``AgenticLoop(...)`` construction
+    so a future refactor that drops the argument fails this test
+    before the audit-subprocess fake-success path re-emerges.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    # The construction site we care about is `loop = AgenticLoop(`.
+    # The source kwarg must appear before the closing paren.
+    construct_idx = source.index("loop = AgenticLoop(")
+    paren_open = source.index("(", construct_idx)
+    # Find the matching close paren — paren-balanced scan, since the
+    # ctor body contains nested calls/conditionals.
+    depth = 1
+    cursor = paren_open + 1
+    while depth > 0 and cursor < len(source):
+        ch = source[cursor]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        cursor += 1
+    ctor_body = source[paren_open:cursor]
+    assert "source=" in ctor_body, (
+        "AgenticLoop(...) is constructed without a `source=` argument; "
+        "the audit subprocess will silently fall back to "
+        "AgenticLoop's default source='payg' and the operator's "
+        "[petri.target] source config will be ignored. Pass the "
+        "binding's source explicitly — see get_binding('target', ...)."
+    )
+
+
+def test_default_geode_runner_uses_get_binding() -> None:
+    """Behavioural pin: the runner consults the binding registry.
+
+    ``get_binding`` is the single resolver shared with the manual
+    ``geode audit`` CLI; using it guarantees the audit subprocess
+    resolves the same source the operator gets at the command line.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    assert "get_binding(" in source, (
+        "geode_target.py no longer calls get_binding(...). The audit "
+        "subprocess will diverge from the manual `geode audit` CLI's "
+        "source resolution. Use plugins.petri_audit.registry.get_binding."
+    )
+
+
+@pytest.mark.parametrize(
+    "category,source_value",
+    [
+        # PAYG — API-key path. OpenAIPaygAdapter / AnthropicPaygAdapter /
+        # GlmPaygAdapter. Operator sets ``[petri.target] source = "payg"``
+        # to force per-token billing.
+        ("PAYG", "anthropic-payg"),
+        ("PAYG", "openai-payg"),
+        # Subscription OAuth — claude-cli (Anthropic Max), codex-oauth
+        # (ChatGPT Plus). These ride the operator's interactive
+        # subscription quota.
+        ("subscription", "claude-cli"),
+        ("subscription", "codex-oauth"),
+        ("subscription", "anthropic-oauth"),
+        # Local CLI subprocess — codex-cli wraps a local Codex
+        # binary. Lower-latency option when an OAuth subscription is
+        # unavailable.
+        ("local-cli", "codex-cli"),
+    ],
+)
+def test_bootstrap_registers_all_three_source_categories(category: str, source_value: str) -> None:
+    """Each source the operator may configure resolves to a registered adapter.
+
+    The full set of three categories (PAYG / subscription / local-cli)
+    must be present after ``bootstrap_builtins()`` so
+    ``AgenticLoop._new_adapter = resolve_for(provider, source)`` does
+    not raise ``AdapterNotFoundError`` regardless of which credential
+    path the operator selects. A regression that drops one of the
+    eight builtin adapter imports surfaces here per-source rather
+    than as a remote audit-subprocess failure.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        list_adapters,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        names = {a.name for a in list_adapters()}
+        assert source_value in names, (
+            f"{category} source {source_value!r} not registered after "
+            f"bootstrap. Registered: {sorted(names)!r}. The audit "
+            f"subprocess will fail when operator configures this source."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()


### PR DESCRIPTION
## Summary
- Resolve the audit subprocess's target `(provider, source)` via `plugins/petri_audit/registry.get_binding("target", model=...)` inside `plugins/petri_audit/targets/geode_target.py:_default_geode_runner` and pass the resolved `source` to `AgenticLoop(..., source=...)`.
- Add regression pin (`tests/test_geode_target_source_wiring.py`, 8 assertions) covering paren-balanced kwarg scan, `get_binding` reference, and adapter-registration for all three source categories (PAYG / subscription OAuth / local CLI).

## Why
Third (and final, for the closed-loop validation path) wiring defect in the audit subprocess chain. PR #1785 fixed `repo_root parents[N]`; PR #1787 added `bootstrap_builtins()` so the registry is populated. With those merged, `AgenticLoop._new_adapter = resolve_for(provider, source)` no longer raises `AdapterNotFoundError: Known pairs: []` — but it still resolved to `OpenAIPaygAdapter` because `geode_target.py` never threaded `source` through. AgenticLoop's `__init__` defaults `self._source = source or "payg"` (`core/agent/loop/agent_loop.py:392`), so every target call landed on the PAYG path. On Pattern B configs (`fallback_to_payg=false`, subscription only) this surfaced as `OpenAIPaygAdapter: OPENAI_API_KEY not set` for every target generate — indistinguishable in the inspect-ai trace from the earlier "registry empty" failure.

Per operator request, all three source categories must reach `AgenticLoop` cleanly:
- **PAYG**: `openai-payg`, `anthropic-payg`, `glm-payg`, `glm-coding-plan` (API-key billing).
- **Subscription OAuth**: `claude-cli` (Anthropic Max), `codex-oauth` (ChatGPT Plus), `anthropic-oauth`.
- **Local CLI**: `codex-cli` (local Codex subprocess).

The fix routes through `get_binding("target", model=...)`, the same resolver the manual `geode audit` CLI consults — so the audit subprocess, the manual command-line audit, and the autoresearch closed-loop all now share one source SoT (`~/.geode/petri.toml` `[petri.<role>]` + the `core/config/self_improving_loop.py` `[self_improving_loop.petri.<role>]` cascade).

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/targets/geode_target.py` | Call `get_binding("target", model=model)` before constructing `AgenticLoop`; pass `binding.provider` + `binding.source`. Falls back to inferred provider + empty source on `get_binding` failure (e.g. model outside the role's `allowed_models`), preserving legacy behaviour for manual / custom-model invocations. |
| `tests/test_geode_target_source_wiring.py` | New 8-assertion regression pin. |
| `CHANGELOG.md` | Add PR-AUDIT-TARGET-SOURCE-WIRE entry under `[Unreleased]`. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 1003 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 463 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_geode_target_source_wiring.py tests/test_geode_target_adapter_bootstrap.py tests/test_runner_repo_root_invariant.py` — 14 passed
- [ ] Live E2E (real closed-loop with all 3 source categories) — runs after merge + rebuild

## Reference
- Wiring chain history: PR #1785 (repo_root) → PR #1787 (adapter bootstrap) → this PR (source kwarg).
- Trace evidence (post PR #1787): `~/Library/Application Support/inspect_ai/traces/trace-28821.log` — 0 `AdapterNotFoundError`, 60+ `OpenAIPaygAdapter: OPENAI_API_KEY not set` WARNINGs from default `source="payg"`.
- Sibling resolver call site: `plugins/petri_audit/cli_audit.py` already routes manual `geode audit` through `get_binding`; this PR brings the audit-subprocess path into parity.
