### PR TITLE
promote hyperparam-foundation to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,59 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-HYPERPARAM-FOUNDATION (2026-05-28)** — Adds the 8th
+  ``target_kind`` slot ``hyperparam`` to ``TARGET_KINDS``, opening a
+  numeric / categorical mutation surface that targets the
+  audit-subprocess command line + AgenticLoop runtime config directly
+  (instead of an LLM-facing wrapper prompt). Motivated by cycle 1-12
+  (2026-05-26 → 05-28, sessions through PR-PETRI-CACHE-DEFAULT-OFF /
+  PR-PROGRAMMD-TARGET-KIND-SYNC) where 11/12 prompt-only mutations
+  produced ``Δ = 0`` for ``redundant_tool_invocation`` — the dim's
+  ``measurement_modality = tool_log`` (programmatic tool-call dedup
+  count) lives below the prompt-following surface, so prompt mutation
+  cannot reach the mechanism. Hyperparam mutation lets the loop tune
+  the audit budget itself (``max_turns``, ``seed_limit``,
+  ``reflection_depth``, ``dim_set``) so the regression dim can move
+  via budget shrink rather than via wrapper-prompt coaching. Schema:
+  flat ``dict[str, str]`` (same shape as the 4 simple-shape kinds);
+  values are string-encoded numerics / categoricals; runtime readers
+  convert at consumption time. Bounds: ``max_turns ∈ [1, 20]``,
+  ``seed_limit ∈ [1, 50]``, ``reflection_depth ∈ [1, 5]``,
+  ``dim_set ∈ {subset, full}`` — enforced at both
+  ``parse_mutation`` (LLM-response time) and ``apply_mutation``
+  (externally-constructed Mutation time) per the boundary-completeness
+  rule. Adds ``GLOBAL_HYPERPARAM_POLICY_PATH``,
+  ``_KIND_TO_PATH["hyperparam"]``, ``_SIBLING_SOT_ENV_MAP["hyperparam"]
+  = "GEODE_HYPERPARAM_OVERRIDE"``,
+  ``_SIBLING_SOT_STRICT_ENV_MAP["hyperparam"]
+  = "GEODE_HYPERPARAM_STRICT"``, the env-literal block in
+  ``autoresearch/train.py`` that propagates the SoT path to the audit
+  subprocess (read-only until PR-3 lands the consumer), and an initial
+  ``autoresearch/state/policies/hyperparam.json`` with defaults
+  matching the current hardcoded audit invocation
+  (``max_turns="5"``, ``seed_limit="8"``, ``dim_set="subset"``,
+  ``reflection_depth="3"``). Mutator system prompt
+  (``_MUTATION_CONTRACT_SUFFIX`` + ``program.md`` "CAN" table) updated
+  with the 8th kind + bounds documentation +
+  ``measurement_modality`` guidance ("use hyperparam when target dim
+  is ``tool_log`` / ``token_count`` and prompt mutations produced
+  ``Δ ≈ 0``"). Pinned by 17 new assertions across
+  ``tests/test_policy_mutation.py`` (bounds validator unit tests,
+  end-to-end parse_mutation acceptance / rejection, apply_mutation
+  isolation against tmp_path) + updates to 4 existing
+  count-coupled tests
+  (``test_target_kinds_count_is_8_post_hyperparam``,
+  ``test_target_kinds_contains_active_eight``,
+  ``test_policy_path_returns_distinct_paths`` 9-path,
+  ``test_active_slots_registered_as_mutation_targets`` 8-set in
+  ADR-012 + 5-slot reader audit, ``test_program_md_can_table_matches_target_kinds``
+  drift invariant auto-extending to 8-row). The audit-subprocess argv
+  translator (``max_turns`` → ``-T max_turns=<n>``, ``seed_limit`` →
+  ``--limit <n>``, ``dim_set`` → ``-T judge_dimensions=<value>``,
+  ``reflection_depth`` → AgenticLoop config) lands in PR-3
+  (PR-HYPERPARAM-WIRE) — this PR is foundation-only.
+
 ### Changed
 - **PR-PROGRAMMD-TARGET-KIND-SYNC (2026-05-28)** — Sync
   ``autoresearch/program.md`` "The agent CAN" markdown table with the

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -77,9 +77,9 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
 - Modify `train.py`'s `WRAPPER_PROMPT_SECTIONS` dict. The system
   prompt sections are fair game for wording changes, additions,
   deletions, and reorderings.
-- Mutate any of the **7 policy SoT files** at
+- Mutate any of the **8 policy SoT files** at
   `autoresearch/state/policies/` (PR-MINIMAL-2 baseline + ADR-012
-  M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE):
+  M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE + PR-HYPERPARAM-FOUNDATION):
 
   | `target_kind`        | File                       | What it controls                                                |
   |----------------------|----------------------------|-----------------------------------------------------------------|
