### PR TITLE
release: v0.99.76 — PR-LANE-CAP-TIGHTER (cap 5/10/5 → 3/6/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.76] - 2026-05-27
+
+> PATCH rotation tightening the v0.99.75 PR-LANE-CAP-CONSERVATIVE
+> defaults a step further. Cap 5/10/5 still demanded ~3 GB of free
+> host RAM per ranker burst, which the operator's M3 16 GB host
+> rarely has without explicit Slack/Chrome/Notion cleanup. Cap 3/6/3
+> brings the peak burst to ~1.5 GB so the safe default actually
+> survives the operator's typical 150-750 MB steady-state PhysMem
+> unused window. Plus the develop-merged ``AgenticLoop`` adapter
+> name-lookup fix that landed after v0.99.75.
+
+### Changed
+- **PR-LANE-CAP-TIGHTER (2026-05-27)** — drop the three
+  freeze-implicated cap defaults a step further on top of
+  PR-LANE-CAP-CONSERVATIVE (v0.99.75). Reason: cap 5 demanded
+  ~3 GB free host RAM that the 16 GB M3 host rarely has at steady
+  state. New burst at cap 3 ≈ 1.5 GB.
+  - ``DEFAULT_CLAUDE_CLI_LANE_MAX`` 5 → **3**
+    (``core/orchestration/claude_cli_lane.py``)
+  - ``DEFAULT_OPENAI_API_LANE_MAX`` 10 → **6**
+    (``core/orchestration/openai_api_lane.py``) — paired at
+    ``2 × claude_cli_lane`` for the 1-claude + 2-codex panel
+  - ``DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`` 5 → **3**
+    (``plugins/seed_generation/agents/ranker.py``)
+  Env override knobs unchanged. Operators on 32 GB hosts should
+  raise lockstep (``=6 / 12 / 6``). Test pins updated:
+  ``test_default_max_concurrent_is_six`` (was ``_is_ten``) and
+  ``test_default_is_three`` (was ``_is_five``).
+
 ### Fixed
 - **PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP (2026-05-27)** — extend
   ``AgenticLoop`` adapter resolution to accept both adapter-name and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.75
+- **Version**: 0.99.76
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.75 — Long-running Autonomous Execution Harness
+# GEODE v0.99.76 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.75**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.76**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.75 — Long-running Autonomous Execution Harness
+# GEODE v0.99.76 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.75**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.76**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/llm/oauth_usage.py
+++ b/core/llm/oauth_usage.py
@@ -14,9 +14,10 @@ Why this exists
 The :class:`Lane` introduced in Phase 2
 (:mod:`core.orchestration.claude_cli_lane`) caps concurrent
 ``claude --print`` fan-out at ``DEFAULT_CLAUDE_CLI_LANE_MAX``
-(currently 5 after PR-LANE-CAP-CONSERVATIVE v0.99.75; previously
-raised to 50 by PR-LANE-CAP-50 v0.99.74 before the 16 GB host
-freeze incident). That cap is necessary but not sufficient: the
+(currently 3 after PR-LANE-CAP-TIGHTER v0.99.76; lowered from 5
+(v0.99.75) → 50 (v0.99.74) as the operator iterated toward a cap
+that fits the 16 GB M3 host's typical steady-state PhysMem unused
+without requiring desktop-app cleanup). That cap is necessary but not sufficient: the
 5-hour token bucket can be 90 % drained while the burst limiter
 is fully reset, and the next acquire would burn the last few
 percent for marginal value. paperclip solves this by polling

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -26,13 +26,17 @@ lane is too restrictive for non-Claude-CLI traffic (API-billed
 Anthropic / OpenAI completions). The two flows need separate caps,
 which is why this lane sits alongside ``global`` rather than under it.
 
-Why ``max_concurrent=5`` (PR-LANE-CAP-CONSERVATIVE, v0.99.75, 2026-05-27)
-========================================================================
+Why ``max_concurrent=3`` (PR-LANE-CAP-TIGHTER, v0.99.76, 2026-05-27)
+====================================================================
 
