### PR TITLE
release: v0.99.85 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+- **PR-CRED-SOURCE-CENTRALIZE (2026-05-29)** — Centralize the LLM
+  credential-source value set into one canonical
+  `core.config.credential_source.CredentialSource` (StrEnum). It was previously
+  defined four ways with *inconsistent membership* — `self_improving_loop.Source`
+  (no `api_key`), the mutator-config `source` Literal (with `api_key`),
+  `seed_generation.auth_coverage.Source` (no `auto`), and bare-`str`
+  `settings.{anthropic,openai}_credential_source` — plus the petri `AUTO_SOURCE` /
+  `PAYG_SOURCE` magic constants, so a change in one silently diverged from the
+  others. All now reference the single enum (`Source` is a re-export;
+  `auth_coverage.Source` is a drift-pinned concrete subset; the settings fields
+  validate against it via a field-validator; the petri constants derive from it).
+  The `project_payg_exclusion_decision` PAYG safety — a subscription-only run must
+  not *silently* fall through to PAYG — moves from a **type-level exclusion**
+  (which caused the fragmentation and blocked an operator's explicit opt-in) to
+  the existing **resolution-time `fallback_to_payg` gate**: `api_key` is a valid
+  config value again, but `auto` expansion still never silently bills the API key.
+  Pinned by `test_credential_source_centralized.py` (enum-drift invariants) and
+  the rewritten `test_d1_provider_closure.py` (api_key now accepted at config,
+  closure enforced at resolution).
+
 ## [0.99.84] - 2026-05-29
 
 > PATCH — self-improving hub polish + loop multi-objective wiring. Hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.85] - 2026-05-29
+
 ### Changed
 - **PR-CRED-SOURCE-CENTRALIZE (2026-05-29)** — Centralize the LLM
   credential-source value set into one canonical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.84
+- **Version**: 0.99.85
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.84 — Long-running Autonomous Execution Harness
+# GEODE v0.99.85 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.84**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.85**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.84 — Long-running Autonomous Execution Harness
+# GEODE v0.99.85 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.84**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.85**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -8,9 +8,14 @@ exposed only for type hints and test fixtures.
 
 from __future__ import annotations
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from core.config.credential_source import (
+    DISABLE_SENTINEL,
+    LEGACY_OAUTH_ALIAS,
+    CredentialSource,
+)
 from core.paths import GLOBAL_ENV_FILE
 
 
@@ -385,8 +390,27 @@ class Settings(BaseSettings):
     # take precedence. No subscription-plan names are hardcoded — the
     # picker labels each source with the plan info pulled from the
     # active credential blob.
-    anthropic_credential_source: str = "auto"  # "auto" | "oauth" | "api_key" | "none"
-    openai_credential_source: str = "auto"  # "auto" | "oauth" | "api_key" | "none"
+    # Valid values: the canonical ``CredentialSource`` members
+    # (auto / api_key / claude-cli / openai-codex) plus the legacy provider-
+    # agnostic ``oauth`` alias and the ``none`` disable sentinel — validated
+    # against the single SoT below (PR-CRED-SOURCE-CENTRALIZE).
+    anthropic_credential_source: str = "auto"
+    openai_credential_source: str = "auto"
+
+    @field_validator("anthropic_credential_source", "openai_credential_source")
+    @classmethod
+    def _validate_credential_source(cls, v: str) -> str:
+        """Validate against the canonical credential-source set + legacy aliases.
+
+        Keeps these operator-facing settings from drifting from
+        :class:`core.config.credential_source.CredentialSource`. ``oauth``
+        (legacy agnostic alias, normalised per-provider downstream) and ``none``
+        (disable) are accepted in addition to the concrete enum members.
+        """
+        allowed = {s.value for s in CredentialSource} | {LEGACY_OAUTH_ALIAS, DISABLE_SENTINEL}
+        if v not in allowed:
+            raise ValueError(f"credential source must be one of {sorted(allowed)}, got {v!r}")
+        return v
 
     # Cost guard — session-level cost limit (0 = no limit)
     cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%

