### PR TITLE
release: v0.99.80 — PR-ADAPTER-PATTERN-UNIFICATION + PR-ADAPTER-TIMEOUT-AND-SERIALIZATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.80] - 2026-05-28
+
+> PATCH release. Bundles two adapter-layer improvements built on
+> v0.99.79's foundation:
+>
+> - **PR-ADAPTER-PATTERN-UNIFICATION** (#1832) — tool layer
+>   (web_search, compaction) now dispatches through the adapter
+>   registry's ``WebSearchCapable`` / ``TextCompletionCapable``
+>   capability mixins (paperclip ``ServerAdapterModule`` mirror), so
+>   the operator's ``/login`` credential-source choice drives every
+>   LLM-touching site uniformly. Replaces the 3-provider direct-SDK
+>   fallback chain that previously bypassed ``infer_source``.
+> - **PR-ADAPTER-TIMEOUT-AND-SERIALIZATION** (#1833) — caps the
+>   2026-05-28 operator-observed 10-minute stall on a stuck Codex
+>   stream via (a) explicit httpx.AsyncClient timeout +
+>   ``max_retries=0`` on every OpenAI-family client (anthropic
+>   parity), (b) UI surface for SDK-internal retries, (c)
+>   ``Summary`` SDK object → dict normalisation so the SQLite session
+>   mirror no longer raises ``TypeError`` on ``codex_reasoning_items``.
+
 ### Fixed
 - **PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28)** — three sister
   fixes for the operator's 2026-05-28 10-minute hang on a single

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.79
+- **Version**: 0.99.80
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.79 — Long-running Autonomous Execution Harness
+# GEODE v0.99.80 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.79**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.80**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.79 — Long-running Autonomous Execution Harness
+# GEODE v0.99.80 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.79**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.80**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.79"
+version = "0.99.80"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.79"
+version = "0.99.80"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.80 PATCH 릴리스 — 5 위치 (CHANGELOG / CLAUDE.md / README.md / README.ko.md / pyproject.toml) 버전 stamp + uv.lock sync
- 이미 develop CI green 머지된 PR-ADAPTER-PATTERN-UNIFICATION (#1832) + PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (#1833) 묶음
- 본 PR 머지 후 develop → main pass-through PR 끊어 main 반영

## Verification
- [x] \`uv run geode version\` → \`GEODE v0.99.80\`
- [x] 5 stamp 위치 모두 0.99.80 (frontier 비교표 포함)
- [x] CHANGELOG \`[Unreleased]\` → \`[0.99.80] - 2026-05-28\` 이동, 2 PR 요약 헤더 포함
- [x] uv.lock geode-agent 버전 sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)