### PR TITLE
chore(self-improving): pin gen-2605-4+3 frozen selection pool for the 10-cycle (B2)

### DIFF
--- a/docs/self-improving/cycle-input-pool.md
+++ b/docs/self-improving/cycle-input-pool.md
@@ -1,0 +1,129 @@
+# Cycle-input seed pool — frozen selection for the upcoming 10-cycle (B2)
+
+Reproducibility record for the **frozen selection pool** the upcoming
+self-improving 10-cycle audits against. The pool directory itself
+(`state/seed-pools/cycle-input/`) is a gitignored runtime artefact
+(`.gitignore` `state/*`); this file is the git-tracked record that makes that
+pool reproducible — its content identity, the runs it was assembled from, and
+the launch wiring the operator uses.
+
+The pool is **not** an LLM output and carries no randomness:
+`scripts/assemble_seed_pool.py` selects runs by a stable `gen_tag` sort key (not
+filesystem mtime) and copies git-tracked survivor bodies into a flat dir, so
+re-running the exact invocation below on the same seeds tree always reproduces
+the same pool with the same content hash.
+
+---
+
+## 1. Frozen pool identity
+
+| Field | Value |
+|-------|-------|
+| Content hash | `pool-68dc6f0c9745` |
+| Total survivors | 10 (5 + 5) |
+| Selected runs | `gen-2605-4-unfaithful_thinking` (`gen-2605-4`), `gen-2605-3-broken_tool_use` (`gen-2605-3`) |
+| Seeds root | `docs/self-improving/petri-bundle/seeds` (git-tracked SoT) |
+| Schema version | 1 (`manifest.json` `schema_version`) |
+
+The two runs are the two most-recent by descending `gen_tag` sort key
+`(stamp, counter)`: `(2605, 4)` then `(2605, 3)`. Selection order is preserved
+in the pool's copy order and in the survivor lists below.
+
+### Survivor ids (10)
+
+`gen-2605-4-unfaithful_thinking` (target dim: unfaithful_thinking) — 5 survivors:
+
+- `gen-2605-4-003-e2b9759a`
+- `gen-2605-4-004-c4e5770b`
+- `gen-2605-4-005-29c3f084`
+- `gen-2605-4-009-1ceb75e0`
+- `gen-2605-4-010-91e734c9`
+
+`gen-2605-3-broken_tool_use` (target dim: broken_tool_use) — 5 survivors:
+
+- `gen-2605-3-002-59743f9d`
+- `gen-2605-3-003-8ddb31d0`
+- `gen-2605-3-005-0ce25ac8`
+- `gen-2605-3-006-6ecf2412`
+- `gen-2605-3-013-fd6b0d2b`
+
+Each survivor body is copied into the pool as `<survivor_id>.md`. The source
+bodies live under `docs/self-improving/petri-bundle/seeds/<run_id>/candidates/`
+(or `candidates_evolved/`) and are git-tracked, so the pool is reproducible from
+a clean clone.
+
+---
+
+## 2. Reproduce the pool
+
+Run from the repository root. `--now` only stamps the manifest's
+`generated_at`; it does not affect the content hash (the deterministic core
+never reads the clock). `--force` wipes a pre-existing pool dir so the copy is a
+clean snapshot.
+
+```bash
+uv run python scripts/assemble_seed_pool.py \
+  --runs 2 \
+  --out state/seed-pools/cycle-input \
+  --now 2026-05-30T00:00:00+00:00 \
+  --force
+```
+
+Expected stdout:
+
+```
+Assembled seed pool: state/seed-pools/cycle-input
+  content hash : pool-68dc6f0c9745
+  total seeds  : 10
+  generated_at : 2026-05-30T00:00:00+00:00
+  runs         :
+    - gen-2605-4-unfaithful_thinking (gen-2605-4): 5 survivors
+    - gen-2605-3-broken_tool_use (gen-2605-3): 5 survivors
+```
+
+If the printed `content hash` is **not** `pool-68dc6f0c9745`, the survivor set
+changed (a run was added/pruned, or survivor bodies edited) — STOP and
+re-pin a new hash before launching, rather than auditing against a drifted pool.
+
+---
+
+## 3. Launch wiring — `AUTORESEARCH_SEED_SELECT`
+
+The 10-cycle is wired to this pool via the `AUTORESEARCH_SEED_SELECT` env
+export, which is **tier-1 precedence** in `autoresearch/train.py`
+`_resolve_seed_select` (it beats the `latest_pointer.json` auto-pick, the
+`config.toml` `[self_improving_loop.autoresearch] seed_select`, and the
+`SEED_SELECT` module constant). The env export wins unconditionally, so the
+operator pins this exact pool for the run without editing
+`core/config/self_improving_loop.py`.
+
+`_resolve_seed_select` returns the env value verbatim as the seed-select argv,
+so it must be an **absolute** path (the autoresearch run process may have a
+different CWD than the repo root). Export it relative to the repo root via
+`${HOME}` (no hardcoded user home is committed here):
+
+```bash
+# Repo root on this machine, e.g. ${HOME}/workspace/geode
+export GEODE_REPO="${HOME}/workspace/geode"
+export AUTORESEARCH_SEED_SELECT="${GEODE_REPO}/state/seed-pools/cycle-input"
+```
+
+The repo-relative pool path is always:
+
+```
+<repo-root>/state/seed-pools/cycle-input
+```
+
+Substitute `<repo-root>` for wherever the GEODE checkout lives on the launch
+machine. Confirm the pool exists (and matches the hash) before launching:
+
+```bash
+ls "$AUTORESEARCH_SEED_SELECT"/manifest.json
+```
+
+> Wiring note: this record deliberately does **not** touch
+> `core/config/self_improving_loop.py` — a committed config pointer would
+> conflict with parallel held-out-bench work on that file and is also
+> unnecessary, since `AUTORESEARCH_SEED_SELECT` is the highest-precedence
+> override and is the documented per-run handoff used by the seed-generation
+> cross-loop.


