### PR TITLE
deploy: portfolio visual-impact pass (develop → main)

### DIFF
--- a/site/src/components/geode/sections/audit-evidence.tsx
+++ b/site/src/components/geode/sections/audit-evidence.tsx
@@ -50,12 +50,15 @@ const rubricRows: RubricRow[] = [
 export function AuditEvidenceSection() {
   const locale = useLocale();
   return (
-    <section className="px-6 py-20">
+    <section className="px-6 py-24">
       <div className="max-w-3xl mx-auto">
-        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
-          How it is measured
+        <div className="flex items-center gap-2">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            How it is measured
+          </span>
         </div>
-        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+        <h2 className="mt-4 font-display tracking-tight text-[var(--ink)] text-[clamp(1.85rem,3.8vw,2.6rem)] leading-[1.12] font-semibold">
           {t(locale, "적대적 감사로 측정", "Measured by an adversarial audit")}
         </h2>
         <p className="mt-4 text-[var(--ink-2)] leading-[1.75] text-[16px]">
@@ -66,25 +69,30 @@ export function AuditEvidenceSection() {
           )}
         </p>
 
-        <div className="mt-8 rounded border border-[var(--rule)] bg-[var(--code-bg)] overflow-x-auto">
-          <div className="flex items-center justify-between px-4 py-2.5 border-b border-[var(--rule)] font-mono text-[10px] tracking-[0.2em] uppercase text-[var(--ink-3)]">
+        <div className="mt-10 rounded-lg border border-[var(--rule)] bg-[var(--code-bg)] overflow-x-auto">
+          <div className="flex items-center justify-between px-5 py-3 border-b border-[var(--rule)] font-mono text-[11px] tracking-[0.2em] uppercase text-[var(--acc-artifact)] font-medium">
             <span>{t(locale, "안전 루브릭", "safety rubric")}</span>
             <span>{t(locale, "규칙", "rule")}</span>
           </div>
-          <div className="font-mono text-[12.5px] leading-relaxed">
+          <div className="font-mono text-[13px] leading-relaxed">
             {rubricRows.map((row, index) => (
               <div
                 key={row.axisEn}
-                className="flex flex-col sm:flex-row gap-y-1 sm:gap-x-4 px-4 py-3"
+                className="flex flex-col sm:flex-row gap-y-1 sm:gap-x-4 px-5 py-4"
                 style={{
                   borderTop: index === 0 ? "none" : "1px solid var(--rule)",
                 }}
               >
                 <div
                   className="sm:w-[34%] shrink-0"
-                  style={{ color: row.critical ? "var(--acc-artifact)" : "var(--ink-1)" }}
+                  style={{
+                    color: row.critical ? "var(--acc-artifact)" : "var(--ink-1)",
+                    fontWeight: row.critical ? 500 : 400,
+                  }}
                 >
-                  {row.critical && <span className="text-[var(--acc-artifact)]">{"⏺"}</span>}{" "}
+                  {row.critical && (
+                    <span className="text-[var(--acc-artifact)] text-[15px]">{"⏺"}</span>
+                  )}{" "}
                   {t(locale, row.axisKo, row.axisEn)}
                 </div>
                 <div className="text-[var(--ink-2)]">{t(locale, row.ruleKo, row.ruleEn)}</div>

--- a/site/src/components/geode/sections/capabilities-tabs.tsx
+++ b/site/src/components/geode/sections/capabilities-tabs.tsx
@@ -173,18 +173,18 @@ const tabs: Tab[] = [
 
 function TabSession({ tab, locale }: { tab: Tab; locale: Locale }) {
   return (
-    <div className="rounded border border-[var(--rule)] bg-[var(--code-bg)] p-4 font-mono text-[12.5px] leading-relaxed text-[var(--code-text)]">
+    <div className="rounded-lg border border-[var(--rule)] bg-[var(--code-bg)] p-5 font-mono text-[13px] leading-relaxed text-[var(--code-text)]">
       <div>
-        {!tab.cli && <span className="text-[var(--ink-3)]">geode &gt;</span>}{" "}
-        <span className="text-[var(--ink-1)]">{t(locale, tab.prompt.ko, tab.prompt.en)}</span>
+        {!tab.cli && <span className="text-[var(--acc-artifact)] font-medium">geode &gt;</span>}{" "}
+        <span className="text-[var(--ink)]">{t(locale, tab.prompt.ko, tab.prompt.en)}</span>
       </div>
       {tab.actions.map((action) => (
-        <div key={action.en} className="mt-2 text-[var(--ink-2)]">
-          <span className="text-[var(--acc-artifact)]">{"⏺"}</span>{" "}
+        <div key={action.en} className="mt-2.5 text-[var(--ink-2)]">
+          <span className="text-[var(--acc-artifact)] text-[15px]">{"⏺"}</span>{" "}
           {t(locale, action.ko, action.en)}
         </div>
       ))}
-      <div className="mt-3 text-[var(--ink-1)]">{t(locale, tab.result.ko, tab.result.en)}</div>
+      <div className="mt-4 text-[var(--ink-1)]">{t(locale, tab.result.ko, tab.result.en)}</div>
     </div>
   );
 }
@@ -194,12 +194,15 @@ export function CapabilitiesTabsSection() {
   const [active, setActive] = useState(tabs[0].id);
   const current = tabs.find((tab) => tab.id === active) ?? tabs[0];
   return (
-    <section className="px-6 py-20">
+    <section className="px-6 py-24">
       <div className="max-w-3xl mx-auto">
-        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
-          Capabilities
+        <div className="flex items-center gap-2">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            Capabilities
+          </span>
         </div>
-        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+        <h2 className="mt-4 font-display tracking-tight text-[var(--ink)] text-[clamp(1.85rem,3.8vw,2.6rem)] leading-[1.12] font-semibold">
           {t(locale, "구성", "What's inside")}
         </h2>
         <p className="mt-4 text-[var(--ink-2)] leading-[1.75] text-[16px]">
@@ -210,16 +213,17 @@ export function CapabilitiesTabsSection() {
           )}
         </p>
 
-        <div className="mt-8">
+        <div className="mt-10">
           <div className="flex flex-wrap gap-x-1 border-b border-[var(--rule)]">
             {tabs.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setActive(tab.id)}
-                className="px-3 py-2 text-[12.5px] font-mono whitespace-nowrap transition-colors"
+                className="px-3.5 py-2.5 text-[13px] font-mono whitespace-nowrap transition-colors"
                 style={{
-                  color: active === tab.id ? "var(--ink)" : "var(--ink-3)",
-                  borderBottom: `2px solid ${active === tab.id ? "var(--acc-line)" : "transparent"}`,
+                  color: active === tab.id ? "var(--acc-artifact)" : "var(--ink-3)",
+                  fontWeight: active === tab.id ? 500 : 400,
+                  borderBottom: `2px solid ${active === tab.id ? "var(--acc-artifact)" : "transparent"}`,
                   marginBottom: "-1px",
                 }}
               >

--- a/site/src/components/geode/sections/hero.tsx
+++ b/site/src/components/geode/sections/hero.tsx
@@ -15,8 +15,9 @@ const videoTabs = [
 export function HeroSection() {
   const locale = useLocale();
   const [activeVideo, setActiveVideo] = useState("demo");
+  const activeTab = videoTabs.find((tab) => tab.id === activeVideo) ?? videoTabs[0];
   return (
-    <section className="relative pt-24 pb-20 px-6">
+    <section className="relative pt-28 pb-24 px-6">
       <div className="max-w-3xl mx-auto">
         <div className="flex items-baseline justify-between mb-12">
           <span className="font-mono text-[11px] tracking-[0.18em] uppercase text-[var(--ink-3)]">
@@ -30,7 +31,7 @@ export function HeroSection() {
         <h1 className="font-display tracking-tight text-[var(--ink)] text-[clamp(3rem,8vw,5rem)] leading-[1.02] font-semibold">
           GEODE
         </h1>
-        <p className="mt-4 font-display text-[clamp(1.25rem,2.5vw,1.6rem)] text-[var(--ink-1)] leading-snug">
+        <p className="mt-4 font-display text-[clamp(1.35rem,2.7vw,1.75rem)] text-[var(--ink-1)] leading-snug">
           {t(
             locale,
             "스스로를 고쳐 쓰는 자율 에이전트 하네스.",
@@ -38,7 +39,7 @@ export function HeroSection() {
           )}
         </p>
 
-        <div className="mt-10 text-[var(--ink-2)] leading-[1.75] text-[16px]">
+        <div className="mt-10 text-[var(--ink-1)] leading-[1.75] text-[16px]">
           <p>
             {t(
               locale,
@@ -46,7 +47,7 @@ export function HeroSection() {
               "GEODE is a self-evolving agent on the non-parametric branch. It never updates model weights. Instead it improves by mutating the scaffolding around itself: its system prompt, tool policy, task decomposition, reflection loop, and skill catalog."
             )}
           </p>
-          <p className="mt-3">
+          <p className="mt-3 text-[var(--ink-2)]">
             {t(
               locale,
               "변화의 적합도는 능력 벤치마크가 아니라 적대적 안전 감사로 측정합니다. 핵심 안전 차원에는 하한선이 있어, 그 선을 넘어 후퇴하는 변화는 거부합니다.",
@@ -55,46 +56,62 @@ export function HeroSection() {
           </p>
         </div>
 
-        <div className="mt-8 rounded border border-[var(--rule)] bg-[var(--code-bg)] px-4 py-3 font-mono text-[12.5px] leading-relaxed text-[var(--code-text)]">
-          <span className="opacity-50">$</span> geode{"\n"}
-          <span className="opacity-50">&gt;</span> inspect this repository and summarize release blockers
+        {/* Hero centerpiece: the run command as a prominent copyable panel. */}
+        <div className="mt-12 rounded-lg border border-[var(--rule)] bg-[var(--code-bg)] px-6 py-5 font-mono text-[15px] leading-loose text-[var(--code-text)]">
+          <div className="text-[var(--ink-3)] text-[11px] tracking-[0.18em] uppercase mb-3">
+            {t(locale, "한 줄로 실행", "run it")}
+          </div>
+          <div>
+            <span className="text-[var(--acc-artifact)] font-medium">{"▸"}</span>{" "}
+            <span className="text-[var(--ink-3)]">uv run geode</span>{" "}
+            <span className="text-[var(--code-string)]">&quot;inspect this repo and summarize release blockers&quot;</span>
+          </div>
         </div>
 
-        <div className="mt-10 flex items-center gap-3">
-          <Link
-            href="https://github.com/mangowhoiscloud/geode"
-            target="_blank"
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--rule)] hover:border-[var(--acc-artifact)] text-[13px] font-mono text-[var(--ink-1)] hover:text-[var(--acc-artifact)] transition-colors"
-          >
-            Source
-          </Link>
-          <Link
-            href="https://rooftopsnow.tistory.com/category/Harness"
-            target="_blank"
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--rule)] hover:border-[var(--acc-artifact)] text-[13px] font-mono text-[var(--ink-1)] hover:text-[var(--acc-artifact)] transition-colors"
-          >
-            Dev Blog
-          </Link>
+        <div className="mt-10 flex flex-wrap items-center gap-x-6 gap-y-3">
           <Link
             href="/docs"
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--rule)] hover:border-[var(--acc-artifact)] text-[13px] font-mono text-[var(--ink-1)] hover:text-[var(--acc-artifact)] transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded bg-[var(--acc-artifact)] text-[var(--paper)] font-medium text-[14px] hover:bg-[var(--acc-soft)] transition-colors"
           >
-            Docs
+            {t(locale, "문서 읽기", "Read the docs")} {"→"}
           </Link>
+          <div className="flex items-center gap-4 text-[13px] font-mono">
+            <Link
+              href="https://github.com/mangowhoiscloud/geode"
+              target="_blank"
+              className="text-[var(--ink-2)] hover:text-[var(--acc-artifact)] transition-colors"
+            >
+              Source
+            </Link>
+            <Link
+              href="https://rooftopsnow.tistory.com/category/Harness"
+              target="_blank"
+              className="text-[var(--ink-2)] hover:text-[var(--acc-artifact)] transition-colors"
+            >
+              {t(locale, "개발 블로그", "Dev Blog")}
+            </Link>
+          </div>
         </div>
       </div>
 
-      {/* video tabs (kept for now; Sprint 4 will move to a separate page) */}
-      <div className="max-w-4xl mx-auto mt-20">
-        <div className="flex justify-center gap-2 mb-3 flex-wrap">
+      {/* See it run: the three demo videos as a clean row under the hero. */}
+      <div className="max-w-4xl mx-auto mt-24">
+        <div className="flex items-center gap-2 mb-6">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            {t(locale, "실행 화면", "See it run")}
+          </span>
+        </div>
+        <div className="flex gap-2 mb-4 flex-wrap border-b border-[var(--rule)]">
           {videoTabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveVideo(tab.id)}
-              className="px-4 py-2 text-[12px] font-mono transition-colors whitespace-nowrap"
+              className="px-4 py-2 text-[12.5px] font-mono transition-colors whitespace-nowrap"
               style={{
                 color: activeVideo === tab.id ? "var(--acc-artifact)" : "var(--ink-3)",
                 borderBottom: `2px solid ${activeVideo === tab.id ? "var(--acc-artifact)" : "transparent"}`,
+                marginBottom: "-1px",
               }}
             >
               {locale === "en" ? tab.labelEn : tab.labelKo}
@@ -103,7 +120,7 @@ export function HeroSection() {
         </div>
         {videoTabs.map((tab) => (
           <div key={tab.id} className="max-w-2xl mx-auto" style={{ display: activeVideo === tab.id ? "block" : "none" }}>
-            <div className="relative rounded overflow-hidden border border-[var(--rule)]" style={{ paddingBottom: "56.25%" }}>
+            <div className="relative rounded-lg overflow-hidden border border-[var(--rule)]" style={{ paddingBottom: "56.25%" }}>
               <iframe
                 className="absolute inset-0 w-full h-full"
                 src={tab.src}
@@ -114,6 +131,9 @@ export function HeroSection() {
             </div>
           </div>
         ))}
+        <p className="max-w-2xl mx-auto mt-3 text-[13px] text-[var(--ink-3)] font-mono">
+          {locale === "en" ? activeTab.labelEn : activeTab.labelKo}
+        </p>
       </div>
 
       {/* Mascot. Sits naturally on the warm dark substrate. */}

--- a/site/src/components/geode/sections/lineage-positioning.tsx
+++ b/site/src/components/geode/sections/lineage-positioning.tsx
@@ -49,12 +49,15 @@ const influences: Influence[] = [
 export function LineagePositioningSection() {
   const locale = useLocale();
   return (
-    <section className="px-6 py-20">
+    <section className="px-6 py-24">
       <div className="max-w-3xl mx-auto">
-        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
-          Where it sits
+        <div className="flex items-center gap-2">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            Where it sits
+          </span>
         </div>
-        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+        <h2 className="mt-4 font-display tracking-tight text-[var(--ink)] text-[clamp(1.85rem,3.8vw,2.6rem)] leading-[1.12] font-semibold">
           {t(locale, "계보 위의 정직한 자리", "An honest place in the lineage")}
         </h2>
         <p className="mt-4 text-[var(--ink-2)] leading-[1.75] text-[16px]">
@@ -71,10 +74,10 @@ export function LineagePositioningSection() {
               key={influence.nameEn}
               className="border-t border-[var(--rule)] py-3 first:border-t-0"
             >
-              <dt className="font-mono text-[13px] text-[var(--ink-1)]">
+              <dt className="font-mono text-[13.5px] text-[var(--acc-artifact)] font-medium">
                 {t(locale, influence.nameKo, influence.nameEn)}
               </dt>
-              <dd className="mt-1 text-[var(--ink-2)] leading-[1.6] text-[15px]">
+              <dd className="mt-1.5 text-[var(--ink-1)] leading-[1.6] text-[15px]">
                 {t(locale, influence.tookKo, influence.tookEn)}
               </dd>
             </div>

--- a/site/src/components/geode/sections/self-evolving.tsx
+++ b/site/src/components/geode/sections/self-evolving.tsx
@@ -25,12 +25,15 @@ const cycleSteps: { ko: string; en: string }[] = [
 export function SelfEvolvingSection() {
   const locale = useLocale();
   return (
-    <section className="px-6 py-20">
+    <section className="px-6 py-24">
       <div className="max-w-3xl mx-auto">
-        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
-          The differentiator
+        <div className="flex items-center gap-2">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            The differentiator
+          </span>
         </div>
-        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+        <h2 className="mt-4 font-display tracking-tight text-[var(--ink)] text-[clamp(1.85rem,3.8vw,2.6rem)] leading-[1.12] font-semibold">
           {t(locale, "self-evolving, 비-파라메트릭", "Self-evolving, non-parametric")}
         </h2>
         <p className="mt-4 text-[var(--ink-2)] leading-[1.75] text-[16px]">
@@ -41,24 +44,24 @@ export function SelfEvolvingSection() {
           )}
         </p>
 
-        <div className="mt-8 rounded-lg border border-[var(--rule)] overflow-x-auto">
+        <div className="mt-10 rounded-lg border border-[var(--rule)] bg-[var(--paper-2)] overflow-x-auto">
           <table className="w-full text-[14px] border-collapse">
             <thead>
               <tr className="bg-[var(--paper-2)]">
-                <th className="text-left p-3 border border-[var(--rule)] font-mono uppercase tracking-wider text-[10px] text-[var(--ink-2)] w-[26%]">
+                <th className="text-left px-5 py-3.5 border-b border-[var(--rule)] font-mono uppercase tracking-[0.18em] text-[11px] text-[var(--acc-artifact)] font-medium w-[28%]">
                   {t(locale, "측면", "Aspect")}
                 </th>
-                <th className="text-left p-3 border border-[var(--rule)] font-mono uppercase tracking-wider text-[10px] text-[var(--ink-2)]">
+                <th className="text-left px-5 py-3.5 border-b border-[var(--rule)] font-mono uppercase tracking-[0.18em] text-[11px] text-[var(--acc-artifact)] font-medium">
                   {t(locale, "값", "Value")}
                 </th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="p-3 border border-[var(--rule)] font-mono text-[12px] text-[var(--acc-artifact)] align-top">
+                <td className="px-5 py-4 border-b border-[var(--rule)] font-mono text-[13px] text-[var(--acc-artifact)] font-medium align-top">
                   {t(locale, "바꾸는 것", "mutates")}
                 </td>
-                <td className="p-3 border border-[var(--rule)] text-[var(--ink-2)] leading-relaxed align-top">
+                <td className="px-5 py-4 border-b border-[var(--rule)] text-[var(--ink-1)] leading-relaxed align-top">
                   {t(
                     locale,
                     "스캐폴딩: 시스템 프롬프트, 도구 정책, 작업 분해, 리플렉션, 스킬",
@@ -67,18 +70,18 @@ export function SelfEvolvingSection() {
                 </td>
               </tr>
               <tr>
-                <td className="p-3 border border-[var(--rule)] font-mono text-[12px] text-[var(--acc-artifact)] align-top">
+                <td className="px-5 py-4 border-b border-[var(--rule)] font-mono text-[13px] text-[var(--ink-2)] align-top">
                   {t(locale, "절대 안 바꾸는 것", "never")}
                 </td>
-                <td className="p-3 border border-[var(--rule)] text-[var(--ink-2)] leading-relaxed align-top">
+                <td className="px-5 py-4 border-b border-[var(--rule)] text-[var(--ink-2)] leading-relaxed align-top">
                   {t(locale, "모델 가중치", "model weights")}
                 </td>
               </tr>
               <tr>
-                <td className="p-3 border border-[var(--rule)] font-mono text-[12px] text-[var(--acc-artifact)] align-top">
+                <td className="px-5 py-4 font-mono text-[13px] text-[var(--ink-2)] align-top">
                   {t(locale, "측정 방법", "measured by")}
                 </td>
-                <td className="p-3 border border-[var(--rule)] text-[var(--ink-2)] leading-relaxed align-top">
+                <td className="px-5 py-4 text-[var(--ink-2)] leading-relaxed align-top">
                   {t(
                     locale,
                     "적대적 안전 감사 (Petri 등급)",

--- a/site/src/components/geode/sections/two-loops.tsx
+++ b/site/src/components/geode/sections/two-loops.tsx
@@ -16,12 +16,15 @@ import { useLocale, t } from "../locale-context";
 export function TwoLoopsSection() {
   const locale = useLocale();
   return (
-    <section className="px-6 py-20">
+    <section className="px-6 py-24">
       <div className="max-w-3xl mx-auto">
-        <div className="font-mono text-[11px] tracking-[0.24em] uppercase text-[var(--acc-artifact)]">
-          How it works
+        <div className="flex items-center gap-2">
+          <span className="h-px w-6 bg-[var(--acc-artifact)]" />
+          <span className="text-[12px] tracking-[0.22em] uppercase text-[var(--acc-artifact)] font-medium">
+            How it works
+          </span>
         </div>
-        <h2 className="mt-3 font-display tracking-tight text-[var(--ink)] text-[clamp(1.7rem,3.6vw,2.4rem)] leading-[1.12] font-semibold">
+        <h2 className="mt-4 font-display tracking-tight text-[var(--ink)] text-[clamp(1.85rem,3.8vw,2.6rem)] leading-[1.12] font-semibold">
           {t(locale, "두 개의 루프", "Two loops")}
         </h2>
         <p className="mt-4 text-[var(--ink-2)] leading-[1.75] text-[16px]">
@@ -32,10 +35,10 @@ export function TwoLoopsSection() {
           )}
         </p>
 
-        <div className="mt-8 flex justify-center">
+        <div className="mt-10 flex justify-center">
           <svg
-            viewBox="0 0 460 280"
-            className="w-full max-w-[460px] h-auto"
+            viewBox="0 0 560 320"
+            className="w-full max-w-xl h-auto"
             role="img"
             aria-label={t(
               locale,
@@ -49,8 +52,8 @@ export function TwoLoopsSection() {
                 viewBox="0 0 10 10"
                 refX="8"
                 refY="5"
-                markerWidth="7"
-                markerHeight="7"
+                markerWidth="8"
+                markerHeight="8"
                 orient="auto-start-reverse"
               >
                 <path d="M 0 1 L 9 5 L 0 9 z" fill="var(--acc-artifact)" />
@@ -70,21 +73,21 @@ export function TwoLoopsSection() {
 
             {/* Outer loop (citrine). scaffold / process */}
             <rect
-              x="14"
-              y="14"
-              width="432"
-              height="252"
-              rx="18"
+              x="16"
+              y="16"
+              width="528"
+              height="288"
+              rx="20"
               fill="none"
               stroke="var(--acc-line)"
-              strokeWidth="1.5"
+              strokeWidth="1.75"
             />
             <text
-              x="230"
-              y="40"
+              x="280"
+              y="46"
               textAnchor="middle"
               fill="var(--acc-line)"
-              fontSize="12.5"
+              fontSize="14"
               fontFamily="var(--font-fira-code), ui-monospace, monospace"
               letterSpacing="0.5"
             >
@@ -92,30 +95,31 @@ export function TwoLoopsSection() {
             </text>
             {/* Outer loop return arrow along the bottom edge */}
             <path
-              d="M 360 252 L 100 252"
+              d="M 440 288 L 120 288"
               fill="none"
               stroke="var(--acc-line)"
-              strokeWidth="1.5"
+              strokeWidth="1.75"
               markerEnd="url(#two-loops-head-outer)"
             />
 
-            {/* Inner loop (amethyst). artifact / runtime, nested inside */}
+            {/* Inner loop (petri-blue, dominant). artifact / runtime, nested inside */}
             <rect
-              x="78"
-              y="74"
-              width="304"
-              height="132"
-              rx="14"
+              x="92"
+              y="84"
+              width="376"
+              height="152"
+              rx="16"
               fill="none"
               stroke="var(--acc-artifact)"
-              strokeWidth="1.5"
+              strokeWidth="3"
             />
             <text
-              x="230"
-              y="98"
+              x="280"
+              y="116"
               textAnchor="middle"
               fill="var(--acc-artifact)"
-              fontSize="12.5"
+              fontSize="15"
+              fontWeight="500"
               fontFamily="var(--font-fira-code), ui-monospace, monospace"
               letterSpacing="0.5"
             >
@@ -123,10 +127,10 @@ export function TwoLoopsSection() {
             </text>
             {/* Inner loop return arrow along the inner bottom edge */}
             <path
-              d="M 320 192 L 140 192"
+              d="M 392 216 L 168 216"
               fill="none"
               stroke="var(--acc-artifact)"
-              strokeWidth="1.5"
+              strokeWidth="3"
               markerEnd="url(#two-loops-head-inner)"
             />
           </svg>


### PR DESCRIPTION
Pass-through of #1911. Hero rebuilt with a filled petri-blue CTA + run-command centerpiece, bold blue section eyebrows + hierarchy, terminal block as protagonist, enlarged two-loops SVG. CI 10/10; Codex no findings.