### PR TITLE
PR-PETRI-CACHE-DEFAULT-OFF: flip cache default to False (closed-loop measurement reliability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,42 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-PETRI-CACHE-DEFAULT-OFF (2026-05-28)** — Flips the
+  ``cache`` default to ``False`` across the petri-audit surface
+  (``plugins/petri_audit/runner.py:run_audit``,
+  ``plugins/petri_audit/cli_audit.py`` typer + argparse entry
+  points, ``core/cli/tool_handlers/audit.py`` tool handler kwarg
+  fallback). Closed-loop measurement reliability fix: inspect-ai's
+  ``CacheEntry._cache_key`` hashes ``(model config exc.
+  {max_connections, adaptive_connections, max_retries, timeout,
+  cache, batch}, input messages, base_url, tool_choice, tools,
+  expiry, scopes, epoch)`` into an md5 pickle file under
+  ``$INSPECT_CACHE_DIR/generate/<model>/`` (default
+  ``~/Library/Caches/inspect_ai/generate/`` on Darwin, expiry 1W).
+  In a self-improving closed loop the mutator only edits the
+  target wrapper while the auditor/judge prompts (defined inside
+  inspect-petri's task code) are stable cycle-over-cycle, so the
+  auditor and judge ``generate`` calls HIT cached trajectories
+  from prior cycles — observed during the 10-cycle run ending
+  2026-05-27 as ``fitness_delta`` deterministically returning to
+  ``{-1.155, -1.156, -1.733}`` regardless of mutation while
+  ``audit_seconds`` varied 181-503s. The 36 ``OPENAI_API_KEY not
+  set`` matches in the same period were string-grep hits inside
+  cached failed-run transcripts, not live warnings. Default OFF
+  restores the one-mutation-one-trajectory invariant the loop's
+  attribution row relies on, at the cost of a fresh
+  auditor+target+judge regenerate per audit (~$2-5/cycle vs
+  ~$0.05-0.30 with cache). The CLI argparse path now carries an
+  explicit ``--cache / --no-cache`` mutually exclusive group
+  (previously only ``--no-cache`` was wired); the Typer surface
+  already had the bidirectional ``--cache/--no-cache`` flag pair,
+  just with the inverted default. All 18 existing tests already
+  pass ``cache=True`` or ``cache=False`` explicitly, so the
+  default flip is invisible to the assertion suite (39 passed, 3
+  skipped on direct surface; 828 passed in the broader audit/cache
+  grep slice).
+
 ### Removed
 - **PR-REVERT-MUTATION-CODE-FOUNDATION (2026-05-28)** — Reverts
   PR-MUTATION-CODE-FOUNDATION (#1802, commit 31ae281f) so main

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -50,7 +50,7 @@ def _build_audit_handlers() -> dict[str, Any]:
         seed_select = kwargs.get("seed_select") or None
         dim_set = kwargs.get("dim_set") or "subset"
         target_tools = kwargs.get("target_tools") or "none"
-        cache = bool(kwargs.get("cache", True))
+        cache = bool(kwargs.get("cache", False))
         dry_run = bool(kwargs.get("dry_run", True))
         confirm = bool(kwargs.get("confirm", False))
 

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -240,7 +240,17 @@ def audit(
         "— inspect-petri default; lets the auditor fabricate tool results, "
         "useful for capability dim studies).",
     ),
-    cache: bool = typer.Option(True, "--cache/--no-cache", help="Petri cache parameter."),
+    cache: bool = typer.Option(
+        False,
+        "--cache/--no-cache",
+        help="Petri cache parameter. Default OFF — inspect-ai trajectory cache "
+        "(``cache_key = (model config, input messages, base_url, tools, "
+        "expiry, scopes, epoch)`` md5) is shared across audits at the same "
+        "process / host, so closed-loop measurement can silently HIT a "
+        "trajectory recorded by a different mutation and replay its score. "
+        "Opt in with ``--cache`` only when you intentionally want to amortise "
+        "auditor/judge generate cost across repeated identical seeds.",
+    ),
     dry_run: bool = typer.Option(
         True,
         "--dry-run/--live",
@@ -326,7 +336,9 @@ def _build_slash_parser() -> argparse.ArgumentParser:
         dest="judge_mode",
         choices=["legacy", "split"],
     )
-    parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
+    cache_group = parser.add_mutually_exclusive_group()
+    cache_group.add_argument("--cache", action="store_true", dest="cache", default=False)
+    cache_group.add_argument("--no-cache", action="store_false", dest="cache")
     parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
     parser.add_argument("--dry-run", action="store_true", dest="dry_run")
     parser.add_argument("--yes", "-y", action="store_true", default=False)

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -521,7 +521,7 @@ def run_audit(
     seeds: int = 1,
     max_turns: int = 10,
     tags: str | None = None,
-    cache: bool = True,
+    cache: bool = False,
     dim_set: str | None = DEFAULT_DIM_SET,
     seed_select: str | None = None,
     target_tools: str = "none",


### PR DESCRIPTION
## Summary
- Flip ``cache`` default to ``False`` across the petri-audit surface (runner / typer CLI / argparse CLI / tool-handler kwarg fallback).
- Closed-loop measurement reliability: inspect-ai's md5-keyed trajectory cache causes auditor + judge ``generate`` HITs across mutations because only the target wrapper changes — fitness_delta then deterministically replays prior cycle scores.
- Adds explicit ``--cache`` argparse flag in a mutually exclusive group with ``--no-cache`` (Typer surface already bidirectional).

## Why
The 10-cycle session ending 2026-05-27 returned ``fitness_delta`` of only ``{-1.155, -1.156, -1.733}`` across all REJECT+REVERT cycles, while ``audit_seconds`` varied 181-503s. Diagnostic confirms inspect-ai cache pollution:

- ``CacheEntry._cache_key`` hashes ``(model config exc. {max_connections, adaptive_connections, max_retries, timeout, cache, batch}, input messages, base_url, tool_choice, tools, expiry, scopes, epoch)`` — pickle file under ``$INSPECT_CACHE_DIR/generate/<model>/`` (default ``~/Library/Caches/inspect_ai/generate/``), 1W expiry.
- Mutator edits target wrapper. Auditor + judge prompts live inside inspect-petri's task code → stable input messages cycle-over-cycle → cache HIT.
- Cached trajectory replays the prior cycle's failed-state transcript, including string ``OPENAI_API_KEY not set`` (the 36 grep matches were stale string hits, not live warnings).
- Default OFF restores the one-mutation-one-trajectory invariant the attribution row relies on.

Cost trade: ~$0.05-0.30/cycle (cache hit) → ~$2-5/cycle (fresh generate). Operator can opt back in with ``--cache``.

## Changes
| File | Change |
|------|--------|
| ``plugins/petri_audit/runner.py:524`` | ``cache: bool = True`` → ``False`` |
| ``plugins/petri_audit/cli_audit.py:243`` | ``typer.Option(True, ...)`` → ``False`` + extended docstring explaining the cache pollution risk |
| ``plugins/petri_audit/cli_audit.py:329`` | argparse ``--no-cache`` (default=True) → mutually exclusive ``--cache / --no-cache`` group (default=False) |
| ``core/cli/tool_handlers/audit.py:53`` | ``kwargs.get("cache", True)`` → ``False`` |
| ``CHANGELOG.md`` | ``[Unreleased] Changed`` entry with cache-key composition + observed-symptom record |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Default flip across all 4 surfaces | Implemented | All callers traced via ``grep -rn cache= plugins/petri_audit/ core/`` |
| Test impact | Verified | All 18 existing tests pass ``cache=`` explicitly — default flip invisible to assertions (39 + 828 passed locally) |
| Argparse parity with Typer | Implemented | Previously only ``--no-cache`` was wired; now ``--cache / --no-cache`` mutually exclusive group |
| Per-mutation cache scoping (``CachePolicy.scopes={"mutation_id": …}``) | Deferred | Belongs in alphaevolve plugin (Sprint β); default-off is the immediate floor |
| ``cache_clear()`` automation at cycle start | Deferred | Default-off makes this unnecessary for the closed-loop path; manual audit ops can still purge if desired |

## Verification
- [x] ``ruff check plugins/petri_audit/ core/cli/tool_handlers/audit.py`` clean
- [x] ``ruff format --check`` clean
- [x] ``mypy plugins/petri_audit/ core/cli/tool_handlers/audit.py`` clean (38 files)
- [x] ``lint-imports`` 4 contracts kept
- [x] ``pytest tests/plugins/petri_audit/test_runner.py tests/test_ol_audit_burst_fix.py`` — 39 passed, 3 skipped
- [x] ``pytest -k "audit or cache"`` — 828 passed, 39 skipped, 7694 deselected

## Reference
- ``.venv/.../inspect_ai/model/_cache.py:138 _cache_key`` — md5 hash composition
- ``.venv/.../inspect_ai/model/_cache.py:264 cache_path`` — env override + Darwin default
- 10-cycle observation (memory: ``feedback-inspect-ai-cache-purge``, ``project-self-improving-loop-handoff`` Finding 1)