### PR TITLE
fix(adapters): codex-oauth aweb_search honours Codex backend instructions + input-list constraints (PR-CODEX-INSTRUCTIONS-FIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,39 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-INSTRUCTIONS-FIX (2026-05-28)** — codex-oauth
+  ``aweb_search`` now satisfies two Codex-backend-specific call-shape
+  constraints discovered via PR-DOC-VERIFY's mandatory live test gate.
+  The PR-NO-FALLBACK initial impl reused the PAYG call shape, which
+  the Codex backend rejected with sequential 400s:
+
+  1. 1st live call → ``400 {'detail': 'Instructions are required'}``.
+     PAYG Responses API treats ``instructions`` as optional; Codex
+     backend enforces it as mandatory on every request (same constraint
+     :meth:`acomplete` already honours).
+  2. 2nd live call (after adding ``instructions``) → ``400 {'detail':
+     'Input must be a list'}``. PAYG accepts ``input`` as a plain
+     string OR typed-item array; Codex backend requires the typed-item
+     list shape (same constraint :meth:`acomplete` already honours via
+     :func:`build_codex_input`).
+  3. 3rd live call (after both fixes) → **200 OK** with real web
+     search results (OpenAI help-center URLs etc.), 11.2s response.
+
+  The docstring attestation flips from ``unverified — live test
+  required`` (PR-DOC-VERIFY) to ``verified live`` with the live-call
+  evidence cited. ``test_codex_oauth_adapter_advertises_web_search``
+  updated to pin the new ``verified live`` string so a future silent
+  docstring rewrite cannot strip the evidence trail.
+
+  **Demonstrates the value of CLAUDE.md §4d (doc-before-behaviour) +
+  PR-NO-FALLBACK's honest dispatch errors working together**: ctx7 was
+  ambiguous on backend acceptance → docstring marked ``unverified`` →
+  live test surfaced the actual constraints one at a time (each as a
+  clean ``AdapterDispatchError`` from the dispatch layer with the 400
+  body) → both fixed in a single follow-up PR → docstring flipped to
+  ``verified live`` with evidence.
+
 ### Changed
 - **PR-DOC-VERIFY (2026-05-28)** — workflow: doc-before-behaviour for
   external SDK / 3rd-party backend capability assumptions. New

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -60,28 +60,29 @@ class CodexOAuthAdapter:
     provider: str = "openai"
     source: str = SOURCE_SUBSCRIPTION
     billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION
-    # PR-NO-FALLBACK (2026-05-28) — web_search re-enabled. SDK-contract-
-    # level confirmation: openai-python SDK's ``ToolParam`` Union
-    # (``openai/types/responses/tool_param.py``) accepts
-    # ``{"type": "web_search"}`` independent of which Responses endpoint
-    # the client targets, and the Codex backend
-    # (chatgpt.com/backend-api/codex/responses) accepts the same
-    # ``tools`` array shape per ``codex-rs/codex-api/README.md::POST
-    # /responses``.
+    # PR-NO-FALLBACK (2026-05-28) — web_search re-enabled.
+    # PR-CODEX-INSTRUCTIONS-FIX (2026-05-28) — **verified live**: the
+    # Codex backend (``chatgpt.com/backend-api/codex/responses``) returns
+    # 200 OK to ``{"type": "web_search"}`` with real web search results
+    # (OpenAI help-center URLs etc.), confirmed via direct adapter call
+    # at 2026-05-28 14:50 KST (11.2s response). The live test revealed
+    # two backend-specific constraints that PAYG Responses API does NOT
+    # enforce — both now enforced in :meth:`aweb_search`:
     #
-    # ``unverified — live test required`` (CLAUDE.md §4d, PR-DOC-VERIFY
-    # 2026-05-28): ctx7 of ``/openai/codex`` does NOT document which
-    # ``type`` values the Codex backend actually accepts in the ``tools``
-    # array. The Codex CLI's own internal web search uses a DIFFERENT
-    # tool schema (``web_run`` ext at ``codex-rs/ext/web-search/``,
-    # ``{"search_query": [{"q": "..."}]}``) which suggests the hosted
-    # ``{"type": "web_search"}`` may not be available on the Codex
-    # backend. The strict-dispatch error contract (PR-NO-FALLBACK) is
-    # the operational safety net — if the backend rejects the tool the
-    # operator sees an honest ``AdapterDispatchError`` naming
-    # ``codex-oauth`` rather than a silent GLM fallback — but the True
-    # flag itself awaits a live web_search call confirmation before
-    # this assumption hardens into a stable contract.
+    #   1. ``instructions`` field mandatory — Codex backend returns 400
+    #      ``Instructions are required`` without it (PAYG treats it as
+    #      optional).
+    #   2. ``input`` must be a typed-item list, not a plain string —
+    #      Codex backend returns 400 ``Input must be a list`` for the
+    #      string form (PAYG accepts both shapes).
+    #
+    # SDK-contract evidence (workflow §4d doc-attestation): openai-python
+    # ``ToolParam`` Union (``openai/types/responses/tool_param.py``)
+    # accepts ``{"type": "web_search"}``; Codex CLI Responses endpoint
+    # accepts ``tools: array`` per ``codex-rs/codex-api/README.md::POST
+    # /responses``. SDK contract was the necessary upstream check; the
+    # two 400 responses + 200 OK after fixing proved the backend
+    # actually exposes the tool.
     supports_web_search: bool = True
     supports_text_completion: bool = True
     _last_error: Exception | None = field(default=None, init=False, repr=False)
@@ -246,12 +247,33 @@ class CodexOAuthAdapter:
         client = self._get_client()
         text_parts: list[str] = []
         source_urls: list[str] = []
+        # PR-CODEX-INSTRUCTIONS-FIX (2026-05-28) — live test progression:
+        #
+        # 1st attempt (PR-NO-FALLBACK initial) → 400 ``Instructions are
+        #    required``. Codex backend enforces ``instructions`` field
+        #    mandatory on every Responses request (mirrors :meth:`acomplete`
+        #    which threads the loop's system prompt into it).
+        # 2nd attempt (instructions added as string ``input``) → 400
+        #    ``Input must be a list``. Codex backend ALSO requires
+        #    ``input`` to be a typed-item array, same as :meth:`acomplete`
+        #    via :func:`build_codex_input`. The standard Responses API
+        #    accepts a plain string; Codex backend tightens the contract.
+        #
+        # Final shape — single user message wrapped in the typed-item array
+        # the backend expects (``{"role": "user", "content": "..."}`` is a
+        # valid entry per ``_convert_user_msg_to_responses``).
+        user_prompt = (
+            f"Search the web for: {query}. Return up to {max_results} relevant "
+            "results with titles, URLs, and brief summaries."
+        )
         kwargs = {
             "model": CODEX_PRIMARY,
-            "input": (
-                f"Search the web for: {query}. Return up to {max_results} relevant "
-                "results with titles, URLs, and brief summaries."
+            "instructions": (
+                "Use the web_search tool to find current information. "
+                "Return up to the requested number of relevant results with "
+                "titles, URLs, and brief summaries."
             ),
+            "input": [{"role": "user", "content": user_prompt}],
             "tools": [{"type": "web_search"}],
             "store": False,
         }

--- a/tests/test_adapter_capability_dispatch.py
+++ b/tests/test_adapter_capability_dispatch.py
@@ -164,14 +164,14 @@ def test_codex_oauth_adapter_advertises_web_search() -> None:
     conservative ``False`` was the root cause of the routing leak that
     landed web_search on ``glm-payg`` for Codex-OAuth operators.
 
-    PR-DOC-VERIFY (2026-05-28) — pins the ``unverified — live test
-    required`` attestation per CLAUDE.md §4d. The Codex backend's actual
-    acceptance of ``{"type": "web_search"}`` is undocumented in ctx7
-    (``/openai/codex`` enumerates the request shape but not valid tool
-    types; the Codex CLI's internal web search uses a different schema).
-    Behavioural confirmation requires a live call; this test pins the
-    docstring attestation so the assumption cannot harden into stable
-    contract through a silent docstring rewrite."""
+    PR-CODEX-INSTRUCTIONS-FIX (2026-05-28) — flipped the docstring
+    attestation from ``unverified — live test required`` to **verified
+    live** after the Codex backend returned 200 OK with real web search
+    results. Two backend-specific constraints (``instructions`` mandatory,
+    ``input`` typed-item list) the live test discovered are now enforced
+    in :meth:`aweb_search`. This test pins the verified attestation
+    string presence so a future silent docstring rewrite cannot drop
+    the evidence trail."""
     import inspect
 
     from core.llm.adapters.codex_oauth import CodexOAuthAdapter
@@ -184,12 +184,12 @@ def test_codex_oauth_adapter_advertises_web_search() -> None:
         "method-missing adapters with a warning."
     )
     src = inspect.getsource(CodexOAuthAdapter)
-    assert "unverified — live test required" in src, (
+    assert "verified live" in src, (
         "CodexOAuthAdapter.supports_web_search=True must carry the "
-        "``unverified — live test required`` attestation per CLAUDE.md §4d "
-        "(doc-before-behaviour). The flag was flipped True based on SDK "
-        "contract alone; Codex backend acceptance of the hosted web_search "
-        "tool is undocumented in ctx7 and requires live confirmation."
+        "``verified live`` attestation per CLAUDE.md §4d (doc-before-"
+        "behaviour). PR-CODEX-INSTRUCTIONS-FIX (2026-05-28) flipped the "
+        "docstring from ``unverified`` after the Codex backend returned "
+        "200 OK with real web search results."
     )
 
 


### PR DESCRIPTION
## Summary
- Live test (per CLAUDE.md §4d doc-before-behaviour gate) of PR-NO-FALLBACK's codex-oauth web_search surfaced two Codex-backend-specific call-shape constraints; both fixed → **200 OK with real web search results** from `chatgpt.com/backend-api/codex/responses`.
- Docstring attestation flipped from `unverified — live test required` (PR-DOC-VERIFY) to `verified live` with the live-call evidence documented.
- Demonstrates CLAUDE.md §4d + PR-NO-FALLBACK working together: ctx7 ambiguous → live test surfaced actual constraints one at a time as honest AdapterDispatchError messages → both fixed → verified.

## Why
PR-NO-FALLBACK Phase 1 enabled `codex_oauth.supports_web_search=True` based on SDK contract evidence (`ToolParam` Union accepts `{"type": "web_search"}`). PR-DOC-VERIFY's §4d marked this `unverified — live test required` because ctx7 didn't confirm Codex backend acceptance. First live call sequence:

```
1. POST chatgpt.com/backend-api/codex/responses → 400 {'detail': 'Instructions are required'}
2. After adding instructions  → 400 {'detail': 'Input must be a list'}
3. After wrapping input as list → 200 OK, 11.2s, real web search results
```

The reused PAYG `openai_web_search` helper didn't honour two Codex-backend constraints that `acomplete` already handles:
- **Constraint 1**: `instructions` field mandatory (PAYG: optional)
- **Constraint 2**: `input` must be typed-item list (PAYG: string OR list)

These mirror the same constraints `acomplete` honours via `_build_codex_call_kwargs` + `build_codex_input`. The PR-NO-FALLBACK initial impl mistakenly inlined a simpler call shape.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/codex_oauth.py::aweb_search` | Add `instructions` field (explicit web-search guidance) + wrap user prompt in `[{"role": "user", "content": prompt}]` typed-item array. Docstring rewritten to **verified live** with the 3-call evidence trail (400 → 400 → 200 OK) |
| `tests/test_adapter_capability_dispatch.py::test_codex_oauth_adapter_advertises_web_search` | Pin updated: `unverified — live test required` → `verified live` (matches new docstring attestation; future silent rewrite cannot drop the evidence trail) |
| `CHANGELOG.md` | [Unreleased] / Fixed entry above PR-DOC-VERIFY |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| instructions field added | Implemented | Mirror acomplete pattern |
| input typed-item list wrap | Implemented | Mirror build_codex_input pattern |
| Docstring attestation flip | Implemented | unverified → verified live with evidence |
| Test pin updated | Implemented | New string pinned |
| Live test passing | Verified | 200 OK 11.2s real results |

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` clean (1025 files)
- [x] `mypy core/ plugins/` clean (465 source files)
- [x] `test_codex_oauth_adapter_advertises_web_search` passes
- [x] **Live test (the gate from PR-DOC-VERIFY §4d)** — `chatgpt.com/backend-api/codex/responses` 200 OK in 11.2s with real web search results (OpenAI help-center URLs in the response text)

## Reference
- Predecessors: PR-NO-FALLBACK #1839 (assumption being verified), PR-DOC-VERIFY #1840 (the doc-attestation rule that required the live test)
- `acomplete` constraint reference: `core/llm/adapters/codex_oauth.py::_build_codex_call_kwargs` docstring (same 2 constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)