-Lowered from 50 (PR-LANE-CAP-50, same-day release v0.99.74) to **5**
-after the ranker smoke on a 16 GB M3 froze the host machine. The
-upstream rate-limit reasoning (Anthropic 50 RPM tier ceiling) was
-correct in isolation but ignored a tighter floor — **local RAM**.
+v0.99.75 dropped this from 50 to 5 after the freeze, but cap 5 still
+required ~3 GB of free host RAM per burst (5 × ~487 MB per match).
+The operator's M3 16 GB host typically has **150-750 MB unused** at
+steady state (with normal desktop apps + Claude Code + Slack /
+Chrome / Notion running), so cap 5 still demands an explicit
+cleanup pass before each smoke — which defeats the "safe default"
+goal. Cap 3 brings the burst to ~1.5 GB and survives without the
+cleanup ritual.
 
 **Measured local cost** (M3 16 GB, 2026-05-27):
 
@@ -40,27 +44,21 @@ correct in isolation but ignored a tighter floor — **local RAM**.
   deps; fresh process each spawn — see
   `paperclip/packages/adapter-utils/src/server-utils.ts:1943` for the
   canonical `child_process.spawn` pattern this lane shadow-fires).
-* Ranker burst at cap 50 with 3-voter panel = 50 matches × 1 claude
-  voter = 50 × 425 MB ≈ **21 GB anonymous RSS** on a 16 GB box. macOS
-  enters compressor thrash within ~60s, paging unrelated apps out, host
-  freezes.
-
-**Cap derivation**: Operator's realistic burst budget after closing
-heavy desktop apps (Slack/Chrome/Notion) ≈ 3 GB. Per-match cost =
-1 claude (425 MB) + 2 codex (62 MB) = ~487 MB. ``3 GB / 487 MB ≈ 6.3``
-→ cap 5 keeps peak burst at ~2.4 GB with a 0.7 GB safety margin
-before compressor pressure becomes pathological.
+* Cap 3 burst: 3 matches × ~487 MB ≈ **1.5 GB peak anonymous RSS**.
+  Fits in the operator's typical "no-cleanup" headroom + compressor
+  give-back.
 
 **Trade-off**: Ranker phase wall-clock grows from ~1 min (cap 50)
-to ~12-25 min for a 50-match Loop 1. Acceptable for nightly /
-autonomous smokes; painful for dev iteration — operators on larger
-boxes (32 GB+) should override via
-:data:`CLAUDE_CLI_LANE_MAX_ENV` (e.g. ``=20`` for 64 GB Mac Studio).
+to ~20-40 min for a 50-match Loop 1. Acceptable for nightly /
+autonomous smokes; operators with larger boxes (32 GB+) or who
+*have* done a heavy-app cleanup should override via
+:data:`CLAUDE_CLI_LANE_MAX_ENV` (e.g. ``=6`` for 32 GB, ``=20+``
+for 64 GB Mac Studio).
 
-**Upstream rate-limit headroom**: Even at cap 5, steady-state
-throughput against Anthropic's 5h pool sits well below the
-documented per-account ceiling, so neither floor (RPM nor token
-pool) is the binding constraint — the local RSS one is.
+**Upstream rate-limit headroom**: At cap 3 the steady-state
+throughput against Anthropic's 5h pool sits orders of magnitude
+below the documented per-account ceiling, so neither floor (RPM nor
+token pool) is the binding constraint — the local RSS one is.
 
 Why module-level (not LaneQueue-registered)
 ===========================================
@@ -132,24 +130,21 @@ silently fall back to the default — the lane should never harden into
 "no slots" mid-run because of a typo.
 """
 
-DEFAULT_CLAUDE_CLI_LANE_MAX = 5
-"""PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — lowered from 50.
+DEFAULT_CLAUDE_CLI_LANE_MAX = 3
+"""PR-LANE-CAP-TIGHTER (v0.99.76, 2026-05-27) — lowered from 5.
 
-The previous PR-LANE-CAP-50 default targeted the Anthropic per-account
-RPM ceiling but ignored local RSS: each ``claude --print`` spawn loads
-a fresh Node V8 (~425 MB resident, measured on the host that froze).
-50 × 425 MB ≈ 21 GB peak anonymous RSS on a 16 GB box → macOS
-compressor thrash → host freeze (incident: gen1-broken_tool_use
-ranker phase, 2026-05-27 04:12 KST).
-
-Cap 5 derives from realistic local headroom (~3 GB after closing
-heavy desktop apps) ÷ per-match cost (~487 MB = 1 claude + 2 codex)
-with a 0.7 GB safety margin. Trade-off — ranker phase wall-clock
-~12-25× slower than cap 50, but the host survives.
+v0.99.75 dropped this from 50 to 5 after the gen1-broken_tool_use
+freeze (Node V8 spawn cost ~425 MB × 50 ≈ 21 GB peak on a 16 GB
+box). Empirically, even cap 5 needs ~3 GB of host headroom (5 ×
+~487 MB per match) that the operator's M3 16 GB rarely has free
+without explicit desktop-app cleanup — the *steady state* PhysMem
+unused on this host hovers around 150-750 MB during normal work.
+Cap 3 keeps the burst to ~1.5 GB which survives without requiring
+the operator to close Slack / Chrome / Notion first.
 
 Operator override via :data:`CLAUDE_CLI_LANE_MAX_ENV`:
-* 16 GB box (this default): leave at 5.
-* 32 GB box: raise to ~10.
+* 16 GB box (this default): leave at 3.
+* 32 GB box: raise to ~6.
 * 64 GB+ Mac Studio / Linux server: raise to 20-50.
 * The Anthropic RPM ceiling kicks in well above any local-RSS-safe
   cap on consumer hardware, so this knob is for memory, not quota."""

