### PR TITLE
fix(transcript): full dialogue.jsonl turn body; only pipeline preview stays short (v0.99.87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,23 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.87] - 2026-05-29
+
+### Fixed
+- **PR-TRANSCRIPT-FULL-BODY (2026-05-29)** — `SessionTranscript` recorded the
+  `dialogue.jsonl` turn body truncated to 500 chars (cut mid-object), even
+  though `_mirror_to_run_transcript` always documented that "the full body
+  stays in dialogue.jsonl" and only the pipeline-timeline preview should be
+  short — a single `_truncate(text, 500)` wrongly fed BOTH. The body of
+  `user_message` / `assistant_message` / `error` events is now captured in full
+  (up to a `MAX_BODY_CHARS = 100_000` sanity ceiling; the 5 MB `MAX_FILE_BYTES`
+  guard + tail-truncate still bound the file), while only the mirrored
+  RunTranscript preview stays at `MAX_PREVIEW_CHARS = 500` (renamed from
+  `MAX_TEXT_CHARS`). Future runs capture full raw conversational transcripts;
+  pinned by `tests/test_transcript.py` (full body, ceiling cap, and the
+  body↔preview split). Tool-call/tool-result events keep the `MAX_INPUT_CHARS`
+  preview (potentially huge I/O, not the conversation).
+
 ## [0.99.86] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.86
+- **Version**: 0.99.87
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.86 — Long-running Autonomous Execution Harness
+# GEODE v0.99.87 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.86**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.87**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.86 — Long-running Autonomous Execution Harness
+# GEODE v0.99.87 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.86**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.87**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/observability/transcript.py
+++ b/core/observability/transcript.py
@@ -52,7 +52,15 @@ def _get_default_transcript_dir() -> Path:
 
 
 DEFAULT_TRANSCRIPT_DIR = _get_default_transcript_dir()
-MAX_TEXT_CHARS = 500
+# PR-TRANSCRIPT-FULL-BODY (2026-05-29) — the ``dialogue.jsonl`` turn body is now
+# captured in full (up to MAX_BODY_CHARS, a sanity ceiling far above any real
+# turn; the 5 MB MAX_FILE_BYTES guard + tail-truncate bound the *file*). Only the
+# preview lifted up into the pipeline-timeline RunTranscript stays short — which
+# is exactly the split ``_mirror_to_run_transcript`` always documented ("the full
+# body stays in dialogue.jsonl"). Previously one 500-char ``_truncate`` fed BOTH
+# the body and the preview, so the recorded turn was a fragment cut mid-object.
+MAX_BODY_CHARS = 100_000
+MAX_PREVIEW_CHARS = 500
 MAX_INPUT_CHARS = 300
 CLEANUP_AGE_DAYS = 30
 MAX_FILE_BYTES = 5 * 1024 * 1024  # 5MB per transcript
@@ -181,23 +189,23 @@ class SessionTranscript:
         self._update_index()
 
     def record_user_message(self, text: str) -> None:
-        truncated = _truncate(text, MAX_TEXT_CHARS)
-        self._append({"event": "user_message", "text": truncated})
+        # Full body to dialogue.jsonl; a short preview to the pipeline timeline.
+        self._append({"event": "user_message", "text": _truncate(text, MAX_BODY_CHARS)})
         self._mirror_to_run_transcript(
             action="agent.user_message",
             entity_type="task",
             entity_id=self._session_id,
-            details={"text": truncated},
+            details={"text": _truncate(text, MAX_PREVIEW_CHARS)},
         )
 
     def record_assistant_message(self, text: str) -> None:
-        truncated = _truncate(text, MAX_TEXT_CHARS)
-        self._append({"event": "assistant_message", "text": truncated})
+        # Full body to dialogue.jsonl; a short preview to the pipeline timeline.
+        self._append({"event": "assistant_message", "text": _truncate(text, MAX_BODY_CHARS)})
         self._mirror_to_run_transcript(
             action="agent.assistant_message",
             entity_type="task",
             entity_id=self._session_id,
-            details={"text": truncated},
+            details={"text": _truncate(text, MAX_PREVIEW_CHARS)},
         )
 
     def record_tool_call(self, tool: str, tool_input: dict[str, Any]) -> None:
@@ -317,7 +325,7 @@ class SessionTranscript:
             {
                 "event": "error",
                 "type": error_type,
-                "msg": _truncate(message, MAX_TEXT_CHARS),
+                "msg": _truncate(message, MAX_BODY_CHARS),
             }
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.86"
+version = "0.99.87"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_session_transcript.py
+++ b/tests/test_session_transcript.py
@@ -38,11 +38,13 @@ class TestSessionTranscriptWrite:
         assert events[5]["event"] == "cost"
         assert events[6]["event"] == "session_end"
 
-    def test_text_truncation(self, tx: SessionTranscript) -> None:
+    def test_body_captured_in_full(self, tx: SessionTranscript) -> None:
+        # PR-TRANSCRIPT-FULL-BODY — dialogue.jsonl keeps the whole turn body
+        # (only the pipeline-timeline mirror preview stays short).
         long_text = "x" * 1000
         tx.record_user_message(long_text)
         events = tx.read_events()
