### PR TITLE
feat(self-improving): per-mutation replicate + fitness-gain ci-excludes-0 verdict + power analysis (E4, v0.99.96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,49 @@ functional change.
 
 ---
 
+## [0.99.96] - 2026-05-30
+
+### Added
+- **E4 (2026-05-30) — statistical power: per-mutation replicate, fitness-gain
+  "ci excludes 0" verdict, and per-campaign power analysis.** The self-improving
+  loop now only CLAIMS a fitness gain when statistics support it (else an HONEST
+  NULL), and tells the operator how many samples are needed:
+  - **`--replicate M` (default `M=1` → zero cost / behaviour change).** Runs the
+    audit `M` times per mutation/cycle so the WITHIN-mutation variance (provider
+    non-determinism) is estimated SEPARATELY from the BETWEEN-seed variance (the
+    `N` samples inside one audit). `M=1` runs the audit exactly once (no loop
+    overhead) and leaves within-variance honestly unestimated, as before;
+    `within_mutation_stderr` + `between_seed_stderr` are recorded distinctly on the
+    cycle (attribution) + promoted-baseline records. Resolved env →
+    `--replicate` → config → `1`.
+  - **Explicit fitness-gain "ci excludes 0" verdict.** A confidence interval on the
+    fitness gain (current vs baseline) is computed and recorded with `gain_ci_low`
+    / `gain_ci_high` / a boolean `gain_ci_excludes_zero` + a human verdict string
+    (`"gain significant"` / `"no evidence yet"`). This is an evidence statement
+    LAYERED ON TOP of the promote gate (it never weakens the gate); at the chosen
+    `DEFAULT_GAIN_CI_Z = 1.0` it reconciles EXACTLY with the gate's
+    `√(σp²+σc²)` σ-margin, so a null run reports "no evidence yet" honestly rather
+    than looking like a silent reject. A bootstrap cycle (no baseline) reports "no
+    evidence yet" (no baseline to gain over).
+  - **Per-campaign power analysis.** Given the observed within+between variance σ,
+    a target effect size δ, α=0.05 and power=0.8, the standard two-sample
+    mean-difference formula `n ≈ 2(z_{α/2}+z_β)²σ²/δ²` computes the required
+    `N_seed × M_replicate` to DETECT δ, emitted per campaign as a log + stdout line.
+    For the real N≈8 / observed stderr≈0.013 case, detecting δ=0.02 at 80% power
+    needs `N_seed≥7 × M_replicate≥1`.
+  - **Flagged knobs.** δ default `0.02` (just above the gate's `0.005` noise floor,
+    ~1.5× the empirical ~0.013 fitness stderr) is `--target-effect-size` / config
+    overridable; the CI method is normal-approximation (`gain ± z·gain_stderr`),
+    chosen over bootstrap because the gain stderr is already a bootstrap estimate
+    and the normal-approx keeps the module pure + reconciled with the gate.
+  - New module `core/self_improving_loop/statistical_power.py`
+    (`decompose_variance`, `gain_ci_excludes_zero`, `required_samples`,
+    `format_power_line`, + the `VarianceDecomposition` / `GainEvidence` /
+    `PowerRequirement` / `PowerRecordFields` dataclasses). All record fields are
+    additive + None-omitting so `M=1` / pre-E4 readers are backward-compatible.
+
+---
+
 ## [0.99.95] - 2026-05-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.95
+- **Version**: 0.99.96
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.95 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.96 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.95 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.96 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -103,7 +103,13 @@ import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # E4 (2026-05-30) — type-only import for the record bundle annotation. The
+    # value is constructed lazily in ``main`` (local import) so this stays
+    # annotation-only and does not eagerly pull the statistics module at import.
+    from core.self_improving_loop.statistical_power import PowerRecordFields
 
 # PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring. ``BenchProvenance``
 # + ``collect_bench_means_from_inspect_ai`` 가 main() 의 audit 사이클에서
@@ -182,6 +188,16 @@ campaign is reproducible (no bare nondeterminism) and the seed is RECORDED on th
 held-out + baseline rows. Ignored for the ``gate`` / ``never`` arms. Resolved by
 :func:`_resolve_promote_policy_seed`."""
 _VALID_PROMOTE_POLICIES = frozenset({"gate", "random", "never"})
+AUDIT_REPLICATE = 1
+"""E4 (2026-05-30) — default per-mutation replicate count ``M``. ``M=1`` runs the
+audit once (today's behaviour, zero extra cost; within-mutation variance left
+unestimated). ``M>1`` runs ``M`` full audits to estimate the WITHIN-mutation
+(provider non-determinism) variance SEPARATELY from the BETWEEN-seed variance.
+Resolved by :func:`_resolve_audit_replicate` (env → CLI → config → this constant)."""
+TARGET_EFFECT_SIZE = 0.02
+"""E4 (2026-05-30) — default fitness-scale effect size δ the power analysis targets
+(see ``statistical_power.DEFAULT_TARGET_EFFECT_SIZE`` for the justification).
+Resolved by :func:`_resolve_target_effect_size`."""
 WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 
 
@@ -224,6 +240,8 @@ def _get_autoresearch_config() -> Any:
             held_out_bench=HELD_OUT_BENCH,
             promote_policy=PROMOTE_POLICY,
             promote_policy_seed=PROMOTE_POLICY_SEED,
+            replicate=AUDIT_REPLICATE,
+            target_effect_size=TARGET_EFFECT_SIZE,
             dim_set=DIM_SET_NAME,
             max_turns=MAX_TURNS,
         )
@@ -406,6 +424,85 @@ def _resolve_promote_policy_seed(cli_override: int | None = None) -> int:
                 PROMOTE_POLICY_SEED,
             )
     return PROMOTE_POLICY_SEED
+
+
+def _resolve_audit_replicate(cli_override: int | None = None) -> int:
+    """Return the per-mutation replicate count ``M`` (E4).
+
+    Precedence mirrors :func:`_resolve_promote_policy`
+    (env ``GEODE_AUDIT_REPLICATE`` / ``AUTORESEARCH_REPLICATE`` → CLI
+    ``--replicate`` → config ``replicate`` → :data:`AUDIT_REPLICATE` (``1``)).
+
+    Graceful contract per tier: a non-integer / <1 env value is warned + skipped
+    to the next tier (a stray export never crashes or silently changes cost). The
+    config tier is Pydantic-validated (``ge=1, le=20``) at load time, so the
+    ``int()`` guard below only defends the test-stub ``SimpleNamespace`` path. The
+    final value is floored at 1 (``M`` is always a positive count)."""
+    for env_name in ("GEODE_AUDIT_REPLICATE", "AUTORESEARCH_REPLICATE"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            try:
+                parsed = int(raw)
+            except ValueError:
+                log.warning("audit replicate env %s=%r is not an integer; ignoring", env_name, raw)
+                continue
+            if parsed >= 1:
+                return parsed
+            log.warning("audit replicate env %s=%r is < 1; ignoring", env_name, raw)
+    if cli_override is not None:
+        return max(1, int(cli_override))
+    configured = getattr(_get_autoresearch_config(), "replicate", None)
+    if configured is not None:
+        try:
+            return max(1, int(configured))
+        except (TypeError, ValueError):
+            log.warning(
+                "replicate config value %r is not an integer; using default %d",
+                configured,
+                AUDIT_REPLICATE,
+            )
+    return AUDIT_REPLICATE
+
+
+def _resolve_target_effect_size(cli_override: float | None = None) -> float:
+    """Return the fitness-scale effect size δ the power analysis targets (E4).
+
+    Precedence mirrors :func:`_resolve_audit_replicate`
+    (env ``GEODE_TARGET_EFFECT_SIZE`` / ``AUTORESEARCH_TARGET_EFFECT_SIZE`` → CLI
+    ``--target-effect-size`` → config ``target_effect_size`` → :data:`TARGET_EFFECT_SIZE`).
+
+    Graceful contract: a non-numeric / non-positive env value is warned + skipped
+    to the next tier; the config tier is Pydantic-validated (``gt=0, le=1``) at load
+    time so the ``float()`` guard only defends the test-stub path. A non-positive
+    final value falls back to the default (δ ≤ 0 is ill-posed for the power
+    formula)."""
+    for env_name in ("GEODE_TARGET_EFFECT_SIZE", "AUTORESEARCH_TARGET_EFFECT_SIZE"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            try:
+                parsed = float(raw)
+            except ValueError:
+                log.warning("target effect size env %s=%r is not a float; ignoring", env_name, raw)
+                continue
+            if parsed > 0.0:
+                return parsed
+            log.warning("target effect size env %s=%r is not positive; ignoring", env_name, raw)
+    if cli_override is not None and float(cli_override) > 0.0:
+        return float(cli_override)
+    configured = getattr(_get_autoresearch_config(), "target_effect_size", None)
+    if configured is not None:
+        try:
+            value = float(configured)
+        except (TypeError, ValueError):
+            log.warning(
+                "target_effect_size config value %r is not a float; using default %s",
+                configured,
+                TARGET_EFFECT_SIZE,
+            )
+        else:
+            if value > 0.0:
+                return value
+    return TARGET_EFFECT_SIZE
 
 
 def _random_accept_draw(seed: int, cycle_index: int) -> bool:
@@ -2448,6 +2545,7 @@ def _append_baseline_registry_row(
     held_out_bench_id: str | None = None,
     promote_policy: str = "gate",
     promote_policy_seed: int = 0,
+    power_stats: PowerRecordFields | None = None,
 ) -> None:
     """Append one ``kind="baseline"`` registry row to ``baseline_archive.jsonl``.
 
@@ -2600,6 +2698,26 @@ def _append_baseline_registry_row(
     if held_out_fitness is not None and held_out_bench_id is not None:
         row["held_out_fitness"] = float(held_out_fitness)
         row["held_out_bench_id"] = str(held_out_bench_id)
+    # E4 (2026-05-30) — fitness-noise decomposition + the explicit gain-evidence
+    # verdict on the promoted baseline row. Each field is recorded only when present
+    # (M=1 leaves within ``None``; pre-E4 promotes pass ``power_stats=None`` → the
+    # whole block is omitted) so the row shape is unchanged for the legacy path —
+    # additive, never a new required key.
+    if power_stats is not None:
+        if power_stats.within_mutation_stderr is not None:
+            row["within_mutation_stderr"] = float(power_stats.within_mutation_stderr)
+        if power_stats.between_seed_stderr is not None:
+            row["between_seed_stderr"] = float(power_stats.between_seed_stderr)
+        if power_stats.gain_ci_excludes_zero is not None:
+            row["gain_ci_low"] = (
+                float(power_stats.gain_ci_low) if power_stats.gain_ci_low is not None else None
+            )
+            row["gain_ci_high"] = (
+                float(power_stats.gain_ci_high) if power_stats.gain_ci_high is not None else None
+            )
+            row["gain_ci_excludes_zero"] = bool(power_stats.gain_ci_excludes_zero)
+            if power_stats.gain_verdict is not None:
+                row["gain_verdict"] = str(power_stats.gain_verdict)
     archive_path = _baseline_archive_path()
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     with archive_path.open("a", encoding="utf-8") as fh:
@@ -2648,6 +2766,12 @@ def _write_baseline(
     # spec. ``"gate"`` (default) reproduces today's selection-arm row + epoch.
     promote_policy: str = "gate",
     promote_policy_seed: int = 0,
+    # E4 (2026-05-30) — the fitness-noise DECOMPOSITION (persisted on the promoted
+    # baseline's ``raw`` namespace alongside ``fitness_stderr``) + the explicit
+    # gain-evidence verdict (on the registry row), bundled into ONE optional
+    # parameter. ``None`` (default) → the keys are omitted (backward-compatible: an
+    # M=1 / pre-E4 baseline keeps its exact shape).
+    power_stats: PowerRecordFields | None = None,
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -2699,6 +2823,13 @@ def _write_baseline(
     # stderr so the next cycle's promote gate reads it as the prior σ.
     if fitness_stderr is not None:
         raw_payload["fitness_stderr"] = float(fitness_stderr)
+    # E4 (2026-05-30) — the within-mutation / between-seed decomposition (both on
+    # the 0-1 fitness scale). Recorded only when present (M=1 leaves within ``None``
+    # → omitted) so the ``raw`` namespace stays backward-compatible.
+    if power_stats is not None and power_stats.within_mutation_stderr is not None:
+        raw_payload["within_mutation_stderr"] = float(power_stats.within_mutation_stderr)
+    if power_stats is not None and power_stats.between_seed_stderr is not None:
+        raw_payload["between_seed_stderr"] = float(power_stats.between_seed_stderr)
     # PR-SIL-5THEME C2 — bench provenance slots. dim 측 PR-1 패턴과 symmetric.
     if bench_stderr:
         raw_payload["bench_stderr"] = {k: float(v) for k, v in bench_stderr.items()}
@@ -2770,6 +2901,8 @@ def _write_baseline(
         # E3 (2026-05-30) — control-arm tag → registry row + epoch spec.
         promote_policy=promote_policy,
         promote_policy_seed=promote_policy_seed,
+        # E4 (2026-05-30) — fitness-noise decomposition + gain-evidence verdict.
+        power_stats=power_stats,
     )
     # Emit BASELINE_PROMOTED after the write succeeds. ``reason``
     # quotes the gate verdict text from ``_should_promote`` (or the
@@ -3462,6 +3595,30 @@ def main() -> int:
         "is Random(seed + cycle_index)); RECORDED on the held-out + baseline rows "
         "so the random campaign is reproducible. Ignored for gate / never.",
     )
+    # E4 (2026-05-30) — statistical power knobs. ``default=None`` so omitting them
+    # falls through to env / config in the resolvers (an explicit value overrides
+    # config the same way the other arms do).
+    parser.add_argument(
+        "--replicate",
+        type=int,
+        default=None,
+        metavar="M",
+        help="run the audit M times per mutation/cycle to estimate WITHIN-mutation "
+        "variance (provider non-determinism) SEPARATELY from BETWEEN-seed variance. "
+        "M=1 (default) runs once with zero extra cost (within-variance unestimated, "
+        "as today); M>1 runs M full audits (cost scales linearly). env "
+        "GEODE_AUDIT_REPLICATE / AUTORESEARCH_REPLICATE / config replicate override.",
+    )
+    parser.add_argument(
+        "--target-effect-size",
+        type=float,
+        default=None,
+        metavar="DELTA",
+        help="the fitness-scale effect size delta the per-campaign power analysis "
+        "targets (default ~0.02, just above the promote gate's noise floor). Feeds "
+        "the required N_seed x M_replicate line. env GEODE_TARGET_EFFECT_SIZE / "
+        "AUTORESEARCH_TARGET_EFFECT_SIZE / config target_effect_size override.",
+    )
     args = parser.parse_args()
 
     session_id = _resolve_session_id()
@@ -3481,6 +3638,11 @@ def main() -> int:
     promote_policy = _resolve_promote_policy(args.promote_policy)
     promote_policy_seed = _resolve_promote_policy_seed(args.promote_policy_seed)
     _cycle_index = _gen_cycle_index(gen_tag)
+    # E4 (2026-05-30) — statistical power knobs. ``replicate`` (M) gates the
+    # per-mutation replicate loop below; ``target_effect_size`` (delta) feeds the
+    # per-campaign power line. Both resolved up-front (env → CLI → config → default).
+    audit_replicate = _resolve_audit_replicate(args.replicate)
+    target_effect_size = _resolve_target_effect_size(args.target_effect_size)
 
     cfg = _get_autoresearch_config()
     # PR-SIL-MULTIOBJ A3 (2026-05-29) — optional cache hygiene before a
@@ -3518,20 +3680,68 @@ def main() -> int:
         },
     )
 
+    # PR-11 P3.1 — anchor_confidence_mode is an env-gate (set by runner.py); read
+    # it up-front so the per-replicate raw-fitness (E4 within-mutation decomposition)
+    # is computed under the SAME fitness-formula path as the gate's ``current_raw``.
+    _anchor_mode_env = os.environ.get("GEODE_SIL_ANCHOR_CONFIDENCE_MODE", "").strip()
+    _anchor_confidence_mode = _anchor_mode_env == "1"
+    # E4 (2026-05-30) — per-mutation REPLICATE loop. Run the audit ``M`` times
+    # (M=1 default → exactly ONE call, no loop overhead / cost change — the
+    # representative tuple below is that single call's result, byte-identical to
+    # the pre-E4 path). M>1 runs M full audits so the WITHIN-mutation fitness
+    # variance (provider non-determinism, same mutation + seeds) can be estimated
+    # SEPARATELY from the BETWEEN-seed variance (the per-audit bootstrap stderr).
+    # The LAST replicate is the representative measurement that drives the existing
+    # promote / record / attribution flow (a single deterministic choice — not an
+    # average — so the downstream dims/stderr/per_sample stay a real audit's data).
+    _replicate_raw_fitnesses: list[float] = []
+    _replicate_between_seed_stderrs: list[float | None] = []
+    dim_means: dict[str, float] = {}
+    dim_stderr: dict[str, float] = {}
+    audit_seconds = 0.0
+    total_seconds = 0.0
+    sample_count: dict[str, int] = {}
+    measurement_modality: dict[str, str] = {}
+    per_sample: list[dict[str, float]] = []
     try:
-        (
-            dim_means,
-            dim_stderr,
-            audit_seconds,
-            total_seconds,
-            sample_count,
-            measurement_modality,
-            per_sample,
-        ) = run_audit(
-            dry_run=args.dry_run,
-            session_id=session_id,
-            gen_tag=gen_tag,
-        )
+        for _replicate_idx in range(audit_replicate):
+            (
+                dim_means,
+                dim_stderr,
+                audit_seconds,
+                total_seconds,
+                sample_count,
+                measurement_modality,
+                per_sample,
+            ) = run_audit(
+                dry_run=args.dry_run,
+                session_id=session_id,
+                gen_tag=gen_tag,
+            )
+            # Per-replicate RAW fitness on the same scale the gate's ``current_raw``
+            # uses (``baseline_means=None`` plain weighted sum, modality + anchor
+            # threaded, bench OMITTED — identical to the gain/σ math's scope) so the
+            # spread across replicates measures the WHOLE-audit fitness wobble.
+            _rep_anchor = {d: dim_means[d] for d in ANCHOR_DIMS if d in dim_means}
+            _replicate_raw_fitnesses.append(
+                compute_fitness(
+                    dim_means,
+                    dim_stderr,
+                    measurement_modality=measurement_modality or None,
+                    anchor_means=_rep_anchor or None,
+                    anchor_confidence_mode=_anchor_confidence_mode,
+                    admire_means=None,
+                )
+            )
+            # Per-replicate BETWEEN-seed stderr — the bootstrap over THIS audit's N
+            # sample rows (seed heterogeneity). ``None`` for <2 rows (dry-run path).
+            _replicate_between_seed_stderrs.append(
+                _fitness_stderr_bootstrap(
+                    per_sample,
+                    measurement_modality=measurement_modality or None,
+                    anchor_confidence_mode=_anchor_confidence_mode,
+                )
+            )
     except Exception as exc:
         # P0b — audit_failed marker for stream consumers. The specific
         # cause (subprocess_timeout / RuntimeError) has its own event
@@ -3606,11 +3816,9 @@ def main() -> int:
     # PR-SIL-5THEME C3 (2026-05-23) — measurement_modality 를
     # compute_fitness 에 forward 해서 analytics dim 의 가중치를 0.5× 로 scale.
     # 이전엔 modality 가 schema 에 emit 됐어도 fitness 계산에서 0 영향이었다.
-    # PR-11 P3.1 (2026-05-25) — anchor_means 추출 + mode env-gate. GEODE config
-    # 의 ``anchor_confidence_mode`` 가 runner.py 에서 env 로 forward (PR-11 동시
-    # 수정). 본 caller 는 dim_means 의 anchor 3 subset 을 빌드해서 forward.
-    _anchor_mode_env = os.environ.get("GEODE_SIL_ANCHOR_CONFIDENCE_MODE", "").strip()
-    _anchor_confidence_mode = _anchor_mode_env == "1"
+    # PR-11 P3.1 (2026-05-25) — anchor_means 추출. ``_anchor_confidence_mode`` 는
+    # E4 의 replicate loop 직전에서 이미 한 번 resolve 됨 (env-gate, runner.py 가
+    # forward). 본 caller 는 dim_means 의 anchor 3 subset 을 빌드해서 forward.
     _anchor_means_current = {d: dim_means[d] for d in ANCHOR_DIMS if d in dim_means}
     # PR-AR-L4b (2026-05-26, ux-removed 2026-05-30) — admire_means caller
     # wiring. admire_means is the Scope A handoff slot — reserved as None
@@ -3639,6 +3847,127 @@ def main() -> int:
         per_sample,
         measurement_modality=measurement_modality or None,
         anchor_confidence_mode=_anchor_confidence_mode,
+    )
+    # E4 (2026-05-30) — STATISTICAL POWER. Three operator deliverables, computed
+    # here so they ride the existing record / log sinks below:
+    #
+    #   (1) variance decomposition — split the observed fitness noise into the
+    #       WITHIN-mutation component (provider non-determinism, the spread of the
+    #       per-replicate raw fitnesses) and the BETWEEN-seed component (seed
+    #       heterogeneity, the per-audit bootstrap stderr). M=1 leaves within
+    #       UNESTIMATED (None) and combined == between (today's single-σ path).
+    #   (2) explicit "ci excludes 0" gain verdict — an HONEST NULL ("no evidence
+    #       yet") layered ON TOP of the promote gate, reconciled with its margin.
+    #   (3) per-campaign power line — required N_seed × M_replicate to detect δ.
+    from core.self_improving_loop.statistical_power import (
+        PowerRecordFields,
+        decompose_variance,
+        format_power_line,
+        gain_ci_excludes_zero,
+        required_samples,
+    )
+
+    variance_decomposition = decompose_variance(
+        _replicate_raw_fitnesses,
+        _replicate_between_seed_stderrs,
+    )
+    # The "current" σ for the gain CI is the combined within+between stderr when M>1
+    # (so the CI accounts for provider jitter too), else the per-audit bootstrap
+    # (today's quantity) — keeps the M=1 verdict identical to the gate's margin math.
+    _current_sigma_for_ci = (
+        variance_decomposition.combined_stderr
+        if audit_replicate > 1 and variance_decomposition.combined_stderr is not None
+        else current_fitness_stderr
+    )
+    # current_raw on the gate's scale (mean over replicates; == the single audit
+    # when M=1). prior_raw is the baseline's 0-1 compute_fitness (the gate's
+    # ``prior_raw``); ``None`` when there is no baseline.
+    _current_raw_for_gain = (
+        statistics.fmean(_replicate_raw_fitnesses) if _replicate_raw_fitnesses else float(fitness)
+    )
+    _baseline_raw_for_gain = _baseline_raw_fitness(
+        baseline_means,
+        baseline_stderr,
+        baseline_measurement_modality=_load_baseline_measurement_modality()
+        if not args.no_baseline
+        else {},
+        baseline_admire_means=_baseline_admire_means,
+        anchor_confidence_mode=_anchor_confidence_mode,
+    )
+    _baseline_fitness_stderr_for_ci = (
+        _load_baseline_fitness_stderr() if not args.no_baseline else None
+    )
+    # gain σ = √(σ_current² + σ_baseline²) — the SAME quantity the promote gate's
+    # margin scales (so DEFAULT_GAIN_CI_Z=1.0 reconciles the verdict with the gate).
+    _sigma_current_sq = (_current_sigma_for_ci or 0.0) ** 2
+    _sigma_baseline_sq = (_baseline_fitness_stderr_for_ci or 0.0) ** 2
+    _gain_stderr = (_sigma_current_sq + _sigma_baseline_sq) ** 0.5
+    # HONEST NULL on a bootstrap cycle: with NO baseline there is nothing to "gain
+    # over", so a gain cannot be CLAIMED regardless of how high the current fitness
+    # is. The verdict is forced to "no evidence yet" (gain=0 → ci straddles 0) — the
+    # bootstrap promote is the gate's own concern (a fresh-start admit), NOT a
+    # statistically-supported improvement. (Reporting "significant" here — as a naive
+    # ``gain = current_fitness`` would — is exactly the false claim E4 must avoid.)
+    if _baseline_raw_for_gain is None:
+        gain_evidence = gain_ci_excludes_zero(0.0, 0.0)
+    else:
+        gain_evidence = gain_ci_excludes_zero(
+            _current_raw_for_gain - _baseline_raw_for_gain, _gain_stderr
+        )
+    # Per-campaign power requirement: required N_seed × M to detect δ at 80% power.
+    power_requirement = required_samples(
+        variance_decomposition.combined_stderr,
+        target_effect_size=target_effect_size,
+        replicate=audit_replicate,
+    )
+    _power_line = format_power_line(power_requirement)
+    log.info("E4 %s", _power_line)
+    log.info(
+        "E4 gain evidence: gain=%+.4f ci=[%+.4f, %+.4f] excludes_zero=%s verdict=%r",
+        gain_evidence.gain,
+        gain_evidence.ci_low,
+        gain_evidence.ci_high,
+        gain_evidence.gain_ci_excludes_zero,
+        gain_evidence.verdict,
+    )
+    _emit_journal(
+        session_id,
+        gen_tag,
+        "statistical_power",
+        payload={
+            "replicate": audit_replicate,
+            "within_mutation_stderr": variance_decomposition.within_mutation_stderr,
+            "between_seed_stderr": variance_decomposition.between_seed_stderr,
+            "combined_stderr": variance_decomposition.combined_stderr,
+            "gain": round(gain_evidence.gain, 6),
+            "gain_stderr": round(gain_evidence.gain_stderr, 6),
+            "gain_ci_low": round(gain_evidence.ci_low, 6),
+            "gain_ci_high": round(gain_evidence.ci_high, 6),
+            "gain_ci_excludes_zero": gain_evidence.gain_ci_excludes_zero,
+            "gain_verdict": gain_evidence.verdict,
+            "target_effect_size": target_effect_size,
+            "required_n_seed": power_requirement.n_seed,
+            "power_line": _power_line,
+        },
+    )
+    # E4 — bundle the new fields for the two record sinks. Both shapes are
+    # None-omitting + additive so M=1 / legacy readers are backward-compatible (a
+    # missing key never breaks a reader). ``_e4_power_stats`` (a PowerRecordFields)
+    # → the on-promote baseline registry row (single arg, under the max-args
+    # ratchet); ``_e4_record_fields`` (kwargs dict) → the per-cycle attribution row.
+    _e4_power_stats = PowerRecordFields.from_evidence(variance_decomposition, gain_evidence)
+    _e4_record_fields: dict[str, Any] = {
+        "within_mutation_stderr": _e4_power_stats.within_mutation_stderr,
+        "between_seed_stderr": _e4_power_stats.between_seed_stderr,
+        "gain_ci_low": _e4_power_stats.gain_ci_low,
+        "gain_ci_high": _e4_power_stats.gain_ci_high,
+        "gain_ci_excludes_zero": _e4_power_stats.gain_ci_excludes_zero,
+        "gain_verdict": _e4_power_stats.gain_verdict,
+    }
+    print(f"e4_power_line:            {_power_line}")
+    print(
+        f"e4_gain_verdict:          {gain_evidence.verdict} "
+        f"(ci excludes 0: {gain_evidence.gain_ci_excludes_zero})"
     )
     # E2 (2026-05-30) — per-cycle fixed-ruler measurement. The held-out bench is
     # a VERSION-FROZEN seed set DISJOINT from the co-evolving ``seed_select`` pool
