### PR TITLE
feat(self-improving): deterministic assemble_seed_pool.py (B1)

### DIFF
--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import shutil
 import sys
 from dataclasses import dataclass
@@ -64,6 +65,13 @@ from pathlib import Path
 from typing import Any
 
 from core.self_improving_loop.baseline_epoch import seed_pool_content_hash
+
+_LOGGER = logging.getLogger("assemble_seed_pool")
+
+#: Sort key for a run whose gen_tag is missing / empty / malformed. An empty
+#: tuple sorts BELOW every well-formed ``(stamp, counter)`` / ``(n,)`` key, so a
+#: malformed run can never be selected as "most recent" over a well-formed one.
+_MALFORMED_SORT_KEY: tuple[int, ...] = ()
 
 DEFAULT_SEEDS_ROOT = Path("docs/self-improving/petri-bundle/seeds")
 #: Default pool destination — under the repo ``state/`` tree (GEODE convention
@@ -83,30 +91,49 @@ class SelectedRun:
     survivors: tuple[tuple[str, Path], ...]
 
 
-def parse_gen_tag_key(gen_tag: str) -> tuple[int, ...]:
+def parse_gen_tag_key(gen_tag: str) -> tuple[int, ...] | None:
     """Parse ``gen_tag`` into an integer tuple for STABLE descending sort.
 
-    ``gen-2605-4`` -> ``(2605, 4)``; legacy bare ``gen1`` -> ``(1,)``. The
-    leading ``gen`` / ``gen-`` prefix is stripped, then the remainder is split on
-    ``-`` and each numeric segment kept. A segment that is not an integer is
-    skipped (graceful contract at the schema-typed ``int()`` cast — a malformed
-    tag never raises, it just contributes fewer key components). A tag with no
-    numeric segment at all yields ``()``, which sorts below every real tag.
+    The accepted schema is EXACTLY one of two shapes:
+
+    - ``gen-<stamp>-<counter>`` (two ints) -> ``(stamp, counter)``,
+      e.g. ``gen-2605-4`` -> ``(2605, 4)``.
+    - legacy bare ``gen<n>`` (one int) -> ``(n,)``, e.g. ``gen1`` -> ``(1,)``.
+
+    Anything else — a missing / empty tag, a non-numeric segment, or SPURIOUS
+    extra numeric segments (``gen-2605-4-999``) — is MALFORMED and returns
+    ``None``. The caller maps ``None`` to :data:`_MALFORMED_SORT_KEY` so a
+    malformed tag sorts LOWEST and is never promoted above a well-formed run by
+    an extra segment (FIX 3) or by a directory-name fallback (FIX 2).
+
+    Graceful contract: every schema-typed ``int()`` cast is guarded; a malformed
+    tag never raises, it resolves to ``None``.
     """
     tag = str(gen_tag).strip()
-    body = tag[3:] if tag.startswith("gen") else tag
-    body = body.lstrip("-")
-    key: list[int] = []
-    for segment in body.split("-"):
-        if not segment:
-            continue
+    if not tag.startswith("gen"):
+        return None
+    remainder = tag[len("gen") :]
+
+    if remainder and remainder[0].isdigit():
+        # Legacy bare ``gen<n>`` — the whole remainder must be a single integer.
         try:
-            key.append(int(segment))
+            return (int(remainder),)
         except (TypeError, ValueError):
-            # Non-numeric segment (e.g. a dim suffix that leaked into the tag) —
-            # skip it rather than fail; the numeric prefix still orders the run.
-            break
-    return tuple(key)
+            return None
+
+    if not remainder.startswith("-"):
+        # Neither ``gen<digit>`` nor ``gen-...`` — malformed (e.g. ``genfoo``).
+        return None
+
+    segments = remainder[1:].split("-")
+    # The hyphenated schema is EXACTLY ``gen-<stamp>-<counter>`` — two segments,
+    # both integers. More or fewer segments (or a non-int) is malformed.
+    if len(segments) != 2:
+        return None
+    try:
+        return (int(segments[0]), int(segments[1]))
+    except (TypeError, ValueError):
+        return None
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
@@ -140,12 +167,16 @@ def collect_valid_survivors(
 ) -> tuple[tuple[str, Path], ...]:
     """Return ``(survivor_id, abs_body_path)`` for each VALID survivor of a run.
 
-    Valid = id in ``state.json["survivors"]`` AND body file
-    ``(run_dir / entry["path"])`` exists. Sorted by survivor id for a
-    deterministic copy order; ``per_run`` (when set) caps to the first N after
-    that sort so the cap is itself deterministic.
+    Valid = id in ``state.json["survivors"]`` AND ``entry["path"]`` is RUN-LOCAL
+    (relative and resolving inside ``run_dir`` — never absolute, never a
+    ``../other-run/file.md`` escape; FIX 4) AND the body file exists on disk.
+    Sorted by survivor id for a deterministic copy order; ``per_run`` (when set)
+    caps to the first N after that sort so the cap is itself deterministic.
     """
     run_root = Path(run_dir)
+    # Anchor for the containment check. ``resolve()`` collapses ``..`` and
+    # symlinks so the parent test below cannot be fooled by a crafted path.
+    run_root_resolved = run_root.resolve()
     state = _load_json_object(run_root / "state.json")
     survivors_meta = _load_json_object(run_root / "survivors.json")
     canonical_ids = _state_survivor_ids(state)
