### PR TITLE
feat(self-improving): --promote-policy control arms (gate/random/never) for 3-arm held-out comparison (E3, v0.99.95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,41 @@ functional change.
 
 ---
 
-## [Unreleased]
+## [0.99.95] - 2026-05-30
 
 ### Added
+- **E3 (2026-05-30) — `--promote-policy {gate|random|never}` control arms for a
+  matched 3-arm held-out comparison.** Enables attributing a fitness gain to
+  SELECTION rather than drift / judge-noise by running each arm as its own full
+  N-cycle campaign on the frozen held-out bench:
+  - `gate` (default) — today's behaviour: the `_should_promote` fitness gate
+    decides (the SELECTION arm). The default path is unchanged in shape.
+  - `random` — random-accept control: the mutation is still applied + audited as
+    normal, but the PROMOTE decision is a SEEDED coin-flip
+    (`random.Random(seed + cycle_index)` in `_random_accept_draw`), NOT the gate.
+    The seed is an explicit arg/config (`--promote-policy-seed`) and is RECORDED
+    on both the held-out + baseline rows, so the random campaign is reproducible.
+  - `never` — no-mutation floor: never promote (baseline frozen across the
+    campaign). The mutation is still generated + audited (loop structure
+    identical to the other arms), only the promote is suppressed; a
+    mutator-driven cycle still reverts the SoT so the floor stays honest. The
+    held-out is scored every cycle → the curve shows pure drift / judge-noise,
+    the floor the other arms must beat.
+
+  Resolved by `autoresearch.train._resolve_promote_policy` /
+  `_resolve_promote_policy_seed` (env `GEODE_PROMOTE_POLICY` /
+  `AUTORESEARCH_PROMOTE_POLICY` → CLI → config → default). `promote_policy` +
+  `promote_policy_seed` are recorded on BOTH the per-cycle held-out attribution
+  row (`mutations.jsonl`) AND the baseline registry row, so the three arms'
+  held-out curves are distinguishable + comparable on the shared frozen ruler.
+  `promote_policy` is also added to the baseline epoch spec
+  (`core.self_improving_loop.baseline_epoch.build_baseline_spec`), bumping
+  `SPEC_SCHEMA_VERSION` `"1"` → `"2"`: gate / random / never hash to DIFFERENT
+  epochs (different production logic, correctly NOT averaged); the held-out bench
+  id is unchanged (the shared ruler does not move). Pinned by
+  `tests/autoresearch/test_promote_policy_control_arms.py` +
+  `tests/test_baseline_epoch.py` (gate vs random vs never distinct epochs, schema
+  2, seeded draw reproducibility).
 - **PR-SEEDGEN-TOKENS (2026-05-30) — per-agent (per-phase) + run-level token
   usage tracking for the seed-generation pipeline.** The LLM `usage` a sub-agent
   already produces (`AgenticResult.usage`, via `TokenTracker.delta_since`) now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.94
+- **Version**: 0.99.95
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.94 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.95 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.94 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.95 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -169,6 +169,19 @@ the curve is comparable across generations. Resolved by
 :func:`_resolve_held_out_bench` (env override → config → this constant)."""
 DIM_SET_NAME = "subset"
 MAX_TURNS = 10
+PROMOTE_POLICY = "gate"
+"""E3 (2026-05-30) — default promote policy: ``"gate"`` (today's behaviour, the
+selection arm). The control arms (``"random"`` random-accept, ``"never"``
+no-mutation floor) enable a matched 3-arm held-out comparison so a fitness gain
+can be attributed to SELECTION rather than drift / judge-noise. Resolved by
+:func:`_resolve_promote_policy` (env override → CLI → config → this constant)."""
+PROMOTE_POLICY_SEED = 0
+"""E3 (2026-05-30) — default RNG seed for ``promote_policy="random"``. The
+per-cycle promote draw is ``random.Random(seed + cycle_index)``, so the random
+campaign is reproducible (no bare nondeterminism) and the seed is RECORDED on the
+held-out + baseline rows. Ignored for the ``gate`` / ``never`` arms. Resolved by
+:func:`_resolve_promote_policy_seed`."""
+_VALID_PROMOTE_POLICIES = frozenset({"gate", "random", "never"})
 WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 
 
@@ -209,6 +222,8 @@ def _get_autoresearch_config() -> Any:
             seed_limit=SEED_LIMIT,
             seed_select=SEED_SELECT,
             held_out_bench=HELD_OUT_BENCH,
+            promote_policy=PROMOTE_POLICY,
+            promote_policy_seed=PROMOTE_POLICY_SEED,
             dim_set=DIM_SET_NAME,
             max_turns=MAX_TURNS,
         )
@@ -302,6 +317,110 @@ def _resolve_held_out_bench() -> str | None:
         return None
     stripped = str(configured).strip()
     return stripped or None
+
+
+def _resolve_promote_policy(cli_override: str | None = None) -> str:
+    """Return the control-arm promote policy (``gate`` / ``random`` / ``never``).
+
+    E3 (2026-05-30). Precedence (mirrors ``_resolve_held_out_bench``, with the
+    CLI arg sitting between env and config):
+
+    1. ``GEODE_PROMOTE_POLICY`` env var (per-run override).
+    2. ``AUTORESEARCH_PROMOTE_POLICY`` env var (the ``AUTORESEARCH_*`` alias).
+    3. ``cli_override`` — the ``--promote-policy`` argv value (``None`` when the
+       operator did not pass it, so it falls through to config).
+    4. ``[self_improving_loop.autoresearch] promote_policy`` from ``config.toml``.
+    5. :data:`PROMOTE_POLICY` module constant (``"gate"``).
+
+    The resolved value is validated against :data:`_VALID_PROMOTE_POLICIES`; an
+    unknown value raises ``ValueError`` rather than silently falling back, so a
+    typo'd arm (e.g. ``--promote-policy gae``) fails loudly instead of running
+    the selection arm under the wrong label and contaminating the comparison.
+    """
+    for env_name in ("GEODE_PROMOTE_POLICY", "AUTORESEARCH_PROMOTE_POLICY"):
+        override = os.environ.get(env_name, "").strip()
+        if override:
+            return _validate_promote_policy(override)
+    if cli_override is not None and cli_override.strip():
+        return _validate_promote_policy(cli_override.strip())
+    configured = getattr(_get_autoresearch_config(), "promote_policy", None)
+    if configured is not None and str(configured).strip():
+        return _validate_promote_policy(str(configured).strip())
+    return PROMOTE_POLICY
+
+
+def _validate_promote_policy(value: str) -> str:
+    if value not in _VALID_PROMOTE_POLICIES:
+        raise ValueError(
+            f"promote_policy {value!r} not in {sorted(_VALID_PROMOTE_POLICIES)} — "
+            "the 3-arm control comparison expects one of gate / random / never"
+        )
+    return value
+
+
+def _resolve_promote_policy_seed(cli_override: int | None = None) -> int:
+    """Return the explicit RNG seed for the ``random`` promote arm.
+
+    E3 (2026-05-30). Precedence mirrors :func:`_resolve_promote_policy`
+    (env ``GEODE_PROMOTE_POLICY_SEED`` / ``AUTORESEARCH_PROMOTE_POLICY_SEED`` →
+    ``--promote-policy-seed`` → config → :data:`PROMOTE_POLICY_SEED`). The seed is
+    RECORDED on the held-out + baseline rows so the random campaign is
+    reproducible from the ledger.
+
+    Contract per tier:
+    - **env** — the raw string is parsed HERE, so a non-integer env value is
+      caught + warned + skipped to the next tier (a stray export never crashes
+      the cycle; the recorded seed then truthfully reflects the value used).
+    - **config** — ``AutoresearchConfig.promote_policy_seed`` is typed ``int`` and
+      the loader (``_get_autoresearch_config`` → ``load_self_improving_loop_config``
+      → Pydantic ``model_validate``) validates it BEFORE this resolver runs. By the
+      project's deliberate loader contract (see ``_get_autoresearch_config`` —
+      ``ValidationError`` bubbles so the operator sees the actionable Pydantic
+      message, same as ``seed_limit`` / ``budget_minutes``), a malformed TOML seed
+      like ``promote_policy_seed = "x"`` fails loudly at load time, NOT here. The
+      ``int(configured)`` guard below therefore only defends the test-stub
+      ``SimpleNamespace`` path (and any future non-loader caller) — it is NOT a
+      silent override of the loader's loud-validation contract for the real
+      config."""
+    for env_name in ("GEODE_PROMOTE_POLICY_SEED", "AUTORESEARCH_PROMOTE_POLICY_SEED"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            try:
+                return int(raw)
+            except ValueError:
+                log.warning(
+                    "promote_policy_seed env %s=%r is not an integer; ignoring",
+                    env_name,
+                    raw,
+                )
+    if cli_override is not None:
+        return int(cli_override)
+    configured = getattr(_get_autoresearch_config(), "promote_policy_seed", None)
+    if configured is not None:
+        try:
+            return int(configured)
+        except (TypeError, ValueError):
+            log.warning(
+                "promote_policy_seed config value %r is not an integer; using default %d",
+                configured,
+                PROMOTE_POLICY_SEED,
+            )
+    return PROMOTE_POLICY_SEED
+
+
+def _random_accept_draw(seed: int, cycle_index: int) -> bool:
+    """Deterministic per-cycle coin-flip for ``promote_policy="random"``.
+
+    The draw is ``random.Random(seed + cycle_index).random() < 0.5`` — a SEEDED
+    RNG (NOT bare ``random.random()``), so the entire random campaign is
+    reproducible: the same ``(seed, cycle_index)`` always yields the same promote
+    decision, and a different seed yields an independent campaign. ``cycle_index``
+    is the campaign's per-cycle generation index so successive cycles draw
+    independent (but reproducible) flips rather than all sharing one draw.
+    """
+    import random as _random
+
+    return _random.Random(seed + cycle_index).random() < 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -1966,6 +2085,26 @@ def _resolve_gen_tag(commit: str) -> str:
     return f"autoresearch-{commit}-gen{counter}"
 
 
+def _gen_cycle_index(gen_tag: str) -> int:
+    """Extract the per-cycle index for the ``random`` promote arm's draw.
+
+    E3 (2026-05-30). The random arm draws ``Random(seed + cycle_index)`` per
+    cycle, so it needs a stable monotonic index. The gen_tag carries a ``-genN``
+    suffix (:func:`_resolve_gen_tag`) which IS the campaign's monotonic cycle
+    counter, so it is reused as the index. A gen_tag without the suffix (an
+    operator-pinned ``AUTORESEARCH_GEN_TAG``) falls back to ``0`` — the draw is
+    still deterministic from the seed, just not per-cycle independent (the
+    operator opted out of the auto counter, so the cycle structure is theirs to
+    own). Always returns a non-negative int (graceful contract — never raises)."""
+    m = _GEN_SUFFIX_RE.search(gen_tag)
+    if m is None:
+        return 0
+    try:
+        return int(m.group(1))
+    except ValueError:  # pragma: no cover — regex restricts to \d+
+        return 0
+
+
 def _append_session_index(
     *,
     session_id: str,
@@ -2307,6 +2446,8 @@ def _append_baseline_registry_row(
     seed_select: str | None = None,
     held_out_fitness: float | None = None,
     held_out_bench_id: str | None = None,
+    promote_policy: str = "gate",
+    promote_policy_seed: int = 0,
 ) -> None:
     """Append one ``kind="baseline"`` registry row to ``baseline_archive.jsonl``.
 
