### PR TITLE
release: v0.99.75 → main (cap walk-back + audit target-source wiring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,48 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.75] - 2026-05-27
+
+> PATCH rotation walking back v0.99.74's PR-LANE-CAP-50 raise after
+> the gen1-broken_tool_use smoke (2026-05-27 04:12 KST) froze the
+> 16 GB M3 host: 50 concurrent ``claude --print`` spawns ≈ 21 GB peak
+> RSS overwhelmed the box. The original cap-50 reasoning held in
+> isolation (Anthropic 50 RPM tier ceiling) but ignored a tighter
+> local floor — Node V8 spawn cost. Plus the develop-merged audit
+> adapter bootstrap fix, runner repo-root parents arithmetic repair,
+> and MUTATION_PROPOSED emit-site completion that were already
+> accumulated on develop.
+
+### Changed
+- **PR-LANE-CAP-CONSERVATIVE (2026-05-27)** — lower the three
+  freeze-implicated default caps after measuring per-subprocess RSS
+  on the freeze host (M3 16 GB):
+  - ``DEFAULT_CLAUDE_CLI_LANE_MAX`` 50 → **5**
+    (``core/orchestration/claude_cli_lane.py``). Each
+    ``claude --print`` is a fresh Node V8 (~425 MB resident);
+    50 × 425 MB ≈ 21 GB on a 16 GB host → macOS compressor thrash.
+  - ``DEFAULT_OPENAI_API_LANE_MAX`` 50 → **10**
+    (``core/orchestration/openai_api_lane.py``). Paired at
+    ``2 × claude_cli_lane`` so the standard 1-claude + 2-codex
+    voter panel saturates both lanes exactly when
+    ``ranker_max_inflight=5``.
+  - ``DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`` 50 → **5**
+    (``plugins/seed_generation/agents/ranker.py``). Matches the
+    ``claude_cli_lane`` cap so the ``asyncio.gather`` submission
+    queue depth = 0 instead of bursting past the lane.
+  Operator override knobs (``GEODE_CLAUDE_CLI_LANE_MAX`` /
+  ``GEODE_OPENAI_API_LANE_MAX`` /
+  ``GEODE_RANKER_MAX_INFLIGHT_MATCHES``) are unchanged; operators on
+  larger hosts (32 GB+) should raise all three in lockstep using the
+  rule-of-thumb table in each module's docstring. Sibling lanes that
+  don't spawn subprocesses (``anthropic_api_lane`` HTTP-only,
+  ``global``, ``seed-generation``) stay at cap 50 — they are not
+  RSS-bounded. Test pins updated:
+  ``tests/core/orchestration/test_openai_api_lane.py::test_default_max_concurrent_is_ten`` +
+  ``tests/plugins/seed_generation/test_ranker_semaphore.py::test_default_is_five``;
+  the claude-cli lane test references ``DEFAULT_CLAUDE_CLI_LANE_MAX``
+  by name so it tracks the constant automatically.
+
 ### Fixed
 - **PR-AUDIT-ADAPTER-BOOTSTRAP-FIX (2026-05-27)** — call
   ``core.llm.adapters.registry.bootstrap_builtins()`` inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Fixed
+- **PR-AUDIT-TARGET-SOURCE-WIRE (2026-05-27)** — route the audit
+  subprocess's target ``(provider, source)`` resolution through
+  ``plugins/petri_audit/registry.get_binding("target", model=...)``
+  in ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``,
+  then pass the resolved ``source`` to ``AgenticLoop(..., source=...)``.
+  Previously the runner constructed ``AgenticLoop`` with only the
+  ``provider`` kwarg and silently inherited the default
+  ``source="payg"``, so the operator's
+  ``[self_improving_loop.petri.target] source`` /
+  ``[petri.target] source`` setting was ignored. On Pattern B
+  (subscription-only with ``fallback_to_payg=false``) every target
+  ``generate`` call surfaced as
+  ``OpenAIPaygAdapter: OPENAI_API_KEY not set`` even with the
+  ``codex-oauth`` source explicitly configured. The fix uses the
+  same resolver the manual ``geode audit`` CLI consults, so the three
+  source categories — PAYG (``openai-payg`` / ``anthropic-payg``),
+  subscription OAuth (``claude-cli`` / ``codex-oauth`` /
+  ``anthropic-oauth``), and local CLI (``codex-cli``) — all reach
+  ``AgenticLoop`` as the operator configured them. Pinned by
+  ``tests/test_geode_target_source_wiring.py`` (8 assertions:
+  source-level paren-balanced scan for ``source=`` kwarg,
+  ``get_binding`` reference, six parametrised category × source
+  checks for adapter registration post-bootstrap).
 - **PR-AUDIT-ADAPTER-BOOTSTRAP-FIX (2026-05-27)** — call
   ``core.llm.adapters.registry.bootstrap_builtins()`` inside
   ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.74
