### PR TITLE
fix(codex): work around openai>=2.26 parse_response crash on Codex output:null (PR-CODEX-OUTPUT-NULL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,40 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-OUTPUT-NULL (2026-05-28)** — work around an ``openai>=2.26``
+  streaming-parser crash on every Codex subscription call. The ChatGPT
+  backend at ``chatgpt.com/backend-api/codex`` delivers ``response.completed``
+  events with ``output: null`` (the actual items arrive as separate
+  ``response.output_item.done`` events that the SDK's accumulator collects
+  into its own snapshot). Starting at SDK 2.26 ``ResponseStreamState.
+  accumulate_event`` calls ``openai.lib._parsing._responses.parse_response
+  (event.response)`` on every ``response.completed`` and ``parse_response``
+  iterates ``response.output`` unconditionally — so ``output is None``
+  raises ``TypeError: 'NoneType' object is not iterable`` during the
+  ``async for event in stream`` loop in ``CodexOAuthAdapter.acomplete``,
+  before our own ``accumulated`` list could absorb the items. Result on
+  the operator's machine: PR-SOURCE-ROUTING (#1822) correctly routed
+  ``gpt-5.x`` to the subscription endpoint and received HTTP 200, but
+  every call then crashed with ``unknown`` error and retried 5× before
+  surfacing ``model_action_required``. Hermes pins ``openai==2.24.0`` and
+  never hit this; GEODE's ``openai>=2.26.0`` resolves to 2.30.0.
+
+  ``core/llm/adapters/_codex_sdk_workaround.py:install()`` patches
+  ``parse_response`` (and the symbol re-imported into the streaming
+  module) to coerce ``response.output`` from ``None`` to ``[]`` before
+  delegating to the original parser. The CodexOAuthAdapter's existing
+  ``accumulated`` list + ``translate_codex_response`` pipeline then
+  produces the real items as before. Installed lazily on the first
+  Codex client construction (adapter ``build_async_codex_client`` AND
+  legacy provider ``_get_async_codex_client``), idempotent across the
+  process. Removable once a future ``openai`` SDK release fixes
+  ``parse_response`` to handle ``response.output is None``.
+
+  Pinned by ``tests/test_codex_sdk_workaround.py`` (5 assertions:
+  unpatched-crash repro, patched-coerce success, idempotence + streaming
+  module rebound, and source-level pins on both client builders).
+
 ## [0.99.77] - 2026-05-28
 
 > PATCH release. Operational regression fix: gpt-5.x interactive turns

--- a/core/llm/adapters/_codex_sdk_workaround.py
+++ b/core/llm/adapters/_codex_sdk_workaround.py
@@ -1,0 +1,127 @@
+"""Workaround for openai>=2.26 streaming parser vs ChatGPT Codex backend.
+
+PR-CODEX-OUTPUT-NULL (2026-05-28). When the OpenAI Python SDK's
+``responses.stream()`` helper consumes a ``response.completed`` SSE event,
+``ResponseStreamState.accumulate_event`` calls
+``openai.lib._parsing._responses.parse_response(response=event.response, ...)``.
+``parse_response`` immediately runs ``for output in response.output:`` —
+which raises ``TypeError: 'NoneType' object is not iterable`` whenever
+``response.output`` is ``None``.
+
+The ChatGPT subscription backend at ``chatgpt.com/backend-api/codex``
+delivers exactly this shape: the actual output items arrive as separate
+``response.output_item.done`` SSE events while the final
+``response.completed`` event carries ``output: null`` (the snapshot lives
+in the SDK's accumulator, not in the completed payload). Hermes pins
+``openai==2.24.0`` (which predates the parse_response call) so they
+never hit this; GEODE's ``openai>=2.26.0`` resolves to 2.30.0 and hits
+it on every Codex subscription call.
+
+The CodexOAuthAdapter already collects ``response.output_item.done``
+events into a local ``accumulated`` list (``codex_oauth.py:118-126``)
+and assigns them onto the final response in
+``translate_codex_response``, so the SDK's structured parsing failure
+is purely a crash-on-iteration artifact — coercing the iteration source
+to ``[]`` when ``None`` lets the SDK reach its completion state and our
+own accumulator pipeline takes over from there.
+
+The patch is idempotent and applies only once per process; it is
+installed lazily on the first import of any module that needs the Codex
+backend so non-OpenAI processes (pure-Anthropic, claude-cli only) don't
+pay for it. We restore the original symbol on test teardown via
+:func:`_for_test_restore` so the unit test can exercise the unpatched
+crash before re-applying the patch.
+
+Removable once a future ``openai`` SDK release fixes
+``parse_response`` to handle ``response.output is None`` (filed
+upstream — see CHANGELOG entry).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+_PATCHED: bool = False
+_ORIGINAL_PARSE_RESPONSE: Any = None
+
+
+def install() -> None:
+    """Patch ``openai.lib._parsing._responses.parse_response`` once.
+
+    Subsequent calls are no-ops. The patch wraps the original function with
+    a ``response.output = response.output or []`` coercion so the inner
+    ``for output in response.output:`` loop becomes a safe no-op when the
+    Codex backend sends a null-output completion event.
+    """
+    global _PATCHED, _ORIGINAL_PARSE_RESPONSE
+
+    if _PATCHED:
+        return
+
+    try:
+        import openai.lib._parsing._responses as _parse_mod
+        import openai.lib.streaming.responses._responses as _stream_mod
+    except ImportError:
+        log.debug("openai SDK not installed; skipping Codex workaround patch")
+        return
+
+    _ORIGINAL_PARSE_RESPONSE = _parse_mod.parse_response
+
+    def _patched(*, text_format: Any, input_tools: Any, response: Any) -> Any:
+        if getattr(response, "output", None) is None:
+            # In-place mutation is safe: the SDK constructs ``event.response``
+            # fresh per ``response.completed`` event and the SDK consumer
+            # (``accumulate_event`` at line 360 of the streaming module)
+            # only forwards the parsed return value, never re-reads the
+            # mutated input.
+            try:
+                response.output = []
+            except (AttributeError, TypeError, ValueError):
+                # Pydantic v2 may reject the attribute set on a frozen model
+                # — fall back to a model_copy with the field overridden.
+                try:
+                    response = response.model_copy(update={"output": []})
+                except Exception:
+                    log.warning(
+                        "codex-sdk-workaround: failed to coerce response.output "
+                        "from None to []; parse_response will likely raise"
+                    )
+        return _ORIGINAL_PARSE_RESPONSE(
+            text_format=text_format,
+            input_tools=input_tools,
+            response=response,
+        )
+
+    _parse_mod.parse_response = _patched
+    # The streaming module imports ``parse_response`` at module load
+    # (``from ..._parsing._responses import ..., parse_response``) so
+    # patching only the source isn't enough — the streaming module's
+    # local reference must be rebound too. ``setattr`` keeps mypy
+    # quiet about the private-attribute access.
+    setattr(_stream_mod, "parse_response", _patched)  # noqa: B010
+    _PATCHED = True
+    log.debug("codex-sdk-workaround: parse_response patched for output=None coercion")
+
+
+def _for_test_restore() -> None:
+    """Restore the original ``parse_response`` for unit tests that need
+    to exercise the unpatched crash. Re-call :func:`install` afterwards
+    to re-apply the patch."""
+    global _PATCHED, _ORIGINAL_PARSE_RESPONSE
+
+    if _ORIGINAL_PARSE_RESPONSE is None:
+        return
+    try:
+        import openai.lib._parsing._responses as _parse_mod
+        import openai.lib.streaming.responses._responses as _stream_mod
+
+        _parse_mod.parse_response = _ORIGINAL_PARSE_RESPONSE
+        setattr(_stream_mod, "parse_response", _ORIGINAL_PARSE_RESPONSE)  # noqa: B010
+    except ImportError:
+        pass
+    _PATCHED = False
+    _ORIGINAL_PARSE_RESPONSE = None

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -236,7 +236,13 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     import openai
 
     from core.config import CODEX_BASE_URL
+    from core.llm.adapters._codex_sdk_workaround import install as _install_codex_workaround
     from core.llm.providers.codex import build_codex_oauth_headers
+
+    # PR-CODEX-OUTPUT-NULL (2026-05-28) — install the SDK parse_response
+    # workaround before the first Codex backend call. Idempotent across
+    # process lifetime; only patches when the openai SDK is importable.
+    _install_codex_workaround()
 
     return openai.AsyncOpenAI(
         api_key=api_key,

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -151,6 +151,13 @@ def _get_async_codex_client() -> Any:
                     log.warning("Codex OAuth token not available")
                     return None
 
+                # PR-CODEX-OUTPUT-NULL (2026-05-28) — mirror the adapter
+                # builder: install the parse_response workaround so the
+                # legacy provider path is also safe on openai >= 2.26.
+                from core.llm.adapters._codex_sdk_workaround import install as _install
+
+                _install()
+
                 _async_codex_client = openai.AsyncOpenAI(
                     api_key=token,
                     base_url=CODEX_BASE_URL,

--- a/tests/test_codex_sdk_workaround.py
+++ b/tests/test_codex_sdk_workaround.py
@@ -1,0 +1,185 @@
+"""Regression pin for PR-CODEX-OUTPUT-NULL (2026-05-28).
+
+The ChatGPT subscription backend at ``chatgpt.com/backend-api/codex``
+delivers ``response.completed`` events with ``output: null`` because the
+actual output items are streamed via separate ``response.output_item.done``
+events. Starting in ``openai`` SDK 2.26+, ``ResponseStreamState.
+accumulate_event`` calls ``parse_response(event.response)`` on every
+``response.completed``; that function iterates ``response.output``
+unconditionally, so ``output is None`` raises
+``TypeError: 'NoneType' object is not iterable`` during the
+``async for event in stream`` loop in
+:meth:`core.llm.adapters.codex_oauth.CodexOAuthAdapter.acomplete` —
+**before** our own ``accumulated`` list could absorb the items.
+
+``core/llm/adapters/_codex_sdk_workaround.py`` patches
+``openai.lib._parsing._responses.parse_response`` (and the symbol
+re-imported into the streaming module) to coerce ``response.output``
+from ``None`` to ``[]`` before delegating to the original parser. The
+test exercises the unpatched crash, applies the patch, and verifies the
+same call now returns cleanly. A second test confirms the patch is
+idempotent (re-installing is a no-op) and that the install is wired into
+both client builders (adapter + legacy provider).
+
+Live HTTP is not required — we synthesise the ``Response`` object the
+SDK would have constructed from a Codex backend ``response.completed``
+SSE event payload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import openai
+except ImportError:  # pragma: no cover — openai is a hard runtime dep
+    pytest.skip("openai SDK not installed", allow_module_level=True)
+
+
+def _make_response_with_null_output() -> object:
+    """Synthesise an ``openai.types.responses.Response`` carrying
+    ``output: None`` — the exact payload the Codex backend sends in its
+    ``response.completed`` SSE event.
+    """
+    from openai.types.responses.response import Response
+
+    # The Pydantic model uses ``output: List[ResponseOutputItem]`` so
+    # we have to construct via ``model_construct`` to bypass validation
+    # — which mirrors what the SDK's internal SSE deserialiser does
+    # when the wire payload says ``"output": null``.
+    return Response.model_construct(
+        id="resp_test",
+        object="response",
+        created_at=0.0,
+        status="completed",
+        output=None,  # the field that crashes parse_response
+        model="gpt-5.5",
+        instructions=None,
+        usage=None,
+        metadata={},
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        temperature=None,
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        text=None,
+        truncation=None,
+        user=None,
+        incomplete_details=None,
+        error=None,
+        store=False,
+    )
+
+
+def test_unpatched_parse_response_raises_on_null_output() -> None:
+    """Source-level pin on the upstream bug we are working around.
+
+    Confirms the failure mode the patch addresses still exists in the
+    installed SDK — if a future ``openai`` release fixes this, the test
+    will start failing and we can delete the workaround module.
+    """
+    from core.llm.adapters import _codex_sdk_workaround as wa
+
+    wa._for_test_restore()
+    try:
+        from openai.lib._parsing._responses import parse_response
+
+        response = _make_response_with_null_output()
+        with pytest.raises(TypeError, match=r"NoneType.*not iterable"):
+            parse_response(text_format=openai.NotGiven(), input_tools=[], response=response)
+    finally:
+        wa.install()
+
+
+def test_patched_parse_response_coerces_null_to_empty() -> None:
+    """After ``install()``, ``parse_response`` returns cleanly on null output.
+
+    The Codex adapter's own ``accumulated`` list rebuilds the real output
+    items from the streamed ``response.output_item.done`` events, so the
+    parsed snapshot being empty is fine — the visible-text-and-tools
+    extraction in ``translate_codex_response`` reads from
+    ``accumulated_items`` first.
+    """
+    from core.llm.adapters import _codex_sdk_workaround as wa
+
+    wa.install()  # idempotent
+    from openai.lib._parsing._responses import parse_response
+
+    response = _make_response_with_null_output()
+    parsed = parse_response(
+        text_format=openai.NotGiven(),
+        input_tools=[],
+        response=response,
+    )
+    # Empty output list is the safe contract — the SDK consumer
+    # (streaming accumulator) doesn't crash and our own accumulator
+    # produces the real items separately.
+    assert list(parsed.output) == [], (
+        f"Patched parse_response returned non-empty output {parsed.output!r}; "
+        f"the workaround should coerce only the None case."
+    )
+
+
+def test_install_is_idempotent_and_streaming_module_rebound() -> None:
+    """Two installs leave both module references pointing at the patched fn.
+
+    The streaming module imports ``parse_response`` at module load
+    (``from ..._parsing._responses import ..., parse_response``) so a
+    naive patch on only the source would leave the streaming module's
+    local reference pointing at the original (unpatched) callable.
+    """
+    from core.llm.adapters import _codex_sdk_workaround as wa
+
+    wa.install()
+    wa.install()  # second call must be a no-op (no double-wrap)
+
+    import openai.lib._parsing._responses as _parse_mod
+    import openai.lib.streaming.responses._responses as _stream_mod
+
+    assert _parse_mod.parse_response is _stream_mod.parse_response, (
+        "_codex_sdk_workaround.install rebound the source but not the "
+        "streaming module's local reference — the SDK's stream "
+        "accumulator will still call the unpatched function."
+    )
+
+
+def test_codex_client_builder_installs_workaround() -> None:
+    """Source-level pin: build_async_codex_client triggers install().
+
+    Greps ``_openai_common.py`` for the install call so a future refactor
+    that drops it (and silently re-introduces the crash on every
+    subscription call) fails this test before the regression re-emerges.
+    """
+    common_source = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_openai_common.py"
+    ).read_text(encoding="utf-8")
+    assert "_install_codex_workaround" in common_source, (
+        "build_async_codex_client no longer installs the parse_response "
+        "workaround; every Codex subscription call will TypeError on "
+        "openai >= 2.26."
+    )
+
+
+def test_legacy_codex_provider_installs_workaround() -> None:
+    """Source-level pin: legacy provider client builder also triggers install()."""
+    provider_source = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "providers" / "codex.py"
+    ).read_text(encoding="utf-8")
+    assert "_codex_sdk_workaround" in provider_source, (
+        "_get_async_codex_client no longer installs the parse_response "
+        "workaround; the legacy provider path will crash on subscription."
+    )
+
+
+# Ensure the patch is re-applied for any downstream tests that may run
+# after this module — leaving the SDK unpatched would break unrelated
+# Codex subscription tests.
+def teardown_module(module: object) -> None:
+    from core.llm.adapters import _codex_sdk_workaround as wa
+
+    wa.install()


