### PR TITLE
release: v0.99.82 — Opus 4.8 호환 + mutator/SPCT 튜닝 번들

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.82] - 2026-05-29
+
 ### Added
 - **PR-OPUS-4-8-COMPAT (2026-05-29)** — Register Opus 4.8
   (``claude-opus-4-8``, 1M context) alongside Opus 4.7 across every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.81
+- **Version**: 0.99.82
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.81 — Long-running Autonomous Execution Harness
+# GEODE v0.99.82 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.81**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.82**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.81 — Long-running Autonomous Execution Harness
+# GEODE v0.99.82 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.81**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.82**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.81"
+version = "0.99.82"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
release rotation 1단계 (release → develop). 5-location 버전 stamp `0.99.81 → 0.99.82` + CHANGELOG `[Unreleased] → [0.99.82] - 2026-05-29` promote + fresh `[Unreleased]` 삽입. develop이 main 예정 상태와 content-equivalent가 되도록 먼저 흡수.

## Included (this version)
- **#1860 PR-OPUS-4-8-COMPAT** (Added) — `claude-opus-4-8`(1M) 호환을 adapter capability 게이트 + CLI UI/UX + pricing + petri/seed_generation role allowlist 전 surface에 추가 (default 미변경)
- **PR-PROMOTE-RATE-BUNDLE** (Changed) — critical_margin/floor/axis-dedup 번들 (cy11-23 PROMOTE 0/9 해소)
- **PR-SPCT-FEWSHOT-PROMPT** (Changed) — SPCT principle length-anchored + few-shot
- **PR-SPCT-CAP-1000** (Changed) — SPCT principle cap 500→1000

## Changes
| File | Change |
|------|--------|
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md` | version 0.99.81 → 0.99.82 (banner + frontier-snapshot prose) |
| `CHANGELOG.md` | [Unreleased] → [0.99.82] - 2026-05-29 promote + fresh [Unreleased] |

## Verification
- [x] 5-location 버전 동기화 확인 (residual 0.99.81 = 0)
- [x] CHANGELOG promote 구조 (fresh [Unreleased] + [0.99.82] header)
- [x] feature → develop (#1860) CI 5/5 green + merged
- [ ] release → develop CI ratchet (이 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)