+- **Version**: 0.99.75
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.74 — Long-running Autonomous Execution Harness
+# GEODE v0.99.75 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.74**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.75**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.74 — Long-running Autonomous Execution Harness
+# GEODE v0.99.75 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.74**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.75**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/llm/oauth_usage.py
+++ b/core/llm/oauth_usage.py
@@ -14,12 +14,14 @@ Why this exists
 The :class:`Lane` introduced in Phase 2
 (:mod:`core.orchestration.claude_cli_lane`) caps concurrent
 ``claude --print`` fan-out at ``DEFAULT_CLAUDE_CLI_LANE_MAX``
-(currently 50, raised from 2 by PR-LANE-CAP-50 2026-05-27). That cap
-is necessary but not sufficient: the 5-hour token bucket can be 90 %
-drained while the burst limiter is fully reset, and the next acquire
-would burn the last few percent for marginal value. paperclip solves
-this by polling ``/api/oauth/usage`` before each spawn and backing
-off when ``five_hour.utilization >= 0.8``.
+(currently 5 after PR-LANE-CAP-CONSERVATIVE v0.99.75; previously
+raised to 50 by PR-LANE-CAP-50 v0.99.74 before the 16 GB host
+freeze incident). That cap is necessary but not sufficient: the
+5-hour token bucket can be 90 % drained while the burst limiter
+is fully reset, and the next acquire would burn the last few
+percent for marginal value. paperclip solves this by polling
+``/api/oauth/usage`` before each spawn and backing off when
+``five_hour.utilization >= 0.8``.
 
 Path notes
 ==========

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -26,42 +26,41 @@ lane is too restrictive for non-Claude-CLI traffic (API-billed
 Anthropic / OpenAI completions). The two flows need separate caps,
 which is why this lane sits alongside ``global`` rather than under it.
 
-Why ``max_concurrent=50`` (PR-LANE-CAP-50, 2026-05-27)
-============================================================
+Why ``max_concurrent=5`` (PR-LANE-CAP-CONSERVATIVE, v0.99.75, 2026-05-27)
+========================================================================
 
-Raised from 2 (PR-RANKER-PARALLEL conservative default) to 4 per
-operator decision "공격적으로 늘려" + the measured PR-RANKER-PARALLEL
-burst evidence (Loop 1: 59 matches × 1 anthropic voter = 59
-``claude --print`` forks queued behind the prior cap-2 ceiling, tail
-latency past 5min).
+Lowered from 50 (PR-LANE-CAP-50, same-day release v0.99.74) to **5**
+after the ranker smoke on a 16 GB M3 froze the host machine. The
+upstream rate-limit reasoning (Anthropic 50 RPM tier ceiling) was
+correct in isolation but ignored a tighter floor — **local RAM**.
 
-**Burst-limiter reality**: Claude Code's documented sub-agent burst
-floor is 3-4 *exclusive of* the operator's host session — the host's
-own OAuth claim does NOT consume a sub-agent slot. So cap 4 = 4
-``claude --print`` sub-agents running concurrently against the
-shared 5h pool, with the host's interactive session as a separate
-budget line item. The two share the same 5h pool *token total* but
-their inflight counts are independent.
+**Measured local cost** (M3 16 GB, 2026-05-27):
 
-**Aggressive headroom trade-off**: Cap 4 sits at the upper edge of
-the documented floor. Two stacked watch-outs:
+* `claude --print` subprocess RSS: ~425 MB per voter (Node V8 + bundled
+  deps; fresh process each spawn — see
+  `paperclip/packages/adapter-utils/src/server-utils.ts:1943` for the
+  canonical `child_process.spawn` pattern this lane shadow-fires).
+* Ranker burst at cap 50 with 3-voter panel = 50 matches × 1 claude
+  voter = 50 × 425 MB ≈ **21 GB anonymous RSS** on a 16 GB box. macOS
+  enters compressor thrash within ~60s, paging unrelated apps out, host
+  freezes.
 
