### PR TITLE
PR-HYPERPARAM-WIRE: thread hyperparam SoT through audit-subprocess argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,41 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **PR-HYPERPARAM-WIRE (2026-05-28)** — Wires the hyperparam mutation
+  SoT (``autoresearch/state/policies/hyperparam.json``, landed in
+  PR-HYPERPARAM-FOUNDATION) into the audit-subprocess argv builder.
+  ``autoresearch/train.py:_build_audit_command`` now reads the SoT
+  (env-path override → in-repo default → graceful empty on
+  missing/malformed) and overlays the three argv-relevant keys onto
+  ``cfg`` defaults:
+  ``max_turns`` → ``--max-turns <n>`` (inspect-petri ``-T max_turns``
+  downstream),
+  ``seed_limit`` → ``--seeds <n>`` (``--limit`` downstream),
+  ``dim_set`` → ``--dim-set <value>`` (``-T judge_dimensions``
+  downstream).
+  Resolution precedence (highest wins): mutation SoT value → cfg
+  default. A mutator-proposed ``max_turns=3`` now actually flows
+  through ``argv[-T max_turns=3]`` into the next audit's inspect-petri
+  run instead of stopping at the SoT JSON. Fallback path covers the
+  edge cases ``parse_mutation`` 's bounds guard cannot
+  (operator-hand-edited SoT to non-int-castable string, key absent,
+  JSON parse failure) — log + use cfg default, never crash the loop.
+  ``reflection_depth`` is **intentionally NOT wired here** because it
+  is a GEODE runtime knob (AgenticLoop reflection-iteration cap), not
+  an inspect-petri argv — the inspect-petri ``target=geode/gpt-5.5``
+  trajectory does not run the GEODE AgenticLoop, so wiring
+  ``reflection_depth`` into ``argv`` would have no measurement
+  effect. Documented in the ``_build_audit_command`` docstring; a
+  follow-up PR will wire it into the GEODE CLI runtime where it does
+  matter. Pinned by 7 new assertions in
+  ``tests/test_autoresearch_train.py``: ``_load_hyperparam_overrides``
+  missing/malformed/env-path branches; ``_hyperparam_int`` override
+  vs missing vs uncastable; ``_build_audit_command`` argv with vs
+  without SoT. Existing
+  ``test_build_audit_command_reads_from_config`` updated to point
+  ``GEODE_HYPERPARAM_OVERRIDE`` at a missing path so cfg-only assertions
+  keep their meaning under the new SoT-precedence contract.
+
 - **PR-HYPERPARAM-FOUNDATION (2026-05-28)** — Adds the 8th
   ``target_kind`` slot ``hyperparam`` to ``TARGET_KINDS``, opening a
   numeric / categorical mutation surface that targets the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -683,6 +683,74 @@ def _emit_journal(
     ).append(event, level=level, payload=payload or {})
 
 