--- a/core/orchestration/openai_api_lane.py
+++ b/core/orchestration/openai_api_lane.py
@@ -15,31 +15,31 @@ Distinct from ``codex_cli_lane`` because:
 - ``openai_api_lane`` gates **direct API call** (no subprocess, just
   ``openai.AsyncOpenAI.responses.create``); 429 surface differs.
 
-Why ``max_concurrent=10`` (PR-LANE-CAP-CONSERVATIVE, v0.99.75)
-=============================================================
+Why ``max_concurrent=6`` (PR-LANE-CAP-TIGHTER, v0.99.76)
+=======================================================
 
-Lowered from 50 (PR-LANE-CAP-50, v0.99.74) to **10** alongside the
-same-PR claude-cli lane drop. Local-RSS reasoning is identical to
-``claude_cli_lane.py``: a ranker burst at cap 50 panel-fires ~150
-voter tasks (50 × 3) and the host froze.
+Lowered from 10 (v0.99.75) to **6** in lockstep with the
+``claude_cli_lane`` 5 → 3 drop. Panel arithmetic: 3 matches × 2
+codex voters per match = 6 in-flight codex calls — exactly
+saturating this cap with zero queue depth, same balance the
+v0.99.75 default had at the 10/5 scale.
 
 Codex API calls are *not* subprocess-based — they fire from the
 parent Python process via ``openai.AsyncOpenAI.responses.create``,
-so the per-task cost is ~31 MB (measured on the freeze host, codex
-subprocess RSS — the API path stays in-process Python and is even
-cheaper). The cap-10 ceiling is **paired with** the new
-claude_cli_lane cap of 5: for the 1-claude + 2-codex panel,
-``ranker_max_inflight=5`` saturates 5 claude slots and 10 codex
-slots simultaneously without bursting.
+so the cap itself is not RSS-bound. The lower default exists only
+to keep the 1-claude + 2-codex panel balanced under the tighter
+``claude_cli_lane=3``; operators raising claude-cli should raise
+this in lockstep.
 
 **Upstream RPM headroom retained**: ChatGPT subscription bucket
-documents ~500 RPM aggregate; cap 10 with ~10s voter wallclock =
-~60 RPM — still 8× below the ceiling, so this is *not* a quota
-governor any more, just a panel-balance one.
+documents ~500 RPM aggregate; cap 6 with ~10s voter wallclock =
+~36 RPM — still 14× below the ceiling, so this is *not* a quota
+governor.
 
-Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Operators
-with bigger boxes raising ``claude_cli_lane`` should raise this
-in proportion (2× the new claude cap is the panel rule).
+Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Rule of
+thumb: keep this at ``2 × claude_cli_lane`` for cross-provider
+panels; codex-only panels (no claude voter) can raise freely up to
+the 500 RPM tier ceiling.
 
 Why module-level (not LaneQueue-registered)
 ===========================================
@@ -80,24 +80,25 @@ OPENAI_API_LANE_NAME = "openai-api"
 OPENAI_API_LANE_MAX_ENV = "GEODE_OPENAI_API_LANE_MAX"
 """Operator override for :data:`DEFAULT_OPENAI_API_LANE_MAX`."""
 