-1. **Pool exhaustion still possible** — the 5h pool's *token*
-   budget is a separate ceiling. Smoke 25 (2026-05-26) hit
-   ``model_action_required`` after ~2h of sustained sub-agent
-   traffic. Cap-raise alone doesn't prevent that; the pool must
-   refresh before resume.
-2. **Host session contention**: if the operator's interactive
-   session is mid-multi-turn while a smoke runs at cap 4, the
-   shared 5h pool drains faster. Operators on Max20x tier with
-   larger pools may raise via :data:`CLAUDE_CLI_LANE_MAX_ENV`;
-   operators on lower tiers may lower to 2-3.
+**Cap derivation**: Operator's realistic burst budget after closing
+heavy desktop apps (Slack/Chrome/Notion) ≈ 3 GB. Per-match cost =
+1 claude (425 MB) + 2 codex (62 MB) = ~487 MB. ``3 GB / 487 MB ≈ 6.3``
+→ cap 5 keeps peak burst at ~2.4 GB with a 0.7 GB safety margin
+before compressor pressure becomes pathological.
 
-**Pre-flight measurement gap**: [[project_lanequeue_handoff_2026_05_22]]
-called for a one-time measurement of the actual burst threshold.
-The PR-LANE-CAP-AGGRESSIVE raise rests on smoke-24-25 empirical
-data (cap 2 demonstrably idle ~95% of the 5h pool RPM budget)
-rather than the original public-doc grounding.
+**Trade-off**: Ranker phase wall-clock grows from ~1 min (cap 50)
+to ~12-25 min for a 50-match Loop 1. Acceptable for nightly /
+autonomous smokes; painful for dev iteration — operators on larger
+boxes (32 GB+) should override via
+:data:`CLAUDE_CLI_LANE_MAX_ENV` (e.g. ``=20`` for 64 GB Mac Studio).
+
+**Upstream rate-limit headroom**: Even at cap 5, steady-state
+throughput against Anthropic's 5h pool sits well below the
+documented per-account ceiling, so neither floor (RPM nor token
+pool) is the binding constraint — the local RSS one is.
 
 Why module-level (not LaneQueue-registered)
 ===========================================
@@ -133,24 +132,27 @@ silently fall back to the default — the lane should never harden into
 "no slots" mid-run because of a typo.
 """
 
-DEFAULT_CLAUDE_CLI_LANE_MAX = 50
-"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 2 to 4.
+DEFAULT_CLAUDE_CLI_LANE_MAX = 5
+"""PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — lowered from 50.
 
-Documented Claude Code burst-limiter floor is 3-4 slots per 5h pool.
-Operator's host Claude Code session occupies 1 slot; the remaining 3
-go to ranker / mutator / audit-spawned sub-agents. Pre-raise the
-ranker's ``asyncio.gather`` burst (`ranker.py:256`) queued all
-voter-side claude-cli calls behind 2-slot cap → 89 × 70s = ~104min
-worst-case lane queue wait, well past the (also raised) 7200s
-timeout. The new cap matches the documented public floor exactly,
-with the host slot accounted for, so a long-running smoke (Loop 1
-ranker with 59 matches × 1 anthropic voter = 59 claude-cli forks) no
-longer creates a queue depth deeper than the 5h pool can sustain.
+The previous PR-LANE-CAP-50 default targeted the Anthropic per-account
+RPM ceiling but ignored local RSS: each ``claude --print`` spawn loads
+a fresh Node V8 (~425 MB resident, measured on the host that froze).
+50 × 425 MB ≈ 21 GB peak anonymous RSS on a 16 GB box → macOS
+compressor thrash → host freeze (incident: gen1-broken_tool_use
+ranker phase, 2026-05-27 04:12 KST).
 