### PR DESCRIPTION
## Summary
- PR-SOURCE-ROUTING (#1822) merge 후 \`gpt-5.x\` 호출이 구독 endpoint 로는 정확히 dispatch (HTTP 200) 되지만, openai SDK 2.30.0 의 stream parser 가 ChatGPT 백엔드의 \`output: null\` shape 처리 실패 → 매번 \`TypeError: 'NoneType' is not iterable\` 으로 crash
- \`core/llm/adapters/_codex_sdk_workaround.py:install()\` 가 SDK 의 \`parse_response\` 를 monkey-patch 해 \`response.output = response.output or []\` coerce
- adapter + legacy provider 양쪽 client 빌더에 install 호출 wiring

## Why
사용자가 v0.99.77 동기화 직후 \`gpt-5.5\` 한 턴이 다음 패턴으로 5회 retry 후 실패:

\`\`\`
POST https://chatgpt.com/backend-api/codex/responses → HTTP 200 OK   ← 라우팅 OK
codex-oauth: responses.stream failed err='NoneType' object is not iterable
LLM call FAILED: gpt-5.5 — unknown
\`\`\`

직접 probe (\`tools=()\`, 최소 입력) 로도 100% 재현. Full traceback:

\`\`\`
File "openai/lib/streaming/responses/_responses.py:360 accumulate_event"
  self._completed_response = parse_response(text_format=..., response=event.response, ...)
File "openai/lib/_parsing/_responses.py:61"
  for output in response.output:    ← response.output is None → TypeError
\`\`\`

ChatGPT 백엔드는 \`response.completed\` 이벤트에 \`output: null\` 을 담아 보냄 (실제 항목은 \`response.output_item.done\` 이벤트로 별도 스트리밍 → SDK 의 snapshot 에 누적). SDK 2.26+ 가 \`response.completed\` 에서 \`parse_response(event.response)\` 를 호출하면서 \`event.response.output\` 가 None 이라 폭주.

**Hermes 비교** (frontier reference): \`openai==2.24.0\` 정확 핀으로 이 회귀 회피. GEODE 는 \`openai>=2.26.0\` 으로 2.30.0 설치 → 어댑터 도입과 SDK 자동 bump 가 시점상 함께 일어남.

\`CodexOAuthAdapter.acomplete\` 가 자체 \`accumulated\` 리스트로 \`response.output_item.done\` 이벤트를 수거해 \`translate_codex_response\` 에서 활용하는 우회를 이미 깔아뒀지만, SDK 의 stream accumulator 가 매 SSE 이벤트마다 \`accumulate_event → parse_response\` 를 호출하므로 우리쪽 \`accumulated.append\` 도달 전에 SDK 가 먼저 터짐.

## Changes
| File | Change |
|------|--------|
| \`core/llm/adapters/_codex_sdk_workaround.py\` | 신규. \`install()\` 가 \`openai.lib._parsing._responses.parse_response\` 를 monkey-patch (response.output=None → []). 스트리밍 모듈의 import 캐시도 함께 rebind. 멱등 |
| \`core/llm/adapters/_openai_common.py\` | \`build_async_codex_client\` 가 client 생성 직전 \`install()\` 호출 |
| \`core/llm/providers/codex.py\` | legacy \`_get_async_codex_client\` 도 동일하게 \`install()\` 호출 (provider 경로 회귀 방지) |
| \`tests/test_codex_sdk_workaround.py\` | 5 assertion: (1) unpatched crash 재현 (2) patched coerce 성공 (3) idempotent + streaming module rebound (4) adapter builder 에 install 와이어드 (5) provider builder 에 install 와이어드 |
| \`CHANGELOG.md\` | Unreleased / Fixed PR-CODEX-OUTPUT-NULL |

## Verification
- [x] \`uv run ruff check core/ tests/ plugins/\` — clean
- [x] \`uv run ruff format --check core/ tests/ plugins/\` — clean
- [x] \`uv run mypy core/ plugins/\` — pre-existing 3건 (develop 동일)
- [x] \`uv run pytest tests/test_codex_sdk_workaround.py tests/test_source_routing_regression.py tests/test_agentic_loop_adapter_name_lookup.py tests/test_paperclip_wiring.py\` — 53/53 pass
- [x] 실측 probe: \`gpt-5.5\` 에 "pong" 요청 → 응답 \`text='pong'\` in=29 out=15 정상

## Reference
- 회귀 도입 시점: openai SDK 2.26+ 의 \`accumulate_event\` 에 \`parse_response\` 호출 추가
- frontier reference: \`hermes-agent/agent/auxiliary_client.py:747\` (openai==2.24.0 핀으로 회귀 회피)
- 직전 PR-SOURCE-ROUTING (#1822) 이 라우팅을 fix 한 직후 노출된 후속 stream-파싱 회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)