### PR TITLE
fix(adapters): cap stalled-stream spin via httpx Timeout + SDK retry pin + Summary dict normalize (PR-ADAPTER-TIMEOUT-AND-SERIALIZATION)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,59 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28)** — three sister
+  fixes for the operator's 2026-05-28 10-minute hang on a single
+  ``gpt-5.5`` turn (serve log 11:06:19 → 11:16:39, 620062 ms latency):
+
+  **A. httpx Timeout wiring + SDK retry pinning.**
+  ``core/llm/adapters/_openai_common.build_async_openai_client`` and
+  ``build_async_codex_client`` previously used the openai SDK's default
+  httpx client, whose read-timeout defaults are long enough that a
+  stalled Codex backend stream silently waited ~10 minutes before the
+  SDK's retry loop kicked in. Both builders now attach an explicit
+  ``httpx.AsyncClient`` with ``settings.llm_*_timeout`` — the same
+  policy the Anthropic adapter has had since v0.99.39 (single source
+  of truth = ``[llm]`` settings). Codex MCP audit BLOCKER caught the
+  second half: without ``max_retries=0`` on the openai client, the SDK
+  retry (default 2) compounds with GEODE's own ``_LLM_RETRY_CAP``
+  retries — capping the read-timeout alone would still leave
+  ``300 s × 2 SDK attempts`` ≈ 10 min before app retry runs. Pinning
+  ``max_retries=0`` on every OpenAI-family client (adapter builders
+  AND legacy provider singletons in ``core/llm/providers/{openai,
+  codex, glm}.py``) mirrors Anthropic's invariant
+  (``_anthropic_common.py:60``) — single source of retry truth =
+  AgenticLoop's ``_call_llm`` retry path.
+
+  **B. SDK retry → UI bridge.** The openai SDK logs ``Retrying request
+  to /responses in 0.49 seconds`` at INFO level on the
+  ``openai._base_client`` logger, but the line landed only in the
+  serve log file — operators watching the CLI spinner saw an opaque
+  hang. New module ``core/llm/adapters/_sdk_retry_visibility.py``
+  installs a ``logging.Handler`` on that logger that re-emits the
+  retry through GEODE's existing ``emit_llm_retry`` event surface
+  (same UI affordance the agent-loop-side retry already uses). Install
+  is idempotent + wired into both adapter client builders.
+
+  **C. Summary SDK object → dict normalisation.** The same incident's
+  serve log surfaced ``TypeError: Object of type Summary is not JSON
+  serializable`` from ``core/memory/session_manager.py:433`` because
+  ``translate_codex_response`` stored OpenAI SDK
+  ``ResponseReasoningItem.Summary`` Pydantic objects verbatim in
+  ``codex_reasoning_items[*]["summary"]``. JSON checkpoint survived
+  (separate writer) but the per-turn SQLite session mirror was lost.
+  New ``_normalize_summary_list`` helper coerces each summary element
+  to a plain ``{"type": "summary_text", "text": ...}`` dict via
+  ``model_dump(mode="json")`` (Pydantic v2 canonical JSON shape) with
+  fallback to ``model_dump()`` then ``.text`` / ``.type`` attribute
+  extraction — so downstream SQLite mirror, JSON checkpoint, and IPC
+  payload only see JSON-safe primitives.
+
+  Pinned by ``tests/test_adapter_timeout_and_serialization.py`` (12
+  assertions) + ``tests/test_adapter_max_retries.py`` (6 assertions —
+  source-level retry pins on every OpenAI-family client builder and
+  the Anthropic parity guard).
+
 ### Changed
 - **PR-ADAPTER-PATTERN-UNIFICATION (2026-05-28)** — restore the GoF
   Adapter pattern's "uniform interface + adaptee SDK isolation +

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -217,9 +217,20 @@ def build_async_openai_client(api_key: str, *, base_url: str | None = None) -> o
         raise ValueError("build_async_openai_client: api_key is empty")
     import openai
 
+    _ensure_sdk_observability_installed()
+    http_client = _build_async_httpx_client()
+    # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28, Codex MCP BLOCKER) —
+    # ``max_retries=0`` disables the SDK-internal retry loop. Without this,
+    # SDK retry x app retry compounds: 300s read-timeout * 2 SDK attempts +
+    # GEODE's own ``_LLM_RETRY_CAP`` retries = 10+ minute spin under stall.
+    # Anthropic adapter applies the same invariant
+    # (``_anthropic_common.py:60``). Single source of retry truth =
+    # AgenticLoop's ``_call_llm`` retry path.
     if base_url:
-        return openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
-    return openai.AsyncOpenAI(api_key=api_key)
+        return openai.AsyncOpenAI(
+            api_key=api_key, base_url=base_url, http_client=http_client, max_retries=0
+        )
+    return openai.AsyncOpenAI(api_key=api_key, http_client=http_client, max_retries=0)
 
 
 def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
@@ -243,11 +254,60 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     # workaround before the first Codex backend call. Idempotent across
     # process lifetime; only patches when the openai SDK is importable.
     _install_codex_workaround()