--- a/core/config/credential_source.py
+++ b/core/config/credential_source.py
@@ -1,0 +1,66 @@
+"""Canonical credential-source enum — single source of truth.
+
+PR-CRED-SOURCE-CENTRALIZE (2026-05-29). The LLM credential-source value set
+was previously defined four different ways, with *inconsistent membership*:
+
+- ``core.config.self_improving_loop.Source`` — ``{claude-cli, openai-codex, auto}``
+  (no ``api_key``)
+- the mutator-config ``source`` Literal — ``{auto, api_key, claude-cli, openai-codex}``
+  (with ``api_key``)
+- ``plugins.seed_generation.auth_coverage.Source`` — ``{claude-cli, openai-codex,
+  api_key}`` (no ``auto``)
+- ``settings.{anthropic,openai}_credential_source`` — bare ``str``
+
+plus the petri magic constants ``AUTO_SOURCE = "auto"`` / ``PAYG_SOURCE =
+"api_key"``. A change in one place silently diverged from the others (e.g.
+``api_key`` accepted by the mutator config but rejected by the autoresearch
+config), which is exactly the fragmentation this module removes: every
+credential-source field now references :class:`CredentialSource`.
+
+``StrEnum`` so members compare equal to their wire string
+(``CredentialSource.AUTO == "auto"``) — existing string comparisons and TOML
+config values keep working, while pydantic gains centralized validation.
+
+PAYG safety
+-----------
+``API_KEY`` is a **valid member everywhere**. Preventing a subscription-only
+run from silently falling through to PAYG is enforced at *resolution* time by
+``[self_improving_loop] fallback_to_payg`` /
+``plugins.petri_audit.credential_source.resolve_credential_source(fallback_to_payg=…)``
+— **not** by narrowing this enum. This moves ``project_payg_exclusion_decision``
+from a type-level exclusion to a runtime gate (the gate is the real safety
+boundary; the type-level narrowing only caused the fragmentation above and
+blocked an operator who explicitly opts into PAYG).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CredentialSource(StrEnum):
+    """The concrete credential sources a provider call can be routed through."""
+
+    #: Resolver picks per the manifest ``allowed`` order (OAuth-first), gated
+    #: by ``fallback_to_payg`` for the PAYG (``api_key``) entry.
+    AUTO = "auto"
+    #: Pay-as-you-go API key (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY``).
+    API_KEY = "api_key"
+    #: Anthropic OAuth via the ``claude`` CLI (subscription).
+    CLAUDE_CLI = "claude-cli"
+    #: OpenAI OAuth via the Codex CLI / ChatGPT subscription.
+    OPENAI_CODEX = "openai-codex"
+
+
+#: Legacy provider-agnostic OAuth alias. Historically some ``.env`` /
+#: ``config.toml`` files set ``*_credential_source = "oauth"``; the resolver
+#: normalises it to the per-provider concrete OAuth source
+#: (``claude-cli`` / ``openai-codex``). Not a :class:`CredentialSource` member
+#: because it is an input alias, not a concrete destination.
+LEGACY_OAUTH_ALIAS = "oauth"
+
+#: Disable sentinel accepted by ``settings.{provider}_credential_source``.
+DISABLE_SENTINEL = "none"
+
+
+__all__ = ["DISABLE_SENTINEL", "LEGACY_OAUTH_ALIAS", "CredentialSource"]

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -52,6 +52,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from core.config.credential_source import CredentialSource
 from core.paths import GLOBAL_CONFIG_TOML
 
 log = logging.getLogger(__name__)
@@ -69,21 +70,24 @@ __all__ = [
 ]
 
 
-# PR-SIL-5THEME C6 (2026-05-23) — D1 provider closure. PAYG (``api_key``)
-# 가 ``PetriRoleConfig.source`` / ``AutoresearchConfig.source`` 의 Literal
-# 에서 제거됨 (durable operator decision per ``project_payg_exclusion_decision.md``,
-# 2026-05-23) — autoresearch / Petri audit 의 provider 선택지에서 영구
-# exclude. 잔존 옵션: ``claude-cli`` (Claude Code Max OAuth) /
-# ``openai-codex`` (ChatGPT subscription OAuth) / ``auto`` (manifest cascade).
-# ``api_key`` 설정 시 Pydantic ValidationError 가 명시 PAYG 사용을 reject
-# — PR-C-P1 의 silent-fallback 차단 패턴 재사용.
+# PR-CRED-SOURCE-CENTRALIZE (2026-05-29) — ``Source`` is now a backward-compat
+# re-export of the canonical :class:`core.config.credential_source.CredentialSource`
+# enum (single SoT). Previously this module, ``MutatorConfig.source``,
+# ``plugins.seed_generation.auth_coverage.Source`` and
+# ``settings.{provider}_credential_source`` each spelled the source set
+# differently (``api_key`` in some, not others; ``auto`` in some, not others) —
+# they now all reference one enum, so a change can no longer silently diverge.
 #
-# **인프라 보존**: ``MutatorConfig.source`` (line 248 의 별도 Literal) 는
-# api_key 포함 4-element 유지 — mutator LLM 호출은 audit role 과 별개,
-# operator 가 Anthropic API key 로 mutator 운영 자유. ``credential_source.py``
-# 의 PAYG fallback 코드 경로도 보존 (다른 caller 가 명시 호출 시 활성).
-Source = Literal["claude-cli", "openai-codex", "auto"]
-"""Credential source label — matches ``plugins.petri_audit.petri.plugin.toml``."""
+# PAYG: ``api_key`` is a valid member again. The
+# ``project_payg_exclusion_decision`` intent — a subscription-only run must not
+# *silently* fall through to PAYG — is preserved at resolution time
+# (``plugins.petri_audit.credential_source.resolve_credential_source`` filters
+# ``api_key`` out of ``auto`` expansion unless ``[self_improving_loop]
+# fallback_to_payg=true``); an operator may still *explicitly* set
+# ``source = "api_key"`` to opt in. The earlier type-level exclusion only caused
+# the fragmentation above and blocked that explicit opt-in.
+Source = CredentialSource
+"""Backward-compat alias of :class:`CredentialSource` (the canonical enum)."""
 
 
 class SelfImprovingLoopBindings(BaseModel):
@@ -181,7 +185,7 @@ class PetriRoleConfig(BaseModel):
     # 가 PAYG 까지 fallback 할 수 있어서 silent leak risk — 명시
     # ``claude-cli`` (Claude Code Max OAuth) 이 default 면 leak 0. operator
     # 가 explicit 으로 ``auto`` 또는 ``openai-codex`` 명시 시 그대로 적용.
-    source: Source = "claude-cli"
+    source: Source = CredentialSource.CLAUDE_CLI
 
 
 class AutoresearchConfig(BaseModel):
@@ -453,7 +457,7 @@ class AutoresearchConfig(BaseModel):
     # 으로 ``api_key`` 는 ``Source`` literal 에서 제거. ``auto`` 는 manifest
     # cascade 가 PAYG 까지 silent fallback 가능 → ``claude-cli`` (Claude
     # Code Max OAuth) 가 새 default.
-    source: Source = "claude-cli"
+    source: Source = CredentialSource.CLAUDE_CLI
     """Credential source for the audit subprocess. PR-SIL-5THEME C6 후 PAYG
     (``api_key``) 는 Source literal 에서 제거. ``claude-cli`` = Claude Code
     Max OAuth (default), ``openai-codex`` = ChatGPT subscription OAuth, ``auto`` =
