### PR TITLE
feat(llm): Opus 4.8(claude-opus-4-8) 호환 추가 — adapter 게이트 + CLI + self-improving loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-OPUS-4-8-COMPAT (2026-05-29)** — Register Opus 4.8
+  (``claude-opus-4-8``, 1M context) alongside Opus 4.7 across every
+  surface where 4.7 was the compatible frontier. Adapter capability
+  gates: added to ``_CONTEXT_MGMT_MODELS`` / ``_ADAPTIVE_MODELS`` /
+  ``_XHIGH_EFFORT_MODELS`` in ``core/llm/providers/anthropic.py`` so the
+  agentic loop sends the context-management + compaction beta header,
+  omits sampling params under adaptive thinking, and accepts the
+  ``xhigh`` effort level. CLI UI/UX: ``core/cli/effort_picker.py``
+  (``_ANTHROPIC_ADAPTIVE_MODELS`` / ``_ANTHROPIC_XHIGH_MODELS`` + picker
+  blurb), ``/model`` menu profile in ``core/cli/commands/_state.py``,
+  and ``/login`` plan-pin hints in ``core/cli/commands/login.py``.
+  Pricing + 1M context window in ``core/llm/model_pricing.toml``
+  (mirrors the $5/$25 Opus tier). Self-improving loop: added to the
+  auditor / target / judge ``allowed_models`` in
+  ``plugins/petri_audit/petri.plugin.toml`` (role defaults unchanged —
+  this is compatibility, not a default switch). Capability grounding:
+  ctx7 platform docs index only up to the 4.6/4.7 family pages, so the
+  4.8-specific 1M-context / adaptive-thinking / ``xhigh`` acceptance is
+  confirmed live by the running harness (the ``/model`` selector
+  configures ``claude-opus-4-8`` with "xhigh effort" by default). Pinned
+  by ``test_opus_4_8_supports_xhigh``, ``test_opus_4_8_includes_xhigh``,
+  ``test_opus_4_8_registered_for_context_management``, and the
+  ``claude-opus-4-8`` row in
+  ``test_adaptive_models_omit_sampling_params``.
+
 ### Changed
 - **PR-PROMOTE-RATE-BUNDLE (2026-05-29)** — Three-option bundle to
   unblock the cy11-23 batch's 0/9 PROMOTE rate. Diagnostic: 6/9

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -51,6 +51,7 @@ class ModelProfile:
 # scan when Codex subscription OAuth is registered (v0.52.4 routing policy);
 # otherwise to `openai` PAYG. Both paths visible via /login dashboard.
 MODEL_PROFILES: list[ModelProfile] = [
+    ModelProfile("claude-opus-4-8", "anthropic", "Opus 4.8", "$$$"),
     ModelProfile(ANTHROPIC_PRIMARY, "anthropic", "Opus 4.7", "$$$"),
     ModelProfile("claude-opus-4-6", "anthropic", "Opus 4.6", "$$$"),
     ModelProfile(ANTHROPIC_SECONDARY, "anthropic", "Sonnet 4.6", "$$"),

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -958,7 +958,7 @@ def _login_use(rest: str) -> None:
         "glm": ["glm-5.1", "glm-5", "glm-5-turbo"],
         "openai": ["gpt-5.4", "gpt-5.4-mini"],
         "openai-codex": ["gpt-5.3-codex", "gpt-5.4-mini"],
-        "anthropic": ["claude-opus-4-7", "claude-sonnet-4-6"],
+        "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6"],
     }
     for model in model_hints.get(plan.provider, []):
         existing = [pid for pid in registry.get_routing(model) if pid != plan.id]

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -33,8 +33,17 @@ _ANTHROPIC_ADAPTIVE_EFFORTS = ("low", "medium", "high", "max", "xhigh")
 _OPENAI_REASONING_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
 _GLM_HYBRID_EFFORTS = ("disabled", "enabled")
 
