### PR TITLE
fix(adapter): content-first stop_reason derivation (PR-CODEX-STOP-REASON-TOOL-USE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,58 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28)** — the Codex backend at
+  ``chatgpt.com/backend-api/codex`` returns ``status="completed"`` for
+  EVERY successful response, regardless of whether the model emitted
+  ``function_call`` items. The v0.99.39+ adapter bridge
+  ``core/llm/adapters/translation.py:_translate_stop_reason`` only
+  looked at the provider string, so ``"completed"`` mapped to
+  ``"end_turn"``. The agent loop then terminated the turn (treating
+  the response as text-only), appended the assistant message with
+  ``tool_use`` blocks BUT skipped tool execution, and the next turn's
+  input carried a ``function_call`` with no matching
+  ``function_call_output``. The Codex backend rejected with
+  ``"No tool output found for function call call_XXXX"`` 400.
+
+  Symptom from the operator's serve log (2026-05-28 08:51:54): turn 2's
+  first LLM call returned 225 output tokens including 2
+  ``function_call`` items, the next LLM call fired 1 ms later (no tool
+  execution time), and ``_log_codex_input_shape`` (backfilled in
+  PR-LEGACY-PROVIDER-REMOVAL) surfaced the missing
+  ``function_call_output`` items at WARN. The legacy
+  ``core/llm/agentic_response.py:normalize_openai_responses`` (used by
+  the deleted ``CodexAgenticAdapter``) had derived ``stop_reason`` from
+  ``has_function_calls`` for exactly this reason; the adapter
+  migration dropped that gate.
+
+  Fix elevates ``has_tool_uses`` (content) to the sole authority over
+  ``stop_reason`` derivation — the provider string never wins on its
+  own. Mirror anti-pattern (provider says ``"tool_use"`` /
+  ``"tool_calls"`` but the adapter forgot to populate ``tool_uses``)
+  also terminates with ``"end_turn"`` plus a WARN flagging the likely
+  extraction bug — preventing the agent loop spin that would have no
+  tool to execute. Frontier-pattern alignment verified against
+  paperclip ``codex-local/src/ui/parse-stdout.ts:194`` + hermes
+  ``agent/codex_responses_adapter.py:1034`` — both derive the terminal
+  flag from the actual presence of tool/function-call items.
+
+  Pinned by ``tests/test_codex_stop_reason_tool_use.py`` (10
+  assertions: Codex / Anthropic / OpenAI Chat / unknown strings ×
+  tool_uses on/off contract cases, mirror-anti-pattern WARN trigger,
+  2 end-to-end through ``agentic_response_from_adapter_result``).
+
+  The B/C sibling sites identified in the 2026-05-28 anti-pattern
+  audit — ``core/llm/adapters/codex_cli.py:124`` (subprocess wraps a
+  CLI agent that handles its own tool execution; emits
+  ``tool_uses=()``) and ``core/llm/adapters/claude_cli.py:241``
+  (``_extract_stop_reason`` may return ``"tool_calls"`` on a
+  petri-audit ``--max-turns 1`` boundary while ``tool_uses=()``) — are
+  implicitly covered by the new strict gate: both flow through this
+  single bridge and the content-first rule keeps them on
+  ``"end_turn"``. No per-adapter patch needed (defence in depth
+  centralised in one place).
+
 ## [0.99.78] - 2026-05-28
 
 > PATCH release. Cleans up the v0.99.39 LLMAdapter sprint's

