### PR TITLE
fix(audit): AgenticLoop adapter-name lookup + petri-surface alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,36 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP (2026-05-27)** — extend
+  ``AgenticLoop`` adapter resolution to accept both adapter-name and
+  category source values. Until this PR the loop's
+  ``resolve_for(provider, source)`` call required source to be one of
+  the three concrete categories (``payg`` / ``subscription`` /
+  ``adapter``). Callers that passed a registered adapter name
+  (``codex-oauth`` / ``claude-cli`` / ``openai-payg`` / ...) raised
+  ``ValueError: source not concrete`` and the audit subprocess
+  silently fell back to the default ``"payg"`` even when the operator
+  explicitly configured a subscription adapter — surfacing as
+  ``OPENAI_API_KEY not set`` for every target call on Pattern B
+  (subscription-only with ``fallback_to_payg=false``). The fix tries
+  ``get_adapter(name)`` first and falls through to the legacy
+  ``resolve_for`` only on miss, so all three source categories
+  (payg / subscription / local-cli) resolve cleanly regardless of
+  which form the caller passes.
+- **PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP / petri alias** —
+  ``plugins/petri_audit/targets/geode_target.py:_default_geode_runner``
+  translates the Petri-surface source alias (``"openai-codex"``,
+  returned by ``get_binding("target")``) to the GEODE registry-side
+  canonical name (``"codex-oauth"``) before passing it to
+  ``AgenticLoop``. Only the ``openai-codex`` ↔ ``codex-oauth`` pair
+  diverges between the two namespaces; the remaining adapter names
+  (``claude-cli`` / ``anthropic-oauth`` / ``codex-cli`` / ``*-payg``)
+  are identical across both. Pinned by
+  ``tests/test_agentic_loop_adapter_name_lookup.py`` (11 assertions:
+  source-level dual-lookup pin, 8 parametrised adapter-name resolves,
+  petri alias translation, category-axis fallback).
+
 ## [0.99.75] - 2026-05-27
 
 > PATCH rotation walking back v0.99.74's PR-LANE-CAP-50 raise after

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -405,13 +405,24 @@ class AgenticLoop:
         # in the legacy provider key but collapse to ``openai`` in the
         # registry (the Codex source is encoded on the ``source`` axis
         # as ``subscription``).
-        # Same shape as :func:`core.self_improving_loop.runner._normalize_provider_for_registry`
-        # and :func:`core.agent.loop._reflection._normalize_provider_for_registry`;
-        # this third copy stays inline rather than hoisted because the
-        # helper is 4 lines.
+        # Related copies in ``runner.py:_normalize_provider_for_registry``
+        # and ``_reflection.py:_normalize_provider_for_registry`` — those
+        # only map ``openai-codex → openai``; this site additionally maps
+        # ``zhipuai → glm``. The three are NOT fully sync'd; align them
+        # if a caller ever surfaces ``zhipuai`` on the reflection /
+        # mutator paths.
         _PROVIDER_NORMALIZATION = {"openai-codex": "openai", "zhipuai": "glm"}
         registry_provider = _PROVIDER_NORMALIZATION.get(self._provider, self._provider)