-_ANTHROPIC_ADAPTIVE_MODELS = frozenset({"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"})
-_ANTHROPIC_XHIGH_MODELS = frozenset({"claude-opus-4-7"})
+# Keep these in sync with the adapter capability gates
+# (``core/llm/providers/anthropic.py`` ``_ADAPTIVE_MODELS`` /
+# ``_XHIGH_EFFORT_MODELS``) — the picker only surfaces an effort knob the
+# API will actually accept. Opus 4.8 (claude-opus-4-8) joins 4.7 in both
+# sets: confirmed live by the running harness (Claude Code's /model selector
+# configures claude-opus-4-8 with "xhigh effort"); ctx7 platform docs index
+# only up to the 4.6/4.7 family pages.
+_ANTHROPIC_ADAPTIVE_MODELS = frozenset(
+    {"claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"}
+)
+_ANTHROPIC_XHIGH_MODELS = frozenset({"claude-opus-4-8", "claude-opus-4-7"})
 
 _OPENAI_RESPONSES_MODELS_PREFIX = ("gpt-5",)
 
@@ -86,9 +95,10 @@ def default_effort(model: str, provider: str) -> str | None:
         return None
     if provider == "anthropic":
         # Anthropic API default is "high" per platform.claude.com docs.
-        # Opus 4.7 official guidance recommends "xhigh" as the *starting
-        # point* for coding/agentic — surface it as the default for that
-        # model so the picker shows what the model actually wants.
+        # Opus 4.7+ official guidance recommends "xhigh" as the *starting
+        # point* for coding/agentic — surface it as the default for the
+        # xhigh-capable models (4.7 / 4.8) so the picker shows what the
+        # model actually wants.
         if model in _ANTHROPIC_XHIGH_MODELS:
             return "xhigh"
         return "high"
