### PR TITLE
release: v0.99.79 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.79] - 2026-05-28
+
+> PATCH release. Single fix: content-first stop_reason derivation in
+> the adapter bridge (PR-CODEX-STOP-REASON-TOOL-USE). The Codex
+> backend's universal ``status="completed"`` response caused
+> ``_translate_stop_reason`` to map every tool-call response to
+> ``"end_turn"`` — the agent loop skipped tool execution, the next
+> turn's input carried a ``function_call`` without
+> ``function_call_output``, and the Codex backend rejected with
+> ``"No tool output found"`` 400. Frontier-pattern aligned with
+> paperclip + hermes (both derive the terminal flag from actual
+> presence of tool/function-call items, not the provider string).
+
 ### Fixed
 - **PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28)** — the Codex backend at
   ``chatgpt.com/backend-api/codex`` returns ``status="completed"`` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,58 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28)** — the Codex backend at
+  ``chatgpt.com/backend-api/codex`` returns ``status="completed"`` for
+  EVERY successful response, regardless of whether the model emitted
+  ``function_call`` items. The v0.99.39+ adapter bridge
+  ``core/llm/adapters/translation.py:_translate_stop_reason`` only
+  looked at the provider string, so ``"completed"`` mapped to
+  ``"end_turn"``. The agent loop then terminated the turn (treating
+  the response as text-only), appended the assistant message with
+  ``tool_use`` blocks BUT skipped tool execution, and the next turn's
+  input carried a ``function_call`` with no matching
+  ``function_call_output``. The Codex backend rejected with
+  ``"No tool output found for function call call_XXXX"`` 400.
+
+  Symptom from the operator's serve log (2026-05-28 08:51:54): turn 2's
+  first LLM call returned 225 output tokens including 2
+  ``function_call`` items, the next LLM call fired 1 ms later (no tool
+  execution time), and ``_log_codex_input_shape`` (backfilled in
+  PR-LEGACY-PROVIDER-REMOVAL) surfaced the missing
+  ``function_call_output`` items at WARN. The legacy
+  ``core/llm/agentic_response.py:normalize_openai_responses`` (used by
+  the deleted ``CodexAgenticAdapter``) had derived ``stop_reason`` from
+  ``has_function_calls`` for exactly this reason; the adapter
+  migration dropped that gate.
+
+  Fix elevates ``has_tool_uses`` (content) to the sole authority over
+  ``stop_reason`` derivation — the provider string never wins on its
+  own. Mirror anti-pattern (provider says ``"tool_use"`` /
+  ``"tool_calls"`` but the adapter forgot to populate ``tool_uses``)
+  also terminates with ``"end_turn"`` plus a WARN flagging the likely
+  extraction bug — preventing the agent loop spin that would have no
+  tool to execute. Frontier-pattern alignment verified against
+  paperclip ``codex-local/src/ui/parse-stdout.ts:194`` + hermes
+  ``agent/codex_responses_adapter.py:1034`` — both derive the terminal
+  flag from the actual presence of tool/function-call items.
+
+  Pinned by ``tests/test_codex_stop_reason_tool_use.py`` (10
+  assertions: Codex / Anthropic / OpenAI Chat / unknown strings ×
+  tool_uses on/off contract cases, mirror-anti-pattern WARN trigger,
+  2 end-to-end through ``agentic_response_from_adapter_result``).
+
+  The B/C sibling sites identified in the 2026-05-28 anti-pattern
+  audit — ``core/llm/adapters/codex_cli.py:124`` (subprocess wraps a
+  CLI agent that handles its own tool execution; emits
+  ``tool_uses=()``) and ``core/llm/adapters/claude_cli.py:241``
+  (``_extract_stop_reason`` may return ``"tool_calls"`` on a
+  petri-audit ``--max-turns 1`` boundary while ``tool_uses=()``) — are
+  implicitly covered by the new strict gate: both flow through this
+  single bridge and the content-first rule keeps them on
+  ``"end_turn"``. No per-adapter patch needed (defence in depth
+  centralised in one place).
+
 ## [0.99.78] - 2026-05-28
 
 > PATCH release. Cleans up the v0.99.39 LLMAdapter sprint's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.78
