### PR TITLE
docs(workflow): doc-before-behaviour rule for external SDK / backend assumptions (PR-DOC-VERIFY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,41 @@ functional change.
 ## [Unreleased]
 
 ### Changed
+- **PR-DOC-VERIFY (2026-05-28)** — workflow: doc-before-behaviour for
+  external SDK / 3rd-party backend capability assumptions. New
+  CANNOT rule (``Quality`` row) + new ``§4d. External-contract
+  attestation`` step in the Verify (Implementation GAP Audit) workflow:
+  any PR that introduces or flips ``supports_X = True`` (or asserts a
+  backend endpoint accepts a particular tools / parameter / model id)
+  must run ``ctx7 library`` + ``ctx7 docs`` first. Three outcomes:
+
+  | ctx7 result | Action |
+  |-------------|--------|
+  | Confirms | Cite the source path in the docstring |
+  | Refutes | Revert + fix the misread |
+  | Ambiguous | Mark ``unverified — live test required`` in docstring, open the live-test gate explicitly |
+
+  Retroactively applied to PR-NO-FALLBACK #1839 —
+  ``codex_oauth.supports_web_search = True`` docstring now carries the
+  ``unverified — live test required`` attestation because ctx7 of
+  ``/openai/codex`` documents the Responses ``tools`` array shape but
+  does NOT enumerate which ``type`` values the Codex backend accepts.
+  The Codex CLI's own internal web search uses a different schema
+  (``codex-rs/ext/web-search/`` ``{"search_query": [...]}``), making
+  the hosted ``{"type": "web_search"}`` acceptance unverified until a
+  live call confirms.
+  ``tests/test_adapter_capability_dispatch.py::test_codex_oauth_adapter_advertises_web_search``
+  pins the docstring attestation presence so it cannot be silently
+  dropped during a future docstring rewrite.
+
+  Operator caught the workflow gap: behaviour verification (serve
+  restart + live web_search trigger) was offered before the doc
+  verification ran. The strict-dispatch error contract from
+  PR-NO-FALLBACK is the operational safety net, but it does not
+  substitute for the gate — a True flag landing in production based on
+  SDK contract inference alone is the exact pattern that creates
+  silent regressions when the backend later changes behaviour.
+
 - **PR-NO-FALLBACK (2026-05-28)** — adapter dispatch is now strict
   single-adapter: the operator's explicit ``/login source`` choice is
   the sole switch. Silent cross-provider / cross-source fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Rationale cites the originating incident when one exists. The `karpathy-patterns
 | | No "graceful" return contract without applying it at every schema-typed cast (not just outer try) | Boundary completeness. *Incident: PR-G3 #1347 (2026-05-20) — `float()` on non-numeric raised before contract* |
 | | No conflating "latest" and "promoted" SoTs — readers must document which they assume; persist both if the loop needs both | SoT clarity. *Incident: PR-G2 #1346 (2026-05-20) — downstream read stale evidence forever* |
 | | No dual SoT (disk + fallback literal) without shared anchor + drift invariant test | Drift prevention. *Incident: PR-MINIMAL-2 #1398 (2026-05-21) — `program.md` ↔ `_FALLBACK_SYSTEM_PROMPT` divergence* |
+| | No external-SDK / 3rd-party-backend capability assumption (e.g. ``supports_X=True``, hosted tool acceptance, model availability) hardcoded as ``True`` without `ctx7 library` + `ctx7 docs` verification first; if ctx7 is ambiguous, mark the assumption ``unverified — live test required`` in the docstring and surface the live-test as an explicit pending verification | Doc-before-behaviour. *Incident: PR-NO-FALLBACK #1839 (2026-05-28) — `codex_oauth.supports_web_search` flipped False → True based on SDK ``ToolParam`` Union alone; Codex backend's actual acceptance of ``{"type": "web_search"}`` is undocumented in ctx7 / Codex CLI repo, so the assumption needed a live-test gate rather than a behavioural test* |
 | **Docs** | No omitting CHANGELOG from code commits | Traceability |
 | | No leaving `[Unreleased]` on main | Release discipline |
 | | No version mismatch across 5 locations | Single source of truth |
@@ -223,7 +224,19 @@ All 4 [Quality Gates](#quality-gates) must pass (lint / type / test / CLI smoke)
 
 Run the `anti-deception-checklist` skill — it covers test deletion/disabling, lint bypass (`# noqa`, `# type: ignore`), coverage regression, secret exposure, and dependency downgrade. Any FAIL verdict blocks merge.
 
-**4d. Verification team (large-scale changes only)**
+**4d. External-contract attestation — doc-before-behaviour**
+
+When the PR introduces or flips an assumption about an external SDK or 3rd-party backend (capability flag, hosted tool acceptance, endpoint behaviour, model availability), run `ctx7 library <name>` → `ctx7 docs <id> "<question>"` **before** any agent-behaviour live test. Three outcomes:
+
+| ctx7 result | Action |
+|-------------|--------|
+| Confirms the assumption | Cite the ctx7 source (file path on GitHub) in the docstring next to the assumption (`# ref: openai/types/responses/tool_param.py:ToolParam`). |
+| Refutes the assumption | Revert the change. Open a separate decision branch about why the assumption was tempting (often a misread doc, fix the misread). |
+| **Ambiguous** (SDK contract allows, backend acceptance undocumented) | Mark the assumption ``unverified — live test required`` in the docstring + open a follow-up task. Do not let the behaviour land in production behind a True-flag without the live-test gate. Honest error message on the dispatch path is the safety net but does not substitute for the gate. |
+
+*Incident: PR-NO-FALLBACK #1839 (2026-05-28) flipped `codex_oauth.supports_web_search` to `True` based on the SDK `ToolParam` Union alone; ctx7 of `/openai/codex` showed Responses API accepts a `tools` array but does NOT document which `type` values the Codex backend accepts. The assumption should have shipped as `unverified` until a live test confirmed.*
+
+**4e. Verification team (large-scale changes only)**
 
 See `verification-team` + `anti-deception-checklist` skills.
 

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -60,17 +60,28 @@ class CodexOAuthAdapter:
     provider: str = "openai"
     source: str = SOURCE_SUBSCRIPTION
     billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION
-    # PR-NO-FALLBACK (2026-05-28) — web_search re-enabled. The Codex
-    # backend (chatgpt.com/backend-api/codex/responses) exposes the same
-    # Responses API contract as the PAYG endpoint; the openai-python
-    # SDK's ``ToolParam`` union accepts ``{"type": "web_search"}`` /
-    # ``{"type": "web_search_preview"}`` independent of which Responses
-    # endpoint the client targets. Reusing :func:`openai_web_search`
-    # routes the call through the same OAuth token the operator's
-    # ``/login openai`` registered — no PAYG key required, no cross-
-    # source fallback. Pre-PR's conservative ``False`` was the source of
-    # the routing leak that made web_search silently land on glm-payg
-    # when the operator was on Codex OAuth.
+    # PR-NO-FALLBACK (2026-05-28) — web_search re-enabled. SDK-contract-
+    # level confirmation: openai-python SDK's ``ToolParam`` Union
+    # (``openai/types/responses/tool_param.py``) accepts
+    # ``{"type": "web_search"}`` independent of which Responses endpoint
+    # the client targets, and the Codex backend
+    # (chatgpt.com/backend-api/codex/responses) accepts the same
+    # ``tools`` array shape per ``codex-rs/codex-api/README.md::POST
+    # /responses``.
+    #
+    # ``unverified — live test required`` (CLAUDE.md §4d, PR-DOC-VERIFY
+    # 2026-05-28): ctx7 of ``/openai/codex`` does NOT document which
+    # ``type`` values the Codex backend actually accepts in the ``tools``
+    # array. The Codex CLI's own internal web search uses a DIFFERENT
+    # tool schema (``web_run`` ext at ``codex-rs/ext/web-search/``,
+    # ``{"search_query": [{"q": "..."}]}``) which suggests the hosted
+    # ``{"type": "web_search"}`` may not be available on the Codex
+    # backend. The strict-dispatch error contract (PR-NO-FALLBACK) is
+    # the operational safety net — if the backend rejects the tool the
+    # operator sees an honest ``AdapterDispatchError`` naming
+    # ``codex-oauth`` rather than a silent GLM fallback — but the True
+    # flag itself awaits a live web_search call confirmation before
+    # this assumption hardens into a stable contract.
     supports_web_search: bool = True
     supports_text_completion: bool = True
     _last_error: Exception | None = field(default=None, init=False, repr=False)

--- a/tests/test_adapter_capability_dispatch.py
+++ b/tests/test_adapter_capability_dispatch.py
@@ -155,14 +155,25 @@ def test_glm_payg_adapter_advertises_web_search_and_text_completion() -> None:
 
 
 def test_codex_oauth_adapter_advertises_web_search() -> None:
-    """PR-NO-FALLBACK (2026-05-28) — the Codex backend exposes the same
-    Responses API contract as PAYG; the openai-python SDK's ``ToolParam``
-    Union accepts ``{"type": "web_search"}`` independent of which endpoint
-    the client targets. ``codex-oauth`` MUST advertise the capability so
-    an operator on a ChatGPT subscription gets web_search routed through
-    their OAuth token (no PAYG key needed) — the prior conservative
-    ``False`` caused the routing leak that landed web_search on
-    ``glm-payg`` for Codex-OAuth operators."""
+    """PR-NO-FALLBACK (2026-05-28) — SDK-contract level: openai-python
+    SDK's ``ToolParam`` Union accepts ``{"type": "web_search"}`` and
+    ``codex-rs/codex-api/README.md`` documents the Responses endpoint
+    accepts a ``tools`` array. ``codex-oauth`` advertises the capability
+    so an operator on a ChatGPT subscription gets web_search routed
+    through their OAuth token (no PAYG key needed) — the prior
+    conservative ``False`` was the root cause of the routing leak that
+    landed web_search on ``glm-payg`` for Codex-OAuth operators.
+
+    PR-DOC-VERIFY (2026-05-28) — pins the ``unverified — live test
+    required`` attestation per CLAUDE.md §4d. The Codex backend's actual
+    acceptance of ``{"type": "web_search"}`` is undocumented in ctx7
+    (``/openai/codex`` enumerates the request shape but not valid tool
+    types; the Codex CLI's internal web search uses a different schema).
+    Behavioural confirmation requires a live call; this test pins the
+    docstring attestation so the assumption cannot harden into stable
+    contract through a silent docstring rewrite."""
+    import inspect
+
     from core.llm.adapters.codex_oauth import CodexOAuthAdapter
 
     adapter = CodexOAuthAdapter()
@@ -171,6 +182,14 @@ def test_codex_oauth_adapter_advertises_web_search() -> None:
         "CodexOAuthAdapter.supports_web_search=True must be backed by a "
         "callable ``aweb_search`` method — dispatch skips flag-set / "
         "method-missing adapters with a warning."
+    )
+    src = inspect.getsource(CodexOAuthAdapter)
+    assert "unverified — live test required" in src, (
+        "CodexOAuthAdapter.supports_web_search=True must carry the "
+        "``unverified — live test required`` attestation per CLAUDE.md §4d "
+        "(doc-before-behaviour). The flag was flipped True based on SDK "
+        "contract alone; Codex backend acceptance of the hosted web_search "
+        "tool is undocumented in ctx7 and requires live confirmation."
     )
 
 


