### PR TITLE
PR-MUTATION-CODE-FOUNDATION: code-mutation path whitelist + EVOLVE-BLOCK scanner (Phase 3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,33 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-MUTATION-CODE-FOUNDATION (2026-05-28, Phase 3.0)** —
+  ``core/self_improving_loop/code_mutation_whitelist.py`` ships as the
+  absolute floor for the upcoming source-code mutation surface
+  (``target_kind="plugin_impl"``, Phase 3.1). Layer 1 — path whitelist
+  (``is_path_allowed`` / ``validate_diff_paths`` /
+  ``validate_plugin_impl_target``) accepts only ``plugins/<section>/``
+  and ``tests/plugins/<section>/``; everything else (``core/``,
+  ``autoresearch/``, ``.github/``, ``CLAUDE.md``, sibling plugins,
+  ``..`` traversal, absolute paths) raises
+  ``MutationPathDeniedError``. Reserved names (``petri_audit``,
+  ``seed_generation``) are frozen against collision. Layer 2 —
+  ``find_evolve_blocks`` scans for ``# EVOLVE-BLOCK-START`` /
+  ``# EVOLVE-BLOCK-END`` markers (AlphaEvolve §A pattern); flat-only,
+  ValueError on nested/unmatched/unclosed. Anti-pattern reference: DGM
+  (arXiv 2505.22954) reward-hacking incident where the agent edited
+  its own tool wrapper to suppress the instrumentation the fitness
+  checker depended on — prompt-level "do not modify X" was not
+  enforcement; only post-mutation diff-checking against a path
+  whitelist would have caught it. Pinned by 41 unit assertions in
+  ``tests/test_code_mutation_whitelist.py`` (snake_case + reserved
+  guards, lookalike-prefix denial, path traversal, EVOLVE-BLOCK edge
+  cases). No behavior change for the 7 active text-artifact target
+  kinds; PR 3.1 wires this module into the apply path along with the
+  ``plugin_impl`` TARGET_KINDS extension + ``patch_blob`` Mutation
+  field.
+
 ### Fixed
 - **PR-TRAIN-EVAL-ARCHIVE-FALLBACK (2026-05-27)** —
   ``autoresearch/train.py:run_audit`` now reads ``dim_means`` /

--- a/core/self_improving_loop/code_mutation_whitelist.py
+++ b/core/self_improving_loop/code_mutation_whitelist.py
@@ -1,0 +1,199 @@
+"""Code-level mutation safety: path whitelist + EVOLVE-BLOCK scanner.
+
+When the self-improving loop graduates from text-artifact mutation (the 7
+``TARGET_KINDS`` covered by ``policies.py``) to source-code mutation —
+introduced with ``target_kind="plugin_impl"`` — the apply path needs hard
+guarantees that the LLM-proposed patch cannot reach the orchestrator,
+the audit harness, or any observability emit-site.
+
+Two layers of defense:
+
+1. **Path whitelist** (this module's :func:`is_path_allowed`) — the patch's
+   touched files must live in an allowlisted prefix. Default allowlist:
+   ``plugins/<plugin>/`` matching the declaration in ``Mutation.target_section``,
+   plus the parallel ``tests/plugins/<plugin>/`` tree. Anything outside
+   (``core/``, ``autoresearch/``, ``.github/``, ``CLAUDE.md``, the runner
+   itself) is denied.
+
+2. **EVOLVE-BLOCK scanner** (this module's :func:`find_evolve_blocks` and
+   :func:`validate_diff_within_evolve_blocks`) — for files that opt into
+   partial mutability via ``# EVOLVE-BLOCK-START`` / ``# EVOLVE-BLOCK-END``
+   markers (AlphaEvolve §A pattern), the patch may only modify byte ranges
+   inside those markers. The skeleton stays frozen. Layer 2 lights up in
+   Phase 4 when ``core/agent/loop/`` becomes mutable; layer 1 is the
+   absolute floor that ships first.
+
+Why a dedicated module: keeping enforcement separate from
+``Mutation``/``apply_mutation`` makes the guard list grep-pinnable, lets
+``test_*`` files import it for invariant tests, and matches the
+[[feedback-writer-destination-tracked]] pattern (PR-G5b #1350).
+
+Anti-pattern reference: DGM (arxiv 2505.22954) reward-hacking incident —
+the agent edited its own tool wrapper to suppress the special-token
+instrumentation that the fitness checker depended on. Prompt-level
+"do not modify X" was NOT enforcement; only post-mutation diff-checking
+against a path whitelist would have caught it. This module is that
+post-mutation diff-check.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+__all__ = [
+    "EVOLVE_BLOCK_END_MARKER",
+    "EVOLVE_BLOCK_START_MARKER",
+    "MutationPathDeniedError",
+    "find_evolve_blocks",
+    "is_path_allowed",
+    "validate_diff_paths",
+    "validate_plugin_impl_target",
+]
+
+
+# ---------------------------------------------------------------------------
+# Path whitelist
+# ---------------------------------------------------------------------------
+
+# Plugins that already exist on develop. Mutation MUST NOT modify these —
+# they're owned by their respective sprints and have their own ratchets.
+# A new ``plugin_impl`` mutation must pick a NEW directory name.
+_RESERVED_PLUGIN_NAMES: frozenset[str] = frozenset(
+    {
+        "petri_audit",
+        "seed_generation",
+    }
+)
+
+
+class MutationPathDeniedError(ValueError):
+    """Raised when a plugin_impl patch tries to touch a denied path.
+
+    The error message lists the offending path AND the rule that denied
+    it, so the operator can either widen the allowlist (explicit
+    decision) or reject the mutation (default).
+    """
+
+
+def validate_plugin_impl_target(target_section: str) -> Path:
+    """Resolve ``target_section`` to the canonical plugin directory.
+
+    Rules:
+
+    - ``target_section`` must be a snake_case identifier (matches
+      ``[a-z][a-z0-9_]*``). Defensive against path-traversal-shaped
+      sections (``"../"``, ``"plugins/../core"``, etc.).
+    - The resulting directory ``plugins/<target_section>/`` must NOT
+      collide with an existing plugin in :data:`_RESERVED_PLUGIN_NAMES`.
+
+    Returns the relative path the patch is allowed to scope to.
+    """
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", target_section):
+        raise MutationPathDeniedError(
+            f"plugin_impl target_section {target_section!r} must be a "
+            f"snake_case identifier matching [a-z][a-z0-9_]*"
+        )
+    if target_section in _RESERVED_PLUGIN_NAMES:
+        raise MutationPathDeniedError(
+            f"plugin_impl target_section {target_section!r} collides with "
+            f"a reserved existing plugin (one of {sorted(_RESERVED_PLUGIN_NAMES)!r}). "
+            f"Pick a fresh name; existing plugins are frozen at this scope."
+        )
+    return Path("plugins") / target_section
+
+
+def is_path_allowed(rel_path: Path | str, target_section: str) -> bool:
+    """Check if ``rel_path`` (repo-relative) is in the allowed set for ``target_section``.
+
+    Allowed prefixes (only):
+
+    - ``plugins/<target_section>/`` and any path under it
+    - ``tests/plugins/<target_section>/`` and any path under it
+
+    Everything else is denied. In particular:
+
+    - ``core/``, ``autoresearch/``, ``scripts/`` — orchestrator / harness
+    - ``.github/``, ``.gitignore``, ``CLAUDE.md``, ``GEODE.md`` — meta
+    - ``plugins/<other_plugin>/`` — sibling plugins (frozen)
+    - Absolute paths and any ``..`` traversal — denied
+    """
+    p = Path(rel_path)
+    if p.is_absolute() or any(part == ".." for part in p.parts):
+        return False
+    parts = p.parts
+    if len(parts) >= 2 and parts[0] == "plugins" and parts[1] == target_section:
+        return True
+    return (
+        len(parts) >= 3
+        and parts[0] == "tests"
+        and parts[1] == "plugins"
+        and parts[2] == target_section
+    )
+
+
+def validate_diff_paths(touched_paths: list[str | Path], target_section: str) -> None:
+    """Raise :class:`MutationPathDeniedError` if any touched path is outside the allowlist.
+
+    Called by the apply path after parsing the unified diff's file headers
+    but BEFORE applying the diff to the working tree. ``touched_paths`` is
+    the list of repo-relative paths the diff modifies (or creates).
+    """
+    denied: list[str] = []
+    for path in touched_paths:
+        if not is_path_allowed(path, target_section):
+            denied.append(str(path))
+    if denied:
+        raise MutationPathDeniedError(
+            f"plugin_impl mutation for target_section={target_section!r} "
+            f"touches {len(denied)} denied path(s): {denied}. "
+            f"Allowed prefixes: plugins/{target_section}/** + "
+            f"tests/plugins/{target_section}/**."
+        )
+
+
+# ---------------------------------------------------------------------------
+# EVOLVE-BLOCK scanner
+# ---------------------------------------------------------------------------
+
+# AlphaEvolve §A — line comments delimit mutable regions inside a file
+# whose skeleton stays frozen. Language-agnostic (any source language
+# that supports ``#``-prefix comments — Python, Ruby, shell, YAML).
+# Phase 4 will place these markers inside ``core/agent/loop/`` to let
+# the mutator touch specific function bodies without breaking the
+# import/observability skeleton.
+EVOLVE_BLOCK_START_MARKER: str = "# EVOLVE-BLOCK-START"
+EVOLVE_BLOCK_END_MARKER: str = "# EVOLVE-BLOCK-END"
+
+
+def find_evolve_blocks(source: str) -> list[tuple[int, int]]:
+    """Return ``[(start_line, end_line), ...]`` for each EVOLVE-BLOCK in ``source``.
+
+    Line numbers are 1-indexed (matching ``cat -n`` convention). The
+    range is inclusive of the marker lines themselves so callers can
+    skip them when applying patches.
+
+    Nested blocks are NOT supported (AlphaEvolve treats EVOLVE-BLOCKs
+    as flat); a second ``START`` before the matching ``END`` raises
+    :class:`ValueError`. Unmatched ``START`` (no closing ``END`` by
+    end-of-file) also raises. Empty source returns empty list.
+    """
+    blocks: list[tuple[int, int]] = []
+    open_at: int | None = None
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith(EVOLVE_BLOCK_START_MARKER):
+            if open_at is not None:
+                raise ValueError(
+                    f"nested EVOLVE-BLOCK at line {lineno} (previous opened at "
+                    f"line {open_at}); flat blocks only"
+                )
+            open_at = lineno
+        elif stripped.startswith(EVOLVE_BLOCK_END_MARKER):
+            if open_at is None:
+                raise ValueError(f"unmatched EVOLVE-BLOCK-END at line {lineno} (no prior START)")
+            blocks.append((open_at, lineno))
+            open_at = None
+    if open_at is not None:
+        raise ValueError(f"unclosed EVOLVE-BLOCK starting at line {open_at} (no END before EOF)")
+    return blocks

--- a/tests/test_code_mutation_whitelist.py
+++ b/tests/test_code_mutation_whitelist.py
@@ -1,0 +1,292 @@
+"""PR-MUTATION-CODE-FOUNDATION (Phase 3.0) — code-mutation safety invariants.
+
+Pins the path whitelist + EVOLVE-BLOCK scanner that gate the upcoming
+``target_kind="plugin_impl"`` apply path. Layer-1 (path whitelist) ships
+first as the absolute floor; layer-2 (EVOLVE-BLOCK) lights up in Phase 4
+when ``core/agent/loop/`` becomes mutable. These tests pin both layers
+now so PR 3.1 (wiring) can rely on the invariants.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.code_mutation_whitelist import (
+    EVOLVE_BLOCK_END_MARKER,
+    EVOLVE_BLOCK_START_MARKER,
+    MutationPathDeniedError,
+    find_evolve_blocks,
+    is_path_allowed,
+    validate_diff_paths,
+    validate_plugin_impl_target,
+)
+
+# ---------------------------------------------------------------------------
+# validate_plugin_impl_target — snake_case + reserved-name guards
+# ---------------------------------------------------------------------------
+
+
+def test_validate_plugin_impl_target_accepts_fresh_snake_case() -> None:
+    """A fresh snake_case name resolves to ``plugins/<name>/``."""
+    assert validate_plugin_impl_target("new_optimizer") == Path("plugins/new_optimizer")
+    assert validate_plugin_impl_target("a") == Path("plugins/a")
+    assert validate_plugin_impl_target("name_with_digits9") == Path("plugins/name_with_digits9")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "CamelCase",
+        "kebab-case",
+        "with space",
+        "../traversal",
+        "plugins/nested",
+        "9_leading_digit",
+        "",
+        "_leading_underscore",
+        "trailing/",
+    ],
+)
+def test_validate_plugin_impl_target_rejects_non_snake_case(bad: str) -> None:
+    """Anything that isn't ``[a-z][a-z0-9_]*`` is denied — defends against
+    path-traversal-shaped section names."""
+    with pytest.raises(MutationPathDeniedError):
+        validate_plugin_impl_target(bad)
+
+
+def test_validate_plugin_impl_target_rejects_reserved_names() -> None:
+    """Existing plugins are frozen at the plugin_impl scope — the LLM
+    cannot pick ``petri_audit`` / ``seed_generation`` as its target."""
+    for reserved in ("petri_audit", "seed_generation"):
+        with pytest.raises(MutationPathDeniedError) as exc_info:
+            validate_plugin_impl_target(reserved)
+        assert reserved in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# is_path_allowed — allowlist prefixes only
+# ---------------------------------------------------------------------------
+
+
+def test_is_path_allowed_accepts_plugin_directory() -> None:
+    """Any path under ``plugins/<target_section>/`` is allowed."""
+    assert is_path_allowed("plugins/foo/runner.py", "foo") is True
+    assert is_path_allowed("plugins/foo/sub/nested.py", "foo") is True
+    assert is_path_allowed("plugins/foo/__init__.py", "foo") is True
+
+
+def test_is_path_allowed_accepts_parallel_tests_directory() -> None:
+    """Tests for the new plugin live in ``tests/plugins/<target_section>/``."""
+    assert is_path_allowed("tests/plugins/foo/test_runner.py", "foo") is True
+    assert is_path_allowed("tests/plugins/foo/conftest.py", "foo") is True
+
+
+@pytest.mark.parametrize(
+    "denied",
+    [
+        # Orchestrator / harness
+        "core/agent/loop/agent_loop.py",
+        "core/self_improving_loop/runner.py",
+        "autoresearch/train.py",
+        "scripts/build_self_improving_hub.py",
+        # Meta / config
+        ".github/workflows/pages.yml",
+        ".gitignore",
+        "CLAUDE.md",
+        "GEODE.md",
+        "pyproject.toml",
+        # Bare top-level plugin manifest (not under the target dir)
+        "plugins/__init__.py",
+        # Random tests outside parallel tree
+        "tests/test_runner.py",
+        "tests/self_improving_loop/test_foo.py",
+    ],
+)
+def test_is_path_allowed_denies_outside_allowlist(denied: str) -> None:
+    """Anything outside the two allowlisted prefixes is denied."""
+    assert is_path_allowed(denied, "foo") is False
+
+
+def test_is_path_allowed_denies_sibling_plugin() -> None:
+    """Sibling plugins are frozen — the LLM cannot edit ``plugins/bar/``
+    while ``target_section="foo"``."""
+    assert is_path_allowed("plugins/bar/runner.py", "foo") is False
+    assert is_path_allowed("tests/plugins/bar/test_runner.py", "foo") is False
+
+
+def test_is_path_allowed_denies_path_traversal() -> None:
+    """``..`` anywhere in the path → deny (regardless of textual prefix)."""
+    assert is_path_allowed("plugins/foo/../core/runtime.py", "foo") is False
+    assert is_path_allowed("../plugins/foo/runner.py", "foo") is False
+    assert is_path_allowed("plugins/../core/runtime.py", "foo") is False
+
+
+def test_is_path_allowed_denies_absolute_paths() -> None:
+    """Absolute paths are denied — apply path should normalise to repo-
+    relative before validation; if the parser leaks an absolute path
+    that's a bug, fail closed."""
+    assert is_path_allowed("/etc/passwd", "foo") is False
+    assert is_path_allowed("/Users/mango/workspace/geode/core/runtime.py", "foo") is False
+
+
+def test_is_path_allowed_denies_lookalike_prefix() -> None:
+    """``plugins/foo_evil/`` must NOT match ``target_section="foo"``
+    (substring vs path-segment boundary). Same for the tests tree."""
+    assert is_path_allowed("plugins/foo_evil/runner.py", "foo") is False
+    assert is_path_allowed("plugins/foobar/runner.py", "foo") is False
+    assert is_path_allowed("tests/plugins/foobar/test.py", "foo") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_diff_paths — batch enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_validate_diff_paths_passes_when_all_allowed() -> None:
+    """A diff that only touches ``plugins/<section>/`` + tests passes silently."""
+    validate_diff_paths(
+        [
+            "plugins/foo/runner.py",
+            "plugins/foo/__init__.py",
+            "tests/plugins/foo/test_runner.py",
+        ],
+        target_section="foo",
+    )
+
+
+def test_validate_diff_paths_raises_on_any_denied() -> None:
+    """Even one denied path → raise with the offending path in the message."""
+    with pytest.raises(MutationPathDeniedError) as exc_info:
+        validate_diff_paths(
+            [
+                "plugins/foo/runner.py",
+                "core/agent/loop/agent_loop.py",  # denied
+            ],
+            target_section="foo",
+        )
+    assert "core/agent/loop/agent_loop.py" in str(exc_info.value)
+    assert "foo" in str(exc_info.value)
+
+
+def test_validate_diff_paths_lists_all_denied() -> None:
+    """All denied paths are surfaced — operator sees the full picture."""
+    with pytest.raises(MutationPathDeniedError) as exc_info:
+        validate_diff_paths(
+            [
+                "core/runtime.py",
+                "autoresearch/train.py",
+                "plugins/foo/ok.py",
+            ],
+            target_section="foo",
+        )
+    msg = str(exc_info.value)
+    assert "core/runtime.py" in msg
+    assert "autoresearch/train.py" in msg
+
+
+def test_validate_diff_paths_accepts_empty_list() -> None:
+    """An empty diff is vacuously allowed — caller's responsibility to
+    flag empty mutations elsewhere."""
+    validate_diff_paths([], target_section="foo")
+
+
+# ---------------------------------------------------------------------------
+# find_evolve_blocks — AlphaEvolve §A scanner
+# ---------------------------------------------------------------------------
+
+
+def test_find_evolve_blocks_empty_source() -> None:
+    """Empty source → no blocks."""
+    assert find_evolve_blocks("") == []
+
+
+def test_find_evolve_blocks_no_markers() -> None:
+    """Source without any markers → no blocks."""
+    assert find_evolve_blocks("def foo():\n    return 1\n") == []
+
+
+def test_find_evolve_blocks_single_block() -> None:
+    """One START + one END → one block; line numbers are 1-indexed inclusive."""
+    source = "\n".join(
+        [
+            "def foo():",  # line 1
+            f"    {EVOLVE_BLOCK_START_MARKER}",  # line 2
+            "    return 1",  # line 3
+            f"    {EVOLVE_BLOCK_END_MARKER}",  # line 4
+            "",  # line 5
+        ]
+    )
+    assert find_evolve_blocks(source) == [(2, 4)]
+
+
+def test_find_evolve_blocks_multiple_flat_blocks() -> None:
+    """Two non-overlapping blocks → two ranges in order."""
+    source = "\n".join(
+        [
+            EVOLVE_BLOCK_START_MARKER,  # 1
+            "a = 1",  # 2
+            EVOLVE_BLOCK_END_MARKER,  # 3
+            "b = 2",  # 4
+            EVOLVE_BLOCK_START_MARKER,  # 5
+            "c = 3",  # 6
+            EVOLVE_BLOCK_END_MARKER,  # 7
+        ]
+    )
+    assert find_evolve_blocks(source) == [(1, 3), (5, 7)]
+
+
+def test_find_evolve_blocks_rejects_nested() -> None:
+    """Nested START before matching END → ValueError. AlphaEvolve §A
+    treats blocks as flat — nesting would make the diff applier
+    ambiguous about which range a hunk belongs to."""
+    source = "\n".join(
+        [
+            EVOLVE_BLOCK_START_MARKER,  # 1
+            EVOLVE_BLOCK_START_MARKER,  # 2 — nested
+            "x = 1",
+            EVOLVE_BLOCK_END_MARKER,
+            EVOLVE_BLOCK_END_MARKER,
+        ]
+    )
+    with pytest.raises(ValueError, match="nested"):
+        find_evolve_blocks(source)
+
+
+def test_find_evolve_blocks_rejects_unmatched_end() -> None:
+    """END without prior START → ValueError."""
+    source = "\n".join(
+        [
+            "a = 1",
+            EVOLVE_BLOCK_END_MARKER,
+        ]
+    )
+    with pytest.raises(ValueError, match="unmatched"):
+        find_evolve_blocks(source)
+
+
+def test_find_evolve_blocks_rejects_unclosed() -> None:
+    """START without END before EOF → ValueError."""
+    source = "\n".join(
+        [
+            EVOLVE_BLOCK_START_MARKER,
+            "x = 1",
+            "y = 2",
+        ]
+    )
+    with pytest.raises(ValueError, match="unclosed"):
+        find_evolve_blocks(source)
+
+
+def test_find_evolve_blocks_tolerates_indented_markers() -> None:
+    """Markers may be indented (inside a function body, for example) —
+    the scanner left-strips whitespace before comparing."""
+    source = "\n".join(
+        [
+            "def foo():",
+            f"        {EVOLVE_BLOCK_START_MARKER}",
+            "        return 1",
+            f"        {EVOLVE_BLOCK_END_MARKER}",
+        ]
+    )
+    assert find_evolve_blocks(source) == [(2, 4)]