@@ -514,9 +518,9 @@ class MutatorConfig(BaseModel):
     """``None`` → inherit ``Settings.model``. Operator sets this only
     when the mutator LLM must differ from the GEODE primary (e.g.
     use a smaller model to keep mutation cost down)."""
-    source: Literal["auto", "api_key", "claude-cli", "openai-codex"] = "auto"
-    """Mirrors :data:`Source`. The router's credential rotator
-    consumes the same enum implicitly via ``[petri.source.<provider>]``."""
+    source: CredentialSource = CredentialSource.AUTO
+    """Canonical :class:`CredentialSource`. The router's credential rotator
+    consumes the same enum via ``[petri.source.<provider>]``."""
     max_tokens: Annotated[int, Field(ge=128, le=200_000)] = 1024
     """Passed through to ``adapter.acomplete``."""
 

--- a/plugins/petri_audit/credential_source.py
+++ b/plugins/petri_audit/credential_source.py
@@ -38,6 +38,8 @@ import logging
 import threading
 from typing import Any
 
+from core.config.credential_source import CredentialSource
+
 from plugins.petri_audit.adapters import (
     get_adapter_metadata,
     is_adapter_available,
@@ -62,8 +64,11 @@ _lock = threading.Lock()
 _suppressed: set[tuple[str, str]] = set()
 
 
-PAYG_SOURCE = "api_key"
+PAYG_SOURCE = CredentialSource.API_KEY.value
 """The conventional name for any pay-as-you-go credential source.
+
+Sourced from the canonical :class:`core.config.credential_source.CredentialSource`
+(PR-CRED-SOURCE-CENTRALIZE) so the PAYG id can't drift from the config layer.
 
 Every provider in the Petri manifest has ``api_key`` as its PAYG entry
 (``anthropic.api_key``, ``openai.api_key``, ``zhipuai.api_key``).

--- a/plugins/petri_audit/manifest.py
+++ b/plugins/petri_audit/manifest.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from core.config.credential_source import CredentialSource
 from pydantic import BaseModel, Field, model_validator
 
 __all__ = [
@@ -41,8 +42,9 @@ DEFAULT_MANIFEST_PATH = Path(__file__).parent / "petri.plugin.toml"
 
 # "auto" is a sentinel — resolved at binding time via
 # ``settings.{provider}_credential_source`` + keychain probe — so it
-# never appears as a concrete adapter key.
-AUTO_SOURCE = "auto"
+# never appears as a concrete adapter key. Sourced from the canonical
+# enum (PR-CRED-SOURCE-CENTRALIZE) so it can't drift from the config layer.
+AUTO_SOURCE = CredentialSource.AUTO.value
 
 
 class RoleSpec(BaseModel):

--- a/plugins/petri_audit/models.py
+++ b/plugins/petri_audit/models.py
@@ -114,7 +114,9 @@ class AuditModelMappingError(ValueError):
     """Raised when a model id cannot be mapped to an ``inspect_ai`` identifier."""
 
 
-def to_inspect_model(geode_id: str, *, use_oauth: bool | None = None) -> str:
+def to_inspect_model(
+    geode_id: str, *, use_oauth: bool | None = None, source: str | None = None
+) -> str:
     """Map a GEODE model id to an ``inspect_ai`` ``provider/model`` identifier.
 
     Used for the ``auditor`` and ``judge`` Petri model-roles. The ``target``
@@ -155,7 +157,17 @@ def to_inspect_model(geode_id: str, *, use_oauth: bool | None = None) -> str:
             f"gpt-*, o3, o4-mini, glm-*) or a raw 'provider/model' string."
         )
 
