### PR TITLE
promote petri-cache-default-off to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,42 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-PETRI-CACHE-DEFAULT-OFF (2026-05-28)** — Flips the
+  ``cache`` default to ``False`` across the petri-audit surface
+  (``plugins/petri_audit/runner.py:run_audit``,
+  ``plugins/petri_audit/cli_audit.py`` typer + argparse entry
+  points, ``core/cli/tool_handlers/audit.py`` tool handler kwarg
+  fallback). Closed-loop measurement reliability fix: inspect-ai's
+  ``CacheEntry._cache_key`` hashes ``(model config exc.
+  {max_connections, adaptive_connections, max_retries, timeout,
+  cache, batch}, input messages, base_url, tool_choice, tools,
+  expiry, scopes, epoch)`` into an md5 pickle file under
+  ``$INSPECT_CACHE_DIR/generate/<model>/`` (default
+  ``~/Library/Caches/inspect_ai/generate/`` on Darwin, expiry 1W).
+  In a self-improving closed loop the mutator only edits the
+  target wrapper while the auditor/judge prompts (defined inside
+  inspect-petri's task code) are stable cycle-over-cycle, so the
+  auditor and judge ``generate`` calls HIT cached trajectories
+  from prior cycles — observed during the 10-cycle run ending
+  2026-05-27 as ``fitness_delta`` deterministically returning to
+  ``{-1.155, -1.156, -1.733}`` regardless of mutation while
+  ``audit_seconds`` varied 181-503s. The 36 ``OPENAI_API_KEY not
+  set`` matches in the same period were string-grep hits inside
+  cached failed-run transcripts, not live warnings. Default OFF
+  restores the one-mutation-one-trajectory invariant the loop's
+  attribution row relies on, at the cost of a fresh
+  auditor+target+judge regenerate per audit (~$2-5/cycle vs
+  ~$0.05-0.30 with cache). The CLI argparse path now carries an
+  explicit ``--cache / --no-cache`` mutually exclusive group
+  (previously only ``--no-cache`` was wired); the Typer surface
+  already had the bidirectional ``--cache/--no-cache`` flag pair,
+  just with the inverted default. All 18 existing tests already
+  pass ``cache=True`` or ``cache=False`` explicitly, so the
+  default flip is invisible to the assertion suite (39 passed, 3
+  skipped on direct surface; 828 passed in the broader audit/cache
+  grep slice).
+
 ### Removed
 - **PR-REVERT-MUTATION-CODE-FOUNDATION (2026-05-28)** — Reverts
   PR-MUTATION-CODE-FOUNDATION (#1802, commit 31ae281f) so main

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -50,7 +50,7 @@ def _build_audit_handlers() -> dict[str, Any]:
         seed_select = kwargs.get("seed_select") or None
         dim_set = kwargs.get("dim_set") or "subset"
         target_tools = kwargs.get("target_tools") or "none"
-        cache = bool(kwargs.get("cache", True))
+        cache = bool(kwargs.get("cache", False))
         dry_run = bool(kwargs.get("dry_run", True))
         confirm = bool(kwargs.get("confirm", False))
 

--- a/core/orchestration/anthropic_api_lane.py
+++ b/core/orchestration/anthropic_api_lane.py
@@ -27,10 +27,12 @@ Mid-range default selected from three reference points:
    without crossing the 50 RPM ceiling on the typical seed-gen Loop
    (59 matches × 1 anthropic voter = 59 RPM if fully parallel, well
    under 50 RPM when amortised across the ~5-min wallclock).
-2. **claude_cli_lane=2** + ``audit_lane=1`` already consume 3 slots
+2. **claude_cli_lane=3** + ``audit_lane=1`` already consume 4 slots
    of the per-account budget when active; the API lane sits on top,
-   so 4 keeps total per-account inflight ≤ 7 (still under the soft
-   throttle threshold per [[project_lanequeue_handoff_2026_05_22]]).
+   so the historical "4 keeps total per-account inflight ≤ 7" budget
+   line still holds — claude-cli's cap has only ever moved within
+   the small-integer band (2 → 4 → 50 → 5 → 3) and stays well below
+   the soft throttle threshold per [[project_lanequeue_handoff_2026_05_22]].
 3. **PR-RANKER-PARALLEL** (the immediate consumer) needs the lane to
    smooth a 59-match burst, not to add ceiling — 4 is enough for
    60% wallclock reduction without 429 spikes (vs unbounded → ~30%

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -155,8 +155,8 @@ CLAUDE_CLI_LANE_TIMEOUT_S = 7200.0
 the last-queued voter to a 60-100min wait, well past 5min — the lane
 would fall through to "timeout" and surface a `TimeoutError` even
 though the subprocess itself was perfectly healthy. The 2h timeout
-covers the worst-case Loop 1 ranker (59 matches × ~70s/voter / cap 4
-= ~17min steady state, with retries up to ~1h). A genuinely-stuck
+covers the worst-case Loop 1 ranker (59 matches × ~70s/voter / cap 3
+= ~23min steady state, with retries up to ~1h). A genuinely-stuck
 subprocess still surfaces — just on a 2h boundary instead of 5min.
 
 Pre-raise rationale (retained for context): A legitimate

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -240,7 +240,17 @@ def audit(
         "— inspect-petri default; lets the auditor fabricate tool results, "
         "useful for capability dim studies).",
     ),
-    cache: bool = typer.Option(True, "--cache/--no-cache", help="Petri cache parameter."),
+    cache: bool = typer.Option(
+        False,
+        "--cache/--no-cache",
+        help="Petri cache parameter. Default OFF — inspect-ai trajectory cache "
+        "(``cache_key = (model config, input messages, base_url, tools, "
+        "expiry, scopes, epoch)`` md5) is shared across audits at the same "
+        "process / host, so closed-loop measurement can silently HIT a "
+        "trajectory recorded by a different mutation and replay its score. "
+        "Opt in with ``--cache`` only when you intentionally want to amortise "
+        "auditor/judge generate cost across repeated identical seeds.",
+    ),
     dry_run: bool = typer.Option(
         True,
         "--dry-run/--live",
@@ -326,7 +336,9 @@ def _build_slash_parser() -> argparse.ArgumentParser:
         dest="judge_mode",
         choices=["legacy", "split"],
     )
-    parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
+    cache_group = parser.add_mutually_exclusive_group()
+    cache_group.add_argument("--cache", action="store_true", dest="cache", default=False)
+    cache_group.add_argument("--no-cache", action="store_false", dest="cache")
     parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
     parser.add_argument("--dry-run", action="store_true", dest="dry_run")
     parser.add_argument("--yes", "-y", action="store_true", default=False)

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -521,7 +521,7 @@ def run_audit(
     seeds: int = 1,
     max_turns: int = 10,
     tags: str | None = None,
-    cache: bool = True,
+    cache: bool = False,
     dim_set: str | None = DEFAULT_DIM_SET,
     seed_select: str | None = None,
     target_tools: str = "none",

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -308,11 +308,11 @@ class Ranker(BaseSeedAgent):
                 )
             )
         try:
-            # PR-LANE-CAP-AGGRESSIVE (2026-05-27) — wrap each
+            # PR-LANE-CAP-TIGHTER (v0.99.76, 2026-05-27) — wrap each
             # ``_play_match_with_checkpoint_report`` in a phase-local
             # semaphore acquire so the gather submission queue depth
             # never exceeds :data:`DEFAULT_RANKER_MAX_INFLIGHT_MATCHES`.
-            # The per-adapter lanes (claude_cli_lane=4 / openai_api_lane=16)
+            # The per-adapter lanes (claude_cli_lane=3 / openai_api_lane=6)
             # already throttle the downstream subprocess/API calls; this
             # cap keeps the gather "in-flight" task count from balloon-
             # ing past the lane ceiling on a 59-match Loop 1 burst.


### PR DESCRIPTION
## Summary
- Promote PR #1807 (PR-PETRI-CACHE-DEFAULT-OFF) develop → main.
- Flips ``cache`` default to ``False`` across petri-audit runner / typer CLI / argparse CLI / tool-handler kwarg fallback. Restores one-mutation-one-trajectory invariant for closed-loop measurement (auditor + judge cache HIT was causing fitness_delta to deterministically replay prior cycle scores).

## Verification
- [x] PR #1807 CI 8/8 green
- [x] 18 existing tests pass ``cache=`` explicitly → default flip invisible to assertion suite