### PR TITLE
fix(routing): infer adapter source from OAuth profile + setting (PR-SOURCE-ROUTING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,54 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-SOURCE-ROUTING (2026-05-28)** — restore subscription-bucket routing
+  for OAuth-registered providers. Three stacked regressions converted every
+  interactive ``gpt-5.x`` turn into a PAYG call even after the operator had
+  completed ``/login openai`` (which registers the
+  ``openai-codex-geode:user`` OAuth profile in :class:`ProfileStore`):
+
+  1. ``AgenticLoop.__init__`` defaulted ``source`` to literal ``"payg"`` so
+     the daemon path (``core/server/supervised/services.py:211`` →
+     ``AgenticLoop(...)`` with no ``source=`` kwarg), the fork-skill path
+     (``core/cli/bootstrap.py:206``), and any sub-agent worker that
+     received ``SubTask.source=""`` (``core/agent/worker.py:374``)
+     collapsed every ``provider="openai-codex"`` call to
+     ``resolve_for("openai", "payg")`` → ``openai-payg`` → ``api.openai.com``.
+     The ``openai_credential_source`` setting written by ``/login source
+     openai oauth`` was defined but never read by any dispatch site.
+  2. ``core/agent/loop/_reflection.py:292`` and
+     ``core/self_improving_loop/runner.py:830`` hard-coded ``"payg"`` so
+     even an explicitly subscription-only Pattern B reflected / mutated
+     through the depleted PAYG endpoint while the main loop sat on the
+     subscription endpoint.
+  3. ``core/llm/errors.py:_classify_openai_error`` returned ``"rate_limit"``
+     for every ``openai.RateLimitError`` — but the OpenAI SDK raises that
+     class for both transient 429 throttling AND ``insufficient_quota`` /
+     ``billing_hard_limit_reached`` (PAYG balance depletion). The
+     operator-facing hint surfaced as "Switch to a different model with
+     ``/model``" instead of "change credential source" — switching model
+     still hit the same depleted bucket.
+
+  Fix introduces ``core/llm/adapters/_source_inference.py`` :func:`infer_source`
+  which consults the ``{provider}_credential_source`` setting + the
+  ProfileStore (any OAuth profile present → promote to ``"subscription"``)
+  and threads it through (a) the AgenticLoop default at
+  ``core/agent/loop/agent_loop.py:392``, (b) the reflection dispatch at
+  ``core/agent/loop/_reflection.py``, and (c) the self-improving mutator
+  dispatch at ``core/self_improving_loop/runner.py``. Callers that pass
+  an explicit ``source=`` kwarg still win (audit-subprocess path via
+  PR #1792 is preserved). ``classify_llm_error`` now gates the
+  ``RateLimitError`` branches (OpenAI + Anthropic) on
+  :func:`is_billing_fatal` so quota-depleted PAYG surfaces as ``"billing"``.
+
+  Pinned by ``tests/test_source_routing_regression.py`` (15 assertions
+  across 3 layers: infer_source resolution priority, AgenticLoop dispatch
+  picks codex-oauth when OAuth profile present, classifier maps
+  ``insufficient_quota`` → billing) plus the legacy ``payg``-default test
+  in ``tests/test_paperclip_wiring.py`` updated to stub ``infer_source``
+  so the API-path pin stays deterministic.
+
 ### Added
 - **PR-HYPERPARAM-WIRE (2026-05-28)** — Wires the hyperparam mutation
   SoT (``autoresearch/state/policies/hyperparam.json``, landed in

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -284,12 +284,16 @@ async def reflect_async(
     # swallowed at WARN" guarantee).
     try:
         provider = _resolve_provider(model)
-        # Step J-b.3 (2026-05-23) — Path-B Protocol dispatch. The
-        # registry's ``payg`` source covers both API-key and OAuth
-        # subscription paths for our reflection model surface;
-        # downstream credential rotation still happens inside the
-        # adapter.
-        adapter = resolve_for(_normalize_provider_for_registry(provider), "payg")
+        # PR-SOURCE-ROUTING (2026-05-28) — reflection used to hard-code
+        # ``"payg"`` so a subscription-only operator (Pattern B) routed
+        # the reflection turn through the depleted PAYG endpoint while
+        # the main loop's gpt-5.x turns landed on the subscription
+        # endpoint. :func:`infer_source` mirrors the AgenticLoop main-
+        # path resolution so the reflection sub-call shares the same
+        # credential source as the parent.
+        from core.llm.adapters._source_inference import infer_source
+
+        adapter = resolve_for(_normalize_provider_for_registry(provider), infer_source(provider))
         tool_summary = _summarise_tool_results(tool_results)
         user_prompt = _build_user_prompt(state, tool_summary)
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -389,7 +389,22 @@ class AgenticLoop:
         # review ("no silent fallback") is preserved — if the requested
         # ``(provider, source)`` isn't in the registry, ``resolve_for``
         # raises and the loop refuses to start.
-        self._source = source or "payg"
+        #
+        # PR-SOURCE-ROUTING (2026-05-28) — the unconditional ``"payg"``
+        # default silently routed every interactive CLI call (the daemon
+        # path at ``core/server/supervised/services.py:211`` never passes
+        # ``source=``) through the PAYG endpoint even when the operator
+        # had completed ``/login openai`` and the
+        # ``openai-codex-geode:user`` OAuth profile was sitting in the
+        # ProfileStore. :func:`infer_source` consults the
+        # ``{provider}_credential_source`` setting + the ProfileStore so
+        # an OAuth-registered provider promotes to ``"subscription"`` by
+        # default; callers that pass an explicit ``source=`` still win.
+        if not source:
+            from core.llm.adapters._source_inference import infer_source
+
+            source = infer_source(provider)
+        self._source = source
         # PR-JSON-WIRE (2026-05-25) — per-loop structured-output JSON
         # Schema. When non-None, every ``_call_llm`` populates
         # ``AdapterCallRequest.response_schema`` with this value so

--- a/core/llm/adapters/_source_inference.py
+++ b/core/llm/adapters/_source_inference.py
@@ -1,0 +1,115 @@
+"""Source inference for AgenticLoop adapter dispatch.
+
+Bridges the operator-facing credential layer (``settings.openai_credential_source``
++ :class:`ProfileStore` OAuth registrations) to the adapter-registry source axis
+(``payg`` / ``subscription``). The legacy ``_resolve_provider(model)`` returns
+only the provider key; the AgenticLoop main path then defaulted ``source`` to
+``"payg"``, so a freshly-completed ``/login openai`` (which writes the
+``openai-codex-geode:user`` OAuth profile) had no path to surface as a
+subscription dispatch — every gpt-5.x call collapsed to
+``resolve_for("openai", "payg")`` → ``openai-payg`` → ``api.openai.com``,
+returning ``insufficient_quota`` whenever the PAYG bucket was depleted while
+the subscription bucket sat unused.
+
+Resolution order (highest precedence first):
+
+1. Explicit operator pin via ``/login source <provider> <type>`` —
+   ``settings.{provider}_credential_source`` of ``"oauth"`` → subscription,
+   ``"api_key"`` → payg. ``"none"`` falls back to payg (the historical default
+   so a disabled credential source still routes through the configured PAYG
+   key rather than raising at the registry).
+2. ``"auto"`` (the unconfigured default) probes :class:`ProfileStore` —
+   any OAuth profile registered for the provider promotes to ``"subscription"``.
+3. ``"payg"`` fallback so the registry resolution never raises on a missing
+   credential source — :func:`resolve_for` will still surface the PAYG
+   adapter's own credential miss with its operator-grade hint.
+
+Only ``openai`` / ``openai-codex`` and ``anthropic`` participate; ``glm`` and
+the local-CLI adapters route through their own picker paths and never reach
+this helper.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from core.llm.adapters.base import SOURCE_PAYG, SOURCE_SUBSCRIPTION
+
+if TYPE_CHECKING:
+    from core.auth.profiles import ProfileStore
+
+log = logging.getLogger(__name__)
+
+
+_SETTINGS_FIELD: dict[str, str] = {
+    "openai": "openai_credential_source",
+    "openai-codex": "openai_credential_source",
+    "anthropic": "anthropic_credential_source",
+}
+
+_OAUTH_PROVIDER_KEY: dict[str, str] = {
+    "openai": "openai-codex",
+    "openai-codex": "openai-codex",
+    "anthropic": "anthropic",
+}
+
+
+def infer_source(provider: str) -> str:
+    """Pick the adapter-registry source for *provider* based on operator state.
+
+    Returns one of :data:`SOURCE_PAYG` / :data:`SOURCE_SUBSCRIPTION`. Falls back
+    to :data:`SOURCE_PAYG` for any provider not in :data:`_SETTINGS_FIELD` so
+    the AgenticLoop registry lookup stays consistent with the historical
+    default (the loop's ``source or "payg"`` had no concept of inference).
+    """
+    field = _SETTINGS_FIELD.get(provider)
+    if field is None:
+        return SOURCE_PAYG
+
+    raw = _read_setting(field)
+    if raw == "oauth":
+        return SOURCE_SUBSCRIPTION
+    if raw in ("api_key", "none"):
+        return SOURCE_PAYG
+    if _has_oauth_profile(provider):
+        return SOURCE_SUBSCRIPTION
+    return SOURCE_PAYG
+
+
+def _read_setting(field: str) -> str:
+    try:
+        from core.config import settings
+    except Exception:
+        log.debug("source-inference: settings import failed; defaulting to auto", exc_info=True)
+        return "auto"
+    raw = getattr(settings, field, "auto")
+    return str(raw or "auto").lower()
+
+
+def _has_oauth_profile(provider: str) -> bool:
+    profile_key = _OAUTH_PROVIDER_KEY.get(provider)
+    if profile_key is None:
+        return False
+    store = _load_profile_store()
+    if store is None:
+        return False
+    from core.auth.profiles import CredentialType
+
+    for profile in store.list_by_provider(profile_key):
+        if profile.credential_type == CredentialType.OAUTH:
+            return True
+    return False
+
+
+def _load_profile_store() -> ProfileStore | None:
+    try:
+        from core.wiring.container import ensure_profile_store
+    except Exception:
+        log.debug("source-inference: profile store import failed", exc_info=True)
+        return None
+    try:
+        return ensure_profile_store()
+    except Exception:
+        log.debug("source-inference: ensure_profile_store raised", exc_info=True)
+        return None

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -295,6 +295,13 @@ def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
     import anthropic
 
     if isinstance(exc, anthropic.RateLimitError):
+        # PR-SOURCE-ROUTING (2026-05-28) — mirror the OpenAI branch:
+        # ``is_billing_fatal`` checks for ``permission_error`` /
+        # ``billing_error`` codes (see ``_ANTHROPIC_BILLING_TYPES``) so a
+        # quota-exhausted Anthropic key surfaces as billing, not as a
+        # transient rate-limit.
+        if is_billing_fatal(exc):
+            return _ERROR_CLASSIFICATION["billing"]
         return _ERROR_CLASSIFICATION["rate_limit"]
     if isinstance(exc, anthropic.APITimeoutError):
         return _ERROR_CLASSIFICATION["timeout"]
@@ -530,6 +537,19 @@ def _classify_openai_error(exc: Exception) -> tuple[str, str, str] | None:
     if isinstance(exc, openai.AuthenticationError):
         return _ERROR_CLASSIFICATION["auth"]
     if isinstance(exc, openai.RateLimitError):
+        # PR-SOURCE-ROUTING (2026-05-28) — the OpenAI SDK raises
+        # ``RateLimitError`` for BOTH transient 429 throttling AND
+        # PAYG ``insufficient_quota`` / ``billing_hard_limit_reached``
+        # (the latter two indicate balance depletion, not throttling).
+        # Without this branch a depleted PAYG bucket surfaces as
+        # "Switch to a different model with /model" — the wrong action
+        # (switching model still hits the same depleted bucket).
+        # ``is_billing_fatal`` inspects ``exc.body['error']['code']``
+        # so OAuth subscription 429s (no ``insufficient_quota`` code)
+        # still classify as rate_limit and follow the existing retry
+        # path.
+        if is_billing_fatal(exc):
+            return _ERROR_CLASSIFICATION["billing"]
         return _ERROR_CLASSIFICATION["rate_limit"]
     if isinstance(exc, openai.APITimeoutError):
         return _ERROR_CLASSIFICATION["timeout"]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -824,10 +824,15 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     # Step J-b.2 (Path-B API path) — resolve_for + acomplete.
     from core.config import settings as _settings
     from core.llm.adapters import resolve_for
+    from core.llm.adapters._source_inference import infer_source
     from core.llm.adapters.base import AdapterCallRequest, Message
     from core.llm.router import call_with_failover
 
-    adapter = resolve_for(_normalize_provider_for_registry(provider), "payg")
+    # PR-SOURCE-ROUTING (2026-05-28) — mutator dispatch used to hard-code
+    # ``"payg"`` so subscription-only Pattern B sent every mutator turn
+    # to the depleted PAYG endpoint. ``infer_source`` mirrors the
+    # AgenticLoop main-path resolution.
+    adapter = resolve_for(_normalize_provider_for_registry(provider), infer_source(provider))
     mutator_temperature = _settings.temperature_self_improving_mutation
 
     async def _do_call(m: str) -> object:

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -239,6 +239,13 @@ def test_default_llm_call_normalizes_openai_codex_provider(
         lambda: cfg_mock,
     )
     monkeypatch.setattr("core.config._resolve_provider", lambda m: "openai-codex")
+    # PR-SOURCE-ROUTING (2026-05-28) — runner now consults
+    # :func:`core.llm.adapters._source_inference.infer_source` instead of
+    # hard-coding ``"payg"``. Pin the test to the historical API-path
+    # default by stubbing the inference helper; the live behaviour
+    # (settings + ProfileStore promotion) is covered by
+    # ``tests/test_source_routing_regression.py``.
+    monkeypatch.setattr("core.llm.adapters._source_inference.infer_source", lambda _p: "payg")
 
     captured: dict[str, object] = {"provider": None, "source": None}
 
@@ -267,7 +274,8 @@ def test_default_llm_call_normalizes_openai_codex_provider(
     result = runner._default_llm_call("SYS", "USR")
     assert result == "from openai-payg"
     # Provider normalisation: ``openai-codex`` (legacy key) → ``openai``
-    # (Path-B registry key). Source stays ``payg`` per API-path default.
+    # (Path-B registry key). Source resolved via stubbed ``infer_source``
+    # returning the API-path default.
     assert captured == {"provider": "openai", "source": "payg"}
 
 

--- a/tests/test_source_routing_regression.py
+++ b/tests/test_source_routing_regression.py
@@ -1,0 +1,436 @@
+"""Regression pin for PR-SOURCE-ROUTING (2026-05-28).
+
+Three layers under test, all stem from one production incident: an operator
+on ChatGPT Pro Lite subscription completed ``/login openai`` (registering
+the ``openai-codex-geode:user`` OAuth profile in :class:`ProfileStore`) but
+the very next ``gpt-5.5`` turn surfaced
+``insufficient_quota — Switch to a different model``. Root cause was
+**three independent regressions stacked**:
+
+1. ``AgenticLoop.__init__`` defaulted ``source`` to literal ``"payg"`` so
+   the daemon path (``core/server/supervised/services.py:211`` →
+   ``AgenticLoop(...)`` with no ``source=`` kwarg) collapsed every
+   ``provider="openai-codex"`` call to ``resolve_for("openai", "payg")``
+   → ``openai-payg`` adapter → ``api.openai.com``.
+2. ``core/agent/loop/_reflection.py:292`` and
+   ``core/self_improving_loop/runner.py:830`` hard-coded ``"payg"`` so
+   subscription-only Pattern B reflected / mutated through the depleted
+   PAYG endpoint while the main loop sat on the subscription endpoint.
+3. ``core/llm/errors.py:_classify_openai_error`` treated
+   ``openai.RateLimitError`` as ``rate_limit`` unconditionally — but the
+   SDK raises the same class for both transient 429 throttling AND
+   ``insufficient_quota`` (PAYG balance depletion). The operator saw
+   "Switch to a different model with ``/model``" — the wrong action
+   (switching model still hits the same depleted bucket).
+
+The fix introduces :func:`core.llm.adapters._source_inference.infer_source`
+which consults the ``{provider}_credential_source`` setting + ProfileStore
+so OAuth-registered providers promote to ``"subscription"`` by default;
+threads it through the AgenticLoop default + the two hard-coded sub-loops;
+and gates the ``RateLimitError`` branch on :func:`is_billing_fatal` so
+``insufficient_quota`` surfaces as ``billing`` (the right action — change
+credential source, not model).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.auth.profiles import AuthProfile, CredentialType, ProfileStore
+from core.llm.adapters._source_inference import infer_source
+from core.llm.adapters.base import SOURCE_PAYG, SOURCE_SUBSCRIPTION
+
+# ---------------------------------------------------------------------------
+# Layer 1 — infer_source resolution priority
+# ---------------------------------------------------------------------------
+
+
+def _stub_store(profiles: list[AuthProfile]) -> ProfileStore:
+    store = ProfileStore()
+    for p in profiles:
+        store.add(p)
+    return store
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Stamp credential_source fields on the singleton settings."""
+    from core.config import settings
+
+    for field, value in overrides.items():
+        monkeypatch.setattr(settings, field, value, raising=False)
+
+
+def _patch_store(monkeypatch: pytest.MonkeyPatch, store: ProfileStore | None) -> None:
+    """Replace the wiring container's profile store accessor for the test."""
+
+    def _fake() -> ProfileStore:
+        if store is None:
+            raise RuntimeError("no store")
+        return store
+
+    monkeypatch.setattr(
+        "core.llm.adapters._source_inference.ensure_profile_store",
+        _fake,
+        raising=False,
+    )
+    # The helper imports inside the function, so also patch the source:
+    import core.wiring.container as _container
+
+    monkeypatch.setattr(_container, "ensure_profile_store", _fake)
+
+
+def test_infer_source_explicit_oauth_setting_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``/login source openai oauth`` → setting=oauth → subscription, no probe."""
+    _patch_settings(monkeypatch, openai_credential_source="oauth")
+    # Store is empty — explicit setting still promotes.
+    _patch_store(monkeypatch, _stub_store([]))
+    assert infer_source("openai") == SOURCE_SUBSCRIPTION
+    assert infer_source("openai-codex") == SOURCE_SUBSCRIPTION
+
+
+def test_infer_source_explicit_api_key_setting_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``/login source openai api_key`` → setting=api_key → payg even with OAuth profile."""
+    _patch_settings(monkeypatch, openai_credential_source="api_key")
+    _patch_store(
+        monkeypatch,
+        _stub_store(
+            [
+                AuthProfile(
+                    name="openai-codex-geode:user",
+                    provider="openai-codex",
+                    credential_type=CredentialType.OAUTH,
+                    key="dummy",
+                    plan_id="openai-codex-geode",
+                )
+            ]
+        ),
+    )
+    assert infer_source("openai") == SOURCE_PAYG
+
+
+def test_infer_source_auto_with_oauth_profile_promotes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """auto + OAuth profile present → subscription (the regression that broke /login openai)."""
+    _patch_settings(monkeypatch, openai_credential_source="auto")
+    _patch_store(
+        monkeypatch,
+        _stub_store(
+            [
+                AuthProfile(
+                    name="openai-codex-geode:user",
+                    provider="openai-codex",
+                    credential_type=CredentialType.OAUTH,
+                    key="dummy",
+                    plan_id="openai-codex-geode",
+                )
+            ]
+        ),
+    )
+    assert infer_source("openai") == SOURCE_SUBSCRIPTION
+    assert infer_source("openai-codex") == SOURCE_SUBSCRIPTION
+
+
+def test_infer_source_auto_with_only_payg_profile_stays_payg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """auto + only PAYG profile (no OAuth) → payg (preserved historical default)."""
+    _patch_settings(monkeypatch, openai_credential_source="auto")
+    _patch_store(
+        monkeypatch,
+        _stub_store(
+            [
+                AuthProfile(
+                    name="openai-payg:env",
+                    provider="openai",
+                    credential_type=CredentialType.API_KEY,
+                    key="sk-dummy",
+                    plan_id="openai-payg",
+                )
+            ]
+        ),
+    )
+    assert infer_source("openai") == SOURCE_PAYG
+
+
+def test_infer_source_unknown_provider_falls_back_to_payg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Providers GEODE doesn't gate (e.g. glm) keep the historical payg default."""
+    _patch_settings(monkeypatch, openai_credential_source="oauth")
+    _patch_store(monkeypatch, None)
+    assert infer_source("glm") == SOURCE_PAYG
+    assert infer_source("unknown") == SOURCE_PAYG
+
+
+def test_infer_source_anthropic_setting_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """anthropic_credential_source is read for anthropic, NOT openai_credential_source."""
+    _patch_settings(
+        monkeypatch,
+        openai_credential_source="oauth",
+        anthropic_credential_source="api_key",
+    )
+    _patch_store(monkeypatch, _stub_store([]))
+    assert infer_source("openai") == SOURCE_SUBSCRIPTION
+    assert infer_source("anthropic") == SOURCE_PAYG
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — AgenticLoop default inference (source-level pin on the wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_loop_default_source_no_longer_payg_literal() -> None:
+    """Source-level pin: AgenticLoop default goes through ``infer_source``, not literal ``"payg"``.
+
+    A regression that re-introduces ``source or "payg"`` would re-collapse
+    every interactive call (the daemon never passes ``source=``) onto the
+    PAYG adapter and silently masquerade an OAuth-registered subscription
+    operator's session as a PAYG call. The fix lives in
+    :func:`core.agent.loop.agent_loop.AgenticLoop.__init__` and must
+    consult :func:`infer_source` before defaulting.
+    """
+    loop_source = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+    # The legacy single-line default must be gone.
+    assert 'self._source = source or "payg"' not in loop_source, (
+        "AgenticLoop.__init__ still uses the literal-payg default — the "
+        "daemon path will silently route OAuth-registered providers through "
+        "the depleted PAYG endpoint."
+    )
+    # The inference call must be present.
+    assert "infer_source(provider)" in loop_source, (
+        "AgenticLoop.__init__ no longer consults infer_source — the "
+        "credential_source setting + ProfileStore OAuth presence will be "
+        "ignored when source is unspecified."
+    )
+
+
+def test_reflection_node_no_longer_hardcodes_payg() -> None:
+    """Source-level pin: reflection dispatch uses ``infer_source(provider)``."""
+    reflection_source = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "_reflection.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        'resolve_for(_normalize_provider_for_registry(provider), "payg")' not in reflection_source
+    ), (
+        "_reflection.py still hard-codes the payg source — subscription-only "
+        "operators reflect through the depleted PAYG endpoint."
+    )
+    assert "infer_source(provider)" in reflection_source, (
+        "_reflection.py no longer threads infer_source through reflection dispatch."
+    )
+
+
+def test_self_improving_runner_no_longer_hardcodes_payg() -> None:
+    """Source-level pin: self-improving mutator uses ``infer_source(provider)``."""
+    runner_source = (
+        Path(__file__).resolve().parents[1] / "core" / "self_improving_loop" / "runner.py"
+    ).read_text(encoding="utf-8")
+    assert 'resolve_for(_normalize_provider_for_registry(provider), "payg")' not in runner_source, (
+        "runner.py still hard-codes the payg source on the mutator path."
+    )
+    assert "infer_source(provider)" in runner_source, (
+        "runner.py no longer threads infer_source through the mutator dispatch."
+    )
+
+
+def test_agentic_loop_explicit_source_still_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``source=`` kwarg bypasses inference (caller authority preserved).
+
+    Pinned because the audit-subprocess path (``geode_target.py`` after PR
+    #1792) deliberately passes the alias-translated source via
+    ``source=...`` — the inference must not override it.
+    """
+    from core.llm.adapters.registry import _reset_for_test
+
+    from core.llm.adapters import bootstrap_builtins
+
+    _patch_settings(monkeypatch, openai_credential_source="oauth")
+    _patch_store(monkeypatch, _stub_store([]))
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+
+        # Build a loop with an explicit source — inference would say
+        # "subscription" but explicit "payg" should win.
+        from core.agent.conversation import ConversationContext
+        from core.agent.loop import AgenticLoop
+        from core.agent.tool_executor import ToolExecutor
+
+        loop = AgenticLoop(
+            ConversationContext(),
+            ToolExecutor(action_handlers={}, hitl_level=0),
+            model="gpt-5.5",
+            provider="openai-codex",
+            source="payg",
+            quiet=True,
+            max_rounds=0,
+        )
+        assert loop._source == "payg", (
+            f"Explicit source='payg' was overridden by inference "
+            f"(loop._source={loop._source!r}); caller authority broken."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+
+def test_agentic_loop_dispatches_codex_oauth_when_oauth_profile_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end pin: gpt-5.5 + OAuth profile → codex-oauth adapter, not openai-payg.
+
+    This is the exact user incident. Without the fix:
+      - ``self._source = source or "payg"`` → ``"payg"``
+      - ``_PROVIDER_NORMALIZATION["openai-codex"]`` → ``"openai"``
+      - ``resolve_for("openai", "payg")`` → ``openai-payg``
+      - HTTP call lands on ``api.openai.com`` → ``insufficient_quota``.
+    With the fix the dispatched adapter must be ``codex-oauth``.
+    """
+    from core.llm.adapters.registry import _reset_for_test
+
+    from core.llm.adapters import bootstrap_builtins
+
+    _patch_settings(monkeypatch, openai_credential_source="auto")
+    _patch_store(
+        monkeypatch,
+        _stub_store(
+            [
+                AuthProfile(
+                    name="openai-codex-geode:user",
+                    provider="openai-codex",
+                    credential_type=CredentialType.OAUTH,
+                    key="dummy",
+                    plan_id="openai-codex-geode",
+                )
+            ]
+        ),
+    )
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+
+        from core.agent.conversation import ConversationContext
+        from core.agent.loop import AgenticLoop
+        from core.agent.tool_executor import ToolExecutor
+
+        loop = AgenticLoop(
+            ConversationContext(),
+            ToolExecutor(action_handlers={}, hitl_level=0),
+            model="gpt-5.5",
+            provider="openai-codex",
+            quiet=True,
+            max_rounds=0,
+        )
+        assert loop._new_adapter.name == "codex-oauth", (
+            f"AgenticLoop dispatched {loop._new_adapter.name!r} instead of "
+            f"codex-oauth; the OAuth-promotion fix is wired wrong and the "
+            f"user's subscription bucket is bypassed."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+
+def test_agentic_loop_dispatches_openai_payg_without_oauth_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Historical default preserved: no OAuth profile → openai-payg dispatch."""
+    from core.llm.adapters.registry import _reset_for_test
+
+    from core.llm.adapters import bootstrap_builtins
+
+    _patch_settings(monkeypatch, openai_credential_source="auto")
+    _patch_store(monkeypatch, _stub_store([]))
+
+    try:
+        _reset_for_test()
+        bootstrap_builtins()
+
+        from core.agent.conversation import ConversationContext
+        from core.agent.loop import AgenticLoop
+        from core.agent.tool_executor import ToolExecutor
+
+        loop = AgenticLoop(
+            ConversationContext(),
+            ToolExecutor(action_handlers={}, hitl_level=0),
+            model="gpt-5.5",
+            provider="openai-codex",
+            quiet=True,
+            max_rounds=0,
+        )
+        assert loop._new_adapter.name == "openai-payg", (
+            f"Without an OAuth profile, AgenticLoop must keep dispatching "
+            f"openai-payg (the historical default); got {loop._new_adapter.name!r}."
+        )
+    finally:
+        _reset_for_test()
+        bootstrap_builtins()
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — classifier: insufficient_quota → billing, not rate_limit
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_rate_limit_error(*, body_code: str | None) -> Exception:
+    """Synthesise an ``openai.RateLimitError`` carrying a structured body."""
+    import httpx
+    import openai
+
+    body: dict[str, object] = {}
+    if body_code is not None:
+        body["error"] = {"code": body_code, "message": "synthetic", "type": body_code}
+    response = httpx.Response(
+        status_code=429,
+        json=body or {"error": {"message": "synthetic"}},
+        request=httpx.Request("POST", "https://api.openai.com/v1/responses"),
+    )
+    return openai.RateLimitError("synthetic", response=response, body=body or None)
+
+
+def test_classifier_insufficient_quota_maps_to_billing() -> None:
+    """PAYG balance depletion must NOT surface as rate_limit (operator gets wrong action)."""
+    from core.llm.errors import classify_llm_error
+
+    exc = _make_openai_rate_limit_error(body_code="insufficient_quota")
+    error_type, severity, hint = classify_llm_error(exc)
+    assert error_type == "billing", (
+        f"insufficient_quota classified as {error_type!r}; the operator will "
+        f"see 'Switch to a different model' instead of the correct 'change "
+        f"credential source' action."
+    )
+    assert severity == "critical"
+    assert "credit" in hint.lower() or "billing" in hint.lower() or "balance" in hint.lower()
+
+
+def test_classifier_billing_hard_limit_maps_to_billing() -> None:
+    """The other PAYG billing-fatal code also routes to billing."""
+    from core.llm.errors import classify_llm_error
+
+    exc = _make_openai_rate_limit_error(body_code="billing_hard_limit_reached")
+    error_type, _, _ = classify_llm_error(exc)
+    assert error_type == "billing"
+
+
+def test_classifier_transient_429_still_rate_limit() -> None:
+    """OAuth subscription 429 (no insufficient_quota code) keeps rate_limit classification.
+
+    The fix must not collapse every RateLimitError into billing — transient
+    throttling on the subscription endpoint (no ``error.code`` field in
+    body) must keep the rate_limit hint so the existing retry path stays
+    reachable.
+    """
+    from core.llm.errors import classify_llm_error
+
+    exc = _make_openai_rate_limit_error(body_code=None)
+    error_type, _, _ = classify_llm_error(exc)
+    assert error_type == "rate_limit", (
+        f"Transient 429 (no billing code) classified as {error_type!r}; "
+        f"the existing retry path is bypassed."
+    )


### PR DESCRIPTION
## Summary
- AgenticLoop / reflection / self-improving mutator 가 OAuth 등록 후에도 항상 PAYG endpoint 로 dispatch 되던 회귀 수정 (3-layer)
- `_source_inference.infer_source` 헬퍼 신설 → `{provider}_credential_source` setting + ProfileStore 의 OAuth 존재 여부로 `payg`/`subscription` 자동 추론
- `classify_llm_error` 가 PAYG `insufficient_quota` 를 `rate_limit` 으로 오분류하던 부수 회귀도 함께 수정

## Why
운영자가 `/login openai` 으로 ChatGPT Pro Lite OAuth 프로필 (`openai-codex-geode:user`) 을 등록한 직후 `gpt-5.5` 한 턴이 즉시 다음 에러로 종료:

> `API rate limited. Switch to a different model with /model and re-run.`
> `model: gpt-5.5 (openai-codex)`, `attempts: 1`
> `detail: You exceeded your current quota, please check your plan and billing details.`

두 endpoint 를 직접 probe 한 결과 **구독 쿼터는 멀쩡**:
- `api.openai.com` (PAYG, `sk-proj-…` key) → HTTP 429 `insufficient_quota` (잔액 0)
- `chatgpt.com/backend-api/codex` (OAuth) → HTTP 400 "Stream must be set to true" (인증·인가·쿼터 모두 OK)

즉 호출이 구독이 아닌 PAYG endpoint 로 새고 있었고, 이는 self-improving 어댑터 sprint (PR-MAINPATH-1 / PR-MAINPATH-67 / PR-DRIFT-CUT) 가 만든 회귀임. 근본 원인 3-layer:

1. **AgenticLoop 기본 source 가 무조건 `"payg"`** — `core/agent/loop/agent_loop.py:392` 에 `self._source = source or "payg"`. CLI daemon (`services.py:211`), fork-skill (`bootstrap.py:206`), 빈 source 로 받는 sub-agent worker (`worker.py:374`) 모두 `source=` 미전달 → `resolve_for("openai", "payg")` → `openai-payg` → `api.openai.com`. `/login source openai oauth` 가 쓰는 `openai_credential_source` 필드는 정의·쓰기는 있지만 **읽는 코드가 0** (dead wiring).
2. **`_reflection.py:292` + `runner.py:830` 하드코딩 `"payg"`** — Pattern B subscription-only 운영자조차 reflection / mutator 가 PAYG 로 빠짐.
3. **`_classify_openai_error` 가 `RateLimitError` → 항상 `rate_limit`** — OpenAI SDK 는 PAYG 잔액 0 (`insufficient_quota` / `billing_hard_limit_reached`) 도 같은 RateLimitError 로 raise. `is_billing_fatal()` 헬퍼는 같은 파일에 존재하지만 classify 경로에서 호출 안 됨 → 잔액 0 응답이 "Switch to a different model" 액션으로 둔갑.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/_source_inference.py` | 신규. `infer_source(provider)` → `{provider}_credential_source` setting 우선, "auto" 시 ProfileStore OAuth probe, 알 수 없는 provider 는 `payg` fallback |
| `core/agent/loop/agent_loop.py` | `source or "payg"` → `source` 미지정 시 `infer_source(provider)` 호출. 명시적 `source=` 는 caller 권한 유지 (audit-subprocess 경로 보호) |
| `core/agent/loop/_reflection.py` | 하드코딩 `"payg"` → `infer_source(provider)` |
| `core/self_improving_loop/runner.py` | 하드코딩 `"payg"` → `infer_source(provider)` |
| `core/llm/errors.py` | OpenAI + Anthropic `RateLimitError` 분기에서 `is_billing_fatal(exc)` 우선 체크 → 잔액 고갈은 `"billing"`, 일시 throttling 은 `"rate_limit"` 유지 |
| `tests/test_source_routing_regression.py` | 신규. 15 assertion / 3 layer (infer_source 우선순위, AgenticLoop dispatch → codex-oauth, classifier → billing) |
| `tests/test_paperclip_wiring.py` | API-path 기본값 테스트가 ProfileStore OAuth 존재 여부에 의존하지 않도록 `infer_source` stub 추가 |
| `CHANGELOG.md` | Unreleased / Fixed 섹션에 PR-SOURCE-ROUTING 항목 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `services.py:211` (CLI daemon) | Fixed via AgenticLoop default | source 미전달 → infer_source 가 OAuth 승격 |
| `bootstrap.py:206` (fork-skill) | Fixed via AgenticLoop default | 동일 |
| `worker.py:374` (sub-agent) | Fixed via AgenticLoop default | `request.source=""` 시 inference 작동 |
| `_reflection.py:292` | Fixed | 하드코딩 제거 |
| `runner.py:830` (self-improving mutator) | Fixed | 하드코딩 제거 |
| `seed-generation` agents | Already OK | `picker_source_to_adapter_source` 가 `openai-codex → subscription` 매핑 |
| `petri-audit` audit subprocess | Already OK | PR #1792 의 `_PETRI_TO_REGISTRY` 가 alias 변환 |
| `_classify_openai_error` | Fixed | `is_billing_fatal` 우선 |
| `classify_llm_error` Anthropic 분기 | Fixed (parity) | 동일 패턴 적용 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — pre-existing 3건만 (`codex_overrides.py`, develop 동일)
- [x] `uv run lint-imports` — 4/4 KEPT
- [x] `uv run pytest tests/ -m "not live"` — **8776 passed**, 18 skipped, 0 new failure (pre-existing 4건은 develop 도 동일하게 실패: m4_4 in-context wiring fixture pollution, autoresearch_train 3건)
- [x] `uv run geode version` → `GEODE v0.99.76`

## Reference
- 사용자 보고: `/login openai` 직후 첫 `gpt-5.5` 호출이 `insufficient_quota` 로 즉시 종료
- 회귀 도입 PR: `c216ee7b` PR-MAINPATH-1, `4f0fad3a` PR-MAINPATH-67, `e27e1c3e` PR-DRIFT-CUT
- 부분 fix 선행 PR: `251d432b` PR-AGENTIC-LOOP-ADAPTER-NAME-LOOKUP (#1792) — audit subprocess 한 경로만 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)