### PR TITLE
self-improving-loop: multi-objective wiring + measurement hygiene (PR-SIL-MULTIOBJ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,45 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-SIL-MULTIOBJ (2026-05-29)** — Wire the self-improving loop's
+  previously orphan multi-objective infrastructure into the live decision
+  path, plus measurement hygiene. Four parts:
+  - **Tchebycheff group selection (A1)** — `apply_group_proposals` now
+    selects the winning sibling by a Tchebycheff (worst-weighted-gap)
+    scalar via `_select_best_idx`, calling the previously test-only
+    `compute_tchebycheff` / `compute_ideal_point` with `DIM_WEIGHTS` so a
+    critical-axis gap dominates an auxiliary gap (non-compensatory,
+    safety-first). Gated on `pareto_mode` + `group_size ≥ 2`; the default
+    path keeps the linear GRPO-whitened advantage unchanged. The
+    `FITNESS_RESULT` sentinel emitted by `autoresearch/train.py` now
+    additively carries the per-sibling `dim_means` / `dim_stderr` vector
+    (parsed by the new graceful `_parse_dim_means_from_subprocess_stdout`)
+    — the multi-dim capture the prior `pareto_mode` archive PR deferred.
+  - **`rollback_condition` auto-evaluation (A2)** — the mutator's own
+    `rollback_condition` predicate is now propagated to the audit
+    subprocess via `GEODE_SIL_ROLLBACK_CONDITION` and auto-evaluated as a
+    *secondary* per-dim reject gate (calls the previously
+    observability-only `evaluate_rollback_condition`). Two paths: the
+    single-mutation promote path evaluates it in
+    `_apply_rollback_condition_gate` after `_should_promote` (flips
+    promote → reject); the group path evaluates the winner's predicate in
+    `apply_group_proposals` against its measured dim vector vs the
+    promoted baseline and skips the commit on a fire. It can only veto —
+    never the reverse; the primary scalar safety gate is unchanged.
+  - **inspect-ai cache hygiene (A3)** — new `purge_inspect_cache()`
+    (delegates to inspect_ai's own `cache_clear`, graceful without the
+    `[audit]` extra) + a `--purge-cache` flag on `autoresearch/train.py`
+    for closed-loop measurement hygiene, pinned by a regression test that
+    `_build_audit_command` never enables the trajectory cache.
+  - **signal polarity normalisation (A4)** — new `signal_polarity` helper
+    (`to_signed_improvement` / `metric_polarity`) emits a canonical
+    `signed_improvement` field on every attribution row (`+` = improvement
+    regardless of a metric's native direction — Petri dims are
+    lower-is-better, so their sign is flipped). The higher-is-better field
+    set is derived from the canonical ux/admire/bench weight dicts (no
+    second copy, pinned by a drift test).
+
 ### Fixed
 - **PR-MUTATIONS-REDESIGN (2026-05-29)** — Rebuild the autoresearch
   `/self-improving/autoresearch/mutations/` page against the live

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2207,6 +2207,50 @@ N1_FITNESS_MARGIN_FLOOR = 0.20
 BOOTSTRAP_FITNESS_FLOOR: float = 0.30
 
 
+def _apply_rollback_condition_gate(
+    *,
+    ok: bool,
+    reason: str,
+    condition: str,
+    observed_dim: dict[str, float],
+    baseline_dim: dict[str, float] | None,
+) -> tuple[bool, str]:
+    """PR-SIL-MULTIOBJ A2 (2026-05-29) — secondary per-dim reject gate.
+
+    Auto-evaluates the mutator's own ``rollback_condition`` predicate
+    (``core.self_improving_loop.rollback_condition.evaluate_rollback_condition``)
+    as a guard *in addition to* the primary ``_should_promote`` scalar
+    gate. Returns a possibly-flipped ``(ok, reason)``.
+
+    Properties (safety-preserving by construction):
+
+    - Only ever flips ``True → False`` (a promote can be vetoed; a reject
+      is never resurrected). The primary gate stays authoritative for
+      rejections.
+    - Dim-based predicates only — ``observed_fitness`` / ``baseline_fitness``
+      are intentionally NOT passed, so the evaluator's "fitness regresses"
+      patterns no-op here (those are already covered by the primary gate).
+      This pass adds only the *per-dim* guards the scalar cannot express,
+      e.g. ``"critical dim regresses by more than 0.5"`` or
+      ``"any dim regresses by more than 1.0"``.
+    - No-op when not promoting, when the predicate is empty/unparseable
+      (``evaluate_rollback_condition`` returns ``False`` on free-text), or
+      when there is no baseline to compare against — so legacy / manual
+      runs are unaffected.
+    """
+    if not ok or not condition.strip() or baseline_dim is None:
+        return ok, reason
+    from core.self_improving_loop.rollback_condition import evaluate_rollback_condition
+
+    if evaluate_rollback_condition(
+        condition.strip(),
+        observed_dim=observed_dim,
+        baseline_dim=baseline_dim,
+    ):
+        return False, f"rollback_condition fired [{condition.strip()}] (secondary per-dim gate)"
+    return ok, reason
+
+
 def _should_promote(
     current_means: dict[str, float],
     current_stderr: dict[str, float],
@@ -2576,6 +2620,14 @@ def main() -> int:
         action="store_true",
         help="skip baseline.json — gate stays dormant even if the file exists",
     )
+    parser.add_argument(
+        "--purge-cache",
+        action="store_true",
+        help="clear inspect_ai's generate trajectory cache before the audit "
+        "(closed-loop measurement hygiene; no-op under --dry-run). Use for a "
+        "fresh baseline or the first cycle of a batch so a residual cached "
+        "trajectory cannot replay a stale score (PR-SIL-MULTIOBJ A3).",
+    )
     promote_group = parser.add_mutually_exclusive_group()
     promote_group.add_argument(
         "--promote",
@@ -2600,6 +2652,19 @@ def main() -> int:
     gen_tag = _resolve_gen_tag(commit)
 
     cfg = _get_autoresearch_config()
+    # PR-SIL-MULTIOBJ A3 (2026-05-29) — optional cache hygiene before a
+    # real audit. Skipped under --dry-run (no subprocess). Best-effort:
+    # the purge helper is graceful when the [audit] extra is absent.
+    if args.purge_cache and not args.dry_run:
+        from plugins.petri_audit.runner import purge_inspect_cache
+
+        _purged = purge_inspect_cache()
+        _emit_journal(
+            session_id,
+            gen_tag,
+            "inspect_cache_purged",
+            payload={"purged": _purged},
+        )
     _emit_journal(
         session_id,
         gen_tag,
@@ -2899,6 +2964,19 @@ def main() -> int:
             baseline_ux_means=_baseline_ux_means or None,
             admire_means=admire_means_current,
             baseline_admire_means=_baseline_admire_means or None,
+        )
+        # PR-SIL-MULTIOBJ A2 (2026-05-29) — secondary reject gate. The
+        # mutator's own ``rollback_condition`` predicate (propagated via
+        # GEODE_SIL_ROLLBACK_CONDITION by the runner) is auto-evaluated
+        # here. It can only flip a promote → reject (never the reverse),
+        # after which the existing reject branch below performs the SoT
+        # revert.
+        ok, reason = _apply_rollback_condition_gate(
+            ok=ok,
+            reason=reason,
+            condition=os.environ.get("GEODE_SIL_ROLLBACK_CONDITION", ""),
+            observed_dim=dim_means,
+            baseline_dim=baseline_means,
         )
         if ok:
             _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
@@ -3205,6 +3283,13 @@ def main() -> int:
     # path (even when GEODE_SIL_* env not set) so non-group callers ignore
     # it safely.
     #
+    # PR-SIL-MULTIOBJ A1 (2026-05-29) — the sentinel now also carries the
+    # per-dim ``dim_means`` (+ ``dim_stderr``) vector so the group caller
+    # can run a Tchebycheff (worst-weighted-gap) selection over siblings
+    # instead of the linear scalar-only advantage. Additive only: the
+    # legacy parser path reads ``fitness`` + ``audit_run_id`` and ignores
+    # the extra keys, so single-mutation / non-pareto callers are unaffected.
+    #
     # Codex MCP review #8 (2026-05-25) — failure path (e.g. early-return
     # at line ~2030 audit failure 또는 quota gate trip) DOES NOT emit this
     # sentinel. The parser (``_parse_fitness_from_subprocess_stdout``) is
@@ -3212,9 +3297,16 @@ def main() -> int:
     # RuntimeError 로 cycle abort. 즉 failure path 의 no-sentinel 은 의도된
     # 동작 (silent zero-fitness fallback 회피).
     print(
-        f"FITNESS_RESULT: "
-        f'{{"fitness": {float(fitness):.6f}, '
-        f'"audit_run_id": "{_sil_audit_run_id}"}}'
+        "FITNESS_RESULT: "
+        + json.dumps(
+            {
+                "fitness": round(float(fitness), 6),
+                "audit_run_id": _sil_audit_run_id,
+                "dim_means": {k: float(v) for k, v in dim_means.items()},
+                "dim_stderr": {k: float(v) for k, v in (dim_stderr or {}).items()},
+            },
+            ensure_ascii=False,
+        )
     )
 
     return 0

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -1317,6 +1317,12 @@ def _cmd_matrix(opts: list[str]) -> None:
     total_kinds = len(matrix)
     total_dims = len({dim for dims in matrix.values() for dim in dims})
     console.print(f"    [muted]{total_kinds} kinds × {total_dims} dims tracked[/muted]")
+    # Cells are the cumulative attribution-weighted contribution
+    # (``attribution_score × observed_dim``). The sign is NOT a clean
+    # goodness signal — ``attribution_score`` is itself signed [-1, 1] —
+    # so this view keeps its raw contribution semantics. The canonical
+    # "+ = improvement" polarity view lives on the per-mutation
+    # ``signed_improvement`` attribution field (PR-SIL-MULTIOBJ A4).
     console.print()
     kind_width = max(len(k) for k in matrix)
     for kind in sorted(matrix):

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -42,6 +42,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from core.self_improving_loop.signal_polarity import to_signed_improvement
+
 if TYPE_CHECKING:
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
@@ -62,6 +64,12 @@ class AttributionRecord(BaseModel):
     kind: str = Field(default="attribution", pattern=r"^attribution$")
     mutation_id: str
     observed_dim: dict[str, float] = Field(default_factory=dict)
+    signed_improvement: dict[str, float] = Field(default_factory=dict)
+    """PR-SIL-MULTIOBJ A4 (2026-05-29) — ``observed_dim`` polarity-
+    normalised so ``+`` always means *improvement* and ``-`` *regression*,
+    regardless of the metric's native direction (Petri dims are
+    lower-is-better, so their sign is flipped here). Display/record only;
+    fitness math is unchanged. Legacy rows omit the field → ``{}``."""
     ci95: dict[str, float] = Field(default_factory=dict)
     significant: dict[str, bool] = Field(default_factory=dict)
     attribution_score: float = 0.0
@@ -258,6 +266,7 @@ def compute_attribution(
         "kind": "attribution",
         "mutation_id": mutation_id,
         "observed_dim": {},
+        "signed_improvement": {},
         "ci95": {},
         "significant": {},
         "attribution_score": 0.0,
@@ -302,6 +311,10 @@ def compute_attribution(
     score = _attribution_score(expected_dim, observed)
 
     payload["observed_dim"] = observed
+    # PR-SIL-MULTIOBJ A4 — canonical "+ = improvement" view of observed_dim.
+    payload["signed_improvement"] = {
+        dim: round(to_signed_improvement(dim, delta), 6) for dim, delta in observed.items()
+    }
     payload["ci95"] = ci
     payload["significant"] = significant
     payload["attribution_score"] = score

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1221,7 +1221,11 @@ def _parse_fitness_from_subprocess_stdout(
     """Parse the ``FITNESS_RESULT: {...}`` sentinel line from
     ``autoresearch/train.py`` stdout end-of-run.
 
-    Sentinel format: ``FITNESS_RESULT: {"fitness": <float>, "audit_run_id": "<id>"}``
+    Sentinel format (PR-SIL-MULTIOBJ A1): ``FITNESS_RESULT: {"fitness":
+    <float>, "audit_run_id": "<id>", "dim_means": {...}, "dim_stderr":
+    {...}}``. This parser reads only the scalar ``fitness`` (+ audit id);
+    the per-dim vectors are read separately by
+    :func:`_parse_dim_means_from_subprocess_stdout`.
 
     Raises RuntimeError when the sentinel is missing or unparseable —
     fail-fast so group sampling cycle aborts cleanly instead of producing
@@ -1255,6 +1259,146 @@ def _parse_fitness_from_subprocess_stdout(
         f"sentinel — autoresearch/train.py end-of-run print missing or stdout "
         f"truncated. audit_run_id={audit_run_id}"
     )
+
+
+def _parse_dim_means_from_subprocess_stdout(
+    stdout: str,
+    *,
+    audit_run_id: str,
+    sibling_idx: int,
+) -> dict[str, float]:
+    """Parse the additive per-dim ``dim_means`` map from the sentinel.
+
+    PR-SIL-MULTIOBJ A1 — companion to
+    :func:`_parse_fitness_from_subprocess_stdout`. The same
+    ``FITNESS_RESULT`` line carries a ``dim_means`` map; this returns it
+    so the group caller can run a Tchebycheff (worst-weighted-gap)
+    selection over siblings.
+
+    *Graceful* by contract: returns ``{}`` (never raises) when the
+    sentinel is absent, unparseable, or predates the additive field, and
+    skips any individual value that is not float-castable. A missing
+    vector only disables the Tchebycheff upgrade for that group — the
+    scalar fitness parser above stays the fail-fast guard for a
+    fully-missing sentinel, so this can never mask an audit failure.
+    """
+    for raw_line in reversed(stdout.splitlines()):
+        line = raw_line.strip()
+        if not line.startswith(_FITNESS_RESULT_SENTINEL):
+            continue
+        payload_str = line[len(_FITNESS_RESULT_SENTINEL) :].strip()
+        try:
+            payload = json.loads(payload_str)
+        except json.JSONDecodeError:
+            return {}
+        raw_means = payload.get("dim_means") if isinstance(payload, dict) else None
+        if not isinstance(raw_means, dict):
+            return {}
+        out: dict[str, float] = {}
+        for dim, value in raw_means.items():
+            try:
+                out[str(dim)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        if (
+            out
+            and audit_run_id
+            and str(payload.get("audit_run_id", ""))
+            not in (
+                "",
+                audit_run_id,
+            )
+        ):
+            log.warning(
+                "self-improving-loop: sibling[%d] dim_means audit_run_id mismatch "
+                "(expected %s) — dropping vector to avoid cross-sibling mixup",
+                sibling_idx,
+                audit_run_id,
+            )
+            return {}
+        return out
+    return {}
+
+
+def _select_best_idx(
+    *,
+    advantages: list[float],
+    sibling_dim_means: list[dict[str, float]],
+    pareto_mode: bool,
+    group_id: str,
+) -> int:
+    """Pick the winning sibling index from a group audit.
+
+    Default (``pareto_mode`` off, or any sibling missing its dim vector):
+    linear top-1 by the GRPO-whitened advantage — unchanged legacy
+    behaviour.
+
+    ``pareto_mode`` on **and** every sibling carries a full dim vector:
+    Tchebycheff (worst-weighted-gap) selection. Each sibling's raw
+    ``dim_means`` is transformed to higher-is-better scores via
+    ``_dim_score``; the ideal point z* is the per-dim best across the
+    group; the winner minimises the max weighted gap to z*
+    (``compute_tchebycheff`` returns the negated gap, so ``argmax`` =
+    closest to ideal). ``DIM_WEIGHTS`` are reused as the Tchebycheff
+    weights so a critical-axis gap (weight 0.10) dominates an auxiliary
+    gap (~0.0333) — a non-compensatory, safety-first selection that the
+    linear scalar advantage cannot express. Both candidate indices are
+    logged for comparison.
+    """
+    linear_idx = max(range(len(advantages)), key=lambda i: advantages[i])
+    if not pareto_mode:
+        return linear_idx
+    if len(sibling_dim_means) != len(advantages) or any(not dm for dm in sibling_dim_means):
+        log.warning(
+            "self-improving-loop: group %s — pareto_mode set but sibling dim "
+            "vectors incomplete (%d/%d non-empty); linear advantage selection",
+            group_id,
+            sum(1 for dm in sibling_dim_means if dm),
+            len(advantages),
+        )
+        return linear_idx
+
+    from autoresearch.train import DIM_WEIGHTS, _dim_score
+
+    from core.self_improving_loop.tchebycheff import (
+        compute_ideal_point,
+        compute_tchebycheff,
+    )
+
+    score_vectors = [
+        {dim: _dim_score(means[dim]) for dim in DIM_WEIGHTS if dim in means}
+        for means in sibling_dim_means
+    ]
+    # Score every sibling on the SAME axes — the intersection of weighted
+    # dims present in all siblings. Without this a sibling whose raw vector
+    # has no DIM_WEIGHTS overlap (or only a partial set) would yield an
+    # empty / short score vector and a Tchebycheff scalar of 0.0, which —
+    # since real scalars are negated gaps (≤ 0) — would spuriously beat
+    # every genuine sibling at ``argmax``. Empty intersection ⇒ linear
+    # fallback (no fair multi-dim comparison is possible).
+    common_dims = set.intersection(*(set(v) for v in score_vectors))
+    if not common_dims:
+        log.warning(
+            "self-improving-loop: group %s — no weighted dim common to all "
+            "siblings; linear advantage selection",
+            group_id,
+        )
+        return linear_idx
+    score_vectors = [{dim: vec[dim] for dim in common_dims} for vec in score_vectors]
+    ideal = compute_ideal_point(score_vectors)
+    tcheby = [
+        compute_tchebycheff(vec, weights=DIM_WEIGHTS, ideal_point=ideal) for vec in score_vectors
+    ]
+    tcheby_idx = max(range(len(tcheby)), key=lambda i: tcheby[i])
+    log.info(
+        "self-improving-loop: group %s — selection linear=sibling[%d] "
+        "tchebycheff=sibling[%d] (tcheby scalars=%s)",
+        group_id,
+        linear_idx,
+        tcheby_idx,
+        [round(t, 4) for t in tcheby],
+    )
+    return tcheby_idx
 
 
 def append_group_variance_history(
@@ -1632,6 +1776,7 @@ def _run_autoresearch_subprocess(
     sibling_sot_path: Path | None = None,
     group_id: str = "",
     no_promote: bool = False,
+    rollback_condition: str = "",
 ) -> subprocess.CompletedProcess[str]:
     """Spawn ``autoresearch/train.py`` for the post-mutation audit.
 
@@ -1666,6 +1811,14 @@ def _run_autoresearch_subprocess(
         env["GEODE_SIL_EXPECTED_DIM"] = json.dumps(expected_dim or {}, ensure_ascii=False)
     if group_id:
         env["GEODE_SIL_GROUP_ID"] = group_id
+    # PR-SIL-MULTIOBJ A2 (2026-05-29) — propagate the mutation's
+    # ``rollback_condition`` predicate so train.py's promote decision can
+    # auto-evaluate it (``evaluate_rollback_condition``) as a *secondary*
+    # reject gate. Empty string ⇒ env unset ⇒ train.py skips the check
+    # (legacy behaviour). The sibling no_promote audits never promote, so
+    # this only bites on the winner's promote run.
+    if rollback_condition:
+        env["GEODE_SIL_ROLLBACK_CONDITION"] = rollback_condition
     # PR-11 P3.1 (2026-05-25) — anchor_confidence_mode env forward. config
     # default 가 False 라 set 안 된 sibling/legacy 동작 영향 0. True 일
     # 때만 train.py 의 caller 가 ``compute_fitness`` 에 multiplier 인자를
@@ -2027,6 +2180,7 @@ class SelfImprovingLoopRunner:
         )
 
         fitness_values: list[float] = []
+        sibling_dim_means: list[dict[str, float]] = []  # PR-SIL-MULTIOBJ A1
         audit_run_ids: list[str] = []
         sibling_sot_paths: list[Path] = []
         sibling_previous_values: list[str] = []
@@ -2062,6 +2216,16 @@ class SelfImprovingLoopRunner:
                     proc.stdout, audit_run_id=audit_run_id, sibling_idx=idx
                 )
                 fitness_values.append(fitness)
+                # PR-SIL-MULTIOBJ A1 — capture the per-dim vector only when
+                # pareto_mode is on (the sole consumer is the Tchebycheff
+                # selection below); pareto-off keeps the legacy linear path
+                # with zero extra parsing.
+                if cfg.autoresearch.pareto_mode:
+                    sibling_dim_means.append(
+                        _parse_dim_means_from_subprocess_stdout(
+                            proc.stdout, audit_run_id=audit_run_id, sibling_idx=idx
+                        )
+                    )
 
             advantages, status = _compute_group_advantage(
                 fitness_values,
@@ -2193,8 +2357,14 @@ class SelfImprovingLoopRunner:
                     _archive_failed,
                 )
 
-            # Top-1 by advantage
-            best_idx = max(range(len(advantages)), key=lambda i: advantages[i])
+            # Top-1 — Tchebycheff (worst-weighted-gap) when pareto_mode +
+            # full sibling dim vectors are available; else linear advantage.
+            best_idx = _select_best_idx(
+                advantages=advantages,
+                sibling_dim_means=sibling_dim_means,
+                pareto_mode=cfg.autoresearch.pareto_mode,
+                group_id=group_id,
+            )
             best_proposal = proposals[best_idx]
             log.info(
                 "self-improving-loop: group %s — best=sibling[%d] advantage=%.4f fitness=%.4f",
@@ -2203,6 +2373,43 @@ class SelfImprovingLoopRunner:
                 advantages[best_idx],
                 fitness_values[best_idx],
             )
+
+            # PR-SIL-MULTIOBJ A2 (group path) — secondary reject gate for
+            # the group winner. Group mode commits the winner directly
+            # (no ``_should_promote`` re-run, so train.py's A2 gate never
+            # fires here), so evaluate the mutator's ``rollback_condition``
+            # against the winner's measured dim vector (captured above for
+            # A1) vs the promoted baseline. A firing predicate skips the
+            # commit (cycle yields no SoT change) — it can only veto, never
+            # loosen. Gated on pareto_mode (vectors present) + a non-empty
+            # predicate; unparseable predicates evaluate False (no-op).
+            if (
+                cfg.autoresearch.pareto_mode
+                and best_proposal.mutation.rollback_condition
+                and best_idx < len(sibling_dim_means)
+                and sibling_dim_means[best_idx]
+            ):
+                from plugins.seed_generation.baseline_reader import load_baseline
+
+                from core.self_improving_loop.rollback_condition import (
+                    evaluate_rollback_condition,
+                )
+
+                _baseline_snap = load_baseline()
+                _baseline_dim = _baseline_snap.dim_means if _baseline_snap is not None else None
+                if _baseline_dim and evaluate_rollback_condition(
+                    best_proposal.mutation.rollback_condition,
+                    observed_dim=sibling_dim_means[best_idx],
+                    baseline_dim=_baseline_dim,
+                ):
+                    log.info(
+                        "self-improving-loop: group %s — winner sibling[%d] "
+                        "rollback_condition fired [%s]; skipping commit (no SoT change)",
+                        group_id,
+                        best_idx,
+                        best_proposal.mutation.rollback_condition,
+                    )
+                    return None
 
             # Commit best to canonical SoT + apply row (kind="applied")
             _committed_sections, previous_value = apply_mutation(
@@ -2607,6 +2814,7 @@ class SelfImprovingLoopRunner:
                 audit_run_id=audit_run_id,
                 mutation_id=mutation.mutation_id if mutation is not None else "",
                 expected_dim=mutation.expected_dim if mutation is not None else None,
+                rollback_condition=(mutation.rollback_condition if mutation is not None else ""),
             )
         except Exception as exc:
             log.warning("self-improving-loop autoresearch re-run failed", exc_info=True)

--- a/core/self_improving_loop/signal_polarity.py
+++ b/core/self_improving_loop/signal_polarity.py
@@ -1,0 +1,70 @@
+"""Signal polarity — canonical "+ = improvement, − = regression".
+
+PR-SIL-MULTIOBJ A4 (2026-05-29). The self-improving loop mixes two
+metric families with opposite native directions:
+
+- **Petri rubric dims** (the 1-10 concerning-behaviour scale) are
+  *lower-is-better*, so a *negative* raw delta (``after - before``) is an
+  improvement.
+- **Positive-pressure axes** (``ux_means`` / ``admire_means`` /
+  ``bench_means`` fields) are *higher-is-better*, so a *positive* raw
+  delta is an improvement.
+
+Readers of ``mutations.jsonl`` / the observability CLI could not tell
+from a raw delta's sign alone whether it was good or bad (the
+[[feedback_dim_convention_direction]] ambiguity — "drop" is good for a
+Petri dim, bad for ``success_rate``). This module supplies a single
+canonical transform so every surface can speak one language: the
+``signed_improvement`` value is **positive when the agent got better**
+and **negative when it got worse**, regardless of the metric's native
+direction.
+
+This is a *record / display* helper only — it does NOT feed
+``compute_fitness`` (which keeps its own ``_dim_score`` transform). The
+higher-is-better field set is derived from the canonical weight dicts
+(``UX_DIM_WEIGHTS`` / ``ADMIRE_DIM_WEIGHTS`` / ``BENCH_DIM_WEIGHTS``) so
+there is no second copy of the field names to drift.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _higher_is_better_fields() -> frozenset[str]:
+    """Field names of the positive-pressure axes (higher-is-better).
+
+    Derived from the autoresearch weight dicts (single SoT). Imported
+    lazily + cached so this module has no import-time coupling to the
+    ``autoresearch`` package (which imports ``core``); the first call
+    resolves the set once.
+    """
+    from autoresearch.admire_means import ADMIRE_DIM_WEIGHTS
+    from autoresearch.bench_means import BENCH_DIM_WEIGHTS
+    from autoresearch.ux_means import UX_DIM_WEIGHTS
+
+    return frozenset({*UX_DIM_WEIGHTS, *ADMIRE_DIM_WEIGHTS, *BENCH_DIM_WEIGHTS})
+
+
+def metric_polarity(metric_name: str) -> int:
+    """Return ``+1`` for higher-is-better metrics, ``-1`` for lower-is-better.
+
+    Lower-is-better (the Petri rubric dims) is the default: anything not
+    in the positive-pressure field set is treated as a concerning-
+    behaviour dim where a lower mean is better.
+    """
+    return 1 if metric_name in _higher_is_better_fields() else -1
+
+
+def to_signed_improvement(metric_name: str, raw_delta: float) -> float:
+    """Polarity-normalised delta: positive ⇒ improvement, negative ⇒ regression.
+
+    For a lower-is-better Petri dim the sign is flipped (a ``-6.0`` raw
+    delta — the mean fell by 6 — becomes ``+6.0`` improvement); for a
+    higher-is-better ux/admire/bench field the sign is unchanged.
+    """
+    return metric_polarity(metric_name) * float(raw_delta)
+
+
+__all__ = ["metric_polarity", "to_signed_improvement"]

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -294,6 +294,50 @@ def build_command(
     return cmd
 
 
+def purge_inspect_cache() -> bool:
+    """Clear inspect_ai's generate trajectory cache before a fresh run.
+
+    PR-SIL-MULTIOBJ A3 (2026-05-29) — the closed loop's audits run with
+    the trajectory cache OFF (no ``-T cache=true``; see ``cli_audit.py``
+    default), but a *residual* cache from an earlier ``geode audit
+    --cache`` run, or from a partially-failed audit on the same host,
+    can still be hit: the cache key is ``(model config, input messages,
+    base_url, tools, expiry, scopes, epoch)``, so a stale trajectory for
+    an identical seed replays its recorded score and silently corrupts a
+    mutation-vs-baseline comparison. Calling this before a fresh baseline
+    extraction or a cycle batch removes that residue.
+
+    Uses inspect_ai's own ``cache_clear`` as the single source of truth
+    for the cache location — the path (``cache_path()``) is platform- and
+    config-dependent, so it is **not** hardcoded here. Graceful: when the
+    ``[audit]`` extra is absent (default ``uv sync``), logs and returns
+    ``False`` rather than raising, so non-audit callers are unaffected.
+
+    Returns ``True`` when the purge completed (cache now empty, whether or
+    not it had content), ``False`` when inspect_ai is unavailable or the
+    clear raised.
+    """
+    try:
+        from inspect_ai.model import cache_clear, cache_path
+    except ImportError:
+        log.warning(
+            "purge_inspect_cache: inspect_ai not installed ([audit] extra) — skipping cache purge"
+        )
+        return False
+    try:
+        target = cache_path()
+        cleared = cache_clear()
+    except Exception as exc:  # pragma: no cover — defensive (inspect_ai internals)
+        log.warning("purge_inspect_cache: cache_clear failed — %s", exc)
+        return False
+    log.info(
+        "purge_inspect_cache: cleared inspect_ai generate cache at %s (cache_clear=%s)",
+        target,
+        cleared,
+    )
+    return True
+
+
 def _validate_dim_path(resolved: Any) -> None:
     """Validate a resolved ``--dim-set`` value (path-like).
 

--- a/tests/core/self_improving_loop/test_attribution_wiring.py
+++ b/tests/core/self_improving_loop/test_attribution_wiring.py
@@ -170,6 +170,57 @@ class TestW2SubprocessEnvPropagation:
         assert "GEODE_SIL_MUTATION_ID" not in captured
         assert "GEODE_SIL_EXPECTED_DIM" not in captured
 
+    def test_run_autoresearch_subprocess_sets_rollback_condition_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """PR-SIL-MULTIOBJ A2 — ``rollback_condition`` propagates to the
+        subprocess env so train.py's secondary gate can evaluate it."""
+        captured: dict[str, str] = {}
+
+        def fake_run(argv: list[str], *args: object, **kwargs: object) -> object:
+            env = kwargs.get("env") or {}
+            captured.update({k: v for k, v in env.items() if k.startswith("GEODE_SIL_")})
+
+            class _Fake:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Fake()
+
+        monkeypatch.setattr("core.self_improving_loop.runner.subprocess.run", fake_run)
+        _run_autoresearch_subprocess(
+            repo_root=tmp_path,
+            dry_run=True,
+            rollback_condition="critical dim regresses by more than 0.5",
+        )
+        assert captured["GEODE_SIL_ROLLBACK_CONDITION"] == "critical dim regresses by more than 0.5"
+
+    def test_run_autoresearch_subprocess_skips_rollback_condition_when_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Empty rollback_condition ⇒ env unset ⇒ train.py skips the gate."""
+        captured: dict[str, str] = {}
+
+        def fake_run(argv: list[str], *args: object, **kwargs: object) -> object:
+            env = kwargs.get("env") or {}
+            captured.update({k: v for k, v in env.items() if k.startswith("GEODE_SIL_")})
+
+            class _Fake:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Fake()
+
+        monkeypatch.setattr("core.self_improving_loop.runner.subprocess.run", fake_run)
+        _run_autoresearch_subprocess(repo_root=tmp_path, dry_run=True, rollback_condition="")
+        assert "GEODE_SIL_ROLLBACK_CONDITION" not in captured
+
 
 # ---------------------------------------------------------------------------
 # W3 — audit_run_id field on apply row

--- a/tests/core/self_improving_loop/test_pareto_mode_wiring.py
+++ b/tests/core/self_improving_loop/test_pareto_mode_wiring.py
@@ -212,3 +212,111 @@ def test_pareto_archive_helper_imports_clean() -> None:
 
     assert ArchiveEntry is not None
     assert append_archive_entry is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. PR-SIL-MULTIOBJ A1 — sibling dim_means parse + Tchebycheff selection
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dim_means_from_sentinel() -> None:
+    """The additive ``dim_means`` map is extracted from the FITNESS_RESULT line."""
+    from core.self_improving_loop.runner import _parse_dim_means_from_subprocess_stdout
+
+    stdout = (
+        "some audit log line\n"
+        'FITNESS_RESULT: {"fitness": 0.5, "audit_run_id": "run1", '
+        '"dim_means": {"broken_tool_use": 2.0, "redundant_tool_invocation": 7.0}, '
+        '"dim_stderr": {}}\n'
+    )
+    means = _parse_dim_means_from_subprocess_stdout(stdout, audit_run_id="run1", sibling_idx=0)
+    assert means == {"broken_tool_use": 2.0, "redundant_tool_invocation": 7.0}
+
+
+def test_parse_dim_means_graceful_on_legacy_or_garbage() -> None:
+    """Missing / legacy / unparseable sentinel → {} (never raises)."""
+    from core.self_improving_loop.runner import _parse_dim_means_from_subprocess_stdout
+
+    # Legacy sentinel without dim_means
+    legacy = 'FITNESS_RESULT: {"fitness": 0.5, "audit_run_id": "run1"}\n'
+    assert _parse_dim_means_from_subprocess_stdout(legacy, audit_run_id="run1", sibling_idx=0) == {}
+    # No sentinel at all
+    assert (
+        _parse_dim_means_from_subprocess_stdout("nothing here\n", audit_run_id="r", sibling_idx=0)
+        == {}
+    )
+    # Garbage payload after the sentinel
+    garbage = "FITNESS_RESULT: {not json\n"
+    assert _parse_dim_means_from_subprocess_stdout(garbage, audit_run_id="r", sibling_idx=0) == {}
+
+
+def test_select_best_idx_linear_when_pareto_off() -> None:
+    """pareto_mode=False → linear top-1 by advantage (legacy, unchanged)."""
+    from core.self_improving_loop.runner import _select_best_idx
+
+    # Sibling 0 has the highest advantage → linear winner regardless of dims.
+    idx = _select_best_idx(
+        advantages=[1.0, 0.5],
+        sibling_dim_means=[],  # not captured when pareto off
+        pareto_mode=False,
+        group_id="g",
+    )
+    assert idx == 0
+
+
+def test_select_best_idx_tchebycheff_overrides_linear() -> None:
+    """pareto_mode=True → worst-weighted-gap (Tchebycheff) winner ≠ linear winner.
+
+    Sibling 0 has the higher linear advantage but a *critical* axis
+    (broken_tool_use, weight 0.10) collapsed to mean 9.0 (score 0.1).
+    Sibling 1 is balanced. The Tchebycheff selection — dominated by the
+    worst weighted gap — must reject the spiky sibling 0 and pick the
+    balanced sibling 1, which the linear advantage cannot do.
+    """
+    from core.self_improving_loop.runner import _select_best_idx
+
+    advantages = [1.0, 0.5]  # linear would pick sibling 0
+    sibling_dim_means = [
+        {"broken_tool_use": 9.0, "redundant_tool_invocation": 1.0},  # spiky: critical bad
+        {"broken_tool_use": 2.0, "redundant_tool_invocation": 2.0},  # balanced
+    ]
+    idx = _select_best_idx(
+        advantages=advantages,
+        sibling_dim_means=sibling_dim_means,
+        pareto_mode=True,
+        group_id="g",
+    )
+    assert idx == 1  # Tchebycheff picks the balanced sibling, not the linear top-1
+
+
+def test_select_best_idx_falls_back_when_vectors_incomplete() -> None:
+    """pareto_mode=True but a sibling vector missing → graceful linear fallback."""
+    from core.self_improving_loop.runner import _select_best_idx
+
+    idx = _select_best_idx(
+        advantages=[0.5, 1.0],  # linear → sibling 1
+        sibling_dim_means=[{"broken_tool_use": 2.0}, {}],  # sibling 1 vector empty
+        pareto_mode=True,
+        group_id="g",
+    )
+    assert idx == 1  # falls back to linear
+
+
+def test_select_best_idx_no_common_weighted_dim_falls_back_to_linear() -> None:
+    """A non-empty raw vector with no DIM_WEIGHTS overlap must not produce
+    a 0.0 Tchebycheff scalar that spuriously beats the always-negative real
+    scalars (Codex review catch). No common weighted dim ⇒ linear fallback.
+    """
+    from core.self_improving_loop.runner import _select_best_idx
+
+    idx = _select_best_idx(
+        advantages=[0.2, 0.9],  # linear → sibling 1
+        sibling_dim_means=[
+            {"broken_tool_use": 2.0},  # weighted dim
+            {"not_a_weighted_dim": 1.0},  # non-empty but zero weighted overlap
+        ],
+        pareto_mode=True,
+        group_id="g",
+    )
+    # No common weighted dim → linear (sibling 1), NOT the empty-score sibling 0.
+    assert idx == 1

--- a/tests/core/self_improving_loop/test_rollback_condition.py
+++ b/tests/core/self_improving_loop/test_rollback_condition.py
@@ -343,3 +343,78 @@ def test_works_with_mutation_rollback_condition_field() -> None:
         baseline_dim={"broken_tool_use": 1.0},
     )
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 10. PR-SIL-MULTIOBJ A2 — secondary reject gate wiring
+#     (_apply_rollback_condition_gate in autoresearch/train.py)
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_gate_flips_promote_to_reject_when_predicate_fires() -> None:
+    """A firing per-dim predicate vetoes a promote (True → False)."""
+    from autoresearch.train import _apply_rollback_condition_gate
+
+    ok, reason = _apply_rollback_condition_gate(
+        ok=True,
+        reason="fitness 0.40 → 0.42 (Δ+0.02)",
+        condition="critical dim regresses by more than 0.5",
+        observed_dim={"broken_tool_use": 2.0},  # baseline 1.0 → +1.0 > 0.5
+        baseline_dim={"broken_tool_use": 1.0},
+    )
+    assert ok is False
+    assert "rollback_condition fired" in reason
+
+
+def test_rollback_gate_noop_when_predicate_does_not_fire() -> None:
+    """A promote survives when the predicate does not trigger."""
+    from autoresearch.train import _apply_rollback_condition_gate
+
+    ok, reason = _apply_rollback_condition_gate(
+        ok=True,
+        reason="promoted",
+        condition="critical dim regresses by more than 0.5",
+        observed_dim={"broken_tool_use": 1.1},  # +0.1 < 0.5 → no fire
+        baseline_dim={"broken_tool_use": 1.0},
+    )
+    assert ok is True
+    assert reason == "promoted"
+
+
+def test_rollback_gate_never_resurrects_a_reject() -> None:
+    """ok=False stays False — the gate only adds rejects, never promotes."""
+    from autoresearch.train import _apply_rollback_condition_gate
+
+    ok, reason = _apply_rollback_condition_gate(
+        ok=False,
+        reason="critical-axis regression (gated fitness = 0.0)",
+        condition="critical dim regresses by more than 0.5",
+        observed_dim={"broken_tool_use": 0.5},  # would NOT fire, but ok already False
+        baseline_dim={"broken_tool_use": 1.0},
+    )
+    assert ok is False
+    assert reason == "critical-axis regression (gated fitness = 0.0)"
+
+
+def test_rollback_gate_noop_on_free_text_or_no_baseline() -> None:
+    """Unparseable free-text predicate or absent baseline ⇒ no-op (legacy)."""
+    from autoresearch.train import _apply_rollback_condition_gate
+
+    # Free-text (mutator prose that matches none of the 4 patterns)
+    ok, _reason = _apply_rollback_condition_gate(
+        ok=True,
+        reason="promoted",
+        condition="revert if the agent feels unsafe",
+        observed_dim={"broken_tool_use": 9.0},
+        baseline_dim={"broken_tool_use": 1.0},
+    )
+    assert ok is True
+    # No baseline to compare against
+    ok2, _ = _apply_rollback_condition_gate(
+        ok=True,
+        reason="bootstrap_promote",
+        condition="critical dim regresses by more than 0.5",
+        observed_dim={"broken_tool_use": 9.0},
+        baseline_dim=None,
+    )
+    assert ok2 is True

--- a/tests/core/self_improving_loop/test_signal_polarity.py
+++ b/tests/core/self_improving_loop/test_signal_polarity.py
@@ -1,0 +1,92 @@
+"""PR-SIL-MULTIOBJ A4 — signal polarity normalisation (+ = improvement).
+
+Covers the ``signal_polarity`` helper, the drift guard that the
+higher-is-better field set is *derived* from the canonical weight dicts
+(no second copy), and the ``compute_attribution`` integration that emits
+a polarity-normalised ``signed_improvement`` alongside ``observed_dim``.
+"""
+
+from __future__ import annotations
+
+from core.self_improving_loop.signal_polarity import (
+    metric_polarity,
+    to_signed_improvement,
+)
+
+
+def test_to_signed_improvement_flips_lower_is_better_petri_dim() -> None:
+    """Petri dim improved (mean 7→1, raw delta -6.0) → +6.0 improvement."""
+    assert to_signed_improvement("redundant_tool_invocation", -6.0) == 6.0
+    # Regressed (mean 1→3, raw delta +2.0) → -2.0 (worse)
+    assert to_signed_improvement("broken_tool_use", 2.0) == -2.0
+
+
+def test_to_signed_improvement_preserves_higher_is_better_axis() -> None:
+    """ux/admire/bench fields keep their sign (higher raw = improvement)."""
+    assert to_signed_improvement("success_rate", 0.2) == 0.2
+    assert to_signed_improvement("pairwise_win_rate", -0.1) == -0.1
+
+
+def test_metric_polarity_values() -> None:
+    assert metric_polarity("broken_tool_use") == -1  # Petri, lower-is-better
+    assert metric_polarity("redundant_tool_invocation") == -1
+    assert metric_polarity("success_rate") == 1  # ux, higher-is-better
+    assert metric_polarity("swe_bench_pro_pass") == 1  # bench
+    assert metric_polarity("pairwise_win_rate") == 1  # admire
+    # Unknown metric defaults to lower-is-better (Petri is the default family)
+    assert metric_polarity("some_future_dim") == -1
+
+
+def test_higher_is_better_set_derived_from_canonical_weights() -> None:
+    """Drift guard — the +1 polarity set is exactly the union of the three
+    canonical weight dicts, so there is no hand-maintained second copy to
+    drift from the SoT."""
+    from autoresearch.admire_means import ADMIRE_DIM_WEIGHTS
+    from autoresearch.bench_means import BENCH_DIM_WEIGHTS
+    from autoresearch.ux_means import UX_DIM_WEIGHTS
+
+    expected = {*UX_DIM_WEIGHTS, *ADMIRE_DIM_WEIGHTS, *BENCH_DIM_WEIGHTS}
+    for field in expected:
+        assert metric_polarity(field) == 1, f"{field} should be higher-is-better"
+
+
+def test_compute_attribution_emits_signed_improvement() -> None:
+    """Integration — the attribution payload carries a polarity-normalised
+    ``signed_improvement`` mirroring ``observed_dim``."""
+    from core.self_improving_loop.attribution import AttributionRecord, compute_attribution
+    from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+    before = BaselineSnapshot(
+        dim_means={"redundant_tool_invocation": 7.0},
+        dim_stderr={"redundant_tool_invocation": 0.1},
+    )
+    after = BaselineSnapshot(
+        dim_means={"redundant_tool_invocation": 1.0},
+        dim_stderr={"redundant_tool_invocation": 0.1},
+    )
+    payload = compute_attribution(
+        mutation_id="mut-1",
+        expected_dim={"redundant_tool_invocation": -0.4},
+        baseline_before=before,
+        baseline_after=after,
+    )
+    # raw observed delta = after - before = -6.0 (lower-is-better → good)
+    assert payload["observed_dim"]["redundant_tool_invocation"] == -6.0
+    # polarity-normalised → +6.0 (improvement)
+    assert payload["signed_improvement"]["redundant_tool_invocation"] == 6.0
+    # schema round-trips the new field
+    record = AttributionRecord.model_validate(payload)
+    assert record.signed_improvement["redundant_tool_invocation"] == 6.0
+
+
+def test_signed_improvement_empty_without_baseline() -> None:
+    """No baseline → no observed_dim → signed_improvement stays {} (legacy)."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="mut-1",
+        expected_dim={"safety": 0.1},
+        baseline_before=None,
+        baseline_after=None,
+    )
+    assert payload["signed_improvement"] == {}

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -749,3 +749,50 @@ def test_n4_estimator_lands_within_landing_zone_for_known_runs() -> None:
         f"estimate ${n6_estimate:.2f} = {ratio:.2f}, want 0.30-1.50. "
         "Re-tune TokenAssumptions or update the historical anchor."
     )
+
+
+# ---------------------------------------------------------------------------
+# purge_inspect_cache — PR-SIL-MULTIOBJ A3 (closed-loop cache hygiene)
+# ---------------------------------------------------------------------------
+
+
+def test_purge_inspect_cache_uses_inspect_api_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When inspect_ai is importable, purge delegates to its ``cache_clear``
+    (SoT for the cache location) and returns True.
+
+    A fake ``inspect_ai.model`` module is injected so the *real* cache is
+    never touched — important because the live loop relies on it.
+    """
+    import sys
+    import types
+
+    from plugins.petri_audit.runner import purge_inspect_cache
+
+    calls = {"clear": 0}
+    fake_model = types.ModuleType("inspect_ai.model")
+    fake_model.cache_clear = lambda model="": (
+        calls.__setitem__("clear", calls["clear"] + 1),
+        True,
+    )[1]  # type: ignore[attr-defined]
+    fake_model.cache_path = lambda model="": Path("fake-inspect-cache")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "inspect_ai", types.ModuleType("inspect_ai"))
+    monkeypatch.setitem(sys.modules, "inspect_ai.model", fake_model)
+
+    assert purge_inspect_cache() is True
+    assert calls["clear"] == 1
+
+
+def test_purge_inspect_cache_graceful_without_audit_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the [audit] extra (inspect_ai import fails) → returns False,
+    never raises."""
+    import sys
+
+    from plugins.petri_audit.runner import purge_inspect_cache
+
+    # Force `from inspect_ai.model import ...` to raise ImportError.
+    monkeypatch.setitem(sys.modules, "inspect_ai.model", None)
+    assert purge_inspect_cache() is False

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -59,6 +59,21 @@ def test_build_audit_command_uses_current_geode_audit_flags() -> None:
         assert stale not in argv, f"unexpected flag {stale} present in {argv}"
 
 
+def test_build_audit_command_never_enables_inspect_cache() -> None:
+    """PR-SIL-MULTIOBJ A3 — closed-loop measurement hygiene regression pin.
+
+    The autoresearch audit argv must never enable inspect_ai's trajectory
+    cache: a cached trajectory for an identical seed replays a stale score
+    and corrupts the mutation-vs-baseline comparison. ``geode audit``
+    defaults to ``--no-cache``, so the invariant is simply that this
+    builder never adds a cache-enabling token (``--cache`` / ``cache=true``).
+    """
+    argv = _build_audit_command()
+    joined = " ".join(str(a) for a in argv).lower()
+    assert "--cache" not in argv
+    assert "cache=true" not in joined
+
+
 def test_wrapper_override_hook_ready_is_true() -> None:
     assert WRAPPER_OVERRIDE_HOOK_READY is True
 


### PR DESCRIPTION
## Summary
- Wire the self-improving loop's previously **orphan** multi-objective infra (`compute_tchebycheff`/`compute_ideal_point`, `evaluate_rollback_condition`) into the live decision path, **low-risk**: the primary promote gate (`_should_promote` + critical min-max floor) is unchanged.
- Add closed-loop measurement hygiene: inspect-ai cache purge + a regression pin, and a canonical `signed_improvement` (+ = improvement) signal on attribution rows.

## Why
The loop *observes* multi-dim (`observed_dim`, `kind_dim_matrix`) but *decides* on a single linear scalar, smothering per-axis signal; the non-compensatory machinery to fix this was built + tested with **zero production callers** ("implemented ≠ wired"). The per-mutation `rollback_condition` was recorded but never auto-evaluated at runtime, and signal polarity was mixed (Petri lower-is-better vs ux/admire/bench higher-is-better) with no canonical sign.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | A1 `_select_best_idx` (Tchebycheff group selection, common-dim guard) + `_parse_dim_means_from_subprocess_stdout`; A2 `rollback_condition` env propagation + group-winner veto |
| `autoresearch/train.py` | A1 `dim_means` on `FITNESS_RESULT` sentinel; A2 `_apply_rollback_condition_gate` after `_should_promote`; A3 `--purge-cache` flag |
| `plugins/petri_audit/runner.py` | A3 `purge_inspect_cache()` (delegates to inspect_ai `cache_clear`, graceful) |
| `core/self_improving_loop/signal_polarity.py` | A4 new — `to_signed_improvement` / `metric_polarity` (higher-is-better set derived from canonical weight dicts) |
| `core/self_improving_loop/attribution.py` | A4 `signed_improvement` field on attribution rows |
| `core/cli/commands/self_improving.py` | matrix view comment clarifying contribution (not goodness) semantics |
| `tests/...` (5 files) | A1-A4 unit tests incl. linear≠Tchebycheff, veto-only gate, cache no-enable pin, polarity drift guard |
| `CHANGELOG.md` | `[Unreleased]` PR-SIL-MULTIOBJ entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Tchebycheff selection | Implemented | gated on `pareto_mode` + `group_size≥2`; default path identical |
| `rollback_condition` runtime gate | Implemented | single-mutation + group paths; veto-only |
| inspect-ai cache purge | Implemented | + regression pin |
| signal polarity | Implemented | record-layer `signed_improvement` |
| `detect_cross_validation_conflict` "direction bug" | Dropped | Explore false positive — internally consistent in raw dim space |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ autoresearch/)
- [x] ruff format --check clean
- [x] mypy clean (466 source files)
- [x] lint-imports clean (4 kept, 0 broken)
- [x] pytest pass — 665 (self_improving_loop + petri_audit + autoresearch suites)
- [x] Codex MCP cross-review clean (3 catches addressed: A2 group-path gap, Tchebycheff empty-vector spurious win, matrix polarity mislabel)

## Reference
Session analysis of the autoresearch outer loop (linear-scalar smothering vs Karpathy single-objective autoresearch); Tchebycheff scalarization (Das & Dennis 1997). Follows decisions: low-risk wiring, merge-first sequencing.