### PR TITLE
promote fix(autoresearch) eval-archive fallback to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-TRAIN-EVAL-ARCHIVE-FALLBACK (2026-05-27)** —
+  ``autoresearch/train.py:run_audit`` now reads ``dim_means`` /
+  ``dim_stderr`` / ``sample_count`` / ``measurement_modality`` from
+  the inspect-ai eval archive (via
+  ``core.audit.dim_extractor.extract_dim_aggregates``) as the
+  primary path, falling back to the legacy subprocess-stdout JSON
+  line only when the archive is missing or the extractor raises.
+  Until this PR the subprocess's final stdout JSON line was the
+  only carrier of these aggregates, so any inspect-ai sample-side
+  ``TypeError`` (observed: ``Object of type Summary is not JSON
+  serializable`` from ``openai/types/responses/response_reasoning_item.py``)
+  corrupted that line and ``train.py`` raised before reaching the
+  baseline writer — even though the audit itself ran cleanly and
+  the archive was intact (15-minute audit + 219K target tokens
+  visible in ``~/.geode/petri/logs/latest.eval`` while
+  ``baseline.json`` stayed untouched). The eval archive has been
+  the canonical SoT for downstream readers since PR-G2
+  (2026-05-20); this PR brings the primary numeric-extract path
+  into the same SoT. Pinned by
+  ``tests/test_autoresearch_train.py`` (3 new assertions: archive
+  preferred when stdout corrupt; archive empty falls back; archive
+  raises falls back). Codex MCP review (1 round): caught warning
+  message lacked archive path + ``exc_info`` (fixed) and the
+  missing real-archive-read tests (added).
+
 ## [0.99.76] - 2026-05-27
 
 > PATCH rotation tightening the v0.99.75 PR-LANE-CAP-CONSERVATIVE

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1008,20 +1008,66 @@ def run_audit(
         )
         raise RuntimeError(f"audit subprocess exit={proc.returncode}; see {RUN_LOG}")
 