-    source_override = _source_from_use_oauth(geode_id, provider, use_oauth)
+    # PR-CRED-SOURCE-CENTRALIZE — an explicit per-role ``source``
+    # (``[self_improving_loop.petri.<role>].source``) wins over the
+    # use_oauth-derived default, so an operator who pins ``source = "api_key"``
+    # for the auditor/judge actually routes there. ``auto`` (the unpinned
+    # default) defers to use_oauth detection + the manifest cascade.
+    from core.config.credential_source import CredentialSource
+
+    if source and source != CredentialSource.AUTO:
+        source_override: str | None = source
+    else:
+        source_override = _source_from_use_oauth(geode_id, provider, use_oauth)
 
     # Cap 'auto' cascade for ids the provider's OAuth backend can't serve
     # (e.g. o3 / o4-mini are not on the Codex catalogue) — force api_key
@@ -182,10 +194,15 @@ def to_inspect_model(geode_id: str, *, use_oauth: bool | None = None) -> str:
             override=source_override,
             fallback_to_payg=self_improving_loop_fallback_policy(),
         )
-    except CredentialResolutionError:
-        # No credential resolves — legacy behaviour returned the api_key
-        # prefix anyway and let inspect_ai surface the env-var error at
-        # call time. Preserve that.
+    except CredentialResolutionError as exc:
+        # PR-CRED-SOURCE-CENTRALIZE — when the STRICT subscription gate fired
+        # (``fallback_to_payg=False`` + only PAYG left), re-raise. Silently
+        # routing to ``api_key`` here would defeat the resolution-time PAYG
+        # guard that this refactor relies on as the safety boundary. Only the
+        # non-strict "no credential at all" case preserves the legacy api_key
+        # prefix (inspect_ai surfaces the env-var error at call time).
+        if exc.subscription_only:
+            raise
         source = "api_key"
 
     manifest = load_manifest()