@@ -3804,6 +4133,11 @@ def main() -> int:
         # The seed is recorded so the random arm's promoted baseline is traceable.
         "promote_policy": promote_policy,
         "promote_policy_seed": promote_policy_seed,
+        # E4 (2026-05-30) — fitness-noise decomposition + gain-evidence verdict on
+        # the promoted baseline, bundled into one PowerRecordFields arg. All
+        # None-omitting (M=1 leaves within unestimated; pre-E4 baselines omit the
+        # block) so the row shape stays backward-compatible.
+        "power_stats": _e4_power_stats,
     }
     if args.dry_run:
         promoted_line = "false (dry-run)"
@@ -4056,6 +4390,11 @@ def main() -> int:
                 # ledger (0 for gate / never).
                 promote_policy=promote_policy,
                 promote_policy_seed=promote_policy_seed,
+                # E4 (2026-05-30) — variance decomposition + the explicit "ci
+                # excludes 0" gain evidence on the per-cycle attribution row. All
+                # fields are None-omitting (M=1 leaves within unestimated; legacy
+                # rows omit the whole block) so the row stays backward-compatible.
+                **_e4_record_fields,
             )
         except Exception:  # pragma: no cover — defensive
             log.warning(

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -102,6 +102,7 @@ import sys
 import time
 import uuid
 from datetime import UTC, datetime
+from math import isfinite
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -450,7 +451,10 @@ def _resolve_audit_replicate(cli_override: int | None = None) -> int:
                 return parsed
             log.warning("audit replicate env %s=%r is < 1; ignoring", env_name, raw)
     if cli_override is not None:
-        return max(1, int(cli_override))
+        try:
+            return max(1, int(cli_override))
+        except (TypeError, ValueError):
+            log.warning("audit replicate CLI value %r is not an integer; ignoring", cli_override)
     configured = getattr(_get_autoresearch_config(), "replicate", None)
     if configured is not None:
         try:
@@ -484,11 +488,23 @@ def _resolve_target_effect_size(cli_override: float | None = None) -> float:
             except ValueError:
                 log.warning("target effect size env %s=%r is not a float; ignoring", env_name, raw)
                 continue
-            if parsed > 0.0:
+            if isfinite(parsed) and parsed > 0.0:
                 return parsed
-            log.warning("target effect size env %s=%r is not positive; ignoring", env_name, raw)
-    if cli_override is not None and float(cli_override) > 0.0:
-        return float(cli_override)
+            log.warning(
+                "target effect size env %s=%r is not a finite positive float; ignoring",
+                env_name,
+                raw,
+            )
+    if cli_override is not None:
+        try:
+            cli_value = float(cli_override)
+        except (TypeError, ValueError):
+            cli_value = 0.0
+        # argparse ``type=float`` accepts ``"nan"`` / ``"inf"`` — reject a
+        # non-finite / non-positive δ (ill-posed for the power formula) rather than
+        # letting it through (graceful contract).
+        if isfinite(cli_value) and cli_value > 0.0:
+            return cli_value
     configured = getattr(_get_autoresearch_config(), "target_effect_size", None)
     if configured is not None:
         try:
@@ -500,7 +516,7 @@ def _resolve_target_effect_size(cli_override: float | None = None) -> float:
                 TARGET_EFFECT_SIZE,
             )
         else:
-            if value > 0.0:
+            if isfinite(value) and value > 0.0:
                 return value
     return TARGET_EFFECT_SIZE
 
@@ -2935,6 +2951,13 @@ def _write_baseline(
 # zero MC noise).
 N1_FITNESS_MARGIN_FLOOR = 0.05
 
+# PR-MARGIN-FITNESS-SCALE (2026-05-30) — the base zero-noise floor (the ``max``'s
+# non-σ term in the promote margin). Single SoT for both ``_should_promote``'s
+# ``fitness_margin_floor`` default AND the E4 gain-CI verdict's floor term (so the
+# verdict never claims significance on a sub-floor gain the gate rejects — they
+# must not drift). See the gain_ci_excludes_zero docstring for the reconciliation.
+_FITNESS_MARGIN_FLOOR_DEFAULT = 0.005
+
 # PR-MARGIN-FITNESS-SCALE (2026-05-30) — the promote margin lives on the
 # FITNESS scale (0–1 weighted aggregate), not the raw dim scale (1–10). The
 # correct noise unit is the stderr of ``compute_fitness`` itself, estimated by
@@ -3128,7 +3151,7 @@ def _should_promote(
     # baseline is ~0.013, so the floor only kicks in when both audits carry
     # ~zero measurement noise. Critical-regress protection stays with
     # critical_margin (Option D) + the N=1 widening floor (0.05).
-    fitness_margin_floor: float = 0.005,
+    fitness_margin_floor: float = _FITNESS_MARGIN_FLOOR_DEFAULT,
     # PR-MARGIN-FITNESS-SCALE (2026-05-30) — sample-bootstrap fitness stderr
     # (captures inter-dim correlation) passed by the audit caller. When None
     # (tests / v1 baselines / summary-only path) the margin falls back to the
@@ -3871,19 +3894,23 @@ def main() -> int:
         _replicate_raw_fitnesses,
         _replicate_between_seed_stderrs,
     )
-    # The "current" σ for the gain CI is the combined within+between stderr when M>1
-    # (so the CI accounts for provider jitter too), else the per-audit bootstrap
-    # (today's quantity) — keeps the M=1 verdict identical to the gate's margin math.
-    _current_sigma_for_ci = (
-        variance_decomposition.combined_stderr
-        if audit_replicate > 1 and variance_decomposition.combined_stderr is not None
-        else current_fitness_stderr
-    )
-    # current_raw on the gate's scale (mean over replicates; == the single audit
-    # when M=1). prior_raw is the baseline's 0-1 compute_fitness (the gate's
-    # ``prior_raw``); ``None`` when there is no baseline.
-    _current_raw_for_gain = (
-        statistics.fmean(_replicate_raw_fitnesses) if _replicate_raw_fitnesses else float(fitness)
+    # The gain-CI VERDICT must reconcile EXACTLY with the promote gate (no
+    # contradiction), so it consumes the gate's OWN inputs — NOT the combined σ /
+    # replicate-mean, which would diverge from what ``_should_promote`` actually
+    # compares. Concretely the verdict uses:
+    #   - current_raw = the REPRESENTATIVE (last) replicate's raw fitness (the same
+    #     ``dim_means`` the gate scores — ``_current_raw_for_representative``), NOT
+    #     the replicate mean.
+    #   - σ_current = ``current_fitness_stderr`` (the gate's ``current_fitness_stderr``
+    #     bootstrap), NOT the combined within+between σ.
+    #   - σ_baseline = ``_load_baseline_fitness_stderr`` (the gate's prior σ).
+    # so gain_stderr = √(σp²+σc²) is the IDENTICAL quantity the gate's margin scales.
+    # The within-mutation jitter from M>1 is NOT folded into the verdict's σ (it
+    # would break the gate-reconciliation); it is reported in the DECOMPOSITION and
+    # in the power line's combined σ instead. Use the representative replicate's raw
+    # so the verdict's ``current_raw`` matches the gate's ``current_raw`` exactly.
+    _current_raw_for_representative = (
+        _replicate_raw_fitnesses[-1] if _replicate_raw_fitnesses else float(fitness)
     )
     _baseline_raw_for_gain = _baseline_raw_fitness(
         baseline_means,
@@ -3899,9 +3926,25 @@ def main() -> int:
     )
     # gain σ = √(σ_current² + σ_baseline²) — the SAME quantity the promote gate's
     # margin scales (so DEFAULT_GAIN_CI_Z=1.0 reconciles the verdict with the gate).
-    _sigma_current_sq = (_current_sigma_for_ci or 0.0) ** 2
+    _sigma_current_sq = (current_fitness_stderr or 0.0) ** 2
     _sigma_baseline_sq = (_baseline_fitness_stderr_for_ci or 0.0) ** 2
     _gain_stderr = (_sigma_current_sq + _sigma_baseline_sq) ** 0.5
+    # The gate's EFFECTIVE floor (the ``max``'s zero-noise term) — the verdict must
+    # honour it too or it would claim "significant" on a sub-floor gain the gate
+    # rejects. Reproduce the gate's N=1-widening: the floor widens to
+    # ``N1_FITNESS_MARGIN_FLOOR`` when a critical dim was measured from N≤1 judge_llm
+    # samples (see ``_should_promote``); else the base ``fitness_margin_floor``.
+    _gate_effective_floor = _FITNESS_MARGIN_FLOOR_DEFAULT
+    if not args.no_baseline:
+        _verdict_sample_count = _load_baseline_sample_count()
+        _verdict_modality = _load_baseline_measurement_modality()
+        _verdict_n1_critical = bool(_verdict_sample_count) and any(
+            _verdict_sample_count.get(dim, 0) <= 1
+            and (_verdict_modality or {}).get(dim, "judge_llm") in JUDGE_LLM_MODALITIES
+            for dim in CRITICAL_DIMS
+        )
+        if _verdict_n1_critical:
+            _gate_effective_floor = N1_FITNESS_MARGIN_FLOOR
     # HONEST NULL on a bootstrap cycle: with NO baseline there is nothing to "gain
     # over", so a gain cannot be CLAIMED regardless of how high the current fitness
     # is. The verdict is forced to "no evidence yet" (gain=0 → ci straddles 0) — the
@@ -3912,9 +3955,13 @@ def main() -> int:
         gain_evidence = gain_ci_excludes_zero(0.0, 0.0)
     else:
         gain_evidence = gain_ci_excludes_zero(
-            _current_raw_for_gain - _baseline_raw_for_gain, _gain_stderr
+            _current_raw_for_representative - _baseline_raw_for_gain,
+            _gain_stderr,
+            floor=_gate_effective_floor,
         )
     # Per-campaign power requirement: required N_seed × M to detect δ at 80% power.
+    # The power analysis DOES use the combined within+between σ (the full noise
+    # budget the operator must overcome), unlike the gate-reconciled verdict above.
     power_requirement = required_samples(
         variance_decomposition.combined_stderr,
         target_effect_size=target_effect_size,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -452,14 +452,16 @@ def _resolve_audit_replicate(cli_override: int | None = None) -> int:
             log.warning("audit replicate env %s=%r is < 1; ignoring", env_name, raw)
     if cli_override is not None:
         try:
+            # OverflowError guards ``int(float("inf"))`` (argparse type=int rejects
+            # it at parse, but the resolver is also called directly).
             return max(1, int(cli_override))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             log.warning("audit replicate CLI value %r is not an integer; ignoring", cli_override)
     configured = getattr(_get_autoresearch_config(), "replicate", None)
     if configured is not None:
         try:
             return max(1, int(configured))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             log.warning(
                 "replicate config value %r is not an integer; using default %d",
                 configured,
@@ -3921,14 +3923,47 @@ def main() -> int:
         baseline_admire_means=_baseline_admire_means,
         anchor_confidence_mode=_anchor_confidence_mode,
     )
-    _baseline_fitness_stderr_for_ci = (
+    # gain σ = √(σ_current² + σ_baseline²) — the SAME quantity (and the SAME
+    # bootstrap-then-MC-fallback) the promote gate's ``_should_promote`` builds, so
+    # DEFAULT_GAIN_CI_Z=1.0 reconciles the verdict with the gate EXACTLY:
+    #   - σ_current: prefer ``current_fitness_stderr`` (the sample bootstrap); when
+    #     ``None`` (dry-run / <2 rows) fall back to ``_fitness_scale_stderr`` on the
+    #     CURRENT dims — the gate's IDENTICAL fallback (else a v1/summary baseline's
+    #     verdict σ would be 0 while the gate's is the MC estimate → contradiction).
+    #   - σ_baseline: prefer the persisted ``raw.fitness_stderr``; when ``None``
+    #     (v1 / pre-E4 baseline) fall back to ``_fitness_scale_stderr`` on the
+    #     BASELINE dims — again the gate's identical fallback.
+    _verdict_baseline_anchor = (
+        {d: baseline_means[d] for d in ANCHOR_DIMS if d in baseline_means}
+        if baseline_means
+        else None
+    )
+    _persisted_baseline_fitness_stderr = (
         _load_baseline_fitness_stderr() if not args.no_baseline else None
     )
-    # gain σ = √(σ_current² + σ_baseline²) — the SAME quantity the promote gate's
-    # margin scales (so DEFAULT_GAIN_CI_Z=1.0 reconciles the verdict with the gate).
-    _sigma_current_sq = (current_fitness_stderr or 0.0) ** 2
-    _sigma_baseline_sq = (_baseline_fitness_stderr_for_ci or 0.0) ** 2
-    _gain_stderr = (_sigma_current_sq + _sigma_baseline_sq) ** 0.5
+    if current_fitness_stderr is not None:
+        _sigma_current = current_fitness_stderr
+    else:
+        _sigma_current = _fitness_scale_stderr(
+            dim_means,
+            dim_stderr,
+            measurement_modality=measurement_modality or None,
+            admire_means=admire_means_current,
+            anchor_means=_anchor_means_current or None,
+            anchor_confidence_mode=_anchor_confidence_mode,
+        )
+    if _persisted_baseline_fitness_stderr is not None or baseline_means is None:
+        _sigma_baseline = _persisted_baseline_fitness_stderr or 0.0
+    else:
+        _sigma_baseline = _fitness_scale_stderr(
+            baseline_means,
+            baseline_stderr,
+            measurement_modality=_load_baseline_measurement_modality() or None,
+            admire_means=_baseline_admire_means or None,
+            anchor_means=_verdict_baseline_anchor,
+            anchor_confidence_mode=_anchor_confidence_mode,
+        )
+    _gain_stderr = (_sigma_current**2 + _sigma_baseline**2) ** 0.5
     # The gate's EFFECTIVE floor (the ``max``'s zero-noise term) — the verdict must
     # honour it too or it would claim "significant" on a sub-floor gain the gate
     # rejects. Reproduce the gate's N=1-widening: the floor widens to

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -414,6 +414,27 @@ class AutoresearchConfig(BaseModel):
     RECORDED on the held-out + baseline rows. Ignored for the ``gate`` / ``never``
     arms. Resolution precedence mirrors ``promote_policy``
     (:func:`autoresearch.train._resolve_promote_policy_seed`)."""
+    replicate: Annotated[int, Field(ge=1, le=20)] = 1
+    """E4 (2026-05-30) — per-mutation REPLICATE count ``M``.
+
+    The audit is run ``M`` times per mutation/cycle to estimate the WITHIN-mutation
+    variance (provider non-determinism) SEPARATELY from the BETWEEN-seed variance
+    (the N samples inside one audit). ``M=1`` (default) leaves today's behaviour
+    unchanged — the audit runs once, within-mutation variance is honestly left
+    unestimated, and there is NO extra cost. ``M>1`` runs ``M`` full audits (so the
+    cost scales linearly — the operator opts in for the variance decomposition).
+    Resolution precedence mirrors ``promote_policy`` (env ``GEODE_AUDIT_REPLICATE``
+    / ``AUTORESEARCH_REPLICATE`` → CLI ``--replicate`` → this config field → ``1``)."""
+    target_effect_size: Annotated[float, Field(gt=0.0, le=1.0)] = 0.02
+    """E4 (2026-05-30) — the fitness-scale effect size δ the power analysis targets.
+
+    Feeds :func:`core.self_improving_loop.statistical_power.required_samples` to
+    compute the required ``N_seed × M_replicate`` to DETECT δ at α=0.05 / 80% power.
+    Default ~0.02 sits just above the promote gate's zero-noise floor — see the
+    ``DEFAULT_TARGET_EFFECT_SIZE`` docstring for the full justification. Resolution
+    precedence mirrors ``replicate`` (env ``GEODE_TARGET_EFFECT_SIZE`` /
+    ``AUTORESEARCH_TARGET_EFFECT_SIZE`` → CLI ``--target-effect-size`` → this config
+    field → ``0.02``)."""
     dim_set: str = "subset"
     max_turns: Annotated[int, Field(ge=1, le=200)] = 10
 

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -115,6 +115,26 @@ class AttributionRecord(BaseModel):
     the ledger; it is recorded for every arm (``0`` for gate / never) so the row
     is uniform. Legacy rows omit both → ``None`` via these defaults; a curve
     consumer filters the JSONL stream on ``promote_policy`` to split the arms."""
+    within_mutation_stderr: float | None = None
+    between_seed_stderr: float | None = None
+    """E4 (2026-05-30) — the within-mutation (provider non-determinism, across the
+    ``--replicate M`` repeated audits) and between-seed (seed heterogeneity, the N
+    samples inside one audit) fitness-stderr DECOMPOSITION, kept distinct so the two
+    noise sources are not conflated. Both on the 0-1 fitness scale.
+    ``within_mutation_stderr`` is ``None`` for the default ``M=1`` path (within
+    variance is unestimable from a single replicate — honestly unestimated, not 0).
+    Legacy rows omit both → ``None`` via these defaults (backward-compatible)."""
+    gain_ci_low: float | None = None
+    gain_ci_high: float | None = None
+    gain_ci_excludes_zero: bool | None = None
+    gain_verdict: str | None = None
+    """E4 (2026-05-30) — the EXPLICIT "ci excludes 0" evidence statement on the
+    fitness gain (current vs baseline) on the 0-1 scale: the CI bounds, a boolean
+    ``gain_ci_excludes_zero`` (``True`` iff ``gain_ci_low > 0`` — a CLAIMED gain),
+    and a human ``gain_verdict`` (``"gain significant"`` / ``"no evidence yet"``).
+    This is the honest-null evidence layer ON TOP of the promote gate (it never
+    weakens the gate; at ``DEFAULT_GAIN_CI_Z=1.0`` it reconciles with the gate's
+    σ-margin). Legacy rows omit all four → ``None`` (backward-compatible)."""
     audit_run_id: str | None = None
     source: str | None = None
     """PR-AR-L6 (2026-05-26) — distinguishes mutator-driven cycle rows
@@ -266,6 +286,12 @@ def compute_attribution(
     held_out_bench_id: str | None = None,
     promote_policy: str | None = None,
     promote_policy_seed: int | None = None,
+    within_mutation_stderr: float | None = None,
+    between_seed_stderr: float | None = None,
+    gain_ci_low: float | None = None,
+    gain_ci_high: float | None = None,
+    gain_ci_excludes_zero: bool | None = None,
+    gain_verdict: str | None = None,
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -358,6 +384,25 @@ def compute_attribution(
         payload["promote_policy_seed"] = int(
             promote_policy_seed if promote_policy_seed is not None else 0
         )
+    # E4 (2026-05-30) — variance decomposition + the explicit "ci excludes 0" gain
+    # evidence. Each field is recorded only when supplied (``None`` → omitted) so a
+    # default ``M=1`` cycle (within unestimable) and legacy rows keep their exact
+    # shape — purely additive, never a new required key. ``within_mutation_stderr``
+    # stays ``None`` on the M=1 path (honest: a single replicate cannot observe
+    # provider jitter), while ``between_seed_stderr`` + the gain CI are present
+    # whenever the audit had ≥2 sample rows.
+    if within_mutation_stderr is not None:
+        payload["within_mutation_stderr"] = round(float(within_mutation_stderr), 6)
+    if between_seed_stderr is not None:
+        payload["between_seed_stderr"] = round(float(between_seed_stderr), 6)
+    if gain_ci_excludes_zero is not None:
+        payload["gain_ci_low"] = round(float(gain_ci_low), 6) if gain_ci_low is not None else None
+        payload["gain_ci_high"] = (
+            round(float(gain_ci_high), 6) if gain_ci_high is not None else None
+        )
+        payload["gain_ci_excludes_zero"] = bool(gain_ci_excludes_zero)
+        if gain_verdict is not None:
+            payload["gain_verdict"] = str(gain_verdict)
     if baseline_before is None or baseline_after is None:
         return payload
 
@@ -413,6 +458,12 @@ def write_attribution(
     held_out_bench_id: str | None = None,
     promote_policy: str | None = None,
     promote_policy_seed: int | None = None,
+    within_mutation_stderr: float | None = None,
+    between_seed_stderr: float | None = None,
+    gain_ci_low: float | None = None,
+    gain_ci_high: float | None = None,
+    gain_ci_excludes_zero: bool | None = None,
+    gain_verdict: str | None = None,
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
 
@@ -444,6 +495,12 @@ def write_attribution(
         held_out_bench_id=held_out_bench_id,
         promote_policy=promote_policy,
         promote_policy_seed=promote_policy_seed,
+        within_mutation_stderr=within_mutation_stderr,
+        between_seed_stderr=between_seed_stderr,
+        gain_ci_low=gain_ci_low,
+        gain_ci_high=gain_ci_high,
+        gain_ci_excludes_zero=gain_ci_excludes_zero,
+        gain_verdict=gain_verdict,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload

--- a/core/self_improving_loop/statistical_power.py
+++ b/core/self_improving_loop/statistical_power.py
@@ -361,10 +361,11 @@ def required_samples(
         delta = 0.0
 
     # ``replicate`` is a count for display only — guard the cast so a malformed
-    # value (e.g. a stray non-int) degrades to 1 rather than raising.
+    # value (a stray non-int, or ``float("inf")`` which raises OverflowError on
+    # ``int()``) degrades to 1 rather than raising.
     try:
         replicate_count = max(1, int(replicate))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         replicate_count = 1
 
     n_seed: int | None

--- a/core/self_improving_loop/statistical_power.py
+++ b/core/self_improving_loop/statistical_power.py
@@ -197,8 +197,11 @@ class GainEvidence:
     ci_high: float
     """Normal-approx CI bounds: ``gain ± DEFAULT_GAIN_CI_Z · gain_stderr``."""
     gain_ci_excludes_zero: bool
-    """``True`` iff the CI lies entirely ABOVE 0 (``ci_low > 0``) — a CLAIMED gain.
-    A CI straddling 0 (or below it) is NOT evidence of a gain."""
+    """``True`` iff the CI lies entirely ABOVE 0 (``ci_low > 0``) AND the gain clears
+    the gate's zero-noise ``floor`` — a CLAIMED gain. A CI straddling 0 (or below
+    it), OR a gain inside the floor, is NOT evidence of a gain. (The floor term is
+    what keeps the verdict from claiming significance on a sub-floor gain the gate
+    rejects — see :func:`gain_ci_excludes_zero`.)"""
     verdict: str
     """Human evidence string: ``"gain significant"`` when the CI excludes 0 on the
     positive side, else ``"no evidence yet"`` (honest null)."""
@@ -216,6 +219,7 @@ def gain_ci_excludes_zero(
     *,
     z: float = DEFAULT_GAIN_CI_Z,
     alpha: float = DEFAULT_ALPHA,
+    floor: float = 0.0,
 ) -> GainEvidence:
     """Compute the explicit "ci excludes 0" evidence statement for a fitness gain.
 
@@ -229,22 +233,32 @@ def gain_ci_excludes_zero(
     The promote gate (``train.py`` ``_should_promote``) promotes iff
     ``current_raw > prior_raw + margin`` where
     ``margin = max(_MARGIN_GAIN_SIGMA · gain_stderr, floor)`` and
-    ``_MARGIN_GAIN_SIGMA = 1.0``. Ignoring the zero-noise ``floor`` (which only
-    binds when ``gain_stderr ≈ 0``), the gate condition is exactly
-    ``gain > 1.0 · gain_stderr`` ⇔ ``gain - z·gain_stderr > 0`` ⇔ ``ci_low > 0``
-    at ``z = DEFAULT_GAIN_CI_Z = 1.0``. So this verdict and the gate agree by
-    construction: when the gate promotes on the σ-margin, the CI excludes 0 and the
-    verdict is "gain significant"; when the gate rejects on the σ-margin, the CI
-    includes 0 and the verdict is "no evidence yet". (The verdict deliberately does
-    NOT re-apply the gate's ``floor`` / N=1 widening / critical-axis reject — those
-    are SAFETY widenings the gate owns; the verdict is the EVIDENCE statement, so it
-    can be "no evidence yet" on a gain the floor also rejects, but it can NEVER say
-    "significant" on a gain the σ-margin rejects. The gate stays authoritative for
-    promotion; this never weakens it.)
+    ``_MARGIN_GAIN_SIGMA = 1.0``. This verdict reproduces BOTH terms of that
+    ``max`` so it NEVER claims significance on a gain the gate rejects:
 
-    Graceful contract: a non-numeric / non-finite ``gain`` or ``gain_stderr`` is
-    coerced to a safe value (``0.0`` gain, ``0.0`` stderr) so the verdict path never
-    raises on a malformed input — it simply reports no evidence.
+    - σ-margin term: ``gain > 1.0 · gain_stderr`` ⇔ ``gain - z·gain_stderr > 0``
+      ⇔ ``ci_low > 0`` at ``z = DEFAULT_GAIN_CI_Z = 1.0`` (the gate's
+      ``_MARGIN_GAIN_SIGMA``). When the caller passes the SAME ``gain_stderr``
+      (``√(σp²+σc²)``) the gate uses, the CI-excludes-0 test and the gate's σ-margin
+      are the IDENTICAL inequality.
+    - floor term: ``gain > floor`` reproduces the gate's zero-noise ``floor`` (the
+      ``max``'s second argument — the effective floor, i.e. the N=1-widened floor
+      when applicable). Without it, a small-positive gain with ≈0 stderr would have
+      ``ci_low > 0`` (significant) while the gate rejects on the floor — exactly the
+      contradiction E4 must avoid. Pass ``floor=0.0`` (default) only when the caller
+      has no floor to honour (the pure-stats unit tests); the live caller passes the
+      gate's effective floor.
+
+    A gain is therefore "gain significant" iff ``ci_low > 0`` AND ``gain > floor`` —
+    the conjunction the gate's ``current_raw > prior_raw + max(σ-margin, floor)``
+    enforces. The verdict can still be "no evidence yet" on a gain the gate's N=1 /
+    critical-axis SAFETY widenings additionally reject (those are the gate's to own),
+    but it can NEVER be "significant" where the gate's margin rejects. The gate stays
+    authoritative for promotion; this never weakens it.
+
+    Graceful contract: a non-numeric / non-finite ``gain``, ``gain_stderr`` or
+    ``floor`` is coerced to a safe value (``0.0``) so the verdict path never raises
+    on a malformed input — it simply reports no evidence.
     """
     try:
         gain_value = float(gain)
@@ -258,11 +272,20 @@ def gain_ci_excludes_zero(
         stderr_value = 0.0
     if not isfinite(stderr_value) or stderr_value < 0.0:
         stderr_value = 0.0
+    try:
+        floor_value = float(floor)
+    except (TypeError, ValueError):
+        floor_value = 0.0
+    if not isfinite(floor_value) or floor_value < 0.0:
+        floor_value = 0.0
 
     half_width = z * stderr_value
     ci_low = gain_value - half_width
     ci_high = gain_value + half_width
-    excludes_zero = ci_low > 0.0
+    # Both the gate's margin terms: the CI must exclude 0 (σ-margin) AND the gain
+    # must clear the zero-noise floor — the conjunction the gate's
+    # max(σ-margin, floor) enforces, so the verdict never contradicts the gate.
+    excludes_zero = ci_low > 0.0 and gain_value > floor_value
     return GainEvidence(
         gain=gain_value,
         gain_stderr=stderr_value,
@@ -332,6 +355,17 @@ def required_samples(
         delta = float(target_effect_size)
     except (TypeError, ValueError):
         delta = 0.0
+    # NaN must NOT slip past ``delta <= 0.0`` (NaN comparisons are False) into the
+    # divide → ``int(nan)`` would raise. Force a non-finite δ to the ill-posed 0.0.
+    if not isfinite(delta):
+        delta = 0.0
+
+    # ``replicate`` is a count for display only — guard the cast so a malformed
+    # value (e.g. a stray non-int) degrades to 1 rather than raising.
+    try:
+        replicate_count = max(1, int(replicate))
+    except (TypeError, ValueError):
+        replicate_count = 1
 
     n_seed: int | None
     if sigma_value is None or delta <= 0.0:
@@ -342,8 +376,9 @@ def required_samples(
         z_alpha = NormalDist().inv_cdf(1.0 - alpha / 2.0)
         z_beta = NormalDist().inv_cdf(power)
         raw_n = 2.0 * (z_alpha + z_beta) ** 2 * (sigma_value**2) / (delta**2)
-        # ceil without importing math: int() truncates toward zero, add 1 unless
-        # already an exact integer. raw_n is always > 0 here.
+        # ceil without importing math.ceil: int() truncates toward zero, add 1
+        # unless already an exact integer. raw_n is always finite + > 0 here
+        # (sigma_value > 0, delta > 0, both finite).
         truncated = int(raw_n)
         n_seed = truncated if truncated == raw_n else truncated + 1
         n_seed = max(1, n_seed)
@@ -354,7 +389,7 @@ def required_samples(
         alpha=alpha,
         power=power,
         n_seed=n_seed,
-        replicate=max(1, int(replicate)),
+        replicate=replicate_count,
     )
 
 

--- a/core/self_improving_loop/statistical_power.py
+++ b/core/self_improving_loop/statistical_power.py
@@ -1,0 +1,436 @@
+"""Statistical power + evidence statements for the self-improving fitness loop.
+
+E4 (2026-05-30). The loop must only CLAIM a fitness gain when statistics
+support it — otherwise it must report an HONEST NULL ("no evidence yet"), and
+it must tell the operator how many samples are needed to detect a target effect.
+This module is the statistics layer that backs those three operator deliverables;
+the wiring (CLI arg, M-loop, record fields) lives in ``autoresearch/train.py``.
+
+Three responsibilities, kept pure (no I/O, no global state) so they are unit-
+testable in isolation:
+
+1. :func:`decompose_variance` — split the observed fitness noise into the
+   WITHIN-mutation component (provider non-determinism, estimated across the
+   ``--replicate M`` repeated audits of the SAME mutation/cycle) and the
+   BETWEEN-seed component (seed heterogeneity, the N samples inside one audit,
+   estimated by the per-audit bootstrap stderr). Keeping the two distinct stops
+   the loop from double-counting noise or from mistaking provider jitter for a
+   real seed-set signal.
+
+2. :func:`gain_ci_excludes_zero` — the operator's explicit evidence rule: a gain
+   is CLAIMED only when the confidence interval on the fitness GAIN excludes 0.
+   Returns the CI bounds + a boolean + a human verdict string. This is layered
+   ON TOP of the promote gate, not a replacement: see the reconciliation note on
+   the function (the gate's ``margin = max(_MARGIN_GAIN_SIGMA·gain_stderr, floor)``
+   IS effectively this same one-sided rule at :data:`DEFAULT_GAIN_CI_Z`).
+
+3. :func:`required_samples` — given the observed combined σ, a target effect size
+   δ, α and power, the standard two-sample mean-difference sample size
+   ``n ≈ 2(z_{α/2}+z_β)²σ²/δ²``. :func:`format_power_line` renders the per-campaign
+   operator line ("to detect δ=… at 80% power you need N≈… × M≈…").
+
+SCALE / DIRECTION CONTRACT
+--------------------------
+Everything here is on the canonical FITNESS scale: 0-1, HIGHER-is-better (the
+``compute_fitness`` output), NOT the Petri 1-10 ``dim_means`` aggregate (which is
+lower-is-better). A positive ``gain`` therefore means improvement, and a CI that
+excludes 0 on the *positive* side is the only "gain significant" verdict. δ is a
+fitness-scale effect size for the same reason. This module never touches dims, so
+the lower-is-better/higher-is-better confusion cannot arise inside it; the caller
+guarantees it passes fitness-scale values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from statistics import NormalDist, fmean, stdev
+
+# --- knobs (config / arg-overridable at the caller) --------------------------
+
+DEFAULT_TARGET_EFFECT_SIZE = 0.02
+"""Default fitness-scale effect size δ to power for.
+
+FLAGGED KNOB (E4). ~0.02 sits just above the promote gate's zero-noise floor
+(``fitness_margin_floor = 0.005``) and is roughly 1.5× the empirically-observed
+fitness-aggregate stderr of a real ~8-sample baseline (~0.013, measured
+2026-05-30; see ``train.py`` ``_MARGIN_GAIN_SIGMA`` comment). Powering for a
+smaller δ would demand an impractically large N; powering for a much larger δ
+would tell the operator they need fewer samples than are needed to clear the
+gate's own noise band — so ~0.02 is the smallest gain the loop can realistically
+both detect AND promote. Operator-overridable via ``--target-effect-size`` /
+config ``target_effect_size`` so a campaign can target a different δ."""
+
+DEFAULT_ALPHA = 0.05
+"""Two-sided significance level for both the gain CI and the power formula."""
+
+DEFAULT_POWER = 0.8
+"""Target statistical power (1 − β) for :func:`required_samples`."""
+
+DEFAULT_GAIN_CI_Z = 1.0
+"""Half-width multiplier (in σ units) for the gain CI the verdict reports.
+
+FLAGGED KNOB (E4 — CI method). We use the NORMAL-APPROXIMATION CI
+(``gain ± z·gain_stderr``), NOT a bootstrap resample of the gain. Justification:
+(a) the gain's stderr is ALREADY a bootstrap estimate on the fitness aggregate
+(``_fitness_stderr_bootstrap`` resamples whole sample rows and recomputes
+``compute_fitness``), so a second bootstrap layer on top would re-bootstrap an
+already-bootstrapped quantity for negligible accuracy gain at real cost; (b) the
+normal-approx keeps this module pure + deterministic (no RNG seed to thread,
+matching the loop's reproducibility constraint); (c) it makes the verdict
+RECONCILE EXACTLY with the promote gate, which already compares the gain against
+``_MARGIN_GAIN_SIGMA·gain_stderr`` (``_MARGIN_GAIN_SIGMA = 1.0``) — see
+:func:`gain_ci_excludes_zero`. ``DEFAULT_GAIN_CI_Z = 1.0`` is therefore the SAME
+band the gate uses, so the two never contradict. (A two-sided 95% CI would use
+z≈1.96; we keep z=1.0 deliberately to mirror the gate's one-σ margin. The
+``alpha`` arg is still recorded for the operator's reference + the power line.)"""
+
+
+@dataclass(frozen=True)
+class VarianceDecomposition:
+    """Within-mutation vs between-seed fitness-noise split (E4 deliverable 1)."""
+
+    within_mutation_stderr: float | None
+    """Stderr of the per-replicate fitness across the ``M`` repeated audits of the
+    SAME mutation (provider non-determinism). ``None`` when ``M < 2`` (the default
+    ``M=1`` path leaves this UNESTIMATED, exactly as before E4 — no behaviour
+    change)."""
+    between_seed_stderr: float | None
+    """Mean of the per-audit bootstrap fitness-stderr across the replicates (the N
+    seeds inside one audit; seed heterogeneity). ``None`` when no replicate
+    supplied a bootstrap stderr (dry-run / <2 sample rows)."""
+    combined_stderr: float | None
+    """Total fitness stderr ``√(within² + between²)`` for the power formula.
+    ``None`` only when BOTH components are ``None``. When one component is missing
+    it is treated as 0 (the other dominates), so an ``M=1`` run still yields the
+    between-seed stderr as the combined σ — identical to today's single-σ path."""
+    replicate_count: int
+    """``M`` — the number of repeated audits the decomposition was built from."""
+
+
+def decompose_variance(
+    replicate_fitnesses: list[float],
+    replicate_between_seed_stderrs: list[float | None],
+) -> VarianceDecomposition:
+    """Split observed fitness noise into within-mutation + between-seed components.
+
+    ``replicate_fitnesses`` is the aggregate fitness from each of the ``M`` repeated
+    audits of the SAME mutation/cycle (one scalar per replicate).
+    ``replicate_between_seed_stderrs`` is the per-audit bootstrap fitness-stderr
+    (the N-seed noise) from each replicate, ``None`` for any replicate that could
+    not estimate it (dry-run / <2 sample rows).
+
+    The two variance sources are estimated SEPARATELY (no double counting):
+
+    - WITHIN-mutation: ``stdev(replicate_fitnesses) / √M`` — the standard error of
+      the per-replicate mean, i.e. how much the WHOLE-audit fitness wobbles when
+      the only thing that changed is the provider's run-to-run non-determinism
+      (same mutation, same seeds). Requires ``M ≥ 2``; ``None`` otherwise (the
+      ``M=1`` default cannot observe within-mutation variance, so it is honestly
+      left unestimated rather than faked as 0).
+    - BETWEEN-seed: the MEAN of the replicates' bootstrap stderrs — the seed
+      heterogeneity already captured inside a single audit's N samples. Averaging
+      across replicates (rather than picking one) uses all the information when
+      ``M > 1`` and is identical to the single value when ``M = 1``.
+
+    ``combined_stderr = √(within² + between²)`` treats a missing component as 0 so
+    the surviving component dominates — an ``M=1`` run therefore reports the
+    between-seed stderr unchanged as the combined σ (today's behaviour), and a
+    dry-run with neither yields ``None``.
+
+    Graceful contract: non-finite / non-numeric replicate values are dropped at
+    the boundary (each ``float(...)`` cast is guarded) so a malformed replicate
+    never raises — it simply does not contribute to the estimate.
+    """
+    clean_fitnesses: list[float] = []
+    for fitness_value in replicate_fitnesses:
+        try:
+            f = float(fitness_value)
+        except (TypeError, ValueError):
+            continue
+        if isfinite(f):  # drop NaN / inf
+            clean_fitnesses.append(f)
+
+    clean_between: list[float] = []
+    for stderr_value in replicate_between_seed_stderrs:
+        if stderr_value is None:
+            continue
+        try:
+            b = float(stderr_value)
+        except (TypeError, ValueError):
+            continue
+        if isfinite(b) and b >= 0.0:
+            clean_between.append(b)
+
+    replicate_count = len(clean_fitnesses)
+
+    within = stdev(clean_fitnesses) / (replicate_count**0.5) if replicate_count >= 2 else None
+
+    between: float | None = fmean(clean_between) if clean_between else None
+
+    if within is None and between is None:
+        combined: float | None = None
+    else:
+        w = within if within is not None else 0.0
+        b = between if between is not None else 0.0
+        combined = (w * w + b * b) ** 0.5
+
+    return VarianceDecomposition(
+        within_mutation_stderr=within,
+        between_seed_stderr=between,
+        combined_stderr=combined,
+        replicate_count=replicate_count,
+    )
+
+
+@dataclass(frozen=True)
+class GainEvidence:
+    """Explicit "ci excludes 0" evidence statement on a fitness gain (E4 #2)."""
+
+    gain: float
+    """Observed fitness gain on the 0-1 scale (``current - baseline``, HIGHER-is-
+    better → positive = improvement)."""
+    gain_stderr: float
+    """Stderr of the gain (``√(σ_current² + σ_baseline²)``) — the SAME quantity the
+    promote gate's margin scales."""
+    ci_low: float
+    ci_high: float
+    """Normal-approx CI bounds: ``gain ± DEFAULT_GAIN_CI_Z · gain_stderr``."""
+    gain_ci_excludes_zero: bool
+    """``True`` iff the CI lies entirely ABOVE 0 (``ci_low > 0``) — a CLAIMED gain.
+    A CI straddling 0 (or below it) is NOT evidence of a gain."""
+    verdict: str
+    """Human evidence string: ``"gain significant"`` when the CI excludes 0 on the
+    positive side, else ``"no evidence yet"`` (honest null)."""
+    alpha: float
+    """Significance level recorded for the operator's reference."""
+
+
+GAIN_SIGNIFICANT = "gain significant"
+NO_EVIDENCE_YET = "no evidence yet"
+
+
+def gain_ci_excludes_zero(
+    gain: float,
+    gain_stderr: float,
+    *,
+    z: float = DEFAULT_GAIN_CI_Z,
+    alpha: float = DEFAULT_ALPHA,
+) -> GainEvidence:
+    """Compute the explicit "ci excludes 0" evidence statement for a fitness gain.
+
+    The operator's rule: claim a gain ONLY when the gain's confidence interval
+    excludes 0. This makes that decision EXPLICIT and human-readable so a null run
+    reports ``"no evidence yet"`` honestly rather than looking like a silent gate
+    reject.
+
+    RECONCILIATION WITH THE PROMOTE GATE (no contradiction by construction)
+    -----------------------------------------------------------------------
+    The promote gate (``train.py`` ``_should_promote``) promotes iff
+    ``current_raw > prior_raw + margin`` where
+    ``margin = max(_MARGIN_GAIN_SIGMA · gain_stderr, floor)`` and
+    ``_MARGIN_GAIN_SIGMA = 1.0``. Ignoring the zero-noise ``floor`` (which only
+    binds when ``gain_stderr ≈ 0``), the gate condition is exactly
+    ``gain > 1.0 · gain_stderr`` ⇔ ``gain - z·gain_stderr > 0`` ⇔ ``ci_low > 0``
+    at ``z = DEFAULT_GAIN_CI_Z = 1.0``. So this verdict and the gate agree by
+    construction: when the gate promotes on the σ-margin, the CI excludes 0 and the
+    verdict is "gain significant"; when the gate rejects on the σ-margin, the CI
+    includes 0 and the verdict is "no evidence yet". (The verdict deliberately does
+    NOT re-apply the gate's ``floor`` / N=1 widening / critical-axis reject — those
+    are SAFETY widenings the gate owns; the verdict is the EVIDENCE statement, so it
+    can be "no evidence yet" on a gain the floor also rejects, but it can NEVER say
+    "significant" on a gain the σ-margin rejects. The gate stays authoritative for
+    promotion; this never weakens it.)
+
+    Graceful contract: a non-numeric / non-finite ``gain`` or ``gain_stderr`` is
+    coerced to a safe value (``0.0`` gain, ``0.0`` stderr) so the verdict path never
+    raises on a malformed input — it simply reports no evidence.
+    """
+    try:
+        gain_value = float(gain)
+    except (TypeError, ValueError):
+        gain_value = 0.0
+    if not isfinite(gain_value):
+        gain_value = 0.0
+    try:
+        stderr_value = float(gain_stderr)
+    except (TypeError, ValueError):
+        stderr_value = 0.0
+    if not isfinite(stderr_value) or stderr_value < 0.0:
+        stderr_value = 0.0
+
+    half_width = z * stderr_value
+    ci_low = gain_value - half_width
+    ci_high = gain_value + half_width
+    excludes_zero = ci_low > 0.0
+    return GainEvidence(
+        gain=gain_value,
+        gain_stderr=stderr_value,
+        ci_low=ci_low,
+        ci_high=ci_high,
+        gain_ci_excludes_zero=excludes_zero,
+        verdict=GAIN_SIGNIFICANT if excludes_zero else NO_EVIDENCE_YET,
+        alpha=alpha,
+    )
+
+
+@dataclass(frozen=True)
+class PowerRequirement:
+    """Sample-size requirement to detect a target effect (E4 deliverable 3)."""
+
+    sigma: float
+    target_effect_size: float
+    alpha: float
+    power: float
+    n_seed: int | None
+    """Required N_seed per arm to detect ``target_effect_size`` at ``power``.
+    ``None`` when σ is unknown (no variance observed yet) or δ ≤ 0 (an
+    ill-posed request — graceful, not a crash)."""
+    replicate: int
+    """The ``M`` (replicate) the campaign actually ran — recorded alongside N so
+    the operator reads the requirement as ``N≈… × M≈…``."""
+
+
+def required_samples(
+    sigma: float | None,
+    *,
+    target_effect_size: float = DEFAULT_TARGET_EFFECT_SIZE,
+    alpha: float = DEFAULT_ALPHA,
+    power: float = DEFAULT_POWER,
+    replicate: int = 1,
+) -> PowerRequirement:
+    """Standard two-sample mean-difference sample size to DETECT ``δ``.
+
+    ``n ≈ 2 · (z_{α/2} + z_β)² · σ² / δ²`` per arm, rounded UP (``ceil``) so the
+    reported N is sufficient, not merely close. This is the textbook power formula
+    for comparing two independent means (current campaign vs baseline / control
+    arm) at two-sided significance ``alpha`` and ``power`` (1 − β).
+
+    - ``z_{α/2}`` is the two-sided critical value (``alpha=0.05 → 1.96``).
+    - ``z_β`` is the power quantile (``power=0.8 → 0.8416``).
+
+    Monotonicity (pinned by tests): N increases with σ² and with 1/δ² — noisier
+    measurements and smaller target effects both demand more samples.
+
+    Graceful contract: ``sigma is None`` (no variance observed yet), a non-finite /
+    negative σ, or ``δ ≤ 0`` (ill-posed) all yield ``n_seed = None`` rather than a
+    divide-by-zero / domain crash — the operator simply sees "N≈? (insufficient
+    variance signal)" in :func:`format_power_line`. σ == 0 (perfectly stable, no
+    noise) yields ``n_seed = 1`` (a single sample detects any δ > 0 when there is
+    no noise)."""
+    if sigma is None:
+        sigma_value: float | None = None
+    else:
+        try:
+            sigma_value = float(sigma)
+        except (TypeError, ValueError):
+            sigma_value = None
+        if sigma_value is not None and (not isfinite(sigma_value) or sigma_value < 0.0):
+            sigma_value = None
+
+    try:
+        delta = float(target_effect_size)
+    except (TypeError, ValueError):
+        delta = 0.0
+
+    n_seed: int | None
+    if sigma_value is None or delta <= 0.0:
+        n_seed = None
+    elif sigma_value == 0.0:
+        n_seed = 1
+    else:
+        z_alpha = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+        z_beta = NormalDist().inv_cdf(power)
+        raw_n = 2.0 * (z_alpha + z_beta) ** 2 * (sigma_value**2) / (delta**2)
+        # ceil without importing math: int() truncates toward zero, add 1 unless
+        # already an exact integer. raw_n is always > 0 here.
+        truncated = int(raw_n)
+        n_seed = truncated if truncated == raw_n else truncated + 1
+        n_seed = max(1, n_seed)
+
+    return PowerRequirement(
+        sigma=sigma_value if sigma_value is not None else 0.0,
+        target_effect_size=delta,
+        alpha=alpha,
+        power=power,
+        n_seed=n_seed,
+        replicate=max(1, int(replicate)),
+    )
+
+
+@dataclass(frozen=True)
+class PowerRecordFields:
+    """The E4 fields persisted on a record row (attribution / baseline registry).
+
+    A single bundle so the record-writer signatures take ONE E4 argument instead of
+    six (keeps ``_write_baseline`` / ``_append_baseline_registry_row`` under the
+    ``max-args`` ratchet). Every field is ``None``-omitting at the writer: ``M=1``
+    leaves ``within_mutation_stderr`` ``None`` (unestimated, honest), and a pre-E4
+    caller passes ``None`` for the whole bundle → no E4 keys are written (legacy
+    row shape preserved)."""
+
+    within_mutation_stderr: float | None = None
+    between_seed_stderr: float | None = None
+    gain_ci_low: float | None = None
+    gain_ci_high: float | None = None
+    gain_ci_excludes_zero: bool | None = None
+    gain_verdict: str | None = None
+
+    @classmethod
+    def from_evidence(
+        cls,
+        decomposition: VarianceDecomposition,
+        evidence: GainEvidence,
+    ) -> PowerRecordFields:
+        """Build the record bundle from the decomposition + the gain verdict."""
+        return cls(
+            within_mutation_stderr=decomposition.within_mutation_stderr,
+            between_seed_stderr=decomposition.between_seed_stderr,
+            gain_ci_low=evidence.ci_low,
+            gain_ci_high=evidence.ci_high,
+            gain_ci_excludes_zero=evidence.gain_ci_excludes_zero,
+            gain_verdict=evidence.verdict,
+        )
+
+
+def format_power_line(requirement: PowerRequirement) -> str:
+    """Render the per-campaign operator power line.
+
+    Example: ``"power: to detect delta=0.0200 fitness at 80% power (alpha=0.05),
+    observed sigma=0.0130 -> need N_seed>=10 x M_replicate>=1"``.
+
+    When σ could not be estimated yet (``n_seed is None``) the line says so
+    honestly rather than printing a fabricated N.
+    """
+    if requirement.n_seed is None:
+        return (
+            f"power: to detect delta={requirement.target_effect_size:.4f} fitness "
+            f"at {requirement.power:.0%} power (alpha={requirement.alpha:.2f}), "
+            f"observed sigma=unknown -> N_seed indeterminate "
+            f"(insufficient variance signal; run --replicate M>=2 or a multi-sample "
+            f"audit to estimate sigma)"
+        )
+    return (
+        f"power: to detect delta={requirement.target_effect_size:.4f} fitness "
+        f"at {requirement.power:.0%} power (alpha={requirement.alpha:.2f}), "
+        f"observed sigma={requirement.sigma:.4f} -> "
+        f"need N_seed>={requirement.n_seed} x M_replicate>={requirement.replicate}"
+    )
+
+
+__all__ = [
+    "DEFAULT_ALPHA",
+    "DEFAULT_GAIN_CI_Z",
+    "DEFAULT_POWER",
+    "DEFAULT_TARGET_EFFECT_SIZE",
+    "GAIN_SIGNIFICANT",
+    "NO_EVIDENCE_YET",
+    "GainEvidence",
+    "PowerRecordFields",
+    "PowerRequirement",
+    "VarianceDecomposition",
+    "decompose_variance",
+    "format_power_line",
+    "gain_ci_excludes_zero",
+    "required_samples",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.95"
+version = "0.99.96"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -339,7 +339,7 @@ ignore = [
 max-complexity = 62
 
 [tool.ruff.lint.pylint]
-max-args = 20         # Worst: 20 (_append_baseline_registry_row — a provenance wiring sink: per-role/seed/bench/held-out/control-arm fields). Target: 8.
+max-args = 21         # Worst: 21 (_append_baseline_registry_row — a provenance wiring sink: per-role/seed/bench/held-out/control-arm/power fields; E4 added the bundled power_stats arg). Target: 8.
 max-branches = 68     # Worst: 68. Target: 15.
 max-returns = 18      # Worst: 18 (PLR0911 silenced project-wide; this kept for ratchet visibility).
 max-statements = 273  # Worst: 273 (god method in cli/__init__.py). Target: 60.

--- a/tests/autoresearch/test_replicate_power_wiring.py
+++ b/tests/autoresearch/test_replicate_power_wiring.py
@@ -1,0 +1,331 @@
+"""E4 (2026-05-30) — wiring tests for the per-mutation replicate loop + the power /
+gain-evidence records in ``autoresearch/train.py``.
+
+The pure statistics (decomposition / ci-excludes-0 / power formula) are pinned in
+``test_statistical_power.py``; this file pins the WIRING:
+
+  1. ``--replicate`` / ``--target-effect-size`` resolver precedence (env → CLI →
+     config → constant) + graceful malformed-env fallback.
+  2. ``main`` runs the audit inside an M-loop and decomposes within vs between —
+     static guards (matching the E2 / E3 ``inspect.getsource`` convention) that the
+     loop + decomposition + power line are actually wired, not just defined.
+  3. M=1 is the DEFAULT path (no cost / behaviour regression): the loop runs the
+     audit exactly once, and the new record fields are None-omitting so M=1 / legacy
+     readers are backward-compatible.
+  4. The new fields flow into BOTH record sinks — the per-cycle attribution row and
+     the on-promote baseline registry row — backward-compatibly.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from autoresearch import train as auto_train
+
+# --- resolver precedence -----------------------------------------------------
+
+
+def _stub_config(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    replicate: int | None = 1,
+    target_effect_size: float | None = 0.02,
+) -> None:
+    monkeypatch.setattr(
+        auto_train,
+        "_get_autoresearch_config",
+        lambda: SimpleNamespace(replicate=replicate, target_effect_size=target_effect_size),
+    )
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "GEODE_AUDIT_REPLICATE",
+        "AUTORESEARCH_REPLICATE",
+        "GEODE_TARGET_EFFECT_SIZE",
+        "AUTORESEARCH_TARGET_EFFECT_SIZE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_replicate_default_is_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env, no CLI, config M=1 → 1 (today's zero-cost default)."""
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, replicate=1)
+    assert auto_train._resolve_audit_replicate(None) == 1
+
+
+def test_replicate_reads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, replicate=3)
+    assert auto_train._resolve_audit_replicate(None) == 3
+
+
+def test_replicate_cli_wins_over_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, replicate=1)
+    assert auto_train._resolve_audit_replicate(5) == 5
+
+
+def test_replicate_env_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_AUDIT_REPLICATE", "4")
+    monkeypatch.delenv("AUTORESEARCH_REPLICATE", raising=False)
+    _stub_config(monkeypatch, replicate=1)
+    assert auto_train._resolve_audit_replicate(2) == 4
+
+
+def test_replicate_malformed_env_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Graceful contract: a non-integer / <1 env value must not crash or silently
+    change cost — it warns + degrades to the next tier."""
+    monkeypatch.setenv("GEODE_AUDIT_REPLICATE", "not-an-int")
+    monkeypatch.delenv("AUTORESEARCH_REPLICATE", raising=False)
+    _stub_config(monkeypatch, replicate=2)
+    assert auto_train._resolve_audit_replicate(None) == 2
+    monkeypatch.setenv("GEODE_AUDIT_REPLICATE", "0")
+    assert auto_train._resolve_audit_replicate(None) == 2
+
+
+def test_target_effect_size_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, target_effect_size=0.02)
+    assert auto_train._resolve_target_effect_size(None) == pytest.approx(0.02)
+
+
+def test_target_effect_size_cli_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, target_effect_size=0.02)
+    assert auto_train._resolve_target_effect_size(0.05) == pytest.approx(0.05)
+
+
+def test_target_effect_size_malformed_env_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_TARGET_EFFECT_SIZE", "nope")
+    monkeypatch.delenv("AUTORESEARCH_TARGET_EFFECT_SIZE", raising=False)
+    _stub_config(monkeypatch, target_effect_size=0.03)
+    assert auto_train._resolve_target_effect_size(None) == pytest.approx(0.03)
+    # non-positive env likewise skipped (ill-posed for the power formula)
+    monkeypatch.setenv("GEODE_TARGET_EFFECT_SIZE", "0")
+    assert auto_train._resolve_target_effect_size(None) == pytest.approx(0.03)
+
+
+# --- main() static wiring guards (E2 / E3 convention) ------------------------
+
+
+def test_main_resolves_replicate_and_effect_size() -> None:
+    source = inspect.getsource(auto_train.main)
+    assert "audit_replicate = _resolve_audit_replicate(args.replicate)" in source
+    assert "target_effect_size = _resolve_target_effect_size(args.target_effect_size)" in source
+
+
+def test_main_runs_audit_in_replicate_loop() -> None:
+    """The audit MUST be invoked inside ``for _replicate_idx in range(audit_replicate)``
+    — the M-loop is wired, not just the knob defined. M=1 → exactly one iteration
+    (no cost change)."""
+    source = inspect.getsource(auto_train.main)
+    assert "for _replicate_idx in range(audit_replicate):" in source
+    # the run_audit call lives inside that loop body (after the for, before the gain block)
+    loop_at = source.index("for _replicate_idx in range(audit_replicate):")
+    decomp_at = source.index("variance_decomposition = decompose_variance(")
+    run_at = source.index("run_audit(", loop_at)
+    assert loop_at < run_at < decomp_at
+
+
+def test_main_decomposes_within_and_between() -> None:
+    source = inspect.getsource(auto_train.main)
+    assert "decompose_variance(" in source
+    assert "_replicate_raw_fitnesses" in source
+    assert "_replicate_between_seed_stderrs" in source
+    # the gain CI verdict + the per-campaign power line are both computed
+    assert "gain_ci_excludes_zero(" in source
+    assert "required_samples(" in source
+    assert "format_power_line(" in source
+
+
+def test_main_emits_power_line_and_verdict() -> None:
+    source = inspect.getsource(auto_train.main)
+    assert "e4_power_line:" in source
+    assert "e4_gain_verdict:" in source
+    assert 'log.info("E4 %s", _power_line)' in source
+
+
+def test_main_threads_e4_fields_into_both_sinks() -> None:
+    """The decomposition + verdict must flow into BOTH the attribution row (kwargs
+    dict ``**_e4_record_fields``) and the on-promote baseline provenance
+    (``power_stats`` bundle) — the two record sinks."""
+    source = inspect.getsource(auto_train.main)
+    assert "_e4_record_fields: dict[str, Any] = {" in source
+    assert "_e4_power_stats = PowerRecordFields.from_evidence(" in source
+    # attribution row consumes the kwargs dict; baseline provenance the bundle
+    assert "**_e4_record_fields" in source
+    assert '"power_stats": _e4_power_stats' in source
+
+
+# --- record backward-compat: attribution row --------------------------------
+
+
+def test_attribution_carries_e4_fields() -> None:
+    """When supplied, the per-cycle attribution row records the decomposition +
+    gain-evidence verdict."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        within_mutation_stderr=0.011,
+        between_seed_stderr=0.013,
+        gain_ci_low=0.04,
+        gain_ci_high=0.08,
+        gain_ci_excludes_zero=True,
+        gain_verdict="gain significant",
+    )
+    assert payload["within_mutation_stderr"] == pytest.approx(0.011)
+    assert payload["between_seed_stderr"] == pytest.approx(0.013)
+    assert payload["gain_ci_excludes_zero"] is True
+    assert payload["gain_verdict"] == "gain significant"
+
+
+def test_attribution_m1_omits_within_keeps_between() -> None:
+    """M=1: within is unestimated (None) → omitted from the row, but the
+    between-seed stderr + the verdict are still present (the row stays useful)."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        within_mutation_stderr=None,
+        between_seed_stderr=0.013,
+        gain_ci_low=-0.01,
+        gain_ci_high=0.03,
+        gain_ci_excludes_zero=False,
+        gain_verdict="no evidence yet",
+    )
+    assert "within_mutation_stderr" not in payload
+    assert payload["between_seed_stderr"] == pytest.approx(0.013)
+    assert payload["gain_ci_excludes_zero"] is False
+
+
+def test_attribution_legacy_omits_all_e4_fields() -> None:
+    """A pre-E4 / no-power caller omits every E4 field → the row shape is exactly
+    the legacy shape (no new required key breaks a reader)."""
+    from core.self_improving_loop.attribution import AttributionRecord, compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+    )
+    for key in (
+        "within_mutation_stderr",
+        "between_seed_stderr",
+        "gain_ci_low",
+        "gain_ci_high",
+        "gain_ci_excludes_zero",
+        "gain_verdict",
+    ):
+        assert key not in payload
+    # and the schema validates the bare payload (defaults to None for the new fields)
+    record = AttributionRecord.model_validate(payload)
+    assert record.within_mutation_stderr is None
+    assert record.gain_ci_excludes_zero is None
+
+
+# --- record backward-compat: baseline registry row --------------------------
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", tmp_path / "baseline.json")
+    fake_cfg = SimpleNamespace(
+        auditor=SimpleNamespace(model="aud-m", source="claude-cli"),
+        target=SimpleNamespace(model="tgt-m", source="openai-codex"),
+        judge=SimpleNamespace(model="jdg-m", source="claude-cli"),
+        mutator=SimpleNamespace(default_model="mut-m", source="openai-codex"),
+        seed_select="petri_17dim",
+        held_out_bench=None,
+        promote_policy="gate",
+        promote_policy_seed=0,
+        replicate=1,
+        target_effect_size=0.02,
+    )
+    monkeypatch.setattr(auto_train, "_get_autoresearch_config", lambda: fake_cfg)
+    return tmp_path
+
+
+def _rows(archive: Path) -> list[dict]:
+    return [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_registry_row_records_e4_fields_when_present(isolated: Path) -> None:
+    from core.self_improving_loop.statistical_power import PowerRecordFields
+
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0},
+        {"broken_tool_use": 0.2},
+        power_stats=PowerRecordFields(
+            within_mutation_stderr=0.011,
+            between_seed_stderr=0.013,
+            gain_ci_low=0.04,
+            gain_ci_high=0.08,
+            gain_ci_excludes_zero=True,
+            gain_verdict="gain significant",
+        ),
+    )
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["within_mutation_stderr"] == pytest.approx(0.011)
+    assert row["between_seed_stderr"] == pytest.approx(0.013)
+    assert row["gain_ci_excludes_zero"] is True
+    assert row["gain_verdict"] == "gain significant"
+
+
+def test_registry_row_m1_default_omits_e4_block(isolated: Path) -> None:
+    """The default ``_write_baseline`` (no E4 args — the M=1 / pre-E4 path) writes a
+    row with NO E4 keys: backward-compatible shape, no new required key."""
+    auto_train._write_baseline({"broken_tool_use": 3.0}, {"broken_tool_use": 0.2})
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    for key in (
+        "within_mutation_stderr",
+        "between_seed_stderr",
+        "gain_ci_low",
+        "gain_ci_high",
+        "gain_ci_excludes_zero",
+        "gain_verdict",
+    ):
+        assert key not in row
+
+
+def test_baseline_raw_payload_carries_decomposition(isolated: Path) -> None:
+    """The promoted ``baseline.json`` ``raw`` namespace carries the within/between
+    decomposition (alongside ``fitness_stderr``) when present — so the next cycle's
+    reader sees the noise split, not just the combined stderr."""
+    from core.self_improving_loop.statistical_power import PowerRecordFields
+
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0},
+        {"broken_tool_use": 0.2},
+        power_stats=PowerRecordFields(within_mutation_stderr=0.011, between_seed_stderr=0.013),
+    )
+    anchor = json.loads((isolated / "baseline.json").read_text(encoding="utf-8"))
+    assert anchor["raw"]["within_mutation_stderr"] == pytest.approx(0.011)
+    assert anchor["raw"]["between_seed_stderr"] == pytest.approx(0.013)
+
+
+def test_baseline_raw_payload_m1_omits_within(isolated: Path) -> None:
+    from core.self_improving_loop.statistical_power import PowerRecordFields
+
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0},
+        {"broken_tool_use": 0.2},
+        power_stats=PowerRecordFields(within_mutation_stderr=None, between_seed_stderr=0.013),
+    )
+    anchor = json.loads((isolated / "baseline.json").read_text(encoding="utf-8"))
+    assert "within_mutation_stderr" not in anchor["raw"]
+    assert anchor["raw"]["between_seed_stderr"] == pytest.approx(0.013)

--- a/tests/autoresearch/test_replicate_power_wiring.py
+++ b/tests/autoresearch/test_replicate_power_wiring.py
@@ -110,6 +110,21 @@ def test_target_effect_size_malformed_env_falls_back(monkeypatch: pytest.MonkeyP
     # non-positive env likewise skipped (ill-posed for the power formula)
     monkeypatch.setenv("GEODE_TARGET_EFFECT_SIZE", "0")
     assert auto_train._resolve_target_effect_size(None) == pytest.approx(0.03)
+    # non-finite env (nan/inf) likewise skipped (would crash the power formula)
+    monkeypatch.setenv("GEODE_TARGET_EFFECT_SIZE", "nan")
+    assert auto_train._resolve_target_effect_size(None) == pytest.approx(0.03)
+
+
+def test_resolver_cli_overrides_graceful_on_nonfinite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Graceful contract (Codex MCP catch): a non-finite / malformed CLI override
+    (argparse ``type=float`` accepts ``nan``/``inf``) must not crash — it degrades to
+    the config / default tier."""
+    _clear_env(monkeypatch)
+    _stub_config(monkeypatch, replicate=2, target_effect_size=0.03)
+    # nan/inf δ from the CLI must not propagate into the power formula
+    assert auto_train._resolve_target_effect_size(float("nan")) == pytest.approx(0.03)
+    assert auto_train._resolve_target_effect_size(float("inf")) == pytest.approx(0.03)
+    assert auto_train._resolve_target_effect_size(-1.0) == pytest.approx(0.03)
 
 
 # --- main() static wiring guards (E2 / E3 convention) ------------------------
@@ -150,6 +165,35 @@ def test_main_emits_power_line_and_verdict() -> None:
     assert "e4_power_line:" in source
     assert "e4_gain_verdict:" in source
     assert 'log.info("E4 %s", _power_line)' in source
+
+
+def test_main_verdict_uses_gate_sigma_and_floor() -> None:
+    """The gain VERDICT must reconcile with the promote gate: it uses the gate's own
+    σ (``current_fitness_stderr``, NOT the combined within+between σ) and passes the
+    gate's effective floor (Codex MCP catches — the verdict previously used combined
+    σ + ignored the floor, both of which could contradict the gate)."""
+    source = inspect.getsource(auto_train.main)
+    # gain σ uses the gate's current_fitness_stderr (not the combined σ)
+    assert "_sigma_current_sq = (current_fitness_stderr or 0.0) ** 2" in source
+    # the verdict passes the gate's effective floor
+    assert "floor=_gate_effective_floor" in source
+    # the floor reproduces the gate's N=1 widening
+    assert "N1_FITNESS_MARGIN_FLOOR" in source
+    # the power analysis (NOT the verdict) is the one that uses the combined σ
+    power_call = source.index("power_requirement = required_samples(")
+    assert "variance_decomposition.combined_stderr" in source[power_call : power_call + 200]
+
+
+def test_fitness_margin_floor_default_is_single_sot() -> None:
+    """The gate's ``fitness_margin_floor`` default and the verdict's floor must be
+    the SAME constant (no dual-SoT drift) — both read _FITNESS_MARGIN_FLOOR_DEFAULT."""
+    import inspect as _inspect
+
+    gate_sig = _inspect.signature(auto_train._should_promote)
+    assert (
+        gate_sig.parameters["fitness_margin_floor"].default
+        == auto_train._FITNESS_MARGIN_FLOOR_DEFAULT
+    )
 
 
 def test_main_threads_e4_fields_into_both_sinks() -> None:

--- a/tests/autoresearch/test_replicate_power_wiring.py
+++ b/tests/autoresearch/test_replicate_power_wiring.py
@@ -125,6 +125,8 @@ def test_resolver_cli_overrides_graceful_on_nonfinite(monkeypatch: pytest.Monkey
     assert auto_train._resolve_target_effect_size(float("nan")) == pytest.approx(0.03)
     assert auto_train._resolve_target_effect_size(float("inf")) == pytest.approx(0.03)
     assert auto_train._resolve_target_effect_size(-1.0) == pytest.approx(0.03)
+    # int(float("inf")) raises OverflowError — the replicate resolver must catch it
+    assert auto_train._resolve_audit_replicate(float("inf")) == 2  # falls back to config
 
 
 # --- main() static wiring guards (E2 / E3 convention) ------------------------
@@ -173,8 +175,14 @@ def test_main_verdict_uses_gate_sigma_and_floor() -> None:
     gate's effective floor (Codex MCP catches — the verdict previously used combined
     σ + ignored the floor, both of which could contradict the gate)."""
     source = inspect.getsource(auto_train.main)
-    # gain σ uses the gate's current_fitness_stderr (not the combined σ)
-    assert "_sigma_current_sq = (current_fitness_stderr or 0.0) ** 2" in source
+    # gain σ uses the gate's current_fitness_stderr (the bootstrap), NOT the
+    # combined within+between σ
+    assert "if current_fitness_stderr is not None:" in source
+    assert "_sigma_current = current_fitness_stderr" in source
+    # σ fallback mirrors the gate's MC fallback when the bootstrap / persisted
+    # stderr is absent (so a v1/summary baseline's verdict σ is not falsely 0)
+    assert "_sigma_current = _fitness_scale_stderr(" in source
+    assert "_sigma_baseline = _fitness_scale_stderr(" in source
     # the verdict passes the gate's effective floor
     assert "floor=_gate_effective_floor" in source
     # the floor reproduces the gate's N=1 widening

--- a/tests/autoresearch/test_statistical_power.py
+++ b/tests/autoresearch/test_statistical_power.py
@@ -224,10 +224,15 @@ def test_power_formula_nonfinite_delta_graceful() -> None:
 
 
 def test_power_formula_malformed_replicate_graceful() -> None:
-    """A malformed ``replicate`` count degrades to 1, never raises (graceful cast)."""
+    """A malformed ``replicate`` count degrades to 1, never raises (graceful cast).
+    Includes ``float('inf')`` which raises OverflowError on ``int()`` (Codex MCP
+    catch — the guard must catch OverflowError too)."""
     req = sp.required_samples(0.013, target_effect_size=0.02, replicate="oops")  # type: ignore[arg-type]
     assert req.replicate == 1
     assert req.n_seed == 7  # the rest of the formula is unaffected
+    req_inf = sp.required_samples(0.013, target_effect_size=0.02, replicate=float("inf"))  # type: ignore[arg-type]
+    assert req_inf.replicate == 1
+    assert req_inf.n_seed == 7
 
 
 def test_power_line_real_campaign_shape() -> None:

--- a/tests/autoresearch/test_statistical_power.py
+++ b/tests/autoresearch/test_statistical_power.py
@@ -137,11 +137,29 @@ def test_verdict_reconciles_with_promote_gate_margin() -> None:
 
 
 def test_gain_verdict_graceful_on_nan() -> None:
-    """Graceful contract: a non-finite gain / stderr never raises — it degrades to
-    a no-evidence verdict."""
+    """Graceful contract: a non-finite gain / stderr / floor never raises — it
+    degrades to a no-evidence verdict."""
     ev = sp.gain_ci_excludes_zero(gain=float("nan"), gain_stderr=float("inf"))
     assert ev.gain_ci_excludes_zero is False
     assert ev.verdict == sp.NO_EVIDENCE_YET
+    ev2 = sp.gain_ci_excludes_zero(gain=0.1, gain_stderr=0.0, floor=float("nan"))
+    # a non-finite floor degrades to 0.0 → the σ-margin term still decides
+    assert ev2.gain_ci_excludes_zero is True
+
+
+def test_verdict_honours_gate_floor() -> None:
+    """A small-positive gain BELOW the gate's zero-noise floor with ≈0 stderr must
+    NOT be claimed significant — the gate rejects it on the floor, so the verdict
+    must too (Codex MCP catch: the verdict previously ignored the floor and would
+    falsely say 'significant')."""
+    # gain 0.003 < floor 0.005, stderr 0 → ci_low = 0.003 > 0 BUT below floor
+    ev = sp.gain_ci_excludes_zero(gain=0.003, gain_stderr=0.0, floor=0.005)
+    assert ev.gain_ci_excludes_zero is False, "sub-floor gain must not be significant"
+    assert ev.verdict == sp.NO_EVIDENCE_YET
+    # a gain ABOVE the floor with ≈0 stderr IS significant (clears both terms)
+    ev2 = sp.gain_ci_excludes_zero(gain=0.02, gain_stderr=0.0, floor=0.005)
+    assert ev2.gain_ci_excludes_zero is True
+    assert ev2.verdict == sp.GAIN_SIGNIFICANT
 
 
 # --- deliverable 3: power-analysis formula ------------------------------------
@@ -193,6 +211,23 @@ def test_power_formula_illposed_delta_graceful() -> None:
     """δ ≤ 0 is ill-posed (divide-by-zero) → indeterminate, not a crash."""
     req = sp.required_samples(0.013, target_effect_size=0.0)
     assert req.n_seed is None
+
+
+def test_power_formula_nonfinite_delta_graceful() -> None:
+    """δ = NaN must NOT slip past the ``δ <= 0`` guard into ``int(nan)`` (NaN
+    comparisons are False) — it degrades to indeterminate, not a crash (Codex MCP
+    catch)."""
+    req = sp.required_samples(0.013, target_effect_size=float("nan"))
+    assert req.n_seed is None
+    req2 = sp.required_samples(0.013, target_effect_size=float("inf"))
+    assert req2.n_seed is None
+
+
+def test_power_formula_malformed_replicate_graceful() -> None:
+    """A malformed ``replicate`` count degrades to 1, never raises (graceful cast)."""
+    req = sp.required_samples(0.013, target_effect_size=0.02, replicate="oops")  # type: ignore[arg-type]
+    assert req.replicate == 1
+    assert req.n_seed == 7  # the rest of the formula is unaffected
 
 
 def test_power_line_real_campaign_shape() -> None:

--- a/tests/autoresearch/test_statistical_power.py
+++ b/tests/autoresearch/test_statistical_power.py
@@ -1,0 +1,208 @@
+"""E4 (2026-05-30) — statistical power: replicate variance decomposition, the
+explicit "ci excludes 0" gain verdict, and the power-analysis sample-size formula.
+
+Pins (matching the E4 deliverables + the operator's flagged knobs):
+
+  1. M=1 default path is UNCHANGED — the replicate loop runs the audit exactly once
+     (no cost / behaviour regression) and within-mutation variance is honestly left
+     unestimated (``None``), not faked as 0.
+  2. M>1 DECOMPOSES the noise — the within-mutation stderr (provider jitter across
+     replicates) and the between-seed stderr (the N samples inside one audit) are
+     reported SEPARATELY (no double-counting), with a synthetic check.
+  3. The gain CI verdict — a clear gain excludes 0 ("gain significant"); a
+     noise-level gain includes 0 ("no evidence yet"); and the verdict RECONCILES
+     with the promote gate's σ-margin (no contradiction).
+  4. The power formula is correct (a known σ/δ → a known N) and MONOTONIC (N grows
+     with σ and with 1/δ²).
+  5. Records carry the new fields BACKWARD-COMPATIBLY (M=1 / no-power-config → no
+     new required key breaks readers).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.self_improving_loop import statistical_power as sp
+
+# --- deliverable 1: variance decomposition (within vs between) ----------------
+
+
+def test_m1_within_unestimated_combined_equals_between() -> None:
+    """M=1 (default): a single replicate cannot observe within-mutation variance →
+    within is honestly ``None`` (NOT 0), and combined == the between-seed stderr
+    (today's single-σ path, unchanged)."""
+    decomp = sp.decompose_variance(
+        replicate_fitnesses=[0.62],
+        replicate_between_seed_stderrs=[0.013],
+    )
+    assert decomp.replicate_count == 1
+    assert decomp.within_mutation_stderr is None
+    assert decomp.between_seed_stderr == pytest.approx(0.013)
+    # combined treats the missing within as 0 → equals between exactly
+    assert decomp.combined_stderr == pytest.approx(0.013)
+
+
+def test_m1_dry_run_no_signal_combined_none() -> None:
+    """M=1 with no bootstrap stderr (dry-run / <2 sample rows) → every component is
+    ``None``: there is no variance signal at all (honest, not a fabricated 0)."""
+    decomp = sp.decompose_variance(
+        replicate_fitnesses=[0.5],
+        replicate_between_seed_stderrs=[None],
+    )
+    assert decomp.within_mutation_stderr is None
+    assert decomp.between_seed_stderr is None
+    assert decomp.combined_stderr is None
+
+
+def test_m_gt_1_decomposes_within_and_between_separately() -> None:
+    """M>1 synthetic: the within-mutation stderr is the standard error of the
+    per-replicate fitness spread, the between-seed stderr is the MEAN of the
+    per-audit bootstrap stderrs, and they are reported as DISTINCT numbers (not
+    conflated / double-counted)."""
+    import statistics as _stats
+
+    fitnesses = [0.60, 0.64, 0.62, 0.66]  # genuine replicate spread
+    betweens = [0.010, 0.014, 0.012, 0.012]
+    decomp = sp.decompose_variance(fitnesses, betweens)
+
+    expected_within = _stats.stdev(fitnesses) / (len(fitnesses) ** 0.5)
+    expected_between = _stats.fmean(betweens)
+    assert decomp.within_mutation_stderr == pytest.approx(expected_within)
+    assert decomp.between_seed_stderr == pytest.approx(expected_between)
+    # the two are genuinely different sources — not the same number
+    assert decomp.within_mutation_stderr != pytest.approx(decomp.between_seed_stderr)
+    # combined is the orthogonal sum, NOT within+between (no double counting)
+    assert decomp.combined_stderr == pytest.approx(
+        (expected_within**2 + expected_between**2) ** 0.5
+    )
+    assert decomp.combined_stderr != pytest.approx(expected_within + expected_between)
+
+
+def test_decompose_drops_nonfinite_replicates_gracefully() -> None:
+    """Graceful contract: a NaN / inf / non-numeric replicate is dropped at the
+    boundary (never raises) and simply does not contribute to the estimate."""
+    decomp = sp.decompose_variance(
+        replicate_fitnesses=[0.60, float("nan"), 0.64, "oops"],  # type: ignore[list-item]
+        replicate_between_seed_stderrs=[0.01, None, float("inf"), 0.02],
+    )
+    # only the two clean fitnesses survive → within estimable from 2 points
+    assert decomp.replicate_count == 2
+    assert decomp.within_mutation_stderr is not None
+    # only the two finite, non-negative betweens survive
+    assert decomp.between_seed_stderr == pytest.approx(0.015)
+
+
+# --- deliverable 2: "ci excludes 0" gain verdict ------------------------------
+
+
+def test_clear_gain_excludes_zero_significant() -> None:
+    """A gain much larger than its stderr → CI excludes 0 → 'gain significant'."""
+    ev = sp.gain_ci_excludes_zero(gain=0.10, gain_stderr=0.01)
+    assert ev.gain_ci_excludes_zero is True
+    assert ev.verdict == sp.GAIN_SIGNIFICANT
+    assert ev.ci_low > 0.0
+
+
+def test_noise_level_gain_includes_zero_no_evidence() -> None:
+    """A gain at / below the noise level → CI straddles 0 → honest 'no evidence
+    yet' (NOT a false 'significant')."""
+    ev = sp.gain_ci_excludes_zero(gain=0.005, gain_stderr=0.013)
+    assert ev.gain_ci_excludes_zero is False
+    assert ev.verdict == sp.NO_EVIDENCE_YET
+    assert ev.ci_low <= 0.0
+
+
+def test_negative_gain_never_significant() -> None:
+    """A regression (negative gain) is never 'significant' on the positive side."""
+    ev = sp.gain_ci_excludes_zero(gain=-0.05, gain_stderr=0.01)
+    assert ev.gain_ci_excludes_zero is False
+    assert ev.verdict == sp.NO_EVIDENCE_YET
+
+
+def test_verdict_reconciles_with_promote_gate_margin() -> None:
+    """The verdict must match the promote gate's σ-margin semantics: at
+    DEFAULT_GAIN_CI_Z=1.0 the CI excludes 0 IFF ``gain > _MARGIN_GAIN_SIGMA *
+    gain_stderr`` (the gate's binding condition, ignoring the zero-noise floor).
+    No contradiction where the gate rejects but the verdict says 'significant'."""
+    from autoresearch.train import _MARGIN_GAIN_SIGMA
+
+    assert sp.DEFAULT_GAIN_CI_Z == _MARGIN_GAIN_SIGMA == 1.0
+    gain_stderr = 0.02
+    # just below the gate margin → gate REJECTS → verdict must be no-evidence
+    below = sp.gain_ci_excludes_zero(gain=gain_stderr * 0.99, gain_stderr=gain_stderr)
+    assert below.gain_ci_excludes_zero is False
+    # just above the gate margin → gate PROMOTES → verdict must be significant
+    above = sp.gain_ci_excludes_zero(gain=gain_stderr * 1.01, gain_stderr=gain_stderr)
+    assert above.gain_ci_excludes_zero is True
+
+
+def test_gain_verdict_graceful_on_nan() -> None:
+    """Graceful contract: a non-finite gain / stderr never raises — it degrades to
+    a no-evidence verdict."""
+    ev = sp.gain_ci_excludes_zero(gain=float("nan"), gain_stderr=float("inf"))
+    assert ev.gain_ci_excludes_zero is False
+    assert ev.verdict == sp.NO_EVIDENCE_YET
+
+
+# --- deliverable 3: power-analysis formula ------------------------------------
+
+
+def test_power_formula_known_sigma_delta_known_n() -> None:
+    """A known (σ, δ) at α=0.05 / power=0.8 yields the textbook N.
+
+    n = 2(z_{0.025}+z_{0.20})² σ²/δ² with z_{0.025}=1.95996, z_{0.20}=0.84162.
+    For σ=0.013, δ=0.02: 2·(2.80158)²·(0.013²)/(0.02²) ≈ 6.63 → ceil → 7."""
+    req = sp.required_samples(0.013, target_effect_size=0.02)
+    assert req.n_seed == 7  # ceil(6.63)
+
+
+def test_power_formula_monotonic_in_sigma() -> None:
+    """N grows with σ (noisier measurement → more samples)."""
+    n_small = sp.required_samples(0.01, target_effect_size=0.02).n_seed
+    n_big = sp.required_samples(0.05, target_effect_size=0.02).n_seed
+    assert n_small is not None and n_big is not None
+    assert n_big > n_small
+
+
+def test_power_formula_monotonic_in_inverse_delta_squared() -> None:
+    """N grows with 1/δ² (smaller target effect → more samples). Halving δ should
+    roughly quadruple N."""
+    n_big_delta = sp.required_samples(0.02, target_effect_size=0.04).n_seed
+    n_small_delta = sp.required_samples(0.02, target_effect_size=0.02).n_seed
+    assert n_big_delta is not None and n_small_delta is not None
+    assert n_small_delta > n_big_delta
+    # quadratic relationship: δ/2 → ~4× N
+    assert n_small_delta == pytest.approx(n_big_delta * 4, rel=0.25)
+
+
+def test_power_formula_indeterminate_when_sigma_unknown() -> None:
+    """Graceful: σ unknown (no variance observed yet) → N indeterminate, NOT a
+    crash or a fabricated number."""
+    req = sp.required_samples(None, target_effect_size=0.02)
+    assert req.n_seed is None
+    assert "indeterminate" in sp.format_power_line(req)
+
+
+def test_power_formula_zero_sigma_needs_one_sample() -> None:
+    """σ=0 (perfectly stable, no noise) → a single sample detects any δ>0."""
+    req = sp.required_samples(0.0, target_effect_size=0.02)
+    assert req.n_seed == 1
+
+
+def test_power_formula_illposed_delta_graceful() -> None:
+    """δ ≤ 0 is ill-posed (divide-by-zero) → indeterminate, not a crash."""
+    req = sp.required_samples(0.013, target_effect_size=0.0)
+    assert req.n_seed is None
+
+
+def test_power_line_real_campaign_shape() -> None:
+    """The per-campaign line for the real N≈8-10 / observed stderr≈0.013 case the
+    operator launches 10 cycles under: it names δ, α, power, σ, and the required
+    N_seed × M_replicate honestly."""
+    req = sp.required_samples(0.013, target_effect_size=0.02, replicate=1)
+    line = sp.format_power_line(req)
+    assert "delta=0.0200" in line
+    assert "alpha=0.05" in line
+    assert "sigma=0.0130" in line
+    assert "N_seed>=7" in line
+    assert "M_replicate>=1" in line

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -2125,6 +2125,9 @@ def test_main_dry_run_emits_full_p0b_event_sequence(
         "config_snapshot",
         "wrapper_override_dumped",
         "baseline_decision",
+        # E4 (2026-05-30) — statistical_power fires after the baseline decision (it
+        # needs the baseline to compute the gain CI) and before per_dim_scores.
+        "statistical_power",
         "per_dim_scores",
         "audit_finished",
     ], f"event sequence mismatch: {events}"
@@ -2187,6 +2190,14 @@ def test_main_dry_run_emits_full_p0b_event_sequence(
         "missing_dims emit drift — main() must use compute_missing_dims, not a literal"
     )
     assert set(by_event["audit_finished"].keys()) == {"dry_run"}
+    # E4 — statistical_power payload carries the decomposition + verdict + power line.
+    sp_payload = by_event["statistical_power"]
+    assert sp_payload["replicate"] == 1  # M=1 default
+    assert sp_payload["within_mutation_stderr"] is None  # M=1 leaves within unestimated
+    assert sp_payload["gain_verdict"] == "no evidence yet"  # no baseline → honest null
+    assert sp_payload["gain_ci_excludes_zero"] is False
+    assert sp_payload["target_effect_size"] == pytest.approx(0.02)
+    assert "power_line" in sp_payload
 
 
 def test_main_dry_run_payloads_exclude_sessions_jsonl_canonical_fields(

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.95"
+version = "0.99.96"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **`--replicate M` (default M=1 → zero cost/behaviour change).** Runs the audit `M` times per mutation/cycle so WITHIN-mutation variance (provider non-determinism) is estimated SEPARATELY from BETWEEN-seed variance (the `N` samples in one audit). `M=1` runs the audit exactly once (no loop overhead) and leaves within-variance honestly unestimated.
- **Explicit fitness-gain "ci excludes 0" verdict.** A CI on the fitness gain (current vs baseline) → `gain_ci_low/high` + boolean `gain_ci_excludes_zero` + a human verdict (`"gain significant"` / `"no evidence yet"`). An honest-null layer ON TOP of the promote gate, reconciled EXACTLY with its `max(√(σp²+σc²), floor)` margin (never weakens the gate).
- **Per-campaign power analysis.** `n ≈ 2(z_{α/2}+z_β)²σ²/δ²` → required `N_seed × M_replicate` to detect δ at α=0.05 / 80% power, emitted per campaign.

## Why
The loop could "promote" or look like it gained fitness without statistical support — a null run looked like a silent reject rather than an honest "no evidence yet", and the operator had no principled answer to "how many samples (N, M) do I need before the 10-cycle launch?". E4 makes the loop only CLAIM a gain when the gain CI excludes 0, decomposes the noise so provider jitter is not conflated with seed signal, and tells the operator the required N×M.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/statistical_power.py` | NEW — pure stats: `decompose_variance`, `gain_ci_excludes_zero` (with gate-floor reconciliation), `required_samples`, `format_power_line`, + `VarianceDecomposition` / `GainEvidence` / `PowerRequirement` / `PowerRecordFields` dataclasses. |
| `autoresearch/train.py` | `--replicate` / `--target-effect-size` args + `_resolve_audit_replicate` / `_resolve_target_effect_size` resolvers; M-loop wrapping `run_audit` in `main()`; E4 block (decomposition + gate-reconciled gain verdict + power line + `statistical_power` journal event + stdout lines); `_FITNESS_MARGIN_FLOOR_DEFAULT` single-SoT constant; `power_stats` bundle threaded into `_write_baseline` / `_append_baseline_registry_row` + `baseline.json` `raw`. |
| `core/self_improving_loop/attribution.py` | New optional E4 fields on `AttributionRecord` + `compute_attribution` / `write_attribution` (None-omitting, backward-compatible). |
| `core/config/self_improving_loop.py` | `replicate` (ge=1,le=20) + `target_effect_size` (gt=0,le=1) config fields. |
| `tests/autoresearch/test_statistical_power.py` | NEW — 19 pure-stats tests (M=1 unchanged, M>1 decomposition, ci verdict + gate-floor reconciliation, power formula + monotonicity + graceful edge cases). |
| `tests/autoresearch/test_replicate_power_wiring.py` | NEW — 22 wiring tests (resolver precedence + graceful casts, M-loop static guards, σ-fallback parity, record backward-compat). |
| `tests/test_autoresearch_train.py` | P0b journal sequence + payload now include the `statistical_power` event. |
| `CHANGELOG.md` / `pyproject.toml` / `CLAUDE.md` / `README.md` / `README.ko.md` | v0.99.95 → v0.99.96 (5 locations) + `### Added`. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Audit-invocation site for the M-loop | Implemented | The single `run_audit(...)` call in `main()` (was un-looped) is now wrapped in `for _replicate_idx in range(audit_replicate)`; M=1 → exactly one iteration, representative = last tuple (byte-identical to pre-E4). |
| Within vs between variance decomposition | Implemented | within = stdev(per-replicate raw)/√M; between = mean of per-audit bootstrap stderrs; combined = √(within²+between²) (orthogonal, no double-count). |
| ci-excludes-0 verdict | Implemented | Reconciled with the gate's `max(σ-margin, floor)` incl. N=1 widening; bootstrap (no-baseline) cycle → honest "no evidence yet". |
| Power analysis | Implemented | δ default 0.02 (flagged, overridable); normal-approx CI (flagged, justified vs bootstrap). |

## Verification
- [x] `ruff check core/ autoresearch/ scripts/ tests/` clean
- [x] `ruff format --check` clean
- [x] `mypy autoresearch/train.py core/self_improving_loop/` clean
- [x] `lint-imports` 4/4 contracts kept
- [x] pytest: 290 pass (tests/autoresearch/ + tests/test_autoresearch_train.py; +41 new E4 tests), no live tests
- [x] Codex MCP adversarial review (2 fix rounds) — all blockers RESOLVED, no new issues

## Reference
E4 of the self-improving statistical-power track, on develop v0.99.95 (E1 fitness scale + E2 held-out + E3 control arms). Power formula: textbook 2-sample mean-difference. Verdict reconciliation: `_should_promote`'s `_MARGIN_GAIN_SIGMA=1.0` σ-margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)