-    summary_line = next(
-        (line for line in reversed(proc.stdout.splitlines()) if line.strip().startswith("{")),
-        None,
-    )
-    if summary_line is None:
-        raise RuntimeError(f"audit output missing summary JSON; see {RUN_LOG}")
-    summary = json.loads(summary_line)
-    dim_means = {k: float(v) for k, v in summary.get("dim_means", {}).items()}
-    dim_stderr = {k: float(v) for k, v in summary.get("dim_stderr", {}).items()}
-    # PR-2 (2026-05-23) — pass through PR-1 dim_extractor provenance.
-    # Older subprocess builds without PR-1 omit these keys; default to
-    # empty dicts so callers can detect "no provenance" without crashing.
-    sample_count = {k: int(v) for k, v in summary.get("sample_count", {}).items()}
-    measurement_modality = {k: str(v) for k, v in summary.get("measurement_modality", {}).items()}
+    # PR-TRAIN-EVAL-ARCHIVE-FALLBACK (2026-05-27) — primary path: read
+    # ``dim_means`` / ``dim_stderr`` / provenance directly from the
+    # ``.eval`` archive via ``core.audit.dim_extractor``. The audit
+    # subprocess's stdout JSON line was the legacy carrier of these
+    # aggregates, but any inspect_ai sample-side ``TypeError`` (e.g.
+    # ``Object of type Summary is not JSON serializable``) corrupts
+    # that final summary line and the parser raises while the eval
+    # archive itself is intact. Reading the archive directly makes
+    # the closed-loop robust to stdout corruption — the eval archive
+    # has been the canonical SoT for downstream readers since PR-G2
+    # (2026-05-20) anyway.
+    #
+    # Fall-through to the stdout JSON when the archive is missing or
+    # the extractor itself fails (defense in depth — preserves the
+    # legacy code path for environments where the archive symlink
+    # isn't wired, e.g. some test fixtures).
+    dim_means = {}
+    dim_stderr = {}
+    sample_count = {}
+    measurement_modality = {}
+
+    archive_path_str = _resolve_eval_archive_path()
+    archive_extracted = False
+    if archive_path_str:
+        try:
+            from core.audit.dim_extractor import extract_dim_aggregates
+
+            agg = extract_dim_aggregates(Path(archive_path_str))
+            dim_means = {k: float(v) for k, v in agg.get("dim_means", {}).items()}
+            dim_stderr = {k: float(v) for k, v in agg.get("dim_stderr", {}).items()}
+            sample_count = {k: int(v) for k, v in agg.get("sample_count", {}).items()}
+            measurement_modality = {
+                k: str(v) for k, v in agg.get("measurement_modality", {}).items()
+            }
+            archive_extracted = bool(dim_means)
+        except Exception as exc:
+            log.warning(
+                "eval archive extract failed at %s (%s); falling back to stdout JSON",
+                archive_path_str,
+                exc,
+                exc_info=True,
+            )
+
+    if not archive_extracted:
+        summary_line = next(
+            (line for line in reversed(proc.stdout.splitlines()) if line.strip().startswith("{")),
+            None,
+        )
+        if summary_line is None:
+            raise RuntimeError(f"audit output missing summary JSON; see {RUN_LOG}")
+        summary = json.loads(summary_line)
+        dim_means = {k: float(v) for k, v in summary.get("dim_means", {}).items()}
+        dim_stderr = {k: float(v) for k, v in summary.get("dim_stderr", {}).items()}
+        # PR-2 (2026-05-23) — pass through PR-1 dim_extractor provenance.
+        # Older subprocess builds without PR-1 omit these keys; default to
+        # empty dicts so callers can detect "no provenance" without crashing.
+        sample_count = {k: int(v) for k, v in summary.get("sample_count", {}).items()}
+        measurement_modality = {
+            k: str(v) for k, v in summary.get("measurement_modality", {}).items()
+        }
     total_seconds = time.time() - started
     return (
         dim_means,

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -486,6 +486,131 @@ def test_real_mode_raises_when_summary_json_missing(
         run_audit(dry_run=False)
 
 
+def test_real_mode_prefers_eval_archive_when_extract_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PR-TRAIN-EVAL-ARCHIVE-FALLBACK — when the eval archive extracts
+    cleanly, train.py uses its dim aggregates and ignores whatever the
+    subprocess wrote to stdout. This is the path that unblocks
+    closed-loop after a Summary-serialization TypeError corrupts the
+    final stdout JSON line but leaves the archive intact.
+    """
+    monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        # stdout JSON intentionally corrupted (mimics Summary-serialize TypeError)
+        result.stdout = "audit complete\n{not valid json\n"
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+    monkeypatch.setattr(auto_train, "_resolve_eval_archive_path", lambda: "/fake/eval.eval")
+
+    def _fake_extract(path: Any) -> dict[str, Any]:
+        return {
+            "dim_means": {"broken_tool_use": 1.0, "input_hallucination": 1.0},
+            "dim_stderr": {"broken_tool_use": 0.0, "input_hallucination": 0.0},
+            "sample_count": {"broken_tool_use": 5, "input_hallucination": 5},
+            "measurement_modality": {
+                "broken_tool_use": "judge_llm",
+                "input_hallucination": "judge_llm",
+            },
+        }
+
+    import core.audit.dim_extractor
+
+    monkeypatch.setattr(core.audit.dim_extractor, "extract_dim_aggregates", _fake_extract)
+
+    dim_means, _stderr, _audit_s, _total_s, sc, mm = run_audit(dry_run=False)
+    assert dim_means["broken_tool_use"] == 1.0
+    assert dim_means["input_hallucination"] == 1.0
+    assert sc["broken_tool_use"] == 5
+    assert mm["broken_tool_use"] == "judge_llm"
+
+
+def test_real_mode_falls_back_to_stdout_when_archive_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the archive resolves but ``extract_dim_aggregates`` returns
+    empty dicts (no numeric data — fresh archive, broken loader), the
+    parser falls through to the legacy stdout JSON path. Preserves the
+    pre-PR behaviour for environments where the archive isn't useful.
+    """
+    monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            "audit complete\n"
+            + json.dumps({"dim_means": {"broken_tool_use": 9.9}, "dim_stderr": {}})
+            + "\n"
+        )
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+    monkeypatch.setattr(auto_train, "_resolve_eval_archive_path", lambda: "/fake/eval.eval")
+
+    import core.audit.dim_extractor
+
+    monkeypatch.setattr(
+        core.audit.dim_extractor,
+        "extract_dim_aggregates",
+        lambda _p: {
+            "dim_means": {},
+            "dim_stderr": {},
+            "sample_count": {},
+            "measurement_modality": {},
+        },
+    )
+
+    dim_means, _stderr, _audit_s, _total_s, _sc, _mm = run_audit(dry_run=False)
+    # Empty archive → stdout JSON's 9.9 wins.
+    assert dim_means["broken_tool_use"] == 9.9
+
+
+def test_real_mode_falls_back_to_stdout_when_archive_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When ``extract_dim_aggregates`` raises (corrupted archive, IO
+    error, inspect-ai version mismatch), the warning is logged and
+    the legacy stdout JSON path takes over. The closed loop must
+    continue rather than crash.
+    """
+    monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            "audit complete\n"
+            + json.dumps({"dim_means": {"broken_tool_use": 7.7}, "dim_stderr": {}})
+            + "\n"
+        )
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+    monkeypatch.setattr(auto_train, "_resolve_eval_archive_path", lambda: "/fake/eval.eval")
+
+    def _raising_extract(_p: Any) -> dict[str, Any]:
+        raise RuntimeError("simulated archive corruption")
+
+    import core.audit.dim_extractor
+
+    monkeypatch.setattr(core.audit.dim_extractor, "extract_dim_aggregates", _raising_extract)
+
+    dim_means, _stderr, _audit_s, _total_s, _sc, _mm = run_audit(dry_run=False)
+    # Extract raised → stdout JSON's 7.7 wins; no exception propagates.
+    assert dim_means["broken_tool_use"] == 7.7
+
+
 def test_dry_run_emits_finite_fitness() -> None:
     dim_means, dim_stderr, audit_seconds, _, _sc, _mm = run_audit(dry_run=True)
     assert dim_means["broken_tool_use"] == pytest.approx(3.4)


### PR DESCRIPTION
## Summary
Promote `feature/train-eval-archive-fallback` (PR #1796) from develop to main. Resolves the last blocker (Summary JSON corruption) for the 5-cycle closed-loop run.

## Verification
- [x] PR #1796 8/8 CI green + merged to develop