--- a/core/llm/adapters/translation.py
+++ b/core/llm/adapters/translation.py
@@ -14,6 +14,7 @@ was removed; this is now the sole call-site for both helpers.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from core.llm.adapters.base import (
@@ -28,6 +29,8 @@ from core.llm.agentic_response import (
     TextBlock,
     ToolUseBlock,
 )
+
+log = logging.getLogger(__name__)
 
 
 def build_adapter_request(
@@ -159,7 +162,7 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
     reasoning_summaries = list(result.reasoning_summaries) if result.reasoning_summaries else None
     return AgenticResponse(
         content=blocks,
-        stop_reason=_translate_stop_reason(result.stop_reason),
+        stop_reason=_translate_stop_reason(result.stop_reason, bool(result.tool_uses)),
         usage=usage,
         codex_reasoning_items=codex_reasoning_items,
         reasoning_summaries=reasoning_summaries,
@@ -167,19 +170,50 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
     )
 
 
-def _translate_stop_reason(stop: str) -> str:
+def _translate_stop_reason(stop: str, has_tool_uses: bool) -> str:
     """Map provider-flavoured stop reasons → AgenticLoop's two-value enum.
 
     :attr:`AgenticResponse.stop_reason` is one of ``"tool_use"`` /
-    ``"end_turn"``. Provider strings map as follows:
+    ``"end_turn"``. **Content is the source of truth** —
+    ``has_tool_uses`` decides single-handedly, the provider string is
+    only consulted to log adapter extraction bugs.
 
-    - Anthropic ``"tool_use"`` → ``"tool_use"``
-    - OpenAI ``"tool_calls"`` → ``"tool_use"``
-    - Codex ``"completed"`` / Anthropic ``"end_turn"`` / OpenAI ``"stop"`` /
-      anything else → ``"end_turn"``
+    PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28) original case — the Codex
+    backend at ``chatgpt.com/backend-api/codex`` returns
+    ``status="completed"`` for EVERY successful response, regardless of
+    whether the model emitted ``function_call`` items. Without the
+    content-first gate the agent loop terminates the turn (treating the
+    response as ``"end_turn"``), appends the assistant message with
+    ``tool_use`` blocks BUT skips tool execution, and the next turn's
+    input carries a ``function_call`` with no matching
+    ``function_call_output`` — the Codex backend rejects with ``"No
+    tool output found for function call call_XXXX"`` 400.
+
+    Frontier-pattern alignment (2026-05-28 audit of paperclip
+    ``codex-local/src/ui/parse-stdout.ts:194`` + hermes
+    ``agent/codex_responses_adapter.py:1034``): both derive the terminal
+    flag from the actual presence of tool/function-call items in the
+    response payload. We mirror that invariant — provider string never
+    wins on its own.
+
+    The mirror-case anti-pattern (provider says ``"tool_use"`` / ``"tool_calls"``
+    but ``tool_uses`` is empty) typically means the adapter failed to
+    populate ``AdapterCallResult.tool_uses``. We log a WARN with the
+    incoming string and terminate the turn — preventing an agent-loop
+    spin that has no tool to execute, and surfacing the underlying
+    extraction bug for the next maintainer.
     """
-    if stop in ("tool_use", "tool_calls"):
+    if has_tool_uses:
         return "tool_use"
+    if stop in ("tool_use", "tool_calls"):
+        log.warning(
+            "translate_stop_reason: provider sent stop_reason=%r but "
+            "AdapterCallResult.tool_uses is empty — treating as 'end_turn'. "
+            "Likely cause: the adapter that produced this result did not "
+            "extract tool_use blocks from the response. Frontier pattern: "
+            "tool extraction must populate tool_uses before this bridge runs.",
+            stop,
+        )
     return "end_turn"
 
 

--- a/tests/test_codex_stop_reason_tool_use.py
+++ b/tests/test_codex_stop_reason_tool_use.py
@@ -1,0 +1,159 @@
+"""Regression pin for PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28).
+
+The Codex backend at ``chatgpt.com/backend-api/codex`` returns
+``status="completed"`` for EVERY successful response, regardless of
+whether the model emitted ``function_call`` items. The legacy
+``normalize_openai_responses`` derived ``stop_reason`` from
+``has_function_calls`` — the new
+``core/llm/adapters/translation.py:_translate_stop_reason`` initially
+only looked at the provider string, so ``"completed"`` mapped to
+``"end_turn"``. The agent loop then terminated the turn (treating the
+response as text-only), appended the assistant message with
+``tool_use`` blocks BUT skipped tool execution. The next turn's input
+carried a ``function_call`` with no matching ``function_call_output``
+and the Codex backend rejected with ``"No tool output found for
+function call call_XXXX"`` 400.
+
+The fix gates the translation on ``has_tool_uses``: presence of
+``tool_uses`` always wins, regardless of provider string.
+
+Symptom reproduction was direct from the operator's serve log:
+
+    08:51:54.087  codex-oauth resp_input shape: ...
+        [3]function_call keys=['arguments', 'call_id', 'name', 'type']
+        [4]function_call keys=['arguments', 'call_id', 'name', 'type']
+        [5]user content=str(34)   ← function_call_output should be here
+    08:51:55.116  codex-oauth: responses.stream failed err='No tool
+        output found for function call call_cVsJdIt2d3TgMtn1i7UHqs2O'
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+from core.llm.adapters.translation import (
+    _translate_stop_reason,
+    agentic_response_from_adapter_result,
+)
+
+
+def _make_result(*, stop_reason: str, tool_uses: tuple = ()) -> AdapterCallResult:
+    return AdapterCallResult(
+        text="here's a tool call" if tool_uses else "plain text response",
+        usage=UsageSummary(input_tokens=10, output_tokens=20),
+        stop_reason=stop_reason,
+        tool_uses=tool_uses,
+        raw_response=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _translate_stop_reason — direct contract
+# ---------------------------------------------------------------------------
+
+
+def test_translate_stop_reason_codex_completed_with_tool_uses_is_tool_use() -> None:
+    """The core fix: Codex returns ``"completed"`` AND tool_uses are
+    non-empty → must be ``"tool_use"`` so the loop executes tools."""
+    assert _translate_stop_reason("completed", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_codex_completed_without_tool_uses_is_end_turn() -> None:
+    """Pure text response from Codex (``"completed"``, no tool_uses) →
+    ``"end_turn"`` so the loop terminates naturally."""
+    assert _translate_stop_reason("completed", has_tool_uses=False) == "end_turn"
+
+
+def test_translate_stop_reason_anthropic_tool_use_string_with_tool_uses_works() -> None:
+    """Happy path — Anthropic ``"tool_use"`` string + non-empty tool_uses."""
+    assert _translate_stop_reason("tool_use", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_provider_says_tool_use_but_empty_is_end_turn(caplog) -> None:  # type: ignore[no-untyped-def]
+    """**Mirror anti-pattern** — provider sends ``"tool_use"`` /
+    ``"tool_calls"`` but the adapter forgot to extract ``tool_uses``.
+
+    Frontier pattern (paperclip + hermes audit, 2026-05-28): content is
+    the source of truth. Without ``tool_uses`` to execute, treating the
+    response as ``"tool_use"`` would spin the agent loop with no work.
+    We instead terminate with ``"end_turn"`` and log a WARN flagging
+    the likely adapter extraction bug.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="core.llm.adapters.translation"):
+        assert _translate_stop_reason("tool_use", has_tool_uses=False) == "end_turn"
+        assert _translate_stop_reason("tool_calls", has_tool_uses=False) == "end_turn"
+    matching = [r for r in caplog.records if "tool_uses is empty" in r.message]
+    assert len(matching) == 2, (
+        f"Expected 2 WARN records flagging the adapter extraction bug, got "
+        f"{len(matching)}. Visible records: {[m.message for m in caplog.records]}"
+    )
+
+
+def test_translate_stop_reason_openai_chat_tool_calls_works() -> None:
+    """OpenAI Chat Completions ``"tool_calls"`` finish_reason mapping
+    (happy path with non-empty tool_uses)."""
+    assert _translate_stop_reason("tool_calls", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_openai_stop_with_tool_uses_is_tool_use() -> None:
+    """Content-first invariant: OpenAI returning ``"stop"`` alongside
+    non-empty tool_uses still surfaces as ``"tool_use"``. Mirrors the
+    legacy ``has_function_calls`` precedence."""
+    assert _translate_stop_reason("stop", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_anthropic_end_turn_no_tool_uses_is_end_turn() -> None:
+    """Standard terminal-text-response case."""
+    assert _translate_stop_reason("end_turn", has_tool_uses=False) == "end_turn"
+
+
+def test_translate_stop_reason_unknown_provider_string_without_tool_uses_is_end_turn() -> None:
+    """Anything not recognised + no tool_uses → conservative end_turn."""
+    assert _translate_stop_reason("something_weird", has_tool_uses=False) == "end_turn"
+    assert _translate_stop_reason("", has_tool_uses=False) == "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# agentic_response_from_adapter_result — end-to-end through the bridge
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_codex_completed_with_tool_uses_yields_tool_use_stop_reason() -> None:
+    """The exact production scenario: adapter returned
+    ``stop_reason="completed"`` (Codex backend) and a non-empty
+    ``tool_uses`` tuple (one or more function_call items extracted
+    from the SSE stream). The bridge must surface
+    ``AgenticResponse.stop_reason="tool_use"`` so AgenticLoop's
+    ``while stop_reason == "tool_use":`` keeps the loop alive and
+    executes the tool."""
+    result = _make_result(
+        stop_reason="completed",
+        tool_uses=({"id": "call_abc", "name": "read", "input": '{"path": "/tmp/x"}'},),
+    )
+    response = agentic_response_from_adapter_result(result)
+    assert response.stop_reason == "tool_use", (
+        f"Bridge surfaced stop_reason={response.stop_reason!r} for a "
+        f"Codex 'completed' response with tool_uses — the agent loop "
+        f"will terminate the turn without executing the tool, the "
+        f"assistant message will be persisted with a tool_use but no "
+        f"matching tool_result, and the next turn's input will be "
+        f"rejected by the Codex backend with 'No tool output found "
+        f"for function call' 400."
+    )
+    # The ToolUseBlock must also be present in content so the next-turn
+    # input builder can emit the matching function_call entry.
+    tool_use_blocks = [b for b in response.content if getattr(b, "type", "") == "tool_use"]
+    assert len(tool_use_blocks) == 1, (
+        f"Expected exactly 1 ToolUseBlock; got {len(tool_use_blocks)} "
+        f"(content={response.content!r})"
+    )
+    assert tool_use_blocks[0].id == "call_abc"
+
+
+def test_bridge_codex_completed_without_tool_uses_yields_end_turn() -> None:
+    """Pure text response from Codex stays end_turn — the loop terminates
+    naturally, no spurious extra LLM call."""
+    result = _make_result(stop_reason="completed")
+    response = agentic_response_from_adapter_result(result)
+    assert response.stop_reason == "end_turn"


### PR DESCRIPTION
## Summary
- Codex 백엔드의 \`status=\"completed\"\` 가 tool_use 발화와 무관하게 항상 옴 → 새 adapter bridge \`_translate_stop_reason\` 이 무조건 \`end_turn\` 매핑 → tool 실행 스킵 → 다음 턴 input 에 \`function_call_output\` 누락 → 400 \"No tool output found for function call\"
- Fix: \`has_tool_uses\` 를 stop_reason 의 **유일한 권위**로 격상. provider 문자열은 보조 신호 (mirror anti-pattern WARN 로깅용)
- Frontier-pattern 정렬: paperclip (\`parse-stdout.ts:194\`) + hermes (\`codex_responses_adapter.py:1034\`) 모두 content-first derive

## Why
운영자가 \`gpt-5.5\` 두 번째 턴에서 즉시 다음 패턴으로 종료:

\`\`\`
✕ Invalid request. Check tool schemas or input.
error_type: bad_request, model: gpt-5.5 (openai-codex), attempts: 0
detail: No tool output found for function call call_cVsJdIt2d3TgMtn1i7UHqs2O
\`\`\`

서브 로그 (PR-LEGACY-PROVIDER-REMOVAL 의 \`_log_codex_input_shape\` 가 즉시 가치 증명):
\`\`\`
08:51:54.087  codex-oauth resp_input shape: ...
    [3]function_call keys=['arguments', 'call_id', 'name', 'type']
    [4]function_call keys=['arguments', 'call_id', 'name', 'type']
    [5]user content=str(34)   ← function_call_output 가 와야 할 자리
08:51:55.116  responses.stream failed err='No tool output found...'
\`\`\`

턴 2 의 첫 LLM call 이 2개 tool_use 발화 → 1ms 만에 다음 LLM call (tool execution 시간 없음). 원인 추적:

| Layer | 문제 |
|---|---|
| \`translation.py:_translate_stop_reason(\"completed\", ...)\` | provider 문자열만 보고 \`\"end_turn\"\` 매핑 |
| AgenticLoop \`while stop_reason == \"tool_use\":\` | 종료 — tool 실행 안 함 |
| 다음 턴 input builder | assistant message 의 tool_use → \`function_call\` 만 emit, paired \`function_call_output\` 없음 |
| Codex 백엔드 | 400 reject |

Legacy \`normalize_openai_responses\` (지난 PR 에서 삭제된 CodexAgenticAdapter 가 사용) 는 \`stop_reason = \"tool_use\" if has_function_calls else \"end_turn\"\` 로 derive 해서 안 깨졌음 — 어댑터 마이그레이션이 이 invariant 를 떨어뜨림.

## Changes
| File | Change |
|------|--------|
| \`core/llm/adapters/translation.py\` | \`_translate_stop_reason\` 에 \`has_tool_uses\` 파라미터 추가, content 가 stop_reason 결정의 유일한 권위. mirror anti-pattern (provider 문자열은 tool_use 인데 tool_uses 비어있음) 은 WARN + end_turn (loop spin 방지 + 어댑터 extraction bug 신호) |
| \`tests/test_codex_stop_reason_tool_use.py\` | 신규 10 assertion: Codex \"completed\" × tool_uses on/off, Anthropic / OpenAI Chat / unknown 문자열 케이스, mirror-anti-pattern WARN trigger, end-to-end through \`agentic_response_from_adapter_result\` |
| \`CHANGELOG.md\` | Unreleased / Fixed PR-CODEX-STOP-REASON-TOOL-USE + frontier audit 결과 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| A: \`translation.py:_translate_stop_reason\` (production-confirmed) | Fixed | content-first gate |
| B: \`codex_cli.py:124\` (\`stop_reason=\"end_turn\"\` 하드코딩) | Implicit fix | tool_uses=() emit → strict gate 가 항상 end_turn 보장. per-adapter 패치 불필요 |
| C: \`claude_cli.py:241\` (\`unknown\"→end_turn\` coerce, petri-audit \`--max-turns 1\` boundary 케이스) | Implicit fix | 동일 메커니즘 |
| Mirror case (provider says tool_use, tool_uses 비어있음) | Fixed | WARN + end_turn |

## Verification
- [x] \`uv run ruff check core/ tests/ plugins/\` — clean
- [x] \`uv run ruff format --check core/ tests/ plugins/\` — clean
- [x] \`uv run mypy core/llm/adapters/translation.py\` — pre-existing 3건만 (codex_overrides.py, develop 동일)
- [x] \`uv run pytest tests/test_codex_stop_reason_tool_use.py\` — **10/10 pass**
- [x] \`uv run pytest tests/ -m \"not live\"\` — **8652 passed, 0 fail** (4 pre-existing 제외)

## Reference
- frontier audit (이번 PR sub-agent): paperclip \`codex-local/src/ui/parse-stdout.ts:194\` (tool_use item gate), hermes \`agent/codex_responses_adapter.py:1034\` (if tool_calls: finish_reason gate)
- 회귀 도입 시점: v0.99.39 LLMAdapter sprint 의 PR-MAINPATH-1 / PR-MAINPATH-67 (legacy normalize_openai_responses 의 has_function_calls derive 가 새 bridge 에서 손실)
- 운영자 보고: 2026-05-28 08:51 turn 2 즉시 실패 + \`_log_codex_input_shape\` 진단 로그
- 관련 PR (어댑터 회귀 시리즈): #1822 (SOURCE-ROUTING), #1825 (OUTPUT-NULL), #1826 (LEGACY-PROVIDER-REMOVAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)