### PR TITLE
chore(release): v0.99.81 — adapter dispatch correctness + observability sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.81] - 2026-05-28
+
+> MINOR release. Eight-PR sprint focused on adapter-layer correctness
+> + observability:
+>
+> - **PR-EXTRACT-LEARNING-MODELS-ADAPTER** (#1836) — last HIGH-traffic
+>   direct-SDK sites migrated to capability dispatch
+> - **PR-LLMCLIENTPORT-COLLAPSE** (#1837) — -1422 LoC dead parallel
+>   adapter hierarchy removed
+> - **PR-TOOL-EXEC-CONTEXT** (#1838) — AgenticLoop adapter routing
+>   propagates into tool dispatch
+> - **PR-NO-FALLBACK** (#1839) — strict single-adapter dispatch;
+>   silent cross-provider / cross-source fallback disabled
+> - **PR-DOC-VERIFY** (#1840) — workflow §4d: doc-before-behaviour
+>   gate for external SDK / 3rd-party backend capability assumptions
+> - **PR-CODEX-INSTRUCTIONS-FIX** (#1841) — codex-oauth web_search
+>   verified live (instructions mandatory + input typed-item list)
+> - **PR-DISPATCH-OBS-EXT** (#1842) — tool-result adapter inline +
+>   serve.log restored + ``geode adapters stats`` CLI +
+>   per-session adapter usage
+> - **PR-CODEX-NO-KEEPALIVE** (#1843) — Codex backend httpx
+>   keep-alive disabled; first-call-after-idle ``APIConnectionError``
+>   (4 ms stale-connection failure) eliminated
+
 ### Fixed
 - **PR-CODEX-NO-KEEPALIVE (2026-05-28)** — Codex backend
   (``chatgpt.com/backend-api/codex/responses``) first-call-after-idle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.80
+- **Version**: 0.99.81
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 393 core + 69 plugins = 462
-- **Tests**: 8485 (+5 live)
+- **Modules**: 396 core + 69 plugins = 465
+- **Tests**: 8504 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.80 — Long-running Autonomous Execution Harness
+# GEODE v0.99.81 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.80**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.81**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.80 — Long-running Autonomous Execution Harness
+# GEODE v0.99.81 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.80**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.81**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.80"
+version = "0.99.81"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.80"
+version = "0.99.81"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.80 → **v0.99.81** (MINOR) — 8-PR sprint covering adapter-dispatch correctness, doc-before-behaviour workflow, Codex backend fixes, and a 4-layer observability extension
- Version bumped across 5 SoT (pyproject.toml + CLAUDE.md + README.md + README.ko.md + CHANGELOG.md)
- Metrics updated: tests 8485 → 8504 (+19), core modules 393 → 396 (+3), plugins 69 (unchanged)
- Release branch → develop (lands version bump on develop first), then develop → main as straight pass-through

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` clean (1027 files)
- [x] `mypy core/ plugins/` clean (465 source files)
- [x] `geode version` → `GEODE v0.99.81`
- [x] 8 PRs that compose this release all merged with CI 8/8 green
- [x] CHANGELOG `[Unreleased]` empty + `[0.99.81] - 2026-05-28` header with all 8 PRs summarised

## Bundle contents
| # | PR | Type | Summary |
|---|----|------|---------|
| #1836 | PR-EXTRACT-LEARNING-MODELS-ADAPTER | Changed | Last HIGH-traffic direct-SDK sites → capability dispatch |
| #1837 | PR-LLMCLIENTPORT-COLLAPSE | Removed | -1422 LoC dead parallel adapter hierarchy |
| #1838 | PR-TOOL-EXEC-CONTEXT | Added | AgenticLoop adapter routing → tool dispatch |
| #1839 | PR-NO-FALLBACK | Changed | Strict single-adapter dispatch; no silent fallback |
| #1840 | PR-DOC-VERIFY | Changed | Workflow §4d: doc-before-behaviour gate |
| #1841 | PR-CODEX-INSTRUCTIONS-FIX | Fixed | codex-oauth web_search verified live |
| #1842 | PR-DISPATCH-OBS-EXT | Added | Tool inline + serve.log + CLI stats + session usage |
| #1843 | PR-CODEX-NO-KEEPALIVE | Fixed | Codex backend stale-connection 4ms failure eliminated |

## Reference
- Gitflow per CLAUDE.md §6: `release/* → develop → main` (release carries stamp + CHANGELOG bumps, merges into develop first so develop never lags behind main; develop → main is then a straight pass-through)
- Next: after this PR lands, open develop → main PR (abbreviated form: Summary + Verification only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)