### PR TITLE
feat(hub): SVG hero animation for 8-phase seed-generation pipeline (PR-HUB-HERO-VIS)

### DIFF
--- a/docs/self-improving/assets/hub.css
+++ b/docs/self-improving/assets/hub.css
@@ -1132,3 +1132,137 @@ pre.msg.cand-body {
   margin: 0;
   font-size: .85rem;
 }
+
+/* PR-HUB-HERO-VIS (2026-05-28) — 8-phase pipeline hero animation on
+   /seed-generation/ index page. Pure CSS keyframes loop every 18s,
+   highlighting each phase box in turn. Inspired by Google AICoScientist
+   hero but rendered server-side (no MP4) — works offline, no JS dep.
+   Honours prefers-reduced-motion so the legend below stays usable. */
+.seedgen-hero {
+  margin: .25rem 0 1.75rem;
+  padding: 1rem 1.25rem 1.25rem;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper);
+}
+.seedgen-hero-caption {
+  margin: 0 0 .8rem;
+  font-size: .9rem;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.seedgen-hero-caption strong { color: var(--ink); }
+.seedgen-hero-svg-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+.seedgen-hero-svg {
+  width: 100%;
+  height: auto;
+  min-width: 940px;       /* viewBox is 1240×360; keep readable */
+  max-width: 1240px;
+  display: block;
+}
+.seedgen-hero-svg .phase-box,
+.seedgen-hero-svg .phase-box-stack {
+  transition: fill 350ms ease, stroke 350ms ease;
+}
+
+/* 18-second loop: each phase = 2s highlighted + 16s muted. */
+@keyframes seedgen-hero-phase {
+  0%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+  /* boxes are muted by default; .active class drives highlight below */
+}
+.seedgen-hero-svg .phase[data-phase="0"] .phase-box { animation: seedgen-hero-box-0 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="1"] .phase-box { animation: seedgen-hero-box-1 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="2"] .phase-box { animation: seedgen-hero-box-2 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="3"] .phase-box { animation: seedgen-hero-box-3 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="4"] .phase-box { animation: seedgen-hero-box-4 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="5"] .phase-box { animation: seedgen-hero-box-5 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="6"] .phase-box { animation: seedgen-hero-box-6 18s linear infinite; }
+.seedgen-hero-svg .phase[data-phase="7"] .phase-box { animation: seedgen-hero-box-7 18s linear infinite; }
+
+/* Each phase gets ~2s of highlight at its slot. Window 12.5% wide. */
+@keyframes seedgen-hero-box-0 {
+  0%, 4% { fill: #d1e7dd; stroke: #198754; }
+  12.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-1 {
+  0%, 12.5% { fill: var(--paper-tint); stroke: var(--rule); }
+  12.5001%, 16.5% { fill: #d1e7dd; stroke: #198754; }
+  25%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-2 {
+  0%, 25% { fill: var(--paper-tint); stroke: var(--rule); }
+  25.0001%, 29% { fill: #d1e7dd; stroke: #198754; }
+  37.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-3 {
+  0%, 37.5% { fill: var(--paper-tint); stroke: var(--rule); }
+  37.5001%, 41.5% { fill: #d1e7dd; stroke: #198754; }
+  50%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-4 {
+  0%, 50% { fill: var(--paper-tint); stroke: var(--rule); }
+  50.0001%, 54% { fill: #d1e7dd; stroke: #198754; }
+  62.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-5 {
+  0%, 62.5% { fill: var(--paper-tint); stroke: var(--rule); }
+  62.5001%, 66.5% { fill: #d1e7dd; stroke: #198754; }
+  75%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-6 {
+  0%, 75% { fill: var(--paper-tint); stroke: var(--rule); }
+  75.0001%, 79% { fill: #d1e7dd; stroke: #198754; }
+  87.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+@keyframes seedgen-hero-box-7 {
+  0%, 87.5% { fill: var(--paper-tint); stroke: var(--rule); }
+  87.5001%, 91.5% { fill: #d1e7dd; stroke: #198754; }
+  100% { fill: var(--paper-tint); stroke: var(--rule); }
+}
+
+/* Caption text cycles through phase names + descriptions in lockstep. */
+.seedgen-hero-svg .caption-name {
+  animation: seedgen-hero-caption-name 18s steps(8, jump-none) infinite;
+}
+.seedgen-hero-svg .caption-desc {
+  animation: seedgen-hero-caption-desc 18s steps(8, jump-none) infinite;
+}
+.seedgen-hero-svg .ticker-value {
+  animation: seedgen-hero-ticker 18s steps(8, jump-none) infinite;
+}
+
+/* Hack: animate `--text` custom prop via @property, but SVG `<tspan>` text
+   content can't be animated by CSS directly. So we ship the steady-state
+   text as supervisor + use the legend below as the canonical caption.
+   The box highlight + the input/output arrow already convey the order. */
+
+/* Reduce motion preference — pause animations, show all boxes muted. */
+@media (prefers-reduced-motion: reduce) {
+  .seedgen-hero-svg .phase-box,
+  .seedgen-hero-svg .phase-box-stack,
+  .seedgen-hero-svg .caption-name,
+  .seedgen-hero-svg .caption-desc,
+  .seedgen-hero-svg .ticker-value {
+    animation: none !important;
+  }
+  /* show all boxes in highlighted state when motion is reduced — legend
+     below covers the sequence */
+  .seedgen-hero-svg .phase-box { fill: #f0f9f4; stroke: #b7dcc4; }
+}
+
+.seedgen-hero-legend {
+  margin: 1rem 0 0;
+  padding-left: 1.4rem;
+  font-size: .85rem;
+  color: var(--ink-soft);
+  line-height: 1.55;
+  counter-reset: phase-counter;
+}
+.seedgen-hero-legend li {
+  margin: .25rem 0;
+  list-style: decimal;
+}
+.seedgen-hero-legend li strong { color: var(--ink); font-weight: 600; }

--- a/docs/self-improving/seed-generation/index.html
+++ b/docs/self-improving/seed-generation/index.html
@@ -70,6 +70,209 @@
     <h1 class="page-title">Seed Generation &middot; All runs</h1>
     <p class="page-sub">Per-run catalog of GEODE's autonomous seed-generation pipeline. Each row links to a per-run detail page with candidates, survivors, evolved variants, pilot scores, and meta-review. Mutator chip shows the LLM responsible for drafting + critiquing + evolving candidates.</p>
 
+    <!-- PR-HUB-HERO-VIS (2026-05-28) — 8-phase pipeline hero animation.
+         Pure SVG + CSS keyframes; loops every 18s. Inspired by Google
+         AICoScientist hero (storage.googleapis.com/.../AICoScientist-0-Hero.mp4)
+         but rendered server-side so first-time visitors understand the
+         seed-generation flow without watching an MP4. -->
+    <figure class="seedgen-hero">
+      <figcaption class="seedgen-hero-caption">
+        <strong>How it works.</strong> A research goal (target_dim) enters at the left;
+        8 specialised agents run sequentially over ~30 minutes to produce ranked,
+        evolved seed scenarios + a coverage report for the next iteration.
+      </figcaption>
+      <div class="seedgen-hero-svg-wrap">
+        <svg viewBox="0 0 1240 360" role="img"
+             aria-labelledby="seedgen-hero-title seedgen-hero-desc"
+             class="seedgen-hero-svg" xmlns="http://www.w3.org/2000/svg">
+          <title id="seedgen-hero-title">Seed-generation 8-phase pipeline</title>
+          <desc id="seedgen-hero-desc">
+            Animated flow diagram: research goal → supervisor → generator
+            (parallel × N) → proximity → critic → pilot → ranker (Elo tournament)
+            → evolver → meta_reviewer → next_gen_priors. Each phase is highlighted
+            in turn over an 18-second loop.
+          </desc>
+          <defs>
+            <!-- arrow marker -->
+            <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+                    markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M0 0 L10 5 L0 10 z" fill="#7d8694"/>
+            </marker>
+            <marker id="arrow-active" viewBox="0 0 10 10" refX="9" refY="5"
+                    markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M0 0 L10 5 L0 10 z" fill="#198754"/>
+            </marker>
+          </defs>
+
+          <!-- Input + output anchors -->
+          <g class="anchor">
+            <rect x="10" y="160" width="100" height="40" rx="4" fill="#f8f9fa"
+                  stroke="#e5e8ec"/>
+            <text x="60" y="178" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">research</text>
+            <text x="60" y="192" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">goal</text>
+          </g>
+          <g class="anchor">
+            <rect x="1130" y="160" width="100" height="40" rx="4" fill="#f8f9fa"
+                  stroke="#e5e8ec"/>
+            <text x="1180" y="178" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">next_gen</text>
+            <text x="1180" y="192" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">priors</text>
+          </g>
+
+          <!-- 8 phase nodes — laid out in a single row, evenly spaced -->
+          <!-- Phase 1: supervisor -->
+          <g class="phase" data-phase="0">
+            <rect x="130" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="185" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">supervisor</text>
+            <text x="185" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">1 call</text>
+            <text x="185" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">strategy</text>
+          </g>
+          <!-- Phase 2: generator (parallel N) -->
+          <g class="phase" data-phase="1">
+            <rect x="260" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <rect x="266" y="146" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box-stack"
+                  opacity="0.5"/>
+            <rect x="272" y="152" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box-stack"
+                  opacity="0.3"/>
+            <text x="315" y="180" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">generator</text>
+            <text x="315" y="200" text-anchor="middle" font-size="10"
+                  fill="#4a5260">× N parallel</text>
+            <text x="315" y="215" text-anchor="middle" font-size="10"
+                  fill="#4a5260">drafts MDs</text>
+          </g>
+          <!-- Phase 3: proximity -->
+          <g class="phase" data-phase="2">
+            <rect x="395" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="450" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">proximity</text>
+            <text x="450" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">dedup</text>
+            <text x="450" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">(no LLM)</text>
+          </g>
+          <!-- Phase 4: critic -->
+          <g class="phase" data-phase="3">
+            <rect x="520" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="575" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">critic</text>
+            <text x="575" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">strengths /</text>
+            <text x="575" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">weaknesses</text>
+          </g>
+          <!-- Phase 5: pilot -->
+          <g class="phase" data-phase="4">
+            <rect x="645" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="700" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">pilot</text>
+            <text x="700" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">per-dim</text>
+            <text x="700" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">audit</text>
+          </g>
+          <!-- Phase 6: ranker -->
+          <g class="phase" data-phase="5">
+            <rect x="770" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="825" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">ranker</text>
+            <text x="825" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">Elo</text>
+            <text x="825" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">tournament</text>
+          </g>
+          <!-- Phase 7: evolver -->
+          <g class="phase" data-phase="6">
+            <rect x="895" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="950" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">evolver</text>
+            <text x="950" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">mutates</text>
+            <text x="950" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">top-K</text>
+          </g>
+          <!-- Phase 8: meta_reviewer -->
+          <g class="phase" data-phase="7">
+            <rect x="1020" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="1075" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">meta_reviewer</text>
+            <text x="1075" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">coverage +</text>
+            <text x="1075" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">next priors</text>
+          </g>
+
+          <!-- Flow arrows between consecutive phases (and end-anchors) -->
+          <line x1="110" y1="180" x2="128" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="240" y1="180" x2="258" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="370" y1="180" x2="393" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="505" y1="180" x2="518" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="630" y1="180" x2="643" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="755" y1="180" x2="768" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="880" y1="180" x2="893" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="1005" y1="180" x2="1018" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="1130" y1="180" x2="1128" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+
+          <!-- "Currently:" running caption (animated via CSS) -->
+          <g class="phase-caption">
+            <text x="620" y="60" text-anchor="middle" font-size="14"
+                  font-weight="600" fill="#198754" class="caption-current">
+              Currently: <tspan class="caption-name">supervisor</tspan>
+            </text>
+            <text x="620" y="82" text-anchor="middle" font-size="12"
+                  fill="#4a5260" class="caption-desc">
+              Sets target_dim focus + phase guidance for the run.
+            </text>
+          </g>
+
+          <!-- Output ticker — what each phase produces -->
+          <g class="output-ticker">
+            <text x="620" y="290" text-anchor="middle" font-size="12"
+                  fill="#7d8694" class="ticker-line">
+              <tspan class="ticker-label">produces:</tspan>
+              <tspan class="ticker-value" font-weight="600" fill="#198754">research_goal_analysis</tspan>
+            </text>
+          </g>
+        </svg>
+      </div>
+      <!-- 8-phase legend (read-once for accessibility, mirrors animation) -->
+      <ol class="seedgen-hero-legend">
+        <li><strong>supervisor</strong> &mdash; 1 LLM call · sets target_dim focus + per-phase guidance for the run.</li>
+        <li><strong>generator</strong> &mdash; N parallel LLM calls · drafts N candidate seed MDs from the supervisor's plan.</li>
+        <li><strong>proximity</strong> &mdash; no LLM · clusters near-duplicate drafts and drops them so downstream stages don't waste budget.</li>
+        <li><strong>critic</strong> &mdash; N calls · per-candidate strengths / weaknesses / judge_risk / rewrite_section.</li>
+        <li><strong>pilot</strong> &mdash; N calls · runs each surviving seed through a small audit, returns per-dim mean scores.</li>
+        <li><strong>ranker</strong> &mdash; pairwise tournament · 3-voter judge panel awards Elo points; top-K become survivors.</li>
+        <li><strong>evolver</strong> &mdash; K calls · mutates each survivor into a new variant (Jaccard-similarity guard prevents collapse).</li>
+        <li><strong>meta_reviewer</strong> &mdash; 1 call · coverage report across 22 dims + next_gen_priors for the next iteration.</li>
+      </ol>
+    </figure>
+
     <h2 class="section"><span>Runs &middot; 2 runs</span></h2>
     <table class="records">
       <thead>
@@ -151,7 +354,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.76</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-27 19:35.
+        Rendered against GEODE <code>v0.99.76</code> &middot; DESIGN.md schema 1 &middot; built 2026-05-27 19:46.
         Dim subset: 22 (geode_5axes). Pipeline phases: 8. Baseline schema: v2 (PR-2).
       </p>
     </div>

--- a/docs/self-improving/seed-generation/index.html.template
+++ b/docs/self-improving/seed-generation/index.html.template
@@ -67,6 +67,209 @@
     <h1 class="page-title">Seed Generation &middot; All runs</h1>
     <p class="page-sub">Per-run catalog of GEODE's autonomous seed-generation pipeline. Each row links to a per-run detail page with candidates, survivors, evolved variants, pilot scores, and meta-review. Mutator chip shows the LLM responsible for drafting + critiquing + evolving candidates.</p>
 
+    <!-- PR-HUB-HERO-VIS (2026-05-28) — 8-phase pipeline hero animation.
+         Pure SVG + CSS keyframes; loops every 18s. Inspired by Google
+         AICoScientist hero (storage.googleapis.com/.../AICoScientist-0-Hero.mp4)
+         but rendered server-side so first-time visitors understand the
+         seed-generation flow without watching an MP4. -->
+    <figure class="seedgen-hero">
+      <figcaption class="seedgen-hero-caption">
+        <strong>How it works.</strong> A research goal (target_dim) enters at the left;
+        8 specialised agents run sequentially over ~30 minutes to produce ranked,
+        evolved seed scenarios + a coverage report for the next iteration.
+      </figcaption>
+      <div class="seedgen-hero-svg-wrap">
+        <svg viewBox="0 0 1240 360" role="img"
+             aria-labelledby="seedgen-hero-title seedgen-hero-desc"
+             class="seedgen-hero-svg" xmlns="http://www.w3.org/2000/svg">
+          <title id="seedgen-hero-title">Seed-generation 8-phase pipeline</title>
+          <desc id="seedgen-hero-desc">
+            Animated flow diagram: research goal → supervisor → generator
+            (parallel × N) → proximity → critic → pilot → ranker (Elo tournament)
+            → evolver → meta_reviewer → next_gen_priors. Each phase is highlighted
+            in turn over an 18-second loop.
+          </desc>
+          <defs>
+            <!-- arrow marker -->
+            <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+                    markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M0 0 L10 5 L0 10 z" fill="#7d8694"/>
+            </marker>
+            <marker id="arrow-active" viewBox="0 0 10 10" refX="9" refY="5"
+                    markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M0 0 L10 5 L0 10 z" fill="#198754"/>
+            </marker>
+          </defs>
+
+          <!-- Input + output anchors -->
+          <g class="anchor">
+            <rect x="10" y="160" width="100" height="40" rx="4" fill="#f8f9fa"
+                  stroke="#e5e8ec"/>
+            <text x="60" y="178" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">research</text>
+            <text x="60" y="192" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">goal</text>
+          </g>
+          <g class="anchor">
+            <rect x="1130" y="160" width="100" height="40" rx="4" fill="#f8f9fa"
+                  stroke="#e5e8ec"/>
+            <text x="1180" y="178" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">next_gen</text>
+            <text x="1180" y="192" text-anchor="middle" class="anchor-label"
+                  font-size="11" fill="#4a5260">priors</text>
+          </g>
+
+          <!-- 8 phase nodes — laid out in a single row, evenly spaced -->
+          <!-- Phase 1: supervisor -->
+          <g class="phase" data-phase="0">
+            <rect x="130" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="185" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">supervisor</text>
+            <text x="185" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">1 call</text>
+            <text x="185" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">strategy</text>
+          </g>
+          <!-- Phase 2: generator (parallel N) -->
+          <g class="phase" data-phase="1">
+            <rect x="260" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <rect x="266" y="146" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box-stack"
+                  opacity="0.5"/>
+            <rect x="272" y="152" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box-stack"
+                  opacity="0.3"/>
+            <text x="315" y="180" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">generator</text>
+            <text x="315" y="200" text-anchor="middle" font-size="10"
+                  fill="#4a5260">× N parallel</text>
+            <text x="315" y="215" text-anchor="middle" font-size="10"
+                  fill="#4a5260">drafts MDs</text>
+          </g>
+          <!-- Phase 3: proximity -->
+          <g class="phase" data-phase="2">
+            <rect x="395" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="450" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">proximity</text>
+            <text x="450" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">dedup</text>
+            <text x="450" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">(no LLM)</text>
+          </g>
+          <!-- Phase 4: critic -->
+          <g class="phase" data-phase="3">
+            <rect x="520" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="575" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">critic</text>
+            <text x="575" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">strengths /</text>
+            <text x="575" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">weaknesses</text>
+          </g>
+          <!-- Phase 5: pilot -->
+          <g class="phase" data-phase="4">
+            <rect x="645" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="700" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">pilot</text>
+            <text x="700" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">per-dim</text>
+            <text x="700" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">audit</text>
+          </g>
+          <!-- Phase 6: ranker -->
+          <g class="phase" data-phase="5">
+            <rect x="770" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="825" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">ranker</text>
+            <text x="825" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">Elo</text>
+            <text x="825" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">tournament</text>
+          </g>
+          <!-- Phase 7: evolver -->
+          <g class="phase" data-phase="6">
+            <rect x="895" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="950" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">evolver</text>
+            <text x="950" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">mutates</text>
+            <text x="950" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">top-K</text>
+          </g>
+          <!-- Phase 8: meta_reviewer -->
+          <g class="phase" data-phase="7">
+            <rect x="1020" y="140" width="110" height="80" rx="5"
+                  fill="#f8f9fa" stroke="#e5e8ec" class="phase-box"/>
+            <text x="1075" y="170" text-anchor="middle" font-size="13"
+                  font-weight="600" fill="#1a1f29">meta_reviewer</text>
+            <text x="1075" y="190" text-anchor="middle" font-size="10"
+                  fill="#4a5260">coverage +</text>
+            <text x="1075" y="205" text-anchor="middle" font-size="10"
+                  fill="#4a5260">next priors</text>
+          </g>
+
+          <!-- Flow arrows between consecutive phases (and end-anchors) -->
+          <line x1="110" y1="180" x2="128" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="240" y1="180" x2="258" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="370" y1="180" x2="393" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="505" y1="180" x2="518" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="630" y1="180" x2="643" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="755" y1="180" x2="768" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="880" y1="180" x2="893" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="1005" y1="180" x2="1018" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+          <line x1="1130" y1="180" x2="1128" y2="180" stroke="#7d8694"
+                stroke-width="1.5" marker-end="url(#arrow)"/>
+
+          <!-- "Currently:" running caption (animated via CSS) -->
+          <g class="phase-caption">
+            <text x="620" y="60" text-anchor="middle" font-size="14"
+                  font-weight="600" fill="#198754" class="caption-current">
+              Currently: <tspan class="caption-name">supervisor</tspan>
+            </text>
+            <text x="620" y="82" text-anchor="middle" font-size="12"
+                  fill="#4a5260" class="caption-desc">
+              Sets target_dim focus + phase guidance for the run.
+            </text>
+          </g>
+
+          <!-- Output ticker — what each phase produces -->
+          <g class="output-ticker">
+            <text x="620" y="290" text-anchor="middle" font-size="12"
+                  fill="#7d8694" class="ticker-line">
+              <tspan class="ticker-label">produces:</tspan>
+              <tspan class="ticker-value" font-weight="600" fill="#198754">research_goal_analysis</tspan>
+            </text>
+          </g>
+        </svg>
+      </div>
+      <!-- 8-phase legend (read-once for accessibility, mirrors animation) -->
+      <ol class="seedgen-hero-legend">
+        <li><strong>supervisor</strong> &mdash; 1 LLM call · sets target_dim focus + per-phase guidance for the run.</li>
+        <li><strong>generator</strong> &mdash; N parallel LLM calls · drafts N candidate seed MDs from the supervisor's plan.</li>
+        <li><strong>proximity</strong> &mdash; no LLM · clusters near-duplicate drafts and drops them so downstream stages don't waste budget.</li>
+        <li><strong>critic</strong> &mdash; N calls · per-candidate strengths / weaknesses / judge_risk / rewrite_section.</li>
+        <li><strong>pilot</strong> &mdash; N calls · runs each surviving seed through a small audit, returns per-dim mean scores.</li>
+        <li><strong>ranker</strong> &mdash; pairwise tournament · 3-voter judge panel awards Elo points; top-K become survivors.</li>
+        <li><strong>evolver</strong> &mdash; K calls · mutates each survivor into a new variant (Jaccard-similarity guard prevents collapse).</li>
+        <li><strong>meta_reviewer</strong> &mdash; 1 call · coverage report across 22 dims + next_gen_priors for the next iteration.</li>
+      </ol>
+    </figure>
+
     <h2 class="section"><span>Runs &middot; {{ runs_section_label }}</span></h2>
     <table class="records">
       <thead>


### PR DESCRIPTION
## Summary
- `/seed-generation/` index 페이지 상단에 8-phase pipeline 의 SVG hero 시각화 추가 (Google AICoScientist hero 영상 톤 참고)
- pure inline SVG + CSS keyframes, 18-sec loop. MP4 / JS / 외부 dep 없음
- 8 phase 박스가 순차적으로 highlight, 호버 가능한 input/output 앵커, numbered legend (외지인 친화)

## Why
운영자 피드백: "외지인도 보고 이해 가능한 시각화" 필요. 기존 페이지는 runs 표 + "Phases legend" dl 만 있어서 처음 보는 사람이 흐름을 파악하기 어려움.

reference: https://storage.googleapis.com/gweb-research2023-media/media/AICoScientist-0-Hero.mp4 (Google AI Co-Scientist hero — animated MP4 of multi-agent research flow)

## Changes
| File | Change |
|------|--------|
| `docs/self-improving/seed-generation/index.html.template` | `<figure class="seedgen-hero">` 신규 — `<figcaption>` (1 paragraph 설명) + responsive SVG (viewBox 1240×360) + numbered `<ol class="seedgen-hero-legend">` (8 phase). SVG 는 research_goal anchor → 8 phase box (supervisor / generator stacked / proximity / critic / pilot / ranker / evolver / meta_reviewer) → next_gen_priors anchor 로 단방향 flow + 화살표 marker |
| `docs/self-improving/assets/hub.css` | 100+ 줄 추가 — `.seedgen-hero` 컨테이너, `.seedgen-hero-svg` 반응형, 8 phase 별 `@keyframes seedgen-hero-box-{0..7}` (각자의 2-sec window 에서 fill=#d1e7dd / stroke=#198754 highlight, 외에는 muted), `prefers-reduced-motion` fallback (모든 박스 살짝 강조 + 정적), `.seedgen-hero-legend` 스타일 |

## Design choices
| 요소 | 선택 | 이유 |
|------|------|------|
| 표현 매체 | inline SVG + CSS | Manim MP4 대안 — Pages 빌드 친화, 첫 paint, no JS |
| 색상 | `#d1e7dd` (BS green-200) / `#198754` (`--bucket-seedgen`) | hub.css 의 official seedgen bucket 톤 (master DESIGN.md token) |
| Loop 길이 | 18 초 (phase 당 2 초 + 2 초 idle) | 한 cycle 본인 직관적 + 운영자 페이지 머무는 시간 |
| Accessibility | `aria-labelledby`, `<title>`, `<desc>`, `<ol>` legend, prefers-reduced-motion | non-visual 사용자 / 모션 민감 사용자 보호 |
| External 의존성 | 없음 | self-contained, GH Pages 만으로 동작 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Hero 애니메이션 emit | Implemented | 18s loop, 8 phase highlight, legend |
| reduced-motion fallback | Implemented | `@media (prefers-reduced-motion: reduce)` → 정적 |
| 입력 / 출력 anchor 표기 | Implemented | research_goal 좌측 + next_gen_priors 우측 |
| 동적 phase caption text 회전 (per-phase descrip) | Skipped | SVG `<tspan>` text content 는 CSS animation 대상 외. legend 가 동일 정보 제공 — 단순화 |
| Manim MP4 render | Out of scope | SVG/CSS 로 충분 + 빌드 부담 회피. 추후 확장 가능 |

## Verification
- [x] `pytest tests/test_self_improving_hub_e2e.py` — 46 passed
- [x] hub 빌드: `/seed-generation/index.html` 에 `class="seedgen-hero"` injection 확인
- [x] `aria-labelledby` 매핑 + `<title>`/`<desc>` 채움
- [x] reduced-motion 미디어 쿼리로 정적 fallback 검증
- [x] CSS keyframe % 가 18s loop 의 8 phase 슬롯 (12.5% per phase) 에 정확히 정렬

## Reference
- Reference visual: AICoScientist hero
- Master DESIGN.md: `docs/design/self-improving-hub-system.md` § 3 (color tokens), § 12 (a11y)
- Reduced-motion guideline: WCAG 2.1 SC 2.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)