+def _hyperparam_int(overrides: dict[str, str], key: str, fallback: int) -> int:
+    """Cast a hyperparam SoT value to int, fall back on missing / bad value.
+
+    Mutator's ``parse_mutation`` already validated integer-castability +
+    bounds, so the cast normally succeeds. The fallback path covers two
+    edge cases:
+
+    1. Operator hand-edited ``hyperparam.json`` to an invalid value
+       (typo, wrong type); we don't want the audit subprocess to crash
+       — log + use the cfg default.
+    2. Key absent from SoT (mutator hasn't touched it yet, or the
+       SoT is the post-init default with only a subset of keys);
+       cfg default is the right answer.
+    """
+    raw = overrides.get(key)
+    if raw is None:
+        return fallback
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "hyperparam SoT %r=%r is not int-castable; falling back to %r",
+            key,
+            raw,
+            fallback,
+        )
+        return fallback
+
+
+def _load_hyperparam_overrides() -> dict[str, str]:
+    """PR-HYPERPARAM-WIRE (2026-05-28) — read the hyperparam mutation
+    SoT and return the override dict, or ``{}`` on absence / parse failure.
+
+    Resolution order matches the other policy SoTs:
+      1. ``GEODE_HYPERPARAM_OVERRIDE`` env var (set by audit subprocess
+         + sibling sampling, see runner.py ``_SIBLING_SOT_ENV_MAP``)
+      2. ``GLOBAL_HYPERPARAM_POLICY_PATH``
+         (``autoresearch/state/policies/hyperparam.json``)
+
+    Return value is a flat ``dict[str, str]`` — same shape as the SoT
+    JSON. Caller is responsible for type-casting + bounds validation
+    (mutator already validated at parse_mutation; this is the
+    runtime-consumer side).
+
+    Returns ``{}`` (graceful) if the file is missing or unreadable so
+    the closed-loop default still flows through. Bounds violations
+    that survived ``parse_mutation`` / ``apply_mutation`` 's two-layer
+    guard would surface as ``ValueError`` from inspect-petri itself
+    (its ``max_turns`` solver arg is a positive int).
+    """
+    env_path = os.environ.get("GEODE_HYPERPARAM_OVERRIDE")
+    if env_path:
+        path = Path(env_path)
+    else:
+        from core.paths import GLOBAL_HYPERPARAM_POLICY_PATH
+
+        path = GLOBAL_HYPERPARAM_POLICY_PATH
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(k, str)}
+
+
 def _build_audit_command() -> list[str]:
     """Construct the ``geode audit`` subprocess argv.
 
@@ -702,19 +770,37 @@ def _build_audit_command() -> list[str]:
     flow through this builder because they're autoresearch-specific
     (not per-role) — the ``--use-oauth`` flag fires whenever
     ``cfg.source`` is anything other than ``"api_key"``.
+
+    PR-HYPERPARAM-WIRE (2026-05-28) — ``cfg.{seed_limit, dim_set,
+    max_turns}`` are now overridable by the mutation SoT at
+    ``autoresearch/state/policies/hyperparam.json``. Resolution
+    precedence (highest wins): mutation SoT value → autoresearch
+    config default. The mutator-proposed values went through
+    ``parse_mutation`` 's bounds guard, so by the time they reach
+    this argv builder the integer cast is already safe; we still
+    fall back to the config default on missing key or stringified
+    value that fails int() (defensive — bounds guard is the primary
+    layer, this is just so a malformed SoT doesn't crash the closed
+    loop). ``reflection_depth`` is NOT wired here — it's a GEODE
+    runtime knob (AgenticLoop reflection-iteration cap), not an
+    inspect-petri argv, and lands in a follow-up PR.
     """
     cfg = _get_autoresearch_config()