@@ -116,7 +126,8 @@ def cycle_effort(current: str, levels: tuple[str, ...], direction: int) -> str:
 
 _MODEL_DESCRIPTIONS: dict[str, str] = {
     # Anthropic
-    "claude-opus-4-7": "Opus 4.7 with 1M context · Most capable for complex work",
+    "claude-opus-4-8": "Opus 4.8 with 1M context · Most capable for complex work",
+    "claude-opus-4-7": "Opus 4.7 with 1M context · High-capability reasoning",
     "claude-opus-4-6": "Opus 4.6 · Strong general-purpose reasoning",
     "claude-sonnet-4-6": "Sonnet 4.6 · Best for everyday tasks",
     "claude-haiku-4-5": "Haiku 4.5 · Fastest for quick answers",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -372,8 +372,8 @@ class Settings(BaseSettings):
 
     # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
     # Maps to Anthropic output_config.effort + OpenAI reasoning.effort.
-    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7-only (the adapter
-    # downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
+    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7+ only (4.7 / 4.8 — the
+    # adapter downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
     agentic_effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh"
 
     # Credential source — chosen via the ``/login source`` picker. The picker

--- a/core/llm/model_pricing.toml
+++ b/core/llm/model_pricing.toml
@@ -19,6 +19,14 @@
 # ── Anthropic (verified 2026-04-23) ───────────────────────────────────────
 # Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
 
+# Opus 4.8 pricing mirrors the established Opus 4.5+ tier ($5 / $25). ctx7
+# platform docs index only up to the 4.6/4.7 pages; refresh against the
+# pricing source above on the next quarterly pass if Anthropic publishes a
+# distinct 4.8 rate.
+[pricing.anthropic."claude-opus-4-8"]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+
 [pricing.anthropic."claude-opus-4-7"]
 input_per_mtok = 5.00
 output_per_mtok = 25.00
@@ -120,13 +128,14 @@ input_per_mtok = 0.00
 output_per_mtok = 0.00  # free tier (limited-time)
 
 # ── Context windows (verified 2026-04-26 / GLM 2026-05-12 GAP-X1) ─────────
-# Anthropic: 1M tokens for opus-4-6/7 + sonnet-4-6; 200K for legacy.
+# Anthropic: 1M tokens for opus-4-6/7/8 + sonnet-4-6; 200K for legacy.
 # OpenAI 5.x: 1.05M tokens for gpt-5.5/5.4/5.4-mini; 200K for 5.3-codex
 # + reasoning (o3/o4-mini). GLM: all share 202_752 (z.ai rounds to 200K
 # in marketing; precise value matters for the 200K guard's early-trip
 # margin).
 
 [context_windows]
+"claude-opus-4-8"            = 1000000
 "claude-opus-4-7"            = 1000000
 "claude-opus-4-6"            = 1000000
 "claude-opus-4-5"            = 200000

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -591,8 +591,11 @@ _API_ALLOWED_KEYS = frozenset(
 # Haiku 4.5 (2025-10-01) predates compact-2026-01-12 and rejects the beta
 # header with a 400 whose message contains "context" — misclassified as
 # context_overflow.  Only 1M-context models are known to support it.
+# Opus 4.8 (claude-opus-4-8) ships with a 1M context window and Claude Code
+# runs it under server-side compaction, so it inherits the same contract.
 _CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
     {
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-opus-4-5",
@@ -606,8 +609,12 @@ _CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
 # (https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
 # #sampling-parameters-removed) and are also rejected by Opus 4.6 when
 # adaptive thinking is on.  Omit them entirely on these models.
+# Opus 4.8 continues the 4.6+ adaptive-thinking contract (the effort knob —
+# incl. ``xhigh`` — only exists for adaptive models, and this session runs
+# claude-opus-4-8 under adaptive thinking; see _XHIGH_EFFORT_MODELS note).
 _ADAPTIVE_MODELS: frozenset[str] = frozenset(
     {
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",
@@ -621,7 +628,12 @@ _ADAPTIVE_MODELS: frozenset[str] = frozenset(
 # coding/agentic workloads (platform.claude.com/docs/en/build-with-claude/
 # effort) — but only the GEODE caller can opt in by setting
 # ``agentic.effort = "xhigh"``; we never auto-upgrade ``high → xhigh``.
-_XHIGH_EFFORT_MODELS: frozenset[str] = frozenset({"claude-opus-4-7"})
+# Opus 4.8 (claude-opus-4-8) accepts ``xhigh`` — confirmed live: Claude Code
+# configures this model with "xhigh effort" by default (the /model selector
+# emits it). ctx7 platform docs only index up to the 4.6/4.7 family pages, so
+# the 4.8-specific acceptance is grounded by the running harness rather than a
+# doc page.
+_XHIGH_EFFORT_MODELS: frozenset[str] = frozenset({"claude-opus-4-8", "claude-opus-4-7"})
 
 
 def _supports_xhigh_effort(model: str) -> bool:

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -38,6 +38,7 @@ enabled_roles = ["auditor", "target", "judge"]
 [petri.role.auditor]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
@@ -52,6 +53,7 @@ role_contract = "roles/auditor.md"
 # LLM GEODE uses internally.
 default_model = "claude-haiku-4-5"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
@@ -65,6 +67,7 @@ role_contract = "roles/target.md"
 [petri.role.judge]
 default_model = "claude-sonnet-4-6"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -22,8 +22,9 @@
 #
 # Supported model lineup (CSP-10, 2026-05-22) — only models currently exposed
 # by Claude Code CLI (anthropic.claude-cli) or Codex CLI (openai.openai-codex)
-# may appear in allowed_models. Anthropic surface: claude-opus-4-7 /
-# claude-sonnet-4-6 / claude-haiku-4-5. Codex surface: gpt-5.5 / gpt-5.4 /
+# may appear in allowed_models. Anthropic surface: claude-opus-4-8 /
+# claude-opus-4-7 / claude-sonnet-4-6 / claude-haiku-4-5. Codex surface:
+# gpt-5.5 / gpt-5.4 /
 # gpt-5.4-mini / gpt-5.3-codex (see core/llm/model_pricing.toml).
 
 [seed_generation]
@@ -58,6 +59,7 @@ enabled_roles = [
 [seed_generation.role.generator]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
@@ -78,6 +80,7 @@ default_model = "claude-opus-4-7"
 # subscription can route critic on the strongest available reasoning
 # model when running through ``source = "claude-cli"``.
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
@@ -95,6 +98,7 @@ default_model = "claude-opus-4-7"
 # ``claude-opus-4-7`` accepted for the same Claude Code Max routing
 # reason as critic — proximity is also a reasoning-heavy role.
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
@@ -115,6 +119,7 @@ default_model = "claude-opus-4-7"
 # Override paths: operators can pin a faster/cheaper model via the
 # allowlist below when the 90s wall-time becomes a bottleneck.
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-haiku-4-5",
     "gpt-5.4-mini",
@@ -127,6 +132,7 @@ role_contract = "plugins/seed_generation/agents/pilot.md"
 # the panel's voter binding (below) drives actual LLM calls.
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
@@ -136,6 +142,7 @@ role_contract = "plugins/seed_generation/agents/ranker.md"
 [seed_generation.role.evolver]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
@@ -145,6 +152,7 @@ role_contract = "plugins/seed_generation/agents/evolver.md"
 [seed_generation.role.meta_reviewer]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
@@ -161,6 +169,7 @@ role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
 [seed_generation.role.supervisor]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
@@ -177,6 +186,7 @@ role_contract = "plugins/seed_generation/agents/supervisor.md"
 [seed_generation.role.literature_review]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",

--- a/tests/test_anthropic_reasoning_v056.py
+++ b/tests/test_anthropic_reasoning_v056.py
@@ -10,9 +10,9 @@ official docs (see ``docs/research/reasoning-depth-audit.md``):
       ``anthropic_adapter.py:1440``.
 
   B3: ``xhigh`` effort is accepted by GEODE's enum but is version-
-      gated to Opus 4.7. On Opus 4.6 / Sonnet 4.6 it downgrades to
-      ``"max"`` (those models reject ``xhigh`` with 400). Mirrors
-      Hermes ``_supports_xhigh_effort`` substring-based gate.
+      gated to Opus 4.7+ (4.7 and 4.8). On Opus 4.6 / Sonnet 4.6 it
+      downgrades to ``"max"`` (those models reject ``xhigh`` with 400).
+      Mirrors Hermes ``_supports_xhigh_effort`` substring-based gate.
 
   C2: Signature round-trip on tool-use multi-turn. All three
       reference codebases (OpenClaw, Claude Code, Hermes) preserve
@@ -33,7 +33,10 @@ from core.llm.providers.anthropic import (
 
 
 class TestXHighEffortGate:
-    """B3 — ``xhigh`` is Opus 4.7-only; downgrades to ``"max"`` elsewhere."""
+    """B3 — ``xhigh`` is Opus 4.7+ (4.7 / 4.8); downgrades to ``"max"`` elsewhere."""
+
+    def test_opus_4_8_supports_xhigh(self) -> None:
+        assert _supports_xhigh_effort("claude-opus-4-8") is True
 
     def test_opus_4_7_supports_xhigh(self) -> None:
         assert _supports_xhigh_effort("claude-opus-4-7") is True

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -91,7 +91,7 @@ def _run_agentic_call(model: str) -> dict[str, Any]:
 
 @pytest.mark.parametrize(
     "model",
-    ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
+    ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
 )
 def test_adaptive_models_omit_sampling_params(model: str) -> None:
     """Opus 4.6+ / Sonnet 4.6 reject temperature; it must not be sent."""
@@ -109,6 +109,15 @@ def test_adaptive_models_omit_sampling_params(model: str) -> None:
 def test_opus_4_7_registered_for_context_management() -> None:
     """Opus 4.7 must enable the context-management + compaction beta header."""
     kwargs = _run_agentic_call("claude-opus-4-7")
+    headers = kwargs.get("extra_headers") or {}
+    beta = headers.get("anthropic-beta", "")
+    assert "context-management-2025-06-27" in beta
+    assert "compact-2026-01-12" in beta
+
+
+def test_opus_4_8_registered_for_context_management() -> None:
+    """Opus 4.8 (1M context) inherits the context-management + compaction beta."""
+    kwargs = _run_agentic_call("claude-opus-4-8")
     headers = kwargs.get("extra_headers") or {}
     beta = headers.get("anthropic-beta", "")
     assert "context-management-2025-06-27" in beta

--- a/tests/test_effort_picker.py
+++ b/tests/test_effort_picker.py
@@ -7,7 +7,7 @@ cycle/default helpers are tested directly.
 
 Pinned 2026-04-28 against:
   - Anthropic effort enum: docs.anthropic.com / platform.claude.com
-    (low/medium/high/max/xhigh; xhigh is Opus 4.7-only)
+    (low/medium/high/max/xhigh; xhigh is Opus 4.7+ — 4.7 / 4.8)
   - OpenAI Responses effort enum: openai-python `shared/reasoning_effort.py`
     (none/minimal/low/medium/high/xhigh)
   - Codex enum: codex-rs `protocol/src/openai_models.rs:43-51`
@@ -26,6 +26,10 @@ from core.cli.effort_picker import (
 
 
 class TestAnthropicEnum:
+    def test_opus_4_8_includes_xhigh(self) -> None:
+        levels = supported_efforts("claude-opus-4-8", "anthropic")
+        assert levels == ("low", "medium", "high", "max", "xhigh")
+
     def test_opus_4_7_includes_xhigh(self) -> None:
         levels = supported_efforts("claude-opus-4-7", "anthropic")
         assert levels == ("low", "medium", "high", "max", "xhigh")
@@ -46,9 +50,11 @@ class TestAnthropicEnum:
 
     def test_default_is_high(self) -> None:
         # Anthropic API default is "high" per platform.claude.com docs.
-        # Opus 4.7's official guidance recommends xhigh as the *starting
+        # Opus 4.7+ official guidance recommends xhigh as the *starting
         # point* for coding/agentic — picker surfaces xhigh as the
-        # default for that model only (sonnet stays on high).
+        # default for the xhigh-capable Opus models (4.7 / 4.8); sonnet
+        # and Opus 4.6 stay on high.
+        assert default_effort("claude-opus-4-8", "anthropic") == "xhigh"
         assert default_effort("claude-opus-4-7", "anthropic") == "xhigh"
         assert default_effort("claude-sonnet-4-6", "anthropic") == "high"
         assert default_effort("claude-opus-4-6", "anthropic") == "high"


### PR DESCRIPTION
## Summary
`claude-opus-4-8`(1M context)를 기존에 `claude-opus-4-7`이 호환 frontier로 등재돼 있던 **모든 surface**에 나란히 추가한다. agentic loop의 adapter capability 게이트, CLI UI/UX, pricing, self-improving loop(petri + seed_generation)의 role allowlist 까지 포함. **default_model 은 의도적으로 미변경** — "호환 추가"이지 "default 교체"가 아님 (4-6이 4-7과 공존하던 것과 동일).

## Why
운영자 요청: agentic loop / self-improving loop에 포함된 사안들에 Opus 4.8 호환 추가 (LLM 호출부가 adapter 구현부로 이전됨, "opus-4-7까지 호환"인 지점에 4-8 추가). 추가 안 하면 4-8 선택 시 effort 화살표 비활성·xhigh 거부·context-management beta 헤더 누락·pricing/context-window 미인식, petri/seed_generation role override 시 `not in allowed_models` 거부.

## Changes

### Core Changes (Code)
- `core/llm/providers/anthropic.py`: `_CONTEXT_MGMT_MODELS` / `_ADAPTIVE_MODELS` / `_XHIGH_EFFORT_MODELS` frozenset에 `claude-opus-4-8` 추가 + grounding 주석
  - 근거: agentic loop이 4-8에 context-management+compaction beta 헤더 전송, adaptive thinking 하 sampling param 생략, xhigh effort 수용하도록
- `core/cli/effort_picker.py`: `_ANTHROPIC_ADAPTIVE_MODELS` / `_ANTHROPIC_XHIGH_MODELS` + `_MODEL_DESCRIPTIONS` blurb + adapter 게이트와 sync 명시 grounding 주석
- `core/cli/commands/_state.py`: `/model` 메뉴 `MODEL_PROFILES`에 `ModelProfile("claude-opus-4-8", "anthropic", "Opus 4.8", "$$$")`
- `core/cli/commands/login.py`: `/login` plan-pin hint anthropic 목록에 4-8
- `core/llm/model_pricing.toml`: `[pricing.anthropic."claude-opus-4-8"]`($5/$25, Opus tier 미러) + `[context_windows]` 1M
- `plugins/petri_audit/petri.plugin.toml`: auditor/target/judge `allowed_models`에 4-8 (default_model 미변경)
- `plugins/seed_generation/seed_generation.plugin.toml`: 9개 role `allowed_models` + supported-surface 주석에 4-8 (default_model 미변경)

### Secondary Changes (Code)
- `core/config/_settings.py`: `agentic_effort` 주석 "xhigh = Opus 4.7-only" → "4.7+ (4.7/4.8)" 정정 (stale 주석)

### Test / Docs Changes
- `tests/test_anthropic_reasoning_v056.py`: `test_opus_4_8_supports_xhigh` + 주석 정정
- `tests/test_effort_picker.py`: `test_opus_4_8_includes_xhigh` + default_effort 4-8 assert + 주석 정정
- `tests/test_anthropic_sampling_params.py`: `test_opus_4_8_registered_for_context_management` + `claude-opus-4-8` parametrize row
- `CHANGELOG.md`: `[Unreleased] > Added > PR-OPUS-4-8-COMPAT`

## Impact Scope
- **Affected modules**: core/llm/providers, core/cli, plugins/petri_audit, plugins/seed_generation
- **Backward compatibility**: 유지 (순수 additive, default 미변경)
- **Test changes**: 추가 4 / 수정 0 / 삭제 0

## Design Decisions
- **호환 추가 vs default 승격**: default_model/routing.toml `[model.defaults]`·`[nodes]`·`_settings.py model` 미변경. 4-8을 신규 primary로 승격하면 self-improving loop baseline 무효화 + per-mutator 격리 이슈가 딸려서 별도 운영자 결정 사안.
- **capability grounding (CANNOT §4d)**: ctx7 platform docs는 4.6/4.7 family 페이지까지만 인덱싱 = ambiguous. 4-8의 1M/adaptive/xhigh 수용은 **running 하니스 라이브 증거**(Claude Code `/model` selector가 `claude-opus-4-8`을 xhigh effort+1M로 구성)로 충족 — ctx7 게이트 통과, 근거를 각 flag 옆 주석에 명기. drift invariant `_XHIGH_EFFORT_MODELS ⊆ _ADAPTIVE_MODELS` 유지.

## Pre-PR Quality Gate
- [x] `ruff check core/ tests/ plugins/` — All checks passed
- [x] `ruff format --check` — OK (997 files)
- [x] `mypy core/ plugins/` — Success (465 source files)
- [x] `bandit -r core/` — 0 issues (High/Medium/Low/Undefined 모두 0)
- [x] `lint-imports` — 4 kept, 0 broken
- [x] 관련 pytest 선택 실행 — effort_picker/reasoning_v056/sampling_params/pricing_loader/petri_audit/seed_generation/drift/model_guidance 전부 pass (전체 스위트는 비용상 미실행)
- [x] CLI smoke — `geode version` OK
- [x] Codex MCP 2차 검증 — 1차 GAP(seed_generation 9-role allowlist 누락 + stale 주석 3건) 검출 → 수정 → 2차 all RESOLVED
- [x] CHANGELOG [Unreleased] 항목 추가

## Reference
운영자 요청 (2026-05-29). capability grounding: running Claude Code 하니스 `/model` selector (claude-opus-4-8 + xhigh + 1M). ctx7 `/websites/platform_claude_ja` (4.6/4.7 family contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)