### PR TITLE
docs(site): drop the code-count dump from the docs landing subtitle

### DIFF
--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -4,12 +4,13 @@ import Link from "next/link";
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 import { DOCS_SITEMAP } from "@/lib/geode-docs/sitemap";
 import { useLocale, t } from "@/components/geode/locale-context";
-import { GEODE_SOT } from "@/data/geode/sot";
 
 export default function DocsIndex() {
   const locale = useLocale();
-  const summaryEn = `A general-purpose autonomous execution agent built on LangGraph. v${GEODE_SOT.version}, Python 3.12+, ${GEODE_SOT.modules.core} core + ${GEODE_SOT.modules.plugins} plugins = ${GEODE_SOT.modules.total} modules, ${GEODE_SOT.tests.standard.toLocaleString()} tests, 81 hook events, 59 tools.`;
-  const summaryKo = `LangGraph 기반 범용 자율 실행 에이전트. v${GEODE_SOT.version}, Python 3.12+, core ${GEODE_SOT.modules.core} + plugins ${GEODE_SOT.modules.plugins} = ${GEODE_SOT.modules.total} 모듈, ${GEODE_SOT.tests.standard.toLocaleString()} 테스트, 81 훅, 59 도구.`;
+  const summaryEn =
+    "A general-purpose autonomous execution agent built on LangGraph. A long-running harness for research, analysis, automation, and scheduling.";
+  const summaryKo =
+    "LangGraph 기반 범용 자율 실행 에이전트. 연구, 분석, 자동화, 스케줄링을 스스로 수행하는 장기 실행 하네스.";
   return (
     <DocsShell
       slug=""


### PR DESCRIPTION
## Summary
- Replace the docs landing subtitle's metric dump (version, Python, 466 modules, 8538 tests, 81 hooks, 59 tools) with a clean qualitative identity line; drop the now-unused `GEODE_SOT` import.

## Why
A code-count dump on a hero subtitle reads as slop and is redundant — the version is already in the docs footer, and the full counts live on architecture/system-index and the portfolio. Operator flagged it on the live landing.

## Changes
| File | Change |
|------|--------|
| `site/src/app/docs/page.tsx` | subtitle `summaryEn`/`summaryKo` → no-count identity line; remove unused `GEODE_SOT` import (only used by the dropped counts; the §Status prose mention is plain text) |

## Verification
- [x] `tsc --noEmit` clean
- [x] `npm run build` green (all routes prerendered)
- [x] `eslint src/app/docs/page.tsx` clean (no unused-import after the removal)
- [x] Docs-only → no version bump, no CHANGELOG

## Reference
Operator: "이런 코드수는 제거해" on the docs landing subtitle.