--- a/plugins/petri_audit/models.py
+++ b/plugins/petri_audit/models.py
@@ -293,10 +293,20 @@ def list_audit_models() -> list[tuple[str, str]]:
     here. Skips models whose provider the mapping rules don't recognise
     (defensive — should be empty in practice).
     """
+    from plugins.petri_audit.credential_source import CredentialResolutionError
+
     pairs: list[tuple[str, str]] = []
     for geode_id in MODEL_PRICING:
         try:
             pairs.append((geode_id, to_inspect_model(geode_id)))
         except AuditModelMappingError:
             continue
+        except CredentialResolutionError:
+            # PR-CRED-SOURCE-CENTRALIZE — catalog listing (--help / tool
+            # description) must stay credential-INDEPENDENT. Now that
+            # ``to_inspect_model`` re-raises the strict subscription gate
+            # (``fallback_to_payg=False``), fall back to the deterministic
+            # api_key-adapter prefix so every catalog model is still listed
+            # regardless of runtime credential availability.
+            pairs.append((geode_id, to_inspect_model(geode_id, source="api_key")))
     return pairs

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -625,16 +625,18 @@ def run_audit(
     # to work in ``dry_run`` mode (CI smoke runs, slash dry-runs,
     # `geode audit` without env keys). Credential resolution happens
     # later, only on the real-run branch.
-    # PR-CRED-SOURCE-CENTRALIZE — capture the per-role ``source`` override
-    # (``[self_improving_loop.petri.<role>].source``) alongside the model so an
-    # explicit ``source = "api_key"`` for the auditor/judge actually routes
-    # there. Previously only ``model`` was read, so the per-role source was a
-    # silent no-op. Defaults None → to_inspect_model's use_oauth/cascade decides.
-    auditor_source: str | None = None
-    judge_source: str | None = None
+    # PR-CRED-SOURCE-CENTRALIZE — the per-role ``source`` override
+    # (``[self_improving_loop.petri.<role>].source``) for auditor/judge is read
+    # *independently* of whether the model axis was supplied via argv, so an
+    # explicit ``source = "api_key"`` routes those roles even when the operator
+    # pins the model. Previously only ``model`` was read → the per-role source
+    # was a silent no-op. None → to_inspect_model's use_oauth/cascade decides.
+    from plugins.petri_audit.user_overrides import read_role_override
+
+    auditor_source: str | None = read_role_override("auditor").get("source")
+    judge_source: str | None = read_role_override("judge").get("source")
     if auditor is None or judge is None or target is None:
         from plugins.petri_audit.manifest import load_manifest
-        from plugins.petri_audit.user_overrides import read_role_override
 
         manifest = load_manifest()
         for slot, role in (("auditor", "auditor"), ("judge", "judge"), ("target", "target")):
@@ -644,14 +646,13 @@ def run_audit(
                 continue
             if slot == "target" and target is not None:
                 continue
-            override = read_role_override(role)
-            resolved = override.get("model") or manifest.get_role(role).default_model
+            resolved = (
+                read_role_override(role).get("model") or manifest.get_role(role).default_model
+            )
             if slot == "auditor":
                 auditor = resolved
-                auditor_source = override.get("source")
             elif slot == "judge":
                 judge = resolved
-                judge_source = override.get("source")
             else:
                 target = resolved
     assert auditor is not None and judge is not None and target is not None  # narrowed

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -625,6 +625,13 @@ def run_audit(
     # to work in ``dry_run`` mode (CI smoke runs, slash dry-runs,
     # `geode audit` without env keys). Credential resolution happens
     # later, only on the real-run branch.
+    # PR-CRED-SOURCE-CENTRALIZE — capture the per-role ``source`` override
+    # (``[self_improving_loop.petri.<role>].source``) alongside the model so an
+    # explicit ``source = "api_key"`` for the auditor/judge actually routes
+    # there. Previously only ``model`` was read, so the per-role source was a
+    # silent no-op. Defaults None → to_inspect_model's use_oauth/cascade decides.
+    auditor_source: str | None = None
+    judge_source: str | None = None
     if auditor is None or judge is None or target is None:
         from plugins.petri_audit.manifest import load_manifest
         from plugins.petri_audit.user_overrides import read_role_override
@@ -637,17 +644,19 @@ def run_audit(
                 continue
             if slot == "target" and target is not None:
                 continue
-            override_model = read_role_override(role).get("model")
-            resolved = override_model or manifest.get_role(role).default_model
+            override = read_role_override(role)
+            resolved = override.get("model") or manifest.get_role(role).default_model
             if slot == "auditor":
                 auditor = resolved
+                auditor_source = override.get("source")
             elif slot == "judge":
                 judge = resolved
+                judge_source = override.get("source")
             else:
                 target = resolved
     assert auditor is not None and judge is not None and target is not None  # narrowed
-    inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth)
-    inspect_judge = to_inspect_model(judge, use_oauth=use_oauth)
+    inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth, source=auditor_source)
+    inspect_judge = to_inspect_model(judge, use_oauth=use_oauth, source=judge_source)
     inspect_target = to_inspect_target(target)
     # Booster A — when audit-mode is active (GEODE_AUDIT_UNRESTRICTED=1,
     # set by ``cli_audit.audit(--unrestricted)`` before this call), inject

--- a/plugins/seed_generation/auth_coverage.py
+++ b/plugins/seed_generation/auth_coverage.py
@@ -33,6 +33,12 @@ __all__ = [
 
 Component = Literal["seed_generation", "petri_audit", "autoresearch", "geode_main"]
 Family = Literal["anthropic", "openai"]
+# Concrete auth-path sources — the non-AUTO members of the canonical
+# ``core.config.credential_source.CredentialSource``. Kept as a Literal (not the
+# enum) because an auth *path* is always a concrete destination, never the
+# ``AUTO`` resolver mode. Pinned to the canonical enum by
+# ``test_credential_source_centralized.test_auth_coverage_source_is_concrete_subset``
+# so it cannot silently drift (PR-CRED-SOURCE-CENTRALIZE).
 Source = Literal["claude-cli", "openai-codex", "api_key"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.84"
+version = "0.99.85"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_credential_source_centralized.py
+++ b/tests/test_credential_source_centralized.py
@@ -84,3 +84,36 @@ def test_settings_credential_source_validates_against_canonical() -> None:
 
     with pytest.raises(ValidationError):
         Settings(anthropic_credential_source="not-a-real-source")
+
+
+def test_explicit_per_role_api_key_routes_to_anthropic_api() -> None:
+    """An explicit per-role ``source = "api_key"`` routes the model to the
+    Anthropic API adapter (not ``claude-cli``) — the operator PAYG opt-in this
+    refactor enables. Without the runner→to_inspect_model source threading
+    (Codex review fix) this opt-in was a silent no-op.
+    """
+    from plugins.petri_audit.models import to_inspect_model
+
+    api_key_routed = to_inspect_model("claude-opus-4-8", source="api_key")
+    cli_routed = to_inspect_model("claude-opus-4-8", source="claude-cli")
+    assert api_key_routed != cli_routed
+    assert api_key_routed.startswith("anthropic/")  # PAYG API adapter prefix
+    assert cli_routed.startswith("claude-cli/")  # subscription OAuth adapter prefix
+
+
+def test_to_inspect_model_reraises_strict_subscription_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the strict subscription gate fires (``subscription_only=True``),
+    ``to_inspect_model`` must re-raise rather than silently routing to
+    ``api_key`` — otherwise the resolution-time PAYG guard is defeated
+    (Codex review fix)."""
+    from plugins.petri_audit import credential_source as cs
+    from plugins.petri_audit import models
+
+    def _raise_strict(provider: str, **_kw: object) -> str:
+        raise cs.CredentialResolutionError("anthropic", ["claude-cli"], subscription_only=True)
+
+    monkeypatch.setattr(cs, "resolve_credential_source", _raise_strict)
+    with pytest.raises(cs.CredentialResolutionError):
+        models.to_inspect_model("claude-opus-4-8")