@@ -90,6 +90,7 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   | `skill_catalog`      | `skill-catalog.json`       | Skill descriptions + `user_invocable` flag (ADR-012 M1)         |
   | `agent_contract`     | `agent-contracts.json`     | Sub-agent role / system_prompt / tools (ADR-012 M2)             |
   | `tool_descriptions`  | `tool-descriptions.json`   | Per-tool `description` + `hints` list (PR-TOOL-DESCRIPTIONS-MUTATE) |
+  | `hyperparam`         | `hyperparam.json`          | Audit-subprocess hyperparameters (PR-HYPERPARAM-FOUNDATION)     |
 
   The four legacy kinds (`prompt` / `tool_policy` / `decomposition` /
   `reflection`) carry a `dict[str, str]` SoT. The three nested kinds
@@ -99,7 +100,28 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   `<tool>.hints`, etc.); `load_policy` / `write_policy` handle the
   conversion. The Mode B runner (`SelfImprovingLoopRunner`) dispatches
   by `Mutation.target_kind` to the matching file; Mode A agents can
-  edit any of the 7 directly via `git`-tracked JSON.
+  edit any of the 8 directly via `git`-tracked JSON.
+
+  `hyperparam` (PR-HYPERPARAM-FOUNDATION, 2026-05-28) is structurally
+  the same `dict[str, str]` schema but semantically distinct: each
+  value is a **string-encoded numeric or categorical** that the audit
+  subprocess + AgenticLoop runtime convert at consumption time. The
+  4 allowed sections + bounds are:
+
+  | Section             | Type        | Bounds                  |
+  |---------------------|-------------|-------------------------|
+  | `max_turns`         | int         | [1, 20]                 |
+  | `seed_limit`        | int         | [1, 50]                 |
+  | `reflection_depth`  | int         | [1, 5]                  |
+  | `dim_set`           | categorical | {`subset`, `full`}      |
+
+  `parse_mutation` + `apply_mutation` both reject hyperparam mutations
+  outside these bounds (fail-closed at two layers). Use a hyperparam
+  mutation when the regression dim's `measurement_modality` is
+  `tool_log` or `token_count` (programmatic / mechanism-level) and
+  prompt mutations have repeatedly produced `Δ ≈ 0` for the target dim
+  — cycle 1-12 (2026-05-26 → 05-28) observed exactly this pattern for
+  `redundant_tool_invocation`, which is what motivates the slot.
 
   `retrieval` was deprecated in ADR-012 S0d (2026-05-21) — the reader
   was never wired (PR-AUDIT-5SLOT). The slot is excluded from

