### PR TITLE
test(hub): isolate built_html/built_seedgen_pages fixtures to tmp out-dirs

### DIFF
--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -64,13 +64,19 @@ def _run_builder(
     bundle_root: Path | None = None,
     autoresearch_root: Path | None = None,
     seedgen_out_dir: Path | None = None,
+    autoresearch_out_dir: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run the hub builder against fixture roots, output into ``out_dir``."""
     out_dir.mkdir(parents=True, exist_ok=True)
-    # Default the seedgen output to a sibling under the test's own out_dir so
-    # builder runs never write into production paths.
+    # Redirect EVERY output dir to a sibling under the test's own out_dir so a
+    # builder run never writes into the production docs/ tree. The builder
+    # defaults --out / --seedgen-out-dir / --autoresearch-out-dir to
+    # docs/self-improving/..., so any flag left at its default silently renders
+    # fixture data into the worktree (the contamination this isolation fixes).
     if seedgen_out_dir is None:
         seedgen_out_dir = out_dir / "seed-generation"
+    if autoresearch_out_dir is None:
+        autoresearch_out_dir = out_dir / "autoresearch"
     cmd: list[str] = [
         sys.executable,
         str(BUILDER),
@@ -78,6 +84,8 @@ def _run_builder(
         str(out_dir / "index.html"),
         "--seedgen-out-dir",
         str(seedgen_out_dir),
+        "--autoresearch-out-dir",
+        str(autoresearch_out_dir),
     ]
     if bundle_root is not None:
         cmd.extend(["--bundle-root", str(bundle_root)])
@@ -517,6 +525,7 @@ def built_seedgen_pages(tmp_path_factory: pytest.TempPathFactory) -> dict[str, s
     out = tmp_path_factory.mktemp("seedgen-out")
     hub_out = out / "hub"
     seedgen_out = out / "seedgen"
+    autoresearch_out = out / "autoresearch"
     result = subprocess.run(  # noqa: S603 — fixture invocation
         [
             sys.executable,
@@ -529,6 +538,11 @@ def built_seedgen_pages(tmp_path_factory: pytest.TempPathFactory) -> dict[str, s
             str(FIXTURE_ROOT / "autoresearch"),
             "--seedgen-out-dir",
             str(seedgen_out),
+            # Redirect autoresearch output to tmp too — without this flag the
+            # builder renders into docs/self-improving/autoresearch/, dirtying
+            # the worktree on every run.
+            "--autoresearch-out-dir",
+            str(autoresearch_out),
         ],
         check=False,
         capture_output=True,
@@ -1623,6 +1637,7 @@ def built_pr3_pages(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
     """
     out = tmp_path_factory.mktemp("seedgen-out-p3")
     seedgen_out = out / "seedgen"
+    autoresearch_out = out / "autoresearch"
     subprocess.run(  # noqa: S603
         [
             sys.executable,
@@ -1635,6 +1650,10 @@ def built_pr3_pages(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
             str(FIXTURE_ROOT / "autoresearch"),
             "--seedgen-out-dir",
             str(seedgen_out),
+            # Redirect autoresearch output to tmp too — otherwise the builder
+            # writes into docs/self-improving/autoresearch/ and dirties the tree.
+            "--autoresearch-out-dir",
+            str(autoresearch_out),
         ],
         check=True,
         cwd=str(REPO_ROOT),


### PR DESCRIPTION
## Summary
- `built_html` and `built_seedgen_pages` (plus `built_pr3_pages` and the shared `_run_builder` helper) ran `scripts/build_self_improving_hub.py` without redirecting `--autoresearch-out-dir`, so the builder fell back to its default and rendered fixture data into the real `docs/self-improving/autoresearch/*.html` — dirtying the worktree on every test run.
- All builder-running fixtures now pass tmp output dirs for ALL output flags (`--out`, `--seedgen-out-dir`, `--autoresearch-out-dir`), mirroring the already-correct `built_autoresearch_pages` fixture.

## Why
The builder defaults `--out` / `--seedgen-out-dir` / `--autoresearch-out-dir` to `docs/self-improving/...`. The `_run_builder` helper redirected `--out` + `--seedgen-out-dir` to tmp but never passed `--autoresearch-out-dir`; the inline `built_seedgen_pages` / `built_pr3_pages` subprocess invocations had the same gap. Confirmed empirically: running a single `built_html`-dependent test dirtied 5 files under `docs/self-improving/autoresearch/`. This is exactly the "Writer destination tracked" anti-pattern surface — a test silently mutating tracked production artifacts.

## Changes
| File | Change |
|------|--------|
| `tests/test_self_improving_hub_e2e.py` | `_run_builder`: add `autoresearch_out_dir` param defaulting to `out_dir/"autoresearch"` and always emit `--autoresearch-out-dir`. `built_seedgen_pages` + `built_pr3_pages` inline invocations: add `--autoresearch-out-dir` pointing at a tmp sibling. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `built_html` (via `_run_builder`) | Fixed | helper now redirects all 3 output flags |
| `built_seedgen_pages` | Fixed | inline subprocess now passes `--autoresearch-out-dir` |
| `built_pr3_pages` | Fixed | inline subprocess now passes `--autoresearch-out-dir` (same latent bug) |
| `_run_builder` callers (builder-runs/idempotent/empty-state/missing-baseline) | Fixed | covered by the helper change |
| `built_autoresearch_pages`, `built_seedgen_tree`, stale-warning, held-out-omit, viewer-diff | Already correct | already passed `--autoresearch-out-dir` |

## Verification
- [x] ruff check clean (`tests/test_self_improving_hub_e2e.py`)
- [x] ruff format --check clean
- [x] pytest pass — `tests/test_self_improving_hub_e2e.py` 60 passed, 1 skipped (inspect_ai audit-extra)
- [x] CRUCIAL: `git status --short docs/self-improving/` EMPTY after the full e2e run (was 5 dirtied autoresearch HTML files before the fix)
- No version bump / no CHANGELOG (test-infra only, per CHANGELOG scope rules)

## Reference
CLAUDE.md "Writer destination tracked" / Wiring Verification anti-patterns; sibling `built_autoresearch_pages` fixture as the correct template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)