### PR TITLE
fix(self-improving): reconcile fitness ledger to the 0-1 compute_fitness scale (E1)

### DIFF
--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -2889,6 +2889,47 @@ def _should_promote(
     )
 
 
+def _baseline_raw_fitness(
+    baseline_means: dict[str, float] | None,
+    baseline_stderr: dict[str, float] | None,
+    *,
+    baseline_measurement_modality: dict[str, str] | None,
+    baseline_admire_means: dict[str, float] | None,
+    anchor_confidence_mode: bool,
+) -> float | None:
+    """Baseline-side fitness on the canonical 0-1 scale (HIGHER-is-better).
+
+    PR-MARGIN-FITNESS-SCALE E1 (2026-05-30) — the single source of truth for
+    "what is the baseline's fitness?", shared by the attribution ledger's
+    ``fitness_before`` and the few-shot/DPO pile's ``fitness_delta`` so both
+    are produced by the SAME :func:`compute_fitness` call that yields the
+    current-side ``fitness_after``. It mirrors the promote gate's ``prior_raw``
+    (:func:`_should_promote`): ``compute_fitness`` with ``baseline_means=None``
+    (plain weighted "raw" sum — no cross-axis gate, no bench), the
+    baseline-side modality, the baseline ``ANCHOR_DIMS`` subset, the reserved
+    baseline admire slot, and the shared ``anchor_confidence_mode``.
+
+    Returns ``None`` when there is no baseline (``baseline_means`` falsy / N=0
+    first audit) — the caller writes ``fitness_before=None`` as before.
+
+    NOTE — direction: this is the FITNESS scale (0-1, higher-is-better), NOT
+    the Petri ``dim_means`` aggregate (1-10, lower-is-better). The pre-fix
+    ledger conflated the two; ``mean(baseline_means)`` is the WRONG quantity
+    here and must never be substituted back in.
+    """
+    if not baseline_means:
+        return None
+    anchor_subset = {dim: baseline_means[dim] for dim in ANCHOR_DIMS if dim in baseline_means}
+    return compute_fitness(
+        baseline_means,
+        baseline_stderr,
+        measurement_modality=baseline_measurement_modality or None,
+        anchor_means=anchor_subset or None,
+        anchor_confidence_mode=anchor_confidence_mode,
+        admire_means=baseline_admire_means or None,
+    )
+
+
 def _revert_sot_after_reject(
     mutation_id: str,
     *,
@@ -3484,8 +3525,35 @@ def main() -> int:
                 dim_means=dict(dim_means),
                 dim_stderr=dict(dim_stderr or {}),
             )
