### PR TITLE
fix(self-improving): pool content-hash bodies-only + held-out fitness parity (v0.99.94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,46 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.94] - 2026-05-30
+
+### Fixed
+- **Seed-pool content hash is now bodies-only (frozen-ruler determinism).**
+  `core.self_improving_loop.baseline_epoch.seed_pool_content_hash` recursed
+  `path.rglob("*")` (ALL files), but `scripts/assemble_seed_pool.py` writes a
+  `manifest.json` INTO the pool dir whose `generated_at` is a timestamp. So the
+  runtime hash on a live pool dir (a) diverged from the assembler's body-only hash
+  and the committed doc pins, and (b) was NON-DETERMINISTIC across re-assembly
+  (the timestamp moved the hash) — re-assembling identical survivor bodies
+  fragmented baselines into different epochs, defeating the "same spec → same
+  hash" frozen-ruler invariant. The hash now fingerprints ONLY the seed `.md`
+  bodies (`rglob("*.md")`, sorted relative-path + sha256), which is exactly the
+  file set the audit's pool loader reads (`directory.glob("*.md")`); `manifest.json`
+  and any other non-`.md` incidental file are excluded. Verified against the live
+  pool dirs WITH `manifest.json` present: selection pool reproduces
+  `pool-68dc6f0c9745`, held-out bench reproduces `pool-c16d186178e1`, and two
+  assemblies with different `--now` timestamps yield the same hash. The
+  `held-out-bench.md` reproduction note is corrected to state the body-only
+  addressing. Pinned by `tests/test_baseline_epoch.py` (masked-scenario:
+  manifest + timestamp invariance) + `tests/test_assemble_seed_pool.py`.
+- **Held-out fitness now shares the gate's fitness formula path.**
+  `score_held_out_bench` (`autoresearch/train.py`) omitted the
+  `anchor_confidence_mode` flag that the promote gate's `current_raw` runs under,
+  so when anchor-confidence mode was on the held-out evidence curve was computed
+  on a subtly different fitness DEFINITION than the baselines it is compared
+  against. The shared flag is now threaded from `main()` into the scorer's
+  `compute_fitness` call WITH the held-out's own `ANCHOR_DIMS` subset as
+  `anchor_means` (the same subset the gate's `current_raw` extracts from its
+  current dims — threading the flag without the subset would silently no-op the
+  multiplier); `baseline_means=None` (fresh-anchor intrinsic, no prior baseline)
+  and `admire_means=None` (the held-out audit emits no admire signal). Pinned by
+  `tests/autoresearch/test_held_out_bench.py`.
+- **Seed-pool assembly fails closed on a path-escaping survivor id.**
+  `scripts/assemble_seed_pool.py` copied each body to `pool_dir / f"{survivor_id}.md"`
+  without validating `survivor_id` is a safe single path segment, so a `../`- or
+  `/`-containing id from the seeds tree could escape the pool dir. A new
+  `_assert_safe_dest_basename` rejects any id that is not a single segment (naming
+  the bad id + run) before the copy. Pinned by `tests/test_assemble_seed_pool.py`.
+
 ## [0.99.93] - 2026-05-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.93
+- **Version**: 0.99.94
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.93 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.94 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.93 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.94 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1264,6 +1264,7 @@ def score_held_out_bench(
     dry_run: bool = False,
     session_id: str = "",
     gen_tag: str = "",
+    anchor_confidence_mode: bool = False,
 ) -> tuple[float, dict[str, float], str]:
     """Measure fitness on the VERSION-FROZEN held-out bench — the fixed ruler.
 
@@ -1280,7 +1281,16 @@ def score_held_out_bench(
       matching ``_append_baseline_registry_row``'s ``intrinsic_fitness``; no
       cross-baseline critical-floor comparison, which would be spurious against a
       frozen ruler that is by construction a *different* seed set from the
-      promoted baseline's pool).
+      promoted baseline's pool). The ``anchor_confidence_mode`` flag the gate runs
+      under is threaded through so the held-out curve and the baselines it is
+      compared against share ONE fitness formula path — when the mode is on, the
+      anchor-confidence multiplier applies the same way it does to ``current_raw``:
+      the held-out's OWN ``ANCHOR_DIMS`` subset is passed as ``anchor_means``
+      alongside the flag (passing the flag without the subset would silently no-op
+      the multiplier, leaving the curve on the mode-off formula). ``baseline_means``
+      stays ``None`` (the held-out has no prior baseline → the fresh-anchor
+      intrinsic, no cross-baseline floor) and ``admire_means`` is ``None`` (the
+      held-out audit produces no admire signal — ``run_audit`` returns dims only).
     - ``held_out_dim_means`` is the per-dim aggregate on the Petri 1-10
       concerning-behaviour scale (lower-is-better dims), straight from
       :func:`run_audit`.
@@ -1325,11 +1335,27 @@ def score_held_out_bench(
             os.environ.pop("AUTORESEARCH_SEED_SELECT", None)
         else:
             os.environ["AUTORESEARCH_SEED_SELECT"] = _prior_override
+    # Same fitness formula path as the gate's ``current_raw`` (train.py
+    # ``_should_promote``) — so the held-out curve and the baselines it is
+    # compared against share ONE fitness definition: ``baseline_means=None``
+    # (fresh-anchor intrinsic, no cross-baseline floor), modality threaded for the
+    # analytics-weight scale, the SHARED ``anchor_confidence_mode`` flag, the
+    # held-out's OWN ``ANCHOR_DIMS`` subset as ``anchor_means`` (the gate extracts
+    # the same subset from its current dims — passing ``anchor_confidence_mode``
+    # without it would silently no-op the multiplier, leaving the curve on the
+    # mode-off formula), and ``admire_means=None`` (the held-out audit emits no
+    # admire signal — ``run_audit`` returns dims only).
+    held_out_anchor = {
+        dim: held_out_dim_means[dim] for dim in ANCHOR_DIMS if dim in held_out_dim_means
+    }
     held_out_fitness = compute_fitness(
         held_out_dim_means,
         held_out_dim_stderr,
         baseline_means=None,
         measurement_modality=held_out_modality or None,
+        anchor_means=held_out_anchor or None,
+        anchor_confidence_mode=anchor_confidence_mode,
+        admire_means=None,
     )
     return float(held_out_fitness), held_out_dim_means, held_out_bench_id
 
@@ -3438,6 +3464,7 @@ def main() -> int:
                 _held_out_bench,
                 session_id=session_id,
                 gen_tag=gen_tag,
+                anchor_confidence_mode=_anchor_confidence_mode,
             )
             del _held_out_dims_unused
             log.info(

--- a/core/self_improving_loop/baseline_epoch.py
+++ b/core/self_improving_loop/baseline_epoch.py
@@ -114,11 +114,22 @@ def seed_pool_content_hash(seed_select: str | None) -> str:
     """Stable identity of the seed pool the audit ran on (decision B).
 
     ``seed_select`` is whatever ``_resolve_seed_select`` returned (a pool path or
-    a selector string). If it points at a directory, hash the **content** (each
-    contained file's relative path + sha256, sorted) so the same survivor set
-    always yields the same id regardless of mtime / absolute location. If it is a
-    plain string selector (or a missing path), hash the string verbatim. Empty
-    input → ``""`` (the spec's pool axis then contributes a stable empty value).
+    a selector string). If it points at a directory, hash ONLY the **seed bodies**
+    — each contained ``.md`` file's relative path + sha256, sorted — so the same
+    survivor set always yields the same id regardless of mtime / absolute
+    location. If it is a plain string selector (or a missing path), hash the
+    string verbatim. Empty input → ``""`` (the spec's pool axis then contributes
+    a stable empty value).
+
+    Pool identity is the *seeds*, never incidental files. The assembler
+    (:mod:`scripts.assemble_seed_pool`) writes a ``manifest.json`` INTO the pool
+    dir, and that manifest carries a ``generated_at`` timestamp — recursing every
+    file (the pre-fix ``rglob("*")``) folded that timestamp into the hash, making
+    the runtime hash NON-DETERMINISTIC across re-assembly and divergent from both
+    the assembler's body-only hash (computed before the manifest is written) and
+    the committed doc pins. Restricting to ``*.md`` bodies (and excluding
+    ``manifest.json`` plus any non-``.md`` incidental file) restores the
+    "same survivor bodies → same hash" frozen-ruler invariant.
     """
     if not seed_select:
         return ""
@@ -127,11 +138,14 @@ def seed_pool_content_hash(seed_select: str | None) -> str:
     path = Path(seed_select).expanduser()
     if path.is_dir():
         parts: list[str] = []
-        for f in sorted(path.rglob("*")):
-            if f.is_file():
-                rel = f.relative_to(path).as_posix()
-                body = hashlib.sha256(f.read_bytes()).hexdigest()
-                parts.append(f"{rel}:{body}")
+        # ``*.md`` only — survivor bodies are the pool's identity. ``manifest.json``
+        # (a non-``.md`` incidental with a ``generated_at`` timestamp) and any
+        # other non-``.md`` file are excluded so the hash is body-deterministic.
+        for body_file in sorted(path.rglob("*.md")):
+            if body_file.is_file():
+                rel = body_file.relative_to(path).as_posix()
+                body_digest = hashlib.sha256(body_file.read_bytes()).hexdigest()
+                parts.append(f"{rel}:{body_digest}")
         digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
         return f"pool-{digest[:_HASH_PREFIX_LEN]}"
     return f"sel-{hashlib.sha256(str(seed_select).encode('utf-8')).hexdigest()[:_HASH_PREFIX_LEN]}"

--- a/docs/self-improving/held-out-bench.md
+++ b/docs/self-improving/held-out-bench.md
@@ -92,8 +92,13 @@ Assembled seed pool: state/seed-pools/held-out
 If the printed `content hash` is **not** `pool-c16d186178e1`, the frozen survivor
 set changed (a run was added/pruned, or survivor bodies edited) — STOP and
 re-pin a new hash, rather than scoring against a drifted "frozen" ruler. The
-`held_out_bench_id` recorded in every cycle row IS this content hash, so a silent
-edit also surfaces as an id change in the curve.
+`held_out_bench_id` recorded in every cycle row IS this content hash, computed by
+`seed_pool_content_hash` on the live bench dir: it hashes ONLY the seed `.md`
+bodies (the assembler's `manifest.json` — and its `generated_at` timestamp — is
+excluded), so the recorded id equals this pin even though the live dir also holds
+`manifest.json`, and re-assembling the same survivor bodies always reproduces it
+regardless of the manifest timestamp. A silent body edit thus surfaces as an id
+change in the curve.
 
 ## 3. Launch wiring — `GEODE_HELD_OUT_BENCH`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.93"
+version = "0.99.94"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -407,6 +407,38 @@ def _assert_no_duplicate_destinations(selected: list[SelectedRun]) -> None:
             first_owner[survivor_id] = run.run_id
 
 
+def _assert_safe_dest_basename(survivor_id: str, *, run_id: str) -> None:
+    """Raise ``SystemExit`` unless ``survivor_id`` is a safe single path segment.
+
+    The flat pool copies a body to ``pool_dir / f"{survivor_id}.md"``. The
+    survivor id comes from the (trusted-but-still) seeds tree, so a crafted id
+    containing ``/`` or ``..`` (or an absolute leading ``/``) would let the
+    destination escape ``pool_dir`` and clobber a file outside the pool. Validate
+    that the id is exactly one path segment — no separator, no parent ref, not
+    absolute — and fail CLOSED (naming the bad id + its run) before the copy, so
+    a path-escape can never write outside the pool.
+    """
+    candidate = str(survivor_id)
+    bad = (
+        not candidate
+        or candidate in (".", "..")
+        or "/" in candidate
+        or "\\" in candidate
+        or Path(candidate).is_absolute()
+        # ``Path(candidate).name`` strips any directory component; if it differs
+        # from the raw id, the id carried a separator / parent-ref the simple
+        # checks above might miss on some platforms.
+        or Path(candidate).name != candidate
+    )
+    if bad:
+        raise SystemExit(
+            f"survivor id {survivor_id!r} in run {run_id!r} is not a safe single "
+            "path segment (contains a separator, a parent reference, or is "
+            f"absolute); refusing to copy to a destination that could escape the "
+            "pool dir"
+        )
+
+
 def assemble_pool(
     *,
     seeds_root: Path,
@@ -451,9 +483,12 @@ def assemble_pool(
     _ensure_out_dir(pool_dir, force=force)
 
     # Deterministic copy order: runs in (already sorted) selection order, then
-    # survivors in id order. Flat <id>.md destinations.
+    # survivors in id order. Flat <id>.md destinations. Each id is validated as a
+    # safe single path segment first, so a crafted ``../`` / ``/`` id from the
+    # seeds tree can never escape ``pool_dir``.
     for run in selected:
         for survivor_id, body_path in run.survivors:
+            _assert_safe_dest_basename(survivor_id, run_id=run.run_id)
             shutil.copyfile(body_path, pool_dir / f"{survivor_id}.md")
 
     content_hash = seed_pool_content_hash(str(pool_dir))

--- a/tests/autoresearch/test_held_out_bench.py
+++ b/tests/autoresearch/test_held_out_bench.py
@@ -135,8 +135,11 @@ def test_score_held_out_bench_returns_fitness_dims_and_stable_id(
     hash of the frozen bench dir — stable across calls for the same content."""
     bench = tmp_path / "frozen_bench"
     bench.mkdir()
-    (bench / "seed_a.yaml").write_text("id: a\n", encoding="utf-8")
-    (bench / "seed_b.yaml").write_text("id: b\n", encoding="utf-8")
+    # Seed bodies are ``.md`` — the only extension the audit's pool loader reads
+    # (``directory.glob("*.md")``) and the only one ``seed_pool_content_hash``
+    # fingerprints (incidental non-.md files are excluded).
+    (bench / "seed_a.md").write_text("id: a\n", encoding="utf-8")
+    (bench / "seed_b.md").write_text("id: b\n", encoding="utf-8")
 
     fitness, dim_means, bench_id = auto_train.score_held_out_bench(str(bench), dry_run=True)
 
@@ -159,9 +162,9 @@ def test_score_held_out_bench_id_changes_when_frozen_set_edited(
     drift is detectable, not hidden."""
     bench = tmp_path / "frozen_bench"
     bench.mkdir()
-    (bench / "seed_a.yaml").write_text("id: a\n", encoding="utf-8")
+    (bench / "seed_a.md").write_text("id: a\n", encoding="utf-8")
     _f, _d, id_before = auto_train.score_held_out_bench(str(bench), dry_run=True)
-    (bench / "seed_a.yaml").write_text("id: a-EDITED\n", encoding="utf-8")
+    (bench / "seed_a.md").write_text("id: a-EDITED\n", encoding="utf-8")
     _f2, _d2, id_after = auto_train.score_held_out_bench(str(bench), dry_run=True)
     assert id_before != id_after
 
@@ -173,7 +176,7 @@ def test_score_held_out_bench_restores_seed_select_env(
     a prior value must be restored (and an unset var stays unset)."""
     bench = tmp_path / "frozen_bench"
     bench.mkdir()
-    (bench / "s.yaml").write_text("id: s\n", encoding="utf-8")
+    (bench / "s.md").write_text("id: s\n", encoding="utf-8")
 
     # Case 1: a prior co-evolving override is restored exactly.
     monkeypatch.setenv("AUTORESEARCH_SEED_SELECT", "co-evolving/survivors")
@@ -186,6 +189,100 @@ def test_score_held_out_bench_restores_seed_select_env(
     monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
     auto_train.score_held_out_bench(str(bench), dry_run=True)
     assert "AUTORESEARCH_SEED_SELECT" not in os.environ
+
+
+def test_score_held_out_bench_uses_same_fitness_formula_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The held-out fitness MUST be computed on the same formula path the gate's
+    ``current_raw`` uses — same compute_fitness arguments — so the curve is not on
+    a subtly different fitness DEFINITION than the baselines it is compared
+    against.
+
+    Pins that ``score_held_out_bench`` threads the shared ``anchor_confidence_mode``
+    flag into compute_fitness WITH the held-out's own ``ANCHOR_DIMS`` subset as
+    ``anchor_means`` (the gate extracts the same subset from its current dims —
+    passing the flag without the subset would silently no-op the multiplier), with
+    ``baseline_means=None`` (fresh-anchor intrinsic) and ``admire_means=None`` (the
+    held-out audit emits no admire signal).
+    """
+    bench = tmp_path / "frozen_bench"
+    bench.mkdir()
+    (bench / "s.md").write_text("id: s\n", encoding="utf-8")
+
+    # Stub the audit to return dims that INCLUDE the anchor dims (a real audit's
+    # dim_extractor collects them; the dry-run synthetic set omits them), so the
+    # anchor-subset extraction is observable.
+    held_dims = {
+        "broken_tool_use": 3.0,
+        "admirable": 2.0,
+        "disappointing": 4.0,
+        "needs_attention": 5.0,
+    }
+
+    def _fake_audit(
+        _dry_run: bool, *, session_id: str = "", gen_tag: str = ""
+    ) -> tuple[
+        dict[str, float],
+        dict[str, float],
+        float,
+        float,
+        dict[str, int],
+        dict[str, str],
+        list[dict[str, float]],
+    ]:
+        return dict(held_dims), {}, 0.0, 0.0, {}, {}, []
+
+    monkeypatch.setattr(auto_train, "run_audit", _fake_audit)
+
+    captured: dict[str, object] = {}
+
+    def _spy(
+        dim_means: dict[str, float],
+        dim_stderr: dict[str, float] | None = None,
+        **kwargs: object,
+    ) -> float:
+        # Capture the keyword formula-path arguments; return a fixed in-range
+        # value (the test asserts on the captured args, not the fitness scalar).
+        captured.update(kwargs)
+        return 0.5
+
+    monkeypatch.setattr(auto_train, "compute_fitness", _spy)
+
+    # mode ON must be threaded through verbatim, WITH a real anchor subset so the
+    # multiplier actually applies (not a silent no-op).
+    auto_train.score_held_out_bench(str(bench), dry_run=True, anchor_confidence_mode=True)
+    assert captured["anchor_confidence_mode"] is True
+    assert captured["baseline_means"] is None
+    assert captured["admire_means"] is None
+    anchor_means = captured["anchor_means"]
+    assert isinstance(anchor_means, dict) and anchor_means
+    # the anchor subset is exactly the held-out dims restricted to ANCHOR_DIMS —
+    # the SAME extraction the gate's current_raw does on its current dims.
+    assert anchor_means == {dim: held_dims[dim] for dim in auto_train.ANCHOR_DIMS}
+
+    captured.clear()
+    # mode OFF (default) is likewise honoured — the curve does not silently flip on.
+    auto_train.score_held_out_bench(str(bench), dry_run=True)
+    assert captured["anchor_confidence_mode"] is False
+
+
+def test_score_held_out_bench_signature_has_anchor_flag() -> None:
+    """The scorer exposes the ``anchor_confidence_mode`` keyword so the live
+    dispatch can thread the gate's flag (formula-parity wiring)."""
+    sig = inspect.signature(auto_train.score_held_out_bench)
+    assert "anchor_confidence_mode" in sig.parameters
+
+
+def test_main_threads_anchor_confidence_mode_into_held_out() -> None:
+    """The live cycle must pass the SAME ``_anchor_confidence_mode`` it gives the
+    promote gate into ``score_held_out_bench`` — a static guard against a
+    half-wired flag that would leave the held-out curve on the mode-off formula."""
+    source = inspect.getsource(auto_train.main)
+    assert "anchor_confidence_mode=_anchor_confidence_mode" in source, (
+        "main must thread _anchor_confidence_mode into score_held_out_bench so the "
+        "held-out curve shares the gate's fitness formula path"
+    )
 
 
 # --- baseline registry row: held-out fields ----------------------------------

--- a/tests/test_assemble_seed_pool.py
+++ b/tests/test_assemble_seed_pool.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 from core.self_improving_loop.baseline_epoch import seed_pool_content_hash
 from scripts.assemble_seed_pool import (
+    _assert_safe_dest_basename,
     _split_run_ids,
     assemble_pool,
     collect_valid_survivors,
@@ -239,15 +240,55 @@ def test_flat_copy_and_manifest_correctness(seeds_tree: Path, tmp_path: Path) ->
     assert by_run["gen-2605-3-broken_tool_use"]["survivor_ids"] == ["g3-001", "g3-evolved"]
     assert manifest["generated_at"] == "2026-05-30T00:00:00+00:00"
 
-    # Manifest content_hash matches a fresh hash of the out dir. The manifest.json
-    # itself is part of the dir; the recorded hash was computed before it was
-    # written, so re-hash a sibling copy holding only the .md bodies.
+    # Manifest content_hash matches a fresh hash of the ACTUAL out dir — the one
+    # that NOW holds manifest.json. ``seed_pool_content_hash`` hashes only the
+    # ``.md`` bodies, so the runtime hash on the live dir equals the assembler's
+    # body-only hash (recorded before the manifest was written). This is the
+    # masked-bug guard: the pre-fix ``rglob("*")`` folded manifest.json's
+    # timestamp into the hash, so this equality FAILED on the live dir.
+    assert (out_dir / "manifest.json").is_file()
+    assert manifest["content_hash"] == seed_pool_content_hash(str(out_dir))
+    assert manifest["content_hash"].startswith("pool-")
+
+    # Sanity: it also equals a bodies-only sibling copy (manifest absent), proving
+    # the two are one and the same identity regardless of the incidental file.
     bodies_only = tmp_path / "bodies_only"
     bodies_only.mkdir()
     for md in out_dir.glob("*.md"):
         (bodies_only / md.name).write_text(md.read_text(encoding="utf-8"), encoding="utf-8")
     assert manifest["content_hash"] == seed_pool_content_hash(str(bodies_only))
-    assert manifest["content_hash"].startswith("pool-")
+
+
+def test_runtime_hash_invariant_to_manifest_timestamp(seeds_tree: Path, tmp_path: Path) -> None:
+    """End-to-end: assembling the SAME survivor bodies with DIFFERENT ``--now``
+    timestamps yields the SAME runtime ``seed_pool_content_hash`` on the live pool
+    dirs (manifest present). Regression for the non-determinism the masked bug
+    introduced — a re-assembly with a fresh timestamp must NOT fork the epoch.
+    """
+    out_a = tmp_path / "pool_a"
+    out_b = tmp_path / "pool_b"
+    manifest_a = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_a,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2026-05-30T00:00:00+00:00",
+    )
+    manifest_b = assemble_pool(
+        seeds_root=seeds_tree,
+        out_dir=out_b,
+        runs=2,
+        per_run=None,
+        force=False,
+        now="2099-12-31T23:59:59+00:00",  # different timestamp
+    )
+    # The two manifests carry DIFFERENT generated_at...
+    assert manifest_a["generated_at"] != manifest_b["generated_at"]
+    # ...yet the runtime hash on each live dir (manifest present) is identical.
+    hash_a = seed_pool_content_hash(str(out_a))
+    hash_b = seed_pool_content_hash(str(out_b))
+    assert hash_a == hash_b == manifest_a["content_hash"] == manifest_b["content_hash"]
 
 
 def test_determinism_same_inputs_same_pool_and_hash(seeds_tree: Path, tmp_path: Path) -> None:
@@ -398,6 +439,62 @@ def test_duplicate_survivor_id_across_runs_fails_closed(tmp_path: Path) -> None:
     assert "gen-2605-3-b" in message
     # Fail-closed BEFORE writing: no pool dir was created.
     assert not out_dir.exists()
+
+
+# --- survivor_id dest-basename path-escape guard -----------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["evil/../escape", "sub/dir", "..", ".", "/abs", "back\\slash", ""],
+)
+def test_assert_safe_dest_basename_rejects_escapes(bad_id: str) -> None:
+    """An id that is not a single safe path segment fails closed (SystemExit
+    naming the bad id), so it can never be copied to a dest outside the pool."""
+    with pytest.raises(SystemExit) as excinfo:
+        _assert_safe_dest_basename(bad_id, run_id="gen-2605-4-x")
+    assert repr(bad_id) in str(excinfo.value)
+
+
+def test_assert_safe_dest_basename_accepts_normal_ids() -> None:
+    """A normal gen_tag-prefixed survivor id is a valid single segment."""
+    _assert_safe_dest_basename("gen-2605-4-003-e2b9759a", run_id="gen-2605-4-x")
+
+
+def test_assemble_pool_fails_closed_on_escaping_survivor_id(tmp_path: Path) -> None:
+    """A survivor whose id contains ``/`` (run-local body, so it passes the
+    valid-survivor filter) would copy to ``pool_dir / sub/evil.md`` — escaping the
+    flat pool. assemble_pool must fail closed BEFORE writing, naming the bad id.
+    """
+    seeds_root = tmp_path / "seeds"
+    run_dir = seeds_root / "gen-2605-4-x"
+    body_rel = "candidates/sub/evil.md"  # run-local nested body for a "/"-id
+    body_abs = run_dir / body_rel
+    body_abs.parent.mkdir(parents=True, exist_ok=True)
+    body_abs.write_text("escaping body\n", encoding="utf-8")
+    # The id itself carries a ``/`` — its body lives at a run-local nested path, so
+    # the valid-survivor filter accepts it. Only the dest-basename guard stops it.
+    (run_dir / "state.json").write_text(
+        json.dumps({"gen_tag": "gen-2605-4", "survivors": ["sub/evil"]}),
+        encoding="utf-8",
+    )
+    (run_dir / "survivors.json").write_text(
+        json.dumps({"survivors": [{"id": "sub/evil", "path": body_rel, "elo_rating": 1000.0}]}),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "pool"
+    with pytest.raises(SystemExit) as excinfo:
+        assemble_pool(
+            seeds_root=seeds_root,
+            out_dir=out_dir,
+            runs=2,
+            per_run=None,
+            force=False,
+            now=None,
+        )
+    assert "sub/evil" in str(excinfo.value)
+    # No stray escaped file was written outside the pool.
+    assert not (out_dir / "sub").exists()
 
 
 # --- FIX 2: missing/empty gen_tag sorts lowest, never selected ---------------

--- a/tests/test_baseline_epoch.py
+++ b/tests/test_baseline_epoch.py
@@ -195,3 +195,47 @@ def test_seed_pool_content_hash_expands_user(
     monkeypatch.setenv("HOME", str(home))
     assert seed_pool_content_hash("~/pool") == seed_pool_content_hash(str(pool))
     assert seed_pool_content_hash("~/pool").startswith("pool-")
+
+
+def test_seed_pool_content_hash_ignores_manifest_json(tmp_path: Path) -> None:
+    """A pool dir's hash is its ``.md`` BODIES only — the assembler's
+    ``manifest.json`` (and its ``generated_at`` timestamp) must NOT move it.
+
+    Regression for the masked bug: the pre-fix ``rglob("*")`` folded
+    ``manifest.json`` into the hash, so the runtime hash on the live pool dir
+    (manifest present) diverged from the assembler's body-only hash AND changed
+    whenever the manifest timestamp changed — fragmenting identical survivor
+    bodies into different epochs. The masking earlier test re-hashed a
+    bodies-only COPY; this one keeps the manifest IN the dir and asserts (a) the
+    hash equals the bodies-only hash and (b) it is invariant when the manifest's
+    timestamp changes.
+    """
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "a.md").write_text("body-a", encoding="utf-8")
+    (pool / "b.md").write_text("body-b", encoding="utf-8")
+
+    # Reference: bodies only (no manifest in the dir).
+    bodies_only = seed_pool_content_hash(str(pool))
+    assert bodies_only.startswith("pool-")
+
+    # (a) Adding manifest.json with a timestamp must not move the hash.
+    (pool / "manifest.json").write_text(
+        '{"generated_at": "2026-05-30T00:00:00+00:00", "x": 1}', encoding="utf-8"
+    )
+    with_manifest = seed_pool_content_hash(str(pool))
+    assert with_manifest == bodies_only
+
+    # (b) Mutating ONLY the manifest's timestamp must not move the hash.
+    (pool / "manifest.json").write_text(
+        '{"generated_at": "2099-12-31T23:59:59+00:00", "x": 2}', encoding="utf-8"
+    )
+    assert seed_pool_content_hash(str(pool)) == bodies_only
+
+    # An UNRELATED non-.md incidental file is likewise excluded.
+    (pool / "notes.txt").write_text("scratch", encoding="utf-8")
+    assert seed_pool_content_hash(str(pool)) == bodies_only
+
+    # But a real .md body edit STILL moves the hash (the fix did not over-narrow).
+    (pool / "a.md").write_text("body-a-EDITED", encoding="utf-8")
+    assert seed_pool_content_hash(str(pool)) != bodies_only

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.93"
+version = "0.99.94"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `seed_pool_content_hash` now fingerprints ONLY the seed `.md` bodies (was `rglob("*")`), so the runtime pool hash is deterministic + reproduces the committed doc pins instead of folding the assembler's `manifest.json` `generated_at` timestamp into the hash.
- `score_held_out_bench` threads the gate's `anchor_confidence_mode` flag + the held-out's own `ANCHOR_DIMS` subset into `compute_fitness`, so the held-out evidence curve shares ONE fitness formula path with the baselines it is compared against.
- `assemble_seed_pool` fails closed on a `survivor_id` that is not a safe single path segment (`/`, `..`, absolute) before the flat-copy.

## Why
A batch verification of `develop` FAILED on one HIGH bug + flagged a MED + a LOW:

- **HIGH** — `seed_pool_content_hash` hashed `path.rglob("*")` (ALL files). The assembler writes `manifest.json` (with a `generated_at` timestamp) INTO the pool dir, so the runtime hash on a live pool dir (a) diverged from the assembler's body-only hash and the committed doc pins, and (b) was NON-DETERMINISTIC across re-assembly — re-assembling identical survivor bodies fragmented baselines into different epochs, defeating the "same spec → same hash" frozen-ruler invariant. Independently reproduced: the buggy runtime hash on the live selection pool was `pool-860d825ee026` (ts A) / `pool-c75c18f743c3` (ts B), neither equal to the pin `pool-68dc6f0c9745`.
- **MED** — `score_held_out_bench`'s `compute_fitness` omitted `anchor_confidence_mode`/`anchor_means` that the gate's `current_raw` includes, so when anchor-confidence mode is on the held-out curve ran on a subtly different fitness DEFINITION than the baselines.
- **LOW** — the flat-copy dest `pool_dir / f"{survivor_id}.md"` did not validate `survivor_id` was a single safe segment, so a `../`/`/`-containing id could escape the pool dir.

The HIGH fix touches `core/self_improving_loop/baseline_epoch.py` (on `main`), so it carries to production.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/baseline_epoch.py` | `seed_pool_content_hash` recurses `*.md` only (excludes `manifest.json` + non-`.md` incidentals) — exactly the file set the audit's pool loader reads (`directory.glob("*.md")`). `sel-`/expanduser/empty behaviour unchanged. |
| `autoresearch/train.py` | `score_held_out_bench` gains `anchor_confidence_mode` kw, extracts the held-out's `ANCHOR_DIMS` subset, passes both into `compute_fitness`; `main()` threads `_anchor_confidence_mode` into the call. |
| `scripts/assemble_seed_pool.py` | new `_assert_safe_dest_basename`; called before each `shutil.copyfile`. |
| `docs/self-improving/held-out-bench.md` | reproduction note corrected to state body-only content-addressing (claim now TRUE). |
| `tests/test_baseline_epoch.py` | masked-scenario test: `.md` bodies + `manifest.json` w/ timestamp reproduces bodies-only hash + is timestamp-invariant. |
| `tests/test_assemble_seed_pool.py` | live-dir hash equals manifest hash (unmasks bug); end-to-end timestamp-invariance; basename-guard tests. |
| `tests/autoresearch/test_held_out_bench.py` | parity test (flag + anchor subset threaded); `.yaml`→`.md` synthetic seeds (matches the loader's real extension). |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md`, `CHANGELOG.md` | v0.99.93 → v0.99.94 + `### Fixed` entries. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| HIGH bodies-only hash | Implemented | selection `pool-68dc6f0c9745` + held-out `pool-c16d186178e1` reproduce on the live dirs (manifest present); deterministic across `--now` timestamps. Pins unchanged (already the body-only hash). |
| MED held-out formula parity | Implemented | flag + held-out anchor subset threaded; matches gate `current_raw`. |
| LOW basename guard | Implemented | fail-closed before copy. |

## Verification
- [x] ruff check clean (`core/ autoresearch/ scripts/ tests/`)
- [x] ruff format --check clean (changed files)
- [x] mypy clean (`autoresearch/train.py core/self_improving_loop/`)
- [x] pytest pass (236 passed, 1 skipped — `test_baseline_epoch` + `test_assemble_seed_pool` + `tests/autoresearch/` + `test_attribution_belief` + `test_self_improving_hub_e2e`)
- [x] HIGH fix re-verified on the ACTUAL pool dirs with `manifest.json` present + timestamp-invariance proof
- [x] Codex MCP read-only review: PASS (both prior findings resolved)

## Reference
Batch verification of `develop`; Codex MCP cross-review (2 findings fixed: held-out anchor-subset threading + `# type: ignore` removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)