--- a/tests/test_credential_source_centralized.py
+++ b/tests/test_credential_source_centralized.py
@@ -1,0 +1,86 @@
+"""Drift invariants for the centralized credential-source enum.
+
+PR-CRED-SOURCE-CENTRALIZE (2026-05-29). The credential-source value set used to
+be spelled four different ways with inconsistent membership; these tests pin
+every (previously-fragmented) site to the single canonical
+:class:`core.config.credential_source.CredentialSource` so the fragmentation
+cannot silently come back.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+from core.config.credential_source import (
+    DISABLE_SENTINEL,
+    LEGACY_OAUTH_ALIAS,
+    CredentialSource,
+)
+from pydantic import ValidationError
+
+
+def test_canonical_membership_is_stable() -> None:
+    """The canonical enum is exactly these four sources. A change here is a
+    deliberate, reviewed event — not an accidental per-module divergence."""
+    assert {s.value for s in CredentialSource} == {
+        "auto",
+        "api_key",
+        "claude-cli",
+        "openai-codex",
+    }
+
+
+def test_self_improving_loop_source_alias_is_canonical() -> None:
+    """``self_improving_loop.Source`` is a re-export of the canonical enum,
+    not a second Literal."""
+    from core.config.self_improving_loop import Source
+
+    assert Source is CredentialSource
+
+
+def test_config_source_fields_use_canonical_enum() -> None:
+    """Every ``source`` field on the loop config models is typed as the
+    canonical enum (previously: two different Literals)."""
+    from core.config.self_improving_loop import (
+        AutoresearchConfig,
+        MutatorConfig,
+        PetriRoleConfig,
+    )
+
+    for model in (PetriRoleConfig, AutoresearchConfig, MutatorConfig):
+        assert model.model_fields["source"].annotation is CredentialSource, model.__name__
+
+
+def test_auth_coverage_source_is_concrete_subset() -> None:
+    """``auth_coverage.Source`` is exactly the *concrete* (non-AUTO) members of
+    the canonical enum — pinned so it can't drift (it stays a Literal because an
+    auth path is never the AUTO resolver mode)."""
+    from plugins.seed_generation.auth_coverage import Source as AuthPathSource
+
+    concrete = {s.value for s in CredentialSource if s is not CredentialSource.AUTO}
+    assert set(get_args(AuthPathSource)) == concrete
+
+
+def test_petri_constants_sourced_from_canonical_enum() -> None:
+    """The petri magic constants derive from the canonical enum (no drift)."""
+    from plugins.petri_audit.credential_source import PAYG_SOURCE
+    from plugins.petri_audit.manifest import AUTO_SOURCE
+
+    assert AUTO_SOURCE == CredentialSource.AUTO.value == "auto"
+    assert PAYG_SOURCE == CredentialSource.API_KEY.value == "api_key"
+
+
+def test_settings_credential_source_validates_against_canonical() -> None:
+    """``settings.{provider}_credential_source`` accepts the canonical members
+    plus the legacy ``oauth`` alias / ``none`` sentinel, and rejects anything
+    else — validated against the single SoT rather than a bare ``str``."""
+    from core.config._settings import Settings
+
+    accepted = {s.value for s in CredentialSource} | {LEGACY_OAUTH_ALIAS, DISABLE_SENTINEL}
+    for value in accepted:
+        s = Settings(anthropic_credential_source=value, openai_credential_source=value)
+        assert s.anthropic_credential_source == value
+
+    with pytest.raises(ValidationError):
+        Settings(anthropic_credential_source="not-a-real-source")

--- a/tests/test_d1_provider_closure.py
+++ b/tests/test_d1_provider_closure.py
@@ -1,55 +1,57 @@
-"""PR-SIL-5THEME C6 — D1 provider B/C closure tests.
+"""D1 provider closure tests — closure now enforced at *resolution*, not type.
 
-operator decision (durable memory ``project_payg_exclusion_decision.md``,
-2026-05-23) 으로 autoresearch / Petri audit 의 provider 선택지에서 PAYG
-(``api_key``) 영구 exclude. 잔존 옵션 = claude-cli / openai-codex / auto.
+PR-CRED-SOURCE-CENTRALIZE (2026-05-29) reversed the original type-level
+exclusion: ``api_key`` was removed from the ``Source`` Literal so the config
+*rejected* it. That caused the credential-source fragmentation (``api_key`` in
+some enums, not others) and blocked an operator who explicitly opts into PAYG.
 
-C6 의 3 wiring:
-1. ``Source`` literal 에서 ``api_key`` 제거 → Pydantic 가 reject (silent
-   leak 차단)
-2. ``PetriRoleConfig.source`` + ``AutoresearchConfig.source`` default
-   ``auto → claude-cli`` (subscription-first 명시)
-3. ``autoresearch/prepare.py`` 의 ``check_subscription_cli_for_source``
-   pre-flight — binary 부재 시 actionable error
+The D1 *intent* — a subscription-only run must not **silently** fall through to
+PAYG — is unchanged, but it is now enforced at **resolution** time:
+``resolve_credential_source(fallback_to_payg=False)`` filters ``api_key`` out of
+``auto`` expansion. ``api_key`` is a valid :class:`CredentialSource` member, so
+the config accepts an *explicit* ``source = "api_key"`` (the deliberate opt-in)
+while ``auto`` still never silently bills the API key. See
+``test_credential_source_centralized.py`` for the resolution-gate + enum-drift
+invariants.
+
+Remaining wiring (unchanged):
+- ``PetriRoleConfig.source`` / ``AutoresearchConfig.source`` default
+  ``claude-cli`` (subscription-first).
+- ``autoresearch/prepare.py`` ``check_subscription_cli_for_source`` pre-flight.
 """
 
 from __future__ import annotations
 
 import pytest
 from autoresearch.prepare import check_subscription_cli_for_source