+- **Version**: 0.99.79
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.78 — Long-running Autonomous Execution Harness
+# GEODE v0.99.79 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.78**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.79**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.78 — Long-running Autonomous Execution Harness
+# GEODE v0.99.79 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.78**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.79**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/llm/adapters/translation.py
+++ b/core/llm/adapters/translation.py
@@ -14,6 +14,7 @@ was removed; this is now the sole call-site for both helpers.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from core.llm.adapters.base import (
@@ -28,6 +29,8 @@ from core.llm.agentic_response import (
     TextBlock,
     ToolUseBlock,
 )
+
+log = logging.getLogger(__name__)
 
 
 def build_adapter_request(
@@ -159,7 +162,7 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
     reasoning_summaries = list(result.reasoning_summaries) if result.reasoning_summaries else None
     return AgenticResponse(
         content=blocks,
-        stop_reason=_translate_stop_reason(result.stop_reason),
+        stop_reason=_translate_stop_reason(result.stop_reason, bool(result.tool_uses)),
         usage=usage,
         codex_reasoning_items=codex_reasoning_items,
         reasoning_summaries=reasoning_summaries,
@@ -167,19 +170,50 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
     )
 
 
-def _translate_stop_reason(stop: str) -> str:
+def _translate_stop_reason(stop: str, has_tool_uses: bool) -> str:
     """Map provider-flavoured stop reasons → AgenticLoop's two-value enum.
 
     :attr:`AgenticResponse.stop_reason` is one of ``"tool_use"`` /
-    ``"end_turn"``. Provider strings map as follows:
+    ``"end_turn"``. **Content is the source of truth** —
+    ``has_tool_uses`` decides single-handedly, the provider string is
+    only consulted to log adapter extraction bugs.
 
-    - Anthropic ``"tool_use"`` → ``"tool_use"``
-    - OpenAI ``"tool_calls"`` → ``"tool_use"``
-    - Codex ``"completed"`` / Anthropic ``"end_turn"`` / OpenAI ``"stop"`` /
-      anything else → ``"end_turn"``
+    PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28) original case — the Codex
+    backend at ``chatgpt.com/backend-api/codex`` returns
+    ``status="completed"`` for EVERY successful response, regardless of
+    whether the model emitted ``function_call`` items. Without the
+    content-first gate the agent loop terminates the turn (treating the
+    response as ``"end_turn"``), appends the assistant message with
+    ``tool_use`` blocks BUT skips tool execution, and the next turn's
+    input carries a ``function_call`` with no matching
+    ``function_call_output`` — the Codex backend rejects with ``"No
+    tool output found for function call call_XXXX"`` 400.
+
+    Frontier-pattern alignment (2026-05-28 audit of paperclip
+    ``codex-local/src/ui/parse-stdout.ts:194`` + hermes
+    ``agent/codex_responses_adapter.py:1034``): both derive the terminal
+    flag from the actual presence of tool/function-call items in the
+    response payload. We mirror that invariant — provider string never
+    wins on its own.
+
+    The mirror-case anti-pattern (provider says ``"tool_use"`` / ``"tool_calls"``
+    but ``tool_uses`` is empty) typically means the adapter failed to
+    populate ``AdapterCallResult.tool_uses``. We log a WARN with the
+    incoming string and terminate the turn — preventing an agent-loop
+    spin that has no tool to execute, and surfacing the underlying
+    extraction bug for the next maintainer.
     """
-    if stop in ("tool_use", "tool_calls"):
+    if has_tool_uses:
         return "tool_use"
+    if stop in ("tool_use", "tool_calls"):
+        log.warning(
+            "translate_stop_reason: provider sent stop_reason=%r but "
+            "AdapterCallResult.tool_uses is empty — treating as 'end_turn'. "
+            "Likely cause: the adapter that produced this result did not "
+            "extract tool_use blocks from the response. Frontier pattern: "
+            "tool extraction must populate tool_uses before this bridge runs.",
+            stop,
+        )
     return "end_turn"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.78"
+version = "0.99.79"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_codex_stop_reason_tool_use.py
+++ b/tests/test_codex_stop_reason_tool_use.py
@@ -1,0 +1,159 @@
+"""Regression pin for PR-CODEX-STOP-REASON-TOOL-USE (2026-05-28).
+
+The Codex backend at ``chatgpt.com/backend-api/codex`` returns
+``status="completed"`` for EVERY successful response, regardless of
+whether the model emitted ``function_call`` items. The legacy
+``normalize_openai_responses`` derived ``stop_reason`` from
+``has_function_calls`` — the new
+``core/llm/adapters/translation.py:_translate_stop_reason`` initially
+only looked at the provider string, so ``"completed"`` mapped to
+``"end_turn"``. The agent loop then terminated the turn (treating the
+response as text-only), appended the assistant message with
+``tool_use`` blocks BUT skipped tool execution. The next turn's input
+carried a ``function_call`` with no matching ``function_call_output``
+and the Codex backend rejected with ``"No tool output found for
+function call call_XXXX"`` 400.
+
+The fix gates the translation on ``has_tool_uses``: presence of
+``tool_uses`` always wins, regardless of provider string.
+
+Symptom reproduction was direct from the operator's serve log:
+
+    08:51:54.087  codex-oauth resp_input shape: ...
+        [3]function_call keys=['arguments', 'call_id', 'name', 'type']
+        [4]function_call keys=['arguments', 'call_id', 'name', 'type']
+        [5]user content=str(34)   ← function_call_output should be here
+    08:51:55.116  codex-oauth: responses.stream failed err='No tool
+        output found for function call call_cVsJdIt2d3TgMtn1i7UHqs2O'
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+from core.llm.adapters.translation import (
+    _translate_stop_reason,
+    agentic_response_from_adapter_result,
+)
+
+
+def _make_result(*, stop_reason: str, tool_uses: tuple = ()) -> AdapterCallResult:
+    return AdapterCallResult(
+        text="here's a tool call" if tool_uses else "plain text response",
+        usage=UsageSummary(input_tokens=10, output_tokens=20),
+        stop_reason=stop_reason,
+        tool_uses=tool_uses,
+        raw_response=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _translate_stop_reason — direct contract
+# ---------------------------------------------------------------------------
+
+
+def test_translate_stop_reason_codex_completed_with_tool_uses_is_tool_use() -> None:
+    """The core fix: Codex returns ``"completed"`` AND tool_uses are
+    non-empty → must be ``"tool_use"`` so the loop executes tools."""
+    assert _translate_stop_reason("completed", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_codex_completed_without_tool_uses_is_end_turn() -> None:
+    """Pure text response from Codex (``"completed"``, no tool_uses) →
+    ``"end_turn"`` so the loop terminates naturally."""
+    assert _translate_stop_reason("completed", has_tool_uses=False) == "end_turn"
+
+
+def test_translate_stop_reason_anthropic_tool_use_string_with_tool_uses_works() -> None:
+    """Happy path — Anthropic ``"tool_use"`` string + non-empty tool_uses."""
+    assert _translate_stop_reason("tool_use", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_provider_says_tool_use_but_empty_is_end_turn(caplog) -> None:  # type: ignore[no-untyped-def]
+    """**Mirror anti-pattern** — provider sends ``"tool_use"`` /
+    ``"tool_calls"`` but the adapter forgot to extract ``tool_uses``.
+
+    Frontier pattern (paperclip + hermes audit, 2026-05-28): content is
+    the source of truth. Without ``tool_uses`` to execute, treating the
+    response as ``"tool_use"`` would spin the agent loop with no work.
+    We instead terminate with ``"end_turn"`` and log a WARN flagging
+    the likely adapter extraction bug.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="core.llm.adapters.translation"):
+        assert _translate_stop_reason("tool_use", has_tool_uses=False) == "end_turn"
+        assert _translate_stop_reason("tool_calls", has_tool_uses=False) == "end_turn"
+    matching = [r for r in caplog.records if "tool_uses is empty" in r.message]
+    assert len(matching) == 2, (
+        f"Expected 2 WARN records flagging the adapter extraction bug, got "
+        f"{len(matching)}. Visible records: {[m.message for m in caplog.records]}"
+    )
+
+
+def test_translate_stop_reason_openai_chat_tool_calls_works() -> None:
+    """OpenAI Chat Completions ``"tool_calls"`` finish_reason mapping
+    (happy path with non-empty tool_uses)."""
+    assert _translate_stop_reason("tool_calls", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_openai_stop_with_tool_uses_is_tool_use() -> None:
+    """Content-first invariant: OpenAI returning ``"stop"`` alongside
+    non-empty tool_uses still surfaces as ``"tool_use"``. Mirrors the
+    legacy ``has_function_calls`` precedence."""
+    assert _translate_stop_reason("stop", has_tool_uses=True) == "tool_use"
+
+
+def test_translate_stop_reason_anthropic_end_turn_no_tool_uses_is_end_turn() -> None:
+    """Standard terminal-text-response case."""
+    assert _translate_stop_reason("end_turn", has_tool_uses=False) == "end_turn"
+
+
+def test_translate_stop_reason_unknown_provider_string_without_tool_uses_is_end_turn() -> None:
+    """Anything not recognised + no tool_uses → conservative end_turn."""
+    assert _translate_stop_reason("something_weird", has_tool_uses=False) == "end_turn"
+    assert _translate_stop_reason("", has_tool_uses=False) == "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# agentic_response_from_adapter_result — end-to-end through the bridge
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_codex_completed_with_tool_uses_yields_tool_use_stop_reason() -> None:
+    """The exact production scenario: adapter returned
+    ``stop_reason="completed"`` (Codex backend) and a non-empty
+    ``tool_uses`` tuple (one or more function_call items extracted
+    from the SSE stream). The bridge must surface
+    ``AgenticResponse.stop_reason="tool_use"`` so AgenticLoop's
+    ``while stop_reason == "tool_use":`` keeps the loop alive and
+    executes the tool."""
+    result = _make_result(
+        stop_reason="completed",
+        tool_uses=({"id": "call_abc", "name": "read", "input": '{"path": "/tmp/x"}'},),
+    )
+    response = agentic_response_from_adapter_result(result)
+    assert response.stop_reason == "tool_use", (
+        f"Bridge surfaced stop_reason={response.stop_reason!r} for a "
+        f"Codex 'completed' response with tool_uses — the agent loop "
+        f"will terminate the turn without executing the tool, the "
+        f"assistant message will be persisted with a tool_use but no "
+        f"matching tool_result, and the next turn's input will be "
+        f"rejected by the Codex backend with 'No tool output found "
+        f"for function call' 400."
+    )
+    # The ToolUseBlock must also be present in content so the next-turn
+    # input builder can emit the matching function_call entry.
+    tool_use_blocks = [b for b in response.content if getattr(b, "type", "") == "tool_use"]
+    assert len(tool_use_blocks) == 1, (
+        f"Expected exactly 1 ToolUseBlock; got {len(tool_use_blocks)} "
+        f"(content={response.content!r})"
+    )
+    assert tool_use_blocks[0].id == "call_abc"
+
+
+def test_bridge_codex_completed_without_tool_uses_yields_end_turn() -> None:
+    """Pure text response from Codex stays end_turn — the loop terminates
+    naturally, no spurious extra LLM call."""
+    result = _make_result(stop_reason="completed")
+    response = agentic_response_from_adapter_result(result)
+    assert response.stop_reason == "end_turn"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.78"
+version = "0.99.79"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- develop → main pass-through (release PR #1830 이 develop 에 stamp + CHANGELOG bump 적용 완료)
- PR-CODEX-STOP-REASON-TOOL-USE (content-first stop_reason derivation) 가 v0.99.79 로 main 도달

## Verification
- [x] release/v0.99.79 → develop CI 9/9 green (PR #1830)
- [x] feature/codex-stop-reason-fix → develop CI 9/9 green (#1829)

🤖 Generated with [Claude Code](https://claude.com/claude-code)