### PR TITLE
docs(portfolio): narrative arc over the flat section scroll

### DIFF
--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -3,6 +3,7 @@
 import { LocaleProvider } from "@/components/geode/locale-context";
 import { GeodeNav } from "@/components/geode/sections/nav";
 import { HeroSection } from "@/components/geode/sections/hero";
+import { ActHeader } from "@/components/geode/sections/act-header";
 import { SelfHostingDefinitionSection } from "@/components/geode/sections/self-hosting-definition";
 import { OsThesisSection } from "@/components/geode/sections/os-thesis";
 import { OsPrimitivesMapSection } from "@/components/geode/sections/os-primitives-map";
@@ -31,51 +32,104 @@ import { BootstrapSection } from "@/components/geode/sections/bootstrap";
 import { TimelineSection } from "@/components/geode/sections/timeline";
 import { GeodeFooter } from "@/components/geode/sections/footer";
 
-const Divider = () => <div className="max-w-3xl mx-auto border-t border-[var(--rule)]" />;
+const actLink =
+  "inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-[var(--rule)] hover:border-[var(--acc-artifact)] text-[13px] font-mono text-[var(--ink-1)] hover:text-[var(--acc-artifact)] transition-colors";
 
 export default function GeodePage() {
   return (
     <LocaleProvider>
-    <main className="min-h-screen bg-[var(--paper)] text-[var(--ink)] overflow-x-hidden">
-      <GeodeNav />
-      <div id="hero"><HeroSection /></div>
-      <div id="definition"><SelfHostingDefinitionSection /></div>
-      <div id="thesis"><OsThesisSection /></div>
-      <div id="primitives"><OsPrimitivesMapSection /></div>
-      <div id="recursion"><RecursionSection /></div>
-      <div id="bootstrap"><BootstrapSection /></div>
-      <Divider />
-      <div id="compute-abi"><ComputeAbiSection /></div>
-      <div id="routing-iq"><RoutingIqSection /></div>
-      <Divider />
-      <Divider />
-      <div id="scaffold"><ScaffoldSection /></div>
-      <div id="kanban"><KanbanSection /></div>
-      <Divider />
-      <div id="loop"><LoopSection /></div>
-      <div id="reasoning"><ReasoningSection /></div>
-      <Divider />
-      <div id="architecture"><ArchitectureSection /></div>
-      <div id="gateway"><GatewaySection /></div>
-      <div id="concurrency"><ConcurrencySection /></div>
-      <div id="headless"><HeadlessSection /></div>
-      <div id="scheduler"><SchedulerSection /></div>
-      <Divider />
-      <div id="hooks"><HooksSection /></div>
-      <div id="agents"><AgentsTasksSection /></div>
-      <div id="tools"><ToolUseSection /></div>
-      <Divider />
-      <div id="context"><ContextTiersSection /></div>
-      <div id="llm"><MultiLlmSection /></div>
-      <Divider />
-      <div id="orchestration"><OrchestrationSection /></div>
-      <div id="feedback"><FeedbackSection /></div>
-      <div id="automation"><AutomationSection /></div>
-      <Divider />
-      <div id="verify"><VerificationSection /></div>
-      <div id="timeline"><TimelineSection /></div>
-      <GeodeFooter />
-    </main>
+      <main className="min-h-screen bg-[var(--paper)] text-[var(--ink)] overflow-x-hidden">
+        <GeodeNav />
+
+        {/* Opening: what GEODE is */}
+        <div id="hero"><HeroSection /></div>
+        <div id="definition"><SelfHostingDefinitionSection /></div>
+        <div id="thesis"><OsThesisSection /></div>
+        <div id="primitives"><OsPrimitivesMapSection /></div>
+        <div id="recursion"><RecursionSection /></div>
+
+        {/* Act I: the inner loop */}
+        <ActHeader
+          id="act-inner"
+          eyebrow="Act I . The inner loop"
+          title="How GEODE runs one task"
+          titleKo="한 작업을 처리하는 법"
+          body="The inner loop is a while(tool_use) agent. Within a round cap and a set of termination paths, it reasons, calls a tool, reads the result, and decides the next step. Everything below feeds that loop: how it reasons, which tools it reaches for, the context it assembles, and how it routes across models."
+          bodyKo="안쪽 루프는 while(tool_use) 에이전트입니다. 라운드 상한과 종료 경로 안에서 추론하고, 도구를 호출하고, 결과를 읽어 다음 단계를 정합니다. 아래의 모든 조각이 이 루프를 떠받칩니다. 어떻게 추론하고, 어떤 도구를 집어 들고, 어떤 컨텍스트를 조립하며, 모델 사이를 어떻게 라우팅하는지입니다."
+        />
+        <div id="loop"><LoopSection /></div>
+        <div id="reasoning"><ReasoningSection /></div>
+        <div id="tools"><ToolUseSection /></div>
+        <div id="context"><ContextTiersSection /></div>
+        <div id="llm"><MultiLlmSection /></div>
+        <div id="compute-abi"><ComputeAbiSection /></div>
+        <div id="routing-iq"><RoutingIqSection /></div>
+
+        {/* Act II: the harness */}
+        <ActHeader
+          id="act-harness"
+          eyebrow="Act II . The harness"
+          title="How a task gets served"
+          titleKo="그 루프가 서빙되는 법"
+          body="One daemon runs the loop for every entry point: a CLI call, a messaging gateway, a scheduled job. The harness is what turns a single loop into a running system. Process layout and boot order, concurrency lanes, the scheduler, the hook bus every subsystem listens on, and the sub-agents a task can spawn."
+          bodyKo="하나의 데몬이 모든 진입점에서 이 루프를 돌립니다. CLI 호출이든, 메신저 게이트웨이든, 예약된 작업이든 같습니다. 하네스는 단일 루프를 살아 있는 시스템으로 만드는 층입니다. 프로세스 구성과 부팅 순서, 동시성 레인, 스케줄러, 모든 서브시스템이 듣는 훅 버스, 그리고 한 작업이 띄우는 서브에이전트입니다."
+        />
+        <div id="architecture"><ArchitectureSection /></div>
+        <div id="gateway"><GatewaySection /></div>
+        <div id="concurrency"><ConcurrencySection /></div>
+        <div id="headless"><HeadlessSection /></div>
+        <div id="scheduler"><SchedulerSection /></div>
+        <div id="hooks"><HooksSection /></div>
+        <div id="agents"><AgentsTasksSection /></div>
+        <div id="orchestration"><OrchestrationSection /></div>
+        <div id="bootstrap"><BootstrapSection /></div>
+
+        {/* Act III: the outer loop (the signature) */}
+        <ActHeader
+          id="act-outer"
+          eyebrow="Act III . The outer loop"
+          title="How GEODE improves itself"
+          titleKo="GEODE가 스스로를 개선하는 법"
+          body="This is what makes GEODE more than a harness. An outer loop mutates the scaffolding the inner loop runs on, audits the result against an adversarial safety rubric, and promotes the change only when it clears a hard floor on the critical dimensions. No weights are touched, and the test set itself is co-evolved alongside the agent."
+          bodyKo="GEODE를 단순한 하네스 이상으로 만드는 부분입니다. 바깥쪽 루프는 안쪽 루프가 올라타는 스캐폴드를 변형하고, 그 결과를 적대적 안전 루브릭으로 감사한 뒤, 핵심 차원의 하한선을 넘겼을 때만 변경을 승격합니다. 가중치는 건드리지 않으며, 평가용 테스트 세트 자체가 에이전트와 함께 진화합니다."
+        >
+          <div className="flex flex-wrap items-center gap-3">
+            <a href="/geode/docs/capabilities/autoresearch" className={actLink}>The closed loop →</a>
+            <a href="/geode/self-improving/" className={actLink}>Live hub →</a>
+            <a href="/geode/self-improving/petri-bundle/" className={actLink}>Audit transcripts →</a>
+          </div>
+        </ActHeader>
+        <div id="feedback"><FeedbackSection /></div>
+        <div id="automation"><AutomationSection /></div>
+        <div id="verify"><VerificationSection /></div>
+
+        {/* Act IV: positioning (framing only) */}
+        <ActHeader
+          id="act-positioning"
+          eyebrow="Act IV . Where it sits"
+          title="An honest place in the lineage"
+          titleKo="계보 위의 정직한 자리"
+          body="The self-improvement loop is not new. Promptbreeder, STOP, ADAS, DGM, and GEPA built the lineage. GEODE's contribution is a recombination. It re-aims that loop from capability to safety, from weights to scaffolding, and runs it on co-evolved adversarial seeds. That is an empty cell in the design space, not a new primitive."
+          bodyKo="자기개선 루프는 새로운 것이 아닙니다. Promptbreeder, STOP, ADAS, DGM, GEPA가 그 계보를 닦았습니다. GEODE의 기여는 재조합입니다. 그 루프를 능력에서 안전으로, 가중치에서 스캐폴드로 다시 겨냥하고, 함께 진화하는 적대적 seed 위에서 돌립니다. 새로운 primitive가 아니라, 설계 공간의 비어 있던 칸입니다."
+        >
+          <a href="/geode/docs/capabilities/lineage" className={actLink}>Lineage and positioning →</a>
+        </ActHeader>
+
+        {/* Act V: how it was built */}
+        <ActHeader
+          id="act-build"
+          eyebrow="Act V . The build"
+          title="Built by its own scaffold"
+          titleKo="자기 자신의 스캐폴드로 빌드한"
+          body="GEODE is built with the same primitives it runs. The development scaffold, the board, and the release line apply the agent's own patterns to itself. The timeline below is how that compounded, chapter by chapter."
+          bodyKo="GEODE는 자신이 실행하는 것과 같은 기본 단위로 빌드됩니다. 개발 스캐폴드와 보드, 릴리스 라인은 에이전트의 패턴을 자기 자신에게 적용한 결과입니다. 아래 타임라인은 그것이 어떻게 챕터를 거듭하며 쌓였는지입니다."
+        />
+        <div id="scaffold"><ScaffoldSection /></div>
+        <div id="kanban"><KanbanSection /></div>
+        <div id="timeline"><TimelineSection /></div>
+
+        <GeodeFooter />
+      </main>
     </LocaleProvider>
   );
 }

