### PR TITLE
fix(adapters): disable httpx keep-alive for Codex backend (PR-CODEX-NO-KEEPALIVE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,50 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+- **PR-CODEX-NO-KEEPALIVE (2026-05-28)** — Codex backend
+  (``chatgpt.com/backend-api/codex/responses``) first-call-after-idle
+  ``APIConnectionError`` eliminated by disabling httpx keep-alive
+  reuse for the Codex OAuth client specifically.
+
+  **Diagnosed via PR-DISPATCH-OBS-EXT observability**:
+  ``adapter_dispatch_attempt`` events in
+  ``~/.geode/runs/subject_gateway_analysis.jsonl`` showed a clean
+  pattern at 2026-05-28 15:44:37 KST (run_id ``f6c51cc5e18d``) — 4
+  parallel ``general_web_search`` calls fired in 4 ms. First call
+  hit ``APIConnectionError`` in **4 ms** (no network roundtrip).
+  Next 3 calls succeeded in 12 / 19 / ~unknown s. Root cause: a
+  previous ``gpt-5.5`` LLM call (8.3 s) had left an idle HTTP/2
+  connection in httpx's keep-alive pool. The Codex backend closes
+  idle connections aggressively (sub-second to a few-second window)
+  without a GOAWAY frame the client can observe in time. The first
+  ``web_search`` reused the now-stale pooled connection → ``httpx
+  .WriteError`` → openai SDK ``APIConnectionError`` instantly.
+  Subsequent calls opened fresh connections and succeeded.
+
+  **Fix**: ``build_async_codex_client`` in ``core/llm/adapters/
+  _openai_common.py`` constructs its own ``httpx.AsyncClient`` with
+  ``httpx.Limits(max_keepalive_connections=0, ...)``. Every Codex
+  call opens a fresh TCP+TLS connection. Costs ~100-300 ms TLS
+  handshake per call but eliminates the stale-connection failure
+  mode entirely. Other OpenAI-family endpoints (api.openai.com
+  PAYG, api.z.ai GLM PAYG, GLM Coding Plan) keep the default
+  ``settings.llm_max_keepalive_connections = 5`` policy via the
+  shared ``_build_async_httpx_client`` helper — they have proper
+  server-side idle timeout policies + GOAWAY signaling.
+
+  **Live verification 2026-05-28 16:00 KST**: 4 parallel
+  ``web_search_via_adapters`` calls through codex-oauth → 4/4
+  ``200 OK`` (7.4 / 7.6 / 10.2 / 41.8 s). No 4 ms ``APIConnection
+  Error``. Each dispatch INFO log line confirms the success
+  outcome.
+
+  Pinned by ``tests/test_codex_no_keepalive.py`` (2 source-level
+  assertions: codex builder body contains ``max_keepalive_connec
+  tions=0``, the default helper still reads
+  ``settings.llm_max_keepalive_connections``, the codex builder
+  does NOT delegate to the default ``_build_async_httpx_client``).
+
 ### Added
 - **PR-DISPATCH-OBS-EXT (2026-05-28)** — four observability
   enhancements layered on PR-NO-FALLBACK's strict-dispatch + per-attempt

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -241,12 +241,33 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     the header + base_url plumbing here). The ``originator: codex_cli_rs``
     header and ``ChatGPT-Account-ID`` (extracted from the JWT) are mandatory
     — the Codex backend rejects unsigned requests with 401.