+    _ensure_sdk_observability_installed()
 
     return openai.AsyncOpenAI(
         api_key=api_key,
         base_url=CODEX_BASE_URL,
         default_headers=build_codex_oauth_headers(api_key),
+        http_client=_build_async_httpx_client(),
+        # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION — see ``build_async_openai_client``
+        # for the retry-compound rationale (Codex MCP BLOCKER 2026-05-28).
+        max_retries=0,
+    )
+
+
+def _ensure_sdk_observability_installed() -> None:
+    """Install the SDK retry → UI bridge once. Safe to call repeatedly."""
+    from core.llm.adapters._sdk_retry_visibility import install as _install_retry_bridge
+
+    _install_retry_bridge()
+
+
+def _build_async_httpx_client() -> Any:
+    """PR-ADAPTER-TIMEOUT (2026-05-28) — share Anthropic adapter's timeout
+    policy with every OpenAI-family client (PAYG OpenAI, Codex OAuth, GLM
+    PAYG, GLM Coding Plan).
+
+    Without an explicit ``http_client``, ``AsyncOpenAI`` uses the SDK's
+    default httpx instance whose read-timeout defaults are long enough that
+    a stalled ``responses.stream`` on the Codex backend silently waited
+    ~10 minutes before the SDK's retry loop kicked in (operator-observed
+    incident 2026-05-28 11:06→11:16, 620062 ms latency). Pinning
+    ``settings.llm_read_timeout`` here caps the stall window — the
+    SDK's ``max_retries`` (default 2) then triggers within minutes
+    instead of hours.
+
+    Reads the same ``llm_*_timeout`` / ``llm_*_connections`` settings the
+    Anthropic adapter consumes so operators tune both providers with one
+    knob (``config.toml [llm]`` or ``GEODE_LLM_READ_TIMEOUT``).
+    """
+    import httpx
+
+    from core.config import settings
+
+    return httpx.AsyncClient(
+        limits=httpx.Limits(
+            max_connections=settings.llm_max_connections,
+            max_keepalive_connections=settings.llm_max_keepalive_connections,
+            keepalive_expiry=settings.llm_keepalive_expiry,
+        ),
+        timeout=httpx.Timeout(
+            connect=settings.llm_connect_timeout,
+            read=settings.llm_read_timeout,
+            write=settings.llm_write_timeout,
+            pool=settings.llm_pool_timeout,
+        ),
     )
 
 
