### PR TITLE
ci(pages): deploy on whole docs/self-improving hub (not just petri-bundle)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,10 +3,13 @@ name: Deploy site to GitHub Pages
 # Builds the Next.js static export under `site/` and deploys it to GitHub
 # Pages. Site URL after deploy: https://mangowhoiscloud.github.io/geode/
 #
-# Triggers on changes to `site/**`, this workflow, or any of the SOT files
-# that `sync-stats` reads (CHANGELOG.md, pyproject.toml, CLAUDE.md). A docs
-# page like `/docs/reference/changelog` therefore stays in sync with
-# CHANGELOG.md without a separate commit to `site/`.
+# Triggers on changes to `site/**`, the self-improving hub under
+# `docs/self-improving/**` (copied into `site/out/self-improving/` at build
+# time), this workflow, or any of the SOT files that `sync-stats` reads
+# (CHANGELOG.md, pyproject.toml, CLAUDE.md). A docs page like
+# `/docs/reference/changelog` therefore stays in sync with CHANGELOG.md
+# without a separate commit to `site/`, and a hub rebuild (seed-generation /
+# mutations / autoresearch HTML) deploys without needing a `site/` touch.
 #
 # Daily 09:00 KST cron also runs as a safety net so the docs page can never
 # fall more than 24 hours behind even if Pages settings get changed by an
@@ -20,7 +23,7 @@ on:
     branches: [main]
     paths:
       - "site/**"
-      - "docs/self-improving/petri-bundle/**"
+      - "docs/self-improving/**"
       - "docs/audits/**"
       - "plugins/petri_audit/judge_dims/**"
       - "CHANGELOG.md"
@@ -32,7 +35,7 @@ on:
   pull_request:
     paths:
       - "site/**"
-      - "docs/self-improving/petri-bundle/**"
+      - "docs/self-improving/**"
       - "docs/audits/**"
       - "plugins/petri_audit/judge_dims/**"
       - ".pymarkdown.json"


### PR DESCRIPTION
## Summary
- Broaden the `pages.yml` deploy trigger from `docs/self-improving/petri-bundle/**` to the whole `docs/self-improving/**`, so a hub-only rebuild (seed-generation / mutations / autoresearch HTML) pushed to main actually fires the deploy.

## Why
`pages.yml` copies all of `docs/self-improving/` into `site/out/self-improving/` at build time (the "Copy docs/self-improving into site/out" step), but the push/PR `paths:` filter only matched the petri-bundle subtree. A hub-only change on main therefore did not trigger a deploy, so the production hub could silently lag the committed renders. (Flagged in the self-improving handoff; root-cause confirmed against the workflow this PR.)

## Changes
| File | Change |
|------|--------|
| `.github/workflows/pages.yml` | push + PR trigger paths `docs/self-improving/petri-bundle/**` -> `docs/self-improving/**`; header comment documents hub coverage |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| A-1 cost -> tokens (USD removal) | **Already done** | origin/develop already returns `cost_total_tokens` (no `total_usd`); templates bind `{{ cost_total_tokens }}`; agent detail uses `tokens`. `usd_spent` survives only as an unsurfaced raw input field. My earlier USD hits were a stale primary-worktree copy. No change needed. |
| A-2 pages.yml trigger gap | Implemented | this PR |

## Verification
- [x] `yaml.safe_load` parses
- [x] `yamllint -c .yamllint.yaml` clean (exit 0)
- [x] Both push and pull_request blocks updated; petri-bundle validation steps unaffected (subsumed by `**`)
- [x] CI-config only -> no version bump, no CHANGELOG (empty `[Unreleased]` stays clean for the pass-through to main)

## Reference
Self-improving hub handoff "pages.yml trigger paths" item; operator request to ship A-1 + A-2 as one PR (A-1 found already-complete via GAP audit).