--- a/site/src/components/geode/sections/act-header.tsx
+++ b/site/src/components/geode/sections/act-header.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useLocale, t } from "../locale-context";
+
+/**
+ * ActHeader. The narrative spine of the portfolio.
+ *
+ * PR-PORTFOLIO-NARRATIVE (2026-05-30). The portfolio was a flat scroll of
+ * co-equal subsystem sections. ActHeader groups them into acts, each opening
+ * with a framing line that says WHY the sections under it hang together, so
+ * the page reads as a story (what it is, how it runs a task, how it is served,
+ * how it improves itself, where it sits, how it was built) instead of a
+ * feature checklist. No box card: an accent eyebrow, a display title, and one
+ * narrative paragraph, over a hairline.
+ */
+type ActHeaderProps = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  titleKo: string;
+  body: string;
+  bodyKo: string;
+  children?: ReactNode;
+};
+
+export function ActHeader({ id, eyebrow, title, titleKo, body, bodyKo, children }: ActHeaderProps) {
+  const locale = useLocale();
+  return (
+    <section id={id} className="px-6 pt-28 pb-4 scroll-mt-16">
+      <div className="max-w-3xl mx-auto border-t border-[var(--rule)] pt-10">
+        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
+          {eyebrow}
+        </div>
+        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+          {t(locale, titleKo, title)}
+        </h2>
+        <p className="mt-4 max-w-2xl text-[var(--ink-2)] leading-[1.75] text-[16px]">
+          {t(locale, bodyKo, body)}
+        </p>
+        {children ? <div className="mt-5">{children}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/geode/sections/nav.tsx
+++ b/site/src/components/geode/sections/nav.tsx
@@ -4,14 +4,12 @@ import { useState, useEffect, useRef } from "react";
 import { LocaleToggle } from "../ui/locale-toggle";
 
 const navItems = [
-  { id: "hero", label: "Overview" },
-  { id: "scaffold", label: "Scaffold" },
-  { id: "loop", label: "Loop" },
-  { id: "architecture", label: "Arch" },
-  { id: "hooks", label: "Runtime" },
-  { id: "context", label: "Memory" },
-  { id: "verify", label: "Verify" },
-  { id: "timeline", label: "Timeline" },
+  { id: "hero", label: "What it is" },
+  { id: "act-inner", label: "Inner loop" },
+  { id: "act-harness", label: "Harness" },
+  { id: "act-outer", label: "Self-improving" },
+  { id: "act-positioning", label: "Positioning" },
+  { id: "act-build", label: "Build" },
 ];
 
 export function GeodeNav() {

--- a/site/src/components/geode/sections/os-thesis.tsx
+++ b/site/src/components/geode/sections/os-thesis.tsx
@@ -28,8 +28,8 @@ const values = [
     id: "V3",
     title: "Compute ABI",
     titleKo: "Compute ABI",
-    body: "4 providers × R1-R9 reasoning wire audit. GLM thinking is GEODE-only.",
-    bodyKo: "4 프로바이더 × R1-R9 리즈닝 와이어 감사. GLM thinking 활성화는 GEODE 단독.",
+    body: "One ABI across providers. R1-R9 reasoning wire audit. GLM thinking is GEODE-only.",
+    bodyKo: "프로바이더를 단일 ABI로. R1-R9 리즈닝 와이어 감사. GLM thinking 활성화는 GEODE 단독.",
   },
   {
     id: "V4",
@@ -42,8 +42,8 @@ const values = [
     id: "V5",
     title: "Operator Discipline",
     titleKo: "운영 규율",
-    body: "Solo. 130+ releases. Zero regression. Built by its own scaffold.",
-    bodyKo: "단독 개발. 130+ 릴리스. 회귀 없음. 자기 스캐폴드로 구축.",
+    body: "Solo. Ratchet discipline, zero regression. Built by its own scaffold.",
+    bodyKo: "단독 개발. ratchet 규율로 회귀 없이. 자기 스캐폴드로 구축.",
   },
 ];
 

--- a/site/src/components/geode/sections/recursion.tsx
+++ b/site/src/components/geode/sections/recursion.tsx
@@ -69,7 +69,7 @@ const mirrors = [
   {
     pattern: "Multi-perspective verification",
     artifactLabel: "Cross-LLM verification",
-    artifactBody: "RESCORE + DUAL_VERIFY across 4 providers. CV<0.05 anchoring detection.",
+    artifactBody: "RESCORE + DUAL_VERIFY across providers. CV<0.05 anchoring detection.",
     artifactFile: "core/llm/prompts/cross_llm.md",
     scaffoldLabel: "Verification Team",
     scaffoldBody: "4 personas (Beck/Karpathy/Steinberger/Cherny) + Anti-Deception checklist.",


### PR DESCRIPTION
## Summary
- The `/portfolio` page was a flat scroll of ~26 co-equal subsystem sections (dividers only), with no framing/narrative. Reads as slop.
- Imposed a **5-act narrative arc** (no section dropped): Opening → Act I inner loop → Act II harness → Act III outer loop (the signature) → Act IV positioning → Act V build.

## Why
Operator: "평탄한 나열 + 프레이밍/내러티브가 부재해서 slop처럼 여겨져." The docs now establish GEODE's character (two loops, self-evolving, safety-audit fitness); the portfolio never told that story, and the metric purge left the sections even flatter.

## Changes
| File | Change |
|------|--------|
| `sections/act-header.tsx` (new) | framing-intro component: accent eyebrow + display title + one narrative paragraph (EN/KR), hairline, no box card |
| `app/portfolio/page.tsx` | sections regrouped into 5 acts with framing headers; Act III links to the docs closed-loop page + live hub + petri-bundle; Act IV links to the lineage page |
| `sections/nav.tsx` | six act anchors instead of eight arbitrary section anchors |
| `sections/os-thesis.tsx`, `sections/recursion.tsx` | removed residual vanity ("130+ releases", "4 providers") |

## Verification
- [x] `next build` passes; all 5 act anchors + titles render in `portfolio.html`
- [x] every prior section still mounted exactly once; no unused/missing imports
- [x] nav ids all resolve; Act III/IV links `/geode`-prefixed to real targets
- [x] link audit exits 0; em-dash-free; KR in TossPayments voice
- [x] Codex MCP reviewed — 7/7 OK
- [ ] CI green; live spot-check after deploy

## Reference
Operator direction + the character/lineage framing established in the docs redesign (#1902).