### PR TITLE
fix(design): restore hub light signature + propagate petri-blue to docs + JSON drill-down jump

### DIFF
--- a/docs/design/self-improving-hub-system.md
+++ b/docs/design/self-improving-hub-system.md
@@ -82,6 +82,8 @@ Visitors range from operators (daily status check) to external readers (PR demo)
 3. **No gradients, no shadows.** Hairline borders only (`var(--rule)`).
 4. **No emoji.** Per `[[feedback-no-box-ui-no-emoji]]`. Role labels are uppercase letterforms with `.role-label` class.
 
+**Signature accent propagation.** `--accent` (`#0d6efd`, the petri Bootstrap-blue) is the signature of the whole self-improving surface. The docs site (dark) propagates it as its `07-self-improving` section identity — token `--acc-si` (`#5B9BFF`, the same hue lightened for AA on the dark substrate). The hub stays light (this palette); the docs stay dark; the shared thread is the accent, not the mode. Docs-side policy: `site/DESIGN.md §11.1`.
+
 ## 4. Typography
 
 | Variable | Family | Weights | Use |

--- a/docs/self-improving/assets/hub.css
+++ b/docs/self-improving/assets/hub.css
@@ -13,41 +13,38 @@
 /* §3 Tokens                                                    */
 /* ============================================================ */
 :root {
-  /* Ink / paper / rule — dark warm Anthropic palette, aligned with the docs
-     site (site/DESIGN.md §2). Warm near-black stone substrate + cream ink so
-     the self-improving hub reads as the same editorial dossier as /docs. */
-  --ink: #ede7da;
-  --ink-soft: #b5ac97;
-  --ink-faint: #807665;
-  --rule: #3a342d;
-  --rule-soft: #2a2520;
-  --paper: #181816;
-  --paper-tint: #23211f;
+  /* Ink / paper / rule */
+  --ink: #1a1f29;
+  --ink-soft: #4a5260;
+  --ink-faint: #7d8694;
+  --rule: #e5e8ec;
+  --rule-soft: #f1f3f5;
+  --paper: #ffffff;
+  --paper-tint: #f8f9fa;
 
-  /* Accent — AMETHYST (docs DESIGN.md --acc-artifact: runtime / model / OS).
-     The hub is the self-improving runtime surface, so it takes the runtime hue. */
-  --accent: #a573e8;
-  --accent-faint: #2a2338;
+  /* Accent (Bootstrap --bs-blue) */
+  --accent: #0d6efd;
+  --accent-faint: #e7f1ff;
 
-  /* Harness chip palette (§3 — 4 chips). Dark bg + light fg for warm-dark. */
-  --chip-payg-bg: #2a2520;
-  --chip-payg-fg: #b5ac97;
-  --chip-claude-bg: #2e2640;
-  --chip-claude-fg: #c9a4f0;
-  --chip-codex-bg: #1d3329;
-  --chip-codex-fg: #7fcfa3;
-  --chip-geode-bg: #262a3c;
-  --chip-geode-fg: #a8c2ff;
+  /* Harness chip palette (§3 — 4 chips, palette explosion forbidden) */
+  --chip-payg-bg: #f1f3f5;
+  --chip-payg-fg: #4a5260;
+  --chip-claude-bg: #efe7fb;
+  --chip-claude-fg: #5a2ca0;
+  --chip-codex-bg: #d1e7dd;
+  --chip-codex-fg: #0a3622;
+  --chip-geode-bg: #cfe2ff;
+  --chip-geode-fg: #052c65;
 
-  /* Surface bucket palette (§3 — 3 buckets). Light-on-dark inline labels. */
-  --bucket-petri: #8ab4ff;
-  --bucket-seedgen: #6fcf97;
-  --bucket-autoresearch: #d5b27a;
+  /* Surface bucket palette (§3 — 3 buckets) */
+  --bucket-petri: #0d6efd;
+  --bucket-seedgen: #198754;
+  --bucket-autoresearch: #b45309;
 
-  /* Warning / stale baseline banner (warm citrine tone per §3 strict-rule 2) */
-  --warning-bg: #2e2417;
-  --warning-fg: #d5b27a;
-  --warning-rule: #5a4a2a;
+  /* Warning / stale baseline banner (reuses autoresearch tone per §3 strict-rule 2) */
+  --warning-bg: #fff4e6;
+  --warning-fg: #7a3e08;
+  --warning-rule: #f4cd9d;
 
   /* Type scale (§4) */
   --font-sans: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
@@ -185,6 +182,11 @@ aside ul.nav-list ul.sub-nav a {
 main.content {
   padding: var(--content-pad-y) var(--content-pad-x);
   max-width: var(--content-max);
+  /* Grid items default to min-width:auto, so a wide child (a non-wrapping
+     JSON drill-down, the 22-col heatmap) would force the 1fr track past the
+     viewport and the whole layout would jump when the drill-down expands.
+     Floor it at 0 so wide content scrolls/wraps inside the column instead. */
+  min-width: 0;
 }
 
 h1.page-title {
@@ -364,7 +366,7 @@ table.records .sub-row .id {
   font-family: var(--font-mono);
 }
 
-.warning code { background: rgba(255,255,255,.08); }
+.warning code { background: rgba(255,255,255,.55); }
 
 /* ============================================================ */
 /* §9 Build info footer                                         */
@@ -728,7 +730,7 @@ table.records.heatmap td.score-na     { background: transparent; color: var(--in
   font-family: var(--font-mono);
 }
 
-.warning-banner code { background: rgba(255, 255, 255, .08); }
+.warning-banner code { background: rgba(255, 255, 255, .55); }
 
 /* Generation timeline row highlight — the currently-promoted    */
 /* row is .active and gets a left rule + tinted background       */
@@ -754,8 +756,12 @@ table.records .gen-timeline-row.active td:first-child {
   vertical-align: baseline;
 }
 
-/* Policy JSON drill-down — overflow-safe pretty-print            */
-/* container. Used inside <details>/<pre> in policies.html.       */
+/* Policy JSON drill-down — wrap, do not force the column wider.   */
+/* Lives in a <td> of an auto-layout table, so a non-wrapping pre  */
+/* would grow the cell (and the page) when <details> expands —     */
+/* the width jumped on open. pre-wrap + overflow-wrap:anywhere     */
+/* keeps min-content tiny so the column stays put; tall JSON       */
+/* scrolls vertically inside max-height. (matches pre.msg policy.) */
 .policy-json {
   margin: .35rem 0 0;
   padding: .65rem .9rem;
@@ -766,8 +772,10 @@ table.records .gen-timeline-row.active td:first-child {
   font-size: .74rem;
   line-height: 1.45;
   color: var(--ink);
-  overflow-x: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-y: auto;
   max-height: 24rem;
 }
 
@@ -780,8 +788,9 @@ table.records .gen-timeline-row.active td:first-child {
   font-size: inherit;
   line-height: inherit;
   color: inherit;
-  overflow-x: auto;
-  white-space: pre;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
 }
 
 /* Δ-fitness color buckets — derived from existing tokens.        */
@@ -943,8 +952,8 @@ table.records.votes td.rationale {
   color: var(--bucket-seedgen);
 }
 .bucket.tie {
-  background: rgba(128,118,101,.18);
-  color: var(--ink-faint);
+  background: rgba(108,117,125,.12);
+  color: #6c757d;
 }
 
 /* ---------------------------------------------------------------------
@@ -1148,42 +1157,42 @@ pre.msg.cand-body {
 
 /* Each phase gets ~2s of highlight at its slot. Window 12.5% wide. */
 @keyframes seedgen-hero-box-0 {
-  0%, 4% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  0%, 4% { fill: #d1e7dd; stroke: #198754; }
   12.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-1 {
   0%, 12.5% { fill: var(--paper-tint); stroke: var(--rule); }
-  12.5001%, 16.5% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  12.5001%, 16.5% { fill: #d1e7dd; stroke: #198754; }
   25%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-2 {
   0%, 25% { fill: var(--paper-tint); stroke: var(--rule); }
-  25.0001%, 29% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  25.0001%, 29% { fill: #d1e7dd; stroke: #198754; }
   37.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-3 {
   0%, 37.5% { fill: var(--paper-tint); stroke: var(--rule); }
-  37.5001%, 41.5% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  37.5001%, 41.5% { fill: #d1e7dd; stroke: #198754; }
   50%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-4 {
   0%, 50% { fill: var(--paper-tint); stroke: var(--rule); }
-  50.0001%, 54% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  50.0001%, 54% { fill: #d1e7dd; stroke: #198754; }
   62.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-5 {
   0%, 62.5% { fill: var(--paper-tint); stroke: var(--rule); }
-  62.5001%, 66.5% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  62.5001%, 66.5% { fill: #d1e7dd; stroke: #198754; }
   75%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-6 {
   0%, 75% { fill: var(--paper-tint); stroke: var(--rule); }
-  75.0001%, 79% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  75.0001%, 79% { fill: #d1e7dd; stroke: #198754; }
   87.5%, 100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 @keyframes seedgen-hero-box-7 {
   0%, 87.5% { fill: var(--paper-tint); stroke: var(--rule); }
-  87.5001%, 91.5% { fill: rgba(111, 207, 151, .22); stroke: #6fcf97; }
+  87.5001%, 91.5% { fill: #d1e7dd; stroke: #198754; }
   100% { fill: var(--paper-tint); stroke: var(--rule); }
 }
 
@@ -1214,7 +1223,7 @@ pre.msg.cand-body {
   }
   /* show all boxes in highlighted state when motion is reduced — legend
      below covers the sequence */
-  .seedgen-hero-svg .phase-box { fill: var(--paper-tint); stroke: var(--rule); }
+  .seedgen-hero-svg .phase-box { fill: #f0f9f4; stroke: #b7dcc4; }
 }
 
 .seedgen-hero-legend {

--- a/site/DESIGN.md
+++ b/site/DESIGN.md
@@ -34,6 +34,8 @@
 | `--acc-artifact` | `#A573E8` | **AMETHYST** — OS / artifact / runtime / model. Distinct from existing DAG-SVG hue space. |
 | `--acc-line` | `#D5B27A` | **CITRINE** — scaffold / line / process / CI. Warm complement to amethyst. |
 | `--acc-soft` | `#C9A4F0` | Hover / elevated state for the amethyst accent. |
+| `--acc-si` | `#5B9BFF` | **PETRI-BLUE** — Self-Improving Loop section identity. The self-improving hub's signature (`#0d6efd`, Bootstrap blue) lightened for AA contrast on the dark substrate. Scoped to the `07-self-improving` docs section only (see §11.1). |
+| `--acc-si-soft` | `#8FBCFF` | Hover state for the self-improving accent. |
 | `--code-bg` | `#0E0E0C` | Code block background. |
 | `--code-text` | `#DDD3BE` | Code block text. Same as `--ink-1`. |
 | `--code-string` | `#D5B27A` | Code strings (citrine, kindred to line accent). |
@@ -49,7 +51,7 @@ section accents and DAG visualizations do not fight each other.
 
 **Single substrate.** Every page is dark by design. There is no light mode. There is no dark-panel-on-light-page pattern. Mascot PNGs and SVG diagrams that were authored for dark mediums sit naturally on this substrate.
 
-**Two accents only.** Amber-terracotta for artifact / OS content. Graphite-blue for scaffold / line / process content. No other hues. Recursion table uses both side-by-side as visual signal.
+**Two accents, plus one scoped section identity.** Amethyst (artifact / OS) and citrine (scaffold / line / process) are the two global accents — no other hues in general content, and the recursion table uses both side-by-side as visual signal. The single exception is `--acc-si` (petri-blue): the Self-Improving Loop section identity, propagated from the hub's signature so the docs section and the hub read as one system. It appears ONLY inside the `07-self-improving` docs section (§11.1), never in global chrome (header, footer, cross-section nav). The mechanism is a `data-doc-section` attribute on the docs shell root plus a `--section-accent` custom property; outside that section `--section-accent` resolves to `--acc-artifact`.
 
 ## 3. Typography Rules
 
@@ -322,9 +324,13 @@ The viewer (`index.html`) uses Bootstrap's default dark palette. The GEODE-autho
 | Rule | `#3a3f44` | `--rule` (`#3A342D`) |
 | Body ink | `#dee2e6` | `--ink` (`#EDE7DA`) |
 | Muted | `#adb5bd` | `--ink-2` (`#B5AC97`) |
-| Accent | `#0d6efd` (Bootstrap blue) | `--acc-artifact` (`#A573E8`) |
+| Accent | `#0d6efd` (Bootstrap blue) | `--acc-si` (`#5B9BFF`) in the `07-self-improving` section; `--acc-artifact` (`#A573E8`) elsewhere |
 
-This palette appears **only** in `docs/petri-bundle/landing.html` and any future static HTML co-located under `docs/petri-bundle/`. Next.js docs pages (under `site/`) continue to use the §2 tokens, with no exception. The bridge palette is documented here so the substrate continuity is explicit, not a drift accident.
+This bridge palette (substrate / elevated / rule / ink) appears **only** in `docs/petri-bundle/landing.html` and any future static HTML co-located under `docs/petri-bundle/`. Next.js docs pages continue to use the §2 substrate/ink tokens, with no exception.
+
+**Accent is the one deliberate exception.** The self-improving hub's signature is the petri Bootstrap-blue `#0d6efd`. It is the identity color of the whole self-improving surface (hub + petri bundle), so the docs propagate it — as `--acc-si` (`#5B9BFF`, lightened for AA on dark) — into the `07-self-improving` docs section: the sidebar group label, the page eyebrow, in-prose links, table-header underline, `pre`/`code` accents, and card-hover borders. This is scoped by a `data-doc-section="07-self-improving"` attribute on the docs shell root (`docs-shell.tsx`) driving a `--section-accent` custom property; outside that section the accent stays `--acc-artifact`. The bridge palette and this accent propagation are documented here so the cross-surface continuity is explicit, not a drift accident.
+
+The hub's own token source of truth is `docs/design/self-improving-hub-system.md §3` (the light signature palette: white paper, `#0d6efd` accent, 3 surface buckets). The hub stays light (its native identity); docs stay dark — the shared thread is the signature accent, not the light/dark mode.
 
 ### 11.2 Anti-slop on bridge surfaces
 

--- a/site/src/app/docs/docs.css
+++ b/site/src/app/docs/docs.css
@@ -133,3 +133,31 @@
   color: #F0F0FF;
   font-weight: 600;
 }
+
+/* ── Self-Improving Loop section identity ──────────────────────────────────
+   The hub (docs/self-improving/) owns a petri Bootstrap-blue signature
+   (#0d6efd). It is propagated here as the section-identity accent for the
+   07-self-improving docs section so the two surfaces read as one system.
+   Scoped via [data-doc-section] on the shell root (set in docs-shell.tsx), so
+   every other section keeps the default docs accent. See DESIGN.md §11.1. */
+[data-doc-section="07-self-improving"] .docs-prose a {
+  color: var(--acc-si);
+}
+[data-doc-section="07-self-improving"] .docs-prose a:hover {
+  color: var(--acc-si-soft);
+}
+[data-doc-section="07-self-improving"] .docs-prose blockquote {
+  border-left-color: color-mix(in srgb, var(--acc-si) 55%, transparent);
+}
+[data-doc-section="07-self-improving"] .docs-prose thead th {
+  border-bottom: 2px solid var(--acc-si);
+}
+[data-doc-section="07-self-improving"] .docs-prose pre {
+  border-color: color-mix(in srgb, var(--acc-si) 32%, rgba(255, 255, 255, 0.06));
+}
+[data-doc-section="07-self-improving"] .docs-prose :not(pre) > code {
+  color: var(--acc-si);
+}
+[data-doc-section="07-self-improving"] .docs-card:hover {
+  border-color: color-mix(in srgb, var(--acc-si) 45%, transparent);
+}

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -37,6 +37,8 @@ h1, h2 {
   --acc-artifact: #A573E8;   /* AMETHYST — OS / artifact / runtime / model */
   --acc-line:     #D5B27A;   /* CITRINE — scaffold / line / process / CI */
   --acc-soft:     #C9A4F0;   /* amethyst hover */
+  --acc-si:       #5B9BFF;   /* SELF-IMPROVING signature — the hub's petri Bootstrap-blue (#0d6efd) lightened for AA on dark. Section-identity accent for the Self-Improving Loop docs section (see DESIGN.md §11.1). */
+  --acc-si-soft:  #8FBCFF;   /* self-improving hover */
 
   --code-bg:      #0E0E0C;
   --code-text:    #DDD3BE;

--- a/site/src/components/geode-docs/docs-shell.tsx
+++ b/site/src/components/geode-docs/docs-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { type ReactNode } from "react";
+import { type ReactNode, type CSSProperties } from "react";
 import { useLocale, useSetLocale, t } from "@/components/geode/locale-context";
 import { DOCS_SITEMAP, adjacentPages, findPage, QUADRANT_META, type DocQuadrant } from "@/lib/geode-docs/sitemap";
 import { GEODE_SOT } from "@/data/geode/sot";
@@ -42,9 +42,17 @@ function Sidebar() {
         {t(locale, "GEODE Docs", "GEODE Docs")}
       </Link>
       <div className="mt-2 space-y-5">
-        {DOCS_SITEMAP.map((section) => (
+        {DOCS_SITEMAP.map((section) => {
+          // The Self-Improving Loop section carries the petri-blue signature
+          // accent (see DESIGN.md §11.1); every other section stays muted.
+          const sectionAccent =
+            section.id === "07-self-improving" ? "var(--acc-si)" : undefined;
+          return (
           <div key={section.id}>
-            <div className="px-3 text-[10px] uppercase tracking-[0.18em] text-white/40 font-semibold mb-2">
+            <div
+              className="px-3 text-[10px] uppercase tracking-[0.18em] text-white/40 font-semibold mb-2"
+              style={sectionAccent ? { color: sectionAccent } : undefined}
+            >
               {t(locale, section.titleKo, section.title)}
             </div>
             <ul className="space-y-0.5">
@@ -62,6 +70,7 @@ function Sidebar() {
                           ? "bg-white/[0.06] text-[#F0F0FF]"
                           : "text-white/60 hover:text-[#F0F0FF] hover:bg-white/[0.03]")
                       }
+                      style={active && sectionAccent ? { color: sectionAccent } : undefined}
                     >
                       <span
                         className="shrink-0 inline-block w-1 h-1 rounded-full"
@@ -78,7 +87,8 @@ function Sidebar() {
               })}
             </ul>
           </div>
-        ))}
+          );
+        })}
       </div>
     </nav>
   );
@@ -94,7 +104,7 @@ function PrevNext({ slug }: { slug: string }) {
         {prev && (
           <Link
             href={pageHref(prev.slug)}
-            className="block group rounded-lg border border-white/[0.06] p-4 hover:border-white/[0.12] transition-colors"
+            className="docs-card block group rounded-lg border border-white/[0.06] p-4 hover:border-white/[0.12] transition-colors"
           >
             <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1">
               {t(locale, "이전", "Previous")}
@@ -109,7 +119,7 @@ function PrevNext({ slug }: { slug: string }) {
         {next && (
           <Link
             href={pageHref(next.slug)}
-            className="block group rounded-lg border border-white/[0.06] p-4 hover:border-white/[0.12] transition-colors"
+            className="docs-card block group rounded-lg border border-white/[0.06] p-4 hover:border-white/[0.12] transition-colors"
           >
             <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1">
               {t(locale, "다음", "Next")}
@@ -178,8 +188,22 @@ export function DocsShell({
     summary && summaryKo ? t(locale, summaryKo, summary) : summary;
   const found = findPage(slug);
   const quadrant = found?.page.quadrant;
+  const currentSection = DOCS_SITEMAP.find((s) =>
+    s.pages.some((p) => p.slug === slug)
+  );
+  // Self-Improving Loop section carries the petri-blue signature; every other
+  // section inherits the default amethyst artifact accent. --section-accent is
+  // consumed by the eyebrow here and by the [data-doc-section] rules in docs.css.
+  const sectionAccent =
+    currentSection?.id === "07-self-improving"
+      ? "var(--acc-si)"
+      : "var(--acc-artifact)";
   return (
-    <div className="min-h-screen bg-[#0B1628] text-[#F0F0FF]">
+    <div
+      className="min-h-screen bg-[#0B1628] text-[#F0F0FF]"
+      data-doc-section={currentSection?.id}
+      style={{ ["--section-accent"]: sectionAccent } as CSSProperties}
+    >
       <header className="sticky top-0 z-30 border-b border-white/[0.06] bg-[#0B1628]/85 backdrop-blur">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
           <div className="flex items-center gap-6">
@@ -211,6 +235,14 @@ export function DocsShell({
 
         <main className="flex-1 min-w-0 max-w-3xl">
           <div className="mb-10">
+            {currentSection && (
+              <div
+                className="mb-2 text-[11px] font-mono uppercase tracking-[0.2em]"
+                style={{ color: "var(--section-accent)" }}
+              >
+                {t(locale, currentSection.titleKo, currentSection.title)}
+              </div>
+            )}
             {quadrant && (
               <div className="mb-3">
                 <QuadrantChip quadrant={quadrant} />


### PR DESCRIPTION
## Summary
- **Revert** the self-improving hub to its **light signature palette** (white paper, `#0d6efd` petri Bootstrap-blue accent, 3 surface buckets). PR #1870 (476d1878) repainted it dark — wrong direction — and drifted `hub.css` away from its own token SoT (`docs/design/self-improving-hub-system.md §3`).
- **Propagate** the signature color outward to docs as the `07-self-improving` **section identity** (`--acc-si #5B9BFF`): sidebar group + active, page eyebrow, prose links, table-header underline, pre/code accent, card-hover. Scoped via `data-doc-section` + `--section-accent`; every other section keeps amethyst.
- **Fix** the policies "view JSON" drill-down **width jump**.

## Why
The design-unify intent was: the self-improving hub has a signature color (the petri-bundle Bootstrap-blue), record it in DESIGN.md, and propagate THAT to docs. The earlier change inverted it (hub repainted to match docs dark), which the operator flagged. Separately, the "view JSON" `<details>` on the policies page sits in an auto-layout table cell, so its non-wrapping JSON forced the cell — and, via the grid `1fr` item's default `min-width:auto`, the whole page — to grow on expand (the width "collapsed/jumped").

## Changes
| File | Change |
|------|--------|
| `docs/self-improving/assets/hub.css` | Revert `:root` + hardcoded sites to the light signature (re-aligns with the hub SoT); `main.content { min-width: 0 }`; `.policy-json` → `pre-wrap` + `overflow-wrap:anywhere` |
| `site/src/app/globals.css` | New `--acc-si` / `--acc-si-soft` tokens |
| `site/src/components/geode-docs/docs-shell.tsx` | Compute current section; `data-doc-section` + `--section-accent` on shell root; section eyebrow; petri-blue sidebar group/active for 07; `docs-card` class on PrevNext |
| `site/src/app/docs/docs.css` | `[data-doc-section="07-self-improving"]`-scoped accent block (links, blockquote, thead th, pre, inline code, card hover) |
| `site/DESIGN.md` | §2 `--acc-si` token + "two accents + one scoped section identity"; §11.1 amended from "no exception" to a documented section-identity exception |
| `docs/design/self-improving-hub-system.md` | §3 signature-propagation note (bidirectional cross-link) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Revert hub palette | Implemented | restored from 7d29bf36 (pre-476d1878); 0 dark-hex residue |
| Record signature in DESIGN.md | Implemented | site/DESIGN.md §2 + §11.1 + hub SoT cross-link |
| Propagate to docs | Implemented | full section theming, scoped to 07-self-improving |
| JSON drill-down jump | Implemented | min-width:0 + wrap |

## Verification
- [x] `tsc --noEmit` clean
- [x] `npm run build` green (all routes prerendered)
- [x] 50 hub e2e tests pass (no test pinned the dark palette; structural rules `.chip`/`.coverage-bar`/`.warning-banner` intact)
- [x] Docs/design-only (hub CSS + site docs + design docs), no core/runtime change → no version bump, no CHANGELOG (supersedes the 476d1878 visual direction)
- [ ] **Dark-on-dark section accent + light hub need a visual confirm on the live site** (headless can't verify aesthetics)

## Reference
Operator correction: signature direction is hub → DESIGN.md → docs (not hub repainted dark). Plus the "view JSON" width-jump report.