@@ -164,6 +195,15 @@ def collect_valid_survivors(
             continue
         if survivor_id not in canonical_ids:
             continue
+        if not _is_run_local(rel_path, run_root_resolved):
+            _LOGGER.warning(
+                "survivor %s in %s has a non-run-local path %r "
+                "(absolute or escapes the run dir); dropping it as invalid",
+                survivor_id,
+                run_root.name,
+                rel_path,
+            )
+            continue
         body_path = run_root / rel_path
         if not body_path.is_file():
             # Phantom survivor: listed in state but its body was pruned. Drop it.
@@ -176,6 +216,21 @@ def collect_valid_survivors(
     return tuple(valid)
 
 
+def _is_run_local(rel_path: str, run_root_resolved: Path) -> bool:
+    """True iff ``rel_path`` is a relative path resolving INSIDE ``run_root``.
+
+    Guards FIX 4: an absolute ``entry["path"]`` or a ``../other-run/file.md``
+    escape is rejected. ``run_root_resolved`` is the already-``resolve()``-d run
+    dir; the body path is resolved the same way and must have ``run_root`` among
+    its parents (``is_relative_to`` is the schema-typed boundary check).
+    """
+    candidate = Path(rel_path)
+    if candidate.is_absolute():
+        return False
+    resolved_body = (run_root_resolved / candidate).resolve()
+    return resolved_body.is_relative_to(run_root_resolved)
+
+
 def select_runs(
     seeds_root: Path,
     *,
@@ -186,10 +241,14 @@ def select_runs(
 
     Run dirs are discovered by the presence of ``state.json`` (the canonical
     per-run marker). Each run's sort key comes from its ``state.json["gen_tag"]``.
-    Ordering is descending by ``(sort_key, run_id)`` — ``run_id`` as the tie-break
-    keeps selection total/deterministic when two runs share a gen_tag. Runs with
-    zero valid survivors are still considered for selection slots but contribute
-    no bodies (an empty run does not silently promote a lower-ranked run).
+    A missing / empty / malformed gen_tag does NOT fall back to ``run_dir.name``
+    for ordering — it maps to :data:`_MALFORMED_SORT_KEY` (sorts lowest) and logs
+    a warning, so a malformed dir name (e.g. ``gen-9999-x``) can never be picked
+    as most-recent over a well-formed run (FIX 2). Ordering is descending by
+    ``(sort_key, run_id)`` — ``run_id`` as the tie-break keeps selection
+    total/deterministic when two runs share a gen_tag. Runs with zero valid
+    survivors are still considered for selection slots but contribute no bodies
+    (an empty run does not silently promote a lower-ranked run).
     """
     root = Path(seeds_root)
     if not root.is_dir():
@@ -201,8 +260,20 @@ def select_runs(
         if not state_path.is_file():
             continue
         state = _load_json_object(state_path)
-        gen_tag = str(state.get("gen_tag", "")) or run_dir.name
-        sort_key = parse_gen_tag_key(gen_tag)
+        # The raw tag is recorded verbatim in the manifest; only the SORT KEY is
+        # derived. run_dir.name is never used as a gen_tag substitute (FIX 2).
+        gen_tag = str(state.get("gen_tag", ""))
+        parsed = parse_gen_tag_key(gen_tag)
+        if parsed is None:
+            _LOGGER.warning(
+                "run %s has a missing/empty/malformed gen_tag %r; "
+                "sorting it lowest (never selected over a well-formed run)",
+                run_dir.name,
+                gen_tag,
+            )
+            sort_key = _MALFORMED_SORT_KEY
+        else:
+            sort_key = parsed
         survivors = collect_valid_survivors(run_dir, per_run=per_run)
         discovered.append(
             SelectedRun(
@@ -231,6 +302,29 @@ def _ensure_out_dir(out_dir: Path, *, force: bool) -> None:
     pool_dir.mkdir(parents=True, exist_ok=True)
 
 
+def _assert_no_duplicate_destinations(selected: list[SelectedRun]) -> None:
+    """Raise ``SystemExit`` if two selected runs map to the same ``<id>.md`` dest.
+
+    Guards FIX 1. The flat pool destination basename is ``<survivor_id>.md``, so
+    two valid survivors with the same id (in different runs) would collide. The
+    error names the colliding id and BOTH run_ids so the operator can locate the
+    anomaly. Checked BEFORE any copy so the pool dir is never left half-written.
+    """
+    first_owner: dict[str, str] = {}
+    for run in selected:
+        for survivor_id, _body_path in run.survivors:
+            prior_run_id = first_owner.get(survivor_id)
+            if prior_run_id is not None:
+                raise SystemExit(
+                    f"duplicate survivor id {survivor_id!r} would collide at "
+                    f"destination {survivor_id}.md: present in both run "
+                    f"{prior_run_id!r} and run {run.run_id!r}; refusing to "
+                    "overwrite a body (ids are normally gen_tag-prefixed, so "
+                    "this signals an anomaly)"
+                )
+            first_owner[survivor_id] = run.run_id
+
+
 def assemble_pool(
     *,
     seeds_root: Path,
@@ -252,6 +346,14 @@ def assemble_pool(
             f"no valid survivors across the {len(selected)} selected run(s) under "
             f"{seeds_root}; nothing to assemble"
         )
+
+    # FAIL CLOSED on a duplicate flat-copy destination. The flat pool writes
+    # ``<id>.md``; if two selected runs each have a valid survivor with the same
+    # id, the later copy would silently overwrite the earlier and the manifest
+    # would over-count. Survivor ids are normally gen_tag-prefixed, so a
+    # collision signals a real anomaly — surface it (naming the id + both
+    # run_ids), never silently drop a body.
+    _assert_no_duplicate_destinations(selected)
 
     pool_dir = Path(out_dir)
     _ensure_out_dir(pool_dir, force=force)

--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -1,0 +1,362 @@
+"""Assemble a combined seed pool from the most-recent seed-generation runs (B1).
+
+The self-improving 10-cycle audits a model against a *pool* of adversarial seed
+prompts. Each seed-generation run (``docs/self-improving/petri-bundle/seeds/<run_id>/``)
+produces ~5 survivor seeds for one target dimension; a cycle wants the union of
+the latest few runs as its input pool. This script builds that pool
+**deterministically** — no LLM, no randomness, no filesystem mtime — so the same
+seeds tree always yields the same pool with the same content identity.
+
+Source of Truth per run dir
+===========================
+
+- ``state.json["survivors"]`` — canonical list of survivor id strings.
+- ``survivors.json["survivors"]`` — ``[{id, path, elo_rating, pilot}]`` where
+  ``path`` is RELATIVE to the run dir (``candidates/<id>.md`` or
+  ``candidates_evolved/<id>.md``).
+
+A survivor is VALID iff its id is in ``state.json["survivors"]`` AND its body
+file ``(run_dir / entry["path"])`` exists on disk. The body-existence check
+drops phantom survivors whose body was pruned.
+
+Run selection
+=============
+
+Runs are time-ordered by a STABLE key parsed from ``gen_tag`` — NOT by
+filesystem mtime — so selection is reproducible across clones / re-syncs.
+``gen-<stamp>-<counter>`` -> ``(stamp, counter)`` (e.g. ``gen-2605-4`` ->
+``(2605, 4)``); a legacy bare ``gen1`` -> ``(1,)`` (sorts below ``gen-2605-*``).
+The top ``--runs`` (default 2) by descending key are selected; on the real seeds
+tree that is ``gen-2605-4`` + ``gen-2605-3``.
+
+Output
+======
+
+The valid survivor ``.md`` bodies are copied into a FLAT pool directory (a flat
+dir of survivor bodies IS a valid pool — the audit's ``flatten_for_inspect_petri``
+passes a flat dir through unchanged). A ``manifest.json`` records the selected
+run ids, per-run survivor ids, total count, content hash, and a caller-supplied
+generation timestamp. The pool's content identity is computed by REUSING
+:func:`core.self_improving_loop.baseline_epoch.seed_pool_content_hash` (gives
+``pool-<hash>``).
+
+Run, e.g.::
+
+    uv run python scripts/assemble_seed_pool.py \\
+        --out state/seed-pools/cycle-input --now 2026-05-30T00:00:00+00:00
+
+Exit codes
+==========
+
+- 0 — pool assembled.
+- 1 — fatal error (out dir non-empty without ``--force``, no valid survivors,
+  unreadable run metadata, missing seeds root).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.self_improving_loop.baseline_epoch import seed_pool_content_hash
+
+DEFAULT_SEEDS_ROOT = Path("docs/self-improving/petri-bundle/seeds")
+#: Default pool destination — under the repo ``state/`` tree (GEODE convention
+#: for runtime artefacts), never ``/tmp``.
+DEFAULT_OUT = Path("state/seed-pools/cycle-input")
+DEFAULT_RUNS = 2
+
+
+@dataclass(frozen=True)
+class SelectedRun:
+    """A run chosen for the pool plus its valid survivors (sort order preserved)."""
+
+    run_id: str
+    gen_tag: str
+    sort_key: tuple[int, ...]
+    #: (survivor_id, absolute body path) for each VALID survivor, sorted by id.
+    survivors: tuple[tuple[str, Path], ...]
+
+
+def parse_gen_tag_key(gen_tag: str) -> tuple[int, ...]:
+    """Parse ``gen_tag`` into an integer tuple for STABLE descending sort.
+
+    ``gen-2605-4`` -> ``(2605, 4)``; legacy bare ``gen1`` -> ``(1,)``. The
+    leading ``gen`` / ``gen-`` prefix is stripped, then the remainder is split on
+    ``-`` and each numeric segment kept. A segment that is not an integer is
+    skipped (graceful contract at the schema-typed ``int()`` cast — a malformed
+    tag never raises, it just contributes fewer key components). A tag with no
+    numeric segment at all yields ``()``, which sorts below every real tag.
+    """
+    tag = str(gen_tag).strip()
+    body = tag[3:] if tag.startswith("gen") else tag
+    body = body.lstrip("-")
+    key: list[int] = []
+    for segment in body.split("-"):
+        if not segment:
+            continue
+        try:
+            key.append(int(segment))
+        except (TypeError, ValueError):
+            # Non-numeric segment (e.g. a dim suffix that leaked into the tag) —
+            # skip it rather than fail; the numeric prefix still orders the run.
+            break
+    return tuple(key)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Read a JSON object from ``path``; raise ``SystemExit`` on any failure.
+
+    Graceful contract at the parse boundary: a missing / unreadable / non-object
+    file is a fatal, explained error (not a silent ``{}`` that would drop a run
+    from selection without the operator noticing).
+    """
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"cannot read JSON object from {path}: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise SystemExit(f"{path} is not a JSON object")
+    return loaded
+
+
+def _state_survivor_ids(state: dict[str, Any]) -> set[str]:
+    """The canonical survivor-id set from ``state.json["survivors"]`` (string ids)."""
+    raw_survivors = state.get("survivors")
+    if not isinstance(raw_survivors, list):
+        return set()
+    return {str(item) for item in raw_survivors}
+
+
+def collect_valid_survivors(
+    run_dir: Path,
+    *,
+    per_run: int | None,
+) -> tuple[tuple[str, Path], ...]:
+    """Return ``(survivor_id, abs_body_path)`` for each VALID survivor of a run.
+
+    Valid = id in ``state.json["survivors"]`` AND body file
+    ``(run_dir / entry["path"])`` exists. Sorted by survivor id for a
+    deterministic copy order; ``per_run`` (when set) caps to the first N after
+    that sort so the cap is itself deterministic.
+    """
+    run_root = Path(run_dir)
+    state = _load_json_object(run_root / "state.json")
+    survivors_meta = _load_json_object(run_root / "survivors.json")
+    canonical_ids = _state_survivor_ids(state)
+
+    entries = survivors_meta.get("survivors")
+    if not isinstance(entries, list):
+        entries = []
+
+    valid: list[tuple[str, Path]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        survivor_id = str(entry.get("id", ""))
+        rel_path = entry.get("path")
+        if not survivor_id or not isinstance(rel_path, str) or not rel_path:
+            continue
+        if survivor_id not in canonical_ids:
+            continue
+        body_path = run_root / rel_path
+        if not body_path.is_file():
+            # Phantom survivor: listed in state but its body was pruned. Drop it.
+            continue
+        valid.append((survivor_id, body_path))
+
+    valid.sort(key=lambda pair: pair[0])
+    if per_run is not None:
+        valid = valid[:per_run]
+    return tuple(valid)
+
+
+def select_runs(
+    seeds_root: Path,
+    *,
+    runs: int,
+    per_run: int | None,
+) -> list[SelectedRun]:
+    """Time-sort run dirs by ``gen_tag`` and return the top ``runs`` with survivors.
+
+    Run dirs are discovered by the presence of ``state.json`` (the canonical
+    per-run marker). Each run's sort key comes from its ``state.json["gen_tag"]``.
+    Ordering is descending by ``(sort_key, run_id)`` — ``run_id`` as the tie-break
+    keeps selection total/deterministic when two runs share a gen_tag. Runs with
+    zero valid survivors are still considered for selection slots but contribute
+    no bodies (an empty run does not silently promote a lower-ranked run).
+    """
+    root = Path(seeds_root)
+    if not root.is_dir():
+        raise SystemExit(f"seeds root {root} does not exist or is not a directory")
+
+    discovered: list[SelectedRun] = []
+    for run_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        state_path = run_dir / "state.json"
+        if not state_path.is_file():
+            continue
+        state = _load_json_object(state_path)
+        gen_tag = str(state.get("gen_tag", "")) or run_dir.name
+        sort_key = parse_gen_tag_key(gen_tag)
+        survivors = collect_valid_survivors(run_dir, per_run=per_run)
+        discovered.append(
+            SelectedRun(
+                run_id=run_dir.name,
+                gen_tag=gen_tag,
+                sort_key=sort_key,
+                survivors=survivors,
+            )
+        )
+
+    discovered.sort(key=lambda run: (run.sort_key, run.run_id), reverse=True)
+    return discovered[:runs]
+
+
+def _ensure_out_dir(out_dir: Path, *, force: bool) -> None:
+    """Prepare the pool dir. Refuse to clobber an existing non-empty dir unless
+    ``force`` — then wipe it so the copy is a clean (deterministic) snapshot."""
+    pool_dir = Path(out_dir)
+    if pool_dir.exists():
+        if not pool_dir.is_dir():
+            raise SystemExit(f"--out {pool_dir} exists and is not a directory")
+        if any(pool_dir.iterdir()) and not force:
+            raise SystemExit(f"--out {pool_dir} is not empty; pass --force to overwrite it")
+        if force:
+            shutil.rmtree(pool_dir)
+    pool_dir.mkdir(parents=True, exist_ok=True)
+
+
+def assemble_pool(
+    *,
+    seeds_root: Path,
+    out_dir: Path,
+    runs: int,
+    per_run: int | None,
+    force: bool,
+    now: str | None,
+) -> dict[str, Any]:
+    """Build the flat pool + manifest deterministically; return the manifest dict.
+
+    ``now`` is supplied by the caller (the manifest's ``generated_at``) — the
+    deterministic core never calls ``datetime.now``, so tests are reproducible.
+    """
+    selected = select_runs(seeds_root, runs=runs, per_run=per_run)
+    total = sum(len(run.survivors) for run in selected)
+    if total == 0:
+        raise SystemExit(
+            f"no valid survivors across the {len(selected)} selected run(s) under "
+            f"{seeds_root}; nothing to assemble"
+        )
+
+    pool_dir = Path(out_dir)
+    _ensure_out_dir(pool_dir, force=force)
+
+    # Deterministic copy order: runs in (already sorted) selection order, then
+    # survivors in id order. Flat <id>.md destinations.
+    for run in selected:
+        for survivor_id, body_path in run.survivors:
+            shutil.copyfile(body_path, pool_dir / f"{survivor_id}.md")
+
+    content_hash = seed_pool_content_hash(str(pool_dir))
+
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": now,
+        "seeds_root": str(seeds_root),
+        "runs_requested": runs,
+        "per_run_cap": per_run,
+        "selected_run_ids": [run.run_id for run in selected],
+        "runs": [
+            {
+                "run_id": run.run_id,
+                "gen_tag": run.gen_tag,
+                "survivor_ids": [survivor_id for survivor_id, _ in run.survivors],
+                "survivor_count": len(run.survivors),
+            }
+            for run in selected
+        ],
+        "total_survivors": total,
+        "content_hash": content_hash,
+    }
+    manifest_path = pool_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def _print_summary(manifest: dict[str, Any], *, out_dir: Path) -> None:
+    """Concise human summary to stdout (no emoji)."""
+    print(f"Assembled seed pool: {out_dir}")
+    print(f"  content hash : {manifest['content_hash']}")
+    print(f"  total seeds  : {manifest['total_survivors']}")
+    print(f"  generated_at : {manifest['generated_at']}")
+    print("  runs         :")
+    for run in manifest["runs"]:
+        print(f"    - {run['run_id']} ({run['gen_tag']}): {run['survivor_count']} survivors")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Assemble a combined seed pool (B1).")
+    parser.add_argument(
+        "--seeds-root",
+        type=Path,
+        default=DEFAULT_SEEDS_ROOT,
+        help=f"seeds SoT root (default: {DEFAULT_SEEDS_ROOT})",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=DEFAULT_RUNS,
+        help=f"number of most-recent runs to include (default: {DEFAULT_RUNS})",
+    )
+    parser.add_argument(
+        "--per-run",
+        type=int,
+        default=None,
+        help="optional cap on survivors per run (default: no cap)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"pool destination directory (default: {DEFAULT_OUT})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite a non-empty --out directory",
+    )
+    parser.add_argument(
+        "--now",
+        type=str,
+        default=None,
+        help="ISO timestamp recorded as the manifest's generated_at "
+        "(optional; not used by the deterministic core)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.runs <= 0:
+        raise SystemExit("--runs must be a positive integer")
+    if args.per_run is not None and args.per_run <= 0:
+        raise SystemExit("--per-run must be a positive integer when given")
+
+    manifest = assemble_pool(
+        seeds_root=args.seeds_root,
+        out_dir=args.out,
+        runs=args.runs,
+        per_run=args.per_run,
+        force=args.force,
+        now=args.now,
+    )
+    _print_summary(manifest, out_dir=args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_assemble_seed_pool.py
+++ b/tests/test_assemble_seed_pool.py
@@ -1,0 +1,350 @@
+"""B1 — deterministic seed-pool assembly (``scripts/assemble_seed_pool.py``).
+
+Pins the four invariants the upcoming 10-cycle depends on:
+
+1. Stable time-sort by ``gen_tag`` picks the highest gen tags (NOT mtime), with a
+   legacy bare ``gen1`` sorting below ``gen-2605-*``.
+2. The valid-survivor filter drops PHANTOM survivors (id in state but body
+   missing) and any id not in ``state.json["survivors"]``.
+3. Determinism — identical inputs yield an identical pool file set and an
+   identical content hash across two independent runs.
+4. Flat ``.md`` copy + manifest correctness, including ``candidates_evolved/``
+   bodies, with the manifest hash matching ``seed_pool_content_hash(out)``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.baseline_epoch import seed_pool_content_hash
+from scripts.assemble_seed_pool import (
+    assemble_pool,
+    collect_valid_survivors,
+    parse_gen_tag_key,
+    select_runs,
+)
+
+
+def _write_run(
+    seeds_root: Path,
+    *,
+    run_id: str,
+    gen_tag: str,
+    survivors_state: list[str],
+    bodies: dict[str, str],
+    rel_subdir: str = "candidates",
+) -> Path:
+    """Create one synthetic seed-generation run dir under ``seeds_root``.
+
+    ``survivors_state`` is the canonical ``state.json["survivors"]`` id list.
+    ``bodies`` maps survivor_id -> body text for which an actual ``.md`` file is
+    written under ``rel_subdir`` (omit an id from ``bodies`` to make it a phantom:
+    listed in state, no body on disk). ``survivors.json`` lists every id in
+    ``survivors_state`` so the body-existence filter is what drops phantoms.
+    """
+    run_dir = seeds_root / run_id
+    body_dir = run_dir / rel_subdir
+    body_dir.mkdir(parents=True, exist_ok=True)
+
+    survivor_entries = []
+    for survivor_id in survivors_state:
+        rel_path = f"{rel_subdir}/{survivor_id}.md"
+        survivor_entries.append({"id": survivor_id, "path": rel_path, "elo_rating": 1000.0})
+        body_text = bodies.get(survivor_id)
+        if body_text is not None:
+            (run_dir / rel_path).write_text(body_text, encoding="utf-8")
+
+    (run_dir / "state.json").write_text(
+        json.dumps({"run_id": run_id, "gen_tag": gen_tag, "survivors": survivors_state}),
+        encoding="utf-8",
+    )
+    (run_dir / "survivors.json").write_text(
+        json.dumps({"run_id": run_id, "gen_tag": gen_tag, "survivors": survivor_entries}),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+@pytest.fixture
+def seeds_tree(tmp_path: Path) -> Path:
+    """A synthetic seeds root with 5 runs across distinct gen_tags.
+
+    - gen-2605-4 / gen-2605-3 : the two highest tags (should be selected by N=2).
+    - gen-2605-2 / gen-2605-1 : lower 2605 tags (should NOT be selected).
+    - gen1                    : legacy bare tag (lowest; never selected).
+
+    gen-2605-3 carries a PHANTOM survivor (``...-phantom`` is in state but has no
+    body) plus a ``candidates_evolved/`` body to exercise that path.
+    """
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-unfaithful_thinking",
+        gen_tag="gen-2605-4",
+        survivors_state=["g4-001", "g4-002"],
+        bodies={"g4-001": "g4 body one\n", "g4-002": "g4 body two\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-3-broken_tool_use",
+        gen_tag="gen-2605-3",
+        survivors_state=["g3-001", "g3-phantom", "g3-evolved"],
+        # g3-phantom is in state but gets no body file -> must be dropped.
+        bodies={"g3-001": "g3 body one\n"},
+    )
+    # Add an evolved-path survivor to gen-2605-3 (separate subdir).
+    g3_dir = seeds_root / "gen-2605-3-broken_tool_use"
+    (g3_dir / "candidates_evolved").mkdir()
+    (g3_dir / "candidates_evolved" / "g3-evolved.md").write_text("g3 evolved\n", encoding="utf-8")
+    survivors_meta = json.loads((g3_dir / "survivors.json").read_text(encoding="utf-8"))
+    for entry in survivors_meta["survivors"]:
+        if entry["id"] == "g3-evolved":
+            entry["path"] = "candidates_evolved/g3-evolved.md"
+    (g3_dir / "survivors.json").write_text(json.dumps(survivors_meta), encoding="utf-8")
+
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-2-redundant_tool_invocation",
+        gen_tag="gen-2605-2",
+        survivors_state=["g2-001"],
+        bodies={"g2-001": "g2 body\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-1-redundant_tool_invocation",
+        gen_tag="gen-2605-1",
+        survivors_state=["g1x-001"],
+        bodies={"g1x-001": "g1x body\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen1-broken_tool_use",
+        gen_tag="gen1",
+        survivors_state=["legacy-001"],
+        bodies={"legacy-001": "legacy body\n"},
+    )
+    return seeds_root
+
+
+def test_parse_gen_tag_key_orders_2605_above_legacy() -> None:
+    assert parse_gen_tag_key("gen-2605-4") == (2605, 4)
+    assert parse_gen_tag_key("gen-2605-3") == (2605, 3)
+    assert parse_gen_tag_key("gen1") == (1,)
+    # Descending sort puts the highest tags first; legacy gen1 sorts last.
+    keys = [parse_gen_tag_key(t) for t in ["gen1", "gen-2605-1", "gen-2605-4", "gen-2605-3"]]
+    assert sorted(keys, reverse=True) == [(2605, 4), (2605, 3), (2605, 1), (1,)]
+
+
+def test_parse_gen_tag_key_non_numeric_segment_is_graceful() -> None:
+    # A non-numeric trailing segment never raises; the numeric prefix still orders.
+    assert parse_gen_tag_key("gen-2605-4-unfaithful") == (2605, 4)
+    assert parse_gen_tag_key("gen-weird") == ()
+
+
+def test_select_runs_picks_two_highest_gen_tags(seeds_tree: Path) -> None:
+    seeds_root = seeds_tree
+    selected = select_runs(seeds_root, runs=2, per_run=None)
+    assert [run.run_id for run in selected] == [
+        "gen-2605-4-unfaithful_thinking",
+        "gen-2605-3-broken_tool_use",
+    ]
+    # gen-2605-2 / gen-2605-1 / gen1 are NOT selected.
+    assert all("gen-2605-2" not in run.run_id for run in selected)
+    assert all(not run.run_id.startswith("gen1-") for run in selected)
+
+
+def test_phantom_and_non_state_ids_are_dropped(seeds_tree: Path) -> None:
+    seeds_root = seeds_tree
+    g3_dir = seeds_root / "gen-2605-3-broken_tool_use"
+    valid = collect_valid_survivors(g3_dir, per_run=None)
+    valid_ids = [survivor_id for survivor_id, _ in valid]
+    # g3-phantom is in state but has no body -> dropped. g3-001 + g3-evolved kept.
+    assert "g3-phantom" not in valid_ids
+    assert valid_ids == ["g3-001", "g3-evolved"]
+
+
+def test_id_not_in_state_is_dropped(tmp_path: Path) -> None:
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    run_dir = _write_run(
+        seeds_root,
+        run_id="gen-2605-9-x",
+        gen_tag="gen-2605-9",
+        survivors_state=["keep-001"],
+        bodies={"keep-001": "kept\n"},
+    )
+    # Add a survivors.json entry + body for an id that is NOT in state.json.
+    (run_dir / "candidates" / "stray-001.md").write_text("stray\n", encoding="utf-8")
+    survivors_meta = json.loads((run_dir / "survivors.json").read_text(encoding="utf-8"))
+    survivors_meta["survivors"].append(
+        {"id": "stray-001", "path": "candidates/stray-001.md", "elo_rating": 999.0}
+    )
+    (run_dir / "survivors.json").write_text(json.dumps(survivors_meta), encoding="utf-8")
+
+    valid_ids = [survivor_id for survivor_id, _ in collect_valid_survivors(run_dir, per_run=None)]
+    assert valid_ids == ["keep-001"]
+
+
+def test_evolved_path_body_is_copied(seeds_tree: Path, tmp_path: Path) -> None:
+    out_dir = tmp_path / "pool"
+    assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_dir,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2026-05-30T00:00:00+00:00",
+    )
+    evolved_pool_body = out_dir / "g3-evolved.md"
+    assert evolved_pool_body.is_file()
+    assert evolved_pool_body.read_text(encoding="utf-8") == "g3 evolved\n"
+
+
+def test_flat_copy_and_manifest_correctness(seeds_tree: Path, tmp_path: Path) -> None:
+    out_dir = tmp_path / "pool"
+    manifest = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_dir,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2026-05-30T00:00:00+00:00",
+    )
+
+    md_files = sorted(p.name for p in out_dir.glob("*.md"))
+    # 2 from gen-2605-4 + (g3-001, g3-evolved) from gen-2605-3 (phantom dropped) = 4.
+    assert md_files == ["g3-001.md", "g3-evolved.md", "g4-001.md", "g4-002.md"]
+    # No tier subdirs — flat pool.
+    assert not [p for p in out_dir.iterdir() if p.is_dir()]
+
+    assert manifest["total_survivors"] == 4
+    assert manifest["selected_run_ids"] == [
+        "gen-2605-4-unfaithful_thinking",
+        "gen-2605-3-broken_tool_use",
+    ]
+    by_run = {run["run_id"]: run for run in manifest["runs"]}
+    assert by_run["gen-2605-4-unfaithful_thinking"]["survivor_ids"] == ["g4-001", "g4-002"]
+    assert by_run["gen-2605-3-broken_tool_use"]["survivor_ids"] == ["g3-001", "g3-evolved"]
+    assert manifest["generated_at"] == "2026-05-30T00:00:00+00:00"
+
+    # Manifest content_hash matches a fresh hash of the out dir. The manifest.json
+    # itself is part of the dir; the recorded hash was computed before it was
+    # written, so re-hash a sibling copy holding only the .md bodies.
+    bodies_only = tmp_path / "bodies_only"
+    bodies_only.mkdir()
+    for md in out_dir.glob("*.md"):
+        (bodies_only / md.name).write_text(md.read_text(encoding="utf-8"), encoding="utf-8")
+    assert manifest["content_hash"] == seed_pool_content_hash(str(bodies_only))
+    assert manifest["content_hash"].startswith("pool-")
+
+
+def test_determinism_same_inputs_same_pool_and_hash(seeds_tree: Path, tmp_path: Path) -> None:
+    out_a = tmp_path / "pool_a"
+    out_b = tmp_path / "pool_b"
+    manifest_a = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_a,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2026-05-30T00:00:00+00:00",
+    )
+    manifest_b = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_b,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2026-05-30T00:00:00+00:00",
+    )
+    assert sorted(p.name for p in out_a.glob("*.md")) == sorted(p.name for p in out_b.glob("*.md"))
+    assert manifest_a["content_hash"] == manifest_b["content_hash"]
+    assert manifest_a["runs"] == manifest_b["runs"]
+
+
+def test_per_run_cap_is_deterministic(seeds_tree: Path, tmp_path: Path) -> None:
+    out_dir = tmp_path / "pool"
+    manifest = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_dir,
+        runs=2,
+        per_run=1,
+        force=False,
+        now=None,
+    )
+    # 1 survivor per selected run -> 2 total; capped survivors are the id-sorted first.
+    assert manifest["total_survivors"] == 2
+    by_run = {run["run_id"]: run for run in manifest["runs"]}
+    assert by_run["gen-2605-4-unfaithful_thinking"]["survivor_ids"] == ["g4-001"]
+    assert by_run["gen-2605-3-broken_tool_use"]["survivor_ids"] == ["g3-001"]
+
+
+def test_refuse_nonempty_out_without_force(seeds_tree: Path, tmp_path: Path) -> None:
+    out_dir = tmp_path / "pool"
+    out_dir.mkdir()
+    (out_dir / "preexisting.md").write_text("do not clobber\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        assemble_pool(
+            seeds_root=seeds_tree,
+            out_dir=out_dir,
+            runs=2,
+            per_run=None,
+            force=False,
+            now=None,
+        )
+    # The pre-existing file is untouched.
+    assert (out_dir / "preexisting.md").read_text(encoding="utf-8") == "do not clobber\n"
+
+
+def test_force_overwrites_nonempty_out(seeds_tree: Path, tmp_path: Path) -> None:
+    out_dir = tmp_path / "pool"
+    out_dir.mkdir()
+    (out_dir / "stale.md").write_text("stale\n", encoding="utf-8")
+    assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_dir,
+        runs=2,
+        per_run=None,
+        force=True,
+        now=None,
+    )
+    # Stale file is gone; only fresh pool bodies + manifest remain.
+    assert not (out_dir / "stale.md").exists()
+    assert sorted(p.name for p in out_dir.glob("*.md")) == [
+        "g3-001.md",
+        "g3-evolved.md",
+        "g4-001.md",
+        "g4-002.md",
+    ]
+
+
+def test_no_valid_survivors_raises(tmp_path: Path) -> None:
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    # A run whose only survivor is a phantom (no body) -> zero valid -> error.
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-1-x",
+        gen_tag="gen-2605-1",
+        survivors_state=["phantom-only"],
+        bodies={},
+    )
+    out_dir = tmp_path / "pool"
+    with pytest.raises(SystemExit):
+        assemble_pool(
+            seeds_root=seeds_root,
+            out_dir=out_dir,
+            runs=2,
+            per_run=None,
+            force=False,
+            now=None,
+        )
+
+
+def test_missing_seeds_root_raises(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        select_runs(tmp_path / "does-not-exist", runs=2, per_run=None)

--- a/tests/test_assemble_seed_pool.py
+++ b/tests/test_assemble_seed_pool.py
@@ -139,10 +139,17 @@ def test_parse_gen_tag_key_orders_2605_above_legacy() -> None:
     assert sorted(keys, reverse=True) == [(2605, 4), (2605, 3), (2605, 1), (1,)]
 
 
-def test_parse_gen_tag_key_non_numeric_segment_is_graceful() -> None:
-    # A non-numeric trailing segment never raises; the numeric prefix still orders.
-    assert parse_gen_tag_key("gen-2605-4-unfaithful") == (2605, 4)
-    assert parse_gen_tag_key("gen-weird") == ()
+def test_parse_gen_tag_key_malformed_returns_none() -> None:
+    # FIX 2/3: anything outside the two accepted shapes (gen-<stamp>-<counter>
+    # or legacy gen<n>) is malformed -> None, so it sorts lowest at the caller.
+    assert parse_gen_tag_key("") is None
+    assert parse_gen_tag_key("gen-weird") is None
+    assert parse_gen_tag_key("genfoo") is None
+    assert parse_gen_tag_key("2605-4") is None  # no gen prefix
+    # A non-numeric trailing segment never raises but is malformed (not (2605,4)).
+    assert parse_gen_tag_key("gen-2605-4-unfaithful") is None
+    # FIX 3: a spurious extra numeric segment must NOT parse above gen-2605-4.
+    assert parse_gen_tag_key("gen-2605-4-999") is None
 
 
 def test_select_runs_picks_two_highest_gen_tags(seeds_tree: Path) -> None:
@@ -348,3 +355,174 @@ def test_no_valid_survivors_raises(tmp_path: Path) -> None:
 def test_missing_seeds_root_raises(tmp_path: Path) -> None:
     with pytest.raises(SystemExit):
         select_runs(tmp_path / "does-not-exist", runs=2, per_run=None)
+
+
+# --- FIX 1: duplicate destination basename across selected runs --------------
+
+
+def test_duplicate_survivor_id_across_runs_fails_closed(tmp_path: Path) -> None:
+    # Two selected runs each contain a VALID survivor with the SAME id. The flat
+    # pool would write <id>.md twice (silent overwrite + manifest over-count), so
+    # assembly must fail closed naming the colliding id.
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-a",
+        gen_tag="gen-2605-4",
+        survivors_state=["dup-001"],
+        bodies={"dup-001": "from run four\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-3-b",
+        gen_tag="gen-2605-3",
+        survivors_state=["dup-001"],
+        bodies={"dup-001": "from run three\n"},
+    )
+    out_dir = tmp_path / "pool"
+    with pytest.raises(SystemExit) as excinfo:
+        assemble_pool(
+            seeds_root=seeds_root,
+            out_dir=out_dir,
+            runs=2,
+            per_run=None,
+            force=False,
+            now=None,
+        )
+    message = str(excinfo.value)
+    assert "dup-001" in message
+    # Both colliding run_ids are surfaced.
+    assert "gen-2605-4-a" in message
+    assert "gen-2605-3-b" in message
+    # Fail-closed BEFORE writing: no pool dir was created.
+    assert not out_dir.exists()
+
+
+# --- FIX 2: missing/empty gen_tag sorts lowest, never selected ---------------
+
+
+def test_missing_gen_tag_sorts_lowest_not_selected(tmp_path: Path) -> None:
+    # A run with an empty gen_tag must sort LOWEST (never beat a well-formed run
+    # via its directory name) — even when its dir name looks like a high tag.
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-2-clean",
+        gen_tag="gen-2605-2",
+        survivors_state=["clean-001"],
+        bodies={"clean-001": "clean body\n"},
+    )
+    # Directory name LOOKS like the newest run, but its gen_tag is empty.
+    _write_run(
+        seeds_root,
+        run_id="gen-9999-x-malformed",
+        gen_tag="",
+        survivors_state=["bad-001"],
+        bodies={"bad-001": "malformed body\n"},
+    )
+    selected = select_runs(seeds_root, runs=1, per_run=None)
+    assert [run.run_id for run in selected] == ["gen-2605-2-clean"]
+
+
+# --- FIX 3: spurious extra numeric segment does not outrank a clean tag -------
+
+
+def test_extra_numeric_segment_does_not_outrank_clean_tag(tmp_path: Path) -> None:
+    # gen-2605-4-999 must NOT tuple-compare above gen-2605-4; the malformed run
+    # sorts lowest, so the clean gen-2605-4 run is selected.
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-clean",
+        gen_tag="gen-2605-4",
+        survivors_state=["clean-001"],
+        bodies={"clean-001": "clean body\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-999-spurious",
+        gen_tag="gen-2605-4-999",
+        survivors_state=["spurious-001"],
+        bodies={"spurious-001": "spurious body\n"},
+    )
+    selected = select_runs(seeds_root, runs=1, per_run=None)
+    assert [run.run_id for run in selected] == ["gen-2605-4-clean"]
+
+
+# --- Tie-break determinism: same gen_tag -> stable order by run_id ------------
+
+
+def test_same_gen_tag_tie_breaks_by_run_id(tmp_path: Path) -> None:
+    # Two runs share gen_tag; descending (sort_key, run_id) is the deterministic
+    # tie-break, so the higher run_id sorts first regardless of fs iteration.
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-alpha",
+        gen_tag="gen-2605-4",
+        survivors_state=["a-001"],
+        bodies={"a-001": "alpha\n"},
+    )
+    _write_run(
+        seeds_root,
+        run_id="gen-2605-4-beta",
+        gen_tag="gen-2605-4",
+        survivors_state=["b-001"],
+        bodies={"b-001": "beta\n"},
+    )
+    selected = select_runs(seeds_root, runs=2, per_run=None)
+    # Descending run_id tie-break: "...beta" > "...alpha".
+    assert [run.run_id for run in selected] == [
+        "gen-2605-4-beta",
+        "gen-2605-4-alpha",
+    ]
+
+
+# --- FIX 4: absolute / escaping survivor body paths are dropped --------------
+
+
+def test_absolute_and_escaping_paths_are_dropped(tmp_path: Path) -> None:
+    seeds_root = tmp_path / "seeds"
+    seeds_root.mkdir()
+    run_dir = _write_run(
+        seeds_root,
+        run_id="gen-2605-5-paths",
+        gen_tag="gen-2605-5",
+        survivors_state=["local-001"],
+        bodies={"local-001": "run-local body\n"},
+    )
+
+    # A body that physically EXISTS outside the run dir (would be accepted if the
+    # path were trusted blindly).
+    outside_body = tmp_path / "outside.md"
+    outside_body.write_text("absolute escape\n", encoding="utf-8")
+    # A sibling run holding a body reachable via ``../``.
+    other_run = seeds_root / "gen-2605-9-other"
+    (other_run / "candidates").mkdir(parents=True)
+    (other_run / "candidates" / "escape.md").write_text("relative escape\n", encoding="utf-8")
+
+    survivors_meta = json.loads((run_dir / "survivors.json").read_text(encoding="utf-8"))
+    state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
+    state["survivors"].extend(["abs-001", "rel-001"])
+    survivors_meta["survivors"].append(
+        {"id": "abs-001", "path": str(outside_body), "elo_rating": 1.0}
+    )
+    survivors_meta["survivors"].append(
+        {
+            "id": "rel-001",
+            "path": "../gen-2605-9-other/candidates/escape.md",
+            "elo_rating": 1.0,
+        }
+    )
+    (run_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (run_dir / "survivors.json").write_text(json.dumps(survivors_meta), encoding="utf-8")
+
+    valid_ids = [survivor_id for survivor_id, _ in collect_valid_survivors(run_dir, per_run=None)]
+    # Only the run-local survivor survives; both escapes are dropped as invalid.
+    assert valid_ids == ["local-001"]
+    assert "abs-001" not in valid_ids
+    assert "rel-001" not in valid_ids


### PR DESCRIPTION
## Summary
- Deterministic (no LLM, no randomness, no mtime) `scripts/assemble_seed_pool.py` that assembles a combined seed pool from the N most-recent seed-generation runs — the input pool for the upcoming closed-loop 10-cycle.
- Time-sorts runs by a STABLE parsed `gen_tag` key, keeps only VALID survivors (id ∈ state.json survivors ∩ body exists), copies them flat, and emits the pool's content-hash via the shared `seed_pool_content_hash`.

## Why
The 10-cycle needs a fixed, reproducible input pool drawn from the latest seed-gen survivors. Doing this by hand or via an LLM is non-deterministic; the operator specified a deterministic script that always yields the same pool + content-hash for the same survivor set.

## Changes
| File | Change |
|------|--------|
| `scripts/assemble_seed_pool.py` (new) | Deterministic assembler: `gen_tag`→int-tuple sort (strict `gen-<stamp>-<counter>` or legacy `gen<n>`; malformed → sorts lowest), valid-survivor filter (state ∩ body-exists, run-local path enforced), flat `.md` copy, `manifest.json`, content-hash via `seed_pool_content_hash`. CLI: `--seeds-root/--runs/--per-run/--out/--force/--now`. Fails closed on dup-id collision, zero survivors, bad args. |
| `tests/test_assemble_seed_pool.py` (new) | 18 tests: time-sort (incl. gen1 vs gen-2605, extra-segment, tie-break), phantom/non-state/path-escape drops, determinism (same hash), candidates_evolved, manifest, dup-id fail-closed. |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean
- [x] pytest 18 passed
- [x] Codex MCP review (4 hardening findings — dup-id overwrite, missing-`gen_tag` dir-name fallback, extra-segment ordering, path-escape — all fixed + tested in commit `6dfdc27d`)
- [x] Real-data dry-run (to tmp, not committed): selects gen-2605-4 + gen-2605-3 = 10 survivors, hash `pool-68dc6f0c9745`, stable across runs

## Reference
operator 2026-05-30 (deterministic pool assembly, no LLM); B-track precondition for the 10-cycle (#21). Pairs with content-addressed epochs (`seed_pool_content_hash`, #1918).

🤖 Generated with [Claude Code](https://claude.com/claude-code)