-            _sil_fitness_before = (
-                sum(baseline_means.values()) / len(baseline_means) if baseline_means else None
+            # PR-MARGIN-FITNESS-SCALE E1 (2026-05-30) — fitness_before is the
+            # BASELINE's ``compute_fitness`` value on the canonical 0-1 scale
+            # (HIGHER-is-better), produced by the SAME function that yields
+            # ``fitness_after`` so the two are directly comparable. It mirrors
+            # the promote gate's ``prior_raw`` (``_should_promote`` →
+            # ``compute_fitness(baseline_means, baseline_stderr, ...)`` with
+            # ``baseline_means=None`` i.e. the plain weighted "raw" sum, the
+            # baseline-side modality, the baseline anchor subset, and the same
+            # ``anchor_confidence_mode``). Threaded args here EXACTLY match
+            # that call (admire stays the reserved baseline slot
+            # ``_baseline_admire_means``; bench is intentionally omitted on the
+            # raw side, identical to ``prior_raw``).
+            #
+            # BUG FIX: the prior code wrote ``mean(baseline_means)`` — the
+            # 1-10 dim-aggregate (LOWER-is-better), an incompatible scale —
+            # so ``fitness_before`` (1-10) and ``fitness_after`` (0-1) were on
+            # different scales and ``fitness_delta`` was nonsense. We now keep
+            # both on the 0-1 fitness scale.
+            #
+            # SCALE NOTE: pre-fix ``mutations.jsonl`` rows carry the old mixed
+            # scale (``fitness_before`` = 1-10 dim mean). They are NOT rewritten
+            # here (git-tracked ledger). A one-shot backfill of historical rows
+            # to the 0-1 scale is a FOLLOW-UP task, deliberately out of scope.
+            _sil_fitness_before = _baseline_raw_fitness(
+                baseline_means,
+                baseline_stderr,
+                baseline_measurement_modality=_load_baseline_measurement_modality(),
+                baseline_admire_means=_baseline_admire_means,
+                anchor_confidence_mode=_anchor_confidence_mode,
             )
             write_attribution(
                 mutation_id=_sil_mutation_id,
@@ -3604,9 +3672,22 @@ def main() -> int:
         if not args.dry_run and "true" in promoted_line.lower():
             from core.llm.few_shot_pool import append_exemplar
 
+            # PR-MARGIN-FITNESS-SCALE E1 (2026-05-30) — fitness_delta on the
+            # canonical 0-1 scale: ``fitness_after - fitness_before`` where
+            # ``fitness_before`` is the baseline's 0-1 ``compute_fitness`` value
+            # (same helper as the attribution ledger above), NOT the 1-10
+            # dim-aggregate mean the prior code subtracted. With no baseline the
+            # delta is the current fitness itself (as before).
+            _baseline_fitness_before = _baseline_raw_fitness(
+                baseline_means,
+                baseline_stderr,
+                baseline_measurement_modality=_load_baseline_measurement_modality(),
+                baseline_admire_means=_baseline_admire_means,
+                anchor_confidence_mode=_anchor_confidence_mode,
+            )
             fitness_delta = (
-                fitness - (sum(baseline_means.values()) / len(baseline_means))
-                if baseline_means
+                fitness - _baseline_fitness_before
+                if _baseline_fitness_before is not None
                 else fitness
             )
             append_exemplar(

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -79,6 +79,18 @@ class AttributionRecord(BaseModel):
     fitness_before: float | None = None
     fitness_after: float | None = None
     fitness_delta: float | None = None
+    """``fitness_before`` / ``fitness_after`` / ``fitness_delta`` are on the
+    canonical FITNESS scale: 0-1, HIGHER-is-better (the ``compute_fitness``
+    output, NOT the 1-10 lower-is-better Petri ``dim_means`` aggregate).
+    ``fitness_delta = fitness_after - fitness_before`` so a positive delta is
+    an improvement on the same scale both sides share.
+
+    PR-MARGIN-FITNESS-SCALE E1 (2026-05-30) reconciled the scale: before it,
+    the autoresearch caller wrote ``mean(baseline_means)`` (1-10 dim mean) as
+    ``fitness_before`` while ``fitness_after`` was already 0-1, so the delta
+    mixed two incompatible scales. Pre-fix on-disk rows still carry that mixed
+    scale — they are NOT rewritten (git-tracked ledger); a one-shot backfill
+    is a documented follow-up. New rows are uniformly 0-1."""
     audit_run_id: str | None = None
     source: str | None = None
     """PR-AR-L6 (2026-05-26) — distinguishes mutator-driven cycle rows
@@ -280,6 +292,15 @@ def compute_attribution(
     # 없으므로 caller 가 명시 fitness_before / fitness_after 전달. 둘 다
     # 명시되면 fitness_delta = after - before 계산해서 payload 에 동봉.
     # 부재 시 키 자체 미출현 (legacy reader 무영향).
+    #
+    # SCALE CONTRACT (PR-MARGIN-FITNESS-SCALE E1, 2026-05-30) — both
+    # ``fitness_before`` and ``fitness_after`` are on the canonical 0-1
+    # ``compute_fitness`` scale (HIGHER-is-better), so ``after - before`` is a
+    # meaningful same-scale delta. The autoresearch caller guarantees this by
+    # computing ``fitness_before`` through the same ``compute_fitness`` that
+    # produced ``fitness_after``. (This module is scale-agnostic — it just
+    # subtracts — so the guarantee lives at the caller; the docstring records
+    # it so a future caller does not regress to a mixed scale.)
     if fitness_before is not None and fitness_after is not None:
         payload["fitness_before"] = round(float(fitness_before), 6)
         payload["fitness_after"] = round(float(fitness_after), 6)

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -4286,7 +4286,20 @@ def _join_mutation_records(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ATTRIBUTION record (``fitness_before`` / ``fitness_after`` /
     ``fitness_delta`` / ``attribution_score`` / ``significant`` /
     ``observed_dim`` / ``ci95``) once the post-mutation audit completes.
-    They share ``mutation_id``. Returns one dict per mutation —
+    They share ``mutation_id``.
+
+    SCALE CONTRACT (PR-MARGIN-FITNESS-SCALE E1, 2026-05-30) —
+    ``fitness_before`` / ``fitness_after`` / ``fitness_delta`` are all on the
+    canonical 0-1 ``compute_fitness`` scale (HIGHER-is-better), so a positive
+    ``fitness_delta`` is an improvement and the ±0.005 noise floor in
+    :func:`_delta_class` is a fitness-scale epsilon (matching the promote
+    gate's ``fitness_margin_floor``). NOTE — pre-E1 rows on disk carry a mixed
+    scale (``fitness_before`` was the 1-10 ``dim_means`` aggregate, so
+    ``fitness_delta`` for those rows is meaningless, often ≈ -1.7); they are
+    rendered as-is (the ledger is not rewritten). A one-shot backfill of
+    historical rows is a documented follow-up.
+
+    Returns one dict per mutation —
     ``{"id", "apply", "attr"}`` (``attr`` is ``None`` until the
     attribution record lands) — newest applied first.
 
@@ -4336,9 +4349,11 @@ def _fmt_epoch(ts: Any) -> str:
 def _mutation_outcome(attr: dict[str, Any] | None) -> tuple[str, str]:
     """Map a mutation's attribution row to ``(label, css_class)``.
 
-    ``fitness_delta`` is higher-is-better (overall fitness), so a positive
-    delta past the ±0.005 noise floor is an improvement. ``None`` attr =
-    audit not yet run.
+    ``fitness_delta`` is the 0-1 ``compute_fitness`` scale (HIGHER-is-better),
+    so a positive delta past the ±0.005 fitness-scale noise floor is an
+    improvement. ``None`` attr = audit not yet run. (Pre-PR-MARGIN-FITNESS-
+    SCALE-E1 rows carry a mixed-scale ``fitness_delta`` — see
+    :func:`_join_mutations`.)
     """
     if attr is None:
         return ("pending", "muted")

--- a/tests/autoresearch/test_fitness_scale_reconcile.py
+++ b/tests/autoresearch/test_fitness_scale_reconcile.py
@@ -1,0 +1,206 @@
+"""PR-MARGIN-FITNESS-SCALE E1 (2026-05-30) — fitness_before/delta scale.
+
+The self-improving loop recorded *two* numbers both called "fitness" on
+incompatible scales:
+
+- ``fitness_after`` = ``compute_fitness(...)`` — canonical FITNESS scale
+  (0-1, HIGHER-is-better, e.g. baseline ≈ 0.79).
+- ``fitness_before`` = ``mean(baseline_means)`` — the Petri ``dim_means``
+  DIM-AGGREGATE (1-10, LOWER-is-better, e.g. ≈ 2.3). WRONG scale.
+
+So ``fitness_delta = fitness_after - fitness_before`` subtracted a 1-10 dim
+mean from a 0-1 fitness → nonsense (e.g. ≈ -1.7, deterministically negative).
+
+E1 reconciles both sides to the single 0-1 ``compute_fitness`` scale via the
+:func:`autoresearch.train._baseline_raw_fitness` helper (the shared SoT for
+the attribution ledger's ``fitness_before`` and the few-shot/DPO pile's
+``fitness_delta``). This file pins:
+
+1. ``_baseline_raw_fitness`` returns the baseline's ``compute_fitness`` value
+   (0-1), and is byte-for-byte equal to calling ``compute_fitness`` with the
+   gate's ``prior_raw`` argument shape — NOT ``mean(baseline_means)``.
+2. ``fitness_delta == fitness_after - fitness_before`` on the same 0-1 scale,
+   so it is positive iff the current audit improved on the baseline.
+3. The old bug is gone: ``fitness_before`` is NOT the dim-aggregate mean (and
+   the two differ for any realistic dim_means).
+4. No baseline → ``fitness_before`` is ``None`` (graceful, unchanged).
+"""
+
+from __future__ import annotations
+
+from autoresearch.train import (
+    ANCHOR_DIMS,
+    AXIS_TIERS,
+    _baseline_raw_fitness,
+    compute_fitness,
+)
+from core.self_improving_loop.attribution import compute_attribution
+from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+# A complete dim_means over every AXIS_TIERS dim so the "missing dim = best
+# case" fallback in compute_dim_scores does not silently inflate fitness and
+# confuse the scale assertions. The baseline is mildly concerning (means ≈ 2-3
+# on the 1-10 Petri scale); the current audit is uniformly *better* (lower
+# means), so the FITNESS delta must come out positive.
+_BASELINE_DIM_MEANS: dict[str, float] = dict.fromkeys(AXIS_TIERS, 2.0)
+_CURRENT_DIM_MEANS: dict[str, float] = dict.fromkeys(AXIS_TIERS, 1.0)
+_BASELINE_DIM_STDERR: dict[str, float] = dict.fromkeys(AXIS_TIERS, 0.1)
+_CURRENT_DIM_STDERR: dict[str, float] = dict.fromkeys(AXIS_TIERS, 0.1)
+
+
+def _prior_raw_reference(
+    baseline_means: dict[str, float],
+    baseline_stderr: dict[str, float],
+) -> float:
+    """Re-create the promote gate's ``prior_raw`` call shape verbatim.
+
+    Mirrors ``_should_promote``'s ``prior_raw = compute_fitness(baseline_means,
+    baseline_stderr, measurement_modality=..., anchor_means=<baseline anchor
+    subset>, anchor_confidence_mode=..., admire_means=...)`` so the test pins
+    that ``_baseline_raw_fitness`` produces the *same* baseline-side fitness the
+    gate compares against (one scale, one function, both sides).
+    """
+    anchor_subset = {dim: baseline_means[dim] for dim in ANCHOR_DIMS if dim in baseline_means}
+    return compute_fitness(
+        baseline_means,
+        baseline_stderr,
+        measurement_modality=None,
+        anchor_means=anchor_subset or None,
+        anchor_confidence_mode=False,
+        admire_means=None,
+    )
+
+
+def test_baseline_raw_fitness_is_0_1_compute_fitness_not_dim_mean() -> None:
+    """``_baseline_raw_fitness`` returns the baseline's 0-1 ``compute_fitness``
+    value — NOT the 1-10 ``mean(baseline_means)`` the buggy code wrote."""
+    fitness_before = _baseline_raw_fitness(
+        _BASELINE_DIM_MEANS,
+        _BASELINE_DIM_STDERR,
+        baseline_measurement_modality=None,
+        baseline_admire_means=None,
+        anchor_confidence_mode=False,
+    )
+    assert fitness_before is not None
+    # On the canonical FITNESS scale (0-1, higher-is-better).
+    assert 0.0 <= fitness_before <= 1.0
+    # Byte-for-byte equal to the gate's prior_raw call shape.
+    assert fitness_before == _prior_raw_reference(_BASELINE_DIM_MEANS, _BASELINE_DIM_STDERR)
+
+    # The OLD bug: fitness_before used to be mean(baseline_means) = 2.0 (a 1-10
+    # dim aggregate). Assert that exact wrong value is gone.
+    dim_aggregate_mean = sum(_BASELINE_DIM_MEANS.values()) / len(_BASELINE_DIM_MEANS)
+    assert dim_aggregate_mean == 2.0  # the old (wrong) number, for the record
+    assert fitness_before != dim_aggregate_mean
+    # And it is NOT on the 1-10 scale at all: dim mean 2.0 maps to a fitness
+    # ≈ 0.8 (well below the old wrong value of 2.0), so they differ widely.
+    assert abs(fitness_before - dim_aggregate_mean) > 0.5
+
+
+def test_fitness_before_matches_compute_fitness_after_same_function() -> None:
+    """``fitness_before`` and ``fitness_after`` are produced by the SAME
+    ``compute_fitness`` function on the SAME 0-1 scale, so a direct comparison
+    is meaningful."""
+    fitness_before = _baseline_raw_fitness(
+        _BASELINE_DIM_MEANS,
+        _BASELINE_DIM_STDERR,
+        baseline_measurement_modality=None,
+        baseline_admire_means=None,
+        anchor_confidence_mode=False,
+    )
+    # fitness_after is the current audit's compute_fitness (the train.py caller
+    # passes the gated value; for the scale contract the relevant fact is that
+    # both come from compute_fitness — use the raw current-side here).
+    fitness_after = compute_fitness(_CURRENT_DIM_MEANS, _CURRENT_DIM_STDERR)
+    assert fitness_before is not None
+    assert 0.0 <= fitness_after <= 1.0
+    # Current means (1.0) are lower-is-better-better than baseline (2.0) → the
+    # FITNESS (higher-is-better) of the current side must exceed the baseline.
+    assert fitness_after > fitness_before
+
+
+def test_fitness_delta_is_after_minus_before_on_0_1_scale() -> None:
+    """``compute_attribution`` computes ``fitness_delta = after - before`` and
+    both sides are on the 0-1 scale, so the delta is the true fitness gain."""
+    fitness_before = _baseline_raw_fitness(
+        _BASELINE_DIM_MEANS,
+        _BASELINE_DIM_STDERR,
+        baseline_measurement_modality=None,
+        baseline_admire_means=None,
+        anchor_confidence_mode=False,
+    )
+    fitness_after = compute_fitness(_CURRENT_DIM_MEANS, _CURRENT_DIM_STDERR)
+    assert fitness_before is not None
+    payload = compute_attribution(
+        mutation_id="e1-scale-check",
+        expected_dim={},
+        baseline_before=BaselineSnapshot(
+            dim_means=dict(_BASELINE_DIM_MEANS),
+            dim_stderr=dict(_BASELINE_DIM_STDERR),
+        ),
+        baseline_after=BaselineSnapshot(
+            dim_means=dict(_CURRENT_DIM_MEANS),
+            dim_stderr=dict(_CURRENT_DIM_STDERR),
+        ),
+        fitness_before=fitness_before,
+        fitness_after=fitness_after,
+    )
+    expected_delta = round(fitness_after - fitness_before, 6)
+    assert payload["fitness_before"] == round(fitness_before, 6)
+    assert payload["fitness_after"] == round(fitness_after, 6)
+    assert payload["fitness_delta"] == expected_delta
+    # Improvement → strictly positive (and a sane 0-1-magnitude number, NOT the
+    # old ≈ -1.7 mixed-scale artefact).
+    assert payload["fitness_delta"] > 0.0
+    assert -1.0 <= payload["fitness_delta"] <= 1.0
+
+
+def test_fitness_delta_old_mixed_scale_artefact_is_gone() -> None:
+    """Regression guard for the exact pre-E1 nonsense. The old code computed
+    ``fitness_after - mean(baseline_means)`` — a 0-1 value minus a 1-10 value,
+    which for an *improving* mutation came out deterministically negative.
+    With the fix the delta is positive for the same improvement."""
+    fitness_after = compute_fitness(_CURRENT_DIM_MEANS, _CURRENT_DIM_STDERR)
+    old_mixed_scale_delta = fitness_after - (
+        sum(_BASELINE_DIM_MEANS.values()) / len(_BASELINE_DIM_MEANS)
+    )
+    # The old artefact: a strongly negative number for an improving mutation.
+    assert old_mixed_scale_delta < -0.5
+
+    fitness_before = _baseline_raw_fitness(
+        _BASELINE_DIM_MEANS,
+        _BASELINE_DIM_STDERR,
+        baseline_measurement_modality=None,
+        baseline_admire_means=None,
+        anchor_confidence_mode=False,
+    )
+    assert fitness_before is not None
+    fixed_delta = fitness_after - fitness_before
+    # The fixed delta is positive (real improvement) — opposite sign to the bug.
+    assert fixed_delta > 0.0
+    assert fixed_delta != old_mixed_scale_delta
+
+
+def test_no_baseline_yields_none_fitness_before() -> None:
+    """Graceful contract — no baseline (first audit / N=0) → ``None``, NOT a
+    crash and NOT a fabricated zero."""
+    assert (
+        _baseline_raw_fitness(
+            None,
+            None,
+            baseline_measurement_modality=None,
+            baseline_admire_means=None,
+            anchor_confidence_mode=False,
+        )
+        is None
+    )
+    assert (
+        _baseline_raw_fitness(
+            {},
+            {},
+            baseline_measurement_modality=None,
+            baseline_admire_means=None,
+            anchor_confidence_mode=False,
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- The per-mutation attribution ledger's `fitness_before` and the few-shot/DPO pile's `fitness_delta` were computed as `mean(baseline_means)` — the Petri **dim-aggregate** scale (1-10, LOWER-is-better, e.g. 2.286) — while `fitness_after` was already the canonical **fitness** scale (0-1, HIGHER-is-better, e.g. 0.79). The delta therefore subtracted two incompatible scales (≈ -1.7 nonsense, deterministically negative even for improving mutations).
- E1 routes both emit sites through a new single-SoT helper `autoresearch/train.py::_baseline_raw_fitness(...)` that produces the baseline's `compute_fitness` value on the 0-1 scale, mirroring the promote gate's `prior_raw` arg-for-arg, so `fitness_before`/`fitness_delta` are now directly comparable to `fitness_after`.
- The audit formula (`compute_fitness`) and the Petri delegation are unchanged. Hub/reader doc-strings record the scale contract and the pre-E1 mixed-scale discontinuity.

## Why
`fitness_delta` is consumed by the few-shot/DPO pile and surfaced on the self-improving hub. With `fitness_before` on the 1-10 dim scale and `fitness_after` on the 0-1 fitness scale, every delta was a meaningless cross-scale subtraction (≈ -1.7), making the ledger's improvement signal unusable. E1 reconciles both sides to the same `compute_fitness` 0-1 scale via one helper so before/after are comparable and a positive delta means a real fitness gain.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | New `_baseline_raw_fitness(...)` helper — single SoT for baseline fitness on the 0-1 scale, mirroring `_should_promote`'s `prior_raw` (baseline means/stderr, baseline-side modality, baseline `ANCHOR_DIMS` subset, shared `anchor_confidence_mode`, baseline admire slot, bench omitted). Both emit sites (`_sil_fitness_before` for the attribution ledger; `fitness_delta` for the few-shot/DPO pile) now call it instead of `mean(baseline_means)`. |
| `core/self_improving_loop/attribution.py` | Scale-contract docstrings on `AttributionRecord.fitness_*` and `compute_attribution` — fields are 0-1 HIGHER-is-better; the module stays scale-agnostic (subtraction only), the guarantee lives at the autoresearch caller. |
| `scripts/build_self_improving_hub.py` | Docstring-only — `_join_mutation_records` / `_mutation_outcome` now record that `fitness_delta` is the 0-1 fitness scale and that the ±0.005 noise floor is a fitness-scale epsilon; pre-E1 on-disk rows carry the old mixed scale (rendered as-is, backfill is a follow-up). No executable change. |
| `tests/autoresearch/test_fitness_scale_reconcile.py` | New — pins (1) helper returns the 0-1 `compute_fitness` value byte-for-byte equal to the gate's `prior_raw` call shape (not the dim mean), (2) `fitness_delta = after - before` on one scale, (3) the old ≈ -1.7 mixed-scale artefact is gone, (4) graceful `None` on no/empty baseline. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Parity with `prior_raw` | Implemented | `_baseline_raw_fitness` args match `_should_promote`'s `prior_raw` arg-for-arg (Codex MCP confirmed CORRECT). |
| Single baseline-fitness SoT | Implemented | Both emit sites call the one helper; no residual `sum(baseline_means.values())` for these paths (Codex confirmed). |
| Reader updates (dpo_stats / meta_judge / hub) | Not needed | Readers are scale-generic / serialize-only; the ±0.005 floor is documented as a fitness-scale epsilon (Codex confirmed no reader assumes 1-10 magnitude). |
| Historical backfill of pre-E1 rows | Deferred (follow-up) | 8 on-disk rows carry the old mixed scale; ledger is git-tracked and not rewritten. Hub renders them as-is — see note below. |

## Verification
- [x] ruff check clean (`autoresearch/ core/self_improving_loop/ scripts/build_self_improving_hub.py tests/autoresearch/`)
- [x] ruff format --check clean (4 changed files already formatted)
- [x] mypy clean (`autoresearch/train.py core/self_improving_loop/` — no issues in 31 source files)
- [x] pytest pass (86 passed — `tests/autoresearch/test_fitness_scale_reconcile.py` + `tests/autoresearch/`)
- [x] Codex MCP adversarial review (read-only): parity (a) CORRECT, asymmetry (b) NIT, readers (c) CORRECT, graceful (d) CORRECT, single SoT (e) CORRECT.

### Codex note — pre-E1 hub aggregation (follow-up, not a code regression)
Codex flagged that the hub's `_mutation_outcome` classification and `_render_mutations_summary` mean-Δfitness still aggregate the 8 historical mixed-scale rows (≈ -1.7) alongside new 0-1 rows. This is a **pre-existing data discontinuity**, not introduced by this PR — the hub aggregation logic is unchanged (docstring-only diff) and already aggregated those rows before E1. It is explicitly documented in the touched docstrings and scoped as the documented one-shot backfill follow-up. It does **not** make E1's before/after incomparable (the actual correctness axis), which Codex confirmed CORRECT.

## Reference
PR-MARGIN-FITNESS-SCALE E1 (2026-05-30). Builds on the margin-fitness-scale + baseline-epoch-partition work already on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)