### PR DESCRIPTION
## Summary
- Commit a git-tracked **reproducibility record** (`docs/self-improving/cycle-input-pool.md`) that pins the frozen selection pool for the upcoming self-improving 10-cycle.
- Records the pool's content identity (`pool-68dc6f0c9745`), the two source runs, all 10 survivor ids, the exact `assemble_seed_pool.py` invocation, and the `AUTORESEARCH_SEED_SELECT` launch export.
- Wires the launch via the documented tier-1 env override — **no `core/config/self_improving_loop.py` edit** (avoids conflict with parallel held-out-bench work on that file).

## Why
The 10-cycle audits a model against a *pool* of adversarial seed prompts. The pool dir (`state/seed-pools/cycle-input/`) is a gitignored runtime artefact, so its content identity, provenance, and launch wiring would otherwise be undocumented and unreproducible. This record makes the pool reproducible from a clean clone (the source survivor bodies are git-tracked, and `assemble_seed_pool.py` is deterministic) and documents the exact operator launch path.

## Changes
| File | Change |
|------|--------|
| `docs/self-improving/cycle-input-pool.md` | New reproducibility record: frozen pool identity (`pool-68dc6f0c9745`, 10 survivors), selected runs `gen-2605-4-unfaithful_thinking` + `gen-2605-3-broken_tool_use`, 10 survivor ids, exact assembler invocation, and the `AUTORESEARCH_SEED_SELECT="${GEODE_REPO}/state/seed-pools/cycle-input"` launch export (home-templated, no hardcoded user path). |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Pool produced + hash verified | Implemented | Assembler ran clean → `pool-68dc6f0c9745`, 10 survivors (5+5), runs gen-2605-4 + gen-2605-3 |
| Git-tracked reproducibility record | Implemented | `docs/self-improving/cycle-input-pool.md` (pool dir stays gitignored under `state/`) |
| Launch wiring | Implemented (via env) | `AUTORESEARCH_SEED_SELECT` is tier-1 precedence in `autoresearch/train.py` `_resolve_seed_select`; documented, not config-edited |
| `core/config/self_improving_loop.py` | Not touched | Deliberate — parallel held-out-bench branch edits this file |

## Verification
- [x] Assembler dry-run: `pool-68dc6f0c9745`, 10 survivors, gen-2605-4 + gen-2605-3 (matches expected)
- [x] Pool dir confirmed gitignored (`git check-ignore state/seed-pools/cycle-input` → `.gitignore:241 state/*`); only the record is committed
- [x] No hardcoded user home in the doc (`${HOME}`-templated + repo-relative only)
- [x] Source survivor bodies git-tracked (reproducible from clean clone)
- [x] Codex MCP read-only review: PASS (hash, run selection, all 10 ids, tier-1 precedence, no leaked home, gitignore, git-tracked bodies all verified)
- [x] No `.py` touched (data/doc only — ruff/mypy/pytest gates N/A)

## Reference
B2 follow-up to B1 (`scripts/assemble_seed_pool.py`, PR #1920). Wiring precedence: `autoresearch/train.py:239` `_resolve_seed_select`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)