@@ -734,7 +794,19 @@ def translate_codex_response(
             # context") the field is structurally required even when
             # there's no chain-of-thought summary to surface.
             summary = _attr_or_key(item, "summary")
-            entry["summary"] = summary if summary else []
+            # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28) — the OpenAI
+            # SDK returns ``summary`` as a list of ``ResponseReasoningItem.
+            # Summary`` Pydantic objects. Storing them verbatim in
+            # ``entry["summary"]`` propagates the SDK type all the way into
+            # ``AgenticResponse.codex_reasoning_items`` and then into the
+            # SQLite session mirror, which fails with
+            # ``TypeError: Object of type Summary is not JSON serializable``
+            # (operator log 2026-05-28 11:16:39 — session_manager.py:433).
+            # JSON checkpoint survived (separate writer), but per-turn
+            # message mirror was lost. Normalise to plain ``dict``
+            # (``{"type": "summary_text", "text": ...}``) so downstream
+            # persistence sees only JSON-safe primitives.
+            entry["summary"] = _normalize_summary_list(summary)
             if summary and isinstance(summary, list):
                 for s in summary:
                     t = s.get("text", "") if isinstance(s, dict) else getattr(s, "text", "") or ""
@@ -764,6 +836,47 @@ def translate_codex_response(
         reasoning_summaries=tuple(reasoning_summaries),
         assistant_phase=assistant_phase,
     )
+
+
+def _normalize_summary_list(summary: Any) -> list[dict[str, Any]]:
+    """PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28) — convert OpenAI
+    SDK ``Summary`` Pydantic objects (or dicts, or unknown) to a list of
+    plain ``{"type": "summary_text", "text": ...}`` dicts so the result
+    is JSON-serialisable downstream (SQLite session mirror, JSON
+    checkpoint, IPC payload).
+
+    Returns ``[]`` for missing / falsy input — matches the original
+    ``summary if summary else []`` shape so the Responses API replay
+    (``build_codex_input``) keeps accepting it.
+    """
+    if not summary or not isinstance(summary, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in summary:
+        if isinstance(item, dict):
+            out.append(dict(item))
+            continue
+        # Pydantic v2 SDK object — prefer ``model_dump(mode="json")`` so
+        # nested types (e.g. datetime, IntEnum) also coerce to JSON-safe
+        # primitives. Fall back to plain ``model_dump()`` if a future SDK
+        # variant doesn't accept the kwarg, and finally to manual
+        # ``.text`` / ``.type`` extraction. Codex MCP review (2026-05-28).
+        dump = getattr(item, "model_dump", None)
+        if callable(dump):
+            dumped: dict[str, Any] | None = None
+            for kwargs in ({"mode": "json"}, {}):
+                try:
+                    dumped = dict(dump(**kwargs))
+                    break
+                except Exception as exc:
+                    log.debug("Summary.model_dump(%r) failed: %s", kwargs, exc)
+            if dumped is not None:
+                out.append(dumped)
+                continue
+        text = getattr(item, "text", "") or ""
+        kind = getattr(item, "type", "summary_text") or "summary_text"
+        out.append({"type": str(kind), "text": str(text)})
+    return out
 
 
 def _attr_or_key(item: Any, name: str) -> Any:

--- a/core/llm/adapters/_sdk_retry_visibility.py
+++ b/core/llm/adapters/_sdk_retry_visibility.py
@@ -1,0 +1,79 @@
+"""Surface OpenAI/httpx SDK-level retries to the agentic UI.
+
+PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28). The OpenAI SDK logs
+``Retrying request to /responses in 0.49 seconds`` via the
+``openai._base_client`` Python logger at ``INFO`` level. GEODE used to
+print that line only into the serve log file, so an operator watching
+the CLI saw the spinner with no signal that the SDK was actively
+retrying — the operator's 2026-05-28 10-minute hang showed exactly
+this gap (one SDK retry, hidden from the UI).
+
+This module installs a ``logging.Handler`` on the ``openai._base_client``
+logger that scrapes the retry message and re-emits it through the
+existing :func:`emit_llm_retry` event — same UI affordance GEODE's own
+agent-loop-side retry surface uses. Idempotent across the process.
+
+Why a logging filter (not an httpx event hook): the SDK manages retries
+internally inside ``AsyncAPIClient._request`` and does not emit an
+event_hook for them. The log line is the only stable surface the SDK
+already exposes for this signal.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+_INSTALLED: bool = False
+_RETRY_PATTERN = re.compile(r"Retrying request to .+ in ([0-9.]+) seconds")
+
+
+class _OpenAISdkRetryEventBridge(logging.Handler):
+    """Logging handler — parses SDK retry-log lines + emits UI event."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return
+        match = _RETRY_PATTERN.search(message)
+        if match is None:
+            return
+        try:
+            delay_s = max(1, int(float(match.group(1))))
+        except (TypeError, ValueError):
+            delay_s = 1
+        try:
+            from core.ui.agentic_ui import emit_llm_retry
+
+            # OpenAI SDK exposes ``max_retries`` via client config but not on
+            # the log record itself. Hardcoded ``(attempt=1, max_attempts=2)``
+            # is a deliberate floor — the UI carries the "retry happening"
+            # signal regardless of which attempt; full attempt tracking
+            # would require monkey-patching the SDK retry loop.
+            emit_llm_retry(delay_s=delay_s, attempt=1, max_attempts=2)
+        except Exception:
+            log.debug("failed to surface SDK retry log to UI", exc_info=True)
+
+
+def install() -> None:
+    """Attach the retry-event bridge once per process. Safe to call from
+    any adapter client builder."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    handler = _OpenAISdkRetryEventBridge(level=logging.INFO)
+    logging.getLogger("openai._base_client").addHandler(handler)
+    _INSTALLED = True
+    log.debug("openai SDK retry → UI bridge installed")
+
+
+def _for_test_reset() -> None:
+    global _INSTALLED
+    _INSTALLED = False
+    sdk_logger = logging.getLogger("openai._base_client")
+    sdk_logger.handlers = [
+        h for h in sdk_logger.handlers if not isinstance(h, _OpenAISdkRetryEventBridge)
+    ]

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -134,6 +134,7 @@ def _get_codex_client() -> Any:
                     api_key=token,
                     base_url=CODEX_BASE_URL,
                     default_headers=build_codex_oauth_headers(token),
+                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
                 )
     return _codex_client
 
@@ -162,6 +163,7 @@ def _get_async_codex_client() -> Any:
                     api_key=token,
                     base_url=CODEX_BASE_URL,
                     default_headers=build_codex_oauth_headers(token),
+                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
                 )
     return _async_codex_client
 

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -63,6 +63,7 @@ def _get_glm_client() -> Any:
                 _glm_client = openai.OpenAI(
                     api_key=api_key,
                     base_url=base_url,
+                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
                 )
     return _glm_client
 
@@ -79,6 +80,7 @@ def _get_async_glm_client() -> Any:
                 _async_glm_client = openai.AsyncOpenAI(
                     api_key=api_key,
                     base_url=base_url,
+                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
                 )
     return _async_glm_client
 

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -61,26 +61,39 @@ def _resolve_openai_key() -> str:
 
 
 def _get_openai_client() -> Any:
-    """Lazy import and return cached OpenAI client (thread-safe)."""
+    """Lazy import and return cached OpenAI client (thread-safe).
+
+    PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28, Codex MCP MED) —
+    ``max_retries=0`` matches the adapter-side invariant
+    (``_openai_common.build_async_openai_client``) so legacy callers that
+    still hit this singleton (paperclip ``OpenAIAdapter``,
+    ``llm_extract_learning``, ``models.py``) don't compound SDK + app
+    retry loops on stalled streams.
+    """
     global _openai_client
     if _openai_client is None:
         with _openai_lock:
             if _openai_client is None:
                 import openai
 
-                _openai_client = openai.OpenAI(api_key=_resolve_openai_key())
+                _openai_client = openai.OpenAI(api_key=_resolve_openai_key(), max_retries=0)
     return _openai_client
 
 
 def _get_async_openai_client() -> Any:
-    """Lazy import and return cached async OpenAI client (thread-safe)."""
+    """Lazy import and return cached async OpenAI client (thread-safe).
+
+    See :func:`_get_openai_client` for the ``max_retries=0`` rationale.
+    """
     global _async_openai_client
     if _async_openai_client is None:
         with _async_openai_lock:
             if _async_openai_client is None:
                 import openai
 
-                _async_openai_client = openai.AsyncOpenAI(api_key=_resolve_openai_key())
+                _async_openai_client = openai.AsyncOpenAI(
+                    api_key=_resolve_openai_key(), max_retries=0
+                )
     return _async_openai_client
 
 

--- a/tests/test_adapter_max_retries.py
+++ b/tests/test_adapter_max_retries.py
@@ -1,0 +1,85 @@
+"""Regression pin for the Codex MCP BLOCKER caught during
+PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28).
+
+Without ``max_retries=0`` on the OpenAI-family clients, the SDK's
+internal retry loop (default 2) compounds with GEODE's own
+``_LLM_RETRY_CAP`` retry path — the operator's 2026-05-28 10-minute
+spin would have stayed at ~10 minutes even after the httpx Timeout fix
+(300 s read × 2 SDK attempts = 600 s before app retry even sees the
+failure). Anthropic adapter has always pinned ``max_retries=0`` —
+this PR brings OpenAI / Codex / GLM (PAYG + OAuth + Coding Plan, plus
+the legacy singleton paths) to the same invariant so retry is owned
+by a single source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_openai_payg_builder_pins_max_retries_zero() -> None:
+    """``build_async_openai_client`` must pass ``max_retries=0`` so SDK
+    retry does not compound with GEODE's agent-loop retry."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_openai_common.py"
+    ).read_text(encoding="utf-8")
+    assert "max_retries=0" in src, (
+        "_openai_common.py no longer pins max_retries=0 on the OpenAI/Codex "
+        "client builders. SDK x app retry compounding re-introduces the "
+        "10-minute spin the operator hit on 2026-05-28."
+    )
+
+
+def test_codex_oauth_builder_pins_max_retries_zero() -> None:
+    """Same invariant for the Codex backend client builder."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_openai_common.py"
+    ).read_text(encoding="utf-8")
+    # The Codex builder's max_retries=0 lives in a different block from the
+    # PAYG one; ensure both code paths set the kwarg by checking source
+    # contains at least two occurrences within the builder region.
+    assert src.count("max_retries=0") >= 2, (
+        "_openai_common.py contains < 2 max_retries=0 occurrences — one of "
+        "build_async_openai_client / build_async_codex_client likely lost "
+        "the pin."
+    )
+
+
+def test_legacy_openai_provider_singleton_pins_max_retries_zero() -> None:
+    """Legacy ``core/llm/providers/openai.py`` singleton is still consumed by
+    paperclip ``OpenAIAdapter`` + llm_extract_learning + models.py — same
+    spinning risk if SDK retry compounds with app retry."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "providers" / "openai.py"
+    ).read_text(encoding="utf-8")
+    assert "max_retries=0" in src, (
+        "Legacy openai provider singleton lost max_retries=0 — spinning "
+        "regresses for paperclip / llm_extract_learning callers."
+    )
+
+
+def test_legacy_codex_provider_singleton_pins_max_retries_zero() -> None:
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "providers" / "codex.py"
+    ).read_text(encoding="utf-8")
+    assert "max_retries=0" in src
+
+
+def test_legacy_glm_provider_singleton_pins_max_retries_zero() -> None:
+    src = (Path(__file__).resolve().parents[1] / "core" / "llm" / "providers" / "glm.py").read_text(
+        encoding="utf-8"
+    )
+    assert "max_retries=0" in src
+
+
+def test_anthropic_adapter_keeps_max_retries_zero() -> None:
+    """Parity pin — Anthropic adapter had this invariant from day 1
+    (``_anthropic_common.py:60``). A future refactor that drops it would
+    introduce the same spinning risk on the Anthropic side."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_anthropic_common.py"
+    ).read_text(encoding="utf-8")
+    assert "max_retries=0" in src, (
+        "_anthropic_common.py no longer pins max_retries=0 — provider parity "
+        "with the new OpenAI/Codex/GLM pinning broken."
+    )