-Operator override via :data:`CLAUDE_CLI_LANE_MAX_ENV` for Max20x tier
-operators with larger 5h pools (5-6) or single-account audit hosts
-that need to push to the documented 4-slot ceiling without host-
-session contention."""
+Cap 5 derives from realistic local headroom (~3 GB after closing
+heavy desktop apps) ÷ per-match cost (~487 MB = 1 claude + 2 codex)
+with a 0.7 GB safety margin. Trade-off — ranker phase wall-clock
+~12-25× slower than cap 50, but the host survives.
+
+Operator override via :data:`CLAUDE_CLI_LANE_MAX_ENV`:
+* 16 GB box (this default): leave at 5.
+* 32 GB box: raise to ~10.
+* 64 GB+ Mac Studio / Linux server: raise to 20-50.
+* The Anthropic RPM ceiling kicks in well above any local-RSS-safe
+  cap on consumer hardware, so this knob is for memory, not quota."""
 
 CLAUDE_CLI_LANE_TIMEOUT_S = 7200.0
 """PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to

--- a/core/orchestration/openai_api_lane.py
+++ b/core/orchestration/openai_api_lane.py
@@ -15,26 +15,31 @@ Distinct from ``codex_cli_lane`` because:
 - ``openai_api_lane`` gates **direct API call** (no subprocess, just
   ``openai.AsyncOpenAI.responses.create``); 429 surface differs.
 
-Why ``max_concurrent=50``
-========================
+Why ``max_concurrent=10`` (PR-LANE-CAP-CONSERVATIVE, v0.99.75)
+=============================================================
 
-Mid-range default selected from three reference points:
+Lowered from 50 (PR-LANE-CAP-50, v0.99.74) to **10** alongside the
+same-PR claude-cli lane drop. Local-RSS reasoning is identical to
+``claude_cli_lane.py``: a ranker burst at cap 50 panel-fires ~150
+voter tasks (50 × 3) and the host froze.
 
-1. **OpenAI Codex Responses API**: ChatGPT subscription bucket
-   is documented to support ~500 RPM aggregate across all models
-   (per the public Codex CLI roll-out post-2025-Q4). gpt-5.x voter
-   calls average ~10s wallclock; 4 inflight × 10s = 0.4s/call
-   serialised throughput ≈ 150 RPM — well under 500.
-2. **codex_cli_lane=2** + ``audit_lane=1`` consume 3 slots of the
-   per-account budget when CLI flows are also active; the API lane
-   sits on top, so 4 keeps total per-account inflight ≤ 7.
-3. **PR-RANKER-PARALLEL** (the immediate consumer): for the typical
-   2-codex + 1-claude-cli voter panel, 4 codex slots = 2 matches'
-   worth of concurrent codex voters — paired with claude_cli_lane=2
-   the two match-side bottlenecks balance.
+Codex API calls are *not* subprocess-based — they fire from the
+parent Python process via ``openai.AsyncOpenAI.responses.create``,
+so the per-task cost is ~31 MB (measured on the freeze host, codex
+subprocess RSS — the API path stays in-process Python and is even
+cheaper). The cap-10 ceiling is **paired with** the new
+claude_cli_lane cap of 5: for the 1-claude + 2-codex panel,
+``ranker_max_inflight=5`` saturates 5 claude slots and 10 codex
+slots simultaneously without bursting.
 
-Operator override via :data:`OPENAI_API_LANE_MAX_ENV` for tiers with
-higher quotas.
+**Upstream RPM headroom retained**: ChatGPT subscription bucket
+documents ~500 RPM aggregate; cap 10 with ~10s voter wallclock =
+~60 RPM — still 8× below the ceiling, so this is *not* a quota
+governor any more, just a panel-balance one.
+
+Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Operators
+with bigger boxes raising ``claude_cli_lane`` should raise this
+in proportion (2× the new claude cap is the panel rule).
 
 Why module-level (not LaneQueue-registered)
 ===========================================
@@ -75,24 +80,24 @@ OPENAI_API_LANE_NAME = "openai-api"
 OPENAI_API_LANE_MAX_ENV = "GEODE_OPENAI_API_LANE_MAX"
 """Operator override for :data:`DEFAULT_OPENAI_API_LANE_MAX`."""
 
-DEFAULT_OPENAI_API_LANE_MAX = 50
-"""PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 4 to 16.
+DEFAULT_OPENAI_API_LANE_MAX = 10
+"""PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — lowered from 50.
 
-OpenAI Codex Responses API documents a 500 RPM aggregate per ChatGPT
-subscription bucket (verified against operator's ``prolite`` plan via
-the JWT's ``rate_limit`` claim window). Voter calls land in 10-15s
-wallclock each, so steady-state throughput = ``60s / call * cap``.
-At cap 16 that's ~64-96 RPM — well under the 500 RPM ceiling, even
-counting the codex_cli_lane (2 slots) + audit_lane (1 slot) running
-concurrently. Pre-raise the cap 4 only used ~24 RPM of the available
-500 budget; the burst from PR-RANKER-PARALLEL (2 × 59 codex voters
-inside ``asyncio.gather``) would queue 110+ calls behind the 4-slot
-cap → 1700s+ tail latency.
+Paired with ``claude_cli_lane=5`` for the standard 1-claude + 2-codex
+voter panel: ``ranker_max_inflight=5`` × 2 codex voters = 10 in-flight
+codex calls, exactly saturating this cap. The 50→10 drop is a sibling
+correction of the same-day claude-cli cap drop (see
+``claude_cli_lane.py`` for the freeze incident that motivated the
+sprint).
 
-Operator override via :data:`OPENAI_API_LANE_MAX_ENV` for tier
-upgrades or downgrades; the env stays the recommended tuning knob,
-the new default is a sane aggressive ceiling for the documented
-prolite/pro/enterprise tiers."""
+Throughput-wise this still leaves ~440 RPM of the documented 500 RPM
+ChatGPT subscription headroom unused — the binding constraint is
+panel balance, not OpenAI quota.
+
+Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Rule of thumb:
+keep this at ``2 × claude_cli_lane`` for cross-provider panels;
+operators running codex-only panels (no claude voter) can raise
+freely up to the 500 RPM tier ceiling."""
 
 OPENAI_API_LANE_TIMEOUT_S = 7200.0
 """PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -1126,9 +1126,9 @@ def register() -> None:
             prompt = serialise_messages_to_prompt(input)
             # PR-LQ-Phase2 (2026-05-22) — share the
             # claude-cli-subagent lane with the self-improving-loop