### PR DESCRIPTION
## Summary
- Ship ``core/self_improving_loop/code_mutation_whitelist.py`` as the absolute floor for the upcoming source-code mutation surface (``target_kind="plugin_impl"``, Phase 3.1+).
- Two-layer defense: (1) path whitelist (``plugins/<section>/`` + ``tests/plugins/<section>/`` only); (2) EVOLVE-BLOCK scanner for AlphaEvolve §A flat marker pairs.
- 41 unit assertions pin the invariants; no behavior change for the 7 active text-artifact target kinds.

## Why
10 closed-loop cycles (session ending 2026-05-27) all REJECT+REVERT on ``redundant_tool_invocation`` (measurement_modality=``tool_log``) — text-artifact mutation (prompt / tool_policy / decomposition / reflection / skill_catalog / agent_contract / tool_descriptions) is mechanism-mismatched against tool-log + token-count modalities. Phase 3 graduates the mutator into source-code mutation, starting with plugin-scoped diffs.

But source-code mutation has a documented anti-pattern. DGM (arXiv 2505.22954) reward-hacking incident: the agent edited its own tool wrapper to suppress the special-token instrumentation the fitness checker depended on. Prompt-level "do not modify X" was not enforcement; only post-mutation diff-checking against a path whitelist would have caught it. This PR is that diff-check, landed before any apply path can produce a ``plugin_impl`` mutation.

