### PR TITLE
feat(seedgen): per-agent + per-phase token usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,46 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+- **PR-SEEDGEN-TOKENS (2026-05-30) — per-agent (per-phase) + run-level token
+  usage tracking for the seed-generation pipeline.** The LLM `usage` a sub-agent
+  already produces (`AgenticResult.usage`, via `TokenTracker.delta_since`) now
+  survives the worker subprocess IPC instead of being dropped before it reaches
+  the aggregators. New token + cost fields (`prompt_tokens` / `completion_tokens`
+  / `usd_spent`) thread along the full chain:
+  `WorkerResult` (populated from `agentic_result.usage`) → `IsolationResult`
+  (parsed from the worker stdout JSON) → `SubResult` (set in
+  `SubAgentManager._to_sub_result`) → each of the 9 seed agents sums its
+  sub-results' usage (via the new `sum_sub_result_tokens` helper in
+  `agents/base.py`) into the returned `SeedAgentResult` → the existing
+  orchestrator run-level rollup (`state.prompt_tokens += result.prompt_tokens`)
+  lights up unchanged. Separately, the per-phase cost grid now works:
+  `Transcript.record_session_end` (and its `_lifecycle` caller, which already
+  read the tracker for `total_cost`) also write `prompt_tokens` /
+  `completion_tokens` from the tracker accumulator into each sub-agent's
+  `dialogue.jsonl` `session_end` event, which the orchestrator's
+  `_persist_per_phase_costs` already sums. Pinned by
+  `tests/test_worker.py` (WorkerResult usage roundtrip),
+  `tests/core/agent/test_sub_result_token_forwarding.py`
+  (IsolationResult → SubResult),
+  `tests/plugins/seed_generation/test_critic.py` (agent rollup +
+  subscription-zero), and `tests/test_session_transcript.py` (session_end token
+  keys).
+
+### Fixed
+- **PR-SEEDGEN-TOKENS (2026-05-30) — seed-generation runs reported all-zero
+  tokens/cost.** The aggregation infrastructure already existed but every link
+  between the producer (`AgenticResult.usage`) and the aggregators dropped the
+  usage: `WorkerResult` / `IsolationResult` / `SubResult` had no usage fields,
+  the agents never assigned tokens, and `record_session_end` never wrote token
+  keys. Plumbed end-to-end (see Added).
+  **Honest limitation:** subscription / CLI-routed calls (claude-cli, codex-cli)
+  return an empty `UsageSummary()` — the subscription path does not expose token
+  usage (`core/llm/adapters/claude_cli.py`, `core/llm/adapters/codex_cli.py`).
+  Token counts are therefore reported only for API-key / payg calls (e.g. payg
+  ranker voters); subscription-routed phases honestly stay 0 and are never
+  fabricated. This is why most phases still show 0 cost today.
+
 ## [0.99.94] - 2026-05-30
 
 ### Fixed

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -73,16 +73,32 @@ def record_transcript_end(loop: AgenticLoop, result: Any) -> None:
             loop._transcript.record_assistant_message(text)
         rounds = getattr(result, "rounds", 0)
 
-        # Read accumulated cost from TokenTracker (was missing → always $0)
+        # Read accumulated cost + tokens from TokenTracker (was missing →
+        # always $0 / 0 tokens). PR-SEEDGEN-TOKENS (2026-05-30) adds the
+        # token reads so the session_end event carries prompt/completion
+        # tokens for the seed-generation per-phase cost grid. These are 0
+        # for subscription / CLI calls (the subscription adapters return an
+        # empty UsageSummary — usage is not exposed), so the accumulator
+        # only reflects API-key / payg calls. Never fabricated.
         total_cost = 0.0
+        prompt_tokens = 0
+        completion_tokens = 0
         try:
             from core.llm.token_tracker import get_tracker
 
-            total_cost = get_tracker().accumulator.total_cost_usd
+            accumulator = get_tracker().accumulator
+            total_cost = accumulator.total_cost_usd
+            prompt_tokens = accumulator.total_input_tokens
+            completion_tokens = accumulator.total_output_tokens
         except Exception:
-            log.debug("Could not read session cost from TokenTracker")
+            log.debug("Could not read session cost/tokens from TokenTracker")
 
-        loop._transcript.record_session_end(rounds=rounds, total_cost=total_cost)
+        loop._transcript.record_session_end(
+            rounds=rounds,
+            total_cost=total_cost,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
     except Exception:
         log.debug("Transcript end recording failed", exc_info=True)
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -312,7 +312,14 @@ class SubTask:
 
 @dataclass
 class SubResult:
-    """Result from a sub-agent execution."""
+    """Result from a sub-agent execution.
+
+    PR-SEEDGEN-TOKENS (2026-05-30) — ``prompt_tokens`` / ``completion_tokens``
+    / ``usd_spent`` carry the sub-agent's LLM usage so fan-out roles
+    (generator / ranker / pilot) and single-shot roles can sum it into
+    their returned ``SeedAgentResult``. These are 0 for subscription /
+    CLI-routed calls (the subscription path does not expose token usage).
+    """
 
     task_id: str
     description: str
@@ -320,6 +327,10 @@ class SubResult:
     output: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
     duration_ms: float = 0.0
+    # LLM usage for this sub-agent (0 for subscription calls — not faked).
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    usd_spent: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""
@@ -979,6 +990,12 @@ class SubAgentManager:
                 success=False,
                 error=isolation.error,
                 duration_ms=isolation.duration_ms,
+                # PR-SEEDGEN-TOKENS — a sub-agent can burn tokens before
+                # failing; forward whatever the worker reported (0 for
+                # subscription calls) so cost accounting stays honest.
+                prompt_tokens=isolation.prompt_tokens,
+                completion_tokens=isolation.completion_tokens,
+                usd_spent=isolation.usd_spent,
             )
         output: dict[str, Any]
         raw_text = isolation.output or ""
@@ -1007,6 +1024,10 @@ class SubAgentManager:
             success=True,
             output=output,
             duration_ms=isolation.duration_ms,
+            # PR-SEEDGEN-TOKENS — forward worker LLM usage to fan-out roles.
+            prompt_tokens=isolation.prompt_tokens,
+            completion_tokens=isolation.completion_tokens,
+            usd_spent=isolation.usd_spent,
         )
 
     def _to_agent_result(self, task: SubTask, isolation: IsolationResult | None) -> SubAgentResult:

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -151,7 +151,23 @@ class WorkerRequest:
 
 @dataclass
 class WorkerResult:
-    """Serializable result from worker subprocess to parent process."""
+    """Serializable result from worker subprocess to parent process.
+
+    PR-SEEDGEN-TOKENS (2026-05-30) — carry per-call LLM usage across the
+    worker IPC boundary so the seed-generation pipeline can roll up
+    per-agent / per-phase / run-level token + cost. The sub-agent's
+    ``AgenticResult.usage`` (captured via ``TokenTracker.delta_since`` in
+    ``core/agent/loop/_lifecycle.py``) was previously dropped here because
+    ``WorkerResult`` had no usage fields, so everything serialized to the
+    parent reported zeros.
+
+    HARD LIMITATION: subscription / CLI-routed calls (claude-cli,
+    codex-cli) return an empty ``UsageSummary()`` — the subscription path
+    does not expose token usage (see ``core/llm/adapters/claude_cli.py``
+    and ``core/llm/adapters/codex_cli.py``). For those calls these fields
+    are honestly left at 0; only API-key / payg calls populate real
+    numbers. We never fabricate counts.
+    """
 
     task_id: str
     success: bool
@@ -159,6 +175,10 @@ class WorkerResult:
     summary: str = ""  # Truncated summary (max 500 chars)
     error: str | None = None
     duration_ms: float = 0.0
+    # LLM usage for this sub-agent invocation (0 for subscription calls).
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    usd_spent: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v is not None}
@@ -172,6 +192,9 @@ class WorkerResult:
             summary=data.get("summary", ""),
             error=data.get("error"),
             duration_ms=data.get("duration_ms", 0.0),
+            prompt_tokens=data.get("prompt_tokens", 0),
+            completion_tokens=data.get("completion_tokens", 0),
+            usd_spent=data.get("usd_spent", 0.0),
         )
 
 
@@ -509,12 +532,28 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     elapsed_ms = (time.time() - started) * 1000
     success, summary, text = _resolve_worker_outcome(agentic_result)
 
+    # PR-SEEDGEN-TOKENS (2026-05-30) — surface the sub-agent's per-arun
+    # usage to the parent. ``agentic_result.usage`` is an ``LLMUsage``
+    # aggregate (or None when the loop made no LLM call); subscription /
+    # CLI calls leave it empty so the fields stay 0 — never fabricated.
+    prompt_tokens = 0
+    completion_tokens = 0
+    usd_spent = 0.0
+    usage = agentic_result.usage if agentic_result is not None else None
+    if usage is not None:
+        prompt_tokens = usage.input_tokens
+        completion_tokens = usage.output_tokens
+        usd_spent = usage.cost_usd
+
     return WorkerResult(
         task_id=request.task_id,
         success=success,
         output=text,
         summary=summary,
         duration_ms=elapsed_ms,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        usd_spent=usd_spent,
     )
 
 

--- a/core/observability/transcript.py
+++ b/core/observability/transcript.py
@@ -177,13 +177,28 @@ class SessionTranscript:
         duration_s: float = 0,
         total_cost: float = 0,
         rounds: int = 0,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
     ) -> None:
+        """Append the ``session_end`` event.
+
+        PR-SEEDGEN-TOKENS (2026-05-30) — ``prompt_tokens`` /
+        ``completion_tokens`` are written so the seed-generation
+        orchestrator's per-phase cost grid can sum them off each
+        sub-agent's ``dialogue.jsonl`` (``_persist_per_phase_costs``
+        already reads these keys). They are 0 for subscription / CLI
+        calls (the subscription path does not expose token usage), so
+        only API-key / payg sub-agents contribute non-zero values —
+        counts are never fabricated.
+        """
         self._append(
             {
                 "event": "session_end",
                 "duration_s": round(duration_s, 1),
                 "total_cost": round(total_cost, 4),
                 "rounds": rounds,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
             }
         )
         self._update_index()

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -50,7 +50,14 @@ class IsolationConfig:
 
 @dataclass
 class IsolationResult:
-    """Result from an isolated execution."""
+    """Result from an isolated execution.
+
+    PR-SEEDGEN-TOKENS (2026-05-30) — ``prompt_tokens`` / ``completion_tokens``
+    / ``usd_spent`` carry the worker subprocess's LLM usage up to the
+    ``SubAgentManager`` so seed-generation roles can roll it up. These are
+    0 for subscription / CLI-routed calls (the subscription path does not
+    expose token usage) and only populated for API-key / payg calls.
+    """
 
     session_id: str
     success: bool
@@ -61,6 +68,10 @@ class IsolationResult:
     started_at: float = 0.0
     completed_at: float = 0.0
     metadata: dict[str, Any] = field(default_factory=dict)
+    # LLM usage forwarded from the worker (0 for subscription calls).
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    usd_spent: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""
@@ -482,6 +493,11 @@ class IsolatedRunner:
                 started_at=started,
                 completed_at=completed,
                 metadata=dict(config.metadata),
+                # PR-SEEDGEN-TOKENS (2026-05-30) — carry worker LLM usage up.
+                # 0 for subscription / CLI calls (no usage exposed).
+                prompt_tokens=result_data.get("prompt_tokens", 0),
+                completion_tokens=result_data.get("completion_tokens", 0),
+                usd_spent=result_data.get("usd_spent", 0.0),
             )
 
             if config.post_to_main:

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -47,13 +47,18 @@ import abc
 import json
 import logging
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 log = logging.getLogger(__name__)
 
-__all__ = ["BaseSeedAgent", "SeedAgentResult", "parse_structured_output"]
+__all__ = [
+    "BaseSeedAgent",
+    "SeedAgentResult",
+    "parse_structured_output",
+    "sum_sub_result_tokens",
+]
 
 
 # Matches a fenced code block containing JSON. The optional language tag
@@ -180,6 +185,38 @@ class SeedAgentResult:
     @property
     def success(self) -> bool:
         return self.status == "ok"
+
+
+def sum_sub_result_tokens(
+    results: Iterable[Any],
+) -> tuple[int, int, float]:
+    """Sum ``(prompt_tokens, completion_tokens, usd_spent)`` over sub-results.
+
+    PR-SEEDGEN-TOKENS (2026-05-30) — fan-out roles (generator / ranker /
+    pilot) and single-shot roles delegate via ``SubAgentManager`` and get
+    back a ``list[SubResult]``. Each ``SubResult`` now carries the worker
+    subprocess's LLM usage (forwarded through ``IsolationResult``). Roles
+    call this to fold every spawned sub-agent's usage into the single
+    ``SeedAgentResult`` they return; the orchestrator's run-level rollup
+    (``orchestrator.py``) then sums those into ``PipelineState``.
+
+    HARD LIMITATION: subscription / CLI-routed calls (claude-cli,
+    codex-cli) return an empty ``UsageSummary()`` — the subscription path
+    does not expose token usage — so their contribution is honestly 0.
+    Only API-key / payg sub-agents (e.g. payg ranker voters) add non-zero
+    numbers. Counts are never fabricated.
+
+    Accepts any iterable of objects exposing the three attributes so it
+    works on real ``SubResult`` instances and lightweight test stubs.
+    """
+    prompt_tokens = 0
+    completion_tokens = 0
+    usd_spent = 0.0
+    for result in results:
+        prompt_tokens += int(getattr(result, "prompt_tokens", 0) or 0)
+        completion_tokens += int(getattr(result, "completion_tokens", 0) or 0)
+        usd_spent += float(getattr(result, "usd_spent", 0.0) or 0.0)
+    return prompt_tokens, completion_tokens, usd_spent
 
 
 class BaseSeedAgent(abc.ABC):

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -46,7 +46,11 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from plugins.seed_generation.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_generation.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    sum_sub_result_tokens,
+)
 from plugins.seed_generation.handoff_schemas import (
     embed_handoff,
     extract_anchor_means,
@@ -139,6 +143,10 @@ class Critic(BaseSeedAgent):
         # announce=False — orchestrator already announces the parent phase.
         results = await self._manager.adelegate(tasks, announce=False)
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — sum sub-agent LLM usage (0 for
+        # subscription calls) into this phase's result.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
+
         # S2-fix pattern — pair by task_id dict lookup, never by position.
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
         reflections: dict[str, dict[str, object]] = {}
@@ -180,11 +188,17 @@ class Critic(BaseSeedAgent):
                     f"all {len(tasks)} critique sub-agents failed; "
                     f"first error: {failed[0][1] if failed else 'unknown'}"
                 ),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         return SeedAgentResult(
             role=self.role,
             output={"reflections": reflections},
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_tasks(self, state: PipelineState) -> list[SubTask]:

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -44,6 +44,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import EVOLVE_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -167,6 +168,10 @@ class Evolver(BaseSeedAgent):
         )
         results = await self._manager.adelegate(tasks, announce=False)
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — sum sub-agent LLM usage (0 for
+        # subscription calls) into this phase's result.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
+
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
         evolved_rows: list[dict[str, Any]] = []
         failed: list[tuple[str, str]] = []
@@ -249,11 +254,17 @@ class Evolver(BaseSeedAgent):
                     f"or returned verdict != 'ok'; "
                     f"first error: {failed[0][1] if failed else 'verdict_not_ok'}"
                 ),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         return SeedAgentResult(
             role=self.role,
             output={"evolved_candidates": evolved_rows},
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_tasks(

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -55,7 +55,11 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from plugins.seed_generation.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_generation.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    sum_sub_result_tokens,
+)
 from plugins.seed_generation.orchestrator import PipelineState
 
 if TYPE_CHECKING:
@@ -141,6 +145,10 @@ class Generator(BaseSeedAgent):
         # events.
         results = await self._manager.adelegate(tasks, announce=False)
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — fold every sub-agent's LLM
+        # usage into this phase's result (0 for subscription calls).
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
+
         # S2-fix (2026-05-18) — pair results by task_id, NOT by positional zip.
         # ``SubAgentManager.delegate`` returns SubResult in *completion* order
         # (poll loop in ``core/agent/sub_agent.py``), not submission order, so
@@ -188,6 +196,9 @@ class Generator(BaseSeedAgent):
                     f"all {len(tasks)} candidate sub-agents failed; "
                     f"first error: {failed[0][1] if failed else 'unknown'}"
                 ),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         # CSP-13 (2026-05-23) — Loop 2 (debate-turn). When the manifest
@@ -202,7 +213,13 @@ class Generator(BaseSeedAgent):
         if debate_transcripts:
             output["debate_transcripts"] = debate_transcripts
 
-        return SeedAgentResult(role=self.role, output=output)
+        return SeedAgentResult(
+            role=self.role,
+            output=output,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
+        )
 
     def _num_turns(self) -> int:
         """Resolve the per-role ``num_turns`` knob (CSP-13).

--- a/plugins/seed_generation/agents/literature_review.py
+++ b/plugins/seed_generation/agents/literature_review.py
@@ -51,6 +51,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import LITERATURE_REVIEW_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -132,12 +133,18 @@ class LiteratureReview(BaseSeedAgent):
             )
 
         result = results[0]
+        # PR-SEEDGEN-TOKENS (2026-05-30) — forward sub-agent LLM usage (0
+        # for subscription calls) onto every return below.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
         if not result.success:
             return SeedAgentResult(
                 role=self.role,
                 status="error",
                 error_category="literature_review_failed",
                 error_message=result.error or "literature_review sub-agent failed",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         parsed = parse_structured_output(
@@ -159,6 +166,9 @@ class LiteratureReview(BaseSeedAgent):
                     "articles_with_reasoning": "",
                     "literature_snapshots": {},
                 },
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         articles = str(parsed.get("articles_with_reasoning", "") or "")
@@ -174,6 +184,9 @@ class LiteratureReview(BaseSeedAgent):
                 "articles_with_reasoning": articles,
                 "literature_snapshots": literature_snapshots,
             },
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _max_papers(self) -> int:

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -48,6 +48,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import META_REVIEW_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -127,12 +128,18 @@ class MetaReviewer(BaseSeedAgent):
             )
 
         result = results[0]
+        # PR-SEEDGEN-TOKENS (2026-05-30) — forward sub-agent LLM usage (0
+        # for subscription calls) onto every return below.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
         if not result.success:
             return SeedAgentResult(
                 role=self.role,
                 status="error",
                 error_category="meta_review_failed",
                 error_message=result.error or "meta_review sub-agent failed",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
         parsed = parse_structured_output(
             result.output,
@@ -144,11 +151,17 @@ class MetaReviewer(BaseSeedAgent):
                 status="error",
                 error_category="meta_review_failed",
                 error_message=(f"malformed meta_review payload: result.output={result.output!r}"),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         return SeedAgentResult(
             role=self.role,
             output={"meta_review": parsed},
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_task(self, state: PipelineState) -> SubTask:

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -43,7 +43,11 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from plugins.seed_generation.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_generation.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    sum_sub_result_tokens,
+)
 from plugins.seed_generation.handoff_schemas import embed_handoff, extract_anchor_means
 from plugins.seed_generation.json_schemas import PILOT_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -124,6 +128,10 @@ class Pilot(BaseSeedAgent):
         # announce=False — orchestrator already announces the parent phase.
         results = await self._manager.adelegate(tasks, announce=False)
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — sum sub-agent LLM usage (0 for
+        # subscription calls) into this phase's result.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
+
         # S2-fix pattern — pair by task_id dict lookup, never by position.
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
         pilot_scores: dict[str, dict[str, object]] = {}
@@ -165,11 +173,17 @@ class Pilot(BaseSeedAgent):
                     f"all {len(tasks)} pilot sub-agents failed; "
                     f"first error: {failed[0][1] if failed else 'unknown'}"
                 ),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         return SeedAgentResult(
             role=self.role,
             output={"pilot_scores": pilot_scores},
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_tasks(self, state: PipelineState) -> list[SubTask]:

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -52,6 +52,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import PROXIMITY_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -135,12 +136,18 @@ class Proximity(BaseSeedAgent):
                 error_message="SubAgentManager returned no results for proximity task.",
             )
         result = results[0]
+        # PR-SEEDGEN-TOKENS (2026-05-30) — forward sub-agent LLM usage (0
+        # for subscription calls) onto every return below.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
         if not result.success:
             return SeedAgentResult(
                 role=self.role,
                 status="error",
                 error_category="proximity_failed",
                 error_message=result.error or "proximity sub-agent failed",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
         parsed = parse_structured_output(result.output, required_fields=_REQUIRED_FIELDS)
         if parsed is None:
@@ -149,6 +156,9 @@ class Proximity(BaseSeedAgent):
                 status="error",
                 error_category="proximity_failed",
                 error_message=(f"malformed proximity payload: result.output={result.output!r}"),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         clusters = parsed.get("similarity_clusters", [])
@@ -160,6 +170,9 @@ class Proximity(BaseSeedAgent):
                 error_message=(
                     f"similarity_clusters must be a list, got {type(clusters).__name__}"
                 ),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         removed_ids, removed_rows = _select_removals(state.candidates, clusters)
@@ -178,6 +191,9 @@ class Proximity(BaseSeedAgent):
                 "similarity_clusters": clusters,
                 "removed_duplicates": removed_rows,
             },
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_task(self, state: PipelineState) -> SubTask:

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -50,6 +50,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import VOTE_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -392,12 +393,29 @@ class Ranker(BaseSeedAgent):
             survivors[:3],
         )
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — total the per-match voter usage
+        # stashed on each ``detail["usage"]`` during ``_play_match``. Only
+        # freshly-played matches appear in ``match_details`` (resumed runs
+        # already counted earlier matches), so no double-counting on resume.
+        prompt_tokens = 0
+        completion_tokens = 0
+        usd_spent = 0.0
+        for detail in match_details:
+            usage = detail.get("usage")
+            if isinstance(usage, dict):
+                prompt_tokens += int(usage.get("prompt_tokens", 0) or 0)
+                completion_tokens += int(usage.get("completion_tokens", 0) or 0)
+                usd_spent += float(usage.get("usd_spent", 0.0) or 0.0)
+
         return SeedAgentResult(
             role=self.role,
             output={
                 "elo_ratings": ratings,
                 "survivors": survivors,
             },
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     async def _play_match_with_checkpoint_report(
@@ -585,6 +603,12 @@ class Ranker(BaseSeedAgent):
         results = await self._manager.adelegate(tasks, announce=False)
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
 
+        # PR-SEEDGEN-TOKENS (2026-05-30) — sum every voter sub-agent's LLM
+        # usage for this match. payg voters (API key) report real numbers;
+        # subscription / CLI voters report 0 (usage not exposed). Stashed on
+        # ``detail["usage"]`` so the phase-level rollup below can total it.
+        match_pt, match_ct, match_usd = sum_sub_result_tokens(results)
+
         votes: list[str] = []
         voter_ids: list[str] = []
         voter_details: list[dict[str, Any]] = []
@@ -643,6 +667,11 @@ class Ranker(BaseSeedAgent):
             "candidate_a": match.a,
             "candidate_b": match.b,
             "votes": voter_details,
+            "usage": {
+                "prompt_tokens": match_pt,
+                "completion_tokens": match_ct,
+                "usd_spent": match_usd,
+            },
         }
 
         if len(votes) < 2:

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -68,6 +68,7 @@ from plugins.seed_generation.agents.base import (
     BaseSeedAgent,
     SeedAgentResult,
     parse_structured_output,
+    sum_sub_result_tokens,
 )
 from plugins.seed_generation.json_schemas import SUPERVISOR_SCHEMA
 from plugins.seed_generation.orchestrator import PipelineState
@@ -139,12 +140,18 @@ class Supervisor(BaseSeedAgent):
             )
 
         result = results[0]
+        # PR-SEEDGEN-TOKENS (2026-05-30) — forward sub-agent LLM usage (0
+        # for subscription calls) onto every return below.
+        prompt_tokens, completion_tokens, usd_spent = sum_sub_result_tokens(results)
         if not result.success:
             return SeedAgentResult(
                 role=self.role,
                 status="error",
                 error_category="supervisor_failed",
                 error_message=result.error or "supervisor sub-agent failed",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
         parsed = parse_structured_output(
             result.output,
@@ -156,11 +163,17 @@ class Supervisor(BaseSeedAgent):
                 status="error",
                 error_category="supervisor_failed",
                 error_message=(f"malformed supervisor payload: result.output={result.output!r}"),
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                usd_spent=usd_spent,
             )
 
         return SeedAgentResult(
             role=self.role,
             output={"supervisor_guidance": parsed},
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usd_spent=usd_spent,
         )
 
     def _build_task(self, state: PipelineState) -> SubTask:

--- a/tests/core/agent/test_sub_result_token_forwarding.py
+++ b/tests/core/agent/test_sub_result_token_forwarding.py
@@ -1,0 +1,116 @@
+"""Pin the worker-IPC → SubResult token forwarding chain.
+
+PR-SEEDGEN-TOKENS (2026-05-30) — the sub-agent runs in a subprocess; its
+``AgenticResult.usage`` reaches the parent as ``WorkerResult`` token
+fields → ``IsolationResult`` → ``SubResult`` (via
+``SubAgentManager._to_sub_result``). Pre-fix every link dropped the
+usage and seed-gen runs reported all zeros. These tests pin the
+``IsolationResult`` → ``SubResult`` link.
+
+HARD CONSTRAINT: subscription / CLI calls expose no usage (the adapters
+return an empty UsageSummary), so a 0-usage IsolationResult must produce
+a 0-usage SubResult — never fabricated.
+"""
+
+from __future__ import annotations
+
+from core.agent.sub_agent import SubAgentManager, SubTask
+from core.orchestration.isolated_execution import IsolatedRunner, IsolationResult
+
+
+def _manager() -> SubAgentManager:
+    return SubAgentManager(IsolatedRunner())
+
+
+def _task() -> SubTask:
+    return SubTask(task_id="t-tok", description="d", task_type="analyze")
+
+
+def test_to_sub_result_forwards_usage_on_success() -> None:
+    mgr = _manager()
+    isolation = IsolationResult(
+        session_id="s",
+        success=True,
+        output='{"ok": true}',
+        prompt_tokens=900,
+        completion_tokens=300,
+        usd_spent=0.018,
+    )
+    sub = mgr._to_sub_result(_task(), isolation)
+    assert sub.success
+    assert sub.prompt_tokens == 900
+    assert sub.completion_tokens == 300
+    assert sub.usd_spent == 0.018
+
+
+def test_to_sub_result_forwards_usage_on_failure() -> None:
+    # A sub-agent can burn tokens before failing — forward them so cost
+    # accounting stays honest even for failed spawns.
+    mgr = _manager()
+    isolation = IsolationResult(
+        session_id="s",
+        success=False,
+        error="boom",
+        prompt_tokens=120,
+        completion_tokens=40,
+        usd_spent=0.003,
+    )
+    sub = mgr._to_sub_result(_task(), isolation)
+    assert not sub.success
+    assert sub.prompt_tokens == 120
+    assert sub.completion_tokens == 40
+    assert sub.usd_spent == 0.003
+
+
+def test_to_sub_result_zero_for_subscription() -> None:
+    mgr = _manager()
+    isolation = IsolationResult(
+        session_id="s",
+        success=True,
+        output='{"ok": true}',
+        # Subscription / CLI path → empty UsageSummary → all 0.
+    )
+    sub = mgr._to_sub_result(_task(), isolation)
+    assert sub.success
+    assert sub.prompt_tokens == 0
+    assert sub.completion_tokens == 0
+    assert sub.usd_spent == 0.0
+
+
+def test_isolation_result_parses_usage_from_worker_payload() -> None:
+    """The worker stdout JSON token keys land on the IsolationResult.
+
+    Mirrors ``IsolatedRunner._spawn_worker``'s parse: a worker payload
+    carrying usage keys must populate the IsolationResult fields. Legacy
+    payloads (no keys) default to 0.
+    """
+    payload = {
+        "task_id": "t",
+        "success": True,
+        "output": "x",
+        "prompt_tokens": 555,
+        "completion_tokens": 222,
+        "usd_spent": 0.05,
+    }
+    result = IsolationResult(
+        session_id="s",
+        success=payload.get("success", False),
+        output=payload.get("output", ""),
+        prompt_tokens=payload.get("prompt_tokens", 0),
+        completion_tokens=payload.get("completion_tokens", 0),
+        usd_spent=payload.get("usd_spent", 0.0),
+    )
+    assert result.prompt_tokens == 555
+    assert result.completion_tokens == 222
+    assert result.usd_spent == 0.05
+
+    legacy = {"task_id": "t", "success": True}
+    legacy_result = IsolationResult(
+        session_id="s",
+        success=legacy.get("success", False),
+        prompt_tokens=legacy.get("prompt_tokens", 0),
+        completion_tokens=legacy.get("completion_tokens", 0),
+        usd_spent=legacy.get("usd_spent", 0.0),
+    )
+    assert legacy_result.prompt_tokens == 0
+    assert legacy_result.usd_spent == 0.0

--- a/tests/plugins/seed_generation/test_critic.py
+++ b/tests/plugins/seed_generation/test_critic.py
@@ -293,6 +293,81 @@ def test_critic_pins_candidate_id_from_task() -> None:
 
 
 # ---------------------------------------------------------------------------
+# PR-SEEDGEN-TOKENS (2026-05-30) — per-agent token rollup
+# ---------------------------------------------------------------------------
+
+
+class _TokenManager:
+    """Returns SubResults carrying per-sub-agent LLM usage.
+
+    Mirrors the real worker IPC contract: each ``SubResult`` now carries
+    ``prompt_tokens`` / ``completion_tokens`` / ``usd_spent`` forwarded
+    from the worker subprocess. ``include_usage=False`` simulates the
+    subscription / CLI path where usage is honestly 0 (the adapters return
+    an empty UsageSummary).
+    """
+
+    def __init__(self, *, include_usage: bool = True) -> None:
+        self._include_usage = include_usage
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        return self.delegate(tasks, announce=announce)
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results: list[SubResult] = []
+        for t in tasks:
+            candidate_id = t.args["candidate_id"]
+            results.append(
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=dict(_good_critique(candidate_id)),
+                    duration_ms=42.0,
+                    prompt_tokens=300 if self._include_usage else 0,
+                    completion_tokens=120 if self._include_usage else 0,
+                    usd_spent=0.012 if self._include_usage else 0.0,
+                )
+            )
+        return results
+
+
+def test_critic_sums_sub_result_tokens_into_result() -> None:
+    """The chain producer→SubResult→SeedAgentResult: per-agent token rollup.
+
+    Three candidate sub-agents each report 300/120 tokens + $0.012; the
+    Critic must fold all three into the single SeedAgentResult so the
+    orchestrator's run-level rollup (which sums result.* into state.*)
+    lights up instead of reporting zeros.
+    """
+    state = _make_state(3)
+    _seed_candidates(state, 3)
+    manager = _TokenManager(include_usage=True)
+    result = asyncio.run(Critic(manager=manager).aexecute(state))  # type: ignore[arg-type]
+    assert result.success
+    assert result.prompt_tokens == 300 * 3
+    assert result.completion_tokens == 120 * 3
+    assert result.usd_spent == 0.012 * 3
+
+
+def test_critic_reports_zero_tokens_for_subscription_calls() -> None:
+    """HARD CONSTRAINT — subscription / CLI calls expose no usage.
+
+    When every sub-agent ran on a subscription adapter (empty
+    UsageSummary), the rolled-up tokens stay honestly 0 — never
+    fabricated.
+    """
+    state = _make_state(2)
+    _seed_candidates(state, 2)
+    manager = _TokenManager(include_usage=False)
+    result = asyncio.run(Critic(manager=manager).aexecute(state))  # type: ignore[arg-type]
+    assert result.success
+    assert result.prompt_tokens == 0
+    assert result.completion_tokens == 0
+    assert result.usd_spent == 0.0
+
+
+# ---------------------------------------------------------------------------
 # G3 — baseline evidence injection (2026-05-20 self-improving-loop wiring)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_transcript.py
+++ b/tests/test_session_transcript.py
@@ -100,6 +100,40 @@ class TestSessionTranscriptIndex:
         assert data["sessions"]["s-test"]["event_count"] == 2
 
 
+class TestSessionEndTokens:
+    """PR-SEEDGEN-TOKENS (2026-05-30) — ``session_end`` carries token keys.
+
+    The seed-generation orchestrator's ``_persist_per_phase_costs`` sums
+    ``prompt_tokens`` / ``completion_tokens`` off each sub-agent's
+    ``dialogue.jsonl`` ``session_end`` event. Pin that the recorder writes
+    those keys so the per-phase cost grid lights up for API-key / payg
+    sub-agents (subscription calls honestly report 0).
+    """
+
+    def test_token_keys_written(self, tx: SessionTranscript) -> None:
+        tx.record_session_end(
+            duration_s=12.0,
+            total_cost=0.042,
+            rounds=4,
+            prompt_tokens=1234,
+            completion_tokens=567,
+        )
+        end = tx.read_events()[-1]
+        assert end["event"] == "session_end"
+        assert end["prompt_tokens"] == 1234
+        assert end["completion_tokens"] == 567
+        assert end["total_cost"] == 0.042
+
+    def test_token_keys_default_zero_for_subscription(self, tx: SessionTranscript) -> None:
+        # Subscription / CLI calls expose no usage → fields stay 0, never
+        # fabricated. The recorder must still emit the keys so the
+        # orchestrator's ``int(evt.get("prompt_tokens") or 0)`` read works.
+        tx.record_session_end(rounds=1)
+        end = tx.read_events()[-1]
+        assert end["prompt_tokens"] == 0
+        assert end["completion_tokens"] == 0
+
+
 class TestCleanup:
     """Old transcript cleanup."""
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -136,6 +136,38 @@ class TestWorkerResult:
         data = res.to_dict()
         assert "error" not in data
 
+    def test_usage_fields_roundtrip(self) -> None:
+        """PR-SEEDGEN-TOKENS — token + cost fields survive IPC serialization.
+
+        The worker runs the sub-agent in a subprocess; without these
+        fields the parent dropped ``agentic_result.usage`` entirely and
+        every seed-gen run reported zero tokens. Pin the roundtrip so the
+        regression cannot return silently.
+        """
+        res = WorkerResult(
+            task_id="t-usage",
+            success=True,
+            output="done",
+            prompt_tokens=4096,
+            completion_tokens=512,
+            usd_spent=0.0231,
+        )
+        restored = WorkerResult.from_dict(res.to_dict())
+        assert restored.prompt_tokens == 4096
+        assert restored.completion_tokens == 512
+        assert restored.usd_spent == 0.0231
+
+    def test_usage_defaults_zero(self) -> None:
+        """Subscription / CLI calls expose no usage → fields default to 0.
+
+        ``from_dict`` of a legacy payload (no usage keys) must not raise
+        and must leave the counts at 0 — we never fabricate tokens.
+        """
+        restored = WorkerResult.from_dict({"task_id": "t-sub", "success": True})
+        assert restored.prompt_tokens == 0
+        assert restored.completion_tokens == 0
+        assert restored.usd_spent == 0.0
+
 
 # ---------------------------------------------------------------------------
 # Worker subprocess integration (no LLM call)


### PR DESCRIPTION
## Summary
- Wire per-agent (per-phase) **and** run-level token-usage tracking into the seed-generation pipeline so `prompt_tokens` / `completion_tokens` / `usd_spent` are populated instead of always-zero.
- The producer (`AgenticResult.usage`) already worked; the usage was dropped at three IPC links before reaching the aggregators. This plumbs it end-to-end.
- Subscription/CLI calls expose no usage — those phases honestly stay 0 (never fabricated).

## Why
Every seed-gen run reported all zeros even though the aggregation infrastructure already existed. A sub-agent's `AgenticResult.usage` (captured via `TokenTracker.delta_since`) was produced but dropped before serialization because:
- **DROP #1:** `WorkerResult` (worker subprocess → parent) had no usage field, so `_resolve_worker_outcome` discarded `agentic_result.usage`.
- **DROP #2:** `IsolationResult` had no usage field; `IsolatedRunner` parsed only success/output/summary/error.
- **DROP #3:** `SubResult` had no token fields; `_to_sub_result` never set them.
- The 9 seed agents never assigned tokens; the run-level rollup therefore summed 0.
- For the per-phase grid: `_persist_per_phase_costs` already sums `prompt_tokens`/`completion_tokens` off each sub-agent's `dialogue.jsonl` `session_end` event, but `Transcript.record_session_end` only wrote `duration_s`/`total_cost`/`rounds` — no token keys.

## Changes
| File | Change |
|------|--------|
| `core/agent/worker.py` | `WorkerResult` gains `prompt_tokens`/`completion_tokens`/`usd_spent` (+ `from_dict`/`to_dict`); `_run_agentic` populates them from `agentic_result.usage` (None-guarded) |
| `core/orchestration/isolated_execution.py` | `IsolationResult` gains the 3 usage fields; worker-stdout parse reads them |
| `core/agent/sub_agent.py` | `SubResult` gains the 3 usage fields; `_to_sub_result` forwards them on both success and failure paths |
| `plugins/seed_generation/agents/base.py` | new `sum_sub_result_tokens(results)` helper (+ `__all__`) |
| `plugins/seed_generation/agents/{generator,ranker,pilot,critic,evolver,literature_review,meta_reviewer,proximity,supervisor}.py` | each sums its sub-results' usage into the returned `SeedAgentResult` (ranker totals per-match voter usage stashed on `detail["usage"]`) |
| `core/observability/transcript.py` | `record_session_end` accepts + writes `prompt_tokens`/`completion_tokens` |
| `core/agent/loop/_lifecycle.py` | `record_transcript_end` reads `total_input_tokens`/`total_output_tokens` from the tracker accumulator (alongside existing `total_cost`) and passes them through |
| `CHANGELOG.md` | `[Unreleased]` Added/Fixed entries incl. the subscription limitation |
| `tests/test_worker.py` | WorkerResult usage roundtrip + defaults-zero |
| `tests/core/agent/test_sub_result_token_forwarding.py` (new) | IsolationResult → SubResult forwarding (success/failure/subscription-zero) |
| `tests/plugins/seed_generation/test_critic.py` | agent rollup + subscription-zero |
| `tests/test_session_transcript.py` | `session_end` carries token keys (+ default 0) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Primary seam (worker IPC → SubResult → SeedAgentResult → run-level) | Implemented | All 9 agents wired |
| Per-phase seam (session_end token keys) | Implemented | No orchestrator change needed — `_persist_per_phase_costs` already sums these keys |
| Subscription tokens | Honestly 0 | Empty `UsageSummary()` from claude-cli/codex-cli; documented in code + CHANGELOG; never fabricated |
| `docs/self-improving/**` | Untouched | Out of scope — real values flow from future runs |
| Version bump / CHANGELOG version section | Not done | `[Unreleased]` only, per instructions |

## Verification
- [x] ruff check clean (15 changed modules + 4 test files)
- [x] ruff format --check clean
- [x] mypy clean (15 source files)
- [x] pytest pass — seed_generation + worker + sub_agent + isolated_execution + transcript + agent/loop + new token-forwarding tests all green
- [x] E2E unchanged (no `docs/self-improving/**` regen)

## Reference
Ground-truth trace verified link-by-link against the live code before fixing; subscription limitation grounded in `core/llm/adapters/claude_cli.py:254` and `core/llm/adapters/codex_cli.py:123` (empty `UsageSummary()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)