### PR TITLE
feat(self-improving): per-cycle reproducibility pins — prompt hash + applied diff + sampling params + seed (E5, v0.99.97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,49 @@ functional change.
 
 ---
 
+## [0.99.97] - 2026-05-30
+
+### Added
+- **E5 (2026-05-30) — per-cycle reproducibility pins: prompt hash, applied diff,
+  sampling params, RNG seed.** Each self-improving-loop ledger row is now
+  INDEPENDENTLY RE-RUNNABLE — a third party can reconstruct exactly what produced
+  an audit result. Four pins are captured at the point of truth (the audit
+  dispatch) and recorded on BOTH per-cycle sinks (the `mutations.jsonl`
+  attribution row and the `baseline_archive.jsonl` registry row), all
+  None-omitting so legacy / no-pin rows keep their exact shape:
+  - **`prompt_hash`** — `sha256:` of the ACTUAL composed wrapper/scaffold system
+    prompt the audit target ran under (the mutation-applied
+    `WRAPPER_PROMPT_SECTIONS`, canonically serialised then hashed — stable for the
+    same prompt, sensitive to any section edit).
+  - **`applied_diff`** — the scaffold mutation actually APPLIED this cycle as a
+    reproducible reference: `sha256:` of the applied content (`new_value`) plus the
+    `applied_diff_target` (section) + `applied_diff_kind` it edited, read from the
+    `kind="applied"` apply row — not a re-derived guess.
+  - **`sampling_params`** — the generation params as SENT for the audit. GEODE's
+    audit dispatch (a `geode audit` subprocess) controls only a subset (`max_turns`
+    / `seeds` / `dim_set` / `source` / `max_connections=1` / `max_samples=1`),
+    recorded as the resolved effective values; the per-token knobs
+    (`temperature` / `top_p` / `max_tokens`) GEODE does NOT pin are recorded as an
+    explicit `"_unpinned"` marker (inspect_ai + provider defaults), not a fabricated
+    value.
+  - **`rng_seed`** — the audit/generation seed as SENT (distinct from E3's
+    `promote_policy_seed`). GEODE sends NO `--seed` to the audit subprocess today,
+    so the honest record is `None` (no seed sent), never a fabricated number.
+  - **Auditability, not determinism.** These pins record WHAT WAS SENT and make NO
+    backend-determinism claim. A ctx7 lookup of inspect_ai
+    (`/ukgovernmentbeis/inspect_ai`, 2026-05-30) confirmed `GenerateConfig` ACCEPTS
+    `seed` / `temperature` / `top_p` (SDK contract) but did NOT document that any
+    backend — least of all GEODE's claude-cli / codex-cli OAuth subscription
+    providers — HONORS `seed` for bit-identical replay; the contract is therefore
+    `unverified — live test required`, and no determinism flag is set to `True`.
+  - New module `core/self_improving_loop/run_provenance.py` (`hash_text`,
+    `compose_wrapper_prompt`, `build_run_provenance`, `RunProvenanceFields` bundle).
+    Threaded through `attribution.write_attribution` / `compute_attribution` +
+    `train.py`'s `_write_baseline` → `_append_baseline_registry_row`. 24 new tests
+    in `tests/autoresearch/test_reproducibility_pins.py`.
+
+---
+
 ## [0.99.96] - 2026-05-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.96
+- **Version**: 0.99.97
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.96 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.97 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.96 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.97 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -110,6 +110,7 @@ if TYPE_CHECKING:
     # E4 (2026-05-30) — type-only import for the record bundle annotation. The
     # value is constructed lazily in ``main`` (local import) so this stays
     # annotation-only and does not eagerly pull the statistics module at import.
+    from core.self_improving_loop.run_provenance import RunProvenanceFields
     from core.self_improving_loop.statistical_power import PowerRecordFields
 
 # PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring. ``BenchProvenance``
@@ -1105,6 +1106,77 @@ def _build_audit_command() -> list[str]:
     if getattr(cfg, "source", "auto") != "api_key":
         argv.append("--use-oauth")
     return argv
+
+
+def _audit_sampling_params_as_sent() -> dict[str, Any]:
+    """The generation params GEODE ACTUALLY sends for the audit (E5 reproducibility pin).
+
+    Records WHAT WAS SENT for auditability — NOT a determinism contract. GEODE's
+    audit dispatch is a ``geode audit`` subprocess (:func:`_build_audit_command`)
+    that controls only a SUBSET of generation params: ``max_turns`` / ``seeds`` /
+    ``dim_set`` / ``source``, and the inspect_ai connection caps
+    (``max_connections=1`` / ``max_samples=1``, pinned in
+    ``plugins/petri_audit/runner.py:build_command``). These are the resolved
+    EFFECTIVE values (mutation-SoT override → config), identical to what
+    ``_build_audit_command`` puts on the argv.
+
+    The per-token sampling knobs (``temperature`` / ``top_p`` / ``max_tokens``) are
+    NOT pinned by GEODE — they fall to the inspect_ai + provider (claude-cli /
+    codex-cli OAuth) defaults — so they are recorded as
+    :data:`~core.self_improving_loop.run_provenance.SAMPLING_UNPINNED` rather than a
+    fabricated value. This is the honest "GEODE did not set this" record; a future
+    PR that pins these knobs (and a ctx7-verified backend-determinism live test)
+    would write the real numbers here.
+    """
+    from core.self_improving_loop.run_provenance import SAMPLING_UNPINNED
+
+    cfg = _get_autoresearch_config()
+    overrides = _load_hyperparam_overrides()
+    return {
+        # GEODE-pinned audit-dispatch params (the resolved effective values).
+        "max_turns": _hyperparam_int(overrides, "max_turns", cfg.max_turns),
+        "seeds": _hyperparam_int(overrides, "seed_limit", cfg.seed_limit),
+        "dim_set": _effective_dim_set(),
+        "source": getattr(cfg, "source", "auto"),
+        "max_connections": 1,
+        "max_samples": 1,
+        # Per-token knobs GEODE does not pin → backend default (UNVERIFIED for
+        # deterministic replay; see run_provenance module docstring + ctx7 note).
+        "temperature": SAMPLING_UNPINNED,
+        "top_p": SAMPLING_UNPINNED,
+        "max_tokens": SAMPLING_UNPINNED,
+    }
+
+
+def _applied_diff_for_mutation(mutation_id: str) -> tuple[str | None, str | None, str | None]:
+    """The scaffold mutation APPLIED this cycle, as a reproducible reference (E5 pin).
+
+    Returns ``(target_section, new_value, target_kind)`` for the
+    ``kind="applied"`` row in ``mutations.jsonl`` whose ``mutation_id`` matches the
+    cycle's applied mutation — the EXACT content the apply step committed. The
+    caller hashes ``new_value`` (``applied_diff_hash``) + records the section + kind
+    so the row carries the diff reference without joining the apply row.
+
+    ``("", "", "")``-shaped graceful return — all ``None`` — when ``mutation_id`` is
+    empty (manual / no-mutation cycle) or no matching apply row exists (a fresh
+    ledger, or the apply row hasn't been written yet). Never raises: a reader-side
+    failure must not break the ledger write.
+    """
+    if not mutation_id:
+        return None, None, None
+    try:
+        from core.self_improving_loop.mutations_reader import read_recent_applies
+
+        for record in reversed(read_recent_applies(n=200)):
+            if record.mutation_id == mutation_id:
+                return record.target_section, record.new_value, record.target_kind
+    except Exception:  # pragma: no cover — defensive; pin simply omitted on failure
+        log.warning(
+            "self-improving-loop applied-diff lookup failed for mutation %s",
+            mutation_id,
+            exc_info=True,
+        )
+    return None, None, None
 
 
 def _dump_wrapper_override() -> Path:
@@ -2564,6 +2636,7 @@ def _append_baseline_registry_row(
     promote_policy: str = "gate",
     promote_policy_seed: int = 0,
     power_stats: PowerRecordFields | None = None,
+    run_provenance: RunProvenanceFields | None = None,
 ) -> None:
     """Append one ``kind="baseline"`` registry row to ``baseline_archive.jsonl``.
 
@@ -2736,6 +2809,14 @@ def _append_baseline_registry_row(
             row["gain_ci_excludes_zero"] = bool(power_stats.gain_ci_excludes_zero)
             if power_stats.gain_verdict is not None:
                 row["gain_verdict"] = str(power_stats.gain_verdict)
+    # E5 (2026-05-30) — reproducibility pins (prompt_hash + applied_diff +
+    # sampling_params + rng_seed) so the promoted baseline's row is independently
+    # re-runnable. ``as_record_kwargs`` returns ONLY the present (non-None) pins, so
+    # a pre-E5 promote (run_provenance=None) writes NO E5 key — the row shape is
+    # unchanged (additive, never a new required key). The pins record WHAT WAS SENT
+    # (auditability); they make no backend-determinism claim (see run_provenance).
+    if run_provenance is not None:
+        row.update(run_provenance.as_record_kwargs())
     archive_path = _baseline_archive_path()
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     with archive_path.open("a", encoding="utf-8") as fh:
@@ -2790,6 +2871,11 @@ def _write_baseline(
     # parameter. ``None`` (default) → the keys are omitted (backward-compatible: an
     # M=1 / pre-E4 baseline keeps its exact shape).
     power_stats: PowerRecordFields | None = None,
+    # E5 (2026-05-30) — reproducibility pins (prompt_hash + applied_diff +
+    # sampling_params + rng_seed) forwarded to the registry row so the promoted
+    # baseline is independently re-runnable. ``None`` (default) → no E5 key written
+    # (backward-compatible — a pre-E5 baseline keeps its exact shape).
+    run_provenance: RunProvenanceFields | None = None,
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -2921,6 +3007,8 @@ def _write_baseline(
         promote_policy_seed=promote_policy_seed,
         # E4 (2026-05-30) — fitness-noise decomposition + gain-evidence verdict.
         power_stats=power_stats,
+        # E5 (2026-05-30) — reproducibility pins forwarded to the registry row.
+        run_provenance=run_provenance,
     )
     # Emit BASELINE_PROMOTED after the write succeeds. ``reason``
     # quotes the gate verdict text from ``_should_promote`` (or the
@@ -4051,6 +4139,33 @@ def main() -> int:
         f"e4_gain_verdict:          {gain_evidence.verdict} "
         f"(ci excludes 0: {gain_evidence.gain_ci_excludes_zero})"
     )
+    # E5 (2026-05-30) — REPRODUCIBILITY PINS. Captured at the POINT OF TRUTH (this
+    # cycle's audit dispatch) so each pin reflects what was ACTUALLY sent, not a
+    # re-derived guess: ``prompt_hash`` from the mutation-applied
+    # ``WRAPPER_PROMPT_SECTIONS`` (the exact wrapper system prompt the target ran
+    # under, the same dict ``_dump_wrapper_override`` writes); ``applied_diff`` from
+    # the ``kind="applied"`` row of THIS cycle's mutation; ``sampling_params`` from
+    # the audit dispatch's resolved effective params; ``rng_seed`` recorded as sent
+    # (``None`` — GEODE sends no ``--seed`` to the audit subprocess; the honest
+    # record, distinct from E3's ``promote_policy_seed``). The bundle is None-omitting
+    # so a manual / no-mutation / dry-run cycle still produces only the pins it has.
+    # Records WHAT WAS SENT (auditability) — no backend-determinism claim.
+    from core.self_improving_loop.run_provenance import build_run_provenance
+
+    _e5_applied_target, _e5_applied_value, _e5_applied_kind = _applied_diff_for_mutation(
+        os.environ.get("GEODE_SIL_MUTATION_ID", "").strip()
+    )
+    _e5_run_provenance = build_run_provenance(
+        wrapper_sections=WRAPPER_PROMPT_SECTIONS,
+        applied_target_section=_e5_applied_target,
+        applied_new_value=_e5_applied_value,
+        applied_target_kind=_e5_applied_kind,
+        sampling_params=_audit_sampling_params_as_sent(),
+        # GEODE sends no audit/generation seed — recorded as sent (None). NOT a
+        # fabricated value, and NO determinism claim (see run_provenance docstring).
+        rng_seed=None,
+    )
+    print(f"e5_prompt_hash:           {_e5_run_provenance.prompt_hash or '(none)'}")
     # E2 (2026-05-30) — per-cycle fixed-ruler measurement. The held-out bench is
     # a VERSION-FROZEN seed set DISJOINT from the co-evolving ``seed_select`` pool
     # the audit above ran on, so its fitness is comparable ACROSS generations.
@@ -4220,6 +4335,11 @@ def main() -> int:
         # None-omitting (M=1 leaves within unestimated; pre-E4 baselines omit the
         # block) so the row shape stays backward-compatible.
         "power_stats": _e4_power_stats,
+        # E5 (2026-05-30) — reproducibility pins (prompt_hash + applied_diff +
+        # sampling_params + rng_seed) on the promoted baseline's registry row so it
+        # is independently re-runnable. None-omitting bundle (a pin with no value is
+        # omitted) → backward-compatible row shape.
+        "run_provenance": _e5_run_provenance,
     }
     if args.dry_run:
         promoted_line = "false (dry-run)"
@@ -4477,6 +4597,10 @@ def main() -> int:
                 # fields are None-omitting (M=1 leaves within unestimated; legacy
                 # rows omit the whole block) so the row stays backward-compatible.
                 **_e4_record_fields,
+                # E5 (2026-05-30) — reproducibility pins on the per-cycle attribution
+                # row (prompt_hash + applied_diff + sampling_params + rng_seed). The
+                # bundle is None-omitting so a no-pin cycle keeps the legacy shape.
+                run_provenance=_e5_run_provenance,
             )
         except Exception:  # pragma: no cover — defensive
             log.warning(

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from core.self_improving_loop.run_provenance import RunProvenanceFields
 from core.self_improving_loop.signal_polarity import to_signed_improvement
 
 if TYPE_CHECKING:
@@ -135,6 +136,23 @@ class AttributionRecord(BaseModel):
     This is the honest-null evidence layer ON TOP of the promote gate (it never
     weakens the gate; at ``DEFAULT_GAIN_CI_Z=1.0`` it reconciles with the gate's
     σ-margin). Legacy rows omit all four → ``None`` (backward-compatible)."""
+    prompt_hash: str | None = None
+    applied_diff_hash: str | None = None
+    applied_diff_target: str | None = None
+    applied_diff_kind: str | None = None
+    sampling_params: dict[str, Any] | None = None
+    rng_seed: int | None = None
+    """E5 (2026-05-30) — per-cycle REPRODUCIBILITY PINS so a row is independently
+    re-runnable. ``prompt_hash`` is the ``sha256:`` of the actual composed wrapper
+    system prompt the target ran under; ``applied_diff_hash`` (+ ``_target`` /
+    ``_kind``) is the ``sha256:`` of the scaffold mutation actually APPLIED this
+    cycle plus where it applied; ``sampling_params`` is the generation params as
+    SENT (GEODE-pinned subset; per-token knobs recorded ``"_unpinned"``); ``rng_seed``
+    is the audit/generation seed as SENT (``None`` when none was sent — distinct from
+    E3's ``promote_policy_seed``). These record WHAT WAS SENT for AUDITABILITY; they
+    make NO backend-determinism claim (the backend may not replay bit-identically —
+    ``unverified``, see :mod:`core.self_improving_loop.run_provenance`). Each field is
+    ``None``-omitting at the writer, so legacy / no-pin rows keep their exact shape."""
     audit_run_id: str | None = None
     source: str | None = None
     """PR-AR-L6 (2026-05-26) — distinguishes mutator-driven cycle rows
@@ -292,6 +310,7 @@ def compute_attribution(
     gain_ci_high: float | None = None,
     gain_ci_excludes_zero: bool | None = None,
     gain_verdict: str | None = None,
+    run_provenance: RunProvenanceFields | None = None,
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -403,6 +422,13 @@ def compute_attribution(
         payload["gain_ci_excludes_zero"] = bool(gain_ci_excludes_zero)
         if gain_verdict is not None:
             payload["gain_verdict"] = str(gain_verdict)
+    # E5 (2026-05-30) — reproducibility pins. ``as_record_kwargs`` returns ONLY the
+    # present (non-None) pins, so a cycle with no prompt / no applied diff / no seed
+    # contributes no key and the row keeps its exact legacy shape (additive, never a
+    # new required key). The pins record WHAT WAS SENT (auditability) — no backend-
+    # determinism claim (see run_provenance module docstring).
+    if run_provenance is not None:
+        payload.update(run_provenance.as_record_kwargs())
     if baseline_before is None or baseline_after is None:
         return payload
 
@@ -464,6 +490,7 @@ def write_attribution(
     gain_ci_high: float | None = None,
     gain_ci_excludes_zero: bool | None = None,
     gain_verdict: str | None = None,
+    run_provenance: RunProvenanceFields | None = None,
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
 
@@ -501,6 +528,7 @@ def write_attribution(
         gain_ci_high=gain_ci_high,
         gain_ci_excludes_zero=gain_ci_excludes_zero,
         gain_verdict=gain_verdict,
+        run_provenance=run_provenance,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload

--- a/core/self_improving_loop/run_provenance.py
+++ b/core/self_improving_loop/run_provenance.py
@@ -1,0 +1,209 @@
+"""Per-cycle reproducibility pins for the self-improving loop ledger (E5, 2026-05-30).
+
+E1-E4 made each ledger row's *outcome* statistically honest (fitness scale,
+held-out ruler, control-arm tag, variance decomposition). E5 makes each row
+INDEPENDENTLY RE-RUNNABLE: it records the four inputs a third party needs to
+reconstruct exactly what produced an audit result, so a row is not just a number
+but a recipe.
+
+Per-role model/lane/source is already recorded
+(:mod:`core.self_improving_loop.role_provenance`); E3 records the
+``promote_policy`` (+ its RNG seed); E4 records replicate / power. E5 adds the
+remaining pins to BOTH per-cycle sinks — the ``mutations.jsonl`` attribution row
+and the ``baseline_archive.jsonl`` registry row — additively (``None`` / absent
+when unavailable, never a new REQUIRED key that breaks an existing reader):
+
+1. ``prompt_hash`` — sha256 of the ACTUAL composed wrapper/scaffold system prompt
+   the audit target ran under (the mutation-applied ``WRAPPER_PROMPT_SECTIONS``,
+   canonically serialised then hashed). Pins "which prompt produced this row".
+2. ``applied_diff`` — the scaffold mutation actually APPLIED this cycle, captured
+   as a reproducible reference: ``sha256`` of the applied content + the
+   ``target_section`` + ``target_kind`` it edited (NOT just a free-text rationale).
+3. ``sampling_params`` — the generation params as SENT for the audit. GEODE's audit
+   dispatch is a subprocess that controls only a subset (``max_turns`` / ``seeds`` /
+   ``dim_set`` / ``source`` / ``max_connections`` / ``max_samples``); the per-token
+   sampling knobs (``temperature`` / ``top_p`` / ``max_tokens``) are NOT pinned by
+   GEODE and fall to the inspect_ai + provider defaults, so they are recorded as
+   ``None`` with an explicit ``"_unpinned"`` marker rather than a fabricated value.
+4. ``rng_seed`` — the audit/generation seed as SENT (distinct from E3's
+   ``promote_policy_seed``, which seeds only the promote coin-flip). GEODE currently
+   sends NO ``--seed`` to the audit subprocess, so the honest record is ``None``
+   (no seed sent), not a fabricated number.
+
+DETERMINISM CAVEAT (CLAUDE.md "doc-before-behaviour" + [[feedback_ctx7_before_backend_assumption]]):
+these pins are for AUDITABILITY — they record WHAT WAS SENT — and make NO claim
+that any backend replays deterministically from them. A ctx7 lookup of inspect_ai
+(2026-05-30, ``/ukgovernmentbeis/inspect_ai``) confirmed ``GenerateConfig`` ACCEPTS
+``seed`` / ``temperature`` / ``top_p`` (SDK contract) but did NOT document that any
+backend — least of all GEODE's claude-cli / codex-cli OAuth subscription providers
+— HONORS ``seed`` for bit-identical reproducible replay. The contract is therefore
+``unverified — live test required``: no determinism flag is set to ``True`` here,
+and ``rng_seed`` is recorded as the value actually sent (``None`` today) so a future
+reader is never misled into assuming a replay is bit-stable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+# Stable marker for a sampling knob GEODE does not pin (left to the inspect_ai +
+# provider default). Recorded as a value (not absence) so a reader can tell
+# "GEODE did not set this" apart from "this knob does not exist".
+SAMPLING_UNPINNED = "_unpinned"
+
+
+def hash_text(text: str | None) -> str | None:
+    """Return the ``sha256:<hex>`` of ``text``, or ``None`` when ``text`` is ``None``.
+
+    Graceful contract — a missing prompt / diff must not crash the ledger write,
+    it simply yields ``None`` and the pin is omitted from the row. A non-``str``
+    that is not ``None`` is coerced via :func:`str` so an unexpected upstream type
+    (e.g. an accidental dict) still hashes a stable representation rather than
+    raising at the cast boundary.
+    """
+    if text is None:
+        return None
+    raw = text if isinstance(text, str) else str(text)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def compose_wrapper_prompt(sections: Mapping[str, Any] | None) -> str | None:
+    """Canonically serialise the wrapper system-prompt section dict for hashing.
+
+    The audit target runs under the mutation-applied ``WRAPPER_PROMPT_SECTIONS``
+    (a ``{section_key: text}`` dict). To make :func:`hash_text` STABLE for the same
+    logical prompt and SENSITIVE to any edit, the dict is serialised with
+    ``sort_keys=True`` (insertion-order independent) and the exact section text
+    preserved (so an edit to any section flips the hash).
+
+    Returns ``None`` for ``None`` / empty input (no prompt to hash → the pin is
+    omitted, legacy shape preserved). Non-``str`` section VALUES are coerced via
+    :func:`str` at the boundary so a malformed section can't raise here.
+    """
+    if not sections:
+        return None
+    normalised = {
+        str(key): (value if isinstance(value, str) else str(value))
+        for key, value in sections.items()
+    }
+    return json.dumps(normalised, ensure_ascii=False, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class RunProvenanceFields:
+    """The E5 reproducibility pins persisted on a record row (attribution / registry).
+
+    One bundle so the record-writer signatures take a SINGLE E5 argument (keeping
+    ``write_attribution`` / ``_append_baseline_registry_row`` under the ``max-args``
+    ratchet, mirroring E4's :class:`PowerRecordFields`). Every field is
+    ``None``-omitting at the writer: a cycle with no pin available (legacy caller,
+    no mutation applied, no prompt composed) passes ``None`` for that field and the
+    writer omits the key — so the row shape is unchanged for existing readers.
+
+    Fields
+    ------
+    prompt_hash
+        ``sha256:<hex>`` of the canonically-serialised wrapper system prompt the
+        target ran under (see :func:`compose_wrapper_prompt` → :func:`hash_text`).
+    applied_diff_hash
+        ``sha256:<hex>`` of the applied mutation's content (``new_value``). A
+        reproducible reference to the exact scaffold change, paired with
+        ``applied_diff_target`` / ``applied_diff_kind`` so a reader knows WHERE it
+        applied without joining the apply row.
+    applied_diff_target
+        The ``target_section`` the mutation edited (dotted notation).
+    applied_diff_kind
+        The ``target_kind`` (``prompt`` / ``tool_policy`` / ...) the mutation edited.
+    sampling_params
+        The generation params as SENT for the audit (the dict actually used). The
+        per-token knobs GEODE does not pin are recorded as :data:`SAMPLING_UNPINNED`.
+    rng_seed
+        The audit/generation seed as SENT — ``None`` when GEODE sent no ``--seed``
+        (the honest record, distinct from E3's ``promote_policy_seed``).
+    """
+
+    prompt_hash: str | None = None
+    applied_diff_hash: str | None = None
+    applied_diff_target: str | None = None
+    applied_diff_kind: str | None = None
+    sampling_params: dict[str, Any] | None = None
+    rng_seed: int | None = None
+
+    def as_record_kwargs(self) -> dict[str, Any]:
+        """Render only the present (non-``None``) pins as record kwargs.
+
+        Used by the attribution writer + the baseline registry writer to splice the
+        pins into the row. An empty dict (every field ``None``) means the row keeps
+        its exact legacy shape — additive, never a new required key.
+        """
+        out: dict[str, Any] = {}
+        if self.prompt_hash is not None:
+            out["prompt_hash"] = self.prompt_hash
+        if self.applied_diff_hash is not None:
+            out["applied_diff_hash"] = self.applied_diff_hash
+        if self.applied_diff_target is not None:
+            out["applied_diff_target"] = self.applied_diff_target
+        if self.applied_diff_kind is not None:
+            out["applied_diff_kind"] = self.applied_diff_kind
+        if self.sampling_params is not None:
+            out["sampling_params"] = dict(self.sampling_params)
+        if self.rng_seed is not None:
+            out["rng_seed"] = int(self.rng_seed)
+        return out
+
+
+def build_run_provenance(
+    *,
+    wrapper_sections: Mapping[str, Any] | None = None,
+    applied_target_section: str | None = None,
+    applied_new_value: str | None = None,
+    applied_target_kind: str | None = None,
+    sampling_params: Mapping[str, Any] | None = None,
+    rng_seed: int | None = None,
+) -> RunProvenanceFields:
+    """Assemble the E5 reproducibility pins from the values ACTUALLY sent for a cycle.
+
+    Captures the pins at the point of truth (the audit dispatch site), so each pin
+    reflects what was sent, not a re-derived guess:
+
+    - ``prompt_hash`` from the composed wrapper sections (the dumped override file's
+      content) — ``None`` when no sections were composed.
+    - ``applied_diff_hash`` from the applied mutation's ``new_value`` — ``None`` when
+      no mutation was applied this cycle (manual / no-mutation cycle).
+    - ``sampling_params`` from the dict of params the dispatch actually sent —
+      ``None`` when not supplied.
+    - ``rng_seed`` recorded verbatim — ``None`` when no seed was sent (the honest
+      record; GEODE's audit dispatch sends none today).
+
+    Every cast is ``None``-tolerant so a partial cycle (e.g. a manual audit with no
+    applied diff) still produces a valid bundle with only the available pins.
+    """
+    return RunProvenanceFields(
+        prompt_hash=hash_text(compose_wrapper_prompt(wrapper_sections)),
+        applied_diff_hash=hash_text(applied_new_value),
+        applied_diff_target=(
+            str(applied_target_section)
+            if applied_target_section is not None and applied_new_value is not None
+            else None
+        ),
+        applied_diff_kind=(
+            str(applied_target_kind)
+            if applied_target_kind is not None and applied_new_value is not None
+            else None
+        ),
+        sampling_params=dict(sampling_params) if sampling_params is not None else None,
+        rng_seed=int(rng_seed) if rng_seed is not None else None,
+    )
+
+
+__all__ = [
+    "SAMPLING_UNPINNED",
+    "RunProvenanceFields",
+    "build_run_provenance",
+    "compose_wrapper_prompt",
+    "hash_text",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.96"
+version = "0.99.97"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -339,7 +339,7 @@ ignore = [
 max-complexity = 62
 
 [tool.ruff.lint.pylint]
-max-args = 21         # Worst: 21 (_append_baseline_registry_row — a provenance wiring sink: per-role/seed/bench/held-out/control-arm/power fields; E4 added the bundled power_stats arg). Target: 8.
+max-args = 22         # Worst: 22 (_append_baseline_registry_row — a provenance wiring sink: per-role/seed/bench/held-out/control-arm/power fields; E4 added the bundled power_stats arg, E5 the bundled run_provenance arg). Target: 8.
 max-branches = 68     # Worst: 68. Target: 15.
 max-returns = 18      # Worst: 18 (PLR0911 silenced project-wide; this kept for ratchet visibility).
 max-statements = 273  # Worst: 273 (god method in cli/__init__.py). Target: 60.

--- a/tests/autoresearch/test_reproducibility_pins.py
+++ b/tests/autoresearch/test_reproducibility_pins.py
@@ -1,0 +1,394 @@
+"""E5 (2026-05-30) — reproducibility pins on the per-cycle ledger rows.
+
+Each ledger row must be INDEPENDENTLY RE-RUNNABLE: a third party should be able to
+reconstruct exactly what produced an audit result. E5 adds four pins to BOTH
+sinks — the ``mutations.jsonl`` attribution row and the ``baseline_archive.jsonl``
+registry row:
+
+  1. ``prompt_hash``    — sha256 of the actual composed wrapper system prompt
+     (stable for the same prompt, changes when the prompt changes).
+  2. ``applied_diff``   — sha256 of the applied mutation's content + its
+     target_section / target_kind.
+  3. ``sampling_params``— the generation params as SENT for the audit.
+  4. ``rng_seed``       — the audit/generation seed as SENT (None when none sent).
+
+These record WHAT WAS SENT for AUDITABILITY — NO backend-determinism claim. The
+pure pin functions are pinned here; the WIRING (the bundle flows into both sinks)
+follows the E2/E4 ``inspect.getsource`` static-guard convention; backward-compat
++ graceful casts close the set.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from core.self_improving_loop.run_provenance import (
+    SAMPLING_UNPINNED,
+    RunProvenanceFields,
+    build_run_provenance,
+    compose_wrapper_prompt,
+    hash_text,
+)
+
+from autoresearch import train as auto_train
+
+# --- pure pins: prompt_hash stability + sensitivity ---------------------------
+
+
+def test_hash_text_none_is_none() -> None:
+    """Graceful contract: a missing prompt → None (the pin is omitted, no crash)."""
+    assert hash_text(None) is None
+
+
+def test_hash_text_is_prefixed_sha256_and_stable() -> None:
+    a = hash_text("the wrapper system prompt")
+    b = hash_text("the wrapper system prompt")
+    assert a is not None and a.startswith("sha256:")
+    assert a == b  # stable for the same input
+
+
+def test_hash_text_changes_when_text_changes() -> None:
+    assert hash_text("prompt A") != hash_text("prompt B")
+
+
+def test_hash_text_coerces_non_str_gracefully() -> None:
+    """A non-str that isn't None must not raise at the cast boundary."""
+    assert hash_text({"unexpected": "dict"}) is not None  # str()-coerced, stable shape
+
+
+def test_compose_wrapper_prompt_is_order_independent_but_content_sensitive() -> None:
+    """prompt_hash must be STABLE for the same logical prompt (insertion order does
+    not matter) and SENSITIVE to any section edit."""
+    p1 = compose_wrapper_prompt({"a": "alpha", "b": "beta"})
+    p2 = compose_wrapper_prompt({"b": "beta", "a": "alpha"})  # reordered
+    assert p1 == p2  # sort_keys → order-independent
+    assert hash_text(p1) == hash_text(p2)
+    # an edit to any section flips the composed string (→ the hash)
+    p3 = compose_wrapper_prompt({"a": "alpha", "b": "BETA-edited"})
+    assert hash_text(p3) != hash_text(p1)
+
+
+def test_compose_wrapper_prompt_empty_is_none() -> None:
+    assert compose_wrapper_prompt(None) is None
+    assert compose_wrapper_prompt({}) is None
+
+
+def test_compose_wrapper_prompt_coerces_non_str_values() -> None:
+    """A non-str section value must not raise — it is str-coerced at the boundary."""
+    composed = compose_wrapper_prompt({"section": 123})
+    assert composed is not None and "123" in composed
+
+
+# --- build_run_provenance: capture WHAT WAS SENT -----------------------------
+
+
+def test_build_run_provenance_full_cycle() -> None:
+    fields = build_run_provenance(
+        wrapper_sections={"role": "you are an agent"},
+        applied_target_section="tool.web_search.description",
+        applied_new_value="search the web carefully",
+        applied_target_kind="tool_policy",
+        sampling_params={"max_turns": 12, "temperature": SAMPLING_UNPINNED},
+        rng_seed=None,
+    )
+    assert fields.prompt_hash is not None and fields.prompt_hash.startswith("sha256:")
+    assert fields.applied_diff_hash == hash_text("search the web carefully")
+    assert fields.applied_diff_target == "tool.web_search.description"
+    assert fields.applied_diff_kind == "tool_policy"
+    assert fields.sampling_params == {"max_turns": 12, "temperature": SAMPLING_UNPINNED}
+    assert fields.rng_seed is None  # honest: no seed sent
+
+
+def test_build_run_provenance_no_applied_diff_omits_target_and_kind() -> None:
+    """A manual / no-mutation cycle (no applied new_value) → diff pins are all None,
+    so the target / kind are not recorded against a phantom diff."""
+    fields = build_run_provenance(
+        wrapper_sections={"role": "agent"},
+        applied_target_section=None,
+        applied_new_value=None,
+        applied_target_kind=None,
+    )
+    assert fields.applied_diff_hash is None
+    assert fields.applied_diff_target is None
+    assert fields.applied_diff_kind is None
+    # the prompt pin is still captured
+    assert fields.prompt_hash is not None
+
+
+def test_build_run_provenance_target_without_value_is_dropped() -> None:
+    """Graceful: a target_section with NO new_value cannot reference a real diff →
+    the target/kind are dropped (no orphan reference)."""
+    fields = build_run_provenance(
+        applied_target_section="tool.x.description",
+        applied_new_value=None,
+        applied_target_kind="tool_policy",
+    )
+    assert fields.applied_diff_hash is None
+    assert fields.applied_diff_target is None
+    assert fields.applied_diff_kind is None
+
+
+def test_as_record_kwargs_omits_none_pins() -> None:
+    """A cycle with NO pins → empty kwargs (the row keeps its exact legacy shape)."""
+    assert RunProvenanceFields().as_record_kwargs() == {}
+
+
+def test_as_record_kwargs_includes_only_present_pins() -> None:
+    out = RunProvenanceFields(
+        prompt_hash="sha256:abc",
+        applied_diff_hash="sha256:def",
+        applied_diff_target="sec",
+        applied_diff_kind="prompt",
+        sampling_params={"max_turns": 8},
+        rng_seed=7,
+    ).as_record_kwargs()
+    assert out == {
+        "prompt_hash": "sha256:abc",
+        "applied_diff_hash": "sha256:def",
+        "applied_diff_target": "sec",
+        "applied_diff_kind": "prompt",
+        "sampling_params": {"max_turns": 8},
+        "rng_seed": 7,
+    }
+
+
+# --- attribution row: pins recorded + backward-compatible --------------------
+
+
+def test_attribution_carries_e5_pins() -> None:
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        run_provenance=RunProvenanceFields(
+            prompt_hash=hash_text("the prompt"),
+            applied_diff_hash=hash_text("the diff"),
+            applied_diff_target="role",
+            applied_diff_kind="prompt",
+            sampling_params={"max_turns": 12, "temperature": SAMPLING_UNPINNED},
+            rng_seed=None,  # honest: no seed sent
+        ),
+    )
+    assert payload["prompt_hash"] == hash_text("the prompt")
+    assert payload["applied_diff_hash"] == hash_text("the diff")
+    assert payload["applied_diff_target"] == "role"
+    assert payload["applied_diff_kind"] == "prompt"
+    assert payload["sampling_params"]["temperature"] == SAMPLING_UNPINNED
+    # rng_seed None → omitted (honest, not a fabricated 0)
+    assert "rng_seed" not in payload
+
+
+def test_attribution_prompt_hash_changes_when_prompt_changes() -> None:
+    """The recorded prompt_hash is sensitive to the actual prompt sent."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    def _hash_in_row(prompt: str) -> str:
+        return compute_attribution(
+            mutation_id="m",
+            expected_dim={},
+            baseline_before=None,
+            baseline_after=None,
+            run_provenance=build_run_provenance(wrapper_sections={"role": prompt}),
+        )["prompt_hash"]
+
+    assert _hash_in_row("prompt A") != _hash_in_row("prompt B")
+    assert _hash_in_row("prompt A") == _hash_in_row("prompt A")
+
+
+def test_attribution_legacy_omits_all_e5_pins() -> None:
+    """A pre-E5 caller (no run_provenance) omits every E5 pin → exact legacy shape,
+    and the schema validates the bare payload (pins default to None)."""
+    from core.self_improving_loop.attribution import AttributionRecord, compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+    )
+    for key in (
+        "prompt_hash",
+        "applied_diff_hash",
+        "applied_diff_target",
+        "applied_diff_kind",
+        "sampling_params",
+        "rng_seed",
+    ):
+        assert key not in payload
+    record = AttributionRecord.model_validate(payload)
+    assert record.prompt_hash is None
+    assert record.applied_diff_hash is None
+    assert record.sampling_params is None
+    assert record.rng_seed is None
+
+
+def test_attribution_none_baseline_still_records_pins() -> None:
+    """Graceful: pins are spliced BEFORE the None-baseline early return, so a cycle
+    with no baseline snapshots still records its reproducibility pins."""
+    from core.self_improving_loop.attribution import compute_attribution
+
+    payload = compute_attribution(
+        mutation_id="m1",
+        expected_dim={},
+        baseline_before=None,  # no baseline → early-return path
+        baseline_after=None,
+        run_provenance=RunProvenanceFields(prompt_hash="sha256:abc"),
+    )
+    assert payload["prompt_hash"] == "sha256:abc"
+
+
+# --- baseline registry row: pins recorded + backward-compatible --------------
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", tmp_path / "baseline.json")
+    fake_cfg = SimpleNamespace(
+        auditor=SimpleNamespace(model="aud-m", source="claude-cli"),
+        target=SimpleNamespace(model="tgt-m", source="openai-codex"),
+        judge=SimpleNamespace(model="jdg-m", source="claude-cli"),
+        mutator=SimpleNamespace(default_model="mut-m", source="openai-codex"),
+        seed_select="petri_17dim",
+        held_out_bench=None,
+        promote_policy="gate",
+        promote_policy_seed=0,
+        replicate=1,
+        target_effect_size=0.02,
+    )
+    monkeypatch.setattr(auto_train, "_get_autoresearch_config", lambda: fake_cfg)
+    return tmp_path
+
+
+def _rows(archive: Path) -> list[dict]:
+    return [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_registry_row_records_e5_pins_when_present(isolated: Path) -> None:
+    auto_train._write_baseline(
+        {"broken_tool_use": 3.0},
+        {"broken_tool_use": 0.2},
+        run_provenance=RunProvenanceFields(
+            prompt_hash="sha256:promptpin",
+            applied_diff_hash="sha256:diffpin",
+            applied_diff_target="role",
+            applied_diff_kind="prompt",
+            sampling_params={"max_turns": 12, "temperature": SAMPLING_UNPINNED},
+            rng_seed=None,
+        ),
+    )
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    assert row["prompt_hash"] == "sha256:promptpin"
+    assert row["applied_diff_hash"] == "sha256:diffpin"
+    assert row["applied_diff_target"] == "role"
+    assert row["applied_diff_kind"] == "prompt"
+    assert row["sampling_params"]["temperature"] == SAMPLING_UNPINNED
+    assert "rng_seed" not in row  # None → omitted (honest)
+
+
+def test_registry_row_default_omits_e5_block(isolated: Path) -> None:
+    """The default ``_write_baseline`` (no run_provenance — the pre-E5 path) writes a
+    row with NO E5 keys: backward-compatible shape, no new required key."""
+    auto_train._write_baseline({"broken_tool_use": 3.0}, {"broken_tool_use": 0.2})
+    row = _rows(isolated / "baseline_archive.jsonl")[0]
+    for key in (
+        "prompt_hash",
+        "applied_diff_hash",
+        "applied_diff_target",
+        "applied_diff_kind",
+        "sampling_params",
+        "rng_seed",
+    ):
+        assert key not in row
+
+
+# --- main() static wiring guards (E2 / E4 convention) ------------------------
+
+
+def test_main_builds_run_provenance_bundle() -> None:
+    source = inspect.getsource(auto_train.main)
+    assert "_e5_run_provenance = build_run_provenance(" in source
+    # captured from the ACTUAL composed prompt + the applied diff + the sent params
+    assert "wrapper_sections=WRAPPER_PROMPT_SECTIONS" in source
+    assert "_applied_diff_for_mutation(" in source
+    assert "sampling_params=_audit_sampling_params_as_sent()" in source
+    # rng_seed recorded as sent (None today) — NO determinism claim / fabricated seed
+    assert "rng_seed=None" in source
+
+
+def test_main_threads_run_provenance_into_both_sinks() -> None:
+    """The pins must flow into BOTH the attribution row and the on-promote baseline
+    provenance — the two record sinks."""
+    source = inspect.getsource(auto_train.main)
+    assert "run_provenance=_e5_run_provenance" in source  # attribution row
+    assert '"run_provenance": _e5_run_provenance' in source  # baseline provenance dict
+
+
+def test_sampling_params_as_sent_marks_unpinned_knobs() -> None:
+    """The per-token knobs GEODE does NOT pin are recorded as the explicit unpinned
+    marker (NOT a fabricated value) — the honest 'GEODE did not set this' record."""
+    params = auto_train._audit_sampling_params_as_sent()
+    assert params["temperature"] == SAMPLING_UNPINNED
+    assert params["top_p"] == SAMPLING_UNPINNED
+    assert params["max_tokens"] == SAMPLING_UNPINNED
+    # the GEODE-pinned dispatch params are concrete
+    assert params["max_connections"] == 1
+    assert params["max_samples"] == 1
+    assert "max_turns" in params and "seeds" in params and "dim_set" in params
+
+
+def test_applied_diff_lookup_empty_mutation_id_is_none() -> None:
+    """No mutation applied (empty id) → all-None graceful return (no crash)."""
+    assert auto_train._applied_diff_for_mutation("") == (None, None, None)
+
+
+def test_applied_diff_lookup_reads_apply_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The applied-diff pin reads the EXACT content the apply step committed (the
+    ``kind="applied"`` row), not a re-derived guess."""
+    from core.self_improving_loop import mutations_reader
+
+    ledger = tmp_path / "mutations.jsonl"
+    ledger.write_text(
+        json.dumps(
+            {
+                "ts": 1.0,
+                "kind": "applied",
+                "mutation_id": "mut-xyz",
+                "target_kind": "tool_policy",
+                "target_section": "tool.web_search.description",
+                "previous_value": "old",
+                "new_value": "the applied content",
+                "rationale": "r",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mutations_reader, "MUTATION_AUDIT_LOG_PATH", ledger)
+    target, value, kind = auto_train._applied_diff_for_mutation("mut-xyz")
+    assert target == "tool.web_search.description"
+    assert value == "the applied content"
+    assert kind == "tool_policy"
+    # and the hash of that value is what build_run_provenance would record
+    assert build_run_provenance(applied_new_value=value).applied_diff_hash == hash_text(
+        "the applied content"
+    )
+
+
+def test_applied_diff_lookup_unknown_id_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.self_improving_loop import mutations_reader
+
+    ledger = tmp_path / "mutations.jsonl"
+    ledger.write_text("", encoding="utf-8")
+    monkeypatch.setattr(mutations_reader, "MUTATION_AUDIT_LOG_PATH", ledger)
+    assert auto_train._applied_diff_for_mutation("nonexistent") == (None, None, None)

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.96"
+version = "0.99.97"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Make every per-cycle self-improving-loop ledger row INDEPENDENTLY RE-RUNNABLE: capture 4 reproducibility pins at the audit-dispatch point of truth and record them on BOTH sinks (the `mutations.jsonl` attribution row + the `baseline_archive.jsonl` registry row), all None-omitting / backward-compatible.
- Pins: `prompt_hash` (sha256 of the composed `WRAPPER_PROMPT_SECTIONS` the target ran under), `applied_diff` (sha256 of the applied mutation's `new_value` + its `target_section`/`target_kind`, read from the `kind="applied"` row), `sampling_params` (audit-dispatch params as sent), `rng_seed` (the audit seed as sent).
- AUDITABILITY, not determinism: the pins record WHAT WAS SENT; they make NO backend-determinism claim.

## Why
E1-E4 made each row's *outcome* statistically honest (fitness scale, held-out ruler, control-arm tag, variance decomposition). But a row was still not a *recipe* — a third party could not reconstruct what produced an audit result: which prompt the target ran under, which scaffold diff was applied, what params were sent. E5 adds those remaining reproducibility pins so a row is independently re-runnable.

Per-role model/lane/source is already recorded (`role_provenance.py`); E3 records `promote_policy(+seed)`; E4 records replicate/power. E5 fills the gap.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/run_provenance.py` | **New module.** `hash_text` (sha256, None-safe), `compose_wrapper_prompt` (sort_keys canonical serialise → stable+sensitive), `RunProvenanceFields` bundle (`as_record_kwargs` omits None pins), `build_run_provenance` (assembles pins from what was sent). |
| `core/self_improving_loop/attribution.py` | Add 6 None-defaulting schema fields to `AttributionRecord`; `compute_attribution` / `write_attribution` accept a `run_provenance` bundle, spliced via `as_record_kwargs()` BEFORE the None-baseline early return (so a no-baseline cycle still records its pins). |
| `autoresearch/train.py` | `_audit_sampling_params_as_sent` (resolved effective dispatch params; per-token knobs `temperature`/`top_p`/`max_tokens` recorded as `"_unpinned"`); `_applied_diff_for_mutation` (reads the `kind="applied"` row by `GEODE_SIL_MUTATION_ID`, graceful all-None on miss); build `_e5_run_provenance` at the point of truth (`wrapper_sections=WRAPPER_PROMPT_SECTIONS`, `rng_seed=None`) + thread into both sinks (`run_provenance=` on attribution + `"run_provenance"` in the baseline provenance dict → `_write_baseline` → `_append_baseline_registry_row`). |
| `pyproject.toml` | `max-args` ratchet 21 → 22 (the `_append_baseline_registry_row` provenance sink gains the bundled `run_provenance` arg; comment updated honestly). Version 0.99.96 → 0.99.97. |
| `tests/autoresearch/test_reproducibility_pins.py` | **New, 24 tests.** prompt_hash stable+sensitive; applied_diff hash + section/kind; sampling_params marks unpinned knobs; rng_seed honest None; backward-compat (no-pin cycle → row omits all pins, schema validates); graceful casts; main()-wiring static guards. |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `README.ko.md` | v0.99.97 + `### Added` E5 entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| prompt_hash | Implemented | sha256 of the actual composed wrapper prompt the target runs under |
| applied_diff | Implemented | sha256 of applied `new_value` + `target_section` + `target_kind` from the apply row (not the rationale) |
| sampling_params | Implemented | dispatch params as sent; per-token knobs `"_unpinned"` (GEODE does not pin them) |
| rng_seed | Implemented | recorded as sent — `None` today (GEODE sends no `--seed`); NOT fabricated, NO determinism flag |

## Determinism / ctx7 attestation
ctx7 `/ukgovernmentbeis/inspect_ai` (2026-05-30): `GenerateConfig` ACCEPTS `seed`/`temperature`/`top_p` (SDK contract) but does NOT document that any backend — least of all GEODE's claude-cli / codex-cli OAuth subscription providers — HONORS `seed` for bit-identical replay. Contract is `unverified — live test required`. No determinism flag set to `True`; pins are for AUDITABILITY (what was sent) only.

## Verification
- [x] ruff check clean (`core/ autoresearch/ scripts/ tests/`)
- [x] ruff format --check clean
- [x] mypy clean (`core/ plugins/` — 464 files)
- [x] lint-imports clean (4 contracts kept, 0 broken)
- [x] pytest pass — 24 new E5 tests; 764 related (self_improving/attribution/mutations_reader/baseline) pass, 0 fail; full `tests/autoresearch/` 200 pass
- [x] dry-run `autoresearch/train.py --dry-run` runs end-to-end (prints `e5_prompt_hash`)
- [x] Codex MCP read-only adversarial review: No blockers found (all 6 criteria OK — capture-at-point-of-truth, stable+sensitive hash, no unverified determinism claim, backward-compat, graceful casts, writer⇄reader parity)

## Reference
E-track follow-on to E1 (fitness scale) / E2 (held-out) / E3 (control arms) / E4 (replicate+power). Frontier pattern: reproducible eval-run provenance (inspect_ai eval headers, W&B run config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)