+    overrides = _load_hyperparam_overrides()
+    effective_seed_limit = _hyperparam_int(overrides, "seed_limit", cfg.seed_limit)
+    effective_dim_set = overrides.get("dim_set") or cfg.dim_set
+    effective_max_turns = _hyperparam_int(overrides, "max_turns", cfg.max_turns)
     geode_bin = shutil.which("geode")
     argv = [geode_bin, "audit"] if geode_bin is not None else ["uv", "run", "geode", "audit"]
     argv += [
         "--seed-select",
         _resolve_seed_select(),
         "--seeds",
-        str(cfg.seed_limit),
+        str(effective_seed_limit),
         "--dim-set",
-        cfg.dim_set,
+        effective_dim_set,
         "--max-turns",
-        str(cfg.max_turns),
+        str(effective_max_turns),
         "--live",
         "--yes",
     ]

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -172,16 +172,151 @@ def test_get_autoresearch_config_defaults_match_module_constants(
     assert cfg.max_turns == MAX_TURNS
 
 
-def test_build_audit_command_reads_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_hyperparam_overrides_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-HYPERPARAM-WIRE (2026-05-28) — graceful return on missing SoT."""
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(tmp_path / "nonexistent.json"))
+    assert auto_train._load_hyperparam_overrides() == {}
+
+
+def test_load_hyperparam_overrides_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-HYPERPARAM-WIRE — malformed JSON → graceful empty (caller
+    falls through to cfg defaults; loop doesn't crash)."""
+    p = tmp_path / "hyperparam.json"
+    p.write_text("not json at all", encoding="utf-8")
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(p))
+    assert auto_train._load_hyperparam_overrides() == {}
+
+
+def test_load_hyperparam_overrides_via_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-HYPERPARAM-WIRE — env var path overrides default path."""
+    import json as _json
+
+    p = tmp_path / "hyperparam.json"
+    p.write_text(
+        _json.dumps({"max_turns": "3", "seed_limit": "12"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(p))
+    overrides = auto_train._load_hyperparam_overrides()
+    assert overrides == {"max_turns": "3", "seed_limit": "12"}
+
+
+def test_hyperparam_int_uses_override_when_present() -> None:
+    """PR-HYPERPARAM-WIRE — ``_hyperparam_int`` casts override to int."""
+    assert auto_train._hyperparam_int({"max_turns": "7"}, "max_turns", 5) == 7
+    assert auto_train._hyperparam_int({"seed_limit": "20"}, "seed_limit", 8) == 20
+
+
+def test_hyperparam_int_falls_back_on_missing_key() -> None:
+    """PR-HYPERPARAM-WIRE — absent key → cfg default."""
+    assert auto_train._hyperparam_int({}, "max_turns", 5) == 5
+    assert auto_train._hyperparam_int({"dim_set": "subset"}, "max_turns", 5) == 5
+
+
+def test_hyperparam_int_falls_back_on_uncastable() -> None:
+    """PR-HYPERPARAM-WIRE — non-int-castable override → cfg default
+    (defensive — parse_mutation's bounds guard is the primary layer)."""
+    assert auto_train._hyperparam_int({"max_turns": "not-a-number"}, "max_turns", 5) == 5
+    assert auto_train._hyperparam_int({"max_turns": "5.5"}, "max_turns", 5) == 5
+
+
+def test_build_audit_command_applies_hyperparam_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-HYPERPARAM-WIRE — mutation SoT values flow into the audit
+    subprocess argv, overriding cfg defaults. This is the wire the PR
+    closes — without it, a mutator-proposed ``max_turns=3`` lands in
+    ``hyperparam.json`` but never reaches the inspect-petri ``-T``
+    flag, leaving the audit with the cfg default (5).
+    """
+    import json as _json
+    from types import SimpleNamespace
+
+    p = tmp_path / "hyperparam.json"
+    p.write_text(
+        _json.dumps({"max_turns": "3", "seed_limit": "12", "dim_set": "full"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(p))
+    monkeypatch.setattr(
+        auto_train,
+        "_get_autoresearch_config",
+        lambda: SimpleNamespace(
+            budget_minutes=10,
+            target_model=None,
+            judge_model=None,
+            source="api_key",
+            seed_limit=25,  # would be on argv without override
+            seed_select="plugins/petri_audit/seeds_safe10",
+            dim_set="legacy",  # would be on argv without override
+            max_turns=20,  # would be on argv without override
+        ),
+    )
+    monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
+    argv = auto_train._build_audit_command()
+    # Override values present.
+    assert "3" in argv  # max_turns
+    assert "12" in argv  # seed_limit
+    assert "full" in argv  # dim_set
+    # cfg defaults NOT present (override won).
+    assert "25" not in argv
+    assert "20" not in argv
+    assert "legacy" not in argv
+
+
+def test_build_audit_command_no_hyperparam_sot_falls_back_to_cfg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-HYPERPARAM-WIRE — when the SoT file is missing, ``_build_audit_command``
+    uses cfg defaults (no behavior change from pre-PR baseline)."""
+    from types import SimpleNamespace
+
+    # Point env to a non-existent path so the override path returns {}.
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(tmp_path / "absent.json"))
+    monkeypatch.setattr(
+        auto_train,
+        "_get_autoresearch_config",
+        lambda: SimpleNamespace(
+            budget_minutes=10,
+            target_model=None,
+            judge_model=None,
+            source="api_key",
+            seed_limit=25,
+            seed_select="plugins/petri_audit/seeds_safe10",
+            dim_set="legacy",
+            max_turns=20,
+        ),
+    )
+    monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
+    argv = auto_train._build_audit_command()
+    # cfg defaults all present.
+    assert "25" in argv  # seed_limit
+    assert "20" in argv  # max_turns
+    assert "legacy" in argv  # dim_set
+
+
+def test_build_audit_command_reads_from_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Monkeypatching _get_autoresearch_config flows through to argv.
 
     PR-MINIMAL-2 (2026-05-21) — ``use_oauth: bool`` replaced by
     ``source: Source`` (B1). ``source == "api_key"`` is the only
     value that suppresses ``--use-oauth``; any other source enables
     it (subscription credential).