+
+    PR-CODEX-NO-KEEPALIVE (2026-05-28) — the Codex backend
+    (``chatgpt.com/backend-api/codex/responses``) closes idle HTTP/2
+    connections aggressively (sub-second to a few-second window)
+    without sending a GOAWAY frame the client can observe in time.
+    First call after an idle period silently reuses a stale connection
+    from httpx's keep-alive pool → ``httpx.WriteError`` → openai SDK
+    ``APIConnectionError`` in ~4ms (no roundtrip). Observed pattern:
+    4 parallel ``web_search`` calls right after a slower LLM call —
+    first one fails instantly, next three open fresh connections and
+    succeed (12-19s typical). Traced via PR-DISPATCH-OBS-EXT's
+    ``adapter_dispatch_attempt`` events 2026-05-28 15:44:37 KST.
+
+    Fix: this client overrides ``max_keepalive_connections=0`` so every
+    Codex backend call opens a fresh TCP+TLS connection. Costs
+    ~100-300ms TLS handshake per call but eliminates the stale-
+    connection failure mode entirely. Other OpenAI-family endpoints
+    (api.openai.com PAYG, api.z.ai GLM PAYG, GLM Coding Plan) keep the
+    default keep-alive policy via :func:`_build_async_httpx_client` —
+    they have proper server-side idle timeout policies + GOAWAY signaling.
     """
     if not api_key:
         raise ValueError("build_async_codex_client: api_key is empty")
+    import httpx
     import openai
 
-    from core.config import CODEX_BASE_URL
+    from core.config import CODEX_BASE_URL, settings
     from core.llm.adapters._codex_sdk_workaround import install as _install_codex_workaround
     from core.llm.providers.codex import build_codex_oauth_headers
 
@@ -256,11 +277,30 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     _install_codex_workaround()
     _ensure_sdk_observability_installed()
 
+    # PR-CODEX-NO-KEEPALIVE (2026-05-28) — Codex-specific httpx client
+    # with ``max_keepalive_connections=0`` (see method docstring for the
+    # stale-connection rationale). Other timeout / pool settings mirror
+    # :func:`_build_async_httpx_client` so operators tune both with the
+    # same ``settings.llm_*`` knobs.
+    codex_http_client = httpx.AsyncClient(
+        limits=httpx.Limits(
+            max_connections=settings.llm_max_connections,
+            max_keepalive_connections=0,
+            keepalive_expiry=settings.llm_keepalive_expiry,
+        ),
+        timeout=httpx.Timeout(
+            connect=settings.llm_connect_timeout,
+            read=settings.llm_read_timeout,
+            write=settings.llm_write_timeout,
+            pool=settings.llm_pool_timeout,
+        ),
+    )
+
     return openai.AsyncOpenAI(
         api_key=api_key,
         base_url=CODEX_BASE_URL,
         default_headers=build_codex_oauth_headers(api_key),
-        http_client=_build_async_httpx_client(),
+        http_client=codex_http_client,
         # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION — see ``build_async_openai_client``
         # for the retry-compound rationale (Codex MCP BLOCKER 2026-05-28).
         max_retries=0,

--- a/tests/test_adapter_timeout_and_serialization.py
+++ b/tests/test_adapter_timeout_and_serialization.py
@@ -306,7 +306,16 @@ def test_translate_codex_response_emits_json_safe_summary() -> None:
 def test_openai_common_documents_timeout_fix() -> None:
     """Pin the helper name + intent in the source. A future refactor
     that drops ``_build_async_httpx_client`` would lose the timeout cap
-    and regress the 10-minute spin — this test fails loudly."""
+    and regress the 10-minute spin — this test fails loudly.
+
+    PR-CODEX-NO-KEEPALIVE (2026-05-28) — ``build_async_codex_client``
+    constructs its own inline ``httpx.AsyncClient`` (with
+    ``max_keepalive_connections=0`` to avoid Codex-backend stale-
+    connection failures) instead of delegating to
+    ``_build_async_httpx_client``. The httpx timeout settings still
+    flow through ``settings.llm_*`` so the original 10-minute spin
+    guarantee is preserved — the assertion now checks the timeout-
+    related settings reads inside the codex builder body."""
     from pathlib import Path
 
     src = (
@@ -316,12 +325,24 @@ def test_openai_common_documents_timeout_fix() -> None:
         "_openai_common.py no longer defines _build_async_httpx_client — "
         "OpenAI/Codex/GLM clients lose explicit Timeout pin."
     )
-    # Both client builders must wire through the helper.
+    # build_async_openai_client wires via the shared helper.
     assert re.search(r"def build_async_openai_client.*?http_client", src, re.DOTALL), (
         "build_async_openai_client lost its http_client= wiring"
     )
-    assert re.search(
-        r"def build_async_codex_client.*?http_client=_build_async_httpx_client",
-        src,
-        re.DOTALL,
-    ), "build_async_codex_client lost its http_client= wiring"
+    # build_async_codex_client now has its own inline httpx client
+    # (PR-CODEX-NO-KEEPALIVE) but still wires it via ``http_client=`` and
+    # still reads the same llm_*_timeout settings the shared helper
+    # uses, so the 10-minute-spin guarantee is preserved.
+    codex_body_match = re.search(r"def build_async_codex_client.*?(?=\n\ndef |\Z)", src, re.DOTALL)
+    assert codex_body_match is not None, "build_async_codex_client missing"
+    codex_src = codex_body_match.group(0)
+    assert "http_client=codex_http_client" in codex_src, (
+        "build_async_codex_client lost its http_client= wiring"
+    )
+    assert "settings.llm_read_timeout" in codex_src, (
+        "build_async_codex_client lost the llm_read_timeout pin — "
+        "the 10-minute-spin guarantee is at risk"
+    )
+    assert "settings.llm_connect_timeout" in codex_src, (
+        "build_async_codex_client lost the llm_connect_timeout pin"
+    )