-            # mutator path so the host OAuth bucket sees at most
-            # ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (raised to 4 in
-            # PR-LANE-CAP-AGGRESSIVE 2026-05-27 from the prior =2)
+            # mutator path so the host OAuth bucket (and now the host
+            # *RAM*) sees at most ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (5
+            # after PR-LANE-CAP-CONSERVATIVE v0.99.75, 2026-05-27)
             # concurrent ``claude --print`` subprocesses. The lane runs
             # the blocking semaphore wait in a worker thread so the
             # event loop is not pinned while queued.

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -297,12 +297,47 @@ async def _default_geode_runner(
 
     bootstrap_builtins()
 
+    # PR-AUDIT-TARGET-SOURCE-WIRE (2026-05-27) — resolve the (provider,
+    # source) pair through ``get_binding("target", ...)`` so the audit
+    # subprocess's adapter selection honours the operator's
+    # ``[self_improving_loop.petri.target] source`` / ``[petri.target]
+    # source`` settings instead of falling through to AgenticLoop's
+    # default ``source="payg"`` and then failing with
+    # ``OPENAI_API_KEY not set`` on subscription-only environments
+    # (Pattern B). ``get_binding`` returns the same source the manual
+    # ``geode audit`` CLI resolves, so the audit subprocess + manual
+    # audit + autoresearch closed-loop now share one source SoT.
+    resolved_provider = infer_provider_from_model(model) if model else "anthropic"
+    resolved_source = ""
+    if model:
+        try:
+            from plugins.petri_audit.registry import get_binding
+
+            binding = get_binding("target", model=model)
+            resolved_provider = binding.provider
+            resolved_source = binding.source
+        except Exception:
+            # get_binding can raise if the model is not in the role
+            # manifest's allowed_models list (manual override / custom
+            # model). Fall through to provider inference + AgenticLoop
+            # default source — preserves legacy behaviour for callers
+            # that have not migrated their config to the [petri.target]
+            # section yet. Logged at DEBUG so production noise stays
+            # quiet but post-mortems can trace the fallback.
+            log.debug(
+                "geode_target: get_binding('target', model=%s) failed; "
+                "falling back to inferred provider + default source",
+                model,
+                exc_info=True,
+            )
+
     loop = AgenticLoop(
         ctx,
         executor,
         system_suffix=system_text,
         model=model,
-        provider=infer_provider_from_model(model) if model else "anthropic",
+        provider=resolved_provider,
+        source=resolved_source,
         disable_settings_drift=(model is not None),
     )
     log.debug(

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -108,34 +108,35 @@ def _serialise_match_outcome(outcome: MatchOutcome) -> dict[str, Any]:
     }
 
 
-# PR-LANE-CAP-50 (2026-05-27) — phase-local concurrency cap for the
-# ranker's ``asyncio.gather`` match-dispatch burst. The cap exists
-# *on top* of the per-adapter lanes (claude_cli=50 / openai_api=50 /
-# anthropic_api=50) to bound the gather submission queue depth.
+# PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — phase-local
+# concurrency cap for the ranker's ``asyncio.gather`` match-dispatch
+# burst. Sits on top of the per-adapter lanes (claude_cli=5 /
+# openai_api=10) and is sized to match them exactly so the gather
+# submission queue doesn't grow a hidden depth.
 #
 # Concurrency budget (default 3-voter panel = 2 codex + 1 claude-cli):
-#   50 matches inflight * 3 voters = 150 voter tasks
-#     - claude-cli tasks: 50 (1 per match) — exactly claude_cli_lane=50
-#     - codex tasks: 100 (2 per match) — 50 inflight + 50 in lane queue
-#   Net: claude-cli saturated, codex 50% utilised with depth-50 queue.
-#   Operator raised lane caps in lockstep so cap 50 is equilibrium
-#   for the documented per-account RPM ceilings (Anthropic tier 1
-#   50 RPM, Codex 500 RPM); higher tiers absorb burst headroom.
+#   5 matches inflight * 3 voters = 15 voter tasks
+#     - claude-cli tasks: 5 (1 per match) — saturates claude_cli_lane=5
+#     - codex tasks: 10 (2 per match)    — saturates openai_api_lane=10
+#   Net: all three caps balance with zero queue behind them.
 #
-# Pre-PR-LANE-CAP-50 (PR-LANE-CAP-AGGRESSIVE, cap 8) gave a 24-task
-# inflight ceiling. Pre-PR-RANKER-PARALLEL (no semaphore) a 59-match
-# Loop 1 burst would push 177 task objects into ``asyncio.wait``
-# queues simultaneously; lanes throttled the subprocess/API side but
-# the awaiting task list itself becomes a memory + scheduler tax.
-# Cap 50 lets the gather "in-flight" stay at 150 voter tasks across
-# the three lanes, with smaller surplus serialised behind the
-# semaphore acquire — operator can drop via
-# :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` if the local lane caps are
-# also lowered proportionally.
-DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 50
-"""Operator default = 50 simultaneous match dispatches inside
-``asyncio.gather``. See :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV` for
-runtime override."""
+# Why 5 (and not the previous 50): PR-LANE-CAP-50 (v0.99.74, same-day
+# release) targeted the Anthropic per-account RPM ceiling but ignored
+# local RSS. Each ``claude --print`` spawn is a fresh Node V8 process
+# (~425 MB measured); 50 of them ≈ 21 GB peak anonymous RSS on a
+# 16 GB host. The gen1-broken_tool_use smoke (2026-05-27 04:12 KST)
+# froze the host machine within ~60 s of the ranker's first
+# match-dispatch burst. See ``core/orchestration/claude_cli_lane.py``
+# for the per-lane derivation; this cap stays in lockstep with that
+# lane so the three caps share one rationale.
+#
+# Operators on bigger hardware should raise all three lockstep,
+# e.g. 32 GB host: ``RANKER_MAX_INFLIGHT_MATCHES=10`` +
+# ``CLAUDE_CLI_LANE_MAX=10`` + ``OPENAI_API_LANE_MAX=20``.
+DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 5
+"""Default match-dispatch cap sized to the local-RSS-safe ceiling on
+a 16 GB host (see module-level comment). Operator override via
+:data:`RANKER_MAX_INFLIGHT_MATCHES_ENV`."""
 
 RANKER_MAX_INFLIGHT_MATCHES_ENV = "GEODE_RANKER_MAX_INFLIGHT_MATCHES"
 """Operator override — raise / lower the phase-local cap. Invalid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.74"
+version = "0.99.75"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/orchestration/test_openai_api_lane.py
+++ b/tests/core/orchestration/test_openai_api_lane.py
@@ -30,14 +30,15 @@ def _reset_lane() -> None:
     reset_openai_api_lane_for_tests()
 
 
-def test_default_max_concurrent_is_fifty() -> None:
-    """Default capacity 50 — PR-LANE-CAP-50 (2026-05-27) raised from
-    16 to 50 per operator decision. OpenAI Codex Responses API
-    documents 500 RPM aggregate per ChatGPT subscription bucket; cap
-    50 yields ~200-300 RPM steady state, well under the 500 RPM
-    ceiling with substantial burst headroom."""
-    assert DEFAULT_OPENAI_API_LANE_MAX == 50
-    assert resolve_openai_api_lane_max() == 50
+def test_default_max_concurrent_is_ten() -> None:
+    """Default capacity 10 — PR-LANE-CAP-CONSERVATIVE (v0.99.75,
+    2026-05-27) lowered from 50 to 10 after the cap-50 ranker burst
+    froze a 16 GB M3 host. Paired with ``claude_cli_lane=5`` for the
+    standard 1-claude + 2-codex voter panel: 5 matches × 2 codex
+    voters = exactly 10 in-flight, no queue. RPM headroom against
+    the 500 RPM ChatGPT subscription ceiling stays at ~440 RPM."""
+    assert DEFAULT_OPENAI_API_LANE_MAX == 10
+    assert resolve_openai_api_lane_max() == 10
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/seed_generation/test_ranker_semaphore.py
+++ b/tests/plugins/seed_generation/test_ranker_semaphore.py
@@ -19,15 +19,15 @@ from plugins.seed_generation.agents.ranker import (
 )
 
 
-def test_default_is_fifty() -> None:
-    """The default cap is 50 — PR-LANE-CAP-50 (2026-05-27) raised
-    from 8 to 50 per operator decision to match the per-adapter
-    lane ceilings (all three lanes raised to 50). 50 matches × 3
-    voters = 150 voter tasks inflight; lane caps absorb (50
-    claude-cli + 50 openai-api = 100 budget, with the 50 surplus
-    queueing inside each lane's semaphore)."""
-    assert DEFAULT_RANKER_MAX_INFLIGHT_MATCHES == 50
-    assert resolve_ranker_max_inflight_matches() == 50
+def test_default_is_five() -> None:
+    """The default cap is 5 — PR-LANE-CAP-CONSERVATIVE (v0.99.75,
+    2026-05-27) lowered from 50 to 5 after the gen1-broken_tool_use
+    smoke at cap 50 froze a 16 GB M3 host (50 × 425 MB ≈ 21 GB peak
+    claude-cli RSS). New cap balances the three lanes exactly: 5
+    matches × 3 voters = 15 tasks, saturating claude_cli_lane=5 + 2
+    × openai_api_lane=10 with zero hidden queue depth."""
+    assert DEFAULT_RANKER_MAX_INFLIGHT_MATCHES == 5
+    assert resolve_ranker_max_inflight_matches() == 5
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_geode_target_source_wiring.py
+++ b/tests/test_geode_target_source_wiring.py
@@ -1,0 +1,139 @@
+"""Regression pin for ``geode_target._default_geode_runner``'s source
+wiring into ``AgenticLoop``.
+
+The audit subprocess invokes the GEODE target through
+``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``.
+Until 2026-05-27 the runner passed only ``provider=...`` to
+``AgenticLoop`` and silently inherited the default ``source="payg"``,
+so the operator's ``[self_improving_loop.petri.target] source`` /
+``[petri.target] source`` setting was ignored. On Pattern B
+(subscription-only, ``fallback_to_payg=false``) this surfaced as
+``OpenAIPaygAdapter: OPENAI_API_KEY not set`` for every target call —
+indistinguishable from a real adapter-missing error in the trace.
+
+The fix routes the (provider, source) pair through
+``plugins/petri_audit/registry.get_binding("target", model=...)``, the
+same resolver the manual ``geode audit`` CLI uses, so the three
+source categories (PAYG / subscription / local-cli) all reach
+``AgenticLoop`` exactly as the operator configured them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_default_geode_runner_passes_source_argument() -> None:
+    """Source-level pin: AgenticLoop is constructed with a ``source=`` kwarg.
+
+    Greps ``plugins/petri_audit/targets/geode_target.py`` for the
+    ``source=`` keyword inside the ``AgenticLoop(...)`` construction
+    so a future refactor that drops the argument fails this test
+    before the audit-subprocess fake-success path re-emerges.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    # The construction site we care about is `loop = AgenticLoop(`.
+    # The source kwarg must appear before the closing paren.
+    construct_idx = source.index("loop = AgenticLoop(")
+    paren_open = source.index("(", construct_idx)
+    # Find the matching close paren — paren-balanced scan, since the
+    # ctor body contains nested calls/conditionals.
+    depth = 1
+    cursor = paren_open + 1
+    while depth > 0 and cursor < len(source):
+        ch = source[cursor]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        cursor += 1
+    ctor_body = source[paren_open:cursor]
+    assert "source=" in ctor_body, (
+        "AgenticLoop(...) is constructed without a `source=` argument; "
+        "the audit subprocess will silently fall back to "
+        "AgenticLoop's default source='payg' and the operator's "
+        "[petri.target] source config will be ignored. Pass the "
+        "binding's source explicitly — see get_binding('target', ...)."
+    )
+
+
+def test_default_geode_runner_uses_get_binding() -> None:
+    """Behavioural pin: the runner consults the binding registry.
+
+    ``get_binding`` is the single resolver shared with the manual
+    ``geode audit`` CLI; using it guarantees the audit subprocess
+    resolves the same source the operator gets at the command line.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    assert "get_binding(" in source, (
+        "geode_target.py no longer calls get_binding(...). The audit "
+        "subprocess will diverge from the manual `geode audit` CLI's "
+        "source resolution. Use plugins.petri_audit.registry.get_binding."
+    )
+
+
+@pytest.mark.parametrize(
+    "category,source_value",
+    [
+        # PAYG — API-key path. OpenAIPaygAdapter / AnthropicPaygAdapter /
+        # GlmPaygAdapter. Operator sets ``[petri.target] source = "payg"``
+        # to force per-token billing.
+        ("PAYG", "anthropic-payg"),
+        ("PAYG", "openai-payg"),
+        # Subscription OAuth — claude-cli (Anthropic Max), codex-oauth
+        # (ChatGPT Plus). These ride the operator's interactive
+        # subscription quota.
+        ("subscription", "claude-cli"),
+        ("subscription", "codex-oauth"),
+        ("subscription", "anthropic-oauth"),
+        # Local CLI subprocess — codex-cli wraps a local Codex
+        # binary. Lower-latency option when an OAuth subscription is
+        # unavailable.
+        ("local-cli", "codex-cli"),
+    ],
+)
+def test_bootstrap_registers_all_three_source_categories(category: str, source_value: str) -> None:
+    """Each source the operator may configure resolves to a registered adapter.
+
+    The full set of three categories (PAYG / subscription / local-cli)
+    must be present after ``bootstrap_builtins()`` so
+    ``AgenticLoop._new_adapter = resolve_for(provider, source)`` does
+    not raise ``AdapterNotFoundError`` regardless of which credential
+    path the operator selects. A regression that drops one of the
+    eight builtin adapter imports surfaces here per-source rather
+    than as a remote audit-subprocess failure.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        list_adapters,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        names = {a.name for a in list_adapters()}
+        assert source_value in names, (
+            f"{category} source {source_value!r} not registered after "
+            f"bootstrap. Registered: {sorted(names)!r}. The audit "
+            f"subprocess will fail when operator configures this source."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.74"
+version = "0.99.75"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **v0.99.75 release** (PR-LANE-CAP-CONSERVATIVE, PR #1790) — walk back v0.99.74 의 PR-LANE-CAP-50 raise. claude-cli/openai-api/ranker default 50 → 5/10/5. operator 의 16 GB M3 host freeze (gen1-broken_tool_use ranker burst, 2026-05-27 04:12 KST) 회복. env override 노브 유지.
- **PR-AUDIT-TARGET-SOURCE-WIRING** (PR #1789, 본 PR 이 원래 promote 하려던 fix) — target binding (provider, source) 를 ``get_binding`` 으로 라우팅. 3-PR audit-subprocess wiring chain (#1785 + #1787 + #1789) 완성.

본 develop → main rotation 은 위 두 항목을 동시에 ship.

## Verification
- [x] PR #1790 (release/v0.99.75 → develop) CI 8/8 green
- [x] PR #1789 8/8 CI green + merged to develop
- [x] 본 develop → main PR 의 CI 도 동일 잡 세트 green 까지 watch 후 머지