### PR TITLE
release: v0.99.77 — PR-SOURCE-ROUTING + PR-HYPERPARAM-WIRE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.77] - 2026-05-28
+
+> PATCH release. Operational regression fix: gpt-5.x interactive turns
+> were silently routing to PAYG even after ``/login openai`` registered
+> the ChatGPT subscription OAuth profile. Three stacked regressions
+> from the self-improving adapter sprint (PR-MAINPATH-1 /
+> PR-MAINPATH-67 / PR-DRIFT-CUT) collapsed every gpt-5.x dispatch to
+> the openai-payg adapter; ``insufficient_quota`` then mis-classified
+> as ``rate_limit`` so the operator-facing hint said "switch model"
+> instead of "change credential source". Also bundles the
+> previously-staged hyperparam wire (audit subprocess argv now honours
+> ``autoresearch/state/policies/hyperparam.json``).
+
 ### Fixed
 - **PR-SOURCE-ROUTING (2026-05-28)** — restore subscription-bucket routing
   for OAuth-registered providers. Three stacked regressions converted every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.76
+- **Version**: 0.99.77
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.76 — Long-running Autonomous Execution Harness
+# GEODE v0.99.77 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.76**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.77**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.76 — Long-running Autonomous Execution Harness
+# GEODE v0.99.77 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.76**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.77**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.76"
+version = "0.99.77"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- v0.99.77 PATCH 릴리스 — 5개 위치 (CHANGELOG / CLAUDE.md / README.md / README.ko.md / pyproject.toml) 버전 stamp 동기화
- 이미 develop 에 CI-green 상태로 머지된 PR-SOURCE-ROUTING (#1822) + PR-HYPERPARAM-WIRE (#1816 + #1819) 묶음
- 본 PR 머지 후 별도로 `develop → main` pass-through PR 끊어 main 반영

## Verification
- [x] `uv run geode version` → `GEODE v0.99.77`
- [x] 5 stamp 위치 모두 0.99.77 (frontier 비교표 GEODE 라인 포함)
- [x] CHANGELOG `[Unreleased]` → `[0.99.77] - 2026-05-28` 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)