### PR TITLE
docs: lead the Reference entry point with lineage, not validation

### DIFF
--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -105,6 +105,77 @@ export default function DocsIndex() {
         }
       />
 
+      <Bi
+        ko={
+          <>
+            <h2>레퍼런스: GEODE의 좌표부터</h2>
+            <p>
+              레퍼런스의 진입점은 검증 절차가 아니라{" "}
+              <strong>자기개선 폐루프의 계보와 좌표</strong>입니다. GEODE가 어떤
+              프론티어 시스템에서 무엇을 빌려오고, 어디서 갈라지는지부터 짚습니다.
+            </p>
+            <ul>
+              <li>
+                <a href="/geode/docs/reference/frontier-comparison">프론티어 비교</a>.
+                Claude Code, Codex CLI, OpenClaw, Hermes에서 빌려온 것과 갈라지는 지점.
+              </li>
+              <li>
+                <a href="/geode/docs/capabilities/lineage">계보와 좌표</a>. 이 루프가
+                self-evolving agents 문헌에서 어디에 위치하는지.
+              </li>
+              <li>
+                <a href="/geode/docs/capabilities/co-scientist">Co-scientist 루프</a>.
+                적대적 seed 분포를 함께 진화시키는 다중 역할 루프.
+              </li>
+              <li>
+                <a href="/geode/docs/reference/external-references">외부 참고</a>. GEODE가
+                인용하는 frontier 시스템과 선행 작업.
+              </li>
+            </ul>
+            <p className="text-white/55 text-sm">
+              검증과 가드레일(G1-G4, BiasBuster, Cross-LLM, 원인 분류 트리, 관측성)은
+              이제 별도 섹션{" "}
+              <a href="/geode/docs/verification/guardrails">검증과 가드레일</a>로
+              묶였습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Reference: GEODE&apos;s position first</h2>
+            <p>
+              The reference entry point leads with the{" "}
+              <strong>self-improving loop&apos;s lineage and position</strong>, not the
+              validation machinery. Start with what GEODE borrows from frontier
+              systems and where it differs.
+            </p>
+            <ul>
+              <li>
+                <a href="/geode/docs/reference/frontier-comparison">Frontier comparison</a>.
+                What GEODE borrows from Claude Code, Codex CLI, OpenClaw, Hermes, and where it differs.
+              </li>
+              <li>
+                <a href="/geode/docs/capabilities/lineage">Lineage and positioning</a>.
+                Where this loop sits in the self-evolving agents literature.
+              </li>
+              <li>
+                <a href="/geode/docs/capabilities/co-scientist">Co-scientist loop</a>.
+                The multi-role loop that co-evolves the adversarial seed distribution.
+              </li>
+              <li>
+                <a href="/geode/docs/reference/external-references">External references</a>.
+                The frontier systems and prior work GEODE cites.
+              </li>
+            </ul>
+            <p className="text-white/55 text-sm">
+              Verification and guardrails (G1-G4, BiasBuster, Cross-LLM, the cause
+              decision tree, observability) now live in their own section,{" "}
+              <a href="/geode/docs/verification/guardrails">Verification and Guardrails</a>.
+            </p>
+          </>
+        }
+      />
+
       <h2>{t(locale, "섹션", "Sections")}</h2>
       <div className="not-prose mt-3 border-t border-[var(--rule)]">
         {DOCS_SITEMAP.map((section) => (

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -19,6 +19,17 @@
  * carries the petri-blue accent). Vanity counts (tool / hook / module / seed
  * numbers) are removed from every title and summary; the system is described
  * by what it does, not by how much of it there is.
+ *
+ * PR-DOCS-REFERENCE-LINEAGE (2026-05-30) — the Reference section used to open
+ * with the verification/* cluster (guardrails, biasbuster, cross-llm, cause
+ * tree, observability), which read as an awkward "reference" entry point. The
+ * section now leads with GEODE's positioning references — frontier comparison
+ * (what GEODE borrows vs. how it differs) and external references — so the
+ * reference entry point foregrounds the self-improving-loop lineage rather than
+ * validation. The verification/* cluster moved into its own section,
+ * "Verification and Guardrails" (id 08b), so it is no longer the face of
+ * Reference. Lineage and Co-scientist stay in The Self-Improving Loop section
+ * (their home); the docs landing reference grouping cross-links to them.
  */
 
 export type DocQuadrant = "tutorial" | "how-to" | "reference" | "explanation";
@@ -145,19 +156,26 @@ export const DOCS_SITEMAP: DocSection[] = [
     title: "Reference",
     titleKo: "레퍼런스",
     pages: [
+      { slug: "reference/frontier-comparison", title: "Frontier comparison", titleKo: "프론티어 비교", summary: "What GEODE borrows from Claude Code, Codex CLI, OpenClaw, and Hermes, and where it differs. The reference entry point for GEODE's position in the lineage.", summaryKo: "GEODE가 Claude Code, Codex CLI, OpenClaw, Hermes에서 무엇을 빌려오고, 어디서 갈라지는지 정리합니다. 계보 속 GEODE의 좌표를 짚는 레퍼런스 진입점입니다.", quadrant: "reference" },
+      { slug: "reference/external-references", title: "External references", titleKo: "외부 참고", summary: "Frontier agent systems, design standards, and prior work GEODE cites — the self-evolving-agents lineage behind the loop.", summaryKo: "GEODE가 인용하는 frontier 에이전트 시스템, 디자인 표준, 선행 작업입니다. 루프 뒤에 있는 self-evolving agents 계보입니다.", quadrant: "reference" },
       { slug: "harness/cli", title: "CLI and slash commands", titleKo: "CLI와 슬래시 명령", summary: "The thin gateway and IPC, and the slash commands it accepts.", summaryKo: "thin 게이트웨이와 IPC, 그리고 받는 슬래시 명령들입니다.", quadrant: "reference" },
+      { slug: "runtime/automation", title: "Automation sidecar", titleKo: "자동화 사이드카", summary: "The feedback loop and model promotion, with drift detection between agent and runtime.", summaryKo: "피드백 루프와 모델 프로모션입니다. 에이전트와 런타임 사이에서 drift를 감지합니다.", quadrant: "reference" },
+      { slug: "runtime/computer-use", title: "Computer use", titleKo: "컴퓨터 사용", summary: "Provider-agnostic desktop automation, Anthropic and OpenAI unified.", summaryKo: "프로바이더 독립 데스크탑 자동화입니다. Anthropic과 OpenAI를 통합합니다.", quadrant: "reference" },
+      { slug: "runtime/ui/cli-latex", title: "CLI LaTeX rendering", titleKo: "CLI LaTeX 렌더링", summary: "Rendering math in the terminal. Detection, Unicode flatten, pretty print, image fallback.", summaryKo: "터미널에서 수식을 렌더링합니다. 감지, Unicode flatten, pretty print, 이미지 폴백을 거칩니다.", quadrant: "reference" },
+      { slug: "reference/changelog", title: "CHANGELOG", titleKo: "CHANGELOG", summary: "Full version history, synced from CHANGELOG.md on every main push.", summaryKo: "main push마다 CHANGELOG.md에서 동기화되는 전체 버전 이력입니다.", quadrant: "reference" },
+      { slug: "reference/petri-bundle-isolation", title: "Petri bundle isolation", titleKo: "Petri 번들 격리", summary: "Operator reference for the publish workflow, validator, and hygiene ratchet.", summaryKo: "publish 워크플로우, validator, hygiene ratchet의 운영자 레퍼런스입니다.", quadrant: "reference" },
+    ],
+  },
+  {
+    id: "08b-verification",
+    title: "Verification and Guardrails",
+    titleKo: "검증과 가드레일",
+    pages: [
       { slug: "verification/guardrails", title: "Guardrails G1-G4", titleKo: "가드레일 G1-G4", summary: "Schema, range, grounding, consistency. A fail-fast ladder over LLM output.", summaryKo: "Schema, range, grounding, consistency입니다. LLM 출력 위의 fail-fast 사다리입니다.", quadrant: "reference" },
       { slug: "verification/biasbuster", title: "BiasBuster", titleKo: "BiasBuster", summary: "Confirmation, recency, and anchoring detection on top of the guardrails.", summaryKo: "가드레일 위에 얹는 confirmation, recency, anchoring 편향 탐지입니다.", quadrant: "reference" },
       { slug: "verification/cross-llm", title: "Cross-LLM verification", titleKo: "Cross-LLM 검증", summary: "An independent second opinion. A different provider re-scores the verdict.", summaryKo: "독립적인 second opinion입니다. 다른 프로바이더가 판정을 다시 채점합니다.", quadrant: "reference" },
       { slug: "verification/cause-decision-tree", title: "Cause decision tree", titleKo: "원인 분류 트리", summary: "Map a failure cause to a recovery action, instead of blindly retrying.", summaryKo: "무작정 재시도하는 대신, 실패 원인을 복구 행동에 매핑합니다.", quadrant: "reference" },
       { slug: "verification/observability", title: "Observability", titleKo: "관측성", summary: "The lenses on a run. Hooks, runlog, audit diagnostics, Petri.", summaryKo: "실행을 들여다보는 렌즈들입니다. 훅, runlog, audit diagnostics, Petri입니다.", quadrant: "reference" },
-      { slug: "runtime/automation", title: "Automation sidecar", titleKo: "자동화 사이드카", summary: "The feedback loop and model promotion, with drift detection between agent and runtime.", summaryKo: "피드백 루프와 모델 프로모션입니다. 에이전트와 런타임 사이에서 drift를 감지합니다.", quadrant: "reference" },
-      { slug: "runtime/computer-use", title: "Computer use", titleKo: "컴퓨터 사용", summary: "Provider-agnostic desktop automation, Anthropic and OpenAI unified.", summaryKo: "프로바이더 독립 데스크탑 자동화입니다. Anthropic과 OpenAI를 통합합니다.", quadrant: "reference" },
-      { slug: "runtime/ui/cli-latex", title: "CLI LaTeX rendering", titleKo: "CLI LaTeX 렌더링", summary: "Rendering math in the terminal. Detection, Unicode flatten, pretty print, image fallback.", summaryKo: "터미널에서 수식을 렌더링합니다. 감지, Unicode flatten, pretty print, 이미지 폴백을 거칩니다.", quadrant: "reference" },
-      { slug: "reference/external-references", title: "External references", titleKo: "외부 참고", summary: "Frontier agent systems, design standards, and prior work GEODE cites.", summaryKo: "GEODE가 인용하는 frontier 에이전트 시스템, 디자인 표준, 선행 작업입니다.", quadrant: "reference" },
-      { slug: "reference/frontier-comparison", title: "Frontier comparison", titleKo: "프론티어 비교", summary: "Where GEODE sits next to Claude Code, Codex CLI, OpenClaw, and Hermes.", summaryKo: "GEODE가 Claude Code, Codex CLI, OpenClaw, Hermes 옆에서 어디에 위치하는지 비교합니다.", quadrant: "reference" },
-      { slug: "reference/changelog", title: "CHANGELOG", titleKo: "CHANGELOG", summary: "Full version history, synced from CHANGELOG.md on every main push.", summaryKo: "main push마다 CHANGELOG.md에서 동기화되는 전체 버전 이력입니다.", quadrant: "reference" },
-      { slug: "reference/petri-bundle-isolation", title: "Petri bundle isolation", titleKo: "Petri 번들 격리", summary: "Operator reference for the publish workflow, validator, and hygiene ratchet.", summaryKo: "publish 워크플로우, validator, hygiene ratchet의 운영자 레퍼런스입니다.", quadrant: "reference" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- The docs Reference section opened with the `verification/*` cluster (guardrails, biasbuster, cross-llm, cause tree, observability), which read awkwardly as the "reference" entry point.
- Reframed so Reference foregrounds **GEODE's position in the self-improving-loop lineage** and its **borrow/differ** points — frontier comparison + external references lead, with lineage + co-scientist cross-linked from the landing.
- The `verification/*` cluster is regrouped into its own section, **Verification and Guardrails**, so it is no longer the face of Reference.

## Why
On the docs site the `reference` quadrant was dominated by VALIDATION content. "Reference" should surface GEODE's self-improving closed-loop lineage and the frontier comparison (what GEODE borrows vs. how it differs), not the validation machinery. No new content was needed — the lineage / frontier-comparison / co-scientist pages already exist; this is an information-architecture reorg.

## Changes
| File | Change |
|------|--------|
| `site/src/lib/geode-docs/sitemap.ts` | `08-reference` reordered to lead with `reference/frontier-comparison` then `reference/external-references`, followed by the genuine reference entries. New section `08b-verification` "Verification and Guardrails" / "검증과 가드레일" holds the five `verification/*` pages. Lineage + co-scientist stay in `04-self-improving` (their home). Header comment documents the reorg. EN + KO parity. |
| `site/src/app/docs/page.tsx` | Added a bilingual "Reference: GEODE's position first" grouping (dense inline link list, no card grid, no accent bars) foregrounding frontier-comparison + lineage + co-scientist + external references, and pointing to the new Verification and Guardrails section. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Lineage / frontier-comparison / co-scientist pages | Already exist | `capabilities/lineage`, `reference/frontier-comparison`, `capabilities/co-scientist` — no new content created |
| Verification pages | Preserved | Not deleted; only regrouped under a new section label |
| CHANGELOG / version bump | Dropped | Docs-only change — out of scope per CHANGELOG scope rules |

## Verification
- [x] `scripts/check_docs_links.py` — no broken internal links, no raw `/docs/` basePath violations (307 link occurrences scanned)
- [x] `npm run build` — compiled successfully, all docs pages prerendered (incl. reference + verification)
- [x] `tsc --noEmit` — clean
- [x] No CHANGELOG / version change (docs-only)

## Reference
Source: GEODE docs IA redesign (PR-DOCS-REDESIGN 2026-05-29 lineage); CLAUDE.md CANNOT rules on no-card-grid-as-nav / no-accent-bars / EN+KO parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)