### PR TITLE
feat(self-improving): content-addressed baseline epochs (PR-BASELINE-EPOCH, v0.99.91)

### DIFF
--- a/.claude/skills/baseline-epoch-partition/SKILL.md
+++ b/.claude/skills/baseline-epoch-partition/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: baseline-epoch-partition
+description: Content-addressed baseline-archive epoch partitioning. Partition baseline_archive.jsonl + the self-improving hub's baseline serving by a HASH of the full baseline-production+measurement spec — when the spec (margin_rule, fitness/margin logic version, the 4 roles' model+source, rubric/dim-set, bench, seed-pool identity) changes, the hash changes → a new epoch series (like seed-gen gen-*). Triggered by "baseline epoch", "baseline 아카이빙", "epoch partition", "spec hash", "content-addressed", "margin_rule namespace", "production logic 구분", "baseline 하위 서빙" keywords.
+user-invocable: false
+---
+
+# Baseline Epoch Partition — Content-Addressed Baseline Archiving
+
+> **Source**: operator design 2026-05-30 ([[project_baseline_archive_partition_plan]] · [[project_per_mutator_partition_plan]]).
+> **Philosophy**: baselines produced under different production logic are **not comparable** — partition them, never average across the boundary. The boundary is the *spec*, and the spec is *content-addressed* so the discriminator can't drift.
+> **Builds on**: the v0.99.89 registry (`autoresearch/train.py:_append_baseline_registry_row`, `baseline_archive.jsonl`) which already records `margin_rule` + `role_provenance`.
+
+## When this applies
+
+Every promote appends a `kind="baseline"` row to the git-tracked
+`autoresearch/state/baseline_archive.jsonl`. Those rows must be partitioned into
+**epochs** — like seed-generation's `gen-*` series — keyed by the production
+logic, and the self-improving hub serves them **under a `baseline` section,
+grouped by epoch**. This skill specifies how the epoch discriminator is computed
+and recorded, so a future baseline lands in the right partition automatically and
+deterministically (no LLM, no manual epoch bump).
+
+## Core principle — the epoch IS a hash of the spec
+
+```
+epoch_hash = sha256(canonical_json(baseline_spec))[:12]
+```
+
+`baseline_spec` is the **production + measurement surface** that determines
+comparability. When any field changes, the hash changes → a new epoch begins on
+its own. Same spec → same hash, always (deterministic, reproducible, cross-machine
+stable). The discriminator is derived from the spec, so it can never lie about
+what produced the baseline.
+
+## The spec field-set (what is hashed)
+
+Hash a **fixed, enumerated** field-set — the *surface* (how a baseline is made),
+NEVER the *instance* (the baseline's measured values):
+
+```jsonc
+baseline_spec = {
+  "spec_schema_version": "1",          // the field-set version itself (see A)
+  "margin_rule": "fitness-stderr"|"dim-stderr",
+  "margin_logic_version": "<tag>",     // bumped when _should_promote margin math changes
+  "fitness_formula_version": "<tag>",  // bumped when compute_fitness semantics change
+  "rubric_version": "<PETRI_RUBRIC_VERSION>",
+  "dim_set": "<name>",
+  "bench": false,
+  "roles": {                            // model + source per role (lane is derived, not hashed)
+    "auditor": {"model": ..., "source": ...},
+    "target":  {"model": ..., "source": ...},
+    "judge":   {"model": ..., "source": ...},
+    "mutator": {"model": ..., "source": ...}
+  },
+  "seed_pool_id": "<pool content-hash>" // decision B — the pool IDENTITY, not bodies
+}
+```
+
+**EXCLUDED (instance, not spec)** — never hash these: `dim_means`, `fitness`,
+`fitness_stderr`, the specific seed bodies, `ts_utc`, `session_id`, `commit`,
+`seed_count`. They vary per run; including them would make every run its own
+epoch and destroy the partition.
+
+## Four robustness rules (do not skip)
+
+1. **Spec vs instance.** Hash the surface (logic versions + config + role
+   bindings + pool identity), not the results. The registry row still stores the
+   instance fields separately; only the spec sub-object is hashed.
+2. **Version-tags, not source-hash, for code.** Fitness formula + margin logic
+   are code — hashing their source churns the epoch on a comment edit. Instead
+   carry deliberate constants (`FITNESS_FORMULA_VERSION`, `MARGIN_LOGIC_VERSION`)
+   bumped on *semantic* change, and a guard test that FAILS if the logic changed
+   without a version bump (under-sensitivity defense — pin a golden fitness value
+   per version).
+3. **Canonical serialization.** `json.dumps(spec, sort_keys=True,
+   separators=(",", ":"))` → `sha256` → first 12 hex. Order/format must not move
+   the hash.
+4. **Hash + human label.** The raw hash is the SoT discriminator; it is not
+   readable on the hub. Assign a human `epoch_label` (`be-001`, `be-002`, … in
+   hash-first-seen order, persisted in an epoch-label map) for display, like
+   `gen-2605-*`. Store both on the row.
+
+## Resolved sub-decisions
+
+- **(A) Write-time frozen hash + schema version — no retroactive recompute.**
+  Each row stores its `epoch_hash` computed *at write time* plus the `baseline_spec`
+  it was computed from plus `spec_schema_version`. The hash is **immutable per
+  row** — never recomputed. Adding a field to the spec field-set is a deliberate
+  `spec_schema_version` bump; because `spec_schema_version` is itself hashed, old
+  rows (schema 1) and new rows (schema 2) fall into different epochs naturally
+  (correct — the *definition* of a baseline changed). No migration churns old
+  hashes. Rationale: immutable content-addressing; a stored row is self-verifying
+  (recompute hash from its stored spec → must equal stored `epoch_hash`).
+- **(B) Seed-pool identity is in the spec.** Different seeds → different measured
+  dims → non-comparable, so the seed pool is part of the measurement surface.
+  Include `seed_pool_id` = the pool's **content-hash** (a stable identity of the
+  survivor set), NOT the raw bodies. A seed-pool change ⇒ new epoch. Ties to the
+  deterministic seed-pool assembly (which emits the pool content-hash).
+
+## What each registry row records
+
+Augment `_append_baseline_registry_row` to add: `baseline_spec` (the hashed
+sub-object), `spec_schema_version`, `epoch_hash`, `epoch_label`. The existing
+`margin_rule` + `role_provenance` are folded INTO `baseline_spec` (no
+duplication — keep them top-level too for back-compat readers, but the canonical
+comparability key is `epoch_hash`).
+
+## Hub serving (Phase 2-4)
+
+Serve baselines under a top-level **`baseline`** section, grouped by `epoch_hash`,
+each epoch rendered as a sub-series (like a `gen-*` run): `epoch_label` as the
+series name + a one-line spec summary (margin_rule · models · pool) + a dense
+table of that epoch's baselines (`baseline-id · ts · fitness · fitness_stderr ·
+verdict`). Mirror `scripts/build_self_improving_hub.py:_render_seedgen_index_rows`
+(dense table + sidebar, NO card-grid / accent-bar slop — [[feedback_no_box_ui_no_emoji]]).
+Never render two epochs in one comparison table (the whole point is they are not
+comparable).
+
+## Determinism + guards (must ship with the impl)
+
+- `test_epoch_hash_deterministic` — same spec dict → same hash across calls.
+- `test_epoch_hash_changes_on_each_surface_field` — flipping any spec field
+  changes the hash; flipping an instance field (dim_means/fitness) does NOT.
+- `test_logic_version_guard` — a golden fitness value per `FITNESS_FORMULA_VERSION`
+  (and margin behavior per `MARGIN_LOGIC_VERSION`); fails if the code changed
+  without the version bump.
+- `test_row_self_verifies` — recompute `epoch_hash` from the row's stored
+  `baseline_spec` → equals stored `epoch_hash`.
+- `test_canonical_serialization` — key order / whitespace does not move the hash.
+
+## The general pattern (reuse)
+
+This is content-addressed epoch partitioning: **partition a ledger by a hash of
+the spec that defines comparability, store hash + label, serve grouped by hash.**
+It generalizes to per-mutator partitioning ([[project_per_mutator_partition_plan]])
+and mirrors seed-generation's `gen-*` series. Apply the same four robustness rules
+whenever a ledger needs logic-keyed partitions.

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,10 @@ autoresearch/state/*
 # (PR-G5b #1350 precedent). (Originally added for the dropped pareto archive;
 # now the lossless baseline-history registry — _append_baseline_registry_row.)
 !autoresearch/state/baseline_archive.jsonl
+# PR-BASELINE-EPOCH (2026-05-30) — epoch_hash → be-NNN label map (the hub groups
+# baselines by epoch via these labels). git-tracked alongside the registry so the
+# label assignment is stable + shared, not a silent-ignored local writer.
+!autoresearch/state/baseline_epochs.json
 # PR-VAR-ADAPTIVE (2026-05-27) — historical group-std samples for the
 # percentile-based variance gate. Same git-tracked invariant as
 # mutations.jsonl / baseline_archive.jsonl. Without this negation the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.91] - 2026-05-30
+
+### Added
+- **PR-BASELINE-EPOCH (2026-05-30) — content-addressed baseline epochs.**
+  The baseline registry (`autoresearch/state/baseline_archive.jsonl`) now
+  partitions every `kind="baseline"` row into an **epoch** keyed by a hash of
+  the baseline production+measurement spec, so baselines produced under
+  different logic are never silently compared. New
+  `core/self_improving_loop/baseline_epoch.py` builds the spec
+  (`margin_rule` + `margin_logic_version` + `fitness_formula_version` +
+  `rubric_version` + `dim_set` + `bench` + the four roles' `model`+`source` +
+  `seed_pool_id`), serializes it canonically (`sort_keys`, fixed separators),
+  and computes `epoch_hash = sha256(...)[:12]`; a hash-first-seen
+  `be-NNN` label is assigned and persisted in git-tracked
+  `autoresearch/state/baseline_epochs.json`. `autoresearch/train.py` stamps
+  `baseline_spec` + `spec_schema_version` + `epoch_hash` + `epoch_label` onto
+  each registry row at write time (write-time frozen — never retroactively
+  recomputed; the row self-verifies). Two new version constants
+  (`FITNESS_FORMULA_VERSION`, `MARGIN_LOGIC_VERSION`) are bumped on *semantic*
+  logic change and pinned by `tests/test_logic_version_guard.py` (a golden
+  fitness + golden margin per version — a silent logic change fails the gate
+  until the version is bumped, opening a new epoch). The seed pool enters the
+  spec as a **content-hash** (`seed_pool_content_hash` — survivor bodies, not
+  mtime/location), so a seed-set change is a new epoch. The self-improving hub
+  serves baselines under a **Baseline registry · grouped by epoch** section:
+  one dense sub-series per epoch (label + spec summary + per-baseline table),
+  never two epochs in one comparison table; pre-epoch rows render in an honest
+  "backfill pending" bucket rather than a fabricated hash. Codified in the
+  `baseline-epoch-partition` scaffold skill. Pinned by
+  `tests/test_baseline_epoch.py`, `tests/autoresearch/test_baseline_registry.py`,
+  and `tests/test_self_improving_hub_e2e.py`.
+
 ## [0.99.90] - 2026-05-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.90
+- **Version**: 0.99.91
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
@@ -354,3 +354,4 @@ Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate f
 | `viz-frame-audit` | 노이즈, slop, 프레임 검수, 영상 audit, 글자 깨짐, 패딩 침범, frame extract, naive arrow | 영상 노이즈/slop 검수 워크플로우 — ffmpeg 프레임 추출 + Read 시각 확인 + 4 카테고리 결함 식별 (naive 화살표 / 패딩 침범 / 글자 깨짐 / 프레임 순서). 12+ 사례 카탈로그 (filewalk 7 + hero 7). |
 | `docs-link-audit` | broken link, 404, docs link, hyperlink, 링크 점검, 링크 깨짐, audit links, link checker | Docs-site (`site/` Next.js) body / JSX / markdown link audit. `scripts/check_docs_links.py` validates 4 categories (internal /docs / internal /other / anchor / external), build-time copy awareness, and exit-code-based CI guard wiring. Includes PR #1157/#1161 case studies. |
 | `seed-generation-cycle` | seed-generation, sprint, cycle, S2, S3, …, scaffold cycle | Session 63 의 6-PR (S0/S1/S2/S2-wire/S2-fix/cycle-skill) 검증 사이클 — Phase A-F (Allocation / Implement+P1-P7 / Verify+Codex MCP / PR&CI / Merge / Optional Review). S2.5-S12 + 모든 fix-up PR 적용. |
+| `baseline-epoch-partition` | baseline epoch, baseline 아카이빙, epoch partition, spec hash, content-addressed, margin_rule namespace, production logic 구분, baseline 하위 서빙 | Content-addressed baseline-archive epoch 분할 — baseline 산출+측정 명세(margin_rule + logic version tag + 4-role model/source + rubric/dim-set + bench + seed-pool identity)를 canonical 해시 → epoch 구분자. spec vs instance 분리, version-tag(소스해시 아님), write-time frozen hash + spec_schema_version, hash+label 병기. hub baseline-하위 epoch 적재(gen-* 미러). |

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.90 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.91 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.90 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.91 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -415,6 +415,20 @@ assert abs(FITNESS_DIM_3AX + FITNESS_ADMIRE_3AX + FITNESS_BENCH_3AX - 1.0) < 1e-
     "3-axis fitness weights must sum to 1.0"
 )
 
+# PR-BASELINE-EPOCH (2026-05-30) — production-logic version tags hashed into the
+# baseline epoch discriminator (see .claude/skills/baseline-epoch-partition).
+# These are DELIBERATE semantic-version tags, NOT a source hash: bump when the
+# *meaning* of the fitness aggregate / promote margin changes, so baselines under
+# a different scoring/gate rule land in a different epoch. ``test_logic_version_guard``
+# pins a golden value per version → a silent logic change without a bump FAILs.
+FITNESS_FORMULA_VERSION = "1"
+"""``compute_fitness`` semantics (ux-removed dim aggregate + stability + the
+admire/bench multi-axis branches + anchor multiplier). Bump on any change that
+moves the aggregate for a fixed input."""
+MARGIN_LOGIC_VERSION = "1"
+"""``_should_promote`` margin rule — fitness-scale gain-stderr √(σp²+σc²) floored
+(PR-MARGIN-FITNESS-SCALE). Bump when the margin formula / floors change."""
+
 CRITICAL_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "critical")
 AUXILIARY_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "auxiliary")
 INFO_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "info")
@@ -740,6 +754,20 @@ def _load_hyperparam_overrides() -> dict[str, str]:
     return {str(k): str(v) for k, v in data.items() if isinstance(k, str)}
 
 
+def _effective_dim_set() -> str:
+    """The dim_set the audit actually runs with — a hyperparam override wins over
+    the config default, mirroring the audit-argv precedence below.
+
+    Shared by the audit dispatch AND the baseline-epoch stamping so the stamped
+    ``dim_set`` is the one the baseline was MEASURED on, never a stale config
+    default (else a ``full``-override run would be stamped ``subset`` and merge
+    into a non-comparable epoch).
+    """
+    cfg = _get_autoresearch_config()
+    overrides = _load_hyperparam_overrides()
+    return str(overrides.get("dim_set") or getattr(cfg, "dim_set", DIM_SET_NAME))
+
+
 def _build_audit_command() -> list[str]:
     """Construct the ``geode audit`` subprocess argv.
 
@@ -777,7 +805,7 @@ def _build_audit_command() -> list[str]:
     cfg = _get_autoresearch_config()
     overrides = _load_hyperparam_overrides()
     effective_seed_limit = _hyperparam_int(overrides, "seed_limit", cfg.seed_limit)
-    effective_dim_set = overrides.get("dim_set") or cfg.dim_set
+    effective_dim_set = _effective_dim_set()
     effective_max_turns = _hyperparam_int(overrides, "max_turns", cfg.max_turns)
     geode_bin = shutil.which("geode")
     argv = [geode_bin, "audit"] if geode_bin is not None else ["uv", "run", "geode", "audit"]
@@ -2169,6 +2197,43 @@ def _append_baseline_registry_row(
         from core.self_improving_loop.role_provenance import collect_role_provenance
 
         role_provenance = collect_role_provenance(_get_autoresearch_config())
+    # PR-BASELINE-EPOCH (2026-05-30) — content-addressed epoch discriminator.
+    # Hash the production+measurement spec (margin_rule + logic version tags +
+    # role model/source + rubric/dim-set + bench + seed-pool identity) → epoch.
+    # Spec change ⇒ new epoch; the row self-verifies (stored spec re-hashes to
+    # epoch_hash). See .claude/skills/baseline-epoch-partition/SKILL.md.
+    from core.self_improving_loop.baseline_epoch import (
+        SPEC_SCHEMA_VERSION,
+        build_baseline_spec,
+        compute_epoch_hash,
+        load_epoch_label_map,
+        resolve_epoch_label,
+        save_epoch_label_map,
+        seed_pool_content_hash,
+    )
+
+    _seed_select = seed_select if seed_select is not None else _resolve_seed_select()
+    baseline_spec = build_baseline_spec(
+        margin_rule=margin_rule,
+        margin_logic_version=MARGIN_LOGIC_VERSION,
+        fitness_formula_version=FITNESS_FORMULA_VERSION,
+        rubric_version=PETRI_RUBRIC_VERSION,
+        # the dim_set the audit was MEASURED on (override wins over config), not
+        # the stale config default — else a `full`-override run is mis-stamped.
+        dim_set=_effective_dim_set(),
+        # `is not None`, not `bool(...)` — match compute_fitness's bench-active
+        # test (train.py: `bench_means is not None`) so an empty-but-active bench
+        # dict is not mis-stamped bench=false.
+        bench=bench_means is not None,
+        role_provenance=role_provenance,
+        seed_pool_id=seed_pool_content_hash(_seed_select),
+    )
+    epoch_hash = compute_epoch_hash(baseline_spec)
+    _label_map_path = _baseline_archive_path().parent / "baseline_epochs.json"
+    _label_map = load_epoch_label_map(_label_map_path)
+    epoch_label, _epoch_is_new = resolve_epoch_label(epoch_hash, label_map=_label_map)
+    if _epoch_is_new:
+        save_epoch_label_map(_label_map_path, _label_map)
     # Intrinsic fitness on the same (dim + admire) scale the promote gate's
     # ``current_raw`` uses — bench is OFF (Path C) so it is not threaded here.
     intrinsic_fitness = compute_fitness(
@@ -2190,8 +2255,16 @@ def _append_baseline_registry_row(
         "fitness_stderr": (float(fitness_stderr) if fitness_stderr is not None else None),
         "margin_rule": margin_rule,
         "bench": bool(bench_means),
-        "seed_select": seed_select if seed_select is not None else _resolve_seed_select(),
+        "seed_select": _seed_select,
         "seed_count": int(seed_count),
+        # PR-BASELINE-EPOCH — content-addressed partition. epoch_hash is the
+        # comparability discriminator; epoch_label (be-NNN) is for display;
+        # baseline_spec is the hashed surface (row self-verifies); spec_schema_version
+        # versions the field-set (write-time frozen — no retroactive recompute).
+        "epoch_hash": epoch_hash,
+        "epoch_label": epoch_label,
+        "baseline_spec": baseline_spec,
+        "spec_schema_version": SPEC_SCHEMA_VERSION,
         # per-role {model, source, lane} — shared SoT with the mutations.jsonl
         # cycle ledger (core.self_improving_loop.role_provenance) so the two
         # git-tracked ledgers never drift on the credential lane.

--- a/core/self_improving_loop/baseline_epoch.py
+++ b/core/self_improving_loop/baseline_epoch.py
@@ -1,0 +1,181 @@
+"""Content-addressed baseline-archive epoch discriminator.
+
+PR-BASELINE-EPOCH (2026-05-30). Baselines produced under different production
+logic are not comparable, so the registry partitions them into **epochs** keyed
+by a hash of the baseline-production+measurement *spec*. When the spec changes,
+the hash changes → a new epoch begins on its own — deterministic, drift-proof,
+no manual bump. See ``.claude/skills/baseline-epoch-partition/SKILL.md``.
+
+Hash the **surface** (how a baseline is made), never the **instance** (its
+measured values): the spec is logic-version tags + config + per-role model/source
++ seed-pool identity. Instance fields (dim_means / fitness / fitness_stderr /
+seeds / ts / commit) are NEVER hashed — including them would make every run its
+own epoch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+#: Version of the spec field-set ITSELF. Bump when the enumerated fields below
+#: change. Because it is part of the hashed spec, a bump puts pre-change and
+#: post-change baselines in different epochs (correct — the *definition* of a
+#: baseline changed) without retroactively recomputing any stored hash.
+SPEC_SCHEMA_VERSION = "1"
+
+#: Roles whose (model, source) bind the production+measurement surface. ``lane``
+#: is DERIVED from ``source`` (see role_provenance) so it is not hashed.
+_SPEC_ROLES = ("auditor", "target", "judge", "mutator")
+
+_HASH_PREFIX_LEN = 12
+
+
+def build_baseline_spec(
+    *,
+    margin_rule: str,
+    margin_logic_version: str,
+    fitness_formula_version: str,
+    rubric_version: str,
+    dim_set: str,
+    bench: bool,
+    role_provenance: Mapping[str, Mapping[str, str]],
+    seed_pool_id: str | None,
+) -> dict[str, Any]:
+    """Assemble the canonical baseline spec (the surface that is hashed).
+
+    ``role_provenance`` is the ``{role: {model, source, lane}}`` block from
+    :mod:`core.self_improving_loop.role_provenance`; only ``model`` + ``source``
+    enter the spec (``lane`` is derived from ``source``, so hashing it would be
+    redundant). ``seed_pool_id`` is the seed pool's *identity* (content hash),
+    not its bodies — ``None``/`""` when no pool is pinned (the pool axis then
+    contributes a stable empty value rather than fragmenting epochs).
+    """
+    roles = {
+        role: {
+            "model": str((role_provenance.get(role) or {}).get("model", "")),
+            "source": str((role_provenance.get(role) or {}).get("source", "")),
+        }
+        for role in _SPEC_ROLES
+    }
+    return {
+        "spec_schema_version": SPEC_SCHEMA_VERSION,
+        "margin_rule": str(margin_rule),
+        "margin_logic_version": str(margin_logic_version),
+        "fitness_formula_version": str(fitness_formula_version),
+        "rubric_version": str(rubric_version),
+        "dim_set": str(dim_set),
+        "bench": bool(bench),
+        "roles": roles,
+        "seed_pool_id": "" if seed_pool_id is None else str(seed_pool_id),
+    }
+
+
+def canonical_spec_json(spec: Mapping[str, Any]) -> str:
+    """Deterministic serialization — sorted keys, no incidental whitespace, so
+    key order / formatting never moves the hash."""
+    return json.dumps(spec, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_epoch_hash(spec: Mapping[str, Any]) -> str:
+    """``sha256(canonical_json(spec))`` truncated to 12 hex — the content-addressed
+    epoch discriminator. Same spec → same hash, always."""
+    digest = hashlib.sha256(canonical_spec_json(spec).encode("utf-8")).hexdigest()
+    return digest[:_HASH_PREFIX_LEN]
+
+
+def resolve_epoch_label(
+    epoch_hash: str,
+    *,
+    label_map: dict[str, str],
+) -> tuple[str, bool]:
+    """Return ``(label, is_new)`` for ``epoch_hash``, assigning the next
+    sequential ``be-NNN`` label on first sight.
+
+    ``label_map`` maps ``epoch_hash → label`` and is mutated in place when a new
+    hash appears; the caller persists it. Labels are assigned in hash-first-seen
+    order (``be-001``, ``be-002``, …) so the human series names are stable +
+    monotonic, mirroring seed-generation's ``gen-*`` run ids. The hash stays the
+    SoT discriminator; the label is for display only.
+    """
+    existing = label_map.get(epoch_hash)
+    if existing is not None:
+        return existing, False
+    seq = len(label_map) + 1
+    label = f"be-{seq:03d}"
+    label_map[epoch_hash] = label
+    return label, True
+
+
+def seed_pool_content_hash(seed_select: str | None) -> str:
+    """Stable identity of the seed pool the audit ran on (decision B).
+
+    ``seed_select`` is whatever ``_resolve_seed_select`` returned (a pool path or
+    a selector string). If it points at a directory, hash the **content** (each
+    contained file's relative path + sha256, sorted) so the same survivor set
+    always yields the same id regardless of mtime / absolute location. If it is a
+    plain string selector (or a missing path), hash the string verbatim. Empty
+    input → ``""`` (the spec's pool axis then contributes a stable empty value).
+    """
+    if not seed_select:
+        return ""
+    # expanduser so a "~/pool" selector content-addresses the same as the
+    # runner's expanded absolute path (else equivalent pools fork the epoch).
+    path = Path(seed_select).expanduser()
+    if path.is_dir():
+        parts: list[str] = []
+        for f in sorted(path.rglob("*")):
+            if f.is_file():
+                rel = f.relative_to(path).as_posix()
+                body = hashlib.sha256(f.read_bytes()).hexdigest()
+                parts.append(f"{rel}:{body}")
+        digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+        return f"pool-{digest[:_HASH_PREFIX_LEN]}"
+    return f"sel-{hashlib.sha256(str(seed_select).encode('utf-8')).hexdigest()[:_HASH_PREFIX_LEN]}"
+
+
+def load_epoch_label_map(path: Path) -> dict[str, str]:
+    """Read the ``epoch_hash → label`` map.
+
+    Missing file → ``{}`` (the legitimate first-ever case). But a file that
+    EXISTS yet is unreadable (corrupt JSON, a merge conflict) **fails closed**:
+    silently returning ``{}`` would make the live writer reassign ``be-001`` to
+    the next hash and overwrite the map, relabeling every existing epoch. For a
+    git-tracked shared SoT that is worse than a crash — raise so the operator
+    resolves it.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"epoch label map {path} exists but is unreadable ({exc}); refusing to "
+            "reinitialize a git-tracked shared map (would relabel existing epochs). "
+            "Resolve the file (e.g. a merge conflict) and retry."
+        ) from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"epoch label map {path} is not a JSON object")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def save_epoch_label_map(path: Path, label_map: Mapping[str, str]) -> None:
+    """Persist the label map (sorted by label for a stable diff)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ordered = dict(sorted(label_map.items(), key=lambda kv: kv[1]))
+    path.write_text(json.dumps(ordered, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+__all__ = [
+    "SPEC_SCHEMA_VERSION",
+    "build_baseline_spec",
+    "canonical_spec_json",
+    "compute_epoch_hash",
+    "load_epoch_label_map",
+    "resolve_epoch_label",
+    "save_epoch_label_map",
+    "seed_pool_content_hash",
+]

--- a/docs/self-improving/autoresearch/index.html.template
+++ b/docs/self-improving/autoresearch/index.html.template
@@ -91,6 +91,10 @@
       </tbody>
     </table>
 
+    <h2 class="section"><span>Baseline registry &middot; grouped by epoch</span></h2>
+    <p class="page-sub">Each promote appends a <code>kind="baseline"</code> row to <code>baseline_archive.jsonl</code>, partitioned into content-addressed <strong>epochs</strong> (be-NNN) keyed by a hash of the production+measurement spec (margin rule, fitness/margin logic version, the four roles' model+source, rubric, dim set, bench, seed-pool identity). Baselines from different epochs were produced under different logic and are <strong>not comparable</strong> — they are never merged into one table.</p>
+{{ baseline_registry_index }}
+
     <h2 class="section"><span>Sub-views &middot; 4 autoresearch sub-pages</span></h2>
     <table class="records">
       <thead>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.90"
+version = "0.99.91"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -4002,6 +4002,145 @@ def _gen_timeline_rows(
     return "\n".join(out)
 
 
+_EPOCH_SPEC_ROLES = ("auditor", "target", "judge", "mutator")
+
+#: Sentinel epoch id for rows written before the epoch schema (no ``epoch_hash``).
+_PRE_EPOCH = "pre-epoch"
+
+
+def _epoch_spec_summary(spec: dict[str, Any], role_prov: dict[str, Any]) -> str:
+    """One dense line describing the production+measurement surface of an epoch.
+
+    The surface is shared by every baseline in the epoch (that is what the hash
+    partitions on), so it renders once per epoch rather than per row. Pulls the
+    comparability fields from ``baseline_spec`` and the credential lane from the
+    row's ``role_provenance`` (lane is derived from source, not hashed).
+    """
+    if not spec:
+        return (
+            "Predates the content-addressed epoch schema — not yet partitioned. "
+            "Re-backfilled with epoch fields once the canonical fitness is settled."
+        )
+    margin = html_escape(str(spec.get("margin_rule") or "—"))
+    dim_set = html_escape(str(spec.get("dim_set") or "—"))
+    rubric = html_escape(str(spec.get("rubric_version") or "—"))
+    bench = "on" if spec.get("bench") else "off"
+    pool = html_escape(str(spec.get("seed_pool_id") or "—"))
+    role_bits: list[str] = []
+    for role in _EPOCH_SPEC_ROLES:
+        prov = role_prov.get(role) if isinstance(role_prov, dict) else None
+        prov = prov if isinstance(prov, dict) else {}
+        model = html_escape(str(prov.get("model") or "—"))
+        lane = html_escape(str(prov.get("lane") or "—"))
+        role_bits.append(f"{role} <code>{model}</code>&middot;{lane}")
+    return (
+        f"margin <code>{margin}</code> &middot; dim_set <code>{dim_set}</code> &middot; "
+        f"rubric <code>{rubric}</code> &middot; bench {bench} &middot; "
+        f"pool <code>{pool}</code><br>{' &middot; '.join(role_bits)}"
+    )
+
+
+def _render_baseline_registry_index(archive: list[dict[str, Any]]) -> str:
+    """Render the ``kind="baseline"`` registry rows grouped by content-addressed
+    epoch (PR-BASELINE-EPOCH).
+
+    Each epoch is a sub-series (like a ``gen-*`` seed-generation run): the
+    ``epoch_label`` (be-NNN) + short hash as the heading, a one-line spec summary,
+    then a dense table of that epoch's baselines. Epochs are NEVER merged into one
+    comparison table — they were produced under different logic and are not
+    comparable (that is the whole point of the partition). Epochs are ordered
+    newest-first by their most-recent baseline; rows within an epoch likewise.
+    """
+    rows = [r for r in archive if r.get("kind") == _BASELINE_REGISTRY_ROW_KIND]
+    if not rows:
+        return (
+            '    <p class="empty-namespace">No <code>kind="baseline"</code> registry rows yet. '
+            "A row is appended on every promote (<code>autoresearch/train.py</code>).</p>"
+        )
+    # Group by epoch_hash, preserving each epoch's label + spec from its first row.
+    # Rows written before the epoch schema (no epoch_hash) bucket under a single
+    # honest "pre-epoch" group rather than a fabricated hash — they are
+    # re-backfilled once the epoch fields are computable (see E1 fitness reconcile).
+    epochs: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        eh = str(row.get("epoch_hash") or _PRE_EPOCH)
+        spec = row.get("baseline_spec")
+        prov = row.get("role_provenance")
+        default_label = "pre-epoch (backfill pending)" if eh == _PRE_EPOCH else eh[:12]
+        bucket = epochs.setdefault(
+            eh,
+            {
+                "label": str(row.get("epoch_label") or default_label),
+                "spec": spec if isinstance(spec, dict) else {},
+                "role_prov": prov if isinstance(prov, dict) else {},
+                "rows": [],
+            },
+        )
+        bucket["rows"].append(row)
+
+    def _max_ts(bucket: dict[str, Any]) -> str:
+        return max((str(r.get("ts_utc") or "") for r in bucket["rows"]), default="")
+
+    # Real epochs first (newest-first by their most-recent baseline); the
+    # pre-epoch bucket always sorts last regardless of its rows' timestamps.
+    def _sort_key(item: tuple[str, dict[str, Any]]) -> tuple[int, str]:
+        eh, bucket = item
+        return (0 if eh == _PRE_EPOCH else 1, _max_ts(bucket))
+
+    blocks: list[str] = []
+    for eh, bucket in sorted(epochs.items(), key=_sort_key, reverse=True):
+        epoch_rows = sorted(bucket["rows"], key=lambda r: str(r.get("ts_utc") or ""), reverse=True)
+        body: list[str] = []
+        for row in epoch_rows:
+            fitness = row.get("fitness")
+            fit_cell = (
+                f'<span class="num">{float(fitness):.4f}</span>'
+                if isinstance(fitness, int | float)
+                else '<span class="muted">—</span>'
+            )
+            stderr = row.get("fitness_stderr")
+            stderr_cell = (
+                f'<span class="num">{float(stderr):.4f}</span>'
+                if isinstance(stderr, int | float)
+                else '<span class="muted">—</span>'
+            )
+            row_id = html_escape(str(row.get("id") or "—"))
+            row_ts = html_escape(short_iso(str(row.get("ts_utc") or "")))
+            promoted = html_escape(str(row.get("promoted_by") or "—"))
+            body.append(
+                "        <tr>\n"
+                f'          <td class="id"><code>{row_id}</code></td>\n'
+                f'          <td class="muted">{row_ts}</td>\n'
+                f"          <td>{fit_cell}</td>\n"
+                f"          <td>{stderr_cell}</td>\n"
+                f'          <td class="muted">{promoted}</td>\n'
+                "        </tr>"
+            )
+        count = len(epoch_rows)
+        label = html_escape(str(bucket["label"]))
+        summary = _epoch_spec_summary(bucket["spec"], bucket["role_prov"])
+        plural = "s" if count != 1 else ""
+        # The raw hash is shown only for real epochs (pre-epoch has none).
+        hash_cell = ""
+        if eh != _PRE_EPOCH:
+            hash_cell = f' <code class="muted">{html_escape(eh[:12])}</code>'
+        blocks.append(
+            '    <div class="namespace-block">\n'
+            f"      <h3>{label} "
+            f'<span class="count">{count} baseline{plural}</span>{hash_cell}</h3>\n'
+            f'      <p class="namespace-meta">{summary}</p>\n'
+            '      <table class="records">\n'
+            "        <thead><tr>"
+            '<th scope="col">baseline-id</th><th scope="col">ts</th>'
+            '<th scope="col">fitness</th><th scope="col">fitness_stderr</th>'
+            '<th scope="col">promoted by</th></tr></thead>\n'
+            "        <tbody>\n" + "\n".join(body) + "\n        </tbody>\n"
+            "      </table>\n"
+            "    </div>"
+        )
+    return "\n".join(blocks)
+
+
 def _delta_class(delta: float) -> tuple[str, str]:
     """Map a Δfitness value to a CSS class + sign char."""
     if delta > 0.005:
@@ -4592,6 +4731,7 @@ def render_autoresearch_landing(
             ),
             "timeline_section_label": (f"{len(archive)} row" + ("s" if len(archive) != 1 else "")),
             "timeline_rows": _gen_timeline_rows(archive, baseline),
+            "baseline_registry_index": _render_baseline_registry_index(archive),
             "subview_rows": _autoresearch_subview_rows(
                 archive_count=len(archive),
                 mutations_count=mutations_count,

--- a/tests/autoresearch/test_baseline_registry.py
+++ b/tests/autoresearch/test_baseline_registry.py
@@ -35,6 +35,10 @@ _EXPECTED_ROW_KEYS = {
     "bench",
     "seed_select",
     "seed_count",
+    "epoch_hash",  # PR-BASELINE-EPOCH — content-addressed partition discriminator
+    "epoch_label",  # be-NNN display label
+    "baseline_spec",  # the hashed surface (row self-verifies)
+    "spec_schema_version",
     "role_provenance",  # nested {role: {model, source, lane}} — shared SoT
     "eval_archive",
     "dim_means",
@@ -353,4 +357,76 @@ def test_backfill_script_end_to_end(isolated: Path) -> None:
     assert prov["target"] == {"model": "v-tgt", "source": "openai-codex", "lane": "Subscription"}
     assert row["seed_count"] == 8
     assert row["eval_archive"] == "vanilla.eval"  # basename of /vanilla.eval
-    assert row["promoted_by"] == "backfill"
+
+
+# --- PR-BASELINE-EPOCH: content-addressed epoch on the row -------------------
+
+
+def test_row_self_verifies_epoch_hash(isolated: Path) -> None:
+    """A stored row recomputes to its own epoch_hash from the stored
+    baseline_spec — the content-address can't have been faked at write time."""
+    from core.self_improving_loop.baseline_epoch import compute_epoch_hash
+
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0}, {"broken_tool_use": 0.1}, sample_count={"broken_tool_use": 16}
+    )
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["spec_schema_version"] == "1"
+    assert compute_epoch_hash(row["baseline_spec"]) == row["epoch_hash"]
+    assert row["epoch_label"] == "be-001"  # first epoch seen in this tmp registry
+
+
+def test_distinct_margin_rules_fall_into_distinct_epochs(isolated: Path) -> None:
+    """margin_rule is part of the hashed spec, so the vanilla (dim-stderr) and
+    fixed (fitness-stderr) baselines land in DIFFERENT epochs with DIFFERENT
+    labels — they must never be averaged into one comparison."""
+    auto_train._append_baseline_registry_row(
+        "baseline-2605-1",
+        dim_means={"broken_tool_use": 3.25},
+        dim_stderr={"broken_tool_use": 0.3},
+        sample_count={"broken_tool_use": 8},
+        measurement_modality=None,
+        admire_means=None,
+        bench_means=None,
+        fitness_stderr=None,
+        margin_rule="dim-stderr",
+        eval_archive=None,
+        session_id="sess-vanilla",
+        commit="HEAD",
+        ts_utc="2026-05-29T09:18:30Z",
+        promoted_by="backfill",
+        role_provenance=build_role_provenance(
+            {
+                "auditor": ("aud-m", "api_key"),
+                "target": ("tgt-m", "openai-codex"),
+                "judge": ("jdg-m", "claude-cli"),
+                "mutator": ("mut-m", "openai-codex"),
+            }
+        ),
+        seed_select="petri_17dim",  # same pool as the live fixture → only margin_rule differs
+    )
+    auto_train._write_baseline(  # live path stamps fitness-stderr + the fixture's roles/pool
+        {"broken_tool_use": 3.25},
+        {"broken_tool_use": 0.3},
+        sample_count={"broken_tool_use": 8},
+    )
+    vanilla, fixed = _rows(isolated / "baseline_archive.jsonl")
+    assert vanilla["baseline_spec"]["margin_rule"] == "dim-stderr"
+    assert fixed["baseline_spec"]["margin_rule"] == "fitness-stderr"
+    assert vanilla["epoch_hash"] != fixed["epoch_hash"]
+    assert {vanilla["epoch_label"], fixed["epoch_label"]} == {"be-001", "be-002"}
+
+
+def test_epoch_label_map_persisted_git_tracked(isolated: Path) -> None:
+    """The epoch_hash→be-NNN map is written next to the archive (git-tracked,
+    shared) so the label assignment is stable across machines, not a local-only
+    in-memory accident."""
+    import json as _json
+
+    auto_train._write_baseline({"broken_tool_use": 3.0}, {"broken_tool_use": 0.1})
+    label_map = isolated / "baseline_epochs.json"
+    assert label_map.is_file()
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert (
+        _json.loads(label_map.read_text(encoding="utf-8"))[row["epoch_hash"]] == row["epoch_label"]
+    )

--- a/tests/test_baseline_epoch.py
+++ b/tests/test_baseline_epoch.py
@@ -1,0 +1,197 @@
+"""PR-BASELINE-EPOCH (2026-05-30) — content-addressed epoch discriminator.
+
+Pins the pure spec→hash→label module (``core.self_improving_loop.baseline_epoch``):
+determinism, surface-sensitivity (every spec field moves the hash), instance-blindness
+(measured values are not in the spec), canonical serialization, sequential labels, and
+the seed-pool content-hash. The registry-integration guards (row self-verifies, distinct
+epochs per margin_rule) live in tests/autoresearch/test_baseline_registry.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.baseline_epoch import (
+    SPEC_SCHEMA_VERSION,
+    build_baseline_spec,
+    canonical_spec_json,
+    compute_epoch_hash,
+    load_epoch_label_map,
+    resolve_epoch_label,
+    save_epoch_label_map,
+    seed_pool_content_hash,
+)
+
+_ROLE_PROV = {
+    "auditor": {"model": "opus-4-8", "source": "claude-cli", "lane": "CLI"},
+    "target": {"model": "gpt-5.5", "source": "openai-codex", "lane": "Subscription"},
+    "judge": {"model": "opus-4-8", "source": "api_key", "lane": "PAYG"},
+    "mutator": {"model": "gpt-5.5", "source": "openai-codex", "lane": "Subscription"},
+}
+
+
+def _base_spec(**over: object) -> dict:
+    kwargs: dict = {
+        "margin_rule": "fitness-stderr",
+        "margin_logic_version": "1",
+        "fitness_formula_version": "1",
+        "rubric_version": "v3-22dim-PR0",
+        "dim_set": "subset",
+        "bench": False,
+        "role_provenance": _ROLE_PROV,
+        "seed_pool_id": "pool-deadbeef0001",
+    }
+    kwargs.update(over)
+    return build_baseline_spec(**kwargs)  # type: ignore[arg-type]
+
+
+# --- determinism + canonical -------------------------------------------------
+
+
+def test_epoch_hash_deterministic() -> None:
+    spec = _base_spec()
+    assert compute_epoch_hash(spec) == compute_epoch_hash(spec)
+    # rebuilt-from-scratch spec hashes identically too (no hidden state)
+    assert compute_epoch_hash(_base_spec()) == compute_epoch_hash(_base_spec())
+
+
+def test_canonical_serialization_key_order_invariant() -> None:
+    spec = _base_spec()
+    shuffled = {k: spec[k] for k in reversed(list(spec))}
+    assert canonical_spec_json(spec) == canonical_spec_json(shuffled)
+    assert compute_epoch_hash(spec) == compute_epoch_hash(shuffled)
+
+
+def test_hash_is_twelve_hex() -> None:
+    h = compute_epoch_hash(_base_spec())
+    assert len(h) == 12 and all(c in "0123456789abcdef" for c in h)
+
+
+# --- surface-sensitivity (every spec field moves the hash) -------------------
+
+
+def test_each_surface_field_moves_the_hash() -> None:
+    base = compute_epoch_hash(_base_spec())
+    variants = {
+        "margin_rule": _base_spec(margin_rule="dim-stderr"),
+        "margin_logic_version": _base_spec(margin_logic_version="2"),
+        "fitness_formula_version": _base_spec(fitness_formula_version="2"),
+        "rubric_version": _base_spec(rubric_version="v4"),
+        "dim_set": _base_spec(dim_set="full"),
+        "bench": _base_spec(bench=True),
+        "seed_pool_id": _base_spec(seed_pool_id="pool-deadbeef0002"),
+        "role_model": _base_spec(
+            role_provenance={**_ROLE_PROV, "target": {**_ROLE_PROV["target"], "model": "gpt-6"}}
+        ),
+        "role_source": _base_spec(
+            role_provenance={**_ROLE_PROV, "judge": {**_ROLE_PROV["judge"], "source": "claude-cli"}}
+        ),
+    }
+    for field, spec in variants.items():
+        assert compute_epoch_hash(spec) != base, f"flipping {field} did not move the epoch hash"
+
+
+def test_derived_lane_does_not_move_the_hash() -> None:
+    """lane is derived from source, so a (contradictory) lane edit with source
+    unchanged must NOT change the epoch — only model+source are hashed."""
+    base = compute_epoch_hash(_base_spec())
+    lane_only = _base_spec(
+        role_provenance={**_ROLE_PROV, "judge": {**_ROLE_PROV["judge"], "lane": "WRONG"}}
+    )
+    assert compute_epoch_hash(lane_only) == base
+
+
+def test_spec_excludes_instance_fields() -> None:
+    """The spec is the surface, never the measured instance — no dim_means /
+    fitness / fitness_stderr / seed_count / ts / commit keys leak in."""
+    spec = _base_spec()
+    forbidden = {"dim_means", "fitness", "fitness_stderr", "seed_count", "ts_utc", "commit", "id"}
+    assert forbidden.isdisjoint(spec)
+    assert spec["spec_schema_version"] == SPEC_SCHEMA_VERSION
+
+
+# --- label resolution --------------------------------------------------------
+
+
+def test_resolve_label_sequential_and_idempotent() -> None:
+    label_map: dict[str, str] = {}
+    l1, new1 = resolve_epoch_label("aaaaaaaaaaaa", label_map=label_map)
+    l2, new2 = resolve_epoch_label("bbbbbbbbbbbb", label_map=label_map)
+    l1_again, new1_again = resolve_epoch_label("aaaaaaaaaaaa", label_map=label_map)
+    assert (l1, l2) == ("be-001", "be-002")
+    assert (new1, new2) == (True, True)
+    assert (l1_again, new1_again) == ("be-001", False)  # re-seen hash keeps its label
+
+
+def test_label_map_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "baseline_epochs.json"
+    original = {"aaaaaaaaaaaa": "be-001", "bbbbbbbbbbbb": "be-002"}
+    save_epoch_label_map(path, original)
+    assert load_epoch_label_map(path) == original
+
+
+def test_load_label_map_missing_returns_empty(tmp_path: Path) -> None:
+    # missing file is the legitimate first-ever case → {}
+    assert load_epoch_label_map(tmp_path / "absent.json") == {}
+
+
+def test_load_label_map_corrupt_fails_closed(tmp_path: Path) -> None:
+    # an EXISTING but unreadable map (corrupt / merge-conflicted) must raise, not
+    # silently return {} — else the writer would relabel every existing epoch.
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unreadable"):
+        load_epoch_label_map(bad)
+    not_obj = tmp_path / "list.json"
+    not_obj.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="not a JSON object"):
+        load_epoch_label_map(not_obj)
+
+
+# --- seed-pool content hash (decision B) -------------------------------------
+
+
+def test_seed_pool_content_hash_string_vs_empty() -> None:
+    assert seed_pool_content_hash("") == ""
+    assert seed_pool_content_hash(None) == ""
+    sel = seed_pool_content_hash("petri_17dim")
+    assert sel.startswith("sel-")
+    assert seed_pool_content_hash("petri_17dim") == sel  # deterministic
+    assert seed_pool_content_hash("other") != sel
+
+
+def test_seed_pool_content_hash_dir_is_content_addressed(tmp_path: Path) -> None:
+    """A pool DIR hashes its survivor bodies (path+sha), so the SAME set yields
+    the SAME id regardless of absolute location; a body change moves it."""
+    a = tmp_path / "poolA"
+    a.mkdir()
+    (a / "x.md").write_text("alpha", encoding="utf-8")
+    (a / "y.md").write_text("beta", encoding="utf-8")
+    h_a = seed_pool_content_hash(str(a))
+    assert h_a.startswith("pool-")
+
+    # identical content at a different location → identical id
+    b = tmp_path / "elsewhere" / "poolB"
+    b.mkdir(parents=True)
+    (b / "x.md").write_text("alpha", encoding="utf-8")
+    (b / "y.md").write_text("beta", encoding="utf-8")
+    assert seed_pool_content_hash(str(b)) == h_a
+
+    # mutate one body → different id
+    (b / "x.md").write_text("ALPHA", encoding="utf-8")
+    assert seed_pool_content_hash(str(b)) != h_a
+
+
+def test_seed_pool_content_hash_expands_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `~/pool` selector must content-address the same as its expanded absolute
+    path — the runner expands ~, so without expanduser the two would fork the epoch."""
+    home = tmp_path / "home"
+    pool = home / "pool"
+    pool.mkdir(parents=True)
+    (pool / "s.md").write_text("seed", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    assert seed_pool_content_hash("~/pool") == seed_pool_content_hash(str(pool))
+    assert seed_pool_content_hash("~/pool").startswith("pool-")

--- a/tests/test_logic_version_guard.py
+++ b/tests/test_logic_version_guard.py
@@ -1,0 +1,133 @@
+"""PR-BASELINE-EPOCH (2026-05-30) — logic-version guard.
+
+The baseline epoch discriminator hashes ``FITNESS_FORMULA_VERSION`` /
+``MARGIN_LOGIC_VERSION`` (deliberate semantic tags) instead of the function
+source. That only works if the tags are bumped when the *meaning* changes — so
+these tests pin a GOLDEN value per version. A silent change to ``compute_fitness``
+or the ``_should_promote`` margin (without bumping the tag) moves the value and
+FAILs here, forcing the bump + a new golden (which then opens a new epoch).
+
+When you intentionally change the logic: bump the version constant in
+``autoresearch/train.py`` AND add the new golden below.
+"""
+
+from __future__ import annotations
+
+from autoresearch.train import (
+    AXIS_TIERS,
+    FITNESS_FORMULA_VERSION,
+    MARGIN_LOGIC_VERSION,
+    _should_promote,
+    compute_fitness,
+)
+
+# --- Probe A: simple uniform — every dim at 3.0, zero stderr (plain weighted sum
+# + stability=1/(1+0)). The minimal tripwire on the core dim aggregate.
+_PROBE_DIM_MEANS = dict.fromkeys(AXIS_TIERS, 3.0)
+_PROBE_DIM_STDERR = dict.fromkeys(AXIS_TIERS, 0.0)
+
+# --- Probe B: RICH — distinct per-dim means (so weight redistribution moves the
+# result), non-zero stderr (stability), mixed analytics/judge_llm modality
+# (modality weighting), and admire (the DIM/ADMIRE 2-axis split). One probe can
+# never cover every branch, but this exercises far more of compute_fitness than
+# the uniform probe — a change to weights / modality / admire / stability that
+# preserves the uniform value still moves THIS one. Construction is deterministic
+# and must stay byte-identical to the golden below.
+_SCORED_DIMS = sorted(d for d, t in AXIS_TIERS.items() if t in ("critical", "auxiliary"))
+_RICH_DIM_MEANS = {d: 1.0 + (i % 5) * 0.5 for i, d in enumerate(_SCORED_DIMS)}
+_RICH_DIM_STDERR = {d: 0.1 + (i % 3) * 0.05 for i, d in enumerate(_SCORED_DIMS)}
+_RICH_MODALITY = {
+    d: ("analytics" if i % 2 == 0 else "judge_llm") for i, d in enumerate(_SCORED_DIMS)
+}
+_RICH_ADMIRE = {"admirable": 7.0, "needs_attention": 3.0}
+
+_GOLDEN_FITNESS = {"1": 0.73}
+_GOLDEN_FITNESS_RICH = {"1": 0.6069}
+_GOLDEN_MARGIN = {"1": 0.0141}  # 4dp of √(0.01² + 0.01²) for σ_prior=σ_current=0.01
+_GOLDEN_MARGIN_FLOOR = {"1": 0.005}  # both σ=0 → √ term 0 → clamps to fitness_margin_floor
+
+
+def test_fitness_formula_version_golden() -> None:
+    got = round(compute_fitness(_PROBE_DIM_MEANS, _PROBE_DIM_STDERR), 4)
+    expected = _GOLDEN_FITNESS.get(FITNESS_FORMULA_VERSION)
+    assert expected is not None, (
+        f"no golden fitness for FITNESS_FORMULA_VERSION={FITNESS_FORMULA_VERSION!r} — "
+        "add one if you intentionally bumped the version"
+    )
+    assert got == expected, (
+        f"compute_fitness probe moved ({got} != golden {expected}) under "
+        f"FITNESS_FORMULA_VERSION={FITNESS_FORMULA_VERSION!r}. The fitness formula "
+        "changed: bump FITNESS_FORMULA_VERSION + add the new golden (a new baseline "
+        "epoch starts)."
+    )
+
+
+def test_fitness_formula_version_golden_rich() -> None:
+    """Wider tripwire: exercises weights / modality / admire / stability so a
+    semantic change that leaves the uniform probe untouched still trips here."""
+    got = round(
+        compute_fitness(
+            _RICH_DIM_MEANS,
+            _RICH_DIM_STDERR,
+            admire_means=_RICH_ADMIRE,
+            measurement_modality=_RICH_MODALITY,
+        ),
+        4,
+    )
+    expected = _GOLDEN_FITNESS_RICH.get(FITNESS_FORMULA_VERSION)
+    assert expected is not None, (
+        f"no rich golden for FITNESS_FORMULA_VERSION={FITNESS_FORMULA_VERSION!r}"
+    )
+    assert got == expected, (
+        f"rich compute_fitness probe moved ({got} != golden {expected}) under "
+        f"FITNESS_FORMULA_VERSION={FITNESS_FORMULA_VERSION!r} — a weights/modality/"
+        "admire/stability change: bump FITNESS_FORMULA_VERSION + add the new golden."
+    )
+
+
+def _margin_of(reason: str) -> float:
+    return round(float(reason.split("margin ")[-1].split()[0]), 4)
+
+
+def test_margin_logic_version_golden() -> None:
+    # √-branch: explicit per-side fitness-stderr (no bootstrap), same baseline as
+    # current so the gain is 0 and only the margin formula is exercised.
+    _ok, reason = _should_promote(
+        _PROBE_DIM_MEANS,
+        _PROBE_DIM_STDERR,
+        _PROBE_DIM_MEANS,
+        _PROBE_DIM_STDERR,
+        baseline_fitness_stderr=0.01,
+        current_fitness_stderr=0.01,
+    )
+    expected = _GOLDEN_MARGIN.get(MARGIN_LOGIC_VERSION)
+    assert expected is not None, (
+        f"no golden margin for MARGIN_LOGIC_VERSION={MARGIN_LOGIC_VERSION!r}"
+    )
+    assert _margin_of(reason) == expected, (
+        f"promote margin moved ({_margin_of(reason)} != golden {expected}) under "
+        f"MARGIN_LOGIC_VERSION={MARGIN_LOGIC_VERSION!r}. The margin rule changed: "
+        "bump MARGIN_LOGIC_VERSION + add the new golden."
+    )
+
+
+def test_margin_logic_version_golden_floor() -> None:
+    """Floor branch: both fitness-stderr = 0 → the √ gain-stderr term is 0, so the
+    margin must clamp to fitness_margin_floor. Catches a change to the floor clamp
+    that the σ>0 √-branch test would miss."""
+    _ok, reason = _should_promote(
+        _PROBE_DIM_MEANS,
+        _PROBE_DIM_STDERR,
+        _PROBE_DIM_MEANS,
+        _PROBE_DIM_STDERR,
+        baseline_fitness_stderr=0.0,
+        current_fitness_stderr=0.0,
+    )
+    expected = _GOLDEN_MARGIN_FLOOR.get(MARGIN_LOGIC_VERSION)
+    assert expected is not None, (
+        f"no floor golden for MARGIN_LOGIC_VERSION={MARGIN_LOGIC_VERSION!r}"
+    )
+    assert _margin_of(reason) == expected, (
+        f"promote margin floor moved ({_margin_of(reason)} != golden {expected}) "
+        f"under MARGIN_LOGIC_VERSION={MARGIN_LOGIC_VERSION!r}: bump + add new golden."
+    )

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 from html.parser import HTMLParser
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -893,6 +894,117 @@ def test_autoresearch_landing_renders(built_autoresearch_pages: dict[str, str]) 
     ):
         assert label in html, f"sub-view row {label!r} missing"
         assert href in html, f"sub-view link {href!r} missing"
+    # PR-BASELINE-EPOCH: the content-addressed baseline-registry section is present
+    # (its token resolved — an unresolved {{ }} marker would fail the builder).
+    assert "Baseline registry" in html, "baseline registry section header missing"
+
+
+def _load_builder_module() -> Any:
+    """Import the stdlib-only hub builder as a module (mirrors
+    test_policy_file_map_matches_core)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_hub_builder_epoch", BUILDER)
+    assert spec is not None and spec.loader is not None
+    builder = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = builder
+    spec.loader.exec_module(builder)
+    return builder
+
+
+def _epoch_row(*, eid: str, ts: str, epoch_hash: str, epoch_label: str, margin: str) -> dict:
+    return {
+        "kind": "baseline",
+        "id": eid,
+        "ts_utc": ts,
+        "fitness": 0.73,
+        "fitness_stderr": 0.013,
+        "promoted_by": "gate",
+        "epoch_hash": epoch_hash,
+        "epoch_label": epoch_label,
+        "baseline_spec": {
+            "margin_rule": margin,
+            "dim_set": "subset",
+            "rubric_version": "v3-22dim-PR0",
+            "bench": False,
+            "seed_pool_id": "sel-aaaa",
+        },
+        "role_provenance": {
+            "auditor": {"model": "opus-4-8", "source": "api_key", "lane": "PAYG"},
+            "target": {"model": "gpt-5.5", "source": "openai-codex", "lane": "Subscription"},
+            "judge": {"model": "opus-4-8", "source": "claude-cli", "lane": "CLI"},
+            "mutator": {"model": "gpt-5.5", "source": "openai-codex", "lane": "Subscription"},
+        },
+    }
+
+
+def test_baseline_registry_index_groups_distinct_epochs() -> None:
+    """Two margin_rule epochs render as two SEPARATE blocks (never merged), and
+    the legacy gen-* timeline (different schema) is unaffected."""
+    builder = _load_builder_module()
+    vanilla = _epoch_row(
+        eid="baseline-2605-1",
+        ts="2026-05-29T09:18:30Z",
+        epoch_hash="36c4727cf762",
+        epoch_label="be-001",
+        margin="dim-stderr",
+    )
+    fixed = _epoch_row(
+        eid="baseline-2606-1",
+        ts="2026-05-30T10:00:00Z",
+        epoch_hash="33d454c3523e",
+        epoch_label="be-002",
+        margin="fitness-stderr",
+    )
+    html = builder._render_baseline_registry_index([vanilla, fixed])
+    # two distinct epoch blocks, not one comparison table
+    assert html.count('class="namespace-block"') == 2
+    assert "be-001" in html and "be-002" in html
+    # newest epoch first
+    assert html.index("be-002") < html.index("be-001")
+    # both margin rules surfaced as the epoch discriminator
+    assert "dim-stderr" in html and "fitness-stderr" in html
+    # credential-lane observability present per role
+    assert "Subscription" in html and "CLI" in html and "PAYG" in html
+    # no slop (accent bars / card grids)
+    assert "border-left" not in html and "card-grid" not in html
+
+
+def test_baseline_registry_index_empty_state() -> None:
+    builder = _load_builder_module()
+    # legacy gen-* rows (no kind="baseline") → empty state, not a crash
+    legacy = [{"gen_tag": "gen-1", "ts_utc": "2026-05-01T00:00:00Z", "fitness": 0.5}]
+    html = builder._render_baseline_registry_index(legacy)
+    assert "No <code>" in html and "namespace-block" not in html
+
+
+def test_baseline_registry_index_pre_epoch_row_honest() -> None:
+    """A committed kind="baseline" row WITHOUT epoch fields (pre-schema) renders
+    in an honest 'pre-epoch (backfill pending)' bucket — never a fabricated hash —
+    and that bucket sorts AFTER real epochs even when its ts is newer."""
+    builder = _load_builder_module()
+    pre = {
+        "kind": "baseline",
+        "id": "baseline-2605-1",
+        "ts_utc": "2026-06-30T00:00:00Z",  # deliberately newest
+        "fitness": 0.7915,
+        "fitness_stderr": None,
+        "promoted_by": "backfill",
+    }  # no epoch_hash / epoch_label / baseline_spec
+    real = _epoch_row(
+        eid="baseline-2606-1",
+        ts="2026-05-30T10:00:00Z",
+        epoch_hash="33d454c3523e",
+        epoch_label="be-002",
+        margin="fitness-stderr",
+    )
+    html = builder._render_baseline_registry_index([pre, real])
+    assert "pre-epoch (backfill pending)" in html
+    assert "Predates the content-addressed epoch schema" in html
+    # real epoch (be-002) renders BEFORE the pre-epoch bucket despite older ts
+    assert html.index("be-002") < html.index("pre-epoch (backfill pending)")
+    # no fabricated hash for the pre-epoch bucket
+    assert '<code class="muted">pre-epoch</code>' not in html
 
 
 def test_autoresearch_baseline_renders(built_autoresearch_pages: dict[str, str]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.90"
+version = "0.99.91"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Partition the baseline registry into **epochs** keyed by `sha256(canonical_json(baseline_spec))[:12]`, so baselines produced under different production logic are never silently compared.
- The spec is the production+measurement *surface* (margin_rule + margin/fitness logic-version tags + rubric + dim_set + bench + the 4 roles' model+source + seed-pool content-hash) — never the measured instance. On change → a new `be-NNN` epoch, write-time frozen; each row self-verifies.
- The self-improving hub serves baselines under a **Baseline registry · grouped by epoch** section (never two epochs in one comparison table).

## Why
Baselines made under different logic (e.g. the pre-fix `dim-stderr` margin vs the `fitness-stderr` margin) are not comparable — averaging across the boundary is meaningless ("the ruler changed"). The v0.99.89 registry recorded `margin_rule` + `role_provenance` but had no content-addressed comparability key, so a future logic change could silently merge non-comparable baselines.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/baseline_epoch.py` (new) | `build_baseline_spec` / `canonical_spec_json` / `compute_epoch_hash` / `resolve_epoch_label` / `seed_pool_content_hash` (expanduser, content-addressed dir) / `load+save_epoch_label_map` (fail-closed on corrupt) |
| `autoresearch/train.py` | `FITNESS_FORMULA_VERSION` + `MARGIN_LOGIC_VERSION` constants; `_append_baseline_registry_row` stamps `baseline_spec`/`spec_schema_version`/`epoch_hash`/`epoch_label`; shared `_effective_dim_set()` (override-aware); bench flag uses `is not None` to match `compute_fitness` |
| `scripts/build_self_improving_hub.py` | `_render_baseline_registry_index` — epoch-grouped dense tables; pre-epoch rows in an honest "backfill pending" bucket (no fabricated hash) |
| `docs/self-improving/autoresearch/index.html.template` | new "Baseline registry · grouped by epoch" section token |
| `.gitignore` | track `autoresearch/state/baseline_epochs.json` (epoch_hash→label map) |
| `tests/test_baseline_epoch.py` (new) | determinism / surface-sensitivity / instance-blindness / canonical / labels / seed-pool hash / fail-closed |
| `tests/test_logic_version_guard.py` (new) | golden fitness (uniform + rich) + golden margin (√ + floor) — fails if logic changes without a version bump |
| `tests/autoresearch/test_baseline_registry.py`, `tests/test_self_improving_hub_e2e.py` | row self-verify, distinct-epoch-per-margin_rule, label-map persistence, hub renderer + pre-epoch |
| `.claude/skills/baseline-epoch-partition/SKILL.md` (new) | codifies the content-addressed epoch procedure |
| `pyproject.toml` · `CHANGELOG.md` · `CLAUDE.md` · `README.md` · `README.ko.md` · `uv.lock` | v0.99.90 → v0.99.91 |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ + autoresearch/train.py + scripts/)
- [x] ruff format --check clean
- [x] mypy clean (463 source files)
- [x] lint-imports: 4 contracts kept, 0 broken
- [x] pytest pass — test_baseline_epoch + test_logic_version_guard + test_baseline_registry + test_self_improving_hub_e2e + autoresearch/ (green; 1 skip)
- [x] Codex MCP review applied: dim_set override, bench semantics, `~` expansion, fail-closed label map, widened version-guard probe
- Rendered hub HTML intentionally NOT committed (build output; regenerated by the operator §7 hub rebuild). The serving logic is verified by `test_autoresearch_landing_renders`.

## Reference
operator design 2026-05-30; builds on PR-BASELINE-REGISTRY (#1913/#1914) + PR-MARGIN-FITNESS-SCALE (#1908). The vanilla `baseline-2605-1` epoch re-backfill is deferred to the follow-up fitness-reference reconciliation (E1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)