+
+    PR-HYPERPARAM-WIRE (2026-05-28) — point ``GEODE_HYPERPARAM_OVERRIDE``
+    at a missing path so the hyperparam SoT override returns ``{}`` and
+    cfg defaults flow through unchanged (this test predates hyperparam
+    SoT and asserts the cfg-only contract).
     """
     from types import SimpleNamespace
 
+    monkeypatch.setenv("GEODE_HYPERPARAM_OVERRIDE", str(tmp_path / "absent.json"))
     monkeypatch.setattr(
         auto_train,
         "_get_autoresearch_config",


### PR DESCRIPTION
## Summary
- Wires the hyperparam mutation SoT (landed in PR-HYPERPARAM-FOUNDATION #1816) into ``autoresearch/train.py:_build_audit_command``.
- Three argv-relevant keys overlay cfg defaults: ``max_turns`` / ``seed_limit`` / ``dim_set``.
- ``reflection_depth`` intentionally NOT wired (it is a GEODE runtime knob, not an inspect-petri argv — see GAP Audit).

## Why
PR-HYPERPARAM-FOUNDATION added the 8th ``target_kind`` slot, the SoT file, the bounds guard, and the mutator-prompt instructions, but stopped at "foundation only" — the consumer side (audit-subprocess argv builder) still used ``cfg.max_turns`` / ``cfg.seed_limit`` / ``cfg.dim_set``. A mutator-proposed ``max_turns=3`` (cycle 13's actual mutation was ``reflection_depth=5``, but the principle applies) would write to ``hyperparam.json`` and never reach the inspect-petri ``-T max_turns`` flag — apply-only, no measurement effect.

This PR closes that gap so subsequent cycles' mutations of ``{max_turns, seed_limit, dim_set}`` actually move the audit budget at runtime, and the mechanism-level lever the loop has been missing for ``tool_log`` / ``token_count`` modality dims becomes real.

## Wiring chain (post-PR)

```
autoresearch/train.py:_build_audit_command()
  ├─ cfg = _get_autoresearch_config()                      ← defaults
  ├─ overrides = _load_hyperparam_overrides()              ← mutation SoT
  ├─ effective_seed_limit = _hyperparam_int(overrides, "seed_limit", cfg.seed_limit)
  ├─ effective_dim_set    = overrides.get("dim_set") or cfg.dim_set
  ├─ effective_max_turns  = _hyperparam_int(overrides, "max_turns",  cfg.max_turns)
  └─ argv = [..., "--seeds", effective_seed_limit, "--dim-set", effective_dim_set, "--max-turns", effective_max_turns, ...]
       ↓ subprocess.run
plugins/petri_audit/cli_audit.py (Typer accepts --seeds / --dim-set / --max-turns)
       ↓
plugins/petri_audit/runner.py:run_audit → build_command
       ↓
inspect eval inspect_petri/audit --limit <effective> -T max_turns=<effective> -T judge_dimensions=<effective>
```

Resolution precedence (highest first): ``GEODE_HYPERPARAM_OVERRIDE`` env path → ``GLOBAL_HYPERPARAM_POLICY_PATH`` (``autoresearch/state/policies/hyperparam.json``) → cfg default.

## Changes
| File | Change |
|------|--------|
| ``autoresearch/train.py`` | New ``_load_hyperparam_overrides()`` (graceful env→default-path read); new ``_hyperparam_int(overrides, key, fallback)`` (cast + fallback on uncastable); ``_build_audit_command()`` overlays mutation SoT onto cfg before argv emission. Docstring updated to document precedence + intentional ``reflection_depth`` exclusion. |
| ``tests/test_autoresearch_train.py`` | 7 new assertions covering ``_load_hyperparam_overrides`` (missing / malformed / env-path) and ``_hyperparam_int`` (override / missing / uncastable) and ``_build_audit_command`` end-to-end (override applied / SoT absent falls back). Existing ``test_build_audit_command_reads_from_config`` now points ``GEODE_HYPERPARAM_OVERRIDE`` at a missing path so cfg-only assertions stay valid under the new SoT-precedence contract. |
| ``CHANGELOG.md`` | ``[Unreleased] Added`` entry. |

Total: **3 files, +260 / -4**.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``max_turns`` wire | Implemented | overlay → argv → inspect-petri ``-T max_turns`` |
| ``seed_limit`` wire | Implemented | overlay → ``--seeds`` → ``--limit`` |
| ``dim_set`` wire | Implemented | overlay → ``--dim-set`` → ``-T judge_dimensions`` |
| ``reflection_depth`` wire | **Deferred (intentional)** | reflection_depth is GEODE runtime knob (AgenticLoop reflection-iteration cap), not an inspect-petri argv. The inspect-petri ``target=geode/gpt-5.5`` trajectory does not run the GEODE AgenticLoop, so wiring ``reflection_depth`` into argv has no measurement effect. Follow-up PR will wire into ``core/agent/loop/`` where it matters. Cycle 13's ``reflection_depth=5`` mutation that landed before this PR remains apply-only — the next mutator iteration will see the attribution Δ=0 and can re-route to ``max_turns`` / ``seed_limit`` / ``dim_set`` which are now live. |
| AgenticLoop ``reflection_depth`` reader | Deferred | Follow-up — orthogonal to audit-subprocess argv wiring. |
| Mutator system-prompt awareness of which 3 keys are now live | Already adequate | ``_MUTATION_CONTRACT_SUFFIX`` from PR-1816 already documents all 4 keys + bounds; mutator can observe attribution Δ=0 for ``reflection_depth`` and self-correct. Stronger guidance is PR-HYPERPARAM-MUTATOR-AWARENESS scope. |
| Bounds re-validation at consumer site | Skipped (defensive enough) | ``parse_mutation`` + ``apply_mutation`` already guard at write time; ``_hyperparam_int`` only catches operator-hand-edit / JSON corruption (graceful fallback to cfg). Bounds violations that survive both write-time gates would surface from inspect-petri itself (positive-int solver arg). |

## Verification
- [x] ``ruff check core/ tests/ plugins/ autoresearch/`` clean
- [x] ``ruff format --check`` clean (after one tests/test_autoresearch_train.py reflow)
- [x] ``mypy autoresearch/train.py`` clean
- [x] ``pytest tests/test_autoresearch_train.py`` — 113/113 pass (was 106; +7 new assertions)
- [x] ``pytest -k "audit or hyperparam or build_audit_command or env_map or sibling"`` — 766 passed, 39 skipped (no regression in the audit / sibling-SoT / env-naming-invariant slice)
- [x] cfg-only path unchanged when SoT absent (``test_build_audit_command_no_hyperparam_sot_falls_back_to_cfg`` pins this)

## Expected effect on cycle 14+
The mutator just had cycle 13 propose ``hyperparam × reflection_depth = 5`` — by the time cycle 14 runs (after this PR merges), the attribution row for cycle 13 will already show ``Δ ≈ 0`` for ``redundant_tool_invocation`` because ``reflection_depth`` was not yet wired. With the new feedback the mutator can either:

1. Re-propose against ``hyperparam × max_turns`` (now live — reducing 5→3 would immediately shrink the tool-call surface and move the ``tool_log`` modality dim)
2. Try ``hyperparam × seed_limit`` (now live — fewer samples = fewer tool calls, indirect lever)
3. Try ``hyperparam × dim_set = "full"`` (less direct, but tests whether the regression dim's measurement is stable under expanded rubric)

The mutator's choice between these is the first real observation of whether the new measurement_modality guidance + bounds doc actually steer cross-kind exploration.

## Reference
- PR-HYPERPARAM-FOUNDATION #1816 — surface + bounds + SoT
- Cycle 13 mutation row (mutation_id ``9d6aca959f2d``, ``hyperparam × reflection_depth``) — the first apply against the new surface
- ``core/self_improving_loop/runner.py:_validate_hyperparam_bounds`` — primary bounds gate (parse + apply layers)
- ``plugins/petri_audit/runner.py:build_command`` — downstream consumer (already cfg-driven, no change needed here)