-        self._new_adapter: Any = resolve_for(registry_provider, self._source)
+        # Adapter resolution: direct registry-name lookup first
+        # (``codex-oauth`` / ``claude-cli`` / ``openai-payg`` / ...),
+        # falling back to the legacy category-axis path for
+        # non-migrated callers (``payg`` / ``subscription`` / ``adapter``).
+        from core.llm.adapters.registry import AdapterNotFoundError, get_adapter
+
+        try:
+            self._new_adapter: Any = get_adapter(self._source)
+        except AdapterNotFoundError:
+            self._new_adapter = resolve_for(registry_provider, self._source)
         # PR-COMM-3b (2026-05-24) — cache the latest claude-cli sessionId
         # the adapter emitted so the SESSION_ENDED hook payload can carry
         # it through to the agent_runtime_state SQLite writer (registered

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -297,16 +297,10 @@ async def _default_geode_runner(
 
     bootstrap_builtins()
 
-    # PR-AUDIT-TARGET-SOURCE-WIRE (2026-05-27) — resolve the (provider,
-    # source) pair through ``get_binding("target", ...)`` so the audit
-    # subprocess's adapter selection honours the operator's
-    # ``[self_improving_loop.petri.target] source`` / ``[petri.target]
-    # source`` settings instead of falling through to AgenticLoop's
-    # default ``source="payg"`` and then failing with
-    # ``OPENAI_API_KEY not set`` on subscription-only environments
-    # (Pattern B). ``get_binding`` returns the same source the manual
-    # ``geode audit`` CLI resolves, so the audit subprocess + manual
-    # audit + autoresearch closed-loop now share one source SoT.
+    # Resolve (provider, source) via ``get_binding`` — the same path
+    # the manual ``geode audit`` CLI uses — so the audit subprocess,
+    # the CLI, and the closed-loop all share one source SoT
+    # (``[petri.target]`` / ``[self_improving_loop.petri.target]``).
     resolved_provider = infer_provider_from_model(model) if model else "anthropic"
     resolved_source = ""
     if model:
@@ -316,6 +310,21 @@ async def _default_geode_runner(
             binding = get_binding("target", model=model)
             resolved_provider = binding.provider
             resolved_source = binding.source
+            # Translate Petri-surface source names to the GEODE
+            # adapter-registry namespace so AgenticLoop's
+            # ``get_adapter(name)`` / ``resolve_for(provider, category)``
+            # lookups hit. Only two pairs diverge:
+            #   ``openai-codex`` (Petri name) → ``codex-oauth`` (registry name)
+            #   ``api_key`` (Petri PAYG, provider-generic) → ``payg``
+            #     (registry category; the fallback ``resolve_for(provider,
+            #     "payg")`` selects the provider-specific ``*-payg`` adapter)
+            # The other concrete sources (``claude-cli`` / ``codex-cli`` /
+            # ``anthropic-oauth``) are identical across both namespaces.
+            _PETRI_TO_REGISTRY = {
+                "openai-codex": "codex-oauth",
+                "api_key": "payg",
+            }
+            resolved_source = _PETRI_TO_REGISTRY.get(resolved_source, resolved_source)
         except Exception:
             # get_binding can raise if the model is not in the role
             # manifest's allowed_models list (manual override / custom

--- a/tests/test_agentic_loop_adapter_name_lookup.py
+++ b/tests/test_agentic_loop_adapter_name_lookup.py
@@ -1,0 +1,310 @@
+"""Regression pin for ``AgenticLoop``'s adapter-name + category dual lookup.
+
+Before PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP (2026-05-27), the loop's
+adapter resolution was a single ``resolve_for(provider, source)`` call
+that required ``source`` to be one of the three concrete categories
+(``payg`` / ``subscription`` / ``adapter``). Callers that passed an
+actual registered adapter name (``codex-oauth`` / ``claude-cli`` /
+``openai-payg`` / ...) hit ``ValueError: source not concrete`` and the
+exception was swallowed upstream — the audit subprocess silently fell
+back to PAYG and emitted ``OPENAI_API_KEY not set`` for every target
+call, masquerading as a credential problem.
+
+The fix tries ``get_adapter(name)`` first (registry-name lookup) and
+falls through to ``resolve_for(provider, source)`` (category lookup)
+only when the direct lookup misses. The two-path resolution lets
+callers pass either form interchangeably, which is what the audit
+subprocess needs (``get_binding("target")`` returns adapter-name)
+while preserving the legacy category-axis path for callers that
+have not migrated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_agentic_loop_resolves_via_get_adapter_first() -> None:
+    """Source-level pin: AgenticLoop tries ``get_adapter`` before ``resolve_for``.
+
+    Greps ``core/agent/loop/agent_loop.py`` for the dual-lookup pattern
+    so a future refactor that drops the adapter-name path fails this
+    test before the audit-subprocess fake-success failure re-emerges.
+    """
+    loop_module = Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "agent_loop.py"
+    source = loop_module.read_text(encoding="utf-8")
+    assert "get_adapter(self._source)" in source, (
+        "agent_loop.py no longer calls get_adapter(self._source). The "
+        "audit subprocess will silently fall back to PAYG when the "
+        "operator's source is an adapter name (e.g. 'codex-oauth')."
+    )
+    assert "AdapterNotFoundError" in source, (
+        "agent_loop.py does not handle AdapterNotFoundError; the "
+        "category-axis fallback (resolve_for) is unreachable."
+    )
+
+
+@pytest.mark.parametrize(
+    "adapter_name",
+    [
+        # Subscription OAuth — adapter names registered by
+        # bootstrap_builtins. ``get_adapter`` resolves them directly;
+        # ``resolve_for("openai", "codex-oauth")`` would raise because
+        # codex-oauth is an adapter name, not a category.
+        "codex-oauth",
+        "claude-cli",
+        "anthropic-oauth",
+        # Local-CLI subprocess wrapper.
+        "codex-cli",
+        # PAYG adapters by name (rather than category) — also
+        # resolvable via ``get_adapter`` so callers don't need to know
+        # which form the source string takes.
+        "openai-payg",
+        "anthropic-payg",
+        "glm-payg",
+        "glm-coding-plan",
+    ],
+)
+def test_agentic_loop_constructs_with_adapter_name_source(adapter_name: str) -> None:
+    """All eight registered adapter names resolve through ``get_adapter``.
+
+    The audit subprocess calls
+    ``AgenticLoop(..., source=binding.source)`` where ``binding.source``
+    is the registered adapter name (after the Petri-surface alias
+    translation in geode_target.py). Each of the eight builtins must
+    resolve cleanly — a regression that drops one (e.g. a refactor
+    that removes ``codex-cli`` from the bootstrap list) surfaces here
+    per-adapter rather than as a remote audit-subprocess WARNING.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        get_adapter,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        adapter = get_adapter(adapter_name)
+        assert adapter is not None, (
+            f"get_adapter({adapter_name!r}) returned None after bootstrap. "
+            f"The audit subprocess will fall back to PAYG when the "
+            f"operator configures this source."
+        )
+        assert adapter.name == adapter_name, (
+            f"get_adapter({adapter_name!r}) returned adapter with name "
+            f"{adapter.name!r} — namespace mismatch."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+
+def test_geode_target_translates_petri_surface_alias() -> None:
+    """Source-level pin: ``geode_target`` maps ``openai-codex`` → ``codex-oauth``.
+
+    Petri's ``get_binding("target")`` returns the Petri-surface name
+    (``openai-codex``) but the GEODE adapter registry uses
+    ``codex-oauth``. Without the translation, AgenticLoop's
+    ``get_adapter("openai-codex")`` misses (the name was never
+    registered) and the fallback ``resolve_for`` raises on the
+    non-concrete source — the audit then falls back to PAYG.
+    """
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    source = target_module.read_text(encoding="utf-8")
+    assert '"openai-codex": "codex-oauth"' in source, (
+        "geode_target.py no longer translates the Petri-surface "
+        "'openai-codex' alias to the GEODE registry name "
+        "'codex-oauth'. The audit subprocess will silently fall back "
+        "to PAYG when the operator pins openai-codex as the source."
+    )
+    assert '"api_key": "payg"' in source, (
+        "geode_target.py no longer translates the Petri-surface "
+        "'api_key' alias to the GEODE registry category 'payg'. PAYG "
+        "operators (anthropic/openai/glm) will fail because Petri's "
+        "concrete PAYG source name is 'api_key' but the GEODE registry "
+        "uses provider-specific '{provider}-payg' adapters; the 'payg' "
+        "category lets resolve_for pick the right one."
+    )
+
+
+def test_petri_to_registry_map_covers_every_petri_concrete_source() -> None:
+    """Map coverage — every Petri concrete source resolves on the GEODE side.
+
+    ``plugins/petri_audit/petri.plugin.toml`` declares the concrete
+    sources per provider:
+
+    - anthropic: ``claude-cli``, ``api_key``
+    - openai: ``openai-codex``, ``api_key``
+    - zhipuai: ``api_key``
+
+    Petri concrete sources that are NOT identical to a registered
+    GEODE adapter name MUST appear in ``_PETRI_TO_REGISTRY`` so the
+    AgenticLoop lookup (``get_adapter`` → ``resolve_for`` fallback)
+    succeeds for every operator configuration.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        list_adapters,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        registry_names = {a.name for a in list_adapters()}
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+    # Concrete sources Petri may emit through ``get_binding``.
+    petri_concrete_sources = {"claude-cli", "openai-codex", "codex-cli", "api_key"}
+    # Categorical fallback values resolve_for accepts.
+    categories = {"payg", "subscription", "adapter"}
+
+    target_module = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "petri_audit"
+        / "targets"
+        / "geode_target.py"
+    )
+    geode_target_src = target_module.read_text(encoding="utf-8")
+
+    # Build the actual translation map by importing the module's
+    # source and evaluating the dict literal. This guards against
+    # ``"api_key": "subscription"`` (a wrong mapping that would
+    # category-resolve but to the wrong adapter category) — the
+    # earlier presence check only verified the key existed.
+    import re
+
+    match = re.search(
+        r"_PETRI_TO_REGISTRY\s*=\s*\{([^}]+)\}",
+        geode_target_src,
+        re.DOTALL,
+    )
+    assert match, "_PETRI_TO_REGISTRY literal not found in geode_target.py"
+    translation_map: dict[str, str] = {}
+    for entry in re.finditer(r'"([^"]+)"\s*:\s*"([^"]+)"', match.group(1)):
+        translation_map[entry.group(1)] = entry.group(2)
+
+    def _value_resolves_for_some_provider(value: str) -> bool:
+        # Direct registry hit (e.g. ``codex-oauth``).
+        if value in registry_names:
+            return True
+        # Category fallback (e.g. ``payg``). ``resolve_for`` raises if
+        # the category is wrong for every provider, so try each one.
+        if value not in categories:
+            return False
+        from core.llm.adapters.registry import (
+            AdapterNotFoundError,
+            resolve_for,
+        )
+
+        for provider in ("openai", "anthropic", "glm"):
+            try:
+                resolve_for(provider, value)
+                return True
+            except (AdapterNotFoundError, ValueError):
+                continue
+        return False
+
+    for petri_source in petri_concrete_sources:
+        # Direct registry hit?
+        if petri_source in registry_names:
+            continue
+        # Otherwise the translation entry must exist AND the translated
+        # value must actually resolve (rejects ``"api_key": "subscription"``
+        # which would be a syntactically valid but semantically wrong
+        # mapping that category-resolves to the wrong adapter pool).
+        translated = translation_map.get(petri_source)
+        assert translated is not None, (
+            f"Petri concrete source {petri_source!r} has no "
+            f"_PETRI_TO_REGISTRY entry. Registered: {sorted(registry_names)}; "
+            f"categories: {sorted(categories)}."
+        )
+        try:
+            _reset_for_test()
+            bootstrap_builtins()
+            assert _value_resolves_for_some_provider(translated), (
+                f"_PETRI_TO_REGISTRY[{petri_source!r}] = {translated!r} "
+                f"does not resolve to any registered adapter nor to a "
+                f"valid category that selects one. The mapping is "
+                f"syntactically present but semantically wrong."
+            )
+        finally:
+            _reset_for_test()
+            bootstrap_builtins()
+
+
+def test_negative_openai_codex_without_translation_misses_registry() -> None:
+    """Without the geode_target translation, ``openai-codex`` would miss.
+
+    Pins the *necessity* of the translation: if a future refactor drops
+    ``_PETRI_TO_REGISTRY`` and passes the raw Petri-surface alias to
+    AgenticLoop, ``get_adapter`` returns ``AdapterNotFoundError`` (the
+    name is unregistered) and the fallback ``resolve_for`` raises
+    ``ValueError`` (the name is not a category) — the audit subprocess
+    silently falls back to PAYG.
+    """
+    from core.llm.adapters.registry import (
+        AdapterNotFoundError,
+        _reset_for_test,
+        bootstrap_builtins,
+        get_adapter,
+        resolve_for,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        # Direct registry lookup of the raw Petri-surface alias misses
+        # because the registered name is ``codex-oauth``.
+        with pytest.raises(AdapterNotFoundError):
+            get_adapter("openai-codex")
+        # Category fallback also misses — ``openai-codex`` is not a
+        # category. ``resolve_for`` raises ValueError on this.
+        with pytest.raises(ValueError, match="not a concrete value"):
+            resolve_for("openai", "openai-codex")
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+
+def test_category_axis_fallback_still_resolves_payg() -> None:
+    """Legacy callers passing ``source="payg"`` (category) still resolve.
+
+    The fallback ``resolve_for(provider, source)`` must remain
+    reachable for the AgenticLoop sites that have not migrated (e.g.
+    sub-agent worker, server-side loop, CLI bootstrap). A regression
+    that drops the except branch would break every non-audit caller.
+    """
+    from core.llm.adapters.registry import (
+        _reset_for_test,
+        bootstrap_builtins,
+        resolve_for,
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+        # Each provider has a payg adapter; verify the category
+        # resolution still finds it. This is what AgenticLoop falls
+        # back to when source="payg" (the existing default behaviour).
+        for provider in ("openai", "anthropic", "glm"):
+            adapter = resolve_for(provider, "payg")
+            assert adapter.source == "payg", (
+                f"resolve_for({provider!r}, 'payg') returned adapter "
+                f"with source={adapter.source!r} — category lookup broke."
+            )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()


### PR DESCRIPTION
## Summary
- `core/agent/loop/agent_loop.py`: try `get_adapter(name)` registry lookup before falling back to `resolve_for(provider, category)`. Callers may now pass either form; until this PR only categories worked and adapter-name callers silently fell back to PAYG.
- `plugins/petri_audit/targets/geode_target.py`: translate Petri-surface source aliases to GEODE registry namespace — `openai-codex → codex-oauth` (direct name), `api_key → payg` (category; `resolve_for` selects the provider-specific `*-payg` adapter for openai/anthropic/glm).
- `tests/test_agentic_loop_adapter_name_lookup.py`: 13 assertions covering source-level pins, 8 parametrised adapter-name resolves, both petri-alias translations, semantic map-coverage (translated value must actually resolve), negative case, and category-axis fallback.
- Codex MCP review (2 rounds, see "Reference") caught the `api_key → payg` gap that would have broken PAYG operators; round-2 catch strengthened the coverage test to verify the translated value actually resolves on the GEODE side.

## Why
Completes the closed-loop audit-subprocess wiring chain begun in PRs #1785/1787/1789. After #1789, the audit subprocess emitted 37 `OpenAIPaygAdapter: OPENAI_API_KEY not set` WARNINGs and **0** actual `geode/gpt-5.5` target `generate` events — the autoresearch promote/revert gate was driven on placeholder `dim_means` rather than real Petri measurements.

Root cause was a namespace mismatch between two layers:
- `plugins.petri_audit.registry.get_binding("target")` returns the Petri-surface source name (`openai-codex` / `api_key` / etc) as declared in `plugins/petri_audit/petri.plugin.toml`.
- `core.llm.adapters.registry` uses provider-specific canonical names (`codex-oauth` / `openai-payg` / `anthropic-payg` / `glm-payg`).

`AgenticLoop` only had one resolver (`resolve_for(provider, source)`), which requires `source` to be one of the three concrete categories (`payg` / `subscription` / `adapter`). Adapter names like `codex-oauth` raised `ValueError: not concrete` and the exception was swallowed upstream — the subprocess silently fell back to PAYG.

The fix is bidirectional: AgenticLoop accepts both adapter names AND categories; geode_target translates Petri-surface aliases to GEODE registry namespace before passing.

## Changes
| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | `get_adapter(name)` first, `resolve_for(provider, source)` fallback on `AdapterNotFoundError`. Comment updated to admit `_PROVIDER_NORMALIZATION` is not fully sync'd with `runner.py` / `_reflection.py` copies. |
| `plugins/petri_audit/targets/geode_target.py` | `_PETRI_TO_REGISTRY = {"openai-codex": "codex-oauth", "api_key": "payg"}` between `get_binding` and `AgenticLoop`. |
| `tests/test_agentic_loop_adapter_name_lookup.py` | New 13-assertion regression pin. Covers all 3 source categories (PAYG / subscription / local-CLI), both petri aliases, semantic map coverage, and the negative case that pins the necessity of translation. |
| `CHANGELOG.md` | Add PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP entry under `[Unreleased]`. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — 1004 files already formatted
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 463 source files
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run python -m pytest tests/test_agentic_loop_adapter_name_lookup.py tests/test_geode_target_adapter_bootstrap.py tests/test_geode_target_source_wiring.py tests/test_runner_repo_root_invariant.py` — 27 passed
- [ ] Live E2E (real target inference, 0 `OPENAI_API_KEY` warnings) — verifies after merge + rebuild

## Reference
- Wiring chain: PR #1785 (repo_root parents[2]) → PR #1787 (adapter bootstrap) → PR #1789 (binding source) → this PR (namespace translation + dual lookup).
- Codex MCP catches (2 rounds): `api_key → payg` gap, coverage-test semantic strengthening. The 1.6 catches/PR average from `[[feedback_codex_mcp_verification]]` held — this PR caught 4 in round 1 and 2 in round 2.
- Trace evidence: `~/Library/Application Support/inspect_ai/traces/trace-65146.log.gz` — post-#1789, 0 `AdapterNotFoundError` (PR #1787 working) but 37 `OPENAI_API_KEY not set` (this PR's target).