+from core.config.credential_source import CredentialSource
 from core.config.self_improving_loop import (
     AutoresearchConfig,
     PetriRoleConfig,
 )
-from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # 1. Source literal — api_key reject
 # ---------------------------------------------------------------------------
 
 
-def test_petri_role_source_api_key_rejected() -> None:
-    """PetriRoleConfig 에 ``source = "api_key"`` 설정 시 Pydantic 가 reject —
-    PAYG 가 audit role 선택지에서 영구 제거됐다는 invariant.
+def test_petri_role_source_accepts_api_key() -> None:
+    """PetriRoleConfig now ACCEPTS ``source = "api_key"`` (centralized enum).
 
-    operator 가 config.toml 에 ``[self_improving_loop.petri.target]
-    source = "api_key"`` 명시 → ValidationError + 어느 값이 invalid 인지
-    명시되는 Pydantic 메시지로 surface.
+    PR-CRED-SOURCE-CENTRALIZE: ``api_key`` is a valid ``CredentialSource``
+    member, so an operator can explicitly opt into PAYG for an audit role. The
+    silent-fallback closure moved to resolution (``fallback_to_payg`` gate),
+    asserted in ``test_credential_source_centralized.py``.
     """
-    with pytest.raises(ValidationError) as exc_info:
-        PetriRoleConfig(source="api_key")  # type: ignore[arg-type]
-    msg = str(exc_info.value)
-    assert "source" in msg
-    assert "api_key" in msg
+    p = PetriRoleConfig(source="api_key")
+    assert p.source == CredentialSource.API_KEY
+    assert p.source == "api_key"  # StrEnum compares equal to its wire string
 
 
-def test_autoresearch_source_api_key_rejected() -> None:
-    """AutoresearchConfig 도 동일 — ``source = "api_key"`` Pydantic reject."""
-    with pytest.raises(ValidationError) as exc_info:
-        AutoresearchConfig(source="api_key")  # type: ignore[arg-type]
-    msg = str(exc_info.value)
-    assert "source" in msg
-    assert "api_key" in msg
+def test_autoresearch_source_accepts_api_key() -> None:
+    """AutoresearchConfig likewise accepts an explicit ``source = "api_key"``."""
+    a = AutoresearchConfig(source="api_key")
+    assert a.source == CredentialSource.API_KEY
 
 
 def test_petri_role_source_accepts_claude_cli() -> None:
@@ -163,22 +165,19 @@ def test_preflight_unknown_source_graceful_skip() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_backend_matrix_api_key_rejected_petri_role() -> None:
-    """4-backend matrix: api_key 만 reject, 다른 3 (claude-cli / openai-codex /
-    auto) 는 accept."""
-    # Reject
-    with pytest.raises(ValidationError):
-        PetriRoleConfig(source="api_key")  # type: ignore[arg-type]
-    # Accept (3 valid sources)
-    for source in ("claude-cli", "openai-codex", "auto"):
-        cfg = PetriRoleConfig(source=source)  # type: ignore[arg-type]
+def test_backend_matrix_all_sources_accepted_petri_role() -> None:
+    """4-source matrix: all four canonical sources (incl. ``api_key``) accept.
+
+    Post-centralization the config no longer type-rejects ``api_key``; every
+    ``CredentialSource`` member is a valid config value.
+    """
+    for source in CredentialSource:
+        cfg = PetriRoleConfig(source=source)
         assert cfg.source == source
 
 
-def test_backend_matrix_api_key_rejected_autoresearch() -> None:
-    """AutoresearchConfig 도 같은 matrix."""
-    with pytest.raises(ValidationError):
-        AutoresearchConfig(source="api_key")  # type: ignore[arg-type]
-    for source in ("claude-cli", "openai-codex", "auto"):
-        cfg = AutoresearchConfig(source=source)  # type: ignore[arg-type]
+def test_backend_matrix_all_sources_accepted_autoresearch() -> None:
+    """AutoresearchConfig accepts every canonical source too."""
+    for source in CredentialSource:
+        cfg = AutoresearchConfig(source=source)
         assert cfg.source == source


### PR DESCRIPTION
## Summary
- develop → main pass-through for the v0.99.85 release (PR-CRED-SOURCE-CENTRALIZE — credential-source enum centralization).
- Version stamp `0.99.85` + CHANGELOG `[0.99.85]` already landed on develop via #1882.

## Verification
- [x] release/v0.99.85 → develop merged (#1882), CI 7/7 green
- [ ] CI 5/5 green on this pass-through