### PR TITLE
refactor(adapters): migrate llm_extract_learning + models.py to capability dispatch (PR-EXTRACT-LEARNING-MODELS-ADAPTER)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,48 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-EXTRACT-LEARNING-MODELS-ADAPTER (2026-05-28)** — Phase 2
+  follow-up to PR-ADAPTER-PATTERN-UNIFICATION (#1832): the last two
+  HIGH-traffic LLM-touching sites that still instantiated provider
+  SDKs directly now route through ``complete_text_via_adapters``.
+
+  1. ``core/hooks/llm_extract_learning.py`` — TURN_COMPLETED hook
+     for learning-pattern extraction. ``_call_budget_llm`` sync→async
+     + dispatch; ``_call_glm_flash`` / ``_call_haiku`` helpers
+     (each instantiating a fresh sync SDK client) deleted. Handler
+     ``_on_turn_complete`` also async (``HookSystem.trigger_async``
+     supports async handlers, fired from ``_lifecycle.py:351`` for
+     this event). Provider order ``("glm", "anthropic", "openai")``
+     preserves the historic free-tier-first preference.
+  2. ``core/agent/loop/models.py::_context_exhausted_message`` —
+     one-shot Haiku call for the context-exhausted localised notice.
+     ``anthropic.Anthropic`` direct instantiation removed; sync→async;
+     all 3 callers (``agent_loop.py:1562/1627/1682``) updated to
+     ``await``. Provider order ``("anthropic", "openai", "glm")``
+     keeps Haiku first while opening fallback for Codex-subscription-
+     only operators (the previous code silently returned the English
+     ``_EXHAUSTED_FALLBACK`` for any operator without an Anthropic
+     key — entire localisation point defeated).
+
+  Codex MCP audit caught a BLOCKER on the first pass: passing a
+  single ``model=`` to every fallback adapter meant Anthropic tried
+  to call ``glm-4.7-flash`` and OpenAI tried ``claude-haiku-*``,
+  guaranteeing every fallback to fail. ``complete_text_via_adapters``
+  now accepts ``model_by_provider: dict[str, str]`` so the caller
+  pins the provider-specific model only where it owns the choice
+  (GLM-flash for the extraction hook, Haiku for the exhausted
+  notice) and lets every other adapter use its own primary. Without
+  this fallback is theatre.
+
+  Pinned by ``tests/test_extract_learning_models_adapter.py`` (8
+  assertions: async signatures on both sites, source-level pins that
+  ``import anthropic`` / ``import openai`` are gone, helper deletions
+  confirmed, provider_order preserved, 3 awaited call sites in
+  agent_loop.py). ``test_glm_flash_hook_reads_settings_learning_extract_model``
+  updated to read ``_call_budget_llm`` source (the renamed homing
+  spot for the ``settings.learning_extract_model`` pass-through).
+
 ## [0.99.80] - 2026-05-28
 
 > PATCH release. Bundles two adapter-layer improvements built on

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1559,7 +1559,7 @@ class AgenticLoop:
                     )
                     self._sync_messages_to_context(messages)
                     result = AgenticResult(
-                        text=_context_exhausted_message(user_input),
+                        text=await _context_exhausted_message(user_input),
                         tool_calls=self._tool_processor.tool_log,
                         rounds=round_idx + 1,
                         error="context_exhausted",
@@ -1624,7 +1624,7 @@ class AgenticLoop:
                 )
                 self._sync_messages_to_context(messages)
                 result = AgenticResult(
-                    text=_context_exhausted_message(user_input),
+                    text=await _context_exhausted_message(user_input),
                     tool_calls=self._tool_processor.tool_log,
                     rounds=round_idx + 1,
                     error="context_exhausted",
@@ -1679,7 +1679,7 @@ class AgenticLoop:
                         )
                         self._sync_messages_to_context(messages)
                         result = AgenticResult(
-                            text=_context_exhausted_message(user_input),
+                            text=await _context_exhausted_message(user_input),
                             tool_calls=self._tool_processor.tool_log,
                             rounds=round_idx + 1,
                             error="context_exhausted",

--- a/core/agent/loop/models.py
+++ b/core/agent/loop/models.py
@@ -33,41 +33,51 @@ _EXHAUSTED_SYSTEM = (
 )
 
 
-def _context_exhausted_message(user_input: str) -> str:
+async def _context_exhausted_message(user_input: str) -> str:
     """Generate context-exhausted message in the user's language via lightweight LLM call.
 
-    Fallback order: Anthropic Haiku (anthropic_api_key) → static
-    ``_EXHAUSTED_FALLBACK`` text. In an OAuth-only environment with no
-    anthropic key, returns the static fallback — graceful, the loop
-    surfaces the static notice to the user. No silent failure.
+    PR-EXTRACT-LEARNING-MODELS-ADAPTER (2026-05-28) — dispatches through
+    :func:`core.llm.adapters.dispatch.complete_text_via_adapters` so a
+    ChatGPT-subscription-only operator (no Anthropic key) finally gets
+    a language-matched notice. The previous direct ``anthropic.Anthropic``
+    instantiation returned the static English fallback for that operator
+    every time, defeating the localisation intent. Provider preference
+    ``("anthropic", "openai", "glm")`` preserves the historic Haiku-
+    first ordering while opening the gpt-5.x + GLM paths.
 
-    TODO (follow-up PR): add a Codex OAuth path so ChatGPT subscription
-    subscription quota can drive the language-matching call. The Codex
-    ``/v1/responses`` streaming request shape lives in
-    ``plugins/petri_audit/codex_provider.py`` and would need to be
-    factored out before reuse here.
+    Returns the static ``_EXHAUSTED_FALLBACK`` on every failure (billing,
+    transient, no-credential) — graceful by design, the loop surfaces
+    SOME message to the user even on a fully-degraded credential surface.
     """
+    from core.config import ANTHROPIC_BUDGET
+    from core.llm.adapters.dispatch import (
+        AdapterDispatchError,
+        complete_text_via_adapters,
+    )
+    from core.llm.errors import BillingError
+
+    # Per-provider model selection (Codex MCP audit 2026-05-28) — Haiku
+    # specifically for Anthropic; OpenAI / GLM fallbacks use their own
+    # cheap defaults so a Codex-subscription-only operator still gets a
+    # localised notice instead of an "Anthropic Haiku" 404 cascade.
     try:
-        import anthropic
-
-        from core.config import ANTHROPIC_BUDGET, settings
-
-        if not settings.anthropic_api_key:
-            return _EXHAUSTED_FALLBACK
-
-        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-        resp = client.messages.create(
-            model=ANTHROPIC_BUDGET,
-            max_tokens=150,
+        result = await complete_text_via_adapters(
+            user_input[:200],
             system=_EXHAUSTED_SYSTEM,
-            messages=[{"role": "user", "content": user_input[:200]}],
+            max_tokens=150,
+            provider_order=("anthropic", "openai", "glm"),
+            model_by_provider={"anthropic": ANTHROPIC_BUDGET},
         )
-        block = resp.content[0] if resp.content else None
-        text = block.text if block and hasattr(block, "text") else ""
-        return text or _EXHAUSTED_FALLBACK
+    except BillingError:
+        log.debug("Exhausted message: every adapter billing-fatal — static fallback")
+        return _EXHAUSTED_FALLBACK
+    except AdapterDispatchError:
+        log.debug("Exhausted message: no capable adapter — static fallback")
+        return _EXHAUSTED_FALLBACK
     except Exception:
         log.debug("Exhausted message LLM call failed, using fallback", exc_info=True)
         return _EXHAUSTED_FALLBACK
+    return (result.text or "").strip() or _EXHAUSTED_FALLBACK
 
 
 @dataclass

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from core.hooks.system import HookEvent
@@ -70,84 +70,56 @@ def _build_context(data: dict[str, Any]) -> str:
     return "\n".join(parts)[:_MAX_CONTEXT_CHARS]
 
 
-def _call_budget_llm(prompt: str) -> str | None:
+async def _call_budget_llm(prompt: str) -> str | None:
     """Call a budget model for extraction. Returns text or None on failure.
 
-    Fallback order: GLM-flash (free, zai_api_key) → Anthropic Haiku
-    (anthropic_api_key). In an OAuth-only environment with no zai /
-    anthropic key, returns ``None`` — graceful, the caller treats
-    extraction as a soft hint and proceeds without it.
+    PR-EXTRACT-LEARNING-MODELS-ADAPTER (2026-05-28) — dispatches through
+    :func:`core.llm.adapters.dispatch.complete_text_via_adapters` so the
+    full operator credential surface (PAYG + Subscription + local-CLI)
+    drives extraction with one switch. The legacy provider-direct
+    ``_call_glm_flash`` / ``_call_haiku`` helpers — each instantiating a
+    fresh sync SDK client + raising bare ``Exception`` to ``log.debug``
+    — are replaced by the central dispatch chain's billing-fatal /
+    transient handling. Returns ``None`` (graceful) when every capable
+    adapter fails so the caller treats extraction as a soft hint.
 
-    TODO (follow-up PR): add a ``_call_codex_oauth`` path so a ChatGPT
-    subscription quota can drive the extraction (matches the
-    PR #1133 OAuth bridge for Petri's judge/auditor). The Codex
-    ``/v1/responses`` streaming-only request shape lives in
-    ``plugins/petri_audit/codex_provider.py`` and would need to be
-    factored out before reuse here.
+    Provider preference defaults to ``("glm", "anthropic", "openai")``
+    — preserves the original "GLM-flash free tier first, Haiku second"
+    ordering. The third slot (``openai``) is new: a Codex-subscription
+    operator with no Anthropic/GLM credentials now gets an extraction
+    path via the GPT-5 Responses endpoint, matching the operator-facing
+    intent the v0.99.79 sprint chase ("config-driven switching across
+    every LLM-touching site").
     """
-    try:
-        from core.config import settings
+    from core.config import settings
+    from core.llm.adapters.dispatch import (
+        AdapterDispatchError,
+        complete_text_via_adapters,
+    )
+    from core.llm.errors import BillingError
 
-        # Try GLM-flash first (free), then Haiku
-        if settings.zai_api_key:
-            return _call_glm_flash(prompt, settings.zai_api_key)
-        if settings.anthropic_api_key:
-            return _call_haiku(prompt, settings.anthropic_api_key)
+    # Per-provider model selection (Codex MCP audit 2026-05-28) — pass the
+    # operator's ``learning_extract_model`` ONLY to GLM (where the default
+    # ``glm-4.7-flash`` belongs); let Anthropic / OpenAI fallbacks use
+    # each adapter's own primary so cross-provider fallback actually
+    # succeeds instead of asking Anthropic to call ``glm-4.7-flash``.
+    try:
+        result = await complete_text_via_adapters(
+            prompt,
+            max_tokens=300,
+            provider_order=("glm", "anthropic", "openai"),
+            model_by_provider={"glm": settings.learning_extract_model},
+        )
+    except BillingError:
+        log.debug("LLM extract: all candidate adapters billing-fatal")
+        return None
+    except AdapterDispatchError:
+        log.debug("LLM extract: no capable adapter succeeded")
         return None
     except Exception:
         log.debug("LLM extract call failed", exc_info=True)
         return None
-
-
-def _call_glm_flash(prompt: str, api_key: str) -> str | None:
-    """Call the GLM free-tier model picked by ``settings.learning_extract_model``.
-
-    PR-1 G-D — pre-fix the model id was a ``"glm-4.7-flash"`` literal,
-    so an operator who wanted to flip to a different free model had to
-    edit this hook. The literal is now wired through the settings so a
-    ``GEODE_LEARNING_EXTRACT_MODEL=glm-5-flash`` env var (or
-    ``config.toml [llm] learning_extract_model``) flips it without
-    touching code.
-    """
-    import openai
-
-    from core.config import GLM_BASE_URL, settings
-
-    client = openai.OpenAI(
-        api_key=api_key,
-        base_url=GLM_BASE_URL,
-    )
-    try:
-        resp = client.chat.completions.create(
-            model=settings.learning_extract_model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=300,
-            temperature=0.0,
-            timeout=10.0,
-        )
-        return resp.choices[0].message.content if resp.choices else None
-    finally:
-        client.close()
-
-
-def _call_haiku(prompt: str, api_key: str) -> str | None:
-    """Call Claude Haiku (budget tier)."""
-    import anthropic
-
-    from core.config import ANTHROPIC_BUDGET
-
-    client = anthropic.Anthropic(api_key=api_key)
-    try:
-        resp = client.messages.create(
-            model=ANTHROPIC_BUDGET,
-            max_tokens=300,
-            messages=[{"role": "user", "content": prompt}],
-            timeout=10.0,
-        )
-        block = resp.content[0] if resp.content else None
-        return block.text if block and hasattr(block, "text") else None
-    finally:
-        client.close()
+    return result.text or None
 
 
 def _parse_extractions(text: str) -> list[tuple[str, str]]:
@@ -174,7 +146,7 @@ def _parse_extractions(text: str) -> list[tuple[str, str]]:
     return results[:3]  # max 3 per extraction
 
 
-def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
+def make_llm_extract_handler() -> tuple[str, Callable[..., Awaitable[None]]]:
     """Create TURN_COMPLETE handler for LLM-based learning extraction.
 
     Claude Code extractMemories pattern: cursor-based incremental extraction
@@ -188,7 +160,7 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
     last_extract_ts: float = float("-inf")
     _seen_inputs: set[int] = set()  # hash of already-extracted user inputs
 
-    def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
+    async def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
         nonlocal turn_count, session_extractions, last_extract_ts
 
         turn_count += 1
@@ -231,7 +203,7 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
             return
 
         prompt = _EXTRACT_PROMPT.format(context=context)
-        llm_output = _call_budget_llm(prompt)
+        llm_output = await _call_budget_llm(prompt)
         if not llm_output:
             return
 

--- a/core/llm/adapters/dispatch.py
+++ b/core/llm/adapters/dispatch.py
@@ -197,12 +197,31 @@ async def complete_text_via_adapters(
     model: str = "",
     max_tokens: int = 1024,
     provider_order: tuple[str, ...] = ("anthropic", "openai", "glm"),
+    model_by_provider: dict[str, str] | None = None,
 ) -> TextCompletionResult:
     """Route a single-turn text-completion request through the adapter registry.
 
     Used by conversation compaction + learning extraction — single LLM round-
     trip, no tool use, no streaming. Same billing-fatal vs transient
     distinction as :func:`web_search_via_adapters`.
+
+    Model selection (Codex MCP audit 2026-05-28, PR-EXTRACT-LEARNING-MODELS-
+    ADAPTER) — three layers, most specific first:
+
+    1. ``model_by_provider[adapter.provider]`` — per-provider override; the
+       caller knows which model to ask each provider for (e.g.
+       ``{"glm": "glm-4.7-flash", "anthropic": ANTHROPIC_BUDGET}``).
+    2. ``model`` — single model id; passed to every candidate. Use only
+       when the caller is confident every fallback adapter accepts it
+       (e.g. the model is a no-op string that each adapter ignores).
+    3. ``""`` (empty) — each adapter's ``acomplete_text`` falls back to
+       its own primary (``ANTHROPIC_PRIMARY``, ``OPENAI_PRIMARY``, etc.).
+
+    Without per-provider mapping the fallback chain becomes a foot-gun:
+    passing ``model="glm-4.7-flash"`` to the Anthropic adapter (because GLM
+    failed) makes Anthropic call its API with ``model=glm-4.7-flash`` and
+    fail. Callers should pass ``model_by_provider`` when fallback across
+    providers is intended.
     """
     candidates = _capability_candidates("supports_text_completion", provider_order=provider_order)
     if not candidates:
@@ -211,10 +230,12 @@ async def complete_text_via_adapters(
         )
     last_billing: BillingError | None = None
     last_other: Exception | None = None
+    overrides = model_by_provider or {}
     for adapter in candidates:
+        chosen_model = overrides.get(adapter.provider, model)
         try:
             text_result: TextCompletionResult = await adapter.acomplete_text(
-                prompt, system=system, model=model, max_tokens=max_tokens
+                prompt, system=system, model=chosen_model, max_tokens=max_tokens
             )
             log.debug("complete_text_via_adapters: success via %s", adapter.name)
             return text_result

--- a/tests/test_extract_learning_models_adapter.py
+++ b/tests/test_extract_learning_models_adapter.py
@@ -1,0 +1,134 @@
+"""Regression pin for PR-EXTRACT-LEARNING-MODELS-ADAPTER (2026-05-28).
+
+Two Phase 2 deferred sites from PR-ADAPTER-PATTERN-UNIFICATION (#1832)
+finally migrated to the adapter registry's
+``complete_text_via_adapters`` dispatch:
+
+1. ``core/hooks/llm_extract_learning.py`` — the TURN_COMPLETED hook
+   that distills learning patterns from agent turns. Previously
+   instantiated bare ``openai.OpenAI`` / ``anthropic.Anthropic`` sync
+   clients with a hand-rolled 2-provider fallback. Now async +
+   capability-based dispatch.
+2. ``core/agent/loop/models.py::_context_exhausted_message`` — the
+   one-shot Haiku call that translates the context-exhausted notice
+   into the user's language. Previously ``anthropic.Anthropic`` only —
+   silently returned the English ``_EXHAUSTED_FALLBACK`` for any
+   operator without an Anthropic key (the entire localisation point
+   defeated). Now async + 3-provider dispatch.
+
+Both sites become async; their call paths (``agent_loop.py:1562 / 1627
+/ 1682`` for the context-exhausted message, ``HookSystem.trigger_async``
+at ``_lifecycle.py:351`` for the extraction handler) are already in
+async contexts so the migration is signature-only at the boundary.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# llm_extract_learning — async + adapter dispatch + no direct SDK imports
+# ---------------------------------------------------------------------------
+
+
+def test_call_budget_llm_is_async() -> None:
+    from core.hooks.llm_extract_learning import _call_budget_llm
+
+    assert inspect.iscoroutinefunction(_call_budget_llm), (
+        "_call_budget_llm must be async so it can await the central "
+        "adapter dispatch — otherwise the hook handler can't bridge."
+    )
+
+
+def test_extract_handler_is_async() -> None:
+    """``HookSystem.trigger_async`` (the TURN_COMPLETED firer) supports
+    async handlers; the extract handler must be one so it can await
+    the dispatch without a sync→async bridge."""
+    from core.hooks.llm_extract_learning import make_llm_extract_handler
+
+    _name, handler = make_llm_extract_handler()
+    assert inspect.iscoroutinefunction(handler)
+
+
+def test_extract_helpers_no_longer_import_provider_sdks_directly() -> None:
+    """Source-level pin: the legacy ``_call_glm_flash`` / ``_call_haiku``
+    helpers (each instantiating a fresh sync SDK client) are gone; the
+    module no longer ``import anthropic`` or ``import openai``
+    standalone. The adapter dispatch encapsulates all SDK touch."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "hooks" / "llm_extract_learning.py"
+    ).read_text(encoding="utf-8")
+    assert "def _call_glm_flash" not in src and "def _call_haiku" not in src, (
+        "Legacy direct-SDK helpers must be deleted — the dispatch chain owns provider selection."
+    )
+    assert "import anthropic" not in src, (
+        "llm_extract_learning must not import anthropic directly anymore."
+    )
+    assert "import openai" not in src, (
+        "llm_extract_learning must not import openai directly anymore."
+    )
+    assert "complete_text_via_adapters" in src
+
+
+def test_extract_dispatch_uses_glm_first_provider_order() -> None:
+    """Preserve the historic preference: GLM-flash (free tier) first,
+    Haiku second, OpenAI third (newly accessible to Codex-subscription-
+    only operators)."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "hooks" / "llm_extract_learning.py"
+    ).read_text(encoding="utf-8")
+    assert '("glm", "anthropic", "openai")' in src, (
+        "Provider order in _call_budget_llm changed; preserve "
+        '("glm", "anthropic", "openai") so the free-tier-first '
+        "extraction policy stays intact."
+    )
+
+
+# ---------------------------------------------------------------------------
+# models._context_exhausted_message — async + adapter dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_context_exhausted_message_is_async() -> None:
+    from core.agent.loop.models import _context_exhausted_message
+
+    assert inspect.iscoroutinefunction(_context_exhausted_message)
+
+
+def test_models_no_longer_imports_anthropic_directly() -> None:
+    """Source-level pin — the legacy direct ``anthropic.Anthropic``
+    instantiation that silently returned ``_EXHAUSTED_FALLBACK`` for
+    OAuth-only operators is gone."""
+    src = (Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "models.py").read_text(
+        encoding="utf-8"
+    )
+    assert "import anthropic" not in src, (
+        "models.py must not instantiate anthropic.Anthropic directly — "
+        "dispatch through complete_text_via_adapters instead."
+    )
+    assert "anthropic.Anthropic(" not in src
+    assert "complete_text_via_adapters" in src
+
+
+def test_context_exhausted_call_sites_are_awaited() -> None:
+    """All three callers in agent_loop.py must await — non-await would
+    embed a coroutine object into the result text (visible UI bug)."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+    assert src.count("await _context_exhausted_message(user_input)") == 3, (
+        "Expected exactly 3 awaited call sites for _context_exhausted_message "
+        "in agent_loop.py (lines 1562 / 1627 / 1682); a missing await would "
+        "embed a coroutine object into the AgenticResult.text."
+    )
+
+
+def test_context_exhausted_dispatch_uses_anthropic_first_provider_order() -> None:
+    """Preserve the historic Haiku-first preference for the language-
+    matched notice; add OpenAI + GLM as fallbacks so Codex-subscription-
+    only operators get a localised notice for the first time."""
+    src = (Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "models.py").read_text(
+        encoding="utf-8"
+    )
+    assert '("anthropic", "openai", "glm")' in src

--- a/tests/test_self_improving_loop_gap_fill.py
+++ b/tests/test_self_improving_loop_gap_fill.py
@@ -246,11 +246,19 @@ def test_settings_carries_learning_extract_model_field() -> None:
 
 
 def test_glm_flash_hook_reads_settings_learning_extract_model() -> None:
+    """PR-EXTRACT-LEARNING-MODELS-ADAPTER (2026-05-28) — the dedicated
+    ``_call_glm_flash`` helper was deleted when the extraction hook
+    migrated to ``complete_text_via_adapters``. The settings-driven
+    model id requirement now lives on the dispatch helper: the helper
+    must still pass ``settings.learning_extract_model`` (not a literal)
+    as the requested model so operators can flip it without code edits.
+    """
     from core.hooks import llm_extract_learning
 
-    src = inspect.getsource(llm_extract_learning._call_glm_flash)
+    src = inspect.getsource(llm_extract_learning._call_budget_llm)
     assert 'model="glm-4.7-flash"' not in src, (
-        "PR-1 G-D — the GLM hook must read settings.learning_extract_model instead of the literal."
+        "PR-1 G-D + PR-EXTRACT-LEARNING-MODELS-ADAPTER — the extraction "
+        "hook must read settings.learning_extract_model, not a literal."
     )
     assert "settings.learning_extract_model" in src
 


### PR DESCRIPTION
## Summary
- Phase 2 follow-up to PR-ADAPTER-PATTERN-UNIFICATION (#1832) — the two HIGH-traffic LLM-touching sites that still instantiated provider SDKs directly now route through `complete_text_via_adapters`.
- Added `model_by_provider: dict[str, str] | None` parameter to dispatch helper (Codex MCP audit catch — passing a single `model=` to every fallback adapter is fallback theatre).
- Both callers become async (`HookSystem.trigger_async` + agent_loop.py call sites already async).

## Why
Two remaining direct-SDK sites broke the operator-facing intent of the v0.99.79 sprint ("config-driven switching across every LLM-touching site"):

1. `core/hooks/llm_extract_learning.py` — `_call_glm_flash` + `_call_haiku` each instantiated a fresh sync SDK client. Operator's `{provider}_credential_source` setting was ignored; OAuth-only operators silently had no extraction path.
2. `core/agent/loop/models.py::_context_exhausted_message` — direct `anthropic.Anthropic(api_key=...)`. A ChatGPT-subscription-only operator (no Anthropic key) returned the static English `_EXHAUSTED_FALLBACK` every time, defeating the localisation point entirely.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/dispatch.py` | Add `model_by_provider` parameter to `complete_text_via_adapters` — per-adapter model override so GLM gets `glm-4.7-flash` and Anthropic gets its own primary on fallback (otherwise Anthropic would be asked to call `glm-4.7-flash` and 404) |
| `core/hooks/llm_extract_learning.py` | `_call_budget_llm` sync→async + dispatch; delete `_call_glm_flash` / `_call_haiku`; handler also async; provider order `(glm, anthropic, openai)` |
| `core/agent/loop/models.py` | `_context_exhausted_message` sync→async + dispatch; remove `import anthropic` + direct client; provider order `(anthropic, openai, glm)` |
| `core/agent/loop/agent_loop.py` | 3 call sites updated to `await _context_exhausted_message(user_input)` (lines 1562 / 1627 / 1682) |
| `tests/test_extract_learning_models_adapter.py` | NEW — 8 assertions: async signatures, source-level pins (no direct SDK imports), provider order, 3 awaited call sites |
| `tests/test_self_improving_loop_gap_fill.py` | Updated `_call_glm_flash` pin → `_call_budget_llm` (renamed homing spot for `settings.learning_extract_model`) |
| `CHANGELOG.md` | PR-EXTRACT-LEARNING-MODELS-ADAPTER entry under [Unreleased] / Changed |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `llm_extract_learning` adapter migration | Implemented | `_call_budget_llm` async dispatch, legacy helpers deleted |
| `models._context_exhausted_message` adapter migration | Implemented | async, 3 call sites awaited |
| `model_by_provider` dispatch parameter | Implemented | Codex MCP BLOCKER fix — per-adapter model selection |
| paperclip `LLMClientPort` × `LLMAdapter` unification | Deferred | Separate sprint; cross-package refactor |
| petri_audit bridge | Deferred | Plugin owns its provider; not GEODE-core |
| `experimental/*` cleanup | Deferred | Unused dead code, not in any production path |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ autoresearch/ scripts/)
- [x] ruff format --check clean
- [x] mypy clean (core/ plugins/)
- [x] pytest pass (8689 passed, 18 skipped, 5 deselected, 280s)
- [x] 2 new failures (`test_codex_cli_provider::test_generate_surfaces_error_event_in_model_output` + `test_paperclip_wiring::test_invoke_codex_cli_argv_shape`) are env-only: `codex-cli-subagent lane blocked — Codex 5-hour OAuth bucket >= throttle threshold`. Operator's local Codex OAuth state, not a code regression. CI does not have this state.
- [x] Codex MCP audit pass — BLOCKER (single `model=` cascade) caught and fixed via `model_by_provider`

## Reference
- Phase 1: PR-ADAPTER-PATTERN-UNIFICATION (#1832) — capability Protocols + central dispatch + `web_tools.py` migration
- Phase 2 (this PR): the two remaining HIGH-traffic direct-SDK sites
- Paperclip `server/src/adapters/registry.ts:768` `findActiveServerAdapter` — ordering precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)