-DEFAULT_OPENAI_API_LANE_MAX = 10
-"""PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — lowered from 50.
+DEFAULT_OPENAI_API_LANE_MAX = 6
+"""PR-LANE-CAP-TIGHTER (v0.99.76, 2026-05-27) — lowered from 10.
 
-Paired with ``claude_cli_lane=5`` for the standard 1-claude + 2-codex
-voter panel: ``ranker_max_inflight=5`` × 2 codex voters = 10 in-flight
-codex calls, exactly saturating this cap. The 50→10 drop is a sibling
-correction of the same-day claude-cli cap drop (see
-``claude_cli_lane.py`` for the freeze incident that motivated the
-sprint).
+Paired with the ``claude_cli_lane`` cap-3 default for the standard
+1-claude + 2-codex voter panel: ``ranker_max_inflight=3`` × 2 codex
+voters = 6 in-flight codex calls, exactly saturating this cap. The
+10 → 6 drop is the sibling correction of the same-PR claude-cli
+cap drop (see ``claude_cli_lane.py`` for why the operator's M3
+16 GB host's steady-state PhysMem unused — ~150-750 MB — couldn't
+absorb cap 5).
 
-Throughput-wise this still leaves ~440 RPM of the documented 500 RPM
-ChatGPT subscription headroom unused — the binding constraint is
-panel balance, not OpenAI quota.
+Throughput-wise this still leaves ~464 RPM of the documented 500
+RPM ChatGPT subscription headroom unused — the binding constraint
+is panel balance, not OpenAI quota.
 
-Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Rule of thumb:
-keep this at ``2 × claude_cli_lane`` for cross-provider panels;
-operators running codex-only panels (no claude voter) can raise
-freely up to the 500 RPM tier ceiling."""
+Operator override via :data:`OPENAI_API_LANE_MAX_ENV`. Rule of
+thumb: keep this at ``2 × claude_cli_lane`` for cross-provider
+panels; operators running codex-only panels (no claude voter) can
+raise freely up to the 500 RPM tier ceiling."""
 
 OPENAI_API_LANE_TIMEOUT_S = 7200.0
 """PR-LANE-CAP-AGGRESSIVE (2026-05-27) — raised from 300s (5min) to

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -1127,8 +1127,8 @@ def register() -> None:
             # PR-LQ-Phase2 (2026-05-22) — share the
             # claude-cli-subagent lane with the self-improving-loop
             # mutator path so the host OAuth bucket (and now the host
-            # *RAM*) sees at most ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (5
-            # after PR-LANE-CAP-CONSERVATIVE v0.99.75, 2026-05-27)
+            # *RAM*) sees at most ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (3
+            # after PR-LANE-CAP-TIGHTER v0.99.76, 2026-05-27)
             # concurrent ``claude --print`` subprocesses. The lane runs
             # the blocking semaphore wait in a worker thread so the
             # event loop is not pinned while queued.

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -108,32 +108,29 @@ def _serialise_match_outcome(outcome: MatchOutcome) -> dict[str, Any]:
     }
 
 
-# PR-LANE-CAP-CONSERVATIVE (v0.99.75, 2026-05-27) — phase-local
+# PR-LANE-CAP-TIGHTER (v0.99.76, 2026-05-27) — phase-local
 # concurrency cap for the ranker's ``asyncio.gather`` match-dispatch
-# burst. Sits on top of the per-adapter lanes (claude_cli=5 /
-# openai_api=10) and is sized to match them exactly so the gather
+# burst. Sits on top of the per-adapter lanes (claude_cli=3 /
+# openai_api=6) and is sized to match them exactly so the gather
 # submission queue doesn't grow a hidden depth.
 #
 # Concurrency budget (default 3-voter panel = 2 codex + 1 claude-cli):
-#   5 matches inflight * 3 voters = 15 voter tasks
-#     - claude-cli tasks: 5 (1 per match) — saturates claude_cli_lane=5
-#     - codex tasks: 10 (2 per match)    — saturates openai_api_lane=10
+#   3 matches inflight * 3 voters = 9 voter tasks
+#     - claude-cli tasks: 3 (1 per match) — saturates claude_cli_lane=3
+#     - codex tasks: 6 (2 per match)     — saturates openai_api_lane=6
 #   Net: all three caps balance with zero queue behind them.
 #
-# Why 5 (and not the previous 50): PR-LANE-CAP-50 (v0.99.74, same-day
-# release) targeted the Anthropic per-account RPM ceiling but ignored
-# local RSS. Each ``claude --print`` spawn is a fresh Node V8 process
-# (~425 MB measured); 50 of them ≈ 21 GB peak anonymous RSS on a
-# 16 GB host. The gen1-broken_tool_use smoke (2026-05-27 04:12 KST)
-# froze the host machine within ~60 s of the ranker's first
-# match-dispatch burst. See ``core/orchestration/claude_cli_lane.py``
-# for the per-lane derivation; this cap stays in lockstep with that
-# lane so the three caps share one rationale.
+# Why 3 (and not the prior v0.99.75 cap 5): cap 5 still needed ~3 GB
+# of free host RAM per burst, but the operator's M3 16 GB host
+# typically has 150-750 MB unused at steady state (Slack / Chrome /
+# Notion all running). Cap 3 brings the peak burst to ~1.5 GB and
+# survives without requiring the operator to close desktop apps
+# first — the "safe default" goal.
 #
 # Operators on bigger hardware should raise all three lockstep,
-# e.g. 32 GB host: ``RANKER_MAX_INFLIGHT_MATCHES=10`` +
-# ``CLAUDE_CLI_LANE_MAX=10`` + ``OPENAI_API_LANE_MAX=20``.
-DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 5
+# e.g. 32 GB host: ``RANKER_MAX_INFLIGHT_MATCHES=6`` +
+# ``CLAUDE_CLI_LANE_MAX=6`` + ``OPENAI_API_LANE_MAX=12``.
+DEFAULT_RANKER_MAX_INFLIGHT_MATCHES = 3
 """Default match-dispatch cap sized to the local-RSS-safe ceiling on
 a 16 GB host (see module-level comment). Operator override via
 :data:`RANKER_MAX_INFLIGHT_MATCHES_ENV`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.75"