### PR DESCRIPTION
## Summary
- New CANNOT rule + new §4d "External-contract attestation" workflow step: any PR that flips an external SDK / 3rd-party backend capability flag (e.g. `supports_X = True`) must run `ctx7 library` + `ctx7 docs` first; if ctx7 is ambiguous, mark the assumption `unverified — live test required` in the docstring instead of silently shipping True.
- Retroactively applied to PR-NO-FALLBACK #1839 — `codex_oauth.supports_web_search = True` docstring + matching test now carry the `unverified — live test required` attestation.

## Why
Operator caught the workflow gap during PR-NO-FALLBACK #1839 verification:
> "에이전트 행동 검증 전에 ctx7으로 문서 검증부터 하라는 얘기였어."

PR-NO-FALLBACK flipped `codex_oauth.supports_web_search` False → True based on the openai-python SDK's `ToolParam` Union accepting `{"type": "web_search"}` — an SDK-contract-level confirmation that does NOT extend to whether the Codex backend (`chatgpt.com/backend-api/codex/responses`) actually accepts the hosted tool.

ctx7 of `/openai/codex` (queried after the operator caught the gap):
- `codex-rs/codex-api/README.md::POST /responses` documents `tools: array` — ⚠️ shape only, valid `type` whitelist absent
- Codex CLI's own internal web search uses a DIFFERENT schema (`codex-rs/ext/web-search/web_run_description.md` with `{"search_query": [{"q": "..."}]}`) — ⚠️ suggests hosted `{"type": "web_search"}` may not be backend-accepted
- Codex backend acceptance — ❌ undocumented anywhere in ctx7

This was the right *call* (SDK contract permits it + operational safety net exists) but the wrong *attestation* (live test should have gated before True landed as stable contract).

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | New CANNOT row (Quality area) — "No external-SDK / 3rd-party-backend capability assumption hardcoded as True without ctx7 verification". + new §4d "External-contract attestation — doc-before-behaviour" with three-outcome decision table (confirms / refutes / ambiguous). Previous §4d "Verification team" moved to §4e |
| `core/llm/adapters/codex_oauth.py` | `supports_web_search = True` docstring rewritten — cites the SDK contract evidence + explicit `unverified — live test required` attestation explaining why ctx7 is ambiguous (Codex CLI's own web search uses different schema; backend acceptance undocumented) |
| `tests/test_adapter_capability_dispatch.py::test_codex_oauth_adapter_advertises_web_search` | NEW assertion via `inspect.getsource` pins the `unverified — live test required` string presence so a future silent docstring rewrite cannot strip the attestation |
| `CHANGELOG.md` | [Unreleased] / Changed entry above PR-NO-FALLBACK |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| CANNOT row added | Implemented | Quality area |
| §4d workflow step added | Implemented | §4d → §4e shift |
| Retroactive attestation on codex_oauth | Implemented | docstring + test pin |
| Memory updated | Implemented | `feedback_ctx7_before_backend_assumption.md` |

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` clean (1025 files)
- [x] `mypy core/ plugins/` clean (465 source files)
- [x] `test_codex_oauth_adapter_advertises_web_search` passes (docstring attestation pin)
- [x] No code-behaviour change — workflow + docstring + test pin only

## Reference
- Operator instruction: "에이전트 행동 검증 전에 ctx7으로 문서 검증부터 하라는 얘기였어. 이 사안 CLAUDE.md와 워크플로우 플랜 절차에 추가해."
- Predecessor: PR-NO-FALLBACK #1839 — the assumption being retroactively attested
- Related: PR-TOOL-EXEC-CONTEXT #1838, PR-ADAPTER-PATTERN-UNIFICATION #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)