### PR TITLE
PR-PROGRAMMD-TARGET-KIND-SYNC: sync program.md CAN table with TARGET_KINDS (5 → 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ functional change.
 ## [Unreleased]
 
 ### Changed
+- **PR-PROGRAMMD-TARGET-KIND-SYNC (2026-05-28)** — Sync
+  ``autoresearch/program.md`` "The agent CAN" markdown table with the
+  actual ``TARGET_KINDS`` tuple in
+  ``core/self_improving_loop/policies.py:188``. Pre-fix the table
+  listed 5 kinds (``prompt`` / ``tool_policy`` / ``decomposition`` /
+  ``retrieval`` / ``reflection``) while ``TARGET_KINDS`` had 7
+  (``skill_catalog`` + ``agent_contract`` + ``tool_descriptions``
+  graduated in ADR-012 M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE;
+  ``retrieval`` deprecated in ADR-012 S0d, reader never wired). Since
+  ``program.md`` is spliced verbatim into the mutator LLM's system
+  prompt by ``runner.py:_build_system_prompt``, the missing rows
+  silently shrank the mutator's effective exploration surface — cycle
+  1-12 (2026-05-26 → 05-28) observed 11/12 proposals stuck on
+  ``prompt`` × ``tool_result_handling``, with zero attempts on
+  ``skill_catalog`` / ``agent_contract`` / ``tool_descriptions``.
+  Table re-formatted to 7 rows + nested-schema explanation (dotted-key
+  flattening for the three M1/M2/T1 graduates) + retrieval deprecation
+  note. Pinned by
+  ``tests/test_self_improving_minimal_1.py::test_program_md_can_table_matches_target_kinds``
+  — a regex extracts kind names from the markdown table and asserts
+  set-equality with ``TARGET_KINDS``, so a future M3/M4 graduation
+  cannot silently regress to the same drift.
+
 - **PR-PETRI-CACHE-DEFAULT-OFF (2026-05-28)** — Flips the
   ``cache`` default to ``False`` across the petri-audit surface
   (``plugins/petri_audit/runner.py:run_audit``,

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -77,22 +77,36 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
 - Modify `train.py`'s `WRAPPER_PROMPT_SECTIONS` dict. The system
   prompt sections are fair game for wording changes, additions,
   deletions, and reorderings.
-- Mutate any of the **5 policy SoT files** at
-  `autoresearch/state/policies/` (PR-MINIMAL-2, 2026-05-21):
+- Mutate any of the **7 policy SoT files** at
+  `autoresearch/state/policies/` (PR-MINIMAL-2 baseline + ADR-012
+  M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE):
 
-  | `target_kind`  | File                            | What it controls                     |
-  |----------------|---------------------------------|--------------------------------------|
-  | `prompt`       | `wrapper-sections.json`         | Wrapper prompt section text (legacy) |
-  | `tool_policy`  | `tool-policy.json`              | Tool selection priority + permissions |
-  | `decomposition`| `decomposition.json`            | Task decomposition heuristics         |
-  | `retrieval`    | `retrieval.json`                | Retrieval (RAG / memory) policies     |
-  | `reflection`   | `reflection.json`               | Self-reflection gate parameters       |
+  | `target_kind`        | File                       | What it controls                                                |
+  |----------------------|----------------------------|-----------------------------------------------------------------|
+  | `prompt`             | `wrapper-sections.json`    | Wrapper prompt section text (legacy)                            |
+  | `tool_policy`        | `tool-policy.json`         | Tool selection priority + permissions                           |
+  | `decomposition`      | `decomposition.json`       | Task decomposition heuristics                                   |
+  | `reflection`         | `reflection.json`          | Self-reflection gate parameters                                 |
+  | `skill_catalog`      | `skill-catalog.json`       | Skill descriptions + `user_invocable` flag (ADR-012 M1)         |
+  | `agent_contract`     | `agent-contracts.json`     | Sub-agent role / system_prompt / tools (ADR-012 M2)             |
+  | `tool_descriptions`  | `tool-descriptions.json`   | Per-tool `description` + `hints` list (PR-TOOL-DESCRIPTIONS-MUTATE) |
 
-  Each file is a `dict[str, str]` (same schema as wrapper-sections so
-  one editing pattern works across all 5). The Mode B runner
-  (`SelfImprovingLoopRunner`) dispatches by `Mutation.target_kind`
-  to the matching file; Mode A agents can edit any of the 5 directly
-  via `git`-tracked JSON.
+  The four legacy kinds (`prompt` / `tool_policy` / `decomposition` /
+  `reflection`) carry a `dict[str, str]` SoT. The three nested kinds
+  (`skill_catalog` / `agent_contract` / `tool_descriptions`) carry a
+  `dict[str, dict]` SoT on disk but the mutation row stays
+  `dict[str, str]` via dotted-key flattening (`<skill>.description`,
+  `<tool>.hints`, etc.); `load_policy` / `write_policy` handle the
+  conversion. The Mode B runner (`SelfImprovingLoopRunner`) dispatches
+  by `Mutation.target_kind` to the matching file; Mode A agents can
+  edit any of the 7 directly via `git`-tracked JSON.
+
+  `retrieval` was deprecated in ADR-012 S0d (2026-05-21) — the reader
+  was never wired (PR-AUDIT-5SLOT). The slot is excluded from
+  `TARGET_KINDS`, so mutator submissions with `target_kind="retrieval"`
+  fail-closed at `parse_mutation`. The mapping in
+  `policies.py:_KIND_TO_PATH` is preserved for a future
+  re-introduction.
 - Tune hyperparameters on `train.py`: `BUDGET_MINUTES`, `SEED_LIMIT`,
   `MAX_TURNS`, `DIM_SET_NAME`, `SOURCE`. Change **one at a time** so the
   fitness delta is attributable. The `auditor` / `target` / `judge` role

--- a/tests/test_self_improving_minimal_1.py
+++ b/tests/test_self_improving_minimal_1.py
@@ -149,3 +149,49 @@ def test_build_system_prompt_includes_program_md_content() -> None:
         f"_build_system_prompt must splice in program.md body — "
         f"needle {needle!r} not found in built prompt"
     )
+
+
+def test_program_md_can_table_matches_target_kinds() -> None:
+    """PR-PROGRAMMD-TARGET-KIND-SYNC (2026-05-28) drift invariant.
+
+    ``autoresearch/program.md`` lists the agent-authoritative
+    ``target_kind`` surface in a markdown table under "The agent CAN".
+    The mutator LLM reads this table verbatim (program.md is spliced
+    into the system prompt), so any row missing here equals a
+    target_kind the mutator will never propose — and any extra row
+    here is a target_kind that fails-closed at ``parse_mutation``.
+
+    Pre-fix incident: program.md listed 5 kinds (prompt / tool_policy /
+    decomposition / retrieval / reflection) while ``TARGET_KINDS`` had 7
+    (skill_catalog / agent_contract / tool_descriptions added,
+    retrieval deprecated in ADR-012 S0d). Cycle 1-12 observed mutator
+    never proposing skill_catalog / agent_contract / tool_descriptions
+    because the table didn't surface them.
+
+    This invariant pins the table → TARGET_KINDS equivalence so a
+    future M3/M4 graduation cannot silently regress to the same drift.
+    """
+    import re
+
+    from core.self_improving_loop.policies import TARGET_KINDS
+
+    from core.self_improving_loop import runner as runner_mod
+
+    program_md = runner_mod._load_program_md()
+    assert program_md is not None
+
+    # Match rows of the form: "| `<kind>` | `<filename>.json` | ..."
+    # Both the kind and filename are backtick-wrapped in the table.
+    row_pattern = re.compile(
+        r"^\s*\|\s*`(\w+)`\s*\|\s*`[\w\-]+\.json`\s*\|",
+        re.MULTILINE,
+    )
+    table_kinds = set(row_pattern.findall(program_md))
+    target_kinds = set(TARGET_KINDS)
+
+    assert table_kinds == target_kinds, (
+        f"program.md 'CAN' table kinds {sorted(table_kinds)!r} != "
+        f"TARGET_KINDS {sorted(target_kinds)!r}. "
+        f"Missing from program.md: {sorted(target_kinds - table_kinds)!r}; "
+        f"extra in program.md: {sorted(table_kinds - target_kinds)!r}."
+    )


### PR DESCRIPTION
## Summary
- Sync ``autoresearch/program.md`` "The agent CAN" table 5 → 7 rows to match the actual ``TARGET_KINDS`` tuple.
- Removes deprecated ``retrieval`` row; adds ``skill_catalog`` / ``agent_contract`` / ``tool_descriptions`` rows.
- Adds drift invariant test that pins the table ↔ TARGET_KINDS equivalence.

## Why
program.md is spliced verbatim into the mutator LLM system prompt by ``runner.py:_build_system_prompt``. Pre-fix the table listed 5 kinds (``prompt`` / ``tool_policy`` / ``decomposition`` / ``retrieval`` / ``reflection``) while ``TARGET_KINDS`` (``core/self_improving_loop/policies.py:188``) held 7 — ``skill_catalog`` + ``agent_contract`` + ``tool_descriptions`` graduated via ADR-012 M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE, ``retrieval`` deprecated in ADR-012 S0d (reader never wired).

Observed effect during cycle 1-12 (2026-05-26 → 05-28): 11/12 proposals stuck on ``prompt × tool_result_handling × redundant_tool_invocation``, with 0 attempts on the 3 graduated kinds. The mutator could see ``_MUTATION_CONTRACT_SUFFIX`` (runner.py:505 — already correct, lists 7 kinds + retrieval deprecation), but the more prominent program.md "CAN" table only surfaced 5 — and the conflicting kind count likely steered the conservative choice toward the older, validated surface.

Drift class: **dual SoT (program.md ↔ TARGET_KINDS) without invariant pin** — the same pattern as PR-MINIMAL-2 #1398 (program.md ↔ _FALLBACK_SYSTEM_PROMPT). CANNOT-rule "No dual SoT (disk + fallback literal) without shared anchor + drift invariant test" applies — fixed here with set-equality assertion.

## Changes
| File | Change |
|------|--------|
| ``autoresearch/program.md`` | "CAN" table 5 → 7 row sync. Adds nested-schema explanation (dotted-key flattening for 3 graduated kinds). Adds retrieval deprecation note pointing at ADR-012 S0d. |
| ``tests/test_self_improving_minimal_1.py`` | New ``test_program_md_can_table_matches_target_kinds``. Regex extracts kind names from the markdown table; asserts set-equality with ``TARGET_KINDS``. |
| ``CHANGELOG.md`` | ``[Unreleased] Changed`` entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Surface 3 graduated kinds | Implemented | Table 5 → 7 rows |
| Remove deprecated retrieval row | Implemented | + deprecation note pointing at ADR-012 S0d |
| Drift invariant test | Implemented | Set-equality assertion via regex extraction |
| _FALLBACK_SYSTEM_PROMPT update | Skipped | Fallback is intentionally simple — only fires when program.md unreadable. ``_MUTATION_CONTRACT_SUFFIX`` (runner.py:505) is the canonical kind-list for mutator and already correct (7 kinds + retrieval deprecation note). |
| retrieval code residual cleanup | Deferred | ``policies.py`` mapping + paths preserved for future re-introduction per ADR-012 S0d note. Cleanup is separate PR scope. |

## Verification
- [x] ``ruff check / ruff format --check / mypy`` clean
- [x] ``pytest tests/test_self_improving_minimal_1.py`` — 8/8 pass (was 7, +1 new drift invariant)
- [x] Drift invariant: regex parses 7 backtick-wrapped kind rows from the new table, set-equality with ``TARGET_KINDS`` confirmed

## Expected effect on cycle 13+
The mutator's next propose call sees the full 7-kind surface in program.md. Combined with the cycle 11/12 attribution history (``prompt × tool_result_handling`` attribution_score = -1.0 twice), this should increase cross-kind exploration probability — particularly toward ``tool_descriptions`` (direct ``broken_tool_use`` mechanism per OpenAI function-calling guidance) and ``skill_catalog`` (mutator's first chance to touch skill descriptions).

## Reference
- ``core/self_improving_loop/policies.py:188`` — ``TARGET_KINDS`` definition (source of truth)
- ``core/self_improving_loop/runner.py:_build_system_prompt`` — splice site
- ``runner.py:505`` (``_MUTATION_CONTRACT_SUFFIX``) — already-correct mirror used as the structural reference
- ADR-012 S0d (retrieval deprecation), M1 (skill_catalog), M2 (agent_contract); PR-TOOL-DESCRIPTIONS-MUTATE
- Cycle 1-12 attribution history (memory: ``project-self-improving-loop-handoff``, ``project-closed-loop-full-verification``)