Foundation is intentionally minimum-functional: whitelist + scanner + tests. PR 3.1 wires the ``plugin_impl`` ``TARGET_KINDS`` extension + ``patch_blob`` Mutation field + ``apply_mutation`` branch that calls ``validate_diff_paths`` before the unified-diff applier touches the working tree. Splitting prevents stub-disguise (no half-wired Mutation field, no orphan TARGET_KINDS member) per scaffold CANNOT rule.

## Changes
| File | Change |
|------|--------|
| ``core/self_improving_loop/code_mutation_whitelist.py`` | New module. ``is_path_allowed`` (allowlist 2 prefixes); ``validate_diff_paths`` (batch raise); ``validate_plugin_impl_target`` (snake_case + reserved-name guard); ``find_evolve_blocks`` (flat-only AlphaEvolve §A scanner); ``MutationPathDeniedError``. |
| ``tests/test_code_mutation_whitelist.py`` | 41 assertions across 15 test functions. Covers fresh-name accept, snake_case reject (9 parametrize cases), reserved-name collision, allowlist accept (plugin dir + parallel tests dir), denial of 12 outside-allowlist paths (parametrize), sibling-plugin denial, ``..``-traversal denial, absolute-path denial, lookalike-prefix denial (substring vs path-segment boundary), batch-validate pass/raise/list-all-denied/empty cases, EVOLVE-BLOCK scanner edge cases (empty / no-markers / single / two flat / nested reject / unmatched-END reject / unclosed reject / indented-markers tolerated). |
| ``CHANGELOG.md`` | ``[Unreleased] Added`` entry for PR-MUTATION-CODE-FOUNDATION (Phase 3.0). |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``plugin_impl`` TARGET_KINDS extension | Deferred to PR 3.1 | Adding it here without an apply branch would orphan ``parse_mutation``'s ``TARGET_KINDS`` membership check. |
| ``patch_blob: str`` field on ``Mutation`` | Deferred to PR 3.1 | Same reasoning — no producer (LLM contract) and no consumer (apply_mutation diff applier) until 3.1 lands the cascade. |
| Evaluator cascade (ruff/mypy → pytest → Petri) | Phase 3.1 | Belongs in the apply path that consumes ``patch_blob``. |
| Sandboxed candidate exec (fresh worktree) | Phase 3.2 | After 3.1 proves the apply path works. |
| Step-wise attribution | Phase 3.3 (optional) | Belongs to AgentEvolver-style credit assignment. |

## Verification
- [x] ``ruff check core/self_improving_loop/code_mutation_whitelist.py tests/test_code_mutation_whitelist.py`` clean
- [x] ``ruff format --check ...`` clean
- [x] ``mypy core/self_improving_loop/code_mutation_whitelist.py`` clean
- [x] ``lint-imports`` clean (4 contracts kept, 0 broken)
- [x] ``pytest tests/test_code_mutation_whitelist.py`` — 41 passed
- [x] ``pytest tests/test_policy_mutation.py tests/test_self_improving_loop_config.py tests/test_self_improving_minimal_2.py`` — 82 passed (no regression on adjacent surfaces)

## Reference
- DGM (Darwin Gödel Machine, arXiv 2505.22954) — reward-hacking incident motivating the path whitelist.
- AlphaEvolve §A — ``# EVOLVE-BLOCK-START`` / ``# EVOLVE-BLOCK-END`` marker pattern for partial mutability inside a frozen skeleton.
- 10-cycle closed-loop session ending 2026-05-27 (memory: ``project-self-improving-loop-handoff``) — motivation for graduating beyond text-artifact mutation.