--- a/tests/test_codex_no_keepalive.py
+++ b/tests/test_codex_no_keepalive.py
@@ -37,11 +37,7 @@ def test_build_async_codex_client_disables_keepalive() -> None:
     workflow guard.
     """
     src = (
-        Path(__file__).resolve().parents[1]
-        / "core"
-        / "llm"
-        / "adapters"
-        / "_openai_common.py"
+        Path(__file__).resolve().parents[1] / "core" / "llm" / "adapters" / "_openai_common.py"
     ).read_text(encoding="utf-8")
 
     # The override must be inside build_async_codex_client, not

--- a/tests/test_codex_no_keepalive.py
+++ b/tests/test_codex_no_keepalive.py
@@ -1,0 +1,101 @@
+"""Regression pin for PR-CODEX-NO-KEEPALIVE (2026-05-28).
+
+The Codex backend (``chatgpt.com/backend-api/codex/responses``) closes
+idle HTTP/2 connections within a few seconds without sending a GOAWAY
+the client can observe in time. The first call after an idle period
+silently reuses a stale connection from httpx's keep-alive pool →
+``APIConnectionError`` in ~4ms (observed pattern: 4 parallel web_search
+right after a slower LLM call — first fails instantly, the next three
+open fresh connections and succeed). Traced via PR-DISPATCH-OBS-EXT's
+``adapter_dispatch_attempt`` events 2026-05-28 15:44:37 KST,
+run_id ``f6c51cc5e18d`` in ``subject_gateway_analysis.jsonl``.
+
+Fix: ``build_async_codex_client`` uses an httpx client with
+``max_keepalive_connections=0`` so every Codex call opens a fresh
+TCP+TLS connection. Other OpenAI-family endpoints
+(``_build_async_httpx_client``) keep the default keep-alive policy.
+
+This test pins the Codex-specific override at the source level so a
+future refactor that consolidates client construction (or accidentally
+swaps back to ``_build_async_httpx_client()``) fails visibly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+
+def test_build_async_codex_client_disables_keepalive() -> None:
+    """Source-level pin: ``build_async_codex_client`` constructs its own
+    httpx client with ``max_keepalive_connections=0``.
+
+    Pinning at the source rather than runtime because constructing an
+    actual ``AsyncOpenAI`` client requires a valid Codex OAuth token
+    and would invoke httpx — both are out of scope for a unit test.
+    The source assertion + the matching CHANGELOG entry are the
+    workflow guard.
+    """
+    src = (
+        Path(__file__).resolve().parents[1]
+        / "core"
+        / "llm"
+        / "adapters"
+        / "_openai_common.py"
+    ).read_text(encoding="utf-8")
+
+    # The override must be inside build_async_codex_client, not
+    # _build_async_httpx_client (which serves other endpoints).
+    import core.llm.adapters._openai_common as openai_common
+
+    codex_builder_src = inspect.getsource(openai_common.build_async_codex_client)
+    assert "max_keepalive_connections=0" in codex_builder_src, (
+        "build_async_codex_client must override httpx Limits with "
+        "max_keepalive_connections=0 — the Codex backend's aggressive "
+        "idle-connection cleanup causes first-call APIConnectionError "
+        "(stale connection reuse). See PR-CODEX-NO-KEEPALIVE docstring."
+    )
+
+    # The default helper used by other OpenAI-family clients (PAYG OpenAI,
+    # GLM PAYG, GLM Coding Plan) keeps the default keep-alive policy.
+    default_builder_src = inspect.getsource(openai_common._build_async_httpx_client)
+    assert "settings.llm_max_keepalive_connections" in default_builder_src, (
+        "_build_async_httpx_client must read settings.llm_max_keepalive_connections "
+        "(default 5) — the no-keepalive override is Codex-specific."
+    )
+
+    # Source-level PR tag pin so the CHANGELOG can grep-verify.
+    assert "PR-CODEX-NO-KEEPALIVE" in src
+
+
+def test_build_async_codex_client_uses_dedicated_httpx_client() -> None:
+    """Codex client construction must NOT call ``_build_async_httpx_client()``
+    — that helper enables keep-alive (5 idle connections by default). The
+    Codex builder constructs an httpx.AsyncClient inline so the keep-alive
+    override is impossible to bypass."""
+    import core.llm.adapters._openai_common as openai_common
+
+    codex_src = inspect.getsource(openai_common.build_async_codex_client)
+    # The default helper name must not appear inside the codex builder body
+    # AFTER the docstring. The simplest check: count, and assert the only
+    # mention (if any) is the docstring's cross-reference.
+    body_lines = codex_src.splitlines()
+    # Strip lines that are pure docstring (between triple-quotes).
+    in_docstring = False
+    docstring_open = '"""'
+    body_only: list[str] = []
+    for ln in body_lines:
+        if docstring_open in ln:
+            in_docstring = not in_docstring
+            continue
+        if not in_docstring:
+            body_only.append(ln)
+    body = "\n".join(body_only)
+    assert "_build_async_httpx_client(" not in body, (
+        "build_async_codex_client body must not delegate to "
+        "_build_async_httpx_client — that helper enables 5 keep-alive "
+        "connections by default which is the failure mode this PR fixes."
+    )
+    # The replacement: inline httpx.AsyncClient with explicit Limits.
+    assert "httpx.AsyncClient(" in body
+    assert "httpx.Limits(" in body