-        assert len(events[0]["text"]) <= 503  # 500 + "..."
+        assert events[0]["text"] == long_text
 
     def test_tool_input_truncation(self, tx: SessionTranscript) -> None:
         long_input = {"data": "y" * 500}

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -6,8 +6,9 @@ import json
 import time
 
 from core.observability.transcript import (
+    MAX_BODY_CHARS,
     MAX_INPUT_CHARS,
-    MAX_TEXT_CHARS,
+    MAX_PREVIEW_CHARS,
     SessionTranscript,
     _truncate,
     cleanup_old_transcripts,
@@ -94,13 +95,58 @@ class TestSessionTranscript:
         assert events[0]["event"] == "subagent_start"
         assert events[1]["event"] == "subagent_complete"
 
-    def test_text_truncation(self, tmp_path):
+    def test_body_captured_in_full(self, tmp_path):
+        # PR-TRANSCRIPT-FULL-BODY — the dialogue.jsonl turn body is NO LONGER
+        # capped at the old 500 preview limit; a real-size turn is kept whole.
         tx = SessionTranscript("s-trunc", tmp_path / "transcripts")
         long_text = "x" * 1000
         tx.record_user_message(long_text)
 
         events = tx.read_events()
-        assert len(events[0]["text"]) == MAX_TEXT_CHARS
+        assert events[0]["text"] == long_text  # full body, not a 500-char fragment
+
+    def test_body_capped_at_ceiling(self, tmp_path):
+        # The only bound on a single turn is the MAX_BODY_CHARS sanity ceiling
+        # (so one pathological turn cannot dwarf the 5MB file guard).
+        tx = SessionTranscript("s-trunc-ceiling", tmp_path / "transcripts")
+        tx.record_assistant_message("y" * (MAX_BODY_CHARS + 5000))
+
+        events = tx.read_events()
+        assert len(events[0]["text"]) == MAX_BODY_CHARS
+        assert events[0]["text"].endswith("...")
+
+    def test_pipeline_preview_stays_short(self, tmp_path):
+        # The split the mirror always documented: the FULL body lands in
+        # dialogue.jsonl, only a short PREVIEW is lifted into the pipeline
+        # timeline (RunTranscript). Pinned so a future edit can't re-truncate
+        # the body or let the preview balloon.
+        import json
+
+        from core.observability.run_dir import run_dir_scope
+        from core.self_improving_loop.run_transcript import (
+            RunTranscript,
+            run_transcript_scope,
+        )
+
+        long_text = "z" * 4000
+        run_path = tmp_path / "transcript.jsonl"
+        with run_dir_scope(str(tmp_path)):
+            journal = RunTranscript(
+                session_id="s-mirror",
+                gen_tag="gen1",
+                component="seed-generation",
+                path=run_path,
+            )
+            with run_transcript_scope(journal):
+                tx = SessionTranscript("s-mirror", tmp_path / "transcripts")
+                tx.record_assistant_message(long_text)
+
+        # dialogue.jsonl body is full…
+        assert tx.read_events()[0]["text"] == long_text
+        # …but the mirrored pipeline-timeline row is a short preview.
+        rows = [json.loads(ln) for ln in run_path.read_text().splitlines() if ln.strip()]
+        mirror = next(r for r in rows if r.get("action") == "agent.assistant_message")
+        assert len(mirror["payload"]["text"]) <= MAX_PREVIEW_CHARS
 
     def test_input_truncation(self, tmp_path):
         tx = SessionTranscript("s-trunc2", tmp_path / "transcripts")


### PR DESCRIPTION
## Summary
- `SessionTranscript` truncated the `dialogue.jsonl` turn body to 500 chars (cut mid-object) AND fed that same 500-char string to the pipeline-timeline mirror — even though `_mirror_to_run_transcript` always documented "the full body stays in dialogue.jsonl".
- Now: body = full (up to `MAX_BODY_CHARS=100_000`), mirror preview = `MAX_PREVIEW_CHARS=500`. PR-B of the operator's "둘 다".

## Why
The seedgen `.eval` viewer originally showed truncated raw-JSON fragments because the dialogue recorder capped every turn at 500 chars. PR-A worked around it by reading `state.json`; PR-B fixes the recorder so **future raw transcripts are captured whole**. The fix realizes the split the mirror docstring already described (full body in dialogue.jsonl, short preview in the pipeline timeline) — a single `_truncate(text, 500)` was wrongly feeding both.

## Changes
| File | Change |
|------|--------|
| `core/observability/transcript.py` | `MAX_TEXT_CHARS`→`MAX_PREVIEW_CHARS` (500, mirror preview only); new `MAX_BODY_CHARS=100_000`; `record_user_message`/`record_assistant_message` write the full body + a short mirror preview; `record_error` body→full. 5 MB `MAX_FILE_BYTES` guard + tail-truncate still bound the file |
| `tests/test_transcript.py`, `tests/test_session_transcript.py` | full-body + ceiling-cap + body↔preview split (binds a RunTranscript, asserts mirror row ≤ `MAX_PREVIEW_CHARS`) |
| `CHANGELOG.md` + 4 stamp files | 0.99.86 → **0.99.87** (PATCH) + CHANGELOG promote |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| dialogue body full | Implemented | user/assistant/error → MAX_BODY_CHARS |
| mirror preview short | Implemented | RunTranscript row ≤ MAX_PREVIEW_CHARS |
| `worker.py:798` summary / `handoff.py:156` error | Left as-is | parent-timeline / Tier-3 snapshot summaries, not the dialogue body — out of scope |
| tool_call/tool_result | Left as-is | MAX_INPUT_CHARS preview (huge I/O, not conversation) |

## Verification
- [x] ruff + format + mypy + `lint-imports` (4/4) clean
- [x] transcript + session-transcript + worker + handoff tests pass (111)
- [x] no `MAX_TEXT_CHARS` left anywhere; version 0.99.87 parity across 5 locations
- [x] Codex MCP reviewed — caught a 2nd test file (`test_session_transcript.py`, literal `<=503`); fixed
- [ ] CI green

## Reference
Operator: "둘 다 (state 전문 + cap 상향)" — PR-A=#1895 (state full), PR-B=this (raise the recorder cap).