### PR TITLE
feat(self-improving): honest evidence page — methods + results + power (E6, v0.99.98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,48 @@ functional change.
 
 ---
 
+## [0.99.98] - 2026-05-30
+
+### Added
+- **E6 (2026-05-30) — honest evidence page: methods + results + power.** A dedicated
+  EVIDENCE sub-page under the autoresearch hub
+  (`/geode/self-improving/autoresearch/evidence/`) that a skeptical reader uses to
+  judge one question — *does scaffold-selection actually improve safety fitness?* —
+  reading ONLY the git-tracked ledgers (`mutations.jsonl` attribution rows +
+  `baseline_archive.jsonl`), with measured values only (no fabricated numbers, no
+  placeholders). Rendered by `scripts/build_self_improving_hub.py`
+  (`render_autoresearch_evidence` + new template
+  `docs/self-improving/autoresearch/evidence.html.template` + an Evidence nav link
+  added to all autoresearch sidebars + the landing sub-view table, now 5 sub-pages).
+  Three sections:
+  - **Methods** — the experimental design, honestly: the FROZEN held-out ruler (E2,
+    `held_out_bench_id`, disjoint from the selection pool) vs the pinned SELECTION
+    pool (B2, `pool-68dc6f0c9745`); the 3 control ARMS (E3: `gate`=selection /
+    `random`=random-accept / `never`=no-mutation floor); per-mutation REPLICATE +
+    the ci-excludes-0 rule (E4); REPRODUCIBILITY pins (E5: prompt_hash / applied_diff
+    / sampling_params / rng_seed); content-addressed EPOCH partition (A). Explains
+    WHY only the held-out curve is evidence and why the cross-arm comparison isolates
+    selection from drift / judge-noise.
+  - **Results** — the per-cycle `held_out_fitness` curve PER ARM (split by
+    `promote_policy`), the 3-arm comparison on the fixed ruler (mean held-out fitness
+    + promotion count per arm), and the per-cycle / per-campaign
+    `gain_ci_excludes_zero` verdict. Dense tables; pre-E1 mixed-scale rows excluded
+    from aggregates. **0 promotions is stated plainly as a TRUST-INCREASING result.**
+  - **Power** — the required `N_seed × M_replicate` line COMPUTED from the recorded
+    combined σ (`√(within²+between²)`) at δ=0.02 / α=0.05 / 80% power (the stdlib
+    `_required_n_seed` mirrors `core/self_improving_loop/statistical_power.py`'s
+    formula, pinned by a drift-guard test), plus the honest verdict: "no evidence
+    yet" when the gain CI includes 0, "indeterminate" when σ is unrecorded — never a
+    fabricated N.
+  - **Graceful empty state.** The matched 3-arm 10-cycle has not run yet, so the page
+    renders the full structure with an honest "awaiting the 3-arm campaign" /
+    "no held-out campaign recorded yet" / "no evidence yet" state where curves / arms
+    are empty — no crash, no fabricated number. The same renderer populates when the
+    campaign later writes the rows. 11 new tests in
+    `tests/test_self_improving_hub_e2e.py` (3-section render, graceful empty state,
+    populated per-arm curve + verdict, power from recorded σ, no-slop, core
+    drift-guards for the arm map + power constants).
+
 ## [0.99.97] - 2026-05-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.97
+- **Version**: 0.99.98
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 396 core + 69 plugins = 465
+- **Modules**: 395 core + 69 plugins = 464
 - **Tests**: 8538 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.97 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.98 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.97 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.98 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/design/self-improving-autoresearch-evidence.md
+++ b/docs/design/self-improving-autoresearch-evidence.md
@@ -1,0 +1,75 @@
+---
+title: DESIGN.md · `/geode/self-improving/autoresearch/evidence/` (Evidence)
+geode_version: 0.99.65
+schema_version: 1
+last_updated: 2026-05-30
+applies_to_geode: ">=0.99.65"
+parent: self-improving-hub-system.md
+---
+
+# DESIGN.md · `/geode/self-improving/autoresearch/evidence/` (Evidence)
+
+> Read [self-improving-hub-system.md](./self-improving-hub-system.md) first.
+
+## 1. Page purpose
+
+ONE honest evidence page — methods + results + power — that a skeptical reader uses
+to judge a single question: **does scaffold-selection actually improve safety
+fitness?** This is EVIDENCE, not presentation. `0 promotions` is a
+TRUST-INCREASING result (a loop that promotes nothing on null evidence is behaving
+correctly) and the page states it plainly. Where a matched campaign has not run
+yet, the page renders an honest "awaiting" / "no evidence yet" state — never a
+fabricated curve, never a placeholder number (CLAUDE.md: measured values only).
+
+This is the hub-SERVING synthesis endpoint for the evidence track. The interactive
+per-cycle held-out curve still renders on the Mutations page (E2-wire's
+`_render_held_out_curve`); this page is the comprehensive synthesis.
+
+## 2. Data sources (recorded ledgers only)
+
+| Source | Used for |
+|---|---|
+| `autoresearch/state/mutations.jsonl` (attribution rows) | per-cycle `held_out_fitness` curve PER ARM (`promote_policy`), `gain_ci_excludes_zero` / `gain_verdict` / `gain_ci_low` / `gain_ci_high` verdicts, `within_mutation_stderr` + `between_seed_stderr` for the power σ |
+| `autoresearch/state/baseline_archive.jsonl` (`kind="baseline"` rows) | promotion count PER ARM (`promote_policy`), per-promote gain verdict |
+
+Pre-E1 mixed-scale rows (`fitness_before > 1.0`) are excluded from aggregates
+(reuses the E1b heuristic). The held-out fields are read directly (they are already
+on the canonical 0-1 fitness scale).
+
+## 3. Sidebar `.active`
+
+`Autoresearch > Evidence`
+
+## 4. Sections
+
+1. **Methods** — the experimental design, honestly: the FROZEN held-out ruler (E2,
+   `held_out_bench_id`) vs the pinned SELECTION pool (B2, `pool-68dc6f0c9745`); the
+   3 ARMS (E3: gate / random / never); per-mutation REPLICATE + the ci-excludes-0
+   rule (E4); REPRODUCIBILITY pins (E5: prompt_hash / applied_diff / sampling_params
+   / rng_seed); content-addressed EPOCH partition (A). Explains WHY (the
+   co-evolving-ruler problem — only the held-out curve is evidence; cross-arm
+   comparison isolates selection from drift / judge-noise).
+2. **Results** — the per-cycle `held_out_fitness` curve PER ARM, the 3-arm
+   comparison on the fixed ruler (mean held-out fitness + promotion count per arm),
+   and the per-cycle / per-campaign `gain_ci_excludes_zero` verdict. Dense tables.
+   Honest empty state per arm when no cycle recorded.
+3. **Power** — the required `N_seed × M_replicate` line computed from the recorded
+   σ (`√(within²+between²)`) at δ=0.02, α=0.05, 80% power (the formula mirrors
+   `core/self_improving_loop/statistical_power.py::required_samples`) + the honest
+   verdict ("no evidence yet" when the gain CI includes 0; "indeterminate" when σ is
+   unrecorded — never a fabricated N).
+
+## 5. Renderer
+
+`scripts/build_self_improving_hub.py::render_autoresearch_evidence` →
+`docs/self-improving/autoresearch/evidence/index.html`. Section bodies:
+`_render_evidence_methods` / `_render_evidence_methods_arms` /
+`_render_evidence_results` / `_render_evidence_verdict` / `_render_evidence_power`.
+The stdlib power-formula mirror `_required_n_seed` + the arm map `_EVIDENCE_ARMS`
+are kept in lockstep with core by drift-guard tests.
+
+## 6. No-slop
+
+Dense `<table class="records">` + `<dl class="status-grid">` only. No card grid, no
+colored `border-left` accent bar, no emoji, no `XXXX` placeholder. Verified by
+`tests/test_self_improving_hub_e2e.py::test_evidence_page_no_slop`.

--- a/docs/design/self-improving-hub-system.md
+++ b/docs/design/self-improving-hub-system.md
@@ -13,6 +13,7 @@ sibling_pages:
   - self-improving-autoresearch-baseline.md
   - self-improving-autoresearch-mutations.md
   - self-improving-autoresearch-results.md
+  - self-improving-autoresearch-evidence.md
   - self-improving-autoresearch-policies.md
 ---
 

--- a/docs/self-improving/autoresearch/baseline.html.template
+++ b/docs/self-improving/autoresearch/baseline.html.template
@@ -47,6 +47,7 @@
         <li><a href="/geode/self-improving/autoresearch/baseline/" class="active" aria-current="page">Baseline</a></li>
         <li><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a></li>
         <li><a href="/geode/self-improving/autoresearch/results/">Results</a></li>
+        <li><a href="/geode/self-improving/autoresearch/evidence/">Evidence</a></li>
         <li><a href="/geode/self-improving/autoresearch/policies/">Policies</a></li>
       </ul>
 

--- a/docs/self-improving/autoresearch/evidence.html.template
+++ b/docs/self-improving/autoresearch/evidence.html.template
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Policies &middot; Autoresearch &middot; GEODE Self-Improving Hub</title>
-<meta name="description" content="Autoresearch policies — 14 git-tracked policy SoT files under autoresearch/state/policies/, one row per file with JSON pretty-print drill-down.">
+<title>Evidence &middot; Autoresearch &middot; GEODE Self-Improving Hub</title>
+<meta name="description" content="Honest evidence page for scaffold-selection: methods (frozen held-out ruler vs pinned selection pool, 3 control arms, replicate + ci-excludes-0, reproducibility pins, content-addressed epochs), results (per-arm held-out curve, 3-arm comparison, promotion count, ci verdict), and power (required N x M, honest null).">
 <link rel="stylesheet" href="/geode/self-improving/assets/hub.css">
 </head>
 <body>
@@ -47,8 +47,8 @@
         <li><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a></li>
         <li><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a></li>
         <li><a href="/geode/self-improving/autoresearch/results/">Results</a></li>
-        <li><a href="/geode/self-improving/autoresearch/evidence/">Evidence</a></li>
-        <li><a href="/geode/self-improving/autoresearch/policies/" class="active" aria-current="page">Policies</a></li>
+        <li><a href="/geode/self-improving/autoresearch/evidence/" class="active" aria-current="page">Evidence</a></li>
+        <li><a href="/geode/self-improving/autoresearch/policies/">Policies</a></li>
       </ul>
 
       <div class="nav-section">Docs</div>
@@ -66,27 +66,25 @@
   </aside>
 
   <main class="content">
-    <h1 class="page-title">Policies <span class="bucket autoresearch">autoresearch</span></h1>
-    <p class="page-sub">14 git-tracked policy SoT files under <code>autoresearch/state/policies/</code>. Each row links to the live JSON via a <code>&lt;details&gt;</code> drill-down. The "mutated by" cell points at the most recent <code>mutations.jsonl</code> row touching that policy.</p>
+    <h1 class="page-title">Evidence <span class="bucket autoresearch">autoresearch</span></h1>
+    <p class="page-sub">One honest page to judge a single question: <strong>does scaffold-selection actually improve safety fitness?</strong> Methods, results, and power, read from the git-tracked ledgers (<code>mutations.jsonl</code> + <code>baseline_archive.jsonl</code>) — measured values only, no fabricated numbers. <strong>0 promotions is a trust-increasing result, not a failure</strong>: a loop that promotes nothing on null evidence is behaving correctly. Where a matched campaign has not run yet, the section says so plainly rather than inventing a curve.</p>
 
-    <h2 class="section"><span>Policies &middot; {{ policies_section_label }}</span></h2>
-    <table class="records">
-      <thead>
-        <tr>
-          <th scope="col">file</th>
-          <th scope="col">last write</th>
-          <th scope="col">size</th>
-          <th scope="col">mutated by</th>
-          <th scope="col">view</th>
-        </tr>
-      </thead>
-      <tbody>
-{{ policies_rows }}
-      </tbody>
-    </table>
+    <h2 class="section"><span>1 &middot; Methods</span></h2>
+    <p class="page-sub">The experimental design, honestly. The only valid evidence of cross-generation improvement is the <strong>frozen held-out ruler</strong>; everything else (the co-evolving selection pool, a single arm's drift, judge noise) is a confound the design isolates.</p>
+{{ methods_grid }}
+{{ methods_arms }}
+
+    <h2 class="section"><span>2 &middot; Results</span></h2>
+    <p class="page-sub">Read from the recorded ledgers. The per-cycle held-out curve PER ARM (split by <code>promote_policy</code>), the 3-arm comparison on the fixed ruler, promotion count per arm, and the ci-excludes-0 verdict. Pre-E1 mixed-scale rows (<code>fitness_before &gt; 1.0</code>) are excluded from aggregates. When no matched 3-arm held-out campaign has been recorded, this section renders the honest "awaiting" state below.</p>
+{{ results_arms }}
+{{ results_verdict }}
+
+    <h2 class="section"><span>3 &middot; Power</span></h2>
+    <p class="page-sub">How many samples are needed to detect a target effect &delta; at 80% power, given the observed fitness-noise &sigma; (recorded E4 decomposition). When the gain CI includes 0 the verdict is "no evidence yet" — stated plainly, not hedged.</p>
+{{ power_block }}
 
     <div class="build-info">
-      <p>Source: <code>autoresearch/state/policies/*.json</code> (14 git-tracked SoT files) &amp; <code>mutations.jsonl</code> for cross-link.</p>
+      <p>Source: <code>autoresearch/state/mutations.jsonl</code> (per-cycle attribution rows: <code>held_out_fitness</code> &middot; <code>promote_policy</code> &middot; <code>gain_ci_excludes_zero</code> &middot; <code>gain_verdict</code> &middot; <code>within_mutation_stderr</code> &middot; <code>between_seed_stderr</code>) + <code>baseline_archive.jsonl</code> (promoted-baseline rows per arm).</p>
       <p>Published by <code>.github/workflows/pages.yml</code> on every <code>main</code> push.</p>
       <p>Repo: <a href="https://github.com/mangowhoiscloud/geode" rel="noopener">github.com/mangowhoiscloud/geode</a></p>
       <p>Harness chip legend:

--- a/docs/self-improving/autoresearch/index.html.template
+++ b/docs/self-improving/autoresearch/index.html.template
@@ -47,6 +47,7 @@
         <li><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a></li>
         <li><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a></li>
         <li><a href="/geode/self-improving/autoresearch/results/">Results</a></li>
+        <li><a href="/geode/self-improving/autoresearch/evidence/">Evidence</a></li>
         <li><a href="/geode/self-improving/autoresearch/policies/">Policies</a></li>
       </ul>
 
@@ -95,7 +96,7 @@
     <p class="page-sub">Each promote appends a <code>kind="baseline"</code> row to <code>baseline_archive.jsonl</code>, partitioned into content-addressed <strong>epochs</strong> (be-NNN) keyed by a hash of the production+measurement spec (margin rule, fitness/margin logic version, the four roles' model+source, rubric, dim set, bench, seed-pool identity). Baselines from different epochs were produced under different logic and are <strong>not comparable</strong> — they are never merged into one table.</p>
 {{ baseline_registry_index }}
 
-    <h2 class="section"><span>Sub-views &middot; 4 autoresearch sub-pages</span></h2>
+    <h2 class="section"><span>Sub-views &middot; 5 autoresearch sub-pages</span></h2>
     <table class="records">
       <thead>
         <tr>

--- a/docs/self-improving/autoresearch/mutations.html.template
+++ b/docs/self-improving/autoresearch/mutations.html.template
@@ -47,6 +47,7 @@
         <li><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a></li>
         <li><a href="/geode/self-improving/autoresearch/mutations/" class="active" aria-current="page">Mutations</a></li>
         <li><a href="/geode/self-improving/autoresearch/results/">Results</a></li>
+        <li><a href="/geode/self-improving/autoresearch/evidence/">Evidence</a></li>
         <li><a href="/geode/self-improving/autoresearch/policies/">Policies</a></li>
       </ul>
 

--- a/docs/self-improving/autoresearch/results.html.template
+++ b/docs/self-improving/autoresearch/results.html.template
@@ -47,6 +47,7 @@
         <li><a href="/geode/self-improving/autoresearch/baseline/">Baseline</a></li>
         <li><a href="/geode/self-improving/autoresearch/mutations/">Mutations</a></li>
         <li><a href="/geode/self-improving/autoresearch/results/" class="active" aria-current="page">Results</a></li>
+        <li><a href="/geode/self-improving/autoresearch/evidence/">Evidence</a></li>
         <li><a href="/geode/self-improving/autoresearch/policies/">Policies</a></li>
       </ul>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.97"
+version = "0.99.98"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -34,10 +34,12 @@ import contextlib
 import datetime as _dt
 import json
 import logging
+import math
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from statistics import NormalDist
 from typing import Any
 from urllib.parse import quote
 
@@ -71,7 +73,31 @@ AUTORESEARCH_RESULTS_TEMPLATE = (
 AUTORESEARCH_POLICIES_TEMPLATE = (
     REPO_ROOT / "docs" / "self-improving" / "autoresearch" / "policies.html.template"
 )
+AUTORESEARCH_EVIDENCE_TEMPLATE = (
+    REPO_ROOT / "docs" / "self-improving" / "autoresearch" / "evidence.html.template"
+)
 PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# E6 (2026-05-30) — the three control arms of the matched held-out comparison.
+# Mirrors the writer-side ``_VALID_PROMOTE_POLICIES`` in ``autoresearch/train.py``
+# (kept stdlib-only here, in lockstep by ``test_evidence_arm_map_matches_core``).
+# gate = selection arm; random = random-accept control; never = no-mutation floor.
+_EVIDENCE_ARMS: tuple[tuple[str, str], ...] = (
+    ("gate", "selection (promote gate)"),
+    ("random", "random-accept control"),
+    ("never", "no-mutation floor"),
+)
+
+# E6 (2026-05-30) — the standard two-sample mean-difference power constants,
+# MIRRORING the SoT in ``core/self_improving_loop/statistical_power.py`` (this
+# builder is intentionally stdlib-only so it cannot import core). The defaults
+# below are the same δ / α / power the writer powers for; the formula
+# (``n ≈ 2(z_{α/2}+z_β)²σ²/δ²``) is reproduced in ``_required_n_seed`` so the page
+# computes N from the RECORDED σ (never a fabricated number). Kept in lockstep by
+# ``test_evidence_power_constants_match_core``.
+_POWER_DEFAULT_TARGET_EFFECT_SIZE = 0.02
+_POWER_DEFAULT_ALPHA = 0.05
+_POWER_DEFAULT_POWER = 0.8
 
 # 12-col header from autoresearch/train.py:1284 RESULTS_TSV_HEADER.
 # Verified against actual code (P-Phase-6 baseline 2026-05-26).
@@ -4280,8 +4306,14 @@ def _autoresearch_subview_rows(
     results_mtime: str,
     policies_mtime: str,
     baseline_mtime: str,
+    held_out_count: int,
 ) -> str:
-    """Render the 4-row sub-view table on the landing page."""
+    """Render the 5-row sub-view table on the landing page.
+
+    ``held_out_count`` is the number of per-cycle held-out points recorded so far
+    (the evidence page's synthesis input); a 0 reads as "awaiting" on that row,
+    matching the page's graceful empty state.
+    """
     rows = [
         (
             "Baseline",
@@ -4301,6 +4333,16 @@ def _autoresearch_subview_rows(
             f"{results_count} rows",
             results_mtime,
             "/geode/self-improving/autoresearch/results/",
+        ),
+        (
+            "Evidence",
+            (
+                f"{held_out_count} held-out points"
+                if held_out_count
+                else "<span class='muted'>awaiting campaign</span>"
+            ),
+            mutations_mtime,
+            "/geode/self-improving/autoresearch/evidence/",
         ),
         (
             "Policies",
@@ -4703,6 +4745,511 @@ def _render_held_out_curve(mutations: list[dict[str, Any]]) -> str:
     )
 
 
+# --------------------------------------------------------------------------- #
+# E6 (2026-05-30) — the honest evidence page (methods + results + power).      #
+# Reads the recorded ledgers ONLY (mutations.jsonl attribution rows +          #
+# baseline_archive.jsonl promoted rows). Measured values only — when a matched #
+# 3-arm held-out campaign has not run yet, every section renders an honest     #
+# "awaiting" state rather than a fabricated curve / placeholder number.        #
+# --------------------------------------------------------------------------- #
+def _required_n_seed(sigma: float | None) -> int | None:
+    """Required N_seed per arm to detect ``_POWER_DEFAULT_TARGET_EFFECT_SIZE`` at
+    ``_POWER_DEFAULT_POWER`` given the RECORDED combined fitness-stderr ``sigma``.
+
+    Mirrors ``core.self_improving_loop.statistical_power.required_samples`` (the
+    stdlib-only builder cannot import core): the textbook two-sample mean-difference
+    sample size ``n ≈ 2·(z_{α/2}+z_β)²·σ²/δ²`` per arm, rounded UP. Computed from the
+    σ actually recorded on the E4 rows — NOT a fabricated number — so the page never
+    invents an N.
+
+    Graceful contract: ``sigma is None`` (no variance observed yet), a non-finite /
+    negative σ, or δ ≤ 0 yields ``None`` (the caller renders "indeterminate" rather
+    than crashing). σ == 0 (perfectly stable) yields 1 (a single sample detects any
+    δ > 0 when there is no noise) — identical to the writer's contract.
+    """
+    if sigma is None:
+        return None
+    try:
+        sigma_value = float(sigma)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(sigma_value) or sigma_value < 0.0:
+        return None
+    delta = _POWER_DEFAULT_TARGET_EFFECT_SIZE
+    if delta <= 0.0:
+        return None
+    if sigma_value == 0.0:
+        return 1
+    z_alpha = NormalDist().inv_cdf(1.0 - _POWER_DEFAULT_ALPHA / 2.0)
+    z_beta = NormalDist().inv_cdf(_POWER_DEFAULT_POWER)
+    raw_n = 2.0 * (z_alpha + z_beta) ** 2 * (sigma_value**2) / (delta**2)
+    truncated = int(raw_n)
+    n_seed = truncated if truncated == raw_n else truncated + 1
+    return max(1, n_seed)
+
+
+def _held_out_attribution_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Attribution rows carrying a numeric ``held_out_fitness``, ordered by ts.
+
+    Graceful at every cast: a non-numeric ``held_out_fitness`` / ``ts`` is skipped
+    (it cannot place a positionable curve point) rather than raising. ``promote_policy``
+    defaults to ``"gate"`` when the row predates E3 (legacy rows are the selection arm).
+    """
+    points: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("kind") != "attribution":
+            continue
+        raw_fitness = row.get("held_out_fitness")
+        if raw_fitness is None:
+            continue
+        try:
+            fitness = float(raw_fitness)
+        except (TypeError, ValueError):
+            continue
+        raw_ts = row.get("ts")
+        if not isinstance(raw_ts, int | float) or isinstance(raw_ts, bool):
+            continue
+        arm = row.get("promote_policy")
+        points.append(
+            {
+                "ts": float(raw_ts),
+                "held_out_fitness": fitness,
+                "held_out_bench_id": str(row.get("held_out_bench_id") or "—"),
+                # Legacy rows (pre-E3) have no promote_policy → treat as the gate arm
+                # (the only arm that existed before the control arms were added).
+                "arm": str(arm) if isinstance(arm, str) and arm else "gate",
+            }
+        )
+    points.sort(key=lambda point: point["ts"])
+    return points
+
+
+def _evidence_gain_verdicts(
+    mutations: list[dict[str, Any]],
+    archive: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Collect the recorded ci-excludes-0 gain verdicts from both ledgers.
+
+    Reads ``gain_ci_excludes_zero`` / ``gain_verdict`` / ``gain_ci_low`` /
+    ``gain_ci_high`` from the attribution rows (per-cycle) and the
+    ``kind="baseline"`` archive rows (per-campaign promote). A row with no recorded
+    verdict (``gain_ci_excludes_zero is None``) contributes nothing. Graceful at the
+    cast boundary: a non-numeric CI bound is rendered as "—", never raises.
+    """
+    out: list[dict[str, Any]] = []
+
+    def _maybe_float(value: Any) -> float | None:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _scan(source_rows: list[dict[str, Any]], source: str, ts_key: str) -> None:
+        for row in source_rows:
+            excludes = row.get("gain_ci_excludes_zero")
+            if not isinstance(excludes, bool):
+                continue
+            out.append(
+                {
+                    "source": source,
+                    "ts": _maybe_float(row.get(ts_key)),
+                    "arm": (
+                        str(row.get("promote_policy"))
+                        if isinstance(row.get("promote_policy"), str) and row.get("promote_policy")
+                        else "gate"
+                    ),
+                    "excludes_zero": excludes,
+                    "verdict": (
+                        str(row.get("gain_verdict"))
+                        if isinstance(row.get("gain_verdict"), str) and row.get("gain_verdict")
+                        else ("gain significant" if excludes else "no evidence yet")
+                    ),
+                    "ci_low": _maybe_float(row.get("gain_ci_low")),
+                    "ci_high": _maybe_float(row.get("gain_ci_high")),
+                }
+            )
+
+    _scan(mutations, "cycle", "ts")
+    _scan(archive, "promote", "ts_utc")
+    return out
+
+
+def _evidence_combined_sigma(mutations: list[dict[str, Any]]) -> float | None:
+    """Most-recent recorded combined fitness-stderr ``√(within²+between²)``.
+
+    Reads ``within_mutation_stderr`` + ``between_seed_stderr`` from the LATEST
+    attribution row that recorded either (ordered by ts). A missing component is
+    treated as 0 (the other dominates) — identical to the writer's
+    ``VarianceDecomposition.combined_stderr`` contract. Returns ``None`` when no row
+    recorded either component (no variance signal yet → the power line says so).
+    Graceful: every cast guarded.
+    """
+    latest_ts: float = float("-inf")
+    latest_sigma: float | None = None
+    for row in mutations:
+        if not isinstance(row, dict) or row.get("kind") != "attribution":
+            continue
+        raw_ts = row.get("ts")
+        if not isinstance(raw_ts, int | float) or isinstance(raw_ts, bool):
+            continue
+        within = row.get("within_mutation_stderr")
+        between = row.get("between_seed_stderr")
+
+        def _comp(value: Any) -> float | None:
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                return None
+            try:
+                f = float(value)
+            except (TypeError, ValueError):
+                return None
+            return f if math.isfinite(f) and f >= 0.0 else None
+
+        w = _comp(within)
+        b = _comp(between)
+        if w is None and b is None:
+            continue
+        combined = ((w or 0.0) ** 2 + (b or 0.0) ** 2) ** 0.5
+        if float(raw_ts) >= latest_ts:
+            latest_ts = float(raw_ts)
+            latest_sigma = combined
+    return latest_sigma
+
+
+def _render_evidence_methods() -> str:
+    """Render the METHODS grid — the experimental design, stated honestly.
+
+    Static design facts (the design does not change per-render), as a dense
+    definition list: the frozen held-out ruler vs the pinned selection pool (E2/B2),
+    the per-mutation replicate + ci-excludes-0 rule (E4), reproducibility pins (E5),
+    and the content-addressed epoch partition (A). Plain text + monospace only — no
+    card grid, accent bar, or emoji.
+    """
+    rows: list[tuple[str, str]] = [
+        (
+            "held-out ruler (E2)",
+            "VERSION-FROZEN bench (<code>held_out_bench_id</code>), an older-runs set "
+            "DISJOINT from the selection pool. <code>held_out_fitness</code> is the SAME "
+            "0-1 <code>compute_fitness</code> (HIGHER-is-better) scored on it EVERY cycle. "
+            "Because the bench never mutates, this curve IS comparable across generations.",
+        ),
+        (
+            "selection pool (B2)",
+            "the PINNED co-evolving pool <code>pool-68dc6f0c9745</code> the loop selects on. "
+            "It co-evolves, so the intrinsic <code>fitness</code> measured on it is NOT "
+            "cross-generation evidence — only the held-out ruler is.",
+        ),
+        (
+            "3 control arms (E3)",
+            "<code>gate</code> = selection (promote gate) &middot; <code>random</code> = "
+            "random-accept control &middot; <code>never</code> = no-mutation floor. The "
+            "cross-arm comparison on the SAME fixed ruler isolates selection from drift + "
+            "judge noise: if gate does not beat random + never on the held-out curve, the "
+            "improvement is not from selection.",
+        ),
+        (
+            "replicate + ci-excludes-0 (E4)",
+            "per-mutation replicate <code>M</code> (repeated audits of the same cycle) "
+            "decomposes provider jitter (within) from seed heterogeneity (between). A gain "
+            "is CLAIMED only when its confidence interval excludes 0 "
+            "(<code>gain_ci_excludes_zero</code>); otherwise the honest verdict is "
+            '"no evidence yet".',
+        ),
+        (
+            "reproducibility pins (E5)",
+            "each cycle records <code>prompt_hash</code> &middot; <code>applied_diff_hash</code> "
+            "&middot; <code>sampling_params</code> &middot; <code>rng_seed</code> so a third "
+            "party can reconstruct WHAT WAS SENT (auditability — no backend-determinism claim).",
+        ),
+        (
+            "epoch partition (A)",
+            "every promoted baseline is hashed into a content-addressed epoch (be-NNN) keyed "
+            "on the production+measurement spec; baselines from different epochs were produced "
+            "under different logic and are never averaged into one comparison.",
+        ),
+    ]
+    out: list[str] = ['    <dl class="status-grid">']
+    for label, value in rows:
+        out.append(f"      <dt>{html_escape(label)}</dt><dd>{value}</dd>")
+    out.append("    </dl>")
+    return "\n".join(out)
+
+
+def _render_evidence_methods_arms() -> str:
+    """Render the 3-arm definition table for the methods section (dense table)."""
+    rows: list[str] = []
+    for arm, label in _EVIDENCE_ARMS:
+        rows.append(
+            "        <tr>\n"
+            f"          <td><code>{html_escape(arm)}</code></td>\n"
+            f"          <td>{html_escape(label)}</td>\n"
+            "        </tr>"
+        )
+    rows_html = "\n".join(rows)
+    return (
+        '    <h3 class="section"><span>Control arms</span></h3>\n'
+        '    <table class="records">\n'
+        "      <thead>\n"
+        "        <tr>\n"
+        '          <th scope="col"><code>promote_policy</code></th>\n'
+        '          <th scope="col">role on the fixed ruler</th>\n'
+        "        </tr>\n"
+        "      </thead>\n"
+        "      <tbody>\n"
+        f"{rows_html}\n"
+        "      </tbody>\n"
+        "    </table>"
+    )
+
+
+def _render_evidence_arm_curve(arm: str, label: str, points: list[dict[str, Any]]) -> str:
+    """Render one arm's per-cycle held-out curve (or its honest empty state)."""
+    if not points:
+        return (
+            f'    <h3 class="section"><span>{html_escape(label)} '
+            f"&middot; <code>{html_escape(arm)}</code></span></h3>\n"
+            '    <p class="empty"><em>No held-out cycle recorded for this arm yet — '
+            "awaiting the matched 3-arm campaign.</em></p>"
+        )
+    rows: list[str] = []
+    prior: float | None = None
+    for index, point in enumerate(points, start=1):
+        fitness = point["held_out_fitness"]
+        if prior is None:
+            delta_cell = '<td class="num muted">—</td>'
+        else:
+            delta = fitness - prior
+            cls = "delta-positive" if delta > 0 else ("delta-negative" if delta < 0 else "muted")
+            delta_cell = f'<td class="num {cls}">{delta:+.4f}</td>'
+        prior = fitness
+        rows.append(
+            "        <tr>\n"
+            f'          <td class="num">{index}</td>\n'
+            f'          <td class="muted">{html_escape(_fmt_epoch(point["ts"]))}</td>\n'
+            f'          <td class="num">{fitness:.4f}</td>\n'
+            f"          {delta_cell}\n"
+            "        </tr>"
+        )
+    rows_html = "\n".join(rows)
+    return (
+        f'    <h3 class="section"><span>{html_escape(label)} '
+        f"&middot; <code>{html_escape(arm)}</code> &middot; "
+        f"{len(points)} generation" + ("s" if len(points) != 1 else "") + "</span></h3>\n"
+        '    <table class="records">\n'
+        "      <thead>\n"
+        "        <tr>\n"
+        '          <th scope="col" class="num">gen</th>\n'
+        '          <th scope="col">measured</th>\n'
+        '          <th scope="col" class="num">held-out fitness</th>\n'
+        '          <th scope="col" class="num">&Delta; vs prior</th>\n'
+        "        </tr>\n"
+        "      </thead>\n"
+        "      <tbody>\n"
+        f"{rows_html}\n"
+        "      </tbody>\n"
+        "    </table>"
+    )
+
+
+def _render_evidence_results(
+    mutations: list[dict[str, Any]],
+    archive: list[dict[str, Any]],
+) -> str:
+    """Render the RESULTS section: per-arm held-out curve + 3-arm comparison +
+    promotion count per arm. Honest empty state when no campaign has run."""
+    points = _held_out_attribution_rows(mutations)
+    by_arm: dict[str, list[dict[str, Any]]] = {arm: [] for arm, _ in _EVIDENCE_ARMS}
+    for point in points:
+        by_arm.setdefault(point["arm"], []).append(point)
+
+    # Promotion count per arm from the promoted-baseline registry rows.
+    promo_by_arm: dict[str, int] = {arm: 0 for arm, _ in _EVIDENCE_ARMS}
+    for row in archive:
+        if not isinstance(row, dict) or row.get("kind") != "baseline":
+            continue
+        arm = row.get("promote_policy")
+        key = str(arm) if isinstance(arm, str) and arm else "gate"
+        promo_by_arm[key] = promo_by_arm.get(key, 0) + 1
+
+    blocks: list[str] = []
+
+    # 3-arm comparison summary (mean held-out fitness + promotion count per arm).
+    comparison_rows: list[str] = []
+    for arm, label in _EVIDENCE_ARMS:
+        arm_points = by_arm.get(arm, [])
+        if arm_points:
+            mean_fitness = sum(p["held_out_fitness"] for p in arm_points) / len(arm_points)
+            mean_cell = f'<td class="num">{mean_fitness:.4f}</td>'
+            n_cell = f'<td class="num">{len(arm_points)}</td>'
+        else:
+            mean_cell = '<td class="num muted">—</td>'
+            n_cell = '<td class="num muted">0</td>'
+        promo = promo_by_arm.get(arm, 0)
+        comparison_rows.append(
+            "        <tr>\n"
+            f"          <td><code>{html_escape(arm)}</code> "
+            f'<span class="muted">{html_escape(label)}</span></td>\n'
+            f"          {n_cell}\n"
+            f"          {mean_cell}\n"
+            f'          <td class="num">{promo}</td>\n'
+            "        </tr>"
+        )
+    comparison_html = "\n".join(comparison_rows)
+    total_points = len(points)
+    total_promos = sum(promo_by_arm.values())
+    if total_points == 0:
+        comparison_note = (
+            "No held-out cycle recorded on any arm yet — the matched 3-arm campaign has "
+            "not run. The table below shows the structure; values populate when the "
+            "campaign writes <code>held_out_fitness</code> + <code>promote_policy</code> rows."
+        )
+    else:
+        comparison_note = (
+            "Mean held-out fitness (the fixed ruler) per arm. Selection (<code>gate</code>) "
+            "is only evidenced if it beats BOTH controls on this ruler. "
+            f"Promotions across all arms: <strong>{total_promos}</strong>"
+            + (
+                " — <strong>0 promotions is a trust-increasing result</strong>: the loop "
+                "correctly promoted nothing on null evidence."
+                if total_promos == 0
+                else "."
+            )
+        )
+    blocks.append(
+        '    <h3 class="section"><span>3-arm comparison &middot; fixed ruler</span></h3>\n'
+        f'    <p class="page-sub">{comparison_note}</p>\n'
+        '    <table class="records">\n'
+        "      <thead>\n"
+        "        <tr>\n"
+        '          <th scope="col">arm</th>\n'
+        '          <th scope="col" class="num">held-out cycles</th>\n'
+        '          <th scope="col" class="num">mean held-out fitness</th>\n'
+        '          <th scope="col" class="num">promotions</th>\n'
+        "        </tr>\n"
+        "      </thead>\n"
+        "      <tbody>\n"
+        f"{comparison_html}\n"
+        "      </tbody>\n"
+        "    </table>"
+    )
+
+    # Per-arm curve (one table per arm; honest empty state per arm).
+    if total_points == 0:
+        blocks.append(
+            '    <p class="empty"><em>No held-out campaign recorded yet — awaiting the '
+            "matched 3-arm 10-cycle run. The per-arm curves render here once "
+            "<code>autoresearch/train.py</code> writes them.</em></p>"
+        )
+    else:
+        for arm, label in _EVIDENCE_ARMS:
+            blocks.append(_render_evidence_arm_curve(arm, label, by_arm.get(arm, [])))
+    return "\n".join(blocks)
+
+
+def _render_evidence_verdict(
+    mutations: list[dict[str, Any]],
+    archive: list[dict[str, Any]],
+) -> str:
+    """Render the per-cycle / per-campaign ci-excludes-0 verdict table (RESULTS).
+
+    Honest empty state when no row recorded a verdict yet.
+    """
+    verdicts = _evidence_gain_verdicts(mutations, archive)
+    if not verdicts:
+        return (
+            '    <h3 class="section"><span>Gain verdict &middot; ci excludes 0</span></h3>\n'
+            '    <p class="empty"><em>No gain verdict recorded yet — no cycle or promote has '
+            "written <code>gain_ci_excludes_zero</code>. With no evidence on disk, the honest "
+            "statement is: <strong>no evidence of a gain yet.</strong></em></p>"
+        )
+    rows: list[str] = []
+    for entry in verdicts:
+        excludes = bool(entry["excludes_zero"])
+        v_cls = "delta-positive" if excludes else "muted"
+        ci_low = entry["ci_low"]
+        ci_high = entry["ci_high"]
+        if ci_low is not None and ci_high is not None:
+            ci_cell = f'<td class="num">[{ci_low:+.4f}, {ci_high:+.4f}]</td>'
+        else:
+            ci_cell = '<td class="num muted">—</td>'
+        ts_value = entry["ts"]
+        ts_cell = (
+            f'<td class="muted">{html_escape(_fmt_epoch(ts_value))}</td>'
+            if isinstance(ts_value, float)
+            else '<td class="muted">—</td>'
+        )
+        rows.append(
+            "        <tr>\n"
+            f'          <td class="muted">{html_escape(entry["source"])}</td>\n'
+            f"          {ts_cell}\n"
+            f"          <td><code>{html_escape(entry['arm'])}</code></td>\n"
+            f"          {ci_cell}\n"
+            f'          <td><span class="{v_cls}">{html_escape(entry["verdict"])}</span></td>\n'
+            "        </tr>"
+        )
+    rows_html = "\n".join(rows)
+    return (
+        '    <h3 class="section"><span>Gain verdict &middot; ci excludes 0 &middot; '
+        f"{len(verdicts)} recorded</span></h3>\n"
+        '    <p class="page-sub">The explicit "ci excludes 0" evidence statement on the '
+        "fitness gain. <code>gain significant</code> only when the CI lies entirely above 0; "
+        "otherwise the honest null: <code>no evidence yet</code>.</p>\n"
+        '    <table class="records">\n'
+        "      <thead>\n"
+        "        <tr>\n"
+        '          <th scope="col">source</th>\n'
+        '          <th scope="col">measured</th>\n'
+        '          <th scope="col">arm</th>\n'
+        '          <th scope="col" class="num">gain CI</th>\n'
+        '          <th scope="col">verdict</th>\n'
+        "        </tr>\n"
+        "      </thead>\n"
+        "      <tbody>\n"
+        f"{rows_html}\n"
+        "      </tbody>\n"
+        "    </table>"
+    )
+
+
+def _render_evidence_power(mutations: list[dict[str, Any]]) -> str:
+    """Render the POWER section: the required-N line from the recorded σ + the
+    honest verdict. Never fabricates a number — σ unknown → "indeterminate"."""
+    sigma = _evidence_combined_sigma(mutations)
+    n_seed = _required_n_seed(sigma)
+    delta = _POWER_DEFAULT_TARGET_EFFECT_SIZE
+    alpha = _POWER_DEFAULT_ALPHA
+    power = _POWER_DEFAULT_POWER
+    if n_seed is None:
+        power_line = (
+            f"To detect &delta;={delta:.4f} fitness at {power:.0%} power "
+            f"(&alpha;={alpha:.2f}), observed &sigma; is <strong>unknown</strong> &mdash; "
+            "N indeterminate (insufficient variance signal; run <code>--replicate M&ge;2</code> "
+            "or a multi-sample audit to estimate &sigma;)."
+        )
+        sigma_cell = "<em>not yet estimated</em>"
+        n_cell = "<em>indeterminate</em>"
+    else:
+        power_line = (
+            f"To detect &delta;={delta:.4f} fitness at {power:.0%} power "
+            f"(&alpha;={alpha:.2f}), observed &sigma;={sigma:.4f} &rarr; "
+            f"need N_seed&ge;<strong>{n_seed}</strong> &times; M_replicate&ge;1."
+        )
+        sigma_cell = f'<span class="num">{sigma:.4f}</span>'
+        n_cell = f'<span class="num">{n_seed}</span>'
+    return (
+        '    <dl class="status-grid">\n'
+        f'      <dt>target effect &delta;</dt><dd><span class="num">{delta:.4f}</span> '
+        "(fitness scale, HIGHER-is-better)</dd>\n"
+        f'      <dt>significance &alpha;</dt><dd><span class="num">{alpha:.2f}</span></dd>\n'
+        f'      <dt>target power</dt><dd><span class="num">{power:.0%}</span></dd>\n'
+        f"      <dt>observed &sigma; (recorded)</dt><dd>{sigma_cell}</dd>\n"
+        f"      <dt>required N_seed per arm</dt><dd>{n_cell}</dd>\n"
+        "    </dl>\n"
+        f'    <p class="page-sub">{power_line}</p>'
+    )
+
+
 def _render_results_header_cells() -> str:
     """Render the 12 <th> cells for the results table header."""
     out: list[str] = []
@@ -4919,6 +5466,7 @@ def render_autoresearch_landing(
     *,
     template: str,
     ctx: _AutoresearchRenderCtx,
+    held_out_count: int = 0,
 ) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     mapping = _autoresearch_base_mapping(ctx)
@@ -4947,6 +5495,7 @@ def render_autoresearch_landing(
                 results_mtime=results_mtime,
                 policies_mtime=policies_mtime,
                 baseline_mtime=baseline_mtime,
+                held_out_count=held_out_count,
             ),
         }
     )
@@ -5121,6 +5670,43 @@ def render_autoresearch_policies(
     return out_path
 
 
+def render_autoresearch_evidence(
+    mutations: list[dict[str, Any]],
+    archive: list[dict[str, Any]],
+    out_dir: Path,
+    *,
+    template: str,
+    ctx: _AutoresearchRenderCtx,
+) -> Path:
+    """Render the E6 evidence page (methods + results + power) at
+    ``autoresearch/evidence/index.html``.
+
+    Reads the recorded ledgers ONLY (``mutations`` = mutations.jsonl rows;
+    ``archive`` = baseline_archive.jsonl rows). Every section degrades gracefully to
+    an honest "awaiting campaign" / "no evidence yet" state when the matched 3-arm
+    held-out campaign has not run — no crash, no fabricated number.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    mapping = _autoresearch_base_mapping(ctx)
+    mapping.update(
+        {
+            "methods_grid": _render_evidence_methods(),
+            "methods_arms": _render_evidence_methods_arms(),
+            "results_arms": _render_evidence_results(mutations, archive),
+            "results_verdict": _render_evidence_verdict(mutations, archive),
+            "power_block": _render_evidence_power(mutations),
+        }
+    )
+    rendered = substitute(template, mapping)
+    leftover = re.findall(r"\{\{\s*([a-zA-Z_]+)\s*\}\}", rendered)
+    if leftover:
+        raise RuntimeError(f"autoresearch evidence unresolved markers: {sorted(set(leftover))}")
+    out_path = out_dir / "evidence" / "index.html"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    return out_path
+
+
 # --------------------------------------------------------------------------- #
 # Substitution + write                                                        #
 # --------------------------------------------------------------------------- #
@@ -5193,6 +5779,11 @@ def main(argv: list[str] | None = None) -> int:
         "--autoresearch-policies-template",
         type=Path,
         default=AUTORESEARCH_POLICIES_TEMPLATE,
+    )
+    parser.add_argument(
+        "--autoresearch-evidence-template",
+        type=Path,
+        default=AUTORESEARCH_EVIDENCE_TEMPLATE,
     )
     args = parser.parse_args(argv)
 
@@ -5364,6 +5955,11 @@ def main(argv: list[str] | None = None) -> int:
         build_date=build_date,
     )
 
+    # E6 (2026-05-30) — held-out point count drives the landing sub-view row's
+    # "N held-out points" / "awaiting campaign" label (the same recorded data the
+    # evidence page synthesises). Counts attribution rows carrying held_out_fitness.
+    held_out_count = len(_held_out_attribution_rows(mutations_rows))
+
     # Each renderer runs independently; log and continue on failure so
     # one broken page doesn't prevent the others from publishing.
     def _safe(name: str, fn: Any) -> None:
@@ -5392,6 +5988,7 @@ def main(argv: list[str] | None = None) -> int:
             out_dir=args.autoresearch_out_dir,
             template=args.autoresearch_landing_template.read_text(encoding="utf-8"),
             ctx=ar_ctx,
+            held_out_count=held_out_count,
         ),
     )
     baseline_transcripts = _load_baseline_transcripts(
@@ -5435,6 +6032,16 @@ def main(argv: list[str] | None = None) -> int:
             mutations_rows,
             args.autoresearch_out_dir,
             template=args.autoresearch_policies_template.read_text(encoding="utf-8"),
+            ctx=ar_ctx,
+        ),
+    )
+    _safe(
+        "evidence",
+        lambda: render_autoresearch_evidence(
+            mutations_rows,
+            archive_rows,
+            args.autoresearch_out_dir,
+            template=args.autoresearch_evidence_template.read_text(encoding="utf-8"),
             ctx=ar_ctx,
         ),
     )

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -4810,14 +4810,19 @@ def _held_out_attribution_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any
         if not isinstance(raw_ts, int | float) or isinstance(raw_ts, bool):
             continue
         arm = row.get("promote_policy")
+        arm_tagged = isinstance(arm, str) and bool(arm)
         points.append(
             {
                 "ts": float(raw_ts),
                 "held_out_fitness": fitness,
                 "held_out_bench_id": str(row.get("held_out_bench_id") or "—"),
-                # Legacy rows (pre-E3) have no promote_policy → treat as the gate arm
-                # (the only arm that existed before the control arms were added).
-                "arm": str(arm) if isinstance(arm, str) and arm else "gate",
+                # A pre-E3 row has no promote_policy. ``arm`` carries the display label
+                # (``"untagged"`` so it is never confused with a real arm) and
+                # ``arm_tagged`` records whether the row genuinely declared an arm — the
+                # results renderer keeps untagged rows OUT of the gate arm so a
+                # pre-experiment cycle never masquerades as matched-campaign evidence.
+                "arm": str(arm) if arm_tagged else "untagged",
+                "arm_tagged": arm_tagged,
             }
         )
     points.sort(key=lambda point: point["ts"])
@@ -4831,10 +4836,13 @@ def _evidence_gain_verdicts(
     """Collect the recorded ci-excludes-0 gain verdicts from both ledgers.
 
     Reads ``gain_ci_excludes_zero`` / ``gain_verdict`` / ``gain_ci_low`` /
-    ``gain_ci_high`` from the attribution rows (per-cycle) and the
-    ``kind="baseline"`` archive rows (per-campaign promote). A row with no recorded
-    verdict (``gain_ci_excludes_zero is None``) contributes nothing. Graceful at the
-    cast boundary: a non-numeric CI bound is rendered as "—", never raises.
+    ``gain_ci_high`` from the attribution rows (per-cycle, numeric ``ts`` epoch) and
+    the ``kind="baseline"`` archive rows (per-campaign promote, ISO-string ``ts_utc``).
+    The two ledgers carry DIFFERENT timestamp shapes, so each is formatted with its
+    own formatter (``_fmt_epoch`` for the numeric cycle ts, ``short_iso`` for the
+    archive ISO string) — a previous version floated both and dropped the archive ts.
+    A row with no recorded verdict (``gain_ci_excludes_zero`` not a bool) contributes
+    nothing. Graceful at every cast: a non-numeric CI bound renders "—", never raises.
     """
     out: list[dict[str, Any]] = []
 
@@ -4846,20 +4854,29 @@ def _evidence_gain_verdicts(
         except (TypeError, ValueError):
             return None
 
-    def _scan(source_rows: list[dict[str, Any]], source: str, ts_key: str) -> None:
+    def _scan(source_rows: list[dict[str, Any]], source: str, ts_label: str) -> None:
         for row in source_rows:
             excludes = row.get("gain_ci_excludes_zero")
             if not isinstance(excludes, bool):
                 continue
+            raw_ts = row.get(ts_label)
+            ts_display = "—"
+            if (
+                source == "cycle"
+                and isinstance(raw_ts, int | float)
+                and not isinstance(raw_ts, bool)
+            ):
+                ts_display = _fmt_epoch(float(raw_ts))
+            elif source == "promote" and isinstance(raw_ts, str) and raw_ts:
+                ts_display = short_iso(raw_ts) or raw_ts
+            arm_tag = row.get("promote_policy")
             out.append(
                 {
                     "source": source,
-                    "ts": _maybe_float(row.get(ts_key)),
-                    "arm": (
-                        str(row.get("promote_policy"))
-                        if isinstance(row.get("promote_policy"), str) and row.get("promote_policy")
-                        else "gate"
-                    ),
+                    "ts_display": ts_display,
+                    # Untagged (pre-E3) rows are labelled "untagged", never silently
+                    # attributed to the gate arm (matches the results-section fix).
+                    "arm": str(arm_tag) if isinstance(arm_tag, str) and arm_tag else "untagged",
                     "excludes_zero": excludes,
                     "verdict": (
                         str(row.get("gain_verdict"))
@@ -5057,27 +5074,49 @@ def _render_evidence_results(
     archive: list[dict[str, Any]],
 ) -> str:
     """Render the RESULTS section: per-arm held-out curve + 3-arm comparison +
-    promotion count per arm. Honest empty state when no campaign has run."""
+    promotion count per arm. Honest empty state when no campaign has run.
+
+    A held-out point / promoted baseline that carries NO ``promote_policy`` (a pre-E3
+    row, written before the control arms existed) is NOT silently attributed to the
+    ``gate`` arm — that would fabricate a gate-arm campaign result where none was run.
+    Untagged rows are counted in an explicit ``untagged (pre-arm)`` bucket so a
+    pre-experiment promotion never masquerades as matched-campaign arm evidence.
+    """
     points = _held_out_attribution_rows(mutations)
     by_arm: dict[str, list[dict[str, Any]]] = {arm: [] for arm, _ in _EVIDENCE_ARMS}
+    untagged_points: list[dict[str, Any]] = []
     for point in points:
-        by_arm.setdefault(point["arm"], []).append(point)
+        if point["arm_tagged"]:
+            by_arm.setdefault(point["arm"], []).append(point)
+        else:
+            untagged_points.append(point)
 
-    # Promotion count per arm from the promoted-baseline registry rows.
+    # Promotion count per arm from the promoted-baseline registry rows. An untagged
+    # baseline (pre-E3) is counted SEPARATELY — never folded into the gate arm.
     promo_by_arm: dict[str, int] = {arm: 0 for arm, _ in _EVIDENCE_ARMS}
+    untagged_promos = 0
     for row in archive:
         if not isinstance(row, dict) or row.get("kind") != "baseline":
             continue
         arm = row.get("promote_policy")
-        key = str(arm) if isinstance(arm, str) and arm else "gate"
-        promo_by_arm[key] = promo_by_arm.get(key, 0) + 1
+        if isinstance(arm, str) and arm in promo_by_arm:
+            promo_by_arm[arm] += 1
+        else:
+            untagged_promos += 1
 
     blocks: list[str] = []
 
-    # 3-arm comparison summary (mean held-out fitness + promotion count per arm).
+    # 3-arm comparison summary (mean held-out fitness + promotion count per arm),
+    # plus an explicit untagged (pre-arm) row when any untagged data exists.
     comparison_rows: list[str] = []
-    for arm, label in _EVIDENCE_ARMS:
-        arm_points = by_arm.get(arm, [])
+    summary_rows: list[tuple[str, str, list[dict[str, Any]], int]] = [
+        (arm, label, by_arm.get(arm, []), promo_by_arm.get(arm, 0)) for arm, label in _EVIDENCE_ARMS
+    ]
+    if untagged_points or untagged_promos:
+        summary_rows.append(
+            ("untagged", "pre-arm (no promote_policy)", untagged_points, untagged_promos)
+        )
+    for arm, label, arm_points, promo in summary_rows:
         if arm_points:
             mean_fitness = sum(p["held_out_fitness"] for p in arm_points) / len(arm_points)
             mean_cell = f'<td class="num">{mean_fitness:.4f}</td>'
@@ -5085,7 +5124,6 @@ def _render_evidence_results(
         else:
             mean_cell = '<td class="num muted">—</td>'
             n_cell = '<td class="num muted">0</td>'
-        promo = promo_by_arm.get(arm, 0)
         comparison_rows.append(
             "        <tr>\n"
             f"          <td><code>{html_escape(arm)}</code> "
@@ -5097,22 +5135,33 @@ def _render_evidence_results(
         )
     comparison_html = "\n".join(comparison_rows)
     total_points = len(points)
-    total_promos = sum(promo_by_arm.values())
-    if total_points == 0:
+    arm_tagged_points = sum(len(v) for v in by_arm.values())
+    if arm_tagged_points == 0:
+        untagged_note = (
+            f" {untagged_promos} promoted baseline"
+            + ("s" if untagged_promos != 1 else "")
+            + (" predate" if untagged_promos != 1 else " predates")
+            + " the control arms (no <code>promote_policy</code> tag) — counted in "
+            "the untagged row, NOT attributed to any arm."
+            if untagged_promos
+            else ""
+        )
         comparison_note = (
-            "No held-out cycle recorded on any arm yet — the matched 3-arm campaign has "
-            "not run. The table below shows the structure; values populate when the "
+            "No arm-tagged held-out cycle recorded yet — the matched 3-arm campaign has "
+            "not run. The table below shows the structure; arm values populate when the "
             "campaign writes <code>held_out_fitness</code> + <code>promote_policy</code> rows."
+            + untagged_note
         )
     else:
+        arm_promos = sum(promo_by_arm.values())
         comparison_note = (
             "Mean held-out fitness (the fixed ruler) per arm. Selection (<code>gate</code>) "
             "is only evidenced if it beats BOTH controls on this ruler. "
-            f"Promotions across all arms: <strong>{total_promos}</strong>"
+            f"Arm-tagged promotions: <strong>{arm_promos}</strong>"
             + (
                 " — <strong>0 promotions is a trust-increasing result</strong>: the loop "
                 "correctly promoted nothing on null evidence."
-                if total_promos == 0
+                if arm_promos == 0
                 else "."
             )
         )
@@ -5144,6 +5193,12 @@ def _render_evidence_results(
     else:
         for arm, label in _EVIDENCE_ARMS:
             blocks.append(_render_evidence_arm_curve(arm, label, by_arm.get(arm, [])))
+        if untagged_points:
+            blocks.append(
+                _render_evidence_arm_curve(
+                    "untagged", "pre-arm (no promote_policy)", untagged_points
+                )
+            )
     return "\n".join(blocks)
 
 
@@ -5173,12 +5228,7 @@ def _render_evidence_verdict(
             ci_cell = f'<td class="num">[{ci_low:+.4f}, {ci_high:+.4f}]</td>'
         else:
             ci_cell = '<td class="num muted">—</td>'
-        ts_value = entry["ts"]
-        ts_cell = (
-            f'<td class="muted">{html_escape(_fmt_epoch(ts_value))}</td>'
-            if isinstance(ts_value, float)
-            else '<td class="muted">—</td>'
-        )
+        ts_cell = f'<td class="muted">{html_escape(str(entry["ts_display"]))}</td>'
         rows.append(
             "        <tr>\n"
             f'          <td class="muted">{html_escape(entry["source"])}</td>\n'

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -1474,6 +1474,51 @@ def test_evidence_results_populated_per_arm_curve() -> None:
     assert "+0.0100" in verdict_html and "+0.0500" in verdict_html, "gain CI bounds missing"
 
 
+def test_evidence_untagged_baseline_not_counted_as_gate_arm() -> None:
+    """E6 honesty (Codex review): a pre-E3 promoted baseline carrying NO
+    promote_policy must NOT be silently attributed to the gate arm — that would
+    fabricate a matched-campaign result. It is counted in an explicit
+    'untagged (pre-arm)' bucket, and the gate arm shows 0 arm-tagged promotions."""
+    from scripts.build_self_improving_hub import _render_evidence_results
+
+    mutations: list = []  # no held-out / arm rows on disk
+    archive = [{"kind": "baseline", "ts_utc": "2026-05-30T00:00:00+00:00"}]  # no promote_policy
+    html = _render_evidence_results(mutations, archive)
+    # The untagged bucket appears + names the pre-arm origin.
+    assert "untagged" in html and "pre-arm" in html, "untagged baseline must be a separate bucket"
+    # The comparison note must NOT claim a gate-arm promotion; it states the baseline
+    # predates the control arms (singular verb for the single fixture baseline).
+    assert "predates the control arms" in html, (
+        "an untagged promotion must be flagged as predating the arms, not folded into gate"
+    )
+    # The gate arm row shows 0 promotions (the untagged baseline is NOT counted there).
+    gate_idx = html.find("selection (promote gate)")
+    assert gate_idx != -1
+    # The gate row's promotions cell (last <td class="num"> in that <tr>) is 0.
+    gate_row = html[gate_idx : html.find("</tr>", gate_idx)]
+    assert ">1<" not in gate_row, "untagged baseline wrongly counted as a gate-arm promotion"
+
+
+def test_evidence_verdict_renders_archive_iso_timestamp() -> None:
+    """E6 parity (Codex review): a promoted-baseline verdict row carries an ISO-string
+    ts_utc, which must be formatted (not dropped as '—' by a numeric-only cast)."""
+    from scripts.build_self_improving_hub import _render_evidence_verdict
+
+    archive = [
+        {
+            "kind": "baseline",
+            "ts_utc": "2026-05-30T12:34:56+00:00",
+            "promote_policy": "gate",
+            "gain_ci_excludes_zero": False,
+            "gain_verdict": "no evidence yet",
+        }
+    ]
+    html = _render_evidence_verdict([], archive)
+    assert "no evidence yet" in html
+    # The ISO date surfaces (short form) — the archive ts is no longer dropped.
+    assert "2026-05-30" in html, "archive ISO ts_utc must be formatted, not rendered as —"
+
+
 def test_evidence_power_reads_recorded_sigma() -> None:
     """E6 POWER (populated path): the required-N line is COMPUTED from the recorded
     combined sigma (within/between stderr), never fabricated. The N matches the

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -917,7 +917,7 @@ def built_autoresearch_pages(tmp_path_factory: pytest.TempPathFactory) -> dict[s
         f"autoresearch builder failed: stdout={result.stdout!r} stderr={result.stderr!r}"
     )
     pages: dict[str, str] = {}
-    for name in ("index", "baseline", "mutations", "results", "policies"):
+    for name in ("index", "baseline", "mutations", "results", "evidence", "policies"):
         # `index` is the landing page; the rest are dir/index.html for trailing-slash URLs.
         path = (
             autoresearch_out / "index.html"
@@ -1324,6 +1324,268 @@ def test_held_out_curve_unit_graceful_skips_bad_values() -> None:
     assert "0.7000" in html
     # The bad-ts row's fitness (0.5) must NOT appear — it was skipped, not floated.
     assert "0.5000" not in html
+
+
+# ---------------------------------------------------------------------------
+# E6 (2026-05-30) — the honest evidence page (methods + results + power)
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_page_renders_three_sections(
+    built_autoresearch_pages: dict[str, str],
+) -> None:
+    """E6: the evidence page renders the 3 sections (methods / results / power),
+    has the Evidence bucket title, and resolves every template marker."""
+    html = built_autoresearch_pages["evidence"]
+    assert "1 &middot; Methods" in html, "Methods section heading missing"
+    assert "2 &middot; Results" in html, "Results section heading missing"
+    assert "3 &middot; Power" in html, "Power section heading missing"
+    # Methods names the frozen ruler vs the pinned pool + the 3 arms + E5 pins + epoch.
+    assert "held-out ruler" in html and "pool-68dc6f0c9745" in html, (
+        "methods must name the frozen held-out ruler vs the pinned selection pool"
+    )
+    for arm in ("gate", "random", "never"):
+        assert arm in html, f"methods must name the {arm!r} control arm"
+    assert "prompt_hash" in html and "applied_diff_hash" in html, "E5 pins not described"
+    assert "epoch" in html.lower(), "content-addressed epoch partition not described"
+    # No unresolved template markers.
+    assert "{{" not in html and "}}" not in html, "unresolved template markers on evidence page"
+
+
+def test_evidence_page_graceful_empty_state(
+    built_autoresearch_pages: dict[str, str],
+) -> None:
+    """E6 CRITICAL: with no matched 3-arm held-out campaign on disk (the real
+    fixture has no promote_policy / gain rows), the page renders the full structure
+    + an HONEST 'awaiting' / 'no evidence yet' state — never a crash, never a
+    fabricated number, never a placeholder like XXXX."""
+    html = built_autoresearch_pages["evidence"]
+    # Honest empty states present.
+    assert "awaiting" in html.lower(), "missing honest 'awaiting campaign' empty state"
+    assert "no evidence" in html.lower(), "missing honest 'no evidence yet' verdict"
+    # NO fabricated number / placeholder.
+    assert "XXXX" not in html, "placeholder XXXX present — measured values only"
+    # The power section, with no recorded sigma, says 'indeterminate' rather than
+    # inventing an N.
+    assert "indeterminate" in html.lower(), (
+        "power section must report N indeterminate when sigma is unrecorded, not fabricate"
+    )
+
+
+def test_evidence_page_states_zero_promotions_as_trust(
+    built_autoresearch_pages: dict[str, str],
+) -> None:
+    """E6 honest framing: 0 promotions is stated as a TRUST-INCREASING result, not
+    a failure (operator's verbatim intent)."""
+    html = built_autoresearch_pages["evidence"]
+    assert "trust-increasing" in html.lower(), (
+        "0-promotion framing as trust-increasing missing from evidence page"
+    )
+
+
+def test_evidence_page_no_slop(built_autoresearch_pages: dict[str, str]) -> None:
+    """E6 no-slop (CLAUDE.md §Docs, feedback_no_box_ui_no_emoji): no colored
+    left-border accent bar, no card-grid navigation, no emoji. Dense tables only."""
+    html = built_autoresearch_pages["evidence"]
+    assert "border-left" not in html, "colored accent bar (border-left) is slop"
+    assert "card-grid" not in html and "subview-card" not in html, "card-grid nav is slop"
+    assert not _find_emoji(html), f"emoji on evidence page: {_find_emoji(html)!r}"
+    # The evidence content uses dense <table class="records"> + <dl class="status-grid">.
+    assert 'class="records"' in html and 'class="status-grid"' in html, (
+        "evidence page must use dense table / definition-list, not card grid"
+    )
+
+
+def test_evidence_page_in_nav_and_subview(
+    built_autoresearch_pages: dict[str, str],
+) -> None:
+    """E6 wiring: the Evidence link is in every autoresearch sidebar + the landing
+    sub-view table now lists 5 sub-pages including Evidence."""
+    for name, html in built_autoresearch_pages.items():
+        assert "/geode/self-improving/autoresearch/evidence/" in html, (
+            f"autoresearch {name} sidebar missing the Evidence nav link"
+        )
+    landing = built_autoresearch_pages["index"]
+    assert "5 autoresearch sub-pages" in landing, "landing sub-view count not bumped to 5"
+    assert "Evidence" in landing, "Evidence sub-view row missing from landing"
+
+
+def test_evidence_results_populated_per_arm_curve() -> None:
+    """E6 RESULTS (populated path): with multi-arm held-out + gain rows, the renderer
+    splits the per-cycle held-out curve PER ARM, computes a 3-arm comparison on the
+    fixed ruler, counts promotions per arm, and renders the ci-excludes-0 verdict.
+    Reads exactly the fields E2-E4 write (held_out_fitness / promote_policy /
+    gain_ci_excludes_zero / gain_verdict)."""
+    from scripts.build_self_improving_hub import (
+        _render_evidence_results,
+        _render_evidence_verdict,
+    )
+
+    mutations = [
+        # gate arm — two held-out cycles, an improvement.
+        {
+            "kind": "attribution",
+            "ts": 10.0,
+            "held_out_fitness": 0.60,
+            "held_out_bench_id": "pool-x",
+            "promote_policy": "gate",
+            "gain_ci_low": 0.01,
+            "gain_ci_high": 0.05,
+            "gain_ci_excludes_zero": True,
+            "gain_verdict": "gain significant",
+        },
+        {
+            "kind": "attribution",
+            "ts": 20.0,
+            "held_out_fitness": 0.64,
+            "held_out_bench_id": "pool-x",
+            "promote_policy": "gate",
+        },
+        # random arm — one held-out cycle, no gain evidence.
+        {
+            "kind": "attribution",
+            "ts": 15.0,
+            "held_out_fitness": 0.59,
+            "held_out_bench_id": "pool-x",
+            "promote_policy": "random",
+            "gain_ci_low": -0.02,
+            "gain_ci_high": 0.02,
+            "gain_ci_excludes_zero": False,
+            "gain_verdict": "no evidence yet",
+        },
+    ]
+    archive = [
+        {"kind": "baseline", "ts_utc": "2026-05-30T00:00:00+00:00", "promote_policy": "gate"},
+    ]
+    results_html = _render_evidence_results(mutations, archive)
+    # Per-arm curve: the gate arm shows 2 generations, random shows 1.
+    assert "gate" in results_html and "random" in results_html and "never" in results_html
+    assert "0.6000" in results_html and "0.6400" in results_html, "gate arm curve values missing"
+    assert "0.5900" in results_html, "random arm curve value missing"
+    # 3-arm comparison: gate has 1 promotion (from the archive row).
+    assert "3-arm comparison" in results_html
+    # never arm has no held-out cycle → honest per-arm empty state.
+    assert "No held-out cycle recorded for this arm yet" in results_html
+
+    verdict_html = _render_evidence_verdict(mutations, archive)
+    assert "gain significant" in verdict_html, "significant verdict not surfaced"
+    assert "no evidence yet" in verdict_html, "honest null verdict not surfaced"
+    # The CI bounds are rendered (read from the recorded fields).
+    assert "+0.0100" in verdict_html and "+0.0500" in verdict_html, "gain CI bounds missing"
+
+
+def test_evidence_power_reads_recorded_sigma() -> None:
+    """E6 POWER (populated path): the required-N line is COMPUTED from the recorded
+    combined sigma (within/between stderr), never fabricated. The N matches the
+    writer's formula for the same sigma."""
+    from scripts.build_self_improving_hub import _render_evidence_power, _required_n_seed
+
+    mutations = [
+        {
+            "kind": "attribution",
+            "ts": 10.0,
+            "within_mutation_stderr": 0.0,
+            "between_seed_stderr": 0.013,
+        },
+    ]
+    html = _render_evidence_power(mutations)
+    # sigma = sqrt(0^2 + 0.013^2) = 0.0130 — surfaced as the recorded sigma.
+    assert "0.0130" in html, "recorded combined sigma not surfaced in power section"
+    # required-N computed from that sigma (not indeterminate when sigma is recorded).
+    sigma = (0.0**2 + 0.013**2) ** 0.5
+    expected_n = _required_n_seed(sigma)
+    assert expected_n is not None
+    assert str(expected_n) in html, f"required N_seed {expected_n} not rendered from recorded sigma"
+    assert "indeterminate" not in html.lower(), "should not say indeterminate when sigma recorded"
+
+
+def test_evidence_power_indeterminate_when_no_sigma() -> None:
+    """E6 POWER honest empty: with no recorded variance signal, the required-N is
+    reported as 'indeterminate' (not a fabricated number)."""
+    from scripts.build_self_improving_hub import _render_evidence_power
+
+    # No within/between stderr on any row → sigma unknown.
+    mutations = [{"kind": "attribution", "ts": 10.0, "held_out_fitness": 0.6}]
+    html = _render_evidence_power(mutations)
+    assert "indeterminate" in html.lower(), "power must report indeterminate when sigma unknown"
+    assert "not yet estimated" in html.lower(), "sigma cell must say not-yet-estimated"
+
+
+def test_evidence_required_n_seed_matches_core_formula() -> None:
+    """E6 drift guard: the stdlib power-formula mirror in the builder reproduces
+    core.self_improving_loop.statistical_power.required_samples for the same sigma."""
+    from core.self_improving_loop.statistical_power import (
+        DEFAULT_ALPHA,
+        DEFAULT_POWER,
+        DEFAULT_TARGET_EFFECT_SIZE,
+        required_samples,
+    )
+    from scripts.build_self_improving_hub import (
+        _POWER_DEFAULT_ALPHA,
+        _POWER_DEFAULT_POWER,
+        _POWER_DEFAULT_TARGET_EFFECT_SIZE,
+        _required_n_seed,
+    )
+
+    # Constants must match the SoT (the stdlib mirror is otherwise silently stale).
+    assert _POWER_DEFAULT_TARGET_EFFECT_SIZE == DEFAULT_TARGET_EFFECT_SIZE
+    assert _POWER_DEFAULT_ALPHA == DEFAULT_ALPHA
+    assert _POWER_DEFAULT_POWER == DEFAULT_POWER
+    for sigma in (0.0, 0.005, 0.013, 0.05, 0.2):
+        assert _required_n_seed(sigma) == required_samples(sigma).n_seed, (
+            f"builder _required_n_seed({sigma}) diverges from required_samples"
+        )
+    # Graceful: None / negative / non-finite sigma → None (no crash, no fabrication).
+    assert _required_n_seed(None) is None
+    assert _required_n_seed(-1.0) is None
+    assert _required_n_seed(float("nan")) is None
+
+
+def test_evidence_arm_map_matches_core() -> None:
+    """E6 drift guard: the builder's 3 control-arm names match the writer-side
+    _VALID_PROMOTE_POLICIES SoT in autoresearch/train.py (parsed textually, since the
+    builder is stdlib-only)."""
+    from scripts.build_self_improving_hub import _EVIDENCE_ARMS
+
+    train_src = (REPO_ROOT / "autoresearch" / "train.py").read_text(encoding="utf-8")
+    m = re.search(r"_VALID_PROMOTE_POLICIES\s*=\s*frozenset\(\{([^}]*)\}\)", train_src)
+    assert m is not None, "could not locate _VALID_PROMOTE_POLICIES in train.py"
+    core_arms = set(re.findall(r'"([a-z_]+)"', m.group(1)))
+    builder_arms = {arm for arm, _label in _EVIDENCE_ARMS}
+    assert builder_arms == core_arms, f"builder arms {builder_arms} drift from core {core_arms}"
+
+
+def test_evidence_results_graceful_on_malformed_rows() -> None:
+    """E6 graceful contract: a non-numeric held_out_fitness / ts / gain CI bound is
+    skipped, not raised — the render never sinks on a malformed ledger row."""
+    from scripts.build_self_improving_hub import (
+        _render_evidence_power,
+        _render_evidence_results,
+        _render_evidence_verdict,
+    )
+
+    mutations = [
+        {"kind": "attribution", "ts": "bad", "held_out_fitness": 0.6, "promote_policy": "gate"},
+        {"kind": "attribution", "ts": 10.0, "held_out_fitness": "oops", "promote_policy": "gate"},
+        {
+            "kind": "attribution",
+            "ts": 20.0,
+            "gain_ci_excludes_zero": False,
+            "gain_ci_low": "x",
+            "gain_ci_high": None,
+        },
+        {"kind": "attribution", "ts": 30.0, "within_mutation_stderr": "nope"},
+    ]
+    archive: list = []
+    # None of these raise.
+    results_html = _render_evidence_results(mutations, archive)
+    verdict_html = _render_evidence_verdict(mutations, archive)
+    power_html = _render_evidence_power(mutations)
+    assert "3-arm comparison" in results_html
+    # The malformed gain CI row still produces a verdict row, with a "—" CI cell.
+    assert "no evidence yet" in verdict_html
+    # The malformed sigma row leaves sigma unestimated → indeterminate.
+    assert "indeterminate" in power_html.lower()
 
 
 def test_autoresearch_results_sparkline(built_autoresearch_pages: dict[str, str]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.97"
+version = "0.99.98"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Adds ONE honest EVIDENCE sub-page under the autoresearch hub (`/geode/self-improving/autoresearch/evidence/`) — methods + results + power — that a skeptical reader uses to judge: *does scaffold-selection actually improve safety fitness?* Reads ONLY the git-tracked ledgers (`mutations.jsonl` + `baseline_archive.jsonl`), measured values only.
- Graceful empty state: the matched 3-arm 10-cycle has not run yet, so the page renders the full structure with an honest "awaiting" / "no evidence yet" / "indeterminate" state where curves/arms are empty — no crash, no fabricated number, no placeholder. The same renderer populates when the campaign lands.
- **0 promotions is framed plainly as a TRUST-INCREASING result.**

## Why
The self-improving loop's evidence (held-out curve, control arms, ci-verdict, power) was scattered across E1-E5 record fields with no single serving endpoint. E6 synthesises them into one honest page so an external reader can judge the central claim without trusting the loop's own promote decision. The co-evolving selection pool is a confound — only the FROZEN held-out ruler is cross-generation evidence, and the cross-arm comparison isolates selection from drift/judge-noise.

## Changes
| File | Change |
|------|--------|
| `scripts/build_self_improving_hub.py` | New `render_autoresearch_evidence` + section renderers (`_render_evidence_methods` / `_methods_arms` / `_results` / `_verdict` / `_power`); per-arm held-out collector with `arm_tagged` flag; stdlib power-formula mirror `_required_n_seed` (+ `_EVIDENCE_ARMS`, `_POWER_DEFAULT_*` constants, both drift-guarded); wired via `_safe("evidence", ...)`; landing sub-view now 5 rows + Evidence held-out count |
| `docs/self-improving/autoresearch/evidence.html.template` | New page template (3 sections, Evidence nav active) |
| `docs/self-improving/autoresearch/{index,baseline,mutations,results,policies}.html.template` | Evidence nav link added to every autoresearch sidebar |
| `docs/design/self-improving-autoresearch-evidence.md` | New page DESIGN doc; added to master `sibling_pages` |
| `tests/test_self_improving_hub_e2e.py` | 13 new tests (3-section render, graceful empty state, 0-promo trust framing, populated per-arm curve + verdict, power from recorded σ, indeterminate-σ, core drift-guards for arm map + power formula, malformed-row graceful, untagged-not-gate, archive ISO ts) |
| `CHANGELOG.md` / `CLAUDE.md` / `README.md` / `README.ko.md` / `pyproject.toml` / `uv.lock` | v0.99.97 → v0.99.98; CLAUDE.md module metric corrected 396 → 395 core (464 total) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Per-cycle held-out curve (interactive) | Already exists | `_render_held_out_curve` on the Mutations page (E2-wire); E6 is the synthesis page, not a duplicate |
| Power required-N | Implemented | Computed from recorded σ via stdlib mirror of `statistical_power.required_samples` (builder is stdlib-only, cannot import core); drift-guard test compares against the SoT |
| Writer-reader parity | Verified | Every rendered field (`held_out_fitness`, `promote_policy`, `gain_ci_*`, `gain_verdict`, `within/between_mutation_stderr`, archive `ts_utc`) is emitted by `attribution.py` / `train.py::_append_baseline_registry_row` |

## Verification
- [x] ruff check clean (`core/ autoresearch/ scripts/ tests/`)
- [x] ruff format --check clean (958 files)
- [x] mypy clean (`scripts/build_self_improving_hub.py`)
- [x] pytest pass (hub e2e 78 passed + 1 pre-existing skip; with reproducibility-pins 102 passed)
- [x] CLI smoke: builder runs, 0 render failures, empty state renders honestly (gate/random/never = 0 promotions, 1 untagged pre-arm baseline)
- [x] Codex MCP read-only review applied: untagged baseline no longer counted as gate-arm promotion; archive ISO ts_utc now formatted (2 fixes + 2 regression tests)

## Reference
Codex MCP review (writer-reader parity, graceful empty state, honesty, no-slop) — 2 blockers fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)