### PR DESCRIPTION
## Summary
- First-call-after-idle `APIConnectionError` on Codex OAuth `web_search` eliminated by disabling httpx keep-alive pool reuse for the Codex client specifically.
- Diagnosed via PR-DISPATCH-OBS-EXT's `adapter_dispatch_attempt` events — the observability the previous PR added paid for itself by surfacing the exact failure pattern in one row.
- Live-verified: 4 parallel `web_search_via_adapters` calls through codex-oauth → 4/4 200 OK (no 4 ms `APIConnectionError`).

## Why
Operator-reported observation:

```
adapter_dispatch_attempt  codex-oauth (openai/subscription) → transient
                          elapsed=4ms  err_type=APIConnectionError
                          err=Connection error.
```

The 4 ms timing is shorter than any plausible network roundtrip — classic stale-keep-alive pattern. Timeline reconstruction from `subject_gateway_analysis.jsonl` run_id `f6c51cc5e18d` at 2026-05-28 15:44 KST:

| t (KST)          | event |
|------------------|-------|
| 15:44:29.707     | `llm_call_start` model=gpt-5.5, provider=openai-codex |
| 15:44:37.979     | `llm_call_end` latency_ms=8272 — leaves keep-alive connection in pool |
| 15:44:37.981-985 | 4× `tool_exec_start` general_web_search (4 ms apart) |
| 15:44:37.986     | `adapter_dispatch_attempt` #1 → APIConnectionError in 4 ms ❌ |
| 15:44:50.026     | `adapter_dispatch_attempt` #2 → success in 12040 ms ✅ |
| 15:44:57.469     | `adapter_dispatch_attempt` #3 → success in 19486 ms ✅ |

The Codex backend (`chatgpt.com/backend-api/codex/responses`) closes idle HTTP/2 connections aggressively (sub-second to few-second window) without sending a GOAWAY the client can observe in time. First call reused the stale pooled connection → `httpx.WriteError` → openai SDK `APIConnectionError` instantly. Subsequent calls opened fresh connections via httpx's bad-conn-recovery path and succeeded.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/_openai_common.py::build_async_codex_client` | Constructs its own `httpx.AsyncClient` with `httpx.Limits(max_keepalive_connections=0, ...)`. Other timeout/pool settings mirror `_build_async_httpx_client` so operators tune both with the same `settings.llm_*` knobs. Docstring documents the rationale + the 15:44:37 incident timestamp |
| `tests/test_codex_no_keepalive.py` | NEW — 2 source-level assertions: codex builder body contains `max_keepalive_connections=0`, the default helper still reads `settings.llm_max_keepalive_connections`, and the codex builder does NOT delegate to `_build_async_httpx_client()` |
| `CHANGELOG.md` | [Unreleased] / Fixed entry above PR-DISPATCH-OBS-EXT |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Codex client httpx override | Implemented | `max_keepalive_connections=0` inline in `build_async_codex_client` |
| Other endpoints unchanged | Verified | PAYG/GLM use `_build_async_httpx_client` (default keep-alive=5) |
| Live test (the diagnostic gate) | Passed | 4/4 parallel web_search → 200 OK |
| Source-level pin | Implemented | Test asserts override presence + non-delegation |

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` clean (1026 files)
- [x] `mypy core/ plugins/` clean (465 source files)
- [x] `test_codex_no_keepalive.py` 2/2 pass
- [x] **Live test**: 4 parallel `web_search_via_adapters` (prefer codex-oauth) → 4/4 200 OK. Previous run produced 1 APIConnectionError + 3 success. Now produces 4 success.

## Reference
- Diagnostic source: ADAPTER_DISPATCH_ATTEMPT events from PR-DISPATCH-OBS-EXT (#1842) — without this observability, the 4 ms failure would have remained "transient connection issue" with no clear root cause
- Predecessor causal chain: PR-NO-FALLBACK #1839 → PR-CODEX-INSTRUCTIONS-FIX #1841 → PR-DISPATCH-OBS-EXT #1842 → this PR
- Operator decision: option 3 of 3 (max_keepalive_connections=0). Options 1 (lane serialization on web_search) and 2 (same-adapter retry on transient) discussed and rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)