--- a/tests/test_adapter_timeout_and_serialization.py
+++ b/tests/test_adapter_timeout_and_serialization.py
@@ -1,0 +1,327 @@
+"""Regression pin for PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28).
+
+Three sister fixes that all stem from one production incident — the
+operator's 2026-05-28 10-minute hang on a single ``gpt-5.5`` turn (serve
+log 11:06:19 → 11:16:39, 620062 ms latency):
+
+A. **httpx Timeout wiring** — ``build_async_openai_client`` /
+   ``build_async_codex_client`` used the openai SDK's default httpx
+   instance, whose read-timeout defaults are long enough that a stalled
+   Codex backend stream silently waited ~10 minutes before the SDK's
+   retry loop kicked in. The fix shares Anthropic's
+   ``settings.llm_*_timeout`` policy with every OpenAI-family client
+   (PAYG OpenAI, Codex OAuth, GLM PAYG, GLM Coding Plan) — capping the
+   stall at ``settings.llm_read_timeout`` (default 300 s).
+
+B. **SDK retry → UI bridge** — ``openai._base_client`` logs
+   ``Retrying request to /responses in 0.49 seconds`` at INFO level
+   when it retries, but the line landed only in the serve log file.
+   The operator watching the CLI spinner had no signal. A
+   ``logging.Handler`` on ``openai._base_client`` re-emits the retry
+   line through GEODE's existing ``emit_llm_retry`` event so the same
+   UI surface that agent-loop-side retries use covers SDK-side
+   retries too.
+
+C. **Summary SDK object → dict normalisation** — the same incident's
+   serve log also surfaced
+   ``TypeError: Object of type Summary is not JSON serializable`` from
+   ``session_manager.py:433`` because ``translate_codex_response``
+   stored OpenAI SDK ``ResponseReasoningItem.Summary`` Pydantic objects
+   verbatim in ``codex_reasoning_items[*]["summary"]``. The fix
+   normalises each summary element to a plain
+   ``{"type": "summary_text", "text": ...}`` dict so the downstream
+   SQLite session mirror + JSON checkpoint + IPC payload only see
+   JSON-safe primitives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from types import SimpleNamespace
+
+# ---------------------------------------------------------------------------
+# A — every OpenAI-family client builder pins explicit httpx Timeout
+# ---------------------------------------------------------------------------
+
+
+def test_build_async_openai_client_uses_explicit_httpx_client() -> None:
+    """PAYG OpenAI client must own a fresh httpx.AsyncClient with explicit
+    Timeout — otherwise SDK default read-timeout can silently hang
+    ~10 minutes on a stalled stream (operator incident 2026-05-28)."""
+    from core.llm.adapters._openai_common import build_async_openai_client
+
+    client = build_async_openai_client("sk-test-not-real")
+    # The openai SDK exposes the underlying transport via ``._client`` on
+    # the AsyncOpenAI instance. We verify the timeout pin propagated.
+    httpx_client = getattr(client, "_client", None)
+    assert httpx_client is not None, (
+        "build_async_openai_client did not attach a custom http_client; "
+        "SDK default httpx timeout kicks in, recreating the 10-minute "
+        "stall incident."
+    )
+    timeout = httpx_client.timeout
+    assert timeout.read is not None and timeout.read <= 600, (
+        f"httpx read timeout = {timeout.read} (None or > 600s); the SDK "
+        f"will hang past the operator-visible threshold."
+    )
+
+
+def test_build_async_codex_client_uses_explicit_httpx_client() -> None:
+    """Codex OAuth client (chatgpt.com/backend-api/codex) — same invariant
+    as PAYG. This is the exact path the operator's spinning hit."""
+    from core.llm.adapters._openai_common import build_async_codex_client
+
+    # Codex client builder requires a non-empty token; pass a dummy.
+    client = build_async_codex_client("dummy-jwt-not-real")
+    httpx_client = getattr(client, "_client", None)
+    assert httpx_client is not None, (
+        "build_async_codex_client did not attach a custom http_client — "
+        "regresses the 2026-05-28 10-minute spin."
+    )
+    timeout = httpx_client.timeout
+    assert timeout.read is not None and timeout.read <= 600
+
+
+def test_openai_payg_adapter_inherits_timeout_via_builder() -> None:
+    """End-to-end pin: instantiating the adapter populates a client that
+    inherits the explicit timeout, even though the adapter never touches
+    httpx directly."""
+    from core.config import settings
+    from core.llm.adapters.openai_payg import OpenAIPaygAdapter
+
+    # Adapter's _get_client raises when no key — temporarily inject one
+    # so the builder runs.
+    monkeypatched = False
+    if not getattr(settings, "openai_api_key", ""):
+        object.__setattr__(settings, "openai_api_key", "sk-test-not-real")
+        monkeypatched = True
+    try:
+        adapter = OpenAIPaygAdapter()
+        client = adapter._get_client()
+        assert client._client.timeout.read is not None
+    finally:
+        if monkeypatched:
+            object.__setattr__(settings, "openai_api_key", "")
+
+
+# ---------------------------------------------------------------------------
+# B — SDK retry log line surfaces through emit_llm_retry
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_retry_visibility_bridge_emits_on_retrying_log_line() -> None:
+    """When openai SDK logs ``Retrying request to ... in 0.5 seconds``,
+    the bridge re-emits the GEODE ``emit_llm_retry`` event so the agentic
+    UI shows the retry — operator no longer sees an opaque spinner."""
+    from core.llm.adapters import _sdk_retry_visibility
+
+    _sdk_retry_visibility._for_test_reset()
+    _sdk_retry_visibility.install()
+
+    emitted: list[tuple[int, int, int]] = []
+
+    def _fake_emit(*, delay_s: int, attempt: int, max_attempts: int) -> None:
+        emitted.append((delay_s, attempt, max_attempts))
+
+    import core.ui.agentic_ui as agentic_ui_pkg
+
+    original = getattr(agentic_ui_pkg, "emit_llm_retry", None)
+    agentic_ui_pkg.emit_llm_retry = _fake_emit  # type: ignore[assignment]
+    try:
+        sdk_logger = logging.getLogger("openai._base_client")
+        # Make sure INFO records reach handlers regardless of root config.
+        sdk_logger.setLevel(logging.INFO)
+        sdk_logger.info("Retrying request to /responses in 0.49 seconds")
+    finally:
+        if original is not None:
+            agentic_ui_pkg.emit_llm_retry = original
+        _sdk_retry_visibility._for_test_reset()
+
+    assert emitted, "Bridge did not re-emit the SDK retry as a GEODE UI event"
+    delay_s, attempt, max_attempts = emitted[0]
+    assert delay_s >= 1
+    assert attempt == 1
+    assert max_attempts == 2
+
+
+def test_sdk_retry_visibility_install_is_idempotent() -> None:
+    """Repeated ``install()`` must not stack handlers — would cause the
+    same retry log line to be emitted N times to the operator."""
+    from core.llm.adapters import _sdk_retry_visibility
+
+    _sdk_retry_visibility._for_test_reset()
+    _sdk_retry_visibility.install()
+    _sdk_retry_visibility.install()
+    _sdk_retry_visibility.install()
+
+    sdk_logger = logging.getLogger("openai._base_client")
+    handler_count = sum(
+        1
+        for h in sdk_logger.handlers
+        if isinstance(h, _sdk_retry_visibility._OpenAISdkRetryEventBridge)
+    )
+    _sdk_retry_visibility._for_test_reset()
+    assert handler_count == 1, f"Expected exactly one retry-bridge handler, got {handler_count}"
+
+
+def test_sdk_retry_visibility_ignores_non_retry_log_lines() -> None:
+    """Only the ``Retrying request to ... in N seconds`` shape triggers
+    the bridge — other openai SDK logs (request starts, response
+    finishes) must not spam the UI."""
+    from core.llm.adapters import _sdk_retry_visibility
+
+    _sdk_retry_visibility._for_test_reset()
+    _sdk_retry_visibility.install()
+
+    emitted: list[object] = []
+
+    def _fake_emit(*, delay_s: int, attempt: int, max_attempts: int) -> None:
+        emitted.append((delay_s, attempt, max_attempts))
+
+    import core.ui.agentic_ui as agentic_ui_pkg
+
+    original = getattr(agentic_ui_pkg, "emit_llm_retry", None)
+    agentic_ui_pkg.emit_llm_retry = _fake_emit  # type: ignore[assignment]
+    try:
+        sdk_logger = logging.getLogger("openai._base_client")
+        sdk_logger.setLevel(logging.INFO)
+        sdk_logger.info("Sending HTTP Request: POST /responses")
+        sdk_logger.info("Received response.completed event")
+    finally:
+        if original is not None:
+            agentic_ui_pkg.emit_llm_retry = original
+        _sdk_retry_visibility._for_test_reset()
+
+    assert emitted == [], f"Bridge emitted on non-retry log lines: {emitted!r} — risks UI spam"
+
+
+# ---------------------------------------------------------------------------
+# C — Summary SDK objects normalise to JSON-safe dicts
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_summary_handles_dict_passthrough() -> None:
+    """Dicts pass through unchanged (no needless wrapping)."""
+    from core.llm.adapters._openai_common import _normalize_summary_list
+
+    out = _normalize_summary_list(
+        [{"type": "summary_text", "text": "hello"}, {"type": "summary_text", "text": "world"}]
+    )
+    assert out == [
+        {"type": "summary_text", "text": "hello"},
+        {"type": "summary_text", "text": "world"},
+    ]
+    assert all(isinstance(o, dict) for o in out)
+
+
+def test_normalize_summary_converts_pydantic_like_objects() -> None:
+    """Pydantic v2 ``model_dump()`` is the preferred extraction. Any
+    object exposing it is normalised via that surface."""
+    from core.llm.adapters._openai_common import _normalize_summary_list
+
+    class _Summary:
+        type = "summary_text"
+        text = "extracted via model_dump"
+
+        def model_dump(self) -> dict:
+            return {"type": self.type, "text": self.text}
+
+    out = _normalize_summary_list([_Summary(), _Summary()])
+    assert out == [
+        {"type": "summary_text", "text": "extracted via model_dump"},
+        {"type": "summary_text", "text": "extracted via model_dump"},
+    ]
+    # Critical invariant: result is JSON-serialisable (the original bug).
+    json.dumps(out)
+
+
+def test_normalize_summary_falls_back_to_attribute_extraction() -> None:
+    """Objects without ``model_dump`` (future SDK variant) still
+    normalise via ``.text`` / ``.type`` attribute extraction."""
+    from core.llm.adapters._openai_common import _normalize_summary_list
+
+    obj = SimpleNamespace(type="custom", text="attr fallback")
+    out = _normalize_summary_list([obj])
+    assert out == [{"type": "custom", "text": "attr fallback"}]
+    json.dumps(out)
+
+
+def test_normalize_summary_handles_empty_and_none() -> None:
+    """Empty list / None / non-list → ``[]`` (matches original
+    ``summary if summary else []`` contract so replay path stays happy)."""
+    from core.llm.adapters._openai_common import _normalize_summary_list
+
+    assert _normalize_summary_list(None) == []
+    assert _normalize_summary_list([]) == []
+    assert _normalize_summary_list("not a list") == []
+    assert _normalize_summary_list({"oops": "wrong shape"}) == []
+
+
+def test_translate_codex_response_emits_json_safe_summary() -> None:
+    """End-to-end pin on the original incident: a translated
+    AdapterCallResult must be JSON-safe so the SQLite session mirror
+    (session_manager.py:433) does not raise TypeError."""
+    from core.llm.adapters._openai_common import translate_codex_response
+
+    class _Summary:
+        type = "summary_text"
+        text = "thinking step"
+
+        def model_dump(self) -> dict:
+            return {"type": self.type, "text": self.text}
+
+    reasoning_item = SimpleNamespace(
+        type="reasoning",
+        encrypted_content="opaque-blob",
+        summary=[_Summary()],
+        id="resp-abc",
+    )
+    response = SimpleNamespace(
+        output_text="hello",
+        output=[reasoning_item],
+        status="completed",
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+    )
+    result = translate_codex_response(response, accumulated_items=[reasoning_item])
+    assert result.reasoning_items, "Expected one normalised reasoning item"
+    entry = result.reasoning_items[0]
+    # The whole entry must JSON-serialise without TypeError — that was
+    # the production failure.
+    json.dumps(entry)
+    # Summary list entries are plain dicts now, not SDK objects.
+    summary_list = entry.get("summary", [])
+    assert all(isinstance(s, dict) for s in summary_list), (
+        f"summary still carries SDK objects: {summary_list!r}"
+    )
+    assert summary_list == [{"type": "summary_text", "text": "thinking step"}]
+
+
+# ---------------------------------------------------------------------------
+# Source-level pin — file content guarantees (single point of regression)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_common_documents_timeout_fix() -> None:
+    """Pin the helper name + intent in the source. A future refactor
+    that drops ``_build_async_httpx_client`` would lose the timeout cap
+    and regress the 10-minute spin — this test fails loudly."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_openai_common.py"
+    ).read_text(encoding="utf-8")
+    assert "_build_async_httpx_client" in src, (
+        "_openai_common.py no longer defines _build_async_httpx_client — "
+        "OpenAI/Codex/GLM clients lose explicit Timeout pin."
+    )
+    # Both client builders must wire through the helper.
+    assert re.search(r"def build_async_openai_client.*?http_client", src, re.DOTALL), (
+        "build_async_openai_client lost its http_client= wiring"
+    )
+    assert re.search(
+        r"def build_async_codex_client.*?http_client=_build_async_httpx_client",
+        src,
+        re.DOTALL,
+    ), "build_async_codex_client lost its http_client= wiring"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -554,9 +554,13 @@ class TestGlmClient:
             from core.llm.providers.glm import _get_glm_client
 
             _get_glm_client()
+            # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28) — singleton
+            # builder now pins ``max_retries=0`` so SDK retry does not
+            # compound with GEODE app retry.
             mock_openai_mod.OpenAI.assert_called_once_with(
                 api_key="test-key",
                 base_url=GLM_BASE_URL,
+                max_retries=0,
             )
 
 


### PR DESCRIPTION
## Summary
- 운영자가 본 2026-05-28 10분 spinning (gpt-5.5, latency=620062ms) 의 3 사이드: (A) httpx default timeout + (B) SDK retry 가 UI 비가시 + (C) Summary SDK 객체 SQLite mirror 실패
- A 는 Codex MCP audit 으로 한 단 더 들어가서 **\`max_retries=0\` 까지 핀** (SDK retry 와 app retry 중첩 방지) — anthropic 의 invariant 와 parity
- 18 신규 assertion + Codex MCP audit BLOCKER + MED 모두 본 PR 에 적용

## Why
운영자 로그 11:06:19 → 11:16:39:
\`\`\`
11:06:19.624  codex-oauth → ChatGPT 백엔드 호출
... 10분간 NO LOG ...
11:16:19.917  openai._base_client INFO Retrying request to /responses in 0.49 seconds
11:16:22.221  POST chatgpt.com/backend-api/codex/responses HTTP/1.1 200 OK
11:16:39.492  LLM call slow: latency=620062ms (10분 20초)
11:16:39.501  session_checkpoint WARNING Failed to mirror messages to sessions.db
              TypeError: Object of type Summary is not JSON serializable
              ... codex_reasoning_items.summary
\`\`\`

원인 분해:
1. **A**: OpenAI SDK 의 default httpx timeout 이 ~600s — Codex SSE stream stall 시 SDK 가 600s 까지 대기 후 자동 retry. anthropic adapter 는 \`settings.llm_*_timeout\` (300s) 으로 cap 했지만 OpenAI/Codex 어댑터에는 미적용
2. **A+ (Codex MCP catch)**: \`max_retries\` 미명시 → SDK default (2) 적용. 300s 적용해도 \`300s × 2 attempts = 600s\` 으로 동일 spin. anthropic 의 \`max_retries=0\` 와 parity 필요
3. **B**: SDK 가 "Retrying request to ... in N seconds" 를 \`openai._base_client\` 로거에 INFO 로 emit 하지만 GEODE UI 미surface. 운영자가 spinner 만 보고 \"왜 멈춰있나\" 의문
4. **C**: \`translate_codex_response\` 가 OpenAI SDK \`Summary\` Pydantic 객체를 dict 변환 없이 \`codex_reasoning_items[*]['summary']\` 에 저장 → SQLite mirror 의 \`json.dumps\` 가 TypeError. JSON checkpoint 는 살아남아 functional impact 작음

## Changes
| File | Change |
|------|--------|
| \`core/llm/adapters/_openai_common.py\` (+119) | \`_build_async_httpx_client\` (anthropic 패턴 mirror, settings.llm_*_timeout) + \`_ensure_sdk_observability_installed\` + \`_normalize_summary_list\` (model_dump mode=json) helpers. \`build_async_openai_client\` + \`build_async_codex_client\` 가 \`http_client=\` + \`max_retries=0\` 명시 |
| \`core/llm/adapters/_sdk_retry_visibility.py\` (NEW, 79) | \`logging.Handler\` 가 \`openai._base_client\` 의 "Retrying request" INFO 라인을 intercept → \`emit_llm_retry\` 재발화. install 멱등 |
| \`core/llm/providers/{openai,codex,glm}.py\` (+5) | legacy singleton 4 builder (sync+async × 2) 에 \`max_retries=0\` 추가 — Codex MCP MED 시정 (paperclip OpenAIAdapter / llm_extract_learning / models.py 호출 경로 동일 보호) |
| \`tests/test_adapter_timeout_and_serialization.py\` (NEW, 12 assertions) | A: explicit http_client 부착 검증 (PAYG + Codex). B: SDK 로그 → emit 검증 + idempotent + non-retry 라인 무시. C: dict passthrough / Pydantic model_dump / attr fallback / 비정상 입력 / end-to-end translate_codex_response JSON-safety |
| \`tests/test_adapter_max_retries.py\` (NEW, 6 assertions) | source-level pin: openai builder × 2 + codex/glm/openai 3 legacy singleton + anthropic parity guard |
| \`CHANGELOG.md\` | Unreleased / Fixed PR-ADAPTER-TIMEOUT-AND-SERIALIZATION |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| A: OpenAI family httpx Timeout (PAYG + Codex OAuth) | Done | anthropic settings 단일 source 공유 |
| A+: \`max_retries=0\` (adapter builders) | Done | Codex MCP BLOCKER 적용 |
| A+: \`max_retries=0\` (legacy provider singletons) | Done | Codex MCP MED 적용 (paperclip / extract_learning / models.py 호출 경로) |
| B: SDK retry → UI bridge | Done | logging.Handler, 멱등, non-retry 라인 무시 |
| C: Summary 정규화 | Done | model_dump(mode="json") + 2-tier fallback |
| Anthropic / GLM web_search subscription 자격 분기 (다음 PR) | Deferred | 본 PR 의 범위 외 |
| llm_extract_learning sync→async 마이그레이션 | Deferred | hook signature 변경 필요 |

## Verification
- [x] \`uv run ruff check core/ tests/ plugins/\` — clean
- [x] \`uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/\` — clean
- [x] \`uv run mypy core/ plugins/\` — Success: no issues found in 468 source files
- [x] \`uv run pytest tests/test_adapter_timeout_and_serialization.py tests/test_adapter_max_retries.py\` — **18/18 pass**
- [x] Codex MCP audit (별도 프로세스, thread 019e6c6b) — BLOCKER + MED 모두 본 PR 에 적용
- [ ] Full suite — CI 가 처리 (이전 PR 들과 동일)

## Reference
- 운영자 로그: 2026-05-28 11:06:19 → 11:16:39 (620062 ms)
- 분석 단서: \`_log_codex_input_shape\` 진단 (PR-LEGACY-PROVIDER-REMOVAL #1826 backfill) 가 input shape 확인
- frontier reference: anthropic adapter (\`_anthropic_common.py:60\`) 의 \`max_retries=0\` invariant
- Codex MCP thread: \`019e6c6b-0f41-7a02-90b7-b0ee8560ba01\`
- 직전 PR 시리즈: #1822 / #1825 / #1826 / #1829 / #1832 (어댑터 회귀 해소 시리즈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)