+version = "0.99.76"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/orchestration/test_openai_api_lane.py
+++ b/tests/core/orchestration/test_openai_api_lane.py
@@ -30,15 +30,16 @@ def _reset_lane() -> None:
     reset_openai_api_lane_for_tests()
 
 
-def test_default_max_concurrent_is_ten() -> None:
-    """Default capacity 10 — PR-LANE-CAP-CONSERVATIVE (v0.99.75,
-    2026-05-27) lowered from 50 to 10 after the cap-50 ranker burst
-    froze a 16 GB M3 host. Paired with ``claude_cli_lane=5`` for the
-    standard 1-claude + 2-codex voter panel: 5 matches × 2 codex
-    voters = exactly 10 in-flight, no queue. RPM headroom against
-    the 500 RPM ChatGPT subscription ceiling stays at ~440 RPM."""
-    assert DEFAULT_OPENAI_API_LANE_MAX == 10
-    assert resolve_openai_api_lane_max() == 10
+def test_default_max_concurrent_is_six() -> None:
+    """Default capacity 6 — PR-LANE-CAP-TIGHTER (v0.99.76, 2026-05-27)
+    lowered from 10 to 6 in lockstep with the ``claude_cli_lane``
+    5 → 3 drop. Paired with ``claude_cli_lane=3`` for the standard
+    1-claude + 2-codex voter panel: 3 matches × 2 codex voters = 6
+    in-flight, saturating this cap with zero queue depth. RPM
+    headroom against the 500 RPM ChatGPT subscription ceiling
+    stays at ~464 RPM."""
+    assert DEFAULT_OPENAI_API_LANE_MAX == 6
+    assert resolve_openai_api_lane_max() == 6
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/seed_generation/test_ranker_semaphore.py
+++ b/tests/plugins/seed_generation/test_ranker_semaphore.py
@@ -19,15 +19,18 @@ from plugins.seed_generation.agents.ranker import (
 )
 
 
-def test_default_is_five() -> None:
-    """The default cap is 5 — PR-LANE-CAP-CONSERVATIVE (v0.99.75,
-    2026-05-27) lowered from 50 to 5 after the gen1-broken_tool_use
-    smoke at cap 50 froze a 16 GB M3 host (50 × 425 MB ≈ 21 GB peak
-    claude-cli RSS). New cap balances the three lanes exactly: 5
-    matches × 3 voters = 15 tasks, saturating claude_cli_lane=5 + 2
-    × openai_api_lane=10 with zero hidden queue depth."""
-    assert DEFAULT_RANKER_MAX_INFLIGHT_MATCHES == 5
-    assert resolve_ranker_max_inflight_matches() == 5
+def test_default_is_three() -> None:
+    """The default cap is 3 — PR-LANE-CAP-TIGHTER (v0.99.76,
+    2026-05-27) lowered from 5 to 3 because cap 5 still required ~3 GB
+    of free host RAM per burst (5 × ~487 MB per match) and the
+    operator's M3 16 GB host typically has 150-750 MB unused at
+    steady state. Cap 3 brings the burst to ~1.5 GB and survives
+    without an explicit desktop-app cleanup pass. New cap balances
+    the three lanes exactly: 3 matches × 3 voters = 9 tasks,
+    saturating claude_cli_lane=3 + 2 × openai_api_lane=6 with zero
+    hidden queue depth."""
+    assert DEFAULT_RANKER_MAX_INFLIGHT_MATCHES == 3
+    assert resolve_ranker_max_inflight_matches() == 3
 
 
 def test_env_override_positive_int(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.75"
+version = "0.99.76"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.75 의 cap 5/10/5 가 여전히 ~3 GB host headroom 을 요구해서 16 GB M3 host 의 normal-state (PhysMem unused ~150-750 MB) 에선 explicit cleanup 없이는 위험. 한 단계 더 낮춰 **3/6/3** 으로 ship. peak burst ~1.5 GB.
- 함께 develop 에 누적된 PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP (PR #1792) 도 같이 ride.

## Why
v0.99.75 release 직후 본 host 상태 측정:
- PhysMem unused: 329 MB (compressor 3.1 GB 이미 사용)
- cap 5 burst = 5 × (425 + 2×31) MB ≈ 2.4 GB → unused budget 초과
- "safe default" 가 매번 사전 정리를 요구하면 그건 safe default 가 아님

cap 3 derivation:
- per-match cost ≈ 487 MB (1 claude + 2 codex)
- 3 × 487 ≈ **1.46 GB peak burst**
- 본 host 의 normal-state 750 MB unused + compressor give-back 으로 흡수 가능
- ranker phase wall-clock ≈ 20-40 분 (cap 5 = 12-25 분의 1.6 배), 한 번도 freeze 없이 끝까지 가는 게 더 중요

## Changes
| File | Change |
|------|--------|
| `core/orchestration/claude_cli_lane.py` | `DEFAULT_CLAUDE_CLI_LANE_MAX` 5 → **3**. docstring rationale: "normal-state PhysMem 150-750 MB 도 absorb" |
| `core/orchestration/openai_api_lane.py` | `DEFAULT_OPENAI_API_LANE_MAX` 10 → **6**. ``2 × claude_cli_lane`` 패널 룰 유지 |
| `plugins/seed_generation/agents/ranker.py` | `DEFAULT_RANKER_MAX_INFLIGHT_MATCHES` 5 → **3** |
| `plugins/petri_audit/claude_cli_provider.py`, `core/llm/oauth_usage.py` | docstring 인용 갱신 (5 → 3) |
| `tests/core/orchestration/test_openai_api_lane.py` | `test_default_max_concurrent_is_ten` → `_is_six` + assertion |
| `tests/plugins/seed_generation/test_ranker_semaphore.py` | `test_default_is_five` → `_is_three` + assertion |
| `CHANGELOG.md` | [Unreleased] → [0.99.76] - 2026-05-27 (PR-LANE-CAP-TIGHTER + PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP) |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md` | version 5 SoT sync 0.99.75 → 0.99.76 |

## Verification
- [x] `ruff check` clean (touched 모듈 + tests/)
- [x] `ruff format --check` 68 files already formatted
- [x] `mypy` clean (5 touched files)
- [x] `lint-imports` 4/4 contracts KEPT
- [x] `pytest tests/plugins/seed_generation/ tests/core/orchestration/` **736 passed, 3 skipped**
- [x] `geode version` → `GEODE v0.99.76`

## Reference
- 측정 host: Apple M3 16 GB, normal-state PhysMem unused 150-750 MB (compressor 2-3 GB)
- 직전 release: PR #1790 (v0.99.75 cap 50 → 5/10/5)
- session 결정: 5/10/5 → 3/6/3 (operator 의 "조금 더 줄이자" 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)