--- a/autoresearch/state/policies/hyperparam.json
+++ b/autoresearch/state/policies/hyperparam.json
@@ -1,0 +1,6 @@
+{
+  "max_turns": "5",
+  "seed_limit": "8",
+  "dim_set": "subset",
+  "reflection_depth": "3"
+}

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -852,6 +852,7 @@ def run_audit(
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_FEW_SHOT_POOL_PATH,
         GLOBAL_HEURISTICS_PATH,
+        GLOBAL_HYPERPARAM_POLICY_PATH,
         GLOBAL_IN_CONTEXT_SLOTS_PATH,
         GLOBAL_PROVIDER_ROUTING_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
@@ -922,6 +923,18 @@ def run_audit(
     if GLOBAL_FEW_SHOT_POOL_PATH.is_file():
         env["GEODE_FEW_SHOT_POOL_OVERRIDE"] = str(GLOBAL_FEW_SHOT_POOL_PATH)
         env["GEODE_FEW_SHOT_POOL_STRICT"] = "1"
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam SoT path
+    # propagation. PR-2 lands the env literal so the sibling-SoT env-map
+    # invariant test passes against the 8-kind TARGET_KINDS. The actual
+    # consumption — ``plugins/petri_audit/runner.py:build_command``
+    # reading the SoT and translating each key to an inspect-petri
+    # ``-T`` flag — lands in PR-3 (PR-HYPERPARAM-WIRE). Until then the
+    # env var is set but no reader inside the audit subprocess loads it;
+    # this is a deliberate 2-PR seam (foundation → wire-through) to
+    # keep each PR's scope small.
+    if GLOBAL_HYPERPARAM_POLICY_PATH.is_file():
+        env["GEODE_HYPERPARAM_OVERRIDE"] = str(GLOBAL_HYPERPARAM_POLICY_PATH)
+        env["GEODE_HYPERPARAM_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/paths.py
+++ b/core/paths.py
@@ -257,6 +257,20 @@ GLOBAL_RETRIEVAL_POLICY_PATH = GLOBAL_POLICIES_DIR / "retrieval.json"
 GLOBAL_REFLECTION_POLICY_PATH = GLOBAL_POLICIES_DIR / "reflection.json"
 # ADR-013 T1 (2026-05-21) — Tool descriptions mutation SoT.
 GLOBAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_POLICIES_DIR / "tool-descriptions.json"
+# PR-HYPERPARAM-FOUNDATION (2026-05-28) — numeric / categorical
+# hyperparameter mutation SoT. Distinct from the 7 text-artifact kinds:
+# this slot directly tunes the audit-subprocess command line
+# (max_turns → -T max_turns=<n>, seed_limit → --limit <n>, dim_set
+# → -T judge_dimensions=..., reflection_depth → AgenticLoop config).
+# Cycle 1-12 (2026-05-26 → 05-28) observed 11/12 prompt-only mutations
+# stuck on redundant_tool_invocation with Δ=0 because the dim's
+# measurement_modality (tool_log: programmatic dedup count) lives below
+# the LLM's prompt-following surface — only mechanism-level levers
+# (turn budget, sample count) can move it. Values are string-encoded
+# at the SoT (``{"max_turns": "5"}``) for schema consistency with the
+# other 4 simple-shape kinds; runtime readers convert to int /
+# categorical at the consumption site (PR-HYPERPARAM-WIRE).
+GLOBAL_HYPERPARAM_POLICY_PATH = GLOBAL_POLICIES_DIR / "hyperparam.json"
 # PR-BACKFILL-SOT (2026-05-21) — operator-local SoT layer for the 4 active
 # mutation surface readers (tool_policy / reflection / decomposition /
 # tool_descriptions). Per-machine overrides without touching in-repo

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from core.paths import (
     GLOBAL_AGENT_CONTRACTS_PATH,
     GLOBAL_DECOMPOSITION_POLICY_PATH,
+    GLOBAL_HYPERPARAM_POLICY_PATH,
     GLOBAL_REFLECTION_POLICY_PATH,
     GLOBAL_RETRIEVAL_POLICY_PATH,
     GLOBAL_SKILL_CATALOG_PATH,
@@ -215,6 +216,26 @@ TARGET_KINDS: tuple[str, ...] = (
     # ``_LIST_FIELDS_BY_KIND`` mapping below converts the comma-joined
     # mutation row back to a list on write.
     "tool_descriptions",
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — numeric / categorical
+    # hyperparameter mutation slot. Distinct from the 7 text-artifact
+    # kinds above: this slot tunes the audit-subprocess command line
+    # + AgenticLoop runtime configuration directly (max_turns →
+    # ``-T max_turns=<n>``, seed_limit → ``--limit <n>``, dim_set →
+    # ``-T judge_dimensions=<value>``, reflection_depth → AgenticLoop
+    # reflection-iteration cap). Flat ``dict[str, str]`` schema with
+    # string-encoded values (``{"max_turns": "5"}``); runtime readers
+    # convert at the consumption site. Bounds enforced at
+    # ``parse_mutation`` via ``_HYPERPARAM_INT_BOUNDS`` /
+    # ``_HYPERPARAM_CATEGORICAL`` (see ``runner.py``) so a mutator
+    # proposing ``max_turns=999`` fails fast instead of silently
+    # crashing the next audit. Motivated by cycle 1-12 (2026-05-26 →
+    # 05-28) where 11/12 prompt-only mutations could not move
+    # ``redundant_tool_invocation`` (tool_log modality, programmatic
+    # tool-call dedup) — turn-budget mutation is the first surface
+    # the loop has that reaches that mechanism layer. PR-3
+    # (PR-HYPERPARAM-WIRE) lands the audit-subprocess argv builder +
+    # AgenticLoop reader.
+    "hyperparam",
 )
 
 # Each kind maps to the SoT file. ``prompt`` re-points to the legacy
@@ -231,6 +252,7 @@ _KIND_TO_PATH: dict[str, Path] = {
     "skill_catalog": GLOBAL_SKILL_CATALOG_PATH,
     "agent_contract": GLOBAL_AGENT_CONTRACTS_PATH,
     "tool_descriptions": GLOBAL_TOOL_DESCRIPTIONS_PATH,
+    "hyperparam": GLOBAL_HYPERPARAM_POLICY_PATH,
 }
 
 # M1+M2 (2026-05-21) — nested-schema kinds. ``load_policy`` /

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -532,12 +532,22 @@ _MUTATION_CONTRACT_SUFFIX = (
     "``reflection`` (reflection.json), ``skill_catalog`` "
     "(skill-catalog.json), ``agent_contract`` (agent-contracts.json), "
     "``tool_descriptions`` (tool-descriptions.json — PR-TOOL-DESCRIPTIONS-MUTATE "
-    "graduation, 2026-05-27). "
+    "graduation, 2026-05-27), or ``hyperparam`` (hyperparam.json — "
+    "PR-HYPERPARAM-FOUNDATION graduation, 2026-05-28: numeric / categorical "
+    "audit-budget tuning). "
     "Omit for prompt-level mutations. For ``tool_descriptions``, the "
     "``target_section`` uses dotted notation: ``<tool_name>.description`` "
     "(string replacement) or ``<tool_name>.hints`` (comma-separated list "
-    "of hint strings). (``retrieval`` was deprecated "
-    "in ADR-012 S0d, 2026-05-21 — see policies.py docstring.)\n"
+    "of hint strings). For ``hyperparam``, the ``target_section`` is one of "
+    "``max_turns`` (integer, bounds [1, 20]), ``seed_limit`` (integer, "
+    "bounds [1, 50]), ``reflection_depth`` (integer, bounds [1, 5]), or "
+    "``dim_set`` (categorical, ∈ {subset, full}); ``new_value`` is the "
+    'string-encoded value (``"5"`` not ``5``). Use a hyperparam mutation '
+    "when the regression dim's measurement_modality is ``tool_log`` or "
+    "``token_count`` (programmatic / mechanism-level) and prompt mutations "
+    "have repeatedly produced ``Δ ≈ 0`` for the target dim. (``retrieval`` "
+    "was deprecated in ADR-012 S0d, 2026-05-21 — see policies.py "
+    "docstring.)\n"
     "- **Principle-first (P3-revised, 2026-05-25, SPCT pattern)**: BEFORE "
     "selecting ``target_section`` and writing ``new_value``, explicitly state "
     "the judging principle that motivates this mutation — what specific axis "
@@ -880,6 +890,68 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     return text
 
 
+# PR-HYPERPARAM-FOUNDATION (2026-05-28) — bounds map for the
+# ``hyperparam`` target_kind. Two shapes:
+#
+#   _HYPERPARAM_INT_BOUNDS:   key → (min, max) for integer-valued knobs
+#   _HYPERPARAM_CATEGORICAL:  key → allowed-string set
+#
+# Bounds chosen so a worst-case mutator proposal cannot:
+#   - run the audit forever (``max_turns ≤ 20`` keeps single-sample
+#     wall-clock under ~60 min even on the slowest claude-cli OAuth lane)
+#   - explode the audit cost (``seed_limit ≤ 50`` caps the per-cycle
+#     sample fan-out — current default 8)
+#   - silently disable the loop (``max_turns ≥ 1``, ``seed_limit ≥ 1``)
+#   - select an undefined dim_set (only ``subset`` / ``full`` are
+#     resolved by ``plugins/petri_audit/dim_set_resolver.py``)
+_HYPERPARAM_INT_BOUNDS: dict[str, tuple[int, int]] = {
+    "max_turns": (1, 20),
+    "seed_limit": (1, 50),
+    "reflection_depth": (1, 5),
+}
+_HYPERPARAM_CATEGORICAL: dict[str, frozenset[str]] = {
+    "dim_set": frozenset({"subset", "full"}),
+}
+_HYPERPARAM_ALLOWED_KEYS: frozenset[str] = frozenset(
+    list(_HYPERPARAM_INT_BOUNDS.keys()) + list(_HYPERPARAM_CATEGORICAL.keys())
+)
+
+
+def _validate_hyperparam_bounds(section: str, value: str) -> None:
+    """Validate a ``hyperparam`` mutation's ``(target_section, new_value)`` pair.
+
+    Raises :class:`ValueError` if ``section`` is unknown, if a numeric
+    section's ``value`` cannot be cast to int, or if the resulting
+    integer / categorical is outside the documented bounds. The bounds
+    are documented inline in the mutator system-prompt suffix
+    (``_MUTATION_CONTRACT_SUFFIX``) so a fail-closed parse here mirrors
+    what the LLM was told.
+    """
+    if section not in _HYPERPARAM_ALLOWED_KEYS:
+        raise ValueError(
+            f"hyperparam target_section {section!r} not in allowed set "
+            f"{sorted(_HYPERPARAM_ALLOWED_KEYS)!r}"
+        )
+    if section in _HYPERPARAM_INT_BOUNDS:
+        lo, hi = _HYPERPARAM_INT_BOUNDS[section]
+        try:
+            n = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"hyperparam {section} new_value {value!r} must be an integer-convertible string"
+            ) from exc
+        if not (lo <= n <= hi):
+            raise ValueError(f"hyperparam {section}={n} out of bounds [{lo}, {hi}]")
+        return
+    # categorical branch — must hit, since _HYPERPARAM_ALLOWED_KEYS
+    # is the union of the two maps.
+    allowed = _HYPERPARAM_CATEGORICAL[section]
+    if value not in allowed:
+        raise ValueError(
+            f"hyperparam {section} new_value {value!r} must be one of {sorted(allowed)!r}"
+        )
+
+
 def parse_mutation(raw: str) -> Mutation:
     """Extract a :class:`Mutation` from the LLM's raw response.
 
@@ -982,6 +1054,14 @@ def parse_mutation(raw: str) -> Mutation:
     target_kind = kind_raw.strip() or "prompt"
     if target_kind not in TARGET_KINDS:
         raise ValueError(f"target_kind {target_kind!r} is not one of {TARGET_KINDS!r}")
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam kind 별 bounds
+    # 검사. mutator 가 ``max_turns=999`` 같은 유효 범위 밖 numeric 또는
+    # ``dim_set="bogus"`` 같은 유효 카테고리 밖 값을 propose 시 audit
+    # 시점에 silently crash 하기 전에 parse 시점에 fail-closed.
+    # Boundary completeness rule (CLAUDE.md → CANNOT → Quality):
+    # apply 시점에도 동일 가드를 적용해 두 layer 모두 보호.
+    if target_kind == "hyperparam":
+        _validate_hyperparam_bounds(target_section.strip(), new_value)
     mutation_id_raw = payload.get("mutation_id")
     # Mutation has a default_factory; pass only when the LLM supplied one.
     if isinstance(mutation_id_raw, str) and mutation_id_raw.strip():
@@ -1048,6 +1128,16 @@ def apply_mutation(
         sections[mutation.target_section] = mutation.new_value
         write_wrapper_prompt_sections(sections)
         return sections, previous_value
+
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — second-layer bounds gate.
+    # parse_mutation already validates at LLM-response time, but the
+    # apply path is reached from other entrypoints (manual ``apply_mutation``
+    # calls in tests / slash / re-runs of a parsed mutation), so a
+    # ``Mutation`` constructed outside ``parse_mutation`` cannot rely on
+    # the first gate. Defensive depth (CLAUDE.md → Wiring Verification →
+    # Conditional Read Parity).
+    if mutation.target_kind == "hyperparam":
+        _validate_hyperparam_bounds(mutation.target_section, mutation.new_value)
 
     # PR-6 policy kinds — tool_policy / decomposition / retrieval /
     # reflection. ``current_sections`` override is honoured for symmetry
@@ -1456,6 +1546,15 @@ _SIBLING_SOT_ENV_MAP: dict[str, str] = {
     # can spawn audit subprocesses pointed at the temp tool-descriptions
     # variant.
     "tool_descriptions": "GEODE_TOOL_DESCRIPTIONS_OVERRIDE",
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — env literal landed in
+    # ``autoresearch/train.py`` so the env-map ↔ TARGET_KINDS invariant
+    # passes against the 8-kind tuple. The audit-subprocess consumer
+    # (``plugins/petri_audit/runner.py:build_command`` reading the SoT
+    # and translating to inspect-petri ``-T`` flags) ships in PR-3
+    # (PR-HYPERPARAM-WIRE). Until then the env var is set but no
+    # reader inside the audit subprocess loads it — a deliberate 2-PR
+    # seam (foundation → wire-through).
+    "hyperparam": "GEODE_HYPERPARAM_OVERRIDE",
 }
 """P1-revised — sibling SoT temp file path 를 propagation 할 env var
 mapping (per ``Mutation.target_kind``). W3 인프라 (``autoresearch/train.py:809+``)
@@ -1472,6 +1571,13 @@ _SIBLING_SOT_STRICT_ENV_MAP: dict[str, str] = {
     # sibling audit subprocess fails fast on schema drift in the temp
     # tool-descriptions JSON, matching the other nested-schema kinds.
     "tool_descriptions": "GEODE_TOOL_DESCRIPTIONS_STRICT",
+    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — strict-load env name
+    # mirrors the other simple-shape kinds. PR-3 (PR-HYPERPARAM-WIRE)
+    # will land the reader that honours the STRICT flag (current
+    # build_command reads inspect-petri argv directly, but the wire-
+    # through PR adds an SoT->argv translator that will respect
+    # STRICT=1 on schema drift).
+    "hyperparam": "GEODE_HYPERPARAM_STRICT",
 }
 """``GEODE_<KIND>_STRICT=1`` mapping — sibling audit 의 strict-load.
 ``prompt`` kind 는 ``_load_wrapper_override`` 가 env path 가 set 되면

--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -231,8 +231,9 @@ def test_adr_cites_train_py_dim_weights_location() -> None:
 def test_active_slots_registered_as_mutation_targets() -> None:
     """S0d (2026-05-21) — retrieval deprecated; M1 — skill_catalog 추가;
     M2 (2026-05-21) — agent_contract 추가; PR-TOOL-DESCRIPTIONS-MUTATE
-    (2026-05-27, #1779) — tool_descriptions graduated from reader-only
-    to active mutation target → 7 active slot."""
+    (2026-05-27, #1779) — tool_descriptions graduated;
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam graduated from
+    new numeric / categorical surface → 8 active slot."""
     import importlib
 
     mod = importlib.import_module("core.self_improving_loop.policies")
@@ -245,9 +246,10 @@ def test_active_slots_registered_as_mutation_targets() -> None:
         "reflection",
         "skill_catalog",
         "agent_contract",
+        "hyperparam",
     }
     assert target_kinds == expected, (
-        f"TARGET_KINDS 는 {expected} (post-tool_descriptions). got={target_kinds}"
+        f"TARGET_KINDS 는 {expected} (post-hyperparam). got={target_kinds}"
     )
     assert "retrieval" not in target_kinds, "retrieval 은 S0d 이후 deprecate 유지"
 

--- a/tests/test_m2_agent_contract_slot.py
+++ b/tests/test_m2_agent_contract_slot.py
@@ -51,12 +51,12 @@ def test_target_kinds_includes_agent_contract() -> None:
     assert "agent_contract" in pol.TARGET_KINDS
 
 
-def test_target_kinds_count_is_7_post_tool_descriptions() -> None:
-    """PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — graduated
-    ``tool_descriptions`` so the active mutation surface count is now 7
-    (was 6 post-M2). Order matters because the type-hint enum derives
-    from the tuple."""
-    assert len(pol.TARGET_KINDS) == 7
+def test_target_kinds_count_is_8_post_hyperparam() -> None:
+    """PR-HYPERPARAM-FOUNDATION (2026-05-28) — graduated
+    ``hyperparam`` so the active mutation surface count is now 8
+    (was 7 post-tool_descriptions). Order matters because the
+    type-hint enum derives from the tuple."""
+    assert len(pol.TARGET_KINDS) == 8
     assert pol.TARGET_KINDS == (
         "prompt",
         "tool_policy",
@@ -65,6 +65,7 @@ def test_target_kinds_count_is_7_post_tool_descriptions() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
+        "hyperparam",
     )
 
 

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -31,11 +31,14 @@ from core.self_improving_loop import policies as _policies_mod
 # ---------------------------------------------------------------------------
 
 
-def test_target_kinds_contains_active_seven() -> None:
+def test_target_kinds_contains_active_eight() -> None:
     """ADR-012 S0d — retrieval deprecated. M1 — skill_catalog 추가.
     M2 (2026-05-21) — agent_contract 추가.
     PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — tool_descriptions 추가.
-    Post-graduation: 7 active mutation targets."""
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가 (numeric /
+    categorical surface for audit-subprocess command-line knobs +
+    AgenticLoop runtime config).
+    Post-graduation: 8 active mutation targets."""
     assert set(TARGET_KINDS) == {
         "prompt",
         "tool_policy",
@@ -44,6 +47,7 @@ def test_target_kinds_contains_active_seven() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
+        "hyperparam",
     }
 
 
@@ -64,12 +68,12 @@ def test_is_valid_target_kind_rejects_unknown() -> None:
 
 def test_policy_path_returns_distinct_paths() -> None:
     """Distinct SoT per kind so policies evolve independently.
-    PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — 7 active kinds
-    (prompt / tool_policy / decomposition / reflection / skill_catalog /
-    agent_contract / tool_descriptions) + retrieval (deprecated but
-    path preserved) = 8 distinct paths."""
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — 8 active kinds (prompt /
+    tool_policy / decomposition / reflection / skill_catalog /
+    agent_contract / tool_descriptions / hyperparam) + retrieval
+    (deprecated but path preserved) = 9 distinct paths."""
     paths = {kind: policy_path(kind) for kind in (*TARGET_KINDS, "retrieval")}
-    assert len(set(paths.values())) == 8
+    assert len(set(paths.values())) == 9
 
 
 def test_policy_path_prompt_points_to_wrapper_sections() -> None:
@@ -480,12 +484,15 @@ def test_rollback_sot_prompt_kind_still_uses_legacy_writer(
 
 
 def test_global_policy_paths_under_policies_dir() -> None:
-    """All 5 SoT paths live under the same in-repo dir
+    """All SoT paths live under the same in-repo dir
     (``autoresearch/state/policies/``) — operators expect them
     co-located, and the in-repo location is git-tracked so ``git diff``
-    shows the current mutation state (PR-RATCHET-1, 2026-05-21)."""
+    shows the current mutation state (PR-RATCHET-1, 2026-05-21).
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) adds the hyperparam SoT path
+    to the co-location invariant."""
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_PATH,
+        GLOBAL_HYPERPARAM_POLICY_PATH,
         GLOBAL_POLICIES_DIR,
         GLOBAL_REFLECTION_POLICY_PATH,
         GLOBAL_RETRIEVAL_POLICY_PATH,
@@ -499,5 +506,177 @@ def test_global_policy_paths_under_policies_dir() -> None:
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_RETRIEVAL_POLICY_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
+        GLOBAL_HYPERPARAM_POLICY_PATH,
     ):
         assert path.parent == GLOBAL_POLICIES_DIR
+
+
+# ---------------------------------------------------------------------------
+# PR-HYPERPARAM-FOUNDATION (2026-05-28) — bounds validator invariants
+# ---------------------------------------------------------------------------
+
+
+def test_hyperparam_bounds_accepts_valid_int() -> None:
+    """Valid integer-section + in-bounds value → no raise."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    _validate_hyperparam_bounds("max_turns", "5")
+    _validate_hyperparam_bounds("max_turns", "1")
+    _validate_hyperparam_bounds("max_turns", "20")
+    _validate_hyperparam_bounds("seed_limit", "8")
+    _validate_hyperparam_bounds("seed_limit", "50")
+    _validate_hyperparam_bounds("reflection_depth", "3")
+    _validate_hyperparam_bounds("reflection_depth", "5")
+
+
+def test_hyperparam_bounds_accepts_valid_categorical() -> None:
+    """Valid categorical-section + allowed value → no raise."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    _validate_hyperparam_bounds("dim_set", "subset")
+    _validate_hyperparam_bounds("dim_set", "full")
+
+
+def test_hyperparam_bounds_rejects_unknown_section() -> None:
+    """Section not in the allow-list → ValueError. Defends against
+    mutator inventing knobs the runtime doesn't read."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    with pytest.raises(ValueError, match="not in allowed set"):
+        _validate_hyperparam_bounds("unknown_section", "5")
+    with pytest.raises(ValueError, match="not in allowed set"):
+        _validate_hyperparam_bounds("BUDGET_MINUTES", "30")
+
+
+def test_hyperparam_bounds_rejects_out_of_range_int() -> None:
+    """Integer-section + value outside [lo, hi] → ValueError."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        _validate_hyperparam_bounds("max_turns", "0")
+    with pytest.raises(ValueError, match="out of bounds"):
+        _validate_hyperparam_bounds("max_turns", "21")
+    with pytest.raises(ValueError, match="out of bounds"):
+        _validate_hyperparam_bounds("seed_limit", "51")
+    with pytest.raises(ValueError, match="out of bounds"):
+        _validate_hyperparam_bounds("reflection_depth", "0")
+    with pytest.raises(ValueError, match="out of bounds"):
+        _validate_hyperparam_bounds("reflection_depth", "6")
+
+
+def test_hyperparam_bounds_rejects_non_integer_string() -> None:
+    """Integer-section + non-numeric value → ValueError. Defends against
+    mutator emitting ``"5.5"`` or ``"high"`` for an int knob."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    with pytest.raises(ValueError, match="integer-convertible"):
+        _validate_hyperparam_bounds("max_turns", "high")
+    with pytest.raises(ValueError, match="integer-convertible"):
+        _validate_hyperparam_bounds("seed_limit", "many")
+    with pytest.raises(ValueError, match="integer-convertible"):
+        _validate_hyperparam_bounds("max_turns", "5.5")
+
+
+def test_hyperparam_bounds_rejects_invalid_categorical() -> None:
+    """Categorical-section + value not in allow-set → ValueError."""
+    from core.self_improving_loop.runner import _validate_hyperparam_bounds
+
+    with pytest.raises(ValueError, match="must be one of"):
+        _validate_hyperparam_bounds("dim_set", "bogus")
+    with pytest.raises(ValueError, match="must be one of"):
+        _validate_hyperparam_bounds("dim_set", "all")
+    with pytest.raises(ValueError, match="must be one of"):
+        _validate_hyperparam_bounds("dim_set", "")
+
+
+def test_parse_mutation_hyperparam_kind_valid() -> None:
+    """End-to-end parse path for a valid hyperparam mutation."""
+    import json
+
+    from core.self_improving_loop.runner import parse_mutation
+
+    payload = json.dumps(
+        {
+            "target_kind": "hyperparam",
+            "target_section": "max_turns",
+            "new_value": "3",
+            "rationale": "Try shorter audit budget — cycle 1-12 had Δ=0 for redundant_tool_invocation under prompt mutation; shorter turn budget directly reduces tool-call surface.",
+            "target_dim": "redundant_tool_invocation",
+            "expected_dim": {"redundant_tool_invocation": -1.0},
+        }
+    )
+    m = parse_mutation(payload)
+    assert m.target_kind == "hyperparam"
+    assert m.target_section == "max_turns"
+    assert m.new_value == "3"
+
+
+def test_parse_mutation_hyperparam_kind_rejects_out_of_bounds() -> None:
+    """Mutator proposing ``max_turns=999`` is caught at parse, not at
+    audit subprocess invocation. Cycle protection."""
+    import json
+
+    from core.self_improving_loop.runner import parse_mutation
+
+    payload = json.dumps(
+        {
+            "target_kind": "hyperparam",
+            "target_section": "max_turns",
+            "new_value": "999",
+            "rationale": "more turns",
+            "target_dim": "redundant_tool_invocation",
+            "expected_dim": {"redundant_tool_invocation": -0.5},
+        }
+    )
+    with pytest.raises(ValueError, match="out of bounds"):
+        parse_mutation(payload)
+
+
+def test_apply_mutation_hyperparam_kind_writes_sot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """apply_mutation routes hyperparam through the generic write_policy
+    path (flat dict[str, str]) — same machinery as the other simple
+    kinds, no special-case writer. Test isolation redirects the SoT
+    path to a tmp file so the canonical
+    ``autoresearch/state/policies/hyperparam.json`` is not mutated."""
+    from core.self_improving_loop.runner import Mutation, apply_mutation
+
+    target = tmp_path / "hyperparam.json"
+    _redirect_kind(monkeypatch, "hyperparam", target)
+    starting = {"max_turns": "5", "seed_limit": "8", "dim_set": "subset", "reflection_depth": "3"}
+    mutation = Mutation(
+        target_section="max_turns",
+        new_value="7",
+        rationale="test apply path",
+        target_kind="hyperparam",
+    )
+    new_sections, previous_value = apply_mutation(mutation, current_sections=starting)
+    assert previous_value == "5"
+    assert new_sections["max_turns"] == "7"
+    # Other keys unchanged
+    assert new_sections["seed_limit"] == "8"
+    assert new_sections["dim_set"] == "subset"
+
+
+def test_apply_mutation_hyperparam_kind_rejects_out_of_bounds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second-layer defense: an externally-constructed Mutation that
+    bypassed parse_mutation cannot still write garbage to the SoT.
+    SoT path redirected for isolation; the raise should happen before
+    any write_policy call, so the tmp file stays untouched as well."""
+    from core.self_improving_loop.runner import Mutation, apply_mutation
+
+    target = tmp_path / "hyperparam.json"
+    _redirect_kind(monkeypatch, "hyperparam", target)
+    bad = Mutation(
+        target_section="max_turns",
+        new_value="999",
+        rationale="bypass parse",
+        target_kind="hyperparam",
+    )
+    with pytest.raises(ValueError, match="out of bounds"):
+        apply_mutation(bad, current_sections={"max_turns": "5"})
+    # Bounds violation must precede the write.
+    assert not target.exists()

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -238,6 +238,7 @@ def test_active_slots_registered_as_mutation_targets() -> None:
     M2 (2026-05-21) — agent_contract 추가 → 6 active slot.
     PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — tool_descriptions 추가
     → 7 active slot.
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가 → 8 active slot.
     retrieval 은 명시적 deprecate 유지; path constant + dict 매핑은
     보존 (별도 ADR 로 RAG 인프라 신설 시 복원 가능)."""
     import importlib
@@ -252,9 +253,10 @@ def test_active_slots_registered_as_mutation_targets() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
+        "hyperparam",
     }
     assert target_kinds == expected, (
-        f"TARGET_KINDS 는 정확히 {expected} (post-tool_descriptions). got={target_kinds}"
+        f"TARGET_KINDS 는 정확히 {expected} (post-hyperparam). got={target_kinds}"
     )
     assert "retrieval" not in target_kinds, "retrieval 은 S0d 이후 deprecate 유지"
     # path constant 보존 — 미래 복원용


### PR DESCRIPTION
## Summary
- Promote PR #1816 (PR-HYPERPARAM-FOUNDATION) develop → main.
- Adds 8th ``target_kind`` slot ``hyperparam`` — numeric / categorical mutation surface for audit-subprocess command line + AgenticLoop runtime config. Schema, bounds, mutator-prompt update, drift-invariant test. Audit-subprocess argv translator deferred to PR-3 (PR-HYPERPARAM-WIRE).

## Verification
- [x] PR #1816 CI 8/8 green
- [x] 334 target_kind / surface / mutation / env_map slice tests pass
- [x] All gates clean (ruff / ruff format --check / mypy / lint-imports)