@@ -2342,6 +2483,14 @@ def _append_baseline_registry_row(
     fingerprint). Both are **omitted** from the row when ``None`` (no held-out
     bench configured) so existing readers see the same shape — the held-out
     fields are purely additive and never a new required key.
+
+    ``promote_policy`` / ``promote_policy_seed`` (E3, 2026-05-30) — the control
+    arm (``gate`` / ``random`` / ``never``) this baseline was produced under, and
+    the RNG seed RECORDED for the ``random`` arm (``0`` for gate / never). They
+    are recorded BOTH as top-level row fields (so the 3-arm comparison can split
+    rows directly) AND inside the hashed ``baseline_spec`` (so the three arms land
+    in distinct epochs — gate ≠ random ≠ never production logic, correctly not
+    averaged). ``gate`` (default) reproduces today's selection-arm row + epoch.
     """
     if margin_rule not in _VALID_MARGIN_RULES:
         raise ValueError(
@@ -2382,6 +2531,10 @@ def _append_baseline_registry_row(
         bench=bench_means is not None,
         role_provenance=role_provenance,
         seed_pool_id=seed_pool_content_hash(_seed_select),
+        # E3 (2026-05-30) — control-arm policy in the hashed spec: gate / random /
+        # never produce baselines under different production logic, so they hash
+        # to DIFFERENT epochs (correctly NOT averaged into one comparison).
+        promote_policy=promote_policy,
     )
     epoch_hash = compute_epoch_hash(baseline_spec)
     _label_map_path = _baseline_archive_path().parent / "baseline_epochs.json"
@@ -2410,6 +2563,13 @@ def _append_baseline_registry_row(
         "fitness_stderr": (float(fitness_stderr) if fitness_stderr is not None else None),
         "margin_rule": margin_rule,
         "bench": bool(bench_means),
+        # E3 (2026-05-30) — control-arm tag (gate / random / never) as a top-level
+        # row field (in addition to being inside the hashed ``baseline_spec``) so
+        # the 3-arm comparison can split rows without re-parsing the spec.
+        # ``promote_policy_seed`` is recorded for every arm (0 for gate / never) so
+        # the random arm's promoted baseline is reproducible from the ledger.
+        "promote_policy": str(promote_policy),
+        "promote_policy_seed": int(promote_policy_seed),
         "seed_select": _seed_select,
         "seed_count": int(seed_count),
         # PR-BASELINE-EPOCH — content-addressed partition. epoch_hash is the
@@ -2484,6 +2644,10 @@ def _write_baseline(
     # these via ``score_held_out_bench`` when ``_resolve_held_out_bench()`` is set.
     held_out_fitness: float | None = None,
     held_out_bench_id: str | None = None,
+    # E3 (2026-05-30) — control-arm tag forwarded to the registry row + the epoch
+    # spec. ``"gate"`` (default) reproduces today's selection-arm row + epoch.
+    promote_policy: str = "gate",
+    promote_policy_seed: int = 0,
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -2603,6 +2767,9 @@ def _write_baseline(
         # E2 (2026-05-30) — fixed-ruler evidence (omitted from the row when None).
         held_out_fitness=held_out_fitness,
         held_out_bench_id=held_out_bench_id,
+        # E3 (2026-05-30) — control-arm tag → registry row + epoch spec.
+        promote_policy=promote_policy,
+        promote_policy_seed=promote_policy_seed,
     )
     # Emit BASELINE_PROMOTED after the write succeeds. ``reason``
     # quotes the gate verdict text from ``_should_promote`` (or the
@@ -3272,6 +3439,29 @@ def main() -> int:
         help="never write baseline.json, even when the auto-rule passes "
         "(observe-only mode for debugging)",
     )
+    # E3 (2026-05-30) — control-arm promote policy for a matched 3-arm held-out
+    # comparison. ``default=None`` (NOT "gate") so that omitting the flag falls
+    # through to env / config in ``_resolve_promote_policy``; an explicit
+    # ``--promote-policy gate`` overrides config the same way the other arms do.
+    parser.add_argument(
+        "--promote-policy",
+        choices=sorted(_VALID_PROMOTE_POLICIES),
+        default=None,
+        help="control arm for the matched 3-arm held-out comparison: 'gate' "
+        "(today's selection gate), 'random' (random-accept control — mutation "
+        "applied + audited as normal but promote is a SEEDED coin-flip), or "
+        "'never' (no-mutation floor — baseline frozen, pure drift / judge-noise "
+        "curve). env GEODE_PROMOTE_POLICY / config promote_policy override; "
+        "default resolves to 'gate'.",
+    )
+    parser.add_argument(
+        "--promote-policy-seed",
+        type=int,
+        default=None,
+        help="explicit RNG seed for --promote-policy random (the per-cycle draw "
+        "is Random(seed + cycle_index)); RECORDED on the held-out + baseline rows "
+        "so the random campaign is reproducible. Ignored for gate / never.",
+    )
     args = parser.parse_args()
 
     session_id = _resolve_session_id()
@@ -3281,6 +3471,16 @@ def main() -> int:
     # gen_tag pair as the eventual sessions.jsonl row.
     commit = os.environ.get("GIT_COMMIT", "HEAD")[:7]
     gen_tag = _resolve_gen_tag(commit)
+
+    # E3 (2026-05-30) — resolve the control-arm promote policy + seed once,
+    # up-front (env → CLI → config → default), so the SAME values tag both the
+    # per-cycle held-out record AND the baseline registry row, and drive the
+    # promote decision below. ``cycle_index`` for the random arm's per-cycle draw
+    # is the gen counter parsed from gen_tag (monotonic within a campaign), so
+    # successive cycles draw independent-but-reproducible coin-flips.
+    promote_policy = _resolve_promote_policy(args.promote_policy)
+    promote_policy_seed = _resolve_promote_policy_seed(args.promote_policy_seed)
+    _cycle_index = _gen_cycle_index(gen_tag)
 
     cfg = _get_autoresearch_config()
     # PR-SIL-MULTIOBJ A3 (2026-05-29) — optional cache hygiene before a
@@ -3598,6 +3798,12 @@ def main() -> int:
         # — see ``baseline_epoch.build_baseline_spec``.
         "held_out_fitness": _held_out_fitness,
         "held_out_bench_id": _held_out_bench_id,
+        # E3 (2026-05-30) — control-arm tag on the baseline registry row, so the
+        # three arms' baselines are distinguishable + land in their own epoch
+        # (build_baseline_spec hashes promote_policy → gate ≠ random ≠ never).
+        # The seed is recorded so the random arm's promoted baseline is traceable.
+        "promote_policy": promote_policy,
+        "promote_policy_seed": promote_policy_seed,
     }
     if args.dry_run:
         promoted_line = "false (dry-run)"
@@ -3611,8 +3817,52 @@ def main() -> int:
         # by operator override, not by the auto-promote gate.
         _write_baseline(dim_means, dim_stderr, manual_promote=True, **_baseline_provenance)
         promoted_line = "true (--promote, manual override)"
+    elif promote_policy == "never":
+        # E3 (2026-05-30) — no-mutation floor: NEVER promote (baseline frozen
+        # across the whole campaign). The held-out is still scored every cycle
+        # (above), so the curve shows pure drift / judge-noise — the floor the
+        # gate + random arms must beat. The mutation IS still generated + audited
+        # (the audit above already ran) so the loop structure is identical to the
+        # other arms — we only suppress the PROMOTE. A mutator-driven cycle still
+        # reverts the SoT (same as a gate reject) so the rejected mutation does
+        # not accumulate and the next cycle starts from the frozen baseline.
+        ok, reason = False, "promote_policy=never (no-mutation floor)"
+        _sil_mid_for_revert = os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+        if _sil_mid_for_revert:
+            revert_ok, revert_detail = _revert_sot_after_reject(_sil_mid_for_revert)
+            reason = (
+                f"{reason}; SoT reverted ({revert_detail})"
+                if revert_ok
+                else f"{reason}; SoT revert FAILED ({revert_detail})"
+            )
+        promoted_line = f"false ({reason})"
+    elif promote_policy == "random":
+        # E3 (2026-05-30) — random-accept control: the mutation is applied +
+        # audited exactly as the gate arm (the audit above already ran), but the
+        # PROMOTE decision is a SEEDED coin-flip, NOT the fitness gate. The draw
+        # is ``Random(promote_policy_seed + cycle_index)`` so the entire random
+        # campaign is reproducible from the recorded seed (no bare randomness).
+        ok = _random_accept_draw(promote_policy_seed, _cycle_index)
+        reason = (
+            f"promote_policy=random (seed={promote_policy_seed}, "
+            f"cycle={_cycle_index}, draw={'accept' if ok else 'reject'})"
+        )
+        if ok:
+            _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
+        else:
+            # Same revert semantics as a gate reject (mutator-driven only).
+            _sil_mid_for_revert = os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+            if _sil_mid_for_revert:
+                revert_ok, revert_detail = _revert_sot_after_reject(_sil_mid_for_revert)
+                reason = (
+                    f"{reason}; SoT reverted ({revert_detail})"
+                    if revert_ok
+                    else f"{reason}; SoT revert FAILED ({revert_detail})"
+                )
+        promoted_line = f"{str(ok).lower()} ({reason})"
     else:
-        # PR-3 of petri-schema-v2 (2026-05-23) — surface the v2
+        # promote_policy == "gate" — the SELECTION arm (today's behaviour,
+        # unchanged). PR-3 of petri-schema-v2 (2026-05-23) — surface the v2
         # ``raw.sample_count`` map to the promotion gate so a baseline
         # measured from N=1 samples on a critical dim requires a wider
         # margin (0.20) before being overwritten. v1 baselines emit no
@@ -3799,6 +4049,13 @@ def main() -> int:
                 # (within-generation ranking only).
                 held_out_fitness=_held_out_fitness,
                 held_out_bench_id=_held_out_bench_id,
+                # E3 (2026-05-30) — control-arm tag on the per-cycle held-out
+                # record so the gate / random / never arms' curves are
+                # distinguishable + comparable on the shared frozen ruler. The
+                # seed is recorded so the random arm is reproducible from the
+                # ledger (0 for gate / never).
+                promote_policy=promote_policy,
+                promote_policy_seed=promote_policy_seed,
             )
         except Exception:  # pragma: no cover — defensive
             log.warning(

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -48,7 +48,7 @@ import os
 import tomllib
 import warnings
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -383,6 +383,37 @@ class AutoresearchConfig(BaseModel):
     :func:`autoresearch.train._resolve_held_out_bench` (env
     ``GEODE_HELD_OUT_BENCH`` / ``AUTORESEARCH_HELD_OUT_BENCH`` → this config field
     → ``None``)."""
+    promote_policy: Literal["gate", "random", "never"] = "gate"
+    """E3 (2026-05-30) — the **control-arm promote policy** for a matched 3-arm
+    held-out comparison (selection vs no-mutation vs random-accept):
+
+    - ``"gate"`` (default) — today's behaviour: the ``_should_promote`` fitness
+      gate decides. The SELECTION arm.
+    - ``"random"`` — random-accept control: the mutation is still applied +
+      audited, but the PROMOTE decision is a coin-flip from a SEEDED RNG
+      (``promote_policy_seed`` + the cycle index), NOT the gate. Reproducible.
+    - ``"never"`` — no-mutation floor: never promote (baseline frozen across the
+      campaign). Each cycle still scores the held-out → the curve shows pure
+      drift / judge-noise — the floor the other arms must beat.
+
+    Each arm is run as its OWN full N-cycle campaign; the per-cycle held-out
+    records are tagged with this policy so the three arms' curves are
+    distinguishable + comparable on the shared frozen ruler. ``promote_policy``
+    is also part of the baseline epoch spec (gate / random / never hash to
+    different epochs — different production logic, correctly not averaged).
+
+    Resolution precedence mirrors ``held_out_bench``:
+    :func:`autoresearch.train._resolve_promote_policy` (env
+    ``GEODE_PROMOTE_POLICY`` / ``AUTORESEARCH_PROMOTE_POLICY`` → CLI
+    ``--promote-policy`` → this config field → ``"gate"``)."""
+    promote_policy_seed: int = 0
+    """E3 (2026-05-30) — the explicit RNG seed for ``promote_policy="random"``.
+
+    The random arm's per-cycle promote draw is ``Random(seed + cycle_index)``,
+    so the entire random campaign is reproducible (no bare nondeterminism) and is
+    RECORDED on the held-out + baseline rows. Ignored for the ``gate`` / ``never``
+    arms. Resolution precedence mirrors ``promote_policy``
+    (:func:`autoresearch.train._resolve_promote_policy_seed`)."""
     dim_set: str = "subset"
     max_turns: Annotated[int, Field(ge=1, le=200)] = 10
 

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -104,6 +104,17 @@ class AttributionRecord(BaseModel):
     cycle when a held-out bench is configured (operator cadence); both fields are
     omitted together when no bench was scored, so legacy / no-bench rows validate
     as ``None`` via these defaults."""
+    promote_policy: str | None = None
+    promote_policy_seed: int | None = None
+    """E3 (2026-05-30) — control-arm tag on the per-cycle held-out record so the
+    three arms' fixed-ruler curves are distinguishable + comparable. ``promote_policy``
+    is ``"gate"`` (selection arm), ``"random"`` (random-accept control), or
+    ``"never"`` (no-mutation floor). ``promote_policy_seed`` is the explicit RNG
+    seed RECORDED for the ``random`` arm (the per-cycle draw is
+    ``Random(seed + cycle_index)``), so the random campaign is reproducible from
+    the ledger; it is recorded for every arm (``0`` for gate / never) so the row
+    is uniform. Legacy rows omit both → ``None`` via these defaults; a curve
+    consumer filters the JSONL stream on ``promote_policy`` to split the arms."""
     audit_run_id: str | None = None
     source: str | None = None
     """PR-AR-L6 (2026-05-26) — distinguishes mutator-driven cycle rows
@@ -253,6 +264,8 @@ def compute_attribution(
     source: str = "mutator",
     held_out_fitness: float | None = None,
     held_out_bench_id: str | None = None,
+    promote_policy: str | None = None,
+    promote_policy_seed: int | None = None,
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -335,6 +348,16 @@ def compute_attribution(
     if held_out_fitness is not None and held_out_bench_id is not None:
         payload["held_out_fitness"] = round(float(held_out_fitness), 6)
         payload["held_out_bench_id"] = str(held_out_bench_id)
+    # E3 (2026-05-30) — control-arm tag so the per-cycle held-out curve can be
+    # split into the gate / random / never arms (the matched 3-arm comparison).
+    # Recorded together when both are supplied (``promote_policy_seed`` is ``0``
+    # for the gate / never arms; the RECORDED seed makes the random arm
+    # reproducible from the ledger). ``None`` → fields omitted (legacy shape).
+    if promote_policy is not None:
+        payload["promote_policy"] = str(promote_policy)
+        payload["promote_policy_seed"] = int(
+            promote_policy_seed if promote_policy_seed is not None else 0
+        )
     if baseline_before is None or baseline_after is None:
         return payload
 
@@ -388,6 +411,8 @@ def write_attribution(
     source: str = "mutator",
     held_out_fitness: float | None = None,
     held_out_bench_id: str | None = None,
+    promote_policy: str | None = None,
+    promote_policy_seed: int | None = None,
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
 
@@ -417,6 +442,8 @@ def write_attribution(
         source=source,
         held_out_fitness=held_out_fitness,
         held_out_bench_id=held_out_bench_id,
+        promote_policy=promote_policy,
+        promote_policy_seed=promote_policy_seed,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload

--- a/core/self_improving_loop/baseline_epoch.py
+++ b/core/self_improving_loop/baseline_epoch.py
@@ -25,7 +25,15 @@ from typing import Any
 #: change. Because it is part of the hashed spec, a bump puts pre-change and
 #: post-change baselines in different epochs (correct — the *definition* of a
 #: baseline changed) without retroactively recomputing any stored hash.
-SPEC_SCHEMA_VERSION = "1"
+#:
+#: "1" → "2" (E3, 2026-05-30): added ``promote_policy`` to the spec. The promote
+#: policy (gate / random / never) is production logic — the gate arm SELECTS on
+#: fitness, the random arm coin-flips, the never arm freezes the baseline — so
+#: the three arms produce baselines under genuinely different production logic
+#: and must not be averaged into one epoch. Old schema-1 rows fall into a prior
+#: epoch (correct — no retroactive recompute; the gate arm under schema 2 simply
+#: opens a new epoch alongside the legacy gate-only rows).
+SPEC_SCHEMA_VERSION = "2"
 
 #: Roles whose (model, source) bind the production+measurement surface. ``lane``
 #: is DERIVED from ``source`` (see role_provenance) so it is not hashed.
@@ -44,6 +52,7 @@ def build_baseline_spec(
     bench: bool,
     role_provenance: Mapping[str, Mapping[str, str]],
     seed_pool_id: str | None,
+    promote_policy: str = "gate",
 ) -> dict[str, Any]:
     """Assemble the canonical baseline spec (the surface that is hashed).
 
@@ -53,6 +62,17 @@ def build_baseline_spec(
     redundant). ``seed_pool_id`` is the seed pool's *identity* (content hash),
     not its bodies — ``None``/`""` when no pool is pinned (the pool axis then
     contributes a stable empty value rather than fragmenting epochs).
+
+    ``promote_policy`` (E3, 2026-05-30; schema 2) — the control-arm promote
+    policy: ``"gate"`` (selection arm, the fitness gate), ``"random"``
+    (random-accept control), or ``"never"`` (no-mutation floor). It is part of
+    the hashed surface because the three arms produce baselines under different
+    production logic, so a gate spec and a random spec hash to DIFFERENT epochs
+    (the 3-arm comparison happens via the per-cycle held-out records tagged by
+    arm, NOT by averaging the arms inside one epoch). Defaults to ``"gate"`` so
+    a caller that omits it reproduces today's selection-arm spec; combined with
+    the schema 1→2 bump, schema-1 gate rows and schema-2 gate rows already sit
+    in different epochs, so the seed_pool / role / margin axes are unaffected.
     """
     roles = {
         role: {
@@ -69,6 +89,7 @@ def build_baseline_spec(
         "rubric_version": str(rubric_version),
         "dim_set": str(dim_set),
         "bench": bool(bench),
+        "promote_policy": str(promote_policy),
         "roles": roles,
         "seed_pool_id": "" if seed_pool_id is None else str(seed_pool_id),
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.94"
+version = "0.99.95"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -339,7 +339,7 @@ ignore = [
 max-complexity = 62
 
 [tool.ruff.lint.pylint]
-max-args = 18         # Worst: 18 (e.g. wiring bootstraps). Target: 8.
+max-args = 20         # Worst: 20 (_append_baseline_registry_row — a provenance wiring sink: per-role/seed/bench/held-out/control-arm fields). Target: 8.
 max-branches = 68     # Worst: 68. Target: 15.
 max-returns = 18      # Worst: 18 (PLR0911 silenced project-wide; this kept for ratchet visibility).
 max-statements = 273  # Worst: 273 (god method in cli/__init__.py). Target: 60.

--- a/tests/autoresearch/test_baseline_registry.py
+++ b/tests/autoresearch/test_baseline_registry.py
@@ -33,6 +33,8 @@ _EXPECTED_ROW_KEYS = {
     "fitness_stderr",
     "margin_rule",
     "bench",
+    "promote_policy",  # E3 — control-arm tag (gate / random / never)
+    "promote_policy_seed",  # E3 — RNG seed recorded for the random arm
     "seed_select",
     "seed_count",
     "epoch_hash",  # PR-BASELINE-EPOCH — content-addressed partition discriminator
@@ -371,7 +373,7 @@ def test_row_self_verifies_epoch_hash(isolated: Path) -> None:
         {"broken_tool_use": 3.0}, {"broken_tool_use": 0.1}, sample_count={"broken_tool_use": 16}
     )
     row = _rows(isolated / "baseline_archive.jsonl")[0]
-    assert row["spec_schema_version"] == "1"
+    assert row["spec_schema_version"] == "2"  # E3 — promote_policy added to spec
     assert compute_epoch_hash(row["baseline_spec"]) == row["epoch_hash"]
     assert row["epoch_label"] == "be-001"  # first epoch seen in this tmp registry
 

--- a/tests/autoresearch/test_promote_policy_control_arms.py
+++ b/tests/autoresearch/test_promote_policy_control_arms.py
@@ -1,0 +1,410 @@
+"""E3 (2026-05-30) — ``--promote-policy`` control arms (gate / random / never).
+
+Enables a MATCHED 3-arm comparison on the frozen held-out bench so a fitness gain
+can be attributed to SELECTION rather than drift / judge-noise:
+
+  - ``gate``   — today's behaviour, the ``_should_promote`` fitness gate (selection arm).
+  - ``random`` — random-accept control: the mutation is still applied + audited as
+                 normal, but the PROMOTE decision is a SEEDED coin-flip (reproducible),
+                 NOT the gate.
+  - ``never``  — no-mutation floor: never promote (baseline frozen across the
+                 campaign); the held-out is still scored every cycle → pure drift /
+                 judge-noise curve, the floor the other arms must beat.
+
+Pins:
+  1. ``_resolve_promote_policy`` / ``_resolve_promote_policy_seed`` precedence
+     (env → CLI → config → constant) + the unknown-value guard.
+  2. ``_random_accept_draw`` is a SEEDED, deterministic, per-cycle draw —
+     reproducible with a fixed seed, independent across cycles, and a different
+     seed gives a different campaign (no bare nondeterminism).
+  3. The live ``main`` cycle ACTUALLY branches on the policy (gate uses the gate;
+     never never promotes + freezes the baseline; random promotes per the draw),
+     and the default gate path is unchanged in shape.
+  4. ``promote_policy`` / ``promote_policy_seed`` are RECORDED on BOTH the per-cycle
+     held-out attribution row AND the baseline registry row.
+  5. A gate spec and a random spec hash to DIFFERENT epochs (schema 2), while the
+     held-out bench id is left untouched (the shared ruler does not move).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from autoresearch import train as auto_train
+
+# --- _resolve_promote_policy precedence --------------------------------------
+
+
+def _stub_config(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    promote_policy: str | None = "gate",
+    promote_policy_seed: int | None = 0,
+) -> None:
+    monkeypatch.setattr(
+        auto_train,
+        "_get_autoresearch_config",
+        lambda: SimpleNamespace(
+            promote_policy=promote_policy,
+            promote_policy_seed=promote_policy_seed,
+        ),
+    )
+
+
+def _clear_policy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "GEODE_PROMOTE_POLICY",
+        "AUTORESEARCH_PROMOTE_POLICY",
+        "GEODE_PROMOTE_POLICY_SEED",
+        "AUTORESEARCH_PROMOTE_POLICY_SEED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_resolve_promote_policy_default_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env, no CLI, config gate → gate (today's selection arm, the default)."""
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy="gate")
+    assert auto_train._resolve_promote_policy(None) == "gate"
+
+
+def test_resolve_promote_policy_reads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy="random")
+    assert auto_train._resolve_promote_policy(None) == "random"
+
+
+def test_resolve_promote_policy_cli_wins_over_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy="gate")
+    assert auto_train._resolve_promote_policy("never") == "never"
+
+
+def test_resolve_promote_policy_geode_env_wins_over_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_PROMOTE_POLICY", "random")
+    monkeypatch.delenv("AUTORESEARCH_PROMOTE_POLICY", raising=False)
+    _stub_config(monkeypatch, promote_policy="gate")
+    # env beats even an explicit CLI value (env is the per-run override tier).
+    assert auto_train._resolve_promote_policy("gate") == "random"
+
+
+def test_resolve_promote_policy_autoresearch_env_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_PROMOTE_POLICY", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_PROMOTE_POLICY", "never")
+    _stub_config(monkeypatch, promote_policy="gate")
+    assert auto_train._resolve_promote_policy(None) == "never"
+
+
+def test_resolve_promote_policy_unknown_value_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo'd arm must fail loudly, not silently run the selection arm under the
+    wrong label and contaminate the comparison."""
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy="gate")
+    with pytest.raises(ValueError, match="gate / random / never"):
+        auto_train._resolve_promote_policy("gae")
+
+
+# --- _resolve_promote_policy_seed precedence ---------------------------------
+
+
+def test_resolve_seed_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy_seed=0)
+    assert auto_train._resolve_promote_policy_seed(None) == 0
+
+
+def test_resolve_seed_reads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy_seed=4242)
+    assert auto_train._resolve_promote_policy_seed(None) == 4242
+
+
+def test_resolve_seed_cli_wins_over_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_policy_env(monkeypatch)
+    _stub_config(monkeypatch, promote_policy_seed=1)
+    assert auto_train._resolve_promote_policy_seed(99) == 99
+
+
+def test_resolve_seed_env_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_PROMOTE_POLICY_SEED", "777")
+    _stub_config(monkeypatch, promote_policy_seed=1)
+    assert auto_train._resolve_promote_policy_seed(99) == 777
+
+
+def test_resolve_seed_malformed_env_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer seed ENV must not crash the cycle (graceful contract) — the
+    resolver parses the raw env string itself, so it warns + degrades to the next
+    tier and the campaign still runs."""
+    monkeypatch.setenv("GEODE_PROMOTE_POLICY_SEED", "not-an-int")
+    monkeypatch.delenv("AUTORESEARCH_PROMOTE_POLICY_SEED", raising=False)
+    _stub_config(monkeypatch, promote_policy_seed=5)
+    assert auto_train._resolve_promote_policy_seed(None) == 5
+
+
+def test_malformed_config_seed_fails_loudly_at_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HONEST contract (Codex MCP, E3): unlike the ENV string (parsed by the
+    resolver), a malformed TOML ``promote_policy_seed`` is rejected by the Pydantic
+    loader BEFORE the resolver runs — the loader is deliberately loud (the same
+    ``ValidationError`` path as ``seed_limit`` / ``budget_minutes``), so the
+    operator sees the actionable message rather than a silent fallback. The
+    resolver's config-tier ``int()`` guard only defends the test-stub
+    ``SimpleNamespace`` path. This pins the loud-at-load behaviour so it is not
+    mistaken for a bug."""
+    from core.config.self_improving_loop import SelfImprovingLoopConfig
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SelfImprovingLoopConfig.model_validate({"autoresearch": {"promote_policy_seed": "x"}})
+
+
+# --- _random_accept_draw: seeded, deterministic, per-cycle -------------------
+
+
+def test_random_draw_reproducible_with_fixed_seed() -> None:
+    """Same (seed, cycle_index) → same decision, ALWAYS. The random campaign is
+    reproducible from the recorded seed (no bare nondeterminism)."""
+    for cycle in range(20):
+        assert auto_train._random_accept_draw(1234, cycle) == auto_train._random_accept_draw(
+            1234, cycle
+        )
+
+
+def test_random_draw_independent_across_cycles() -> None:
+    """Successive cycles draw INDEPENDENT flips (not all sharing one draw) — so a
+    fixed-seed campaign is a genuine random-accept sequence, not one repeated coin."""
+    draws = [auto_train._random_accept_draw(1234, c) for c in range(40)]
+    # both outcomes appear over 40 cycles (overwhelmingly likely for a fair coin;
+    # this also proves the cycle index actually varies the draw)
+    assert any(draws) and not all(draws)
+
+
+def test_random_draw_different_seed_different_campaign() -> None:
+    """A different seed yields an independent campaign — the two seeds disagree on
+    at least one cycle (so the seed is load-bearing, not ignored)."""
+    a = [auto_train._random_accept_draw(1, c) for c in range(40)]
+    b = [auto_train._random_accept_draw(2, c) for c in range(40)]
+    assert a != b
+
+
+def test_gen_cycle_index_parses_gen_suffix() -> None:
+    """The per-cycle index is the gen counter parsed from gen_tag (monotonic
+    within a campaign)."""
+    assert auto_train._gen_cycle_index("autoresearch-abc123-gen7") == 7
+    # operator-pinned tag with no -genN suffix → 0 (deterministic, not per-cycle)
+    assert auto_train._gen_cycle_index("my-pinned-campaign") == 0
+
+
+# --- live main() dispatch: the policy is WIRED, not just defined -------------
+
+
+def test_main_resolves_promote_policy_in_live_path() -> None:
+    """``main`` must resolve the policy + seed from args (the CLI override) and the
+    per-cycle index — a static pin against a defined-but-never-resolved knob."""
+    source = inspect.getsource(auto_train.main)
+    assert "promote_policy = _resolve_promote_policy(args.promote_policy)" in source
+    assert "promote_policy_seed = _resolve_promote_policy_seed(args.promote_policy_seed)" in source
+    assert "_cycle_index = _gen_cycle_index(gen_tag)" in source
+
+
+def test_main_branches_on_policy() -> None:
+    """The live promote decision must DISPATCH on the policy: a ``never`` branch
+    that never writes the baseline + a ``random`` branch that draws the seeded
+    coin. Static guard against "policy resolved but the decision still always uses
+    the gate"."""
+    source = inspect.getsource(auto_train.main)
+    assert 'elif promote_policy == "never":' in source
+    assert 'elif promote_policy == "random":' in source
+    # the random branch actually invokes the seeded draw
+    assert "_random_accept_draw(promote_policy_seed, _cycle_index)" in source
+
+
+def test_main_gate_path_unchanged_in_shape() -> None:
+    """The gate arm (the ``else`` branch) still runs ``_should_promote`` + the
+    rollback gate + ``_write_baseline`` — the default path is unchanged."""
+    source = inspect.getsource(auto_train.main)
+    assert "ok, reason = _should_promote(" in source
+    assert "_apply_rollback_condition_gate(" in source
+    # gate is the fall-through else (not a new elif that could be skipped)
+    assert source.index('elif promote_policy == "random":') < source.index(
+        "ok, reason = _should_promote("
+    ), "the gate must remain the final else branch (today's default behaviour)"
+
+
+def test_never_branch_never_calls_should_promote() -> None:
+    """``never`` must NOT consult the fitness gate at all — the baseline is frozen
+    regardless of fitness. Pin that the never branch's body has no _should_promote
+    call (it would otherwise be a gate-in-disguise)."""
+    source = inspect.getsource(auto_train.main)
+    never_start = source.index('elif promote_policy == "never":')
+    random_start = source.index('elif promote_policy == "random":')
+    never_body = source[never_start:random_start]
+    assert "_should_promote" not in never_body, (
+        "the never arm must never call the promote gate — the baseline is frozen"
+    )
+    assert "_write_baseline" not in never_body, (
+        "the never arm must never write the baseline — it is the no-mutation floor"
+    )
+
+
+def test_main_forwards_policy_into_attribution_and_provenance() -> None:
+    """The control-arm tag must flow into BOTH sinks: the per-cycle attribution row
+    (the curve SoT) and the on-promote baseline provenance."""
+    source = inspect.getsource(auto_train.main)
+    # attribution row (write_attribution kwargs)
+    assert "promote_policy=promote_policy" in source
+    assert "promote_policy_seed=promote_policy_seed" in source
+    # baseline provenance dict
+    assert '"promote_policy": promote_policy' in source
+    assert '"promote_policy_seed": promote_policy_seed' in source
+
+
+# --- baseline registry row: control-arm fields -------------------------------
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", tmp_path / "baseline.json")
+    fake_cfg = SimpleNamespace(
+        auditor=SimpleNamespace(model="aud-m", source="claude-cli"),
+        target=SimpleNamespace(model="tgt-m", source="openai-codex"),
+        judge=SimpleNamespace(model="jdg-m", source="claude-cli"),
+        mutator=SimpleNamespace(default_model="mut-m", source="openai-codex"),
+        seed_select="petri_17dim",
+        held_out_bench=None,
+        promote_policy="gate",
+        promote_policy_seed=0,
+    )
+    monkeypatch.setattr(auto_train, "_get_autoresearch_config", lambda: fake_cfg)
+    return tmp_path
+
+
+def _rows(archive: Path) -> list[dict]:
+    return [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_row_records_default_gate_policy(isolated: Path) -> None:
+    """The default ``_write_baseline`` (no policy override) records the gate arm —
+    backward-compatible default."""
+    auto_train._write_baseline({"broken_tool_use": 3.0}, {"broken_tool_use": 0.2})
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["promote_policy"] == "gate"
+    assert row["promote_policy_seed"] == 0
+
+
+def test_row_records_random_arm_with_seed(isolated: Path) -> None:
+    """The random arm's baseline row records the policy + the RECORDED seed so the
+    campaign is reproducible from the ledger."""
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0},
+        {"broken_tool_use": 0.2},
+        promote_policy="random",
+        promote_policy_seed=4242,
+    )
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["promote_policy"] == "random"
+    assert row["promote_policy_seed"] == 4242
+    # also inside the hashed spec (the epoch discriminator)
+    assert row["baseline_spec"]["promote_policy"] == "random"
+
+
+def test_row_self_verifies_under_schema_2(isolated: Path) -> None:
+    """The stored row recomputes to its own epoch_hash under schema 2."""
+    from core.self_improving_loop.baseline_epoch import compute_epoch_hash
+
+    auto_train._write_baseline({"broken_tool_use": 3.0}, {"broken_tool_use": 0.2})
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["spec_schema_version"] == "2"
+    assert compute_epoch_hash(row["baseline_spec"]) == row["epoch_hash"]
+
+
+# --- epoch distinctness: gate / random / never hash differently --------------
+
+
+def test_gate_random_never_are_distinct_epochs() -> None:
+    """A gate spec, a random spec, and a never spec hash to THREE different epochs
+    (different production logic, correctly NOT averaged into one comparison)."""
+    from core.self_improving_loop.baseline_epoch import build_baseline_spec, compute_epoch_hash
+
+    role_prov = {
+        "auditor": {"model": "m", "source": "s"},
+        "target": {"model": "m", "source": "s"},
+        "judge": {"model": "m", "source": "s"},
+        "mutator": {"model": "m", "source": "s"},
+    }
+    common = {
+        "margin_rule": "fitness-stderr",
+        "margin_logic_version": "1",
+        "fitness_formula_version": "1",
+        "rubric_version": "v3",
+        "dim_set": "subset",
+        "bench": False,
+        "role_provenance": role_prov,
+        "seed_pool_id": "pool-x",
+    }
+    h_gate = compute_epoch_hash(build_baseline_spec(**common, promote_policy="gate"))  # type: ignore[arg-type]
+    h_random = compute_epoch_hash(build_baseline_spec(**common, promote_policy="random"))  # type: ignore[arg-type]
+    h_never = compute_epoch_hash(build_baseline_spec(**common, promote_policy="never"))  # type: ignore[arg-type]
+    assert len({h_gate, h_random, h_never}) == 3
+
+
+def test_promote_policy_seed_not_in_epoch_spec() -> None:
+    """The SEED is an instance/reproducibility field, NOT a production-logic axis —
+    two random campaigns with different seeds are the SAME logic (random-accept), so
+    they must share an epoch. The seed is recorded on the ROW + held-out record, not
+    folded into the epoch hash (else every random seed would fragment the epoch)."""
+    from core.self_improving_loop.baseline_epoch import build_baseline_spec
+
+    spec = build_baseline_spec(
+        margin_rule="fitness-stderr",
+        margin_logic_version="1",
+        fitness_formula_version="1",
+        rubric_version="v3",
+        dim_set="subset",
+        bench=False,
+        role_provenance={
+            r: {"model": "m", "source": "s"} for r in ("auditor", "target", "judge", "mutator")
+        },
+        seed_pool_id="pool-x",
+        promote_policy="random",
+    )
+    assert "promote_policy_seed" not in spec
+    assert spec["promote_policy"] == "random"
+
+
+# --- attribution record: control-arm tag -------------------------------------
+
+
+def test_attribution_records_policy_tag() -> None:
+    """The per-cycle held-out attribution row carries the control-arm tag so the
+    three arms' fixed-ruler curves are splittable + comparable."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        promote_policy="random",
+        promote_policy_seed=4242,
+    )
+    assert payload["promote_policy"] == "random"
+    assert payload["promote_policy_seed"] == 4242
+
+
+def test_attribution_omits_policy_when_none() -> None:
+    """Legacy / unspecified rows omit the policy fields (backward-compatible shape)."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+    )
+    assert "promote_policy" not in payload
+    assert "promote_policy_seed" not in payload

--- a/tests/test_baseline_epoch.py
+++ b/tests/test_baseline_epoch.py
@@ -80,6 +80,7 @@ def test_each_surface_field_moves_the_hash() -> None:
         "rubric_version": _base_spec(rubric_version="v4"),
         "dim_set": _base_spec(dim_set="full"),
         "bench": _base_spec(bench=True),
+        "promote_policy": _base_spec(promote_policy="random"),  # E3 — control arm
         "seed_pool_id": _base_spec(seed_pool_id="pool-deadbeef0002"),
         "role_model": _base_spec(
             role_provenance={**_ROLE_PROV, "target": {**_ROLE_PROV["target"], "model": "gpt-6"}}
@@ -109,6 +110,35 @@ def test_spec_excludes_instance_fields() -> None:
     forbidden = {"dim_means", "fitness", "fitness_stderr", "seed_count", "ts_utc", "commit", "id"}
     assert forbidden.isdisjoint(spec)
     assert spec["spec_schema_version"] == SPEC_SCHEMA_VERSION
+
+
+# --- E3: promote_policy control arm in the spec (schema 2) -------------------
+
+
+def test_schema_is_version_2() -> None:
+    """E3 bumped the spec field-set version 1 → 2 (promote_policy added). Old
+    schema-1 rows fall into a prior epoch (correct — no retroactive recompute)."""
+    assert SPEC_SCHEMA_VERSION == "2"
+    assert _base_spec()["spec_schema_version"] == "2"
+
+
+def test_gate_vs_random_spec_distinct_epoch() -> None:
+    """A gate spec and a random spec hash to DIFFERENT epochs — the selection arm
+    and the random-accept control are different production logic and must never be
+    averaged into one comparison."""
+    h_gate = compute_epoch_hash(_base_spec(promote_policy="gate"))
+    h_random = compute_epoch_hash(_base_spec(promote_policy="random"))
+    h_never = compute_epoch_hash(_base_spec(promote_policy="never"))
+    assert len({h_gate, h_random, h_never}) == 3
+
+
+def test_promote_policy_in_spec_seed_is_not() -> None:
+    """``promote_policy`` is a production-logic axis (in the hashed spec), but the
+    RNG SEED is an instance/reproducibility field — two random campaigns with
+    different seeds are the same logic, so the seed must NOT fragment the epoch."""
+    spec = _base_spec(promote_policy="random")
+    assert spec["promote_policy"] == "random"
+    assert "promote_policy_seed" not in spec
 
 
 # --- label resolution --------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.94"
+version = "0.99.95"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Add `--promote-policy {gate|random|never}` (CLI + config field, env-overridable, default `gate`) enabling a MATCHED 3-arm comparison on the frozen held-out bench — selection vs no-mutation vs random-accept — so a fitness gain is attributable to SELECTION rather than drift / judge-noise.
- Each arm runs as its own full N-cycle campaign (3x audit cost incurred at run time, not here — mechanism + tests only, NO live runs).
- `promote_policy` + `promote_policy_seed` recorded on BOTH the per-cycle held-out attribution row (`mutations.jsonl`) AND the baseline registry row; `promote_policy` added to the baseline epoch spec (schema `1`->`2`) so gate / random / never land in distinct epochs.

## Why
A single (1+1) selection campaign cannot tell whether a held-out fitness gain is real SELECTION pressure or just baseline drift / judge-noise. The matched 3-arm comparison gives a control: `never` is the no-mutation floor (pure drift/noise), `random` is the random-accept control, and `gate` is the selection arm — all measured on the same frozen ruler, tagged by arm so their curves are splittable + comparable.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | `PROMOTE_POLICY` / `PROMOTE_POLICY_SEED` consts; `_resolve_promote_policy` / `_resolve_promote_policy_seed` (env→CLI→config→const) + unknown-value guard; `_random_accept_draw` (seeded `Random(seed+cycle_index)`); `_gen_cycle_index`; `--promote-policy` / `--promote-policy-seed` CLI args; `main()` promote branch dispatches on policy (`never` never promotes + freezes baseline; `random` seeded coin-flip; `gate`=else, unchanged); thread policy+seed into `_write_baseline` → `_append_baseline_registry_row` (row + epoch spec) + `write_attribution` |
| `core/config/self_improving_loop.py` | `AutoresearchConfig.promote_policy` (`Literal[gate,random,never]`) + `promote_policy_seed: int` fields |
| `core/self_improving_loop/baseline_epoch.py` | `build_baseline_spec(promote_policy=...)` in the hashed spec; `SPEC_SCHEMA_VERSION` `"1"`->`"2"` |
| `core/self_improving_loop/attribution.py` | `promote_policy` / `promote_policy_seed` on `AttributionRecord` + `compute_attribution` / `write_attribution` |
| `pyproject.toml` | version `0.99.94`->`0.99.95`; `max-args` 18->20 (provenance wiring sink) |
| `tests/autoresearch/test_promote_policy_control_arms.py` | NEW — resolver precedence, seeded-draw reproducibility, live wiring, row recording, epoch distinctness, backward-compat |
| `tests/test_baseline_epoch.py`, `tests/autoresearch/test_baseline_registry.py` | schema-2 + promote_policy spec/row guards |
| CHANGELOG / CLAUDE.md / README*.md | v0.99.95 + `### Added` entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Promote decision site | Implemented | `main()` `else`/`elif promote_policy ==` branch, `_should_promote` call kept for gate |
| Per-cycle held-out scoring + write_attribution | Reused | E2 path tagged with policy+seed |
| Baseline registry row | Implemented | top-level `promote_policy`/`promote_policy_seed` + inside hashed spec |
| Epoch schema bump | Implemented | `1`->`2`; gate/random/never distinct epochs; seed NOT in spec (same logic = same epoch) |

## never mutation-gen decision
`never` still GENERATES + AUDITS the mutation (loop structure identical to the other arms — the audit above already ran); only the PROMOTE is suppressed, and a mutator-driven cycle still reverts the SoT so the floor stays honest (the rejected mutation does not accumulate). This keeps the three arms' per-cycle cost + structure matched; the only cheaper alternative (skip mutation-gen) would make `never` a structurally different loop and break the matched comparison.

## Verification
- [x] ruff check clean (`core/ autoresearch/ scripts/ tests/`)
- [x] ruff format --check clean
- [x] mypy clean (`autoresearch/train.py core/self_improving_loop/`)
- [x] pytest pass (187 targeted: tests/autoresearch/ + test_baseline_epoch + test_logic_version_guard + test_self_improving_loop_config; 812 in the broader baseline/attribution/promote/epoch/self_improving filter)
- [x] CLI smoke (`geode version` → v0.99.95; `--promote-policy` in `--help`)
- [x] lint-imports 4/4 contracts kept
- [x] ledger paths `git check-ignore`-clean

## Reference
Codex MCP read-only adversarial review: 6 core control-arm claims PASS (seeded random draw, never-never-promotes, policy wired, arm tag recorded both sinks, epoch schema bump, gate path unchanged). One finding addressed: the config-tier seed graceful-fallback docstring over-claimed — corrected to document the Pydantic loader's deliberate loud-at-load validation (same path as `seed_limit`), pinned by `test_malformed_config_seed_fails_loudly_at_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)