### PR TITLE
chore(self-improving): PR-CLEANUP-SIL — remove dead rank_kinds_by_dim + refresh stale comments (v0.99.101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,44 @@ functional change.
 
 ---
 
+## [0.99.101] - 2026-05-31
+
+### Removed
+- **PR-CLEANUP-SIL (2026-05-31) — remove the one grep-proven dead self-improving-loop
+  helper + refresh stale doubt comments.** A conservative cleanup pass over the
+  self-improving loop, applying the audit-before-migrate discipline (grep-prove
+  caller=0 before deleting; FLAG when in doubt). The three helpers a stale memory
+  note flagged as "orphan" (`credit_assignment`, `kind_dim_matrix`,
+  `evaluate_rollback_condition`) were re-audited: `credit_assignment` no longer
+  exists (removed with PR-GROUP-REMOVAL), while `compute_kind_dim_matrix` and
+  `evaluate_rollback_condition` are now production-wired (the former via
+  `format_mutator_feedback_block` → `core/self_improving_loop/runner.py`, the latter
+  via `_apply_rollback_condition_gate` → `autoresearch/train.py`'s promote gate) — so
+  they were kept. The only genuinely-dead remnant: `rank_kinds_by_dim`
+  (`core/self_improving_loop/kind_dim_matrix.py`), the transpose of the still-wired
+  `rank_dims_by_kind`, never given a caller by PR-WIRE-1. Removed the function, its
+  `__all__` entry, its docstring bullet, and its four unit tests
+  (`tests/core/self_improving_loop/test_kind_dim_matrix.py`).
+
+### Fixed
+- **PR-CLEANUP-SIL (2026-05-31) — stale-comment refresh (no behaviour change).** The
+  petri target runner's F-A3 entry-observability comment
+  (`plugins/petri_audit/targets/geode_target.py`) no longer reads as lingering doubt
+  about whether `GeodeModelAPI.generate` is invoked — it now affirms that
+  PR-AUDIT-SCAFFOLD-WIRE (#1938) verified the `geode/gpt-5.5 → GeodeModelAPI.generate
+  → _default_geode_runner → AgenticLoop` route. The `_TOP_KINDS_IN_BLOCK` docstring
+  in `core/self_improving_loop/mutator_feedback.py` now describes its actual use as
+  the `rank_dims_by_kind(..., limit=...)` per-kind dim cap (the code's actual call)
+  instead of the removed transpose helper. The
+  group/swarm/Pareto/Tchebycheff/`group_size`/`applied_sibling` sweep found the
+  CODE already removed by PR-DROP-GROUP-SAMPLING / PR-GROUP-REMOVAL — only explanatory
+  comments/docstrings on still-live code plus two legitimate regression tests that
+  pin that legacy `applied_sibling` rows are *ignored* by the current (1+1)-ES reader
+  (`tests/autoresearch/test_sot_revert_on_reject.py`,
+  `tests/core/self_improving_loop/test_mutations_reader.py`, both kept) — so no
+  executable code was cut there. One stale docstring in `test_sot_revert_on_reject.py`
+  that cited the removed `policies.write_sibling_in_memory` was corrected.
+
 ## [0.99.100] - 2026-05-31
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.100
+- **Version**: 0.99.101
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.100 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.101 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.100 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.101 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving_loop/kind_dim_matrix.py
+++ b/core/self_improving_loop/kind_dim_matrix.py
@@ -12,8 +12,6 @@ attribution 으로는 (kind × dim) interaction 추적 불가.
   produce.
 - :func:`rank_dims_by_kind(matrix, kind)` — 한 kind 가 가장 영향 준 dim 들
   내림차순.
-- :func:`rank_kinds_by_dim(matrix, dim)` — 한 dim 에 가장 영향 준 kind 들
-  내림차순.
 
 PR-12 ``read_recent_applies`` + PR-12 ``read_recent_attributions`` 결과를
 caller 가 inject — module 자체는 pure (I/O X). caller (CLI / dashboard) 가
@@ -90,23 +88,7 @@ def rank_dims_by_kind(
     return ranked
 
 
-def rank_kinds_by_dim(
-    matrix: dict[str, dict[str, float]],
-    dim: str,
-    *,
-    limit: int | None = None,
-) -> list[tuple[str, float]]:
-    """Return ``[(kind, score), ...]`` sorted by absolute score descending
-    for the given dim. Empty list when no kind has touched the dim."""
-    kinds_touching = [(kind, dims.get(dim, 0.0)) for kind, dims in matrix.items() if dim in dims]
-    ranked = sorted(kinds_touching, key=lambda kv: abs(kv[1]), reverse=True)
-    if limit is not None:
-        return ranked[:limit]
-    return ranked
-
-
 __all__ = [
     "compute_kind_dim_matrix",
     "rank_dims_by_kind",
-    "rank_kinds_by_dim",
 ]

--- a/core/self_improving_loop/mutator_feedback.py
+++ b/core/self_improving_loop/mutator_feedback.py
@@ -56,11 +56,11 @@ dashboard surface), so the mutator sees the same compact rollup the
 operator inspects."""
 
 _TOP_KINDS_IN_BLOCK = 3
-"""Cap on the number of kinds surfaced per dim in the matrix block.
-Mirrors ``rank_kinds_by_dim(..., limit=3)`` convention from the same
-operator CLI surface. The active mutator surface is currently 6 kinds
-(``TARGET_KINDS``), so top-3 surfaces the dominant half without
-saturating the line length."""
+"""Cap on the number of dim rows surfaced per kind in the matrix block.
+Passed as ``rank_dims_by_kind(matrix, kind, limit=...)`` — the same
+convention the operator CLI surface uses — so each of the active
+``TARGET_KINDS`` shows only its top-3 most-attributed dims, keeping the
+block dense without saturating the line length."""
 
 
 def format_mutator_feedback_block(

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -219,11 +219,13 @@ async def _default_geode_runner(
 
     system_text, history, last_user = _split_messages(messages)
 
-    # Defect A F-A3 (2026-05-11) — entry observability. Before this PR
-    # the live audit gave no signal whether GeodeModelAPI.generate was
-    # actually flowing through the runner, so chasing "tracker 0 records"
-    # post-mortems meant reading the inspect log's ModelEvent stream
-    # backward. INFO-level on entry, DEBUG once AgenticLoop is up.
+    # Defect A F-A3 (2026-05-11) — entry observability. This INFO line is
+    # the runner's confirmed entry signal: PR-AUDIT-SCAFFOLD-WIRE
+    # (v0.99.100, #1938) verified the closed loop's audit DOES route
+    # ``geode/gpt-5.5 → GeodeModelAPI.generate → _default_geode_runner →
+    # AgenticLoop`` and reach here, so the mutated scaffold is what Petri
+    # audits. The line stays as a live entry trace (paired with the diag()
+    # below) for per-run post-mortems; DEBUG once AgenticLoop is up.
     log.info(
         "petri runner entry: msg_count=%d last_user_chars=%d model=%s",
         len(messages),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.100"
+version = "0.99.101"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/autoresearch/test_sot_revert_on_reject.py
+++ b/tests/autoresearch/test_sot_revert_on_reject.py
@@ -245,10 +245,11 @@ def test_revert_returns_false_when_writer_raises(tmp_path: Path) -> None:
 
 
 def test_only_kind_applied_is_considered_not_applied_sibling(tmp_path: Path) -> None:
-    """``applied_sibling`` rows (group sampling's non-best) must NOT be
-    used as revert targets — those mutations were never committed to the
-    canonical SoT (sibling-only temp file via
-    ``policies.write_sibling_in_memory``)."""
+    """Legacy ``applied_sibling`` rows (from the removed group-sampling
+    era — PR-GROUP-REMOVAL) must NOT be used as revert targets: those
+    non-best siblings were never committed to the canonical SoT. The
+    current (1+1)-ES reader filters on ``kind="applied"`` only, so this
+    pins that a stray legacy row is ignored rather than reverted."""
     from autoresearch.train import _revert_sot_after_reject
 
     log_path = tmp_path / "mutations.jsonl"

--- a/tests/core/cli/test_self_improving_wire1.py
+++ b/tests/core/cli/test_self_improving_wire1.py
@@ -3,8 +3,8 @@
 The 2026-05-26 autoresearch attribution sprint Phase A audit identified
 production-orphan helpers in ``core/self_improving_loop/``:
 
-* ``compute_kind_dim_matrix`` / ``rank_dims_by_kind`` /
-  ``rank_kinds_by_dim`` (kind_dim_matrix.py) — 0 production callers
+* ``compute_kind_dim_matrix`` / ``rank_dims_by_kind`` (kind_dim_matrix.py)
+  — 0 production callers
 * ``evaluate_rollback_condition`` (rollback_condition.py) — 0 production
   callers; only the *field* ``rollback_condition`` on Mutation was
   wired (displayed in CLI), never evaluated.
@@ -18,7 +18,9 @@ data is missing, (d) the ``--last N`` argv parsing.
 
 (The ``credit`` sub-action wiring ``aggregate_credit_history`` was
 removed with the group-sampling machinery in PR-GROUP-REMOVAL,
-2026-05-29.)
+2026-05-29. The transpose helper ``rank_kinds_by_dim`` — never wired by
+this PR, transpose of the still-wired ``rank_dims_by_kind`` — was removed
+as dead code in PR-CLEANUP-SIL, 2026-05-31.)
 """
 
 from __future__ import annotations

--- a/tests/core/self_improving_loop/test_kind_dim_matrix.py
+++ b/tests/core/self_improving_loop/test_kind_dim_matrix.py
@@ -3,7 +3,7 @@
 Scope:
 - compute_kind_dim_matrix: empty / inner-join on mutation_id / signed contribution /
   orphan attribution skip / orphan apply skip / single kind multi-dim accumulation
-- rank_dims_by_kind / rank_kinds_by_dim: absolute-magnitude sort / limit / missing key
+- rank_dims_by_kind: absolute-magnitude sort / limit / missing key
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ import pytest
 from core.self_improving_loop.kind_dim_matrix import (
     compute_kind_dim_matrix,
     rank_dims_by_kind,
-    rank_kinds_by_dim,
 )
 
 
@@ -153,49 +152,7 @@ def test_rank_dims_with_limit() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. rank_kinds_by_dim
-# ---------------------------------------------------------------------------
-
-
-def test_rank_kinds_by_dim_sorted_descending_abs() -> None:
-    matrix = {
-        "prompt": {"safety": 0.2},
-        "tool_policy": {"safety": -0.5},
-        "reflection": {"safety": 0.1},
-    }
-    ranked = rank_kinds_by_dim(matrix, "safety")
-    assert ranked == [("tool_policy", -0.5), ("prompt", 0.2), ("reflection", 0.1)]
-
-
-def test_rank_kinds_by_dim_missing_dim_empty() -> None:
-    matrix = {"prompt": {"safety": 0.2}}
-    assert rank_kinds_by_dim(matrix, "nonexistent_dim") == []
-
-
-def test_rank_kinds_skips_kinds_without_dim() -> None:
-    """Only kinds whose dim dict contains the queried dim appear."""
-    matrix = {
-        "prompt": {"safety": 0.2},
-        "tool_policy": {"helpfulness": 0.5},  # no 'safety'
-    }
-    ranked = rank_kinds_by_dim(matrix, "safety")
-    assert len(ranked) == 1
-    assert ranked[0] == ("prompt", 0.2)
-
-
-def test_rank_kinds_with_limit() -> None:
-    matrix = {
-        "prompt": {"safety": 0.2},
-        "tool_policy": {"safety": -0.5},
-        "reflection": {"safety": 0.1},
-        "skill_catalog": {"safety": 0.4},
-    }
-    ranked = rank_kinds_by_dim(matrix, "safety", limit=2)
-    assert len(ranked) == 2
-
-
-# ---------------------------------------------------------------------------
-# 4. Real ApplyRecord + AttributionRecord integration
+# 3. Real ApplyRecord + AttributionRecord integration
 # ---------------------------------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.100"
+version = "0.99.101"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Conservative self-improving-loop cleanup applying the audit-before-migrate discipline: grep-prove caller=0 before deleting, FLAG when uncertain.
- The three helpers a stale memory note flagged as "orphan" were re-audited and **2 of 3 turned out production-wired** (the disconnection claim was a measurement artifact) — only `rank_kinds_by_dim` is genuinely dead and removed.
- Two stale comments refreshed (no behaviour change); version bumped 0.99.100 → 0.99.101 (PATCH).

## Why
A stale memory note (`project_autoresearch_separation_architecture.md`) listed `credit_assignment`, `kind_dim_matrix`, `evaluate_rollback_condition` as "production-caller-0 orphans". Re-grepping showed that note predates two wiring PRs, so deleting on that hunch would have removed live code (the exact "strong disconnected claim = measurement artifact" trap this task warned about). Only one true dead remnant (`rank_kinds_by_dim`) survived audit, plus a few stale comments that confused the intended scaffold→Petri→baseline→approve design.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/kind_dim_matrix.py` | Remove dead `rank_kinds_by_dim` (transpose of still-wired `rank_dims_by_kind`, caller=0) + its `__all__` entry + docstring bullet |
| `tests/core/self_improving_loop/test_kind_dim_matrix.py` | Remove the 4 `rank_kinds_by_dim` unit tests + import + scope line |
| `core/self_improving_loop/mutator_feedback.py` | `_TOP_KINDS_IN_BLOCK` docstring now describes its actual use (`rank_dims_by_kind(..., limit=...)` per-kind dim cap) instead of the removed transpose |
| `plugins/petri_audit/targets/geode_target.py` | F-A3 entry-observability comment refreshed: affirms PR-AUDIT-SCAFFOLD-WIRE (#1938) verified the `geode/gpt-5.5 → GeodeModelAPI.generate → _default_geode_runner → AgenticLoop` route, instead of reading as lingering doubt (log line itself unchanged) |
| `tests/core/cli/test_self_improving_wire1.py` | Header note: `rank_kinds_by_dim` provenance (removed as dead code) |
| `tests/autoresearch/test_sot_revert_on_reject.py` | Dropped stale docstring cite of removed `policies.write_sibling_in_memory` |
| `CHANGELOG.md` / `CLAUDE.md` / `README.md` / `README.ko.md` / `pyproject.toml` / `uv.lock` | Version 0.99.100 → 0.99.101 (5-location sync + lock) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `credit_assignment` | Already gone | 0 references anywhere; removed with PR-GROUP-REMOVAL (per `test_self_improving_wire1` header) |
| `kind_dim_matrix` / `compute_kind_dim_matrix` | KEPT — wired | `format_mutator_feedback_block` → `runner.py:419` (production mutator-feedback prompt) + CLI `_cmd_matrix` |
| `evaluate_rollback_condition` | KEPT — wired | `_apply_rollback_condition_gate` → `train.py:4473` promote gate (fires every cycle) + CLI `rollback-check` |
| `rank_kinds_by_dim` | **Removed** | caller=0 (def + `__all__` + 2 docstrings + tests only); no dynamic dispatch; Codex MCP confirmed no dangling refs |
| geode_target doubt comment / dead fallback | Comment refreshed, no dead branch | The `get_binding` try/except is live (handles custom/override models — `get_binding` raises `ValueError` at `registry.py:132`) |
| group/swarm/Pareto/Tchebycheff/`group_size`/`applied_sibling` | No code to cut | CODE already removed by PR-DROP-GROUP-SAMPLING/PR-GROUP-REMOVAL; only explanatory comments + 2 kept `applied_sibling` ignore-guard regression tests remain |
| **FLAG (not removed): 6 reader-only `TARGET_KINDS`** | KEPT | `style_guide`, `provider_routing`, `cache_policy`, `heuristics`, `in_context_slots`, `few_shot_pool` — intentional phased-rollout contract in `_READER_ONLY_KINDS`, reader-side wired (e.g. `apply_few_shot_pool`, `apply_cache_policy_breakpoints`, `apply_provider_routing_policy`, `apply_in_context_slots`), pinned by 3 invariant tests incl. `len == 6`. Removal would break the enum contract + tests. |
| **FLAG (not removed): `codex_provider` / `claude_cli_provider`** | KEPT | All 3 petri provider modules registered in `plugins/petri_audit/__init__.py` (lines 61/97/113), many downstream callers (seed_generation, mcp_bridge, adapters). Back active roles (target/mutator/auditor). No dead target-specific remnant found. |

## Verification
- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check` clean (996 files)
- [x] `mypy core/ plugins/` clean (464 files)
- [x] `lint-imports` clean (4 contracts kept)
- [x] `pytest tests/ -m "not live"` → **8481 passed, 61 skipped, 7 failed**. The 7 failures are **pre-existing** — verified identical on unmodified develop (git-stash A/B): `test_cli_audit.py` + `test_oauth_judge.py` (pre-warned flakes), 4× `test_seed_eval_export.py` (`ModuleNotFoundError: inspect_ai` — `[audit]` extra absent in fresh venv), `test_m4_4_in_context_wiring.py` (tool-hints assertion). None touch the modified files.
- [x] **DRY-RUN smoke**: `GEODE_CODEX_OAUTH_POLL_DISABLED=1 uv run python autoresearch/train.py --dry-run` → **exit 0**. Key output: `fitness: 0.716529`, `target_model: gpt-5.5`, `wrapper_override_active: true`, `section_count: 5`, `FITNESS_RESULT: {...}` sentinel emitted, `baseline_promoted: false (dry-run)`. Confirms loop wiring composes after the removals.
- [x] Codex MCP review (read-only): confirmed no dangling import/`__all__`, removal truly dead, kept helpers genuinely wired, no over-removal. 3 Low findings (docstring accuracy + CHANGELOG precision) all addressed in this PR.

## Reference
Task: conservative cleanup of dead/cruft obstructing the scaffold→Petri→baseline→approve design. Audit-before-migrate (`feedback_audit_before_migrate`) + measurement-artifact lesson (`project_closed_loop_full_verification`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)