### PR TITLE
feat(observability): tool-result adapter inline + serve.log + CLI stats + session adapter usage (PR-DISPATCH-OBS-EXT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,58 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-DISPATCH-OBS-EXT (2026-05-28)** — four observability
+  enhancements layered on PR-NO-FALLBACK's strict-dispatch + per-attempt
+  hook. Operator-facing answer to "which adapter actually handled this
+  call?" without grep+timestamp cross-correlation.
+
+  1. **Tool result adapter inline** —
+     :class:`core.llm.adapters.base.WebSearchResult` +
+     :class:`TextCompletionResult` gain ``adapter_name`` /
+     ``adapter_provider`` / ``adapter_source`` fields (all ``str = ""``
+     defaults). ``dispatch.web_search_via_adapters`` +
+     ``dispatch.complete_text_via_adapters`` enrich via
+     ``dataclasses.replace`` after the capability impl returns — single
+     point of enrichment so the 4 web_search impls and 4 text_completion
+     impls don't all have to update. ``web_tools.py`` + ``web_search.py``
+     surface the new fields in the tool result dict; ``tool_exec_end``
+     metadata now carries them inline.
+
+  2. **Serve log file recovery** —
+     :func:`core.cli.typer_serve.serve` wires a ``RotatingFileHandler``
+     at ``~/.geode/logs/serve.log`` (10MB × 5 backups) with auto-mkdir.
+     The legacy serve.log writer was deleted in a prior v0.99.x cleanup;
+     ``cmd_lifecycle`` status was still pointing at
+     ``SERVE_LOG_PATH`` but nothing populated it. Restored so dispatch
+     INFO logs persist across serve restarts.
+
+  3. **CLI dispatch stats** — new ``geode adapters stats [--since 1h]
+     [--runs-dir DIR]`` reads ``ADAPTER_DISPATCH_ATTEMPT`` events from
+     ``~/.geode/runs/*.jsonl``, filters by time window, aggregates by
+     ``(capability, adapter_name, provider, source)`` into a dense table
+     with per-outcome counts (success / billing / transient / unavailable)
+     + p50/p95 latency. ``--since`` parser supports s/m/h/d/w suffixes.
+
+  4. **Session-end adapter usage** — new ``ContextVar`` per session;
+     ``begin_session_adapter_tracking`` (called by AgenticLoop at
+     SESSION_STARTED) resets it; ``_fire_attempt`` increments;
+     ``get_session_adapter_usage`` reads. ``_lifecycle.py`` emits
+     ``adapter_usage`` ``{adapter_name: {outcome: count}}`` into
+     SESSION_ENDED payload, then calls ``end_session_adapter_tracking``
+     to clear (Codex MCP audit catch — without the reset, a leaked
+     post-finalization dispatch would mutate a stale counter). Caveat
+     documented: TURN_COMPLETED hooks (e.g. ``turn_llm_extract``) fire
+     AFTER SESSION_ENDED is built, so their dispatch attempts are not
+     in this aggregate — they belong to turn_complete accounting.
+
+  Pinned by ``tests/test_dispatch_obs_ext.py`` (15 assertions:
+  dataclass field shape, single-point enrichment, counter accumulate,
+  outside-session empty, source-level pins for lifecycle + agent_loop +
+  tools + typer_serve, CLI stats parses jsonl + rejects malformed
+  --since + empty-window message, end_session_adapter_tracking clears
+  counter).
+
 ### Fixed
 - **PR-CODEX-INSTRUCTIONS-FIX (2026-05-28)** — codex-oauth
   ``aweb_search`` now satisfies two Codex-backend-specific call-shape

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -169,6 +169,30 @@ def _final_hook_payloads(
     if new_adapter is not None:
         adapter_type = str(getattr(new_adapter, "name", ""))
 
+    # PR-DISPATCH-OBS-EXT (2026-05-28) — read the per-session adapter
+    # usage counter (populated by dispatch._fire_attempt across the
+    # session's lifetime) and emit it inline. Operators see "this session
+    # routed N calls through codex-oauth (3 success, 1 transient) +
+    # 2 calls through glm-payg (2 success)" without having to parse the
+    # ADAPTER_DISPATCH_ATTEMPT event stream.
+    #
+    # Caveat — captures attempts up to SESSION_ENDED emission. TURN_COMPLETED
+    # hooks (e.g. ``turn_llm_extract`` calling complete_text_via_adapters)
+    # fire AFTER this payload is built, so their dispatch attempts are NOT
+    # in this aggregate. Acceptable: post-turn extraction belongs to
+    # ``turn_complete`` accounting, not session_end. Codex MCP audit
+    # 2026-05-28 — limitation documented.
+    #
+    # Reset to ``None`` after read so any leaked post-finalization
+    # dispatch (background async hook) doesn't mutate a stale counter.
+    from core.llm.adapters.dispatch import (
+        end_session_adapter_tracking,
+        get_session_adapter_usage,
+    )
+
+    adapter_usage = get_session_adapter_usage()
+    end_session_adapter_tracking()
+
     session_ended = {
         "model": loop.model,
         "provider": loop._provider,
@@ -182,6 +206,8 @@ def _final_hook_payloads(
         "component": component,
         "adapter_type": adapter_type,
         "claude_cli_session_id": getattr(loop, "_last_emitted_session_id", ""),
+        # PR-DISPATCH-OBS-EXT (2026-05-28) — per-session aggregate.
+        "adapter_usage": adapter_usage,
     }
     turn_completed = {
         "user_input": user_input,

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -831,6 +831,14 @@ class AgenticLoop:
             self._transcript.record_session_start(model=self.model, provider=self._provider)
             self._transcript.record_user_message(user_input)
 
+        # PR-DISPATCH-OBS-EXT (2026-05-28) — start a fresh per-session
+        # adapter usage counter so dispatch attempts during this session
+        # accumulate into a dict that SESSION_ENDED can emit as
+        # ``adapter_usage`` aggregate.
+        from core.llm.adapters.dispatch import begin_session_adapter_tracking
+
+        begin_session_adapter_tracking()
+
         # Hook: SESSION_START
         if self._hooks:
             await self._hooks.trigger_async(

--- a/core/cli/cmd_adapters.py
+++ b/core/cli/cmd_adapters.py
@@ -165,7 +165,11 @@ def adapters_stats(
                         continue
                     try:
                         d = json.loads(line)
-                    except Exception:  # noqa: S112 — malformed jsonl line, count + skip
+                    except json.JSONDecodeError:
+                        # Malformed jsonl line — count via rows_scanned, skip
+                        # rather than abort the whole window analysis. ruff
+                        # S112 / bandit B112 are satisfied by the narrow
+                        # exception type (not bare ``Exception``).
                         continue
                     if d.get("timestamp", 0) < cutoff:
                         continue

--- a/core/cli/cmd_adapters.py
+++ b/core/cli/cmd_adapters.py
@@ -6,7 +6,7 @@ v0.99.40 Follow-up D of the paperclip-style LLMAdapter abstraction
 PAYG / Subscription / Adapter paths are available + verify each path's
 environment before scheduling a seed-generation run.
 
-Two read-only subcommands:
+Three read-only subcommands:
 
 - ``geode adapters list`` — enumerate registered adapters with
   ``billing_type``, ``test_environment`` summary, and supported model
@@ -14,6 +14,12 @@ Two read-only subcommands:
 - ``geode adapters detect-model <adapter>`` — paperclip ``detectModel``
   equivalent; reports the currently configured model + provenance from
   the adapter's ``detect_credential()`` hook.
+- ``geode adapters stats [--since 1h]`` — aggregate
+  ``ADAPTER_DISPATCH_ATTEMPT`` hook events from ``~/.geode/runs/*.jsonl``
+  by ``(capability, adapter_name)`` with per-outcome counts + p50/p95
+  latency. Operators answer "what did dispatch actually route through in
+  the last N minutes?" without grepping jsonl by hand
+  (PR-DISPATCH-OBS-EXT 2026-05-28).
 
 UI: dense aligned table, plain text. No box-card / no emoji (per
 ``feedback_no_box_ui_no_emoji`` memory).
@@ -77,6 +83,142 @@ def adapters_detect_model(name: str) -> None:
     typer.echo(f"  source: {detection.source_path}")
     if detection.candidates:
         typer.echo(f"  candidates: {', '.join(detection.candidates)}")
+
+
+_SINCE_UNITS: dict[str, int] = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+
+def _parse_since(spec: str) -> int:
+    """Parse ``1h`` / ``30m`` / ``2d`` style window into seconds.
+
+    Raises ``typer.BadParameter`` on unparseable input — explicit failure
+    beats silently defaulting to "all of history" which could surface
+    weeks-old data with no warning.
+    """
+    spec = spec.strip().lower()
+    if not spec:
+        raise typer.BadParameter("--since cannot be empty (e.g. 1h, 30m, 24h, 7d)")
+    unit = spec[-1]
+    if unit not in _SINCE_UNITS:
+        raise typer.BadParameter(
+            f"--since unit {unit!r} not recognized. Use s/m/h/d/w (e.g. 1h, 30m, 7d)."
+        )
+    try:
+        magnitude = int(spec[:-1])
+    except ValueError as exc:
+        raise typer.BadParameter(
+            f"--since magnitude {spec[:-1]!r} not a number (e.g. 1h, 30m)"
+        ) from exc
+    return magnitude * _SINCE_UNITS[unit]
+
+
+@app.command("stats")
+def adapters_stats(
+    since: str = typer.Option(
+        "1h", "--since", help="Time window (1h / 30m / 24h / 7d). Default: 1h."
+    ),
+    runs_dir: str = typer.Option(
+        "",
+        "--runs-dir",
+        help="Override runs directory. Defaults to ~/.geode/runs/.",
+    ),
+) -> None:
+    """Aggregate ADAPTER_DISPATCH_ATTEMPT events from ``~/.geode/runs/*.jsonl``
+    by ``(capability, adapter_name)``.
+
+    PR-DISPATCH-OBS-EXT (2026-05-28) — operator-facing answer to "what
+    did dispatch actually route through in the last N minutes/hours/days?"
+    without having to grep through jsonl manually. Reads only the
+    structured ``ADAPTER_DISPATCH_ATTEMPT`` rows the dispatch layer
+    emits — no LLM call needed.
+    """
+    import json
+    import time
+    from pathlib import Path
+
+    window_s = _parse_since(since)
+    cutoff = time.time() - window_s
+
+    if runs_dir:
+        runs_path = Path(runs_dir).expanduser()
+    else:
+        from core.paths import GLOBAL_RUNS_DIR
+
+        runs_path = GLOBAL_RUNS_DIR
+    if not runs_path.exists():
+        typer.echo(f"runs dir not found: {runs_path}")
+        raise typer.Exit(code=1)
+
+    # Key = (capability, adapter_name, provider, source) → list of (outcome, elapsed_ms)
+    buckets: dict[tuple[str, str, str, str], list[tuple[str, float]]] = {}
+    rows_scanned = 0
+    for jsonl in sorted(runs_path.glob("*.jsonl")):
+        try:
+            with jsonl.open(encoding="utf-8") as fh:
+                for line in fh:
+                    rows_scanned += 1
+                    # Cheap pre-filter — production gateway uses compact
+                    # ``json.dumps`` (no spaces) but test-injected fixtures
+                    # often use the default spaced form. Match the event
+                    # name only, both forms include it.
+                    if "adapter_dispatch_attempt" not in line:
+                        continue
+                    try:
+                        d = json.loads(line)
+                    except Exception:  # noqa: S112 — malformed jsonl line, count + skip
+                        continue
+                    if d.get("timestamp", 0) < cutoff:
+                        continue
+                    md = d.get("metadata", {}) or {}
+                    key = (
+                        str(md.get("capability", "")),
+                        str(md.get("adapter_name", "")),
+                        str(md.get("provider", "")),
+                        str(md.get("source", "")),
+                    )
+                    buckets.setdefault(key, []).append(
+                        (str(md.get("outcome", "")), float(md.get("elapsed_ms", 0.0)))
+                    )
+        except OSError:
+            continue
+
+    if not buckets:
+        n_files = len(list(runs_path.glob("*.jsonl")))
+        typer.echo(f"No ADAPTER_DISPATCH_ATTEMPT events in {runs_path} within --since {since}.")
+        typer.echo(f"  (scanned {rows_scanned} jsonl rows across {n_files} files)")
+        raise typer.Exit()
+
+    header = (
+        f"{'CAPABILITY':<28} {'ADAPTER':<20} {'PROVIDER':<10} {'SOURCE':<14} "
+        f"{'TOTAL':>6} {'OK':>6} {'BIL':>5} {'TRN':>5} {'UNV':>5} {'p50':>9} {'p95':>9}"
+    )
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    sorted_keys = sorted(buckets.keys())
+    for key in sorted_keys:
+        capability, adapter_name, provider, source = key
+        attempts = buckets[key]
+        n = len(attempts)
+        outcomes: dict[str, int] = {}
+        for outcome, _ in attempts:
+            outcomes[outcome] = outcomes.get(outcome, 0) + 1
+        success = outcomes.get("success", 0)
+        billing = outcomes.get("billing", 0)
+        transient = outcomes.get("transient", 0)
+        unavailable = outcomes.get("unavailable", 0)
+        elapsed_sorted = sorted(e for _, e in attempts)
+        p50 = elapsed_sorted[len(elapsed_sorted) // 2]
+        p95_idx = min(len(elapsed_sorted) - 1, int(len(elapsed_sorted) * 0.95))
+        p95 = elapsed_sorted[p95_idx]
+        typer.echo(
+            f"{capability:<28} {adapter_name:<20} {provider:<10} {source:<14} "
+            f"{n:>6d} {success:>6d} {billing:>5d} {transient:>5d} {unavailable:>5d} "
+            f"{p50:>7.0f}ms {p95:>7.0f}ms"
+        )
+    typer.echo(
+        f"\n{sum(len(v) for v in buckets.values())} dispatch attempt(s) across "
+        f"{len(buckets)} (capability,adapter) bucket(s), window=--since {since}."
+    )
 
 
 __all__ = ["app"]

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -33,10 +33,36 @@ def serve(
     import signal
     import time as _time
 
-    _logging.basicConfig(
-        level=_logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    # PR-DISPATCH-OBS-EXT (2026-05-28) — restore serve.log file handler.
+    # The legacy serve.log path (``~/.geode/logs/serve.log``) was deleted
+    # at some point in the v0.99.x cleanup. Without a file handler the
+    # INFO-level dispatch events (per-attempt observability from
+    # PR-NO-FALLBACK) only go to stdout, lost on serve restart. The
+    # ``cmd_lifecycle`` status command also depends on SERVE_LOG_PATH
+    # existing (``cmd_lifecycle.py:319``).
+    from logging.handlers import RotatingFileHandler
+
+    from core.paths import SERVE_LOG_PATH
+
+    SERVE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _fmt = _logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    _file_handler = RotatingFileHandler(
+        SERVE_LOG_PATH, maxBytes=10 * 1024 * 1024, backupCount=5, encoding="utf-8"
     )
+    _file_handler.setLevel(_logging.INFO)
+    _file_handler.setFormatter(_fmt)
+    _stream_handler = _logging.StreamHandler()
+    _stream_handler.setLevel(_logging.INFO)
+    _stream_handler.setFormatter(_fmt)
+    _root = _logging.getLogger()
+    _root.setLevel(_logging.INFO)
+    # Replace any pre-existing handlers (basicConfig may have been invoked
+    # earlier by an imported module) so we don't double-log.
+    for _h in list(_root.handlers):
+        _root.removeHandler(_h)
+    _root.addHandler(_file_handler)
+    _root.addHandler(_stream_handler)
+    log.info("serve.log opened: %s (10MB x5 rotation)", SERVE_LOG_PATH)
 
     # ContextVars only (memory, profile, env) — no resource creation
     from core.cli.bootstrap import setup_contextvars

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -345,20 +345,41 @@ class WebSearchResult:
     brief blurbs). ``source_urls`` is the extracted URL list when the provider
     exposes it (Anthropic ``web_search_tool_result`` blocks); other providers
     leave it empty.
+
+    ``adapter_name`` / ``adapter_provider`` / ``adapter_source`` carry the
+    routing identity forward into the tool layer so the tool's
+    ``tool_exec_end`` metadata can answer "which adapter handled this"
+    inline — operators no longer need to cross-correlate by timestamp
+    with ``ADAPTER_DISPATCH_ATTEMPT`` events
+    (PR-DISPATCH-OBS-EXT 2026-05-28). The fields default to empty
+    strings so existing capability impls (which set only ``adapter_name``)
+    still build a valid result; the dispatch layer enriches them with
+    the selected adapter's ``provider`` / ``source`` after a successful
+    call.
     """
 
     query: str
     text: str
     source_urls: tuple[str, ...] = ()
     adapter_name: str = ""
+    adapter_provider: str = ""
+    adapter_source: str = ""
 
 
 @dataclass(frozen=True)
 class TextCompletionResult:
-    """Single-turn text completion result — used by compaction / extraction."""
+    """Single-turn text completion result — used by compaction / extraction.
+
+    Same adapter-identity fields as :class:`WebSearchResult` for the same
+    reason (PR-DISPATCH-OBS-EXT 2026-05-28) — the compaction / extraction
+    callers can now record which adapter actually handled the call.
+    """
 
     text: str
     usage: UsageSummary
+    adapter_name: str = ""
+    adapter_provider: str = ""
+    adapter_source: str = ""
 
 
 @runtime_checkable

--- a/core/llm/adapters/dispatch.py
+++ b/core/llm/adapters/dispatch.py
@@ -42,8 +42,10 @@ journals so operators can trace exactly which adapter was tried.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import time
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
@@ -58,6 +60,62 @@ log = logging.getLogger(__name__)
 
 
 _DEFAULT_PROVIDER_ORDER: tuple[str, ...] = ("anthropic", "openai", "glm")
+
+
+# ---------------------------------------------------------------------------
+# Per-session adapter usage counter — PR-DISPATCH-OBS-EXT (2026-05-28)
+# ---------------------------------------------------------------------------
+#
+# A ContextVar holding an ``{adapter_name: {outcome: count}}`` map. Set fresh
+# at session start (via :func:`begin_session_adapter_tracking`), incremented
+# inside :func:`_fire_attempt`, read at session end (via
+# :func:`get_session_adapter_usage`) so the SESSION_ENDED hook payload can
+# carry an aggregate breakdown of which adapter handled how many calls and
+# with what outcome — the operator-facing answer to "what did this session
+# actually route through" in one row, not N rows.
+#
+# Defaults to ``None`` so dispatches outside an AgenticLoop session (CLI
+# helpers, tests, hooks running between sessions) silently skip the
+# accumulation — the per-attempt hook + INFO log remain the universal
+# observability surface.
+
+_session_adapter_usage_ctx: ContextVar[dict[str, dict[str, int]] | None] = ContextVar(
+    "session_adapter_usage", default=None
+)
+
+
+def begin_session_adapter_tracking() -> None:
+    """Reset the session-scoped adapter usage counter.
+
+    Called once by :class:`AgenticLoop` at session start so dispatch
+    attempts during this session accumulate into a fresh dict that
+    SESSION_ENDED can emit.
+    """
+    _session_adapter_usage_ctx.set({})
+
+
+def get_session_adapter_usage() -> dict[str, dict[str, int]]:
+    """Return the current session's adapter usage breakdown.
+
+    Empty dict when called outside a tracked session — safe for callers
+    that emit unconditionally.
+    """
+    counter = _session_adapter_usage_ctx.get()
+    return dict(counter) if counter is not None else {}
+
+
+def end_session_adapter_tracking() -> None:
+    """Clear the per-session counter back to ``None`` (Codex MCP audit
+    2026-05-28).
+
+    Called by the lifecycle helper AFTER it has read the final breakdown
+    via :func:`get_session_adapter_usage` so any stray dispatch that
+    fires in the same context after session finalisation (background
+    hook task, leaked async coroutine) does not mutate a stale counter
+    that no longer corresponds to an active session.
+    """
+    _session_adapter_usage_ctx.set(None)
+
 
 _SOURCE_SWITCH_HINT = (
     "Switch credential source explicitly via /login: "
@@ -228,14 +286,25 @@ def _registered_adapter_summary() -> str:
 
 
 def _fire_attempt(attempt: AdapterAttempt) -> None:
-    """Fire ``ADAPTER_DISPATCH_ATTEMPT`` hook + INFO log.
+    """Fire ``ADAPTER_DISPATCH_ATTEMPT`` hook + INFO log + accumulate
+    per-session counter.
 
     Hook payload mirrors :class:`AdapterAttempt` fields so journal /
     serve-log writers see a single structured row per attempt. Hook
     failures must not poison dispatch — :func:`fire_hook` swallows
     handler errors at DEBUG; the surrounding try guards module-load
     edge cases (router hooks not yet wired).
+
+    PR-DISPATCH-OBS-EXT (2026-05-28) — also increments the per-session
+    ``_session_adapter_usage_ctx`` counter so SESSION_ENDED can surface
+    an aggregate ``{adapter_name: {outcome: count}}`` breakdown without
+    requiring the lifecycle helper to re-parse the per-attempt event
+    stream.
     """
+    counter = _session_adapter_usage_ctx.get()
+    if counter is not None:
+        bucket = counter.setdefault(attempt.adapter_name, {})
+        bucket[attempt.outcome] = bucket.get(attempt.outcome, 0) + 1
     log.info(
         "dispatch[%s] %s (%s/%s) → %s in %.0fms%s",
         attempt.capability,
@@ -385,7 +454,16 @@ async def web_search_via_adapters(
             elapsed_ms=elapsed_ms,
         )
     )
-    return result
+    # PR-DISPATCH-OBS-EXT (2026-05-28) — enrich the result with the selected
+    # adapter's identity so the tool layer can surface it inline in
+    # ``tool_exec_end`` metadata. Single-point enrichment avoids touching
+    # every capability impl in :mod:`_capability_impls`.
+    return dataclasses.replace(
+        result,
+        adapter_name=adapter.name,
+        adapter_provider=adapter.provider,
+        adapter_source=adapter.source,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -513,13 +591,25 @@ async def complete_text_via_adapters(
             elapsed_ms=elapsed_ms,
         )
     )
-    return result
+    # PR-DISPATCH-OBS-EXT (2026-05-28) — mirror the web_search enrichment so
+    # text-completion callers (compaction / extraction / context-exhausted)
+    # can record which adapter handled the call without re-querying the
+    # registry.
+    return dataclasses.replace(
+        result,
+        adapter_name=adapter.name,
+        adapter_provider=adapter.provider,
+        adapter_source=adapter.source,
+    )
 
 
 __all__ = [
     "AdapterAttempt",
     "AdapterDispatchError",
     "AdapterUnavailableError",
+    "begin_session_adapter_tracking",
     "complete_text_via_adapters",
+    "end_session_adapter_tracking",
+    "get_session_adapter_usage",
     "web_search_via_adapters",
 ]

--- a/core/tools/web_search.py
+++ b/core/tools/web_search.py
@@ -124,6 +124,9 @@ class WebSearchTool:
                 "search_results": result.text,
                 "source": result.adapter_name,
                 "source_urls": list(result.source_urls),
+                # PR-DISPATCH-OBS-EXT (2026-05-28) — see GeneralWebSearchTool
+                "adapter_provider": result.adapter_provider,
+                "adapter_source": result.adapter_source,
             }
         }
 

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -218,6 +218,12 @@ class GeneralWebSearchTool:
                 "search_results": result.text,
                 "source": result.adapter_name,
                 "source_urls": list(result.source_urls),
+                # PR-DISPATCH-OBS-EXT (2026-05-28) — inline adapter
+                # provider + source so ``tool_exec_end`` metadata answers
+                # "which adapter handled this" without operators having to
+                # cross-correlate by timestamp with ADAPTER_DISPATCH_ATTEMPT.
+                "adapter_provider": result.adapter_provider,
+                "adapter_source": result.adapter_source,
             }
         }
 

--- a/tests/test_dispatch_obs_ext.py
+++ b/tests/test_dispatch_obs_ext.py
@@ -1,0 +1,365 @@
+"""Regression pin for PR-DISPATCH-OBS-EXT (2026-05-28).
+
+Four observability enhancements layered on top of PR-NO-FALLBACK's
+strict-dispatch + ADAPTER_DISPATCH_ATTEMPT hook:
+
+1. ``WebSearchResult`` / ``TextCompletionResult`` carry the selected
+   adapter's identity inline (``adapter_name`` / ``adapter_provider`` /
+   ``adapter_source``) — single-point enrichment at the dispatch layer.
+2. ``begin_session_adapter_tracking`` + ``get_session_adapter_usage``
+   provide a per-session ``{adapter_name: {outcome: count}}`` aggregate
+   that ``SESSION_ENDED`` emits inline.
+3. ``geode adapters stats`` CLI parses ``ADAPTER_DISPATCH_ATTEMPT``
+   events from ``~/.geode/runs/*.jsonl`` into a (capability, adapter)
+   table with per-outcome counts + p50/p95 latency.
+4. ``typer_serve`` restores the ``RotatingFileHandler`` at
+   ``SERVE_LOG_PATH`` so the dispatch INFO logs land in
+   ``~/.geode/logs/serve.log`` (file recovery; serve startup writes
+   "serve.log opened" at INFO).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Result dataclasses carry adapter identity fields
+# ---------------------------------------------------------------------------
+
+
+def test_web_search_result_carries_adapter_identity_fields() -> None:
+    import dataclasses
+
+    from core.llm.adapters.base import WebSearchResult
+
+    fields = {f.name for f in dataclasses.fields(WebSearchResult)}
+    assert {"adapter_name", "adapter_provider", "adapter_source"}.issubset(fields)
+
+    result = WebSearchResult(
+        query="q",
+        text="hello",
+        adapter_name="codex-oauth",
+        adapter_provider="openai",
+        adapter_source="subscription",
+    )
+    assert result.adapter_provider == "openai"
+    assert result.adapter_source == "subscription"
+
+
+def test_text_completion_result_carries_adapter_identity_fields() -> None:
+    import dataclasses
+
+    from core.llm.adapters.base import TextCompletionResult, UsageSummary
+
+    fields = {f.name for f in dataclasses.fields(TextCompletionResult)}
+    assert {"adapter_name", "adapter_provider", "adapter_source"}.issubset(fields)
+
+    result = TextCompletionResult(
+        text="hello",
+        usage=UsageSummary(input_tokens=1, output_tokens=2),
+        adapter_name="anthropic-payg",
+        adapter_provider="anthropic",
+        adapter_source="payg",
+    )
+    assert result.adapter_provider == "anthropic"
+    assert result.adapter_source == "payg"
+
+
+def test_dispatch_enriches_web_search_result_with_adapter_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-point enrichment: even when the capability impl forgets to
+    fill ``adapter_provider`` / ``adapter_source``, ``dispatch`` overwrites
+    them with the selected adapter's identity before returning."""
+    from core.llm.adapters.base import WebSearchResult
+    from core.llm.adapters.dispatch import web_search_via_adapters
+
+    adapter = MagicMock(
+        spec_set=["name", "provider", "source", "supports_web_search", "aweb_search"]
+    )
+    adapter.name = "codex-oauth"
+    adapter.provider = "openai"
+    adapter.source = "subscription"
+    adapter.supports_web_search = True
+    adapter.aweb_search = AsyncMock(
+        return_value=WebSearchResult(query="q", text="hello", adapter_name="codex-oauth")
+    )
+    monkeypatch.setattr("core.llm.adapters.dispatch.list_adapters", lambda: [adapter])
+    monkeypatch.setattr(
+        "core.llm.adapters._source_inference.infer_source", lambda provider: "subscription"
+    )
+
+    result = asyncio.run(
+        web_search_via_adapters("q", prefer_provider="openai", prefer_source="subscription")
+    )
+    assert result.adapter_name == "codex-oauth"
+    assert result.adapter_provider == "openai"
+    assert result.adapter_source == "subscription"
+
+
+# ---------------------------------------------------------------------------
+# 2. Per-session adapter usage counter
+# ---------------------------------------------------------------------------
+
+
+def test_session_adapter_usage_accumulates_across_dispatch_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``begin_session_adapter_tracking`` resets the counter; subsequent
+    dispatch attempts increment it; ``get_session_adapter_usage`` returns
+    the accumulated breakdown by ``{adapter_name: {outcome: count}}``."""
+    from core.llm.adapters.base import WebSearchResult
+    from core.llm.adapters.dispatch import (
+        begin_session_adapter_tracking,
+        get_session_adapter_usage,
+        web_search_via_adapters,
+    )
+    from core.llm.errors import BillingError
+
+    adapter_ok = MagicMock(
+        spec_set=["name", "provider", "source", "supports_web_search", "aweb_search"]
+    )
+    adapter_ok.name = "codex-oauth"
+    adapter_ok.provider = "openai"
+    adapter_ok.source = "subscription"
+    adapter_ok.supports_web_search = True
+    adapter_ok.aweb_search = AsyncMock(
+        return_value=WebSearchResult(query="q", text="ok", adapter_name="codex-oauth")
+    )
+
+    adapter_bill = MagicMock(
+        spec_set=["name", "provider", "source", "supports_web_search", "aweb_search"]
+    )
+    adapter_bill.name = "anthropic-payg"
+    adapter_bill.provider = "anthropic"
+    adapter_bill.source = "payg"
+    adapter_bill.supports_web_search = True
+    adapter_bill.aweb_search = AsyncMock(side_effect=BillingError("quota", provider="anthropic"))
+
+    monkeypatch.setattr(
+        "core.llm.adapters.dispatch.list_adapters", lambda: [adapter_ok, adapter_bill]
+    )
+    monkeypatch.setattr("core.llm.adapters._source_inference.infer_source", lambda provider: "payg")
+
+    begin_session_adapter_tracking()
+    assert get_session_adapter_usage() == {}
+
+    asyncio.run(
+        web_search_via_adapters("q", prefer_provider="openai", prefer_source="subscription")
+    )
+    asyncio.run(
+        web_search_via_adapters("q", prefer_provider="openai", prefer_source="subscription")
+    )
+    with pytest.raises(BillingError):
+        asyncio.run(web_search_via_adapters("q", prefer_provider="anthropic", prefer_source="payg"))
+
+    usage = get_session_adapter_usage()
+    assert usage == {
+        "codex-oauth": {"success": 2},
+        "anthropic-payg": {"billing": 1},
+    }
+
+
+def test_session_adapter_usage_returns_empty_outside_tracked_session() -> None:
+    """Dispatches outside a tracked session (CLI helpers, tests that don't
+    call ``begin_session_adapter_tracking``) silently skip accumulation."""
+    from contextvars import Context
+
+    from core.llm.adapters.dispatch import get_session_adapter_usage
+
+    # Fresh Context() inherits no values — every ContextVar reads its default.
+    ctx = Context()
+    result = ctx.run(get_session_adapter_usage)
+    assert result == {}
+
+
+def test_session_end_payload_includes_adapter_usage() -> None:
+    """Source-level pin: ``_build_lifecycle_payloads`` reads
+    ``get_session_adapter_usage`` and emits ``adapter_usage`` into the
+    SESSION_ENDED metadata."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "_lifecycle.py"
+    ).read_text(encoding="utf-8")
+    assert "get_session_adapter_usage" in src
+    assert '"adapter_usage": adapter_usage' in src
+
+
+def test_agentic_loop_starts_session_adapter_tracking() -> None:
+    """Source-level pin: AgenticLoop calls ``begin_session_adapter_tracking``
+    at session start so the SESSION_ENDED payload has a populated counter."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+    assert "begin_session_adapter_tracking()" in src
+
+
+def test_lifecycle_resets_tracking_after_session_end() -> None:
+    """Codex MCP audit catch — without an explicit ``end_session_adapter_tracking``
+    call after the SESSION_ENDED payload is built, any post-finalization
+    dispatch leaked into the same context would mutate a stale counter.
+    Source-level pin so the reset cannot be silently dropped."""
+    src = (
+        Path(__file__).resolve().parents[1] / "core" / "agent" / "loop" / "_lifecycle.py"
+    ).read_text(encoding="utf-8")
+    assert "end_session_adapter_tracking" in src
+
+
+def test_end_session_adapter_tracking_clears_counter() -> None:
+    """After ``end_session_adapter_tracking``, ``get_session_adapter_usage``
+    returns empty even if the counter had values."""
+    from core.llm.adapters.dispatch import (
+        begin_session_adapter_tracking,
+        end_session_adapter_tracking,
+        get_session_adapter_usage,
+    )
+
+    begin_session_adapter_tracking()
+    # Simulate an attempt landing in the counter.
+    from core.llm.adapters.dispatch import _session_adapter_usage_ctx
+
+    counter = _session_adapter_usage_ctx.get()
+    assert counter is not None
+    counter.setdefault("test-adapter", {})["success"] = 1
+    assert get_session_adapter_usage() == {"test-adapter": {"success": 1}}
+    end_session_adapter_tracking()
+    assert get_session_adapter_usage() == {}
+
+
+# ---------------------------------------------------------------------------
+# 3. CLI `geode adapters stats` parses jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_adapters_stats_parses_dispatch_attempts_from_jsonl(tmp_path: Path) -> None:
+    """End-to-end: write a synthetic ADAPTER_DISPATCH_ATTEMPT jsonl,
+    invoke the CLI command, parse the table from stdout."""
+    import time
+
+    from core.cli.cmd_adapters import app
+    from typer.testing import CliRunner
+
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    jsonl = runs_dir / "test.jsonl"
+
+    now = time.time()
+    events = [
+        {
+            "event": "adapter_dispatch_attempt",
+            "timestamp": now - 60,  # 1 min ago — inside --since 1h window
+            "metadata": {
+                "adapter_name": "codex-oauth",
+                "provider": "openai",
+                "source": "subscription",
+                "capability": "supports_web_search",
+                "outcome": "success",
+                "elapsed_ms": 11184.0,
+            },
+        },
+        {
+            "event": "adapter_dispatch_attempt",
+            "timestamp": now - 30,
+            "metadata": {
+                "adapter_name": "glm-payg",
+                "provider": "glm",
+                "source": "payg",
+                "capability": "supports_text_completion",
+                "outcome": "billing",
+                "elapsed_ms": 250.0,
+            },
+        },
+        # Outside window — should NOT appear in the --since 1h slice
+        {
+            "event": "adapter_dispatch_attempt",
+            "timestamp": now - 7200,  # 2h ago
+            "metadata": {
+                "adapter_name": "glm-payg",
+                "provider": "glm",
+                "source": "payg",
+                "capability": "supports_text_completion",
+                "outcome": "success",
+                "elapsed_ms": 100.0,
+            },
+        },
+    ]
+    jsonl.write_text("\n".join(json.dumps(e) for e in events), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--since", "1h", "--runs-dir", str(runs_dir)])
+    assert result.exit_code == 0, result.output
+    assert "codex-oauth" in result.output
+    assert "supports_web_search" in result.output
+    assert "glm-payg" in result.output
+    assert "supports_text_completion" in result.output
+    # Total = 2 (in-window), not 3 (the 2h-old event filtered out)
+    assert "2 dispatch attempt" in result.output
+
+
+def test_adapters_stats_rejects_malformed_since() -> None:
+    from core.cli.cmd_adapters import app
+    from typer.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--since", "1x"])
+    assert result.exit_code != 0
+    assert "unit" in result.output.lower()
+
+
+def test_adapters_stats_empty_window_message(tmp_path: Path) -> None:
+    """When the window has zero events, the CLI prints a no-match message
+    + the number of rows it scanned."""
+    from core.cli.cmd_adapters import app
+    from typer.testing import CliRunner
+
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "empty.jsonl").write_text("", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--since", "1h", "--runs-dir", str(runs_dir)])
+    assert result.exit_code == 0
+    assert "No ADAPTER_DISPATCH_ATTEMPT events" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 4. typer_serve wires RotatingFileHandler at SERVE_LOG_PATH
+# ---------------------------------------------------------------------------
+
+
+def test_typer_serve_wires_rotating_file_handler_for_serve_log() -> None:
+    """Source-level pin: ``serve`` opens a RotatingFileHandler at
+    ``SERVE_LOG_PATH`` with 10MB / 5-backup rotation so dispatch INFO
+    logs persist across serve restarts."""
+    src = inspect.getsource(__import__("core.cli.typer_serve", fromlist=["serve"]).serve)
+    assert "RotatingFileHandler" in src
+    assert "SERVE_LOG_PATH" in src
+    assert "10 * 1024 * 1024" in src
+    assert "backupCount=5" in src
+    assert "mkdir(parents=True, exist_ok=True)" in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Tool result inlines adapter_provider / adapter_source
+# ---------------------------------------------------------------------------
+
+
+def test_web_tools_general_web_search_surfaces_adapter_identity() -> None:
+    src = (Path(__file__).resolve().parents[1] / "core" / "tools" / "web_tools.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"adapter_provider": result.adapter_provider' in src
+    assert '"adapter_source": result.adapter_source' in src
+
+
+def test_web_search_tool_surfaces_adapter_identity() -> None:
+    src = (Path(__file__).resolve().parents[1] / "core" / "tools" / "web_search.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"adapter_provider": result.adapter_provider' in src
+    assert '"adapter_source": result.adapter_source' in src


### PR DESCRIPTION
## Summary
Four operator-facing observability enhancements layered on PR-NO-FALLBACK's strict-dispatch + ADAPTER_DISPATCH_ATTEMPT hook. Operator answer to "which adapter actually handled this call?" without timestamp cross-correlation.

## Why
PR-NO-FALLBACK shipped per-attempt observability (`ADAPTER_DISPATCH_ATTEMPT` hook + INFO log), but operator-side analysis still required:
- grep through `~/.geode/runs/*.jsonl` to cross-correlate `tool_exec_end` (no adapter info) with `adapter_dispatch_attempt` (no tool name) by timestamp
- INFO logs only went to stdout — `~/.geode/logs/serve.log` was deleted in a prior v0.99.x cleanup but `cmd_lifecycle` status still pointed at the path
- No CLI command to view recent dispatch activity at a glance
- No per-session aggregate breakdown — operator had to sum events themselves

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/base.py::WebSearchResult` + `TextCompletionResult` | +3 fields each: `adapter_name` / `adapter_provider` / `adapter_source` (all `str = ""` defaults — back-compat with existing constructors) |
| `core/llm/adapters/dispatch.py` | Single-point enrichment via `dataclasses.replace` after capability impl returns; new `_session_adapter_usage_ctx: ContextVar`; `_fire_attempt` increments counter; new `begin_session_adapter_tracking` / `get_session_adapter_usage` / `end_session_adapter_tracking` helpers |
| `core/cli/typer_serve.py::serve` | Wires `RotatingFileHandler` at `SERVE_LOG_PATH` (10MB × 5 backups) with `parents=True, exist_ok=True` mkdir; replaces existing root handlers to avoid double-log |
| `core/cli/cmd_adapters.py` | New `geode adapters stats [--since 1h] [--runs-dir DIR]` — reads `*.jsonl`, filters by event name + time window, aggregates `(capability, adapter, provider, source)` → table with counts per outcome + p50/p95 latency. `_parse_since` supports s/m/h/d/w suffixes; `typer.BadParameter` on malformed |
| `core/agent/loop/agent_loop.py` | Calls `begin_session_adapter_tracking()` right before SESSION_STARTED hook |
| `core/agent/loop/_lifecycle.py::_final_hook_payloads` | Reads `get_session_adapter_usage()` → emits `adapter_usage` in SESSION_ENDED payload; calls `end_session_adapter_tracking()` after read (Codex MCP audit catch) |
| `core/tools/web_tools.py` + `core/tools/web_search.py` | Tool result dict includes `adapter_provider` + `adapter_source` |
| `tests/test_dispatch_obs_ext.py` | NEW — 15 assertions covering dataclass field shape, dispatch enrichment, counter accumulate + reset + outside-session empty, lifecycle source pins, CLI stats parse + window filter + malformed input + empty window message, typer_serve source pin |
| `CHANGELOG.md` | [Unreleased] / Added entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Tool result adapter inline | Implemented | dispatch enriches via dataclasses.replace |
| Serve log file recovery | Implemented | RotatingFileHandler 10MB × 5 |
| CLI stats command | Implemented | `geode adapters stats --since 1h` |
| Session-end adapter usage | Implemented | + end_session_adapter_tracking reset (Codex MCP CONCERN fix) |
| TURN_COMPLETED post-payload caveat | Documented | not in scope to re-architect |

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` clean (1026 files)
- [x] `mypy core/ plugins/` clean (465 source files)
- [x] `test_dispatch_obs_ext.py` 15/15 pass
- [x] Full suite (excl. petri_audit + env-only) — 3 pre-existing `test_seed_eval_export` failures (per memory `project_session65_deferred_followup`), no new failures
- [x] Live `geode adapters stats --since 24h` ran against `~/.geode/runs/` and produced actual stats from PR-NO-FALLBACK's existing dispatch events
- [x] **Codex MCP audit** — no BLOCKER. 1 CONCERN (counter not reset → stale state risk + TURN_COMPLETED timing) fixed via `end_session_adapter_tracking` + documented caveat. 1 NIT (duplicate dataclasses import) removed.

## Reference
- Predecessors: PR-NO-FALLBACK #1839 (the dispatch observability foundation), PR-CODEX-INSTRUCTIONS-FIX #1841 (live test that proved dispatch error contract works)
- Operator request: "phase 2 관측성 추가 부탁해" — all 4 selected dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)