### PR TITLE
feat(self-improving): PR-CAMPAIGN-DRIVER — committed campaign driver (v0.99.102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,47 @@ functional change.
 
 ---
 
+## [0.99.102] - 2026-05-31
+
+### Added
+- **PR-CAMPAIGN-DRIVER (2026-05-31) — committed, unit-tested self-improving campaign
+  driver (`scripts/run_campaign.py` + `scripts/watch_campaign.py`).** Implements
+  `docs/self-improving/campaign-procedure.md` as a real, importable module + CLI that
+  *sequences* the existing pieces (it decides no policy of its own):
+  - **gen-0 K-repeat baseline** (default K=5) — runs K manual measurements of the
+    genesis scaffold via `uv run python autoresearch/train.py` (real audit, no
+    mutation, `source="manual"`; the 1st bootstrap-establishes `baseline.json`),
+    reads each run's `held_out_fitness` + `fitness` from the new `kind="attribution"`
+    rows in `mutations.jsonl`, and computes the **noise band** (mean ± stderr of the K
+    held-out values). Then snapshots the full scaffold SoT
+    (`autoresearch/state/policies/*.{json,jsonl}` + `baseline.json`) to a gen-0 dir.
+  - **3-arm loop** (`never → random → gate`, gate LAST) — each arm restores the gen-0
+    snapshot (matched reset), sets `GEODE_PROMOTE_POLICY` (+ deterministic
+    `GEODE_PROMOTE_POLICY_SEED=424200+i` for `random`), runs N (default 10) cycles with
+    `commit_enabled=(arm=="gate")`.
+  - **propose-guard** — wraps `SelfImprovingLoopRunner.propose()` in a re-proposal loop
+    (up to M=8) that re-proposes on `RepetitiveMutationError` OR a measurement-hyperparam
+    `ValueError` (`seed_limit`/`max_turns`/`dim_set` now rejected), then skips the cycle
+    as a logged no-op rather than crashing the campaign.
+  - **degeneracy guard** — reads the newest `.eval` via `inspect_ai.log.read_eval_log`
+    and requires `status=success` + samples>0 + >0 scored dims (falls back to the
+    attribution row's `between_seed_stderr` ≥ floor when `inspect_ai` is absent); HALTs
+    the campaign on a degenerate audit.
+  - **flushed progress log** to `autoresearch/state/campaign-progress.log` (a gitignored
+    runtime artifact) tee'd to stdout — one line per cycle plus gen-0 noise-band +
+    per-arm summaries (long-task-watcher: flushed echo, not buffered).
+  - **env setup** — sets `GEODE_CODEX_OAUTH_POLL_DISABLED=1`, `AUTORESEARCH_SEED_SELECT`,
+    `GEODE_HELD_OUT_BENCH`, and `GEODE_AUDIT_MAX_SAMPLES`/`GEODE_AUDIT_MAX_CONNECTIONS`
+    (default 3/8 — a forward-looking knob; the single-OAuth `petri_audit/runner.py` lane
+    still pins `--max-samples 1 --max-connections 1`). `ANTHROPIC_API_KEY` is the
+    operator shell wrapper's responsibility.
+  - `--dry-run` passes through to `train.py` + the runner so the whole chain is
+    smoke-testable with synthetic audits (no PAYG/network). `scripts/watch_campaign.py`
+    gives an on-demand digest from the progress log + mutator attribution rows
+    (split by `promote_policy`) + baseline epochs.
+  - 23 unit tests in `tests/test_run_campaign.py` mock every boundary (propose,
+    train.py subprocess, `read_eval_log`, SoT files) — NO live audits.
+
 ## [0.99.101] - 2026-05-31
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.101
+- **Version**: 0.99.102
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.101 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.102 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.101 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.102 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.101"
+version = "0.99.102"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/run_campaign.py
+++ b/scripts/run_campaign.py
@@ -1,0 +1,1053 @@
+#!/usr/bin/env python3
+"""Self-improving campaign driver — the committed, unit-tested orchestrator.
+
+PR-CAMPAIGN-DRIVER (2026-05-31). Implements the procedure spelled out in
+``docs/self-improving/campaign-procedure.md`` (the canonical SoT) as a real,
+importable module with a CLI front end. The driver does NOT decide policy — it
+*sequences* the pieces that already exist:
+
+* ``autoresearch/train.py`` — the manual measurement path (one real Petri audit,
+  no mutation, ``source="manual"``; the first run bootstrap-establishes
+  ``baseline.json``). The campaign spawns it via ``uv run python
+  autoresearch/train.py`` and reads each run's ``held_out_fitness`` + ``fitness``
+  from the new ``kind="attribution"`` rows it appends to ``mutations.jsonl``.
+* ``core.self_improving_loop.runner.SelfImprovingLoopRunner`` — one
+  ``propose()`` + guard + ``apply_proposal()`` per cycle. The driver wraps
+  ``propose()`` in a re-proposal loop (the *propose-guard*) so a
+  ``RepetitiveMutationError`` or a measurement-hyperparam ``ValueError`` does not
+  burn the cycle.
+* ``GEODE_PROMOTE_POLICY`` (+ ``GEODE_PROMOTE_POLICY_SEED``) — the control-arm
+  knob (``autoresearch/train.py::_resolve_promote_policy``). The driver runs the
+  3 arms in the order **never → random → gate** (gate LAST), each from a matched
+  gen-0 SoT reset.
+
+The campaign is split into pure, testable units (snapshot/restore, the
+propose-guard, the degeneracy guard, the gen-0 noise-band collection) so the
+unit suite in ``tests/test_run_campaign.py`` can exercise every boundary with
+mocks and NO live audit / network / PAYG spend. ``--dry-run`` passes the flag
+through to ``train.py`` AND to the runner (``rerun_dry_run=True``) so the whole
+chain can be smoke-tested end-to-end with synthetic audits.
+
+ENV SETUP (operator handoff)
+----------------------------
+The operator's shell wrapper is responsible for exporting ``ANTHROPIC_API_KEY``
+(the driver cannot source ``~/.geode/.env`` from inside Python). The driver sets,
+in the env it passes to each subprocess:
+
+* ``GEODE_CODEX_OAUTH_POLL_DISABLED=1`` — bypass GEODE's pre-emptive 5-hour
+  throttle so the ChatGPT-Plus subscription bucket is used directly
+  (``reference_codex_oauth_throttle_bypass``).
+* ``AUTORESEARCH_SEED_SELECT=<repo>/state/seed-pools/cycle-input`` — the
+  co-evolving selection pool (highest-precedence override, see
+  ``docs/self-improving/cycle-input-pool.md``).
+* ``GEODE_HELD_OUT_BENCH=<repo>/state/seed-pools/held-out`` — the version-frozen
+  ruler (``autoresearch/train.py::_resolve_held_out_bench``).
+* ``GEODE_AUDIT_MAX_SAMPLES`` / ``GEODE_AUDIT_MAX_CONNECTIONS`` (default 3 / 8) —
+  the fan-out caps. NOTE: today ``plugins/petri_audit/runner.py::build_command``
+  hard-codes ``--max-samples 1 --max-connections 1`` for the single-OAuth lane
+  (campaign-procedure.md §8). The driver exports these as a forward-looking knob
+  the operator's multi-account lane can honour; it does not silently change the
+  audit fan-out for a single-OAuth run.
+
+The driver never runs a live audit itself under ``--dry-run``; the operator runs
+the live campaign with real credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from core.self_improving_loop.runner import Proposal, SelfImprovingLoopRunner
+
+log = logging.getLogger("run_campaign")
+
+# ---------------------------------------------------------------------------
+# Constants — defaults match campaign-procedure.md §4 / §6
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+"""The git repo root. ``scripts/run_campaign.py`` → ``parents[1]`` = repo root."""
+
+AUTORESEARCH_STATE_DIR = REPO_ROOT / "autoresearch" / "state"
+POLICIES_DIR = AUTORESEARCH_STATE_DIR / "policies"
+BASELINE_JSON = AUTORESEARCH_STATE_DIR / "baseline.json"
+MUTATIONS_JSONL = AUTORESEARCH_STATE_DIR / "mutations.jsonl"
+PROGRESS_LOG = AUTORESEARCH_STATE_DIR / "campaign-progress.log"
+
+#: gen-0 SoT snapshot destination (under the gitignored ``state/`` runtime tree
+#: so a matched-reset snapshot of a real campaign never enters git history).
+GEN0_SNAPSHOT_DIR = REPO_ROOT / "state" / "campaign" / "gen-0-snapshot"
+
+#: Seed-pool launch wiring (campaign-procedure.md §3, cycle-input-pool.md).
+CYCLE_INPUT_POOL = REPO_ROOT / "state" / "seed-pools" / "cycle-input"
+HELD_OUT_BENCH = REPO_ROOT / "state" / "seed-pools" / "held-out"
+
+#: Petri eval archive (campaign-procedure.md §7) — the degeneracy guard reads
+#: the newest ``.eval`` here.
+PETRI_LOGS_DIR = Path("~/.geode/petri/logs").expanduser()
+
+DEFAULT_N = 10
+"""Cycles per arm (campaign-procedure.md §6)."""
+DEFAULT_K = 5
+"""gen-0 baseline repeats (campaign-procedure.md §4 — K-repeat noise band)."""
+DEFAULT_MAX_PROPOSE_ATTEMPTS = 8
+"""propose-guard re-proposal cap (M)."""
+DEFAULT_ARMS = ("never", "random", "gate")
+"""Control arms, gate LAST (campaign-procedure.md §6)."""
+DEFAULT_RANDOM_SEED_BASE = 424200
+"""Deterministic ``GEODE_PROMOTE_POLICY_SEED`` base for the random arm; the
+per-arm seed is ``DEFAULT_RANDOM_SEED_BASE + arm_index``."""
+
+DEFAULT_AUDIT_MAX_SAMPLES = 3
+DEFAULT_AUDIT_MAX_CONNECTIONS = 8
+
+#: Fallback degeneracy threshold when ``inspect_ai`` is unavailable — the
+#: attribution row's ``between_seed_stderr`` collapsing below this floor is the
+#: signature of an all-identical (degenerate) audit.
+BETWEEN_SEED_STDERR_FLOOR = 0.01
+
+
+# ---------------------------------------------------------------------------
+# Progress log — flushed tee (long-task-watcher: flushed echo, not buffered)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProgressLog:
+    """A line-flushed tee to ``campaign-progress.log`` + stdout.
+
+    Per the long-task-watcher skill: emit a *flushed* line per event so an
+    operator tailing the file (``tail -F``) sees live progress, never a buffered
+    blob at the end. Each ``emit`` is timestamped and ``flush()``-ed immediately.
+    """
+
+    path: Path
+    _fh: Any = field(default=None, init=False, repr=False)
+
+    def __enter__(self) -> ProgressLog:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = self.path.open("a", encoding="utf-8")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._fh is not None:
+            self._fh.flush()
+            self._fh.close()
+            self._fh = None
+
+    def emit(self, message: str) -> None:
+        """Write one timestamped line to the log file + stdout, flushed."""
+        line = f"{_utc_now_iso()} {message}"
+        print(line, flush=True)
+        if self._fh is not None:
+            self._fh.write(line + "\n")
+            self._fh.flush()
+
+
+def _utc_now_iso() -> str:
+    from datetime import datetime
+
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Env setup (campaign-procedure.md §5 / operator handoff)
+# ---------------------------------------------------------------------------
+
+
+def build_campaign_env(
+    *,
+    promote_policy: str | None = None,
+    promote_policy_seed: int | None = None,
+    audit_max_samples: int = DEFAULT_AUDIT_MAX_SAMPLES,
+    audit_max_connections: int = DEFAULT_AUDIT_MAX_CONNECTIONS,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Compose the env passed to a ``train.py`` subprocess / cycle.
+
+    Starts from ``base_env`` (default ``os.environ``) so the operator's shell
+    wrapper export of ``ANTHROPIC_API_KEY`` flows through, then layers the
+    campaign-fixed env.
+
+    ``promote_policy`` / ``promote_policy_seed`` are *authoritative*: when
+    supplied they are set, and when ``None`` the corresponding env var is
+    explicitly REMOVED (not merely left alone). This matters because the base env
+    may carry a stale ``GEODE_PROMOTE_POLICY`` / ``GEODE_PROMOTE_POLICY_SEED`` from
+    the operator's shell — a gen-0 baseline run must inherit NO arm, and the
+    ``gate`` / ``never`` arms must inherit NO seed (else `_resolve_promote_policy`
+    / `_resolve_promote_policy_seed` would pick up the stale env, which is
+    highest-precedence, and the ledger would record a wrong arm / seed).
+    """
+    env = dict(base_env if base_env is not None else os.environ)
+    env["GEODE_CODEX_OAUTH_POLL_DISABLED"] = "1"
+    env["AUTORESEARCH_SEED_SELECT"] = str(CYCLE_INPUT_POOL)
+    env["GEODE_HELD_OUT_BENCH"] = str(HELD_OUT_BENCH)
+    env["GEODE_AUDIT_MAX_SAMPLES"] = str(audit_max_samples)
+    env["GEODE_AUDIT_MAX_CONNECTIONS"] = str(audit_max_connections)
+    # The AUTORESEARCH_* aliases are tier-2 in train.py's resolvers, so a stale
+    # alias would shadow our removal of the GEODE_* var — clear both names.
+    if promote_policy is not None:
+        env["GEODE_PROMOTE_POLICY"] = promote_policy
+    else:
+        env.pop("GEODE_PROMOTE_POLICY", None)
+        env.pop("AUTORESEARCH_PROMOTE_POLICY", None)
+    if promote_policy_seed is not None:
+        env["GEODE_PROMOTE_POLICY_SEED"] = str(promote_policy_seed)
+    else:
+        env.pop("GEODE_PROMOTE_POLICY_SEED", None)
+        env.pop("AUTORESEARCH_PROMOTE_POLICY_SEED", None)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# SoT snapshot / restore (campaign-procedure.md §6 — matched gen-0 reset)
+# ---------------------------------------------------------------------------
+
+#: Glob patterns under ``autoresearch/state/`` that make up the full scaffold
+#: SoT a matched reset must round-trip (campaign-procedure.md §1, §2.1, §7).
+_SNAPSHOT_SOURCES: tuple[tuple[Path, str], ...] = (
+    (POLICIES_DIR, "*.json"),
+    (POLICIES_DIR, "*.jsonl"),
+)
+
+
+def snapshot_sot(dest_dir: Path) -> list[Path]:
+    """Copy the full scaffold SoT into ``dest_dir`` for a matched reset.
+
+    Captures every ``autoresearch/state/policies/*.{json,jsonl}`` plus
+    ``baseline.json``. Returns the list of destination paths written. The dest
+    dir is wiped first so a re-snapshot is a clean overwrite (never a merge of a
+    stale snapshot with a fresh one).
+    """
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
+    policies_dest = dest_dir / "policies"
+    policies_dest.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for src_dir, pattern in _SNAPSHOT_SOURCES:
+        if not src_dir.exists():
+            continue
+        for src in sorted(src_dir.glob(pattern)):
+            dst = policies_dest / src.name
+            shutil.copy2(src, dst)
+            written.append(dst)
+    if BASELINE_JSON.exists():
+        dst = dest_dir / "baseline.json"
+        shutil.copy2(BASELINE_JSON, dst)
+        written.append(dst)
+    return written
+
+
+def restore_sot(snapshot_dir: Path) -> list[Path]:
+    """Restore the scaffold SoT from a ``snapshot_sot`` directory — an EXACT
+    matched reset.
+
+    Round-trips ``snapshot_sot`` exactly: the policy files are copied back into
+    ``autoresearch/state/policies/`` and ``baseline.json`` back into
+    ``autoresearch/state/``. Crucially this is a *mirror*, not an overlay: any
+    live ``policies/*.{json,jsonl}`` file that is NOT in the snapshot is DELETED,
+    so an earlier arm that created a new policy file (e.g. the gate arm inserting
+    ``wrapper-sections.json`` where gen-0 had only ``hyperparam.json``) cannot
+    contaminate the next arm's matched start (Codex MCP finding #1). Returns the
+    list of restored live paths. ``FileNotFoundError`` if the snapshot dir is
+    absent (a matched reset must be exact).
+    """
+    if not snapshot_dir.exists():
+        raise FileNotFoundError(
+            f"gen-0 snapshot dir {snapshot_dir} missing — cannot do a matched arm reset"
+        )
+    restored: list[Path] = []
+    policies_src = snapshot_dir / "policies"
+    POLICIES_DIR.mkdir(parents=True, exist_ok=True)
+    snapshot_names = {p.name for p in policies_src.glob("*")} if policies_src.exists() else set()
+    # Remove orphan live policy files absent from the snapshot (mirror semantics).
+    for pattern in ("*.json", "*.jsonl"):
+        for live in POLICIES_DIR.glob(pattern):
+            if live.name not in snapshot_names:
+                live.unlink()
+    if policies_src.exists():
+        for src in sorted(policies_src.glob("*")):
+            dst = POLICIES_DIR / src.name
+            shutil.copy2(src, dst)
+            restored.append(dst)
+    baseline_src = snapshot_dir / "baseline.json"
+    if baseline_src.exists():
+        AUTORESEARCH_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(baseline_src, BASELINE_JSON)
+        restored.append(BASELINE_JSON)
+    return restored
+
+
+# ---------------------------------------------------------------------------
+# Attribution-row reads (collect the per-cycle / per-baseline fitness signal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CycleSignal:
+    """The fitness signal one cycle / baseline run produced, read from the
+    newest ``kind="attribution"`` row in ``mutations.jsonl``."""
+
+    held_out_fitness: float | None
+    fitness: float | None
+    fitness_delta: float | None
+    promote_policy: str | None
+    source: str | None
+    between_seed_stderr: float | None
+
+
+def count_attribution_rows(path: Path | None = None) -> int:
+    """Count ``kind="attribution"`` rows currently in ``mutations.jsonl``.
+
+    Captured BEFORE a run so :func:`read_latest_attribution` can require that a
+    NEW row was appended after the run started (Codex MCP finding #2): a run that
+    wrote no attribution row (a ``--dry-run``, a held-out failure, or a nonzero
+    audit swallowed by the runner) must NOT silently reuse the prior cycle's stale
+    row as if it were this cycle's signal.
+    """
+    target = path if path is not None else MUTATIONS_JSONL
+    if not target.exists():
+        return 0
+    count = 0
+    with target.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict) and row.get("kind") == "attribution":
+                count += 1
+    return count
+
+
+def read_latest_attribution(path: Path | None = None, *, min_rows: int = 0) -> CycleSignal | None:
+    """Read the newest ``kind="attribution"`` row from ``mutations.jsonl``.
+
+    Returns ``None`` when no attribution row exists yet (fresh repo / a cycle
+    whose audit produced no row). Reads ``fitness`` from ``fitness_after`` (the
+    attribution schema's name for the cycle's measured fitness), falling back to
+    a bare ``fitness`` key for forward-compat.
+
+    ``min_rows`` is the row count captured BEFORE the run (via
+    :func:`count_attribution_rows`). The newest row is returned only when the
+    current attribution-row count EXCEEDS ``min_rows`` — i.e. this run actually
+    appended a fresh row. When the count did not advance, the run produced no new
+    signal and ``None`` is returned (no stale-row reuse). ``min_rows=0`` (default)
+    keeps the unconditional "newest row" behaviour for direct callers / tests.
+    """
+    target = path if path is not None else MUTATIONS_JSONL
+    if not target.exists():
+        return None
+    latest: dict[str, Any] | None = None
+    seen = 0
+    with target.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict) and row.get("kind") == "attribution":
+                latest = row
+                seen += 1
+    if latest is None or seen <= min_rows:
+        return None
+    return CycleSignal(
+        held_out_fitness=_as_float(latest.get("held_out_fitness")),
+        fitness=_as_float(latest.get("fitness_after", latest.get("fitness"))),
+        fitness_delta=_as_float(latest.get("fitness_delta")),
+        promote_policy=_as_str(latest.get("promote_policy")),
+        source=_as_str(latest.get("source")),
+        between_seed_stderr=_as_float(latest.get("between_seed_stderr")),
+    )
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _as_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+# ---------------------------------------------------------------------------
+# Degeneracy guard (campaign-procedure.md §5.6)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    """Outcome of the per-cycle degeneracy guard."""
+
+    ok: bool
+    reason: str
+
+
+def newest_eval_path(logs_dir: Path = PETRI_LOGS_DIR) -> Path | None:
+    """Return the most-recently-modified ``*.eval`` in ``logs_dir`` (skips the
+    ``latest.eval`` pointer copy)."""
+    if not logs_dir.exists():
+        return None
+    evals = [p for p in logs_dir.glob("*.eval") if p.name != "latest.eval"]
+    if not evals:
+        return None
+    return max(evals, key=lambda p: p.stat().st_mtime)
+
+
+def degeneracy_guard(
+    *,
+    logs_dir: Path = PETRI_LOGS_DIR,
+    signal: CycleSignal | None = None,
+) -> GuardResult:
+    """Reject a degenerate audit (campaign-procedure.md §5.6).
+
+    Primary path — read the newest ``.eval`` via ``inspect_ai.log.read_eval_log``
+    and require: ``status == "success"`` AND ``samples > 0`` AND at least one
+    sample carries ``> 0`` scored dims. A broken setup (auditor quota throttle →
+    0 samples, all-zero dims) HALTs the campaign so it never burns the full run.
+
+    Fallback path — when ``inspect_ai`` is unavailable (the import is guarded), or
+    no ``.eval`` exists, fall back to the attribution row's
+    ``between_seed_stderr`` ≥ ``BETWEEN_SEED_STDERR_FLOOR`` check (a collapsed
+    stderr is the signature of an all-identical degenerate audit).
+    """
+    try:
+        from inspect_ai.log import read_eval_log
+    except ImportError:
+        return _degeneracy_guard_fallback(signal)
+
+    eval_path = newest_eval_path(logs_dir)
+    if eval_path is None:
+        return _degeneracy_guard_fallback(signal)
+
+    try:
+        loaded = read_eval_log(str(eval_path))
+    except Exception as exc:  # pragma: no cover — defensive read
+        return GuardResult(ok=False, reason=f"eval read failed: {exc}")
+
+    status = str(getattr(loaded, "status", "?"))
+    if status != "success":
+        return GuardResult(ok=False, reason=f"eval status={status!r} (not success)")
+    samples = list(getattr(loaded, "samples", None) or [])
+    if not samples:
+        return GuardResult(ok=False, reason="eval has 0 samples")
+    scored_dims = _count_scored_dims(samples)
+    if scored_dims <= 0:
+        return GuardResult(ok=False, reason="eval has 0 scored dims")
+    return GuardResult(ok=True, reason=f"status=success samples={len(samples)} dims={scored_dims}")
+
+
+def _count_scored_dims(samples: Sequence[Any]) -> int:
+    """Count distinct scored dims across the samples — mirrors
+    ``plugins/petri_audit/eval_archive.py`` (``scores["audit_judge"].value`` is a
+    per-dim dict)."""
+    dims: set[str] = set()
+    for s in samples:
+        scores = getattr(s, "scores", None) or {}
+        judge = scores.get("audit_judge") if isinstance(scores, dict) else None
+        value = getattr(judge, "value", None)
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool):
+                    dims.add(k)
+    return len(dims)
+
+
+def _degeneracy_guard_fallback(signal: CycleSignal | None) -> GuardResult:
+    if signal is None or signal.between_seed_stderr is None:
+        # No eval and no stderr signal — cannot confirm health; HALT rather than
+        # silently proceed on a broken setup.
+        return GuardResult(
+            ok=False,
+            reason="no eval log and no between_seed_stderr — cannot confirm audit health",
+        )
+    if signal.between_seed_stderr < BETWEEN_SEED_STDERR_FLOOR:
+        return GuardResult(
+            ok=False,
+            reason=(
+                f"between_seed_stderr {signal.between_seed_stderr:.4f} "
+                f"< floor {BETWEEN_SEED_STDERR_FLOOR} (degenerate all-identical audit)"
+            ),
+        )
+    return GuardResult(
+        ok=True,
+        reason=f"fallback ok (between_seed_stderr={signal.between_seed_stderr:.4f})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# propose-guard (campaign-procedure.md §5.1 — re-propose on guarded rejection)
+# ---------------------------------------------------------------------------
+
+
+def propose_with_guard(
+    runner: SelfImprovingLoopRunner,
+    *,
+    max_attempts: int = DEFAULT_MAX_PROPOSE_ATTEMPTS,
+    progress: ProgressLog | None = None,
+) -> Proposal | None:
+    """Call ``runner.propose()`` up to ``max_attempts`` times.
+
+    Re-proposes on a guarded rejection:
+
+    * ``RepetitiveMutationError`` — the dedup / axis-family guard fired.
+    * a ``ValueError`` from the measurement-hyperparam rejection — the mutator
+      proposed ``seed_limit`` / ``max_turns`` / ``dim_set`` (now FIXED), or any
+      other parse/validation ``ValueError``.
+
+    Returns the first clean ``Proposal``; returns ``None`` (the cycle is a
+    logged no-op, NOT a crash) when the attempts are exhausted. ``RepetitiveMutationError``
+    subclasses ``ValueError``, so we catch the subclass first to log it
+    distinctly, then the broad ``ValueError`` for measurement-hyperparam /
+    malformed-JSON rejections.
+    """
+    from core.self_improving_loop.mutator_feedback import RepetitiveMutationError
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return runner.propose()
+        except RepetitiveMutationError as exc:
+            if progress is not None:
+                progress.emit(f"propose-guard attempt {attempt}/{max_attempts}: repetitive — {exc}")
+        except ValueError as exc:
+            if progress is not None:
+                progress.emit(f"propose-guard attempt {attempt}/{max_attempts}: rejected — {exc}")
+    if progress is not None:
+        progress.emit(f"propose-guard exhausted {max_attempts} attempts — cycle skipped as no-op")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# gen-0 K-repeat baseline + noise band (campaign-procedure.md §4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NoiseBand:
+    """The gen-0 noise band — mean ± stderr of K held-out fitness repeats."""
+
+    k: int
+    held_out_values: tuple[float, ...]
+    fitness_values: tuple[float, ...]
+    mean: float | None
+    stderr: float | None
+
+    def summary(self) -> str:
+        if self.mean is None or self.stderr is None:
+            return (
+                f"gen-0 noise band: K={self.k} "
+                f"collected={len(self.held_out_values)} (no held-out values)"
+            )
+        return (
+            f"gen-0 noise band: K={self.k} held_out_mean={self.mean:.4f} "
+            f"stderr={self.stderr:.4f} values={[round(v, 4) for v in self.held_out_values]}"
+        )
+
+
+def compute_noise_band(
+    held_out_values: Sequence[float],
+    fitness_values: Sequence[float],
+    *,
+    k: int,
+) -> NoiseBand:
+    """Mean ± stderr of the K held-out repeats (campaign-procedure.md §4)."""
+    held = tuple(float(v) for v in held_out_values)
+    fit = tuple(float(v) for v in fitness_values)
+    if not held:
+        return NoiseBand(k=k, held_out_values=held, fitness_values=fit, mean=None, stderr=None)
+    mean = statistics.fmean(held)
+    stderr = statistics.stdev(held) / (len(held) ** 0.5) if len(held) >= 2 else 0.0
+    return NoiseBand(k=k, held_out_values=held, fitness_values=fit, mean=mean, stderr=stderr)
+
+
+def run_gen0_baseline(
+    *,
+    k: int,
+    dry_run: bool,
+    audit_max_samples: int,
+    audit_max_connections: int,
+    progress: ProgressLog,
+    train_runner: Any | None = None,
+) -> NoiseBand:
+    """Run K manual measurements of the genesis scaffold + compute the noise band.
+
+    Each repeat spawns ``uv run python autoresearch/train.py`` (real audit, no
+    mutation, ``source="manual"``; the 1st run bootstrap-establishes
+    ``baseline.json``). After each run the newest ``kind="attribution"`` row is
+    read for its ``held_out_fitness`` + ``fitness``.
+
+    ``train_runner`` is injected so tests can stub the subprocess — it is a
+    callable ``(env) -> subprocess.CompletedProcess``. The default spawns the
+    real ``train.py`` subprocess.
+    """
+    runner_fn = train_runner if train_runner is not None else _spawn_train_subprocess
+    held_out_values: list[float] = []
+    fitness_values: list[float] = []
+    for i in range(1, k + 1):
+        env = build_campaign_env(
+            audit_max_samples=audit_max_samples,
+            audit_max_connections=audit_max_connections,
+        )
+        progress.emit(f"gen-0 baseline repeat {i}/{k}: spawning train.py (dry_run={dry_run})")
+        rows_before = count_attribution_rows()
+        result = runner_fn(env=env, dry_run=dry_run)
+        if getattr(result, "returncode", 0) != 0:
+            progress.emit(
+                f"gen-0 baseline repeat {i}/{k}: train.py exited "
+                f"{getattr(result, 'returncode', '?')} — skipping signal read"
+            )
+            continue
+        # Require a NEW attribution row from THIS run (no stale-row reuse).
+        signal = read_latest_attribution(min_rows=rows_before)
+        if signal is None:
+            progress.emit(
+                f"gen-0 baseline repeat {i}/{k}: no NEW attribution row "
+                "(run wrote none — e.g. dry-run / held-out skip)"
+            )
+            continue
+        if signal.held_out_fitness is not None:
+            held_out_values.append(signal.held_out_fitness)
+        if signal.fitness is not None:
+            fitness_values.append(signal.fitness)
+        progress.emit(
+            f"gen-0 baseline repeat {i}/{k}: held_out={signal.held_out_fitness} "
+            f"fitness={signal.fitness} source={signal.source}"
+        )
+    band = compute_noise_band(held_out_values, fitness_values, k=k)
+    progress.emit(band.summary())
+    return band
+
+
+def _spawn_train_subprocess(
+    *, env: dict[str, str], dry_run: bool
+) -> subprocess.CompletedProcess[str]:
+    """Spawn ``uv run python autoresearch/train.py`` (real audit, no mutation)."""
+    argv = ["uv", "run", "python", "autoresearch/train.py"]
+    if dry_run:
+        argv.append("--dry-run")
+    return subprocess.run(  # noqa: S603 — argv built from constants
+        argv,
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Arm loop (campaign-procedure.md §6)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArmSummary:
+    """Roll-up of one arm's N cycles."""
+
+    arm: str
+    cycles_run: int
+    cycles_skipped: int
+    promotes: int
+    halted: bool
+
+    def summary(self) -> str:
+        return (
+            f"arm '{self.arm}' summary: cycles={self.cycles_run} skipped={self.cycles_skipped} "
+            f"promotes={self.promotes} halted={self.halted}"
+        )
+
+
+def _make_runner(*, arm: str, env: dict[str, str], dry_run: bool) -> SelfImprovingLoopRunner:
+    """Construct a runner for an arm cycle.
+
+    The runner spawns ``train.py`` itself (``rerun_enabled=True``). It inherits
+    the arm's env via ``os.environ`` because
+    ``runner.py::_run_autoresearch_subprocess`` copies ``os.environ`` — so the
+    campaign sets the arm env into ``os.environ`` around the cycle (restored
+    afterwards). ``commit_enabled`` is True ONLY for the gate arm (the real
+    optimizer persists; the control arms do not git-commit). ``rerun_dry_run``
+    mirrors the campaign ``--dry-run`` so a smoke run passes ``train.py --dry-run``
+    (synthetic audit, no PAYG); the live campaign runs ``dry_run=False`` for a
+    real Petri audit.
+    """
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    return SelfImprovingLoopRunner(
+        commit_enabled=(arm == "gate"),
+        rerun_enabled=True,
+        rerun_dry_run=dry_run,
+    )
+
+
+class _OfflineSmokeRunner:
+    """A fully synthetic runner for the ``--dry-run`` smoke path.
+
+    The real :class:`~core.self_improving_loop.runner.SelfImprovingLoopRunner`
+    dispatches a live mutator LLM call in ``propose()`` and writes the real
+    in-repo SoT (``wrapper-sections.json`` + ``mutations.jsonl``) in
+    ``apply_proposal()``. Neither is appropriate for a no-PAYG smoke that must
+    leave the repo SoT untouched. This stand-in returns a canned
+    :class:`Proposal` and records applies in memory only — so a smoke proves the
+    orchestration wiring (gen-0 → snapshot → arm sequencing → propose-guard →
+    apply → guard) runs end-to-end with NO network and NO SoT mutation.
+    """
+
+    def __init__(self, *, arm: str) -> None:
+        self.arm = arm
+        self.applied: list[Proposal] = []
+
+    def propose(self) -> Proposal:
+        from core.self_improving_loop.runner import Mutation, Proposal
+
+        mutation = Mutation(
+            target_section="campaign_dry_run_smoke",
+            new_value="dry-run smoke mutation — synthetic, no live audit",
+            rationale="dry-run smoke (no PAYG)",
+            target_kind="prompt",
+        )
+        return Proposal(mutation=mutation)
+
+    def apply_proposal(self, proposal: Proposal) -> Any:
+        self.applied.append(proposal)
+        return proposal.mutation
+
+
+def _make_offline_runner(*, arm: str, env: dict[str, str], dry_run: bool) -> _OfflineSmokeRunner:
+    """Offline synthetic runner for the ``--dry-run`` smoke path — no network, no
+    SoT write."""
+    return _OfflineSmokeRunner(arm=arm)
+
+
+def run_arm(
+    *,
+    arm: str,
+    arm_index: int,
+    n: int,
+    max_propose_attempts: int,
+    audit_max_samples: int,
+    audit_max_connections: int,
+    dry_run: bool,
+    progress: ProgressLog,
+    snapshot_dir: Path = GEN0_SNAPSHOT_DIR,
+    runner_factory: Any | None = None,
+    guard_fn: Any | None = None,
+) -> ArmSummary:
+    """Run one arm: matched gen-0 reset → set arm env → N propose/guard/apply cycles.
+
+    ``runner_factory`` (``(arm, env, dry_run) -> runner``) and ``guard_fn``
+    (``(signal) -> GuardResult``) are injected so tests can substitute mocks. The
+    real path uses ``_make_runner`` + ``degeneracy_guard``. Under ``--dry-run`` with
+    no injected factory, an OFFLINE synthetic runner (``_make_offline_runner``) is
+    used so the smoke run never dispatches a mutator LLM call (no PAYG/network).
+    """
+    if runner_factory is not None:
+        factory = runner_factory
+    elif dry_run:
+        factory = _make_offline_runner
+    else:
+        factory = _make_runner
+    if guard_fn is not None:
+        guard = guard_fn
+    elif dry_run:
+        # Dry-run skips the degeneracy guard: train.py --dry-run writes NO
+        # attribution row (synthetic dims carry no signal) and produces no fresh
+        # .eval, so there is nothing healthy to confirm. A permissive guard keeps
+        # the smoke path from HALTing on the absence of live evidence.
+        guard = lambda _signal: GuardResult(ok=True, reason="dry-run (guard skipped)")  # noqa: E731
+    else:
+        guard = lambda signal: degeneracy_guard(signal=signal)  # noqa: E731
+
+    if dry_run:
+        # Dry-run is read-only w.r.t. the git-tracked policy SoT: the offline
+        # runner writes nothing, so a matched reset would only re-copy identical
+        # bytes. Skipping restore_sot keeps the smoke from touching
+        # ``autoresearch/state/policies/*`` at all (Codex MCP finding #5).
+        progress.emit(f"arm '{arm}' (index {arm_index}): dry-run (gen-0 restore skipped)")
+    else:
+        progress.emit(f"arm '{arm}' (index {arm_index}): restoring gen-0 SoT snapshot")
+        restore_sot(snapshot_dir)
+
+    seed = DEFAULT_RANDOM_SEED_BASE + arm_index if arm == "random" else None
+    env = build_campaign_env(
+        promote_policy=arm,
+        promote_policy_seed=seed,
+        audit_max_samples=audit_max_samples,
+        audit_max_connections=audit_max_connections,
+    )
+    progress.emit(
+        f"arm '{arm}': GEODE_PROMOTE_POLICY={arm} "
+        f"GEODE_PROMOTE_POLICY_SEED={seed} commit_enabled={arm == 'gate'}"
+    )
+
+    cycles_run = 0
+    cycles_skipped = 0
+    promotes = 0
+    halted = False
+    # Stash + overlay the arm env into os.environ so the runner's spawned
+    # train.py subprocess (which copies os.environ) inherits the arm's
+    # promote-policy + seed-pool wiring. Restored in the finally.
+    _saved_env = {
+        key: os.environ.get(key)
+        for key in (
+            "GEODE_PROMOTE_POLICY",
+            "GEODE_PROMOTE_POLICY_SEED",
+            "AUTORESEARCH_SEED_SELECT",
+            "GEODE_HELD_OUT_BENCH",
+            "GEODE_CODEX_OAUTH_POLL_DISABLED",
+            "GEODE_AUDIT_MAX_SAMPLES",
+            "GEODE_AUDIT_MAX_CONNECTIONS",
+        )
+    }
+    try:
+        for key in _saved_env:
+            if key in env:
+                os.environ[key] = env[key]
+            else:
+                os.environ.pop(key, None)
+        for cycle in range(1, n + 1):
+            runner = factory(arm=arm, env=env, dry_run=dry_run)
+            proposal = propose_with_guard(
+                runner, max_attempts=max_propose_attempts, progress=progress
+            )
+            if proposal is None:
+                cycles_skipped += 1
+                progress.emit(f"arm '{arm}' cycle {cycle}/{n}: SKIP (propose-guard exhausted)")
+                continue
+            rows_before = count_attribution_rows()
+            runner.apply_proposal(proposal)
+            cycles_run += 1
+            # Only this cycle's freshly-appended attribution row counts as signal
+            # (no stale-row reuse if the audit wrote nothing) — Codex MCP #2.
+            signal = read_latest_attribution(min_rows=rows_before)
+            promoted = _promoted_this_cycle(signal)
+            if promoted:
+                promotes += 1
+            guard_result = guard(signal)
+            progress.emit(_cycle_line(arm=arm, cycle=cycle, n=n, signal=signal, guard=guard_result))
+            if not guard_result.ok:
+                progress.emit(
+                    f"HALT arm '{arm}' cycle {cycle}/{n}: degenerate audit — {guard_result.reason}"
+                )
+                halted = True
+                break
+    finally:
+        for key, prior in _saved_env.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
+
+    arm_summary = ArmSummary(
+        arm=arm,
+        cycles_run=cycles_run,
+        cycles_skipped=cycles_skipped,
+        promotes=promotes,
+        halted=halted,
+    )
+    progress.emit(arm_summary.summary())
+    return arm_summary
+
+
+def _promoted_this_cycle(signal: CycleSignal | None) -> bool:
+    """A positive ``fitness_delta`` on the newest attribution row is the per-cycle
+    promote proxy (the baseline advanced). ``None`` / non-positive ⇒ reject."""
+    if signal is None or signal.fitness_delta is None:
+        return False
+    return signal.fitness_delta > 0.0
+
+
+def _cycle_line(
+    *, arm: str, cycle: int, n: int, signal: CycleSignal | None, guard: GuardResult
+) -> str:
+    """One per-cycle progress line (campaign-procedure.md §4 progress-log fields)."""
+    if signal is None:
+        return (
+            f"arm '{arm}' cycle {cycle}/{n}: NO-SIGNAL "
+            f"guard={'ok' if guard.ok else 'degenerate'} ({guard.reason})"
+        )
+    promote = "promote" if _promoted_this_cycle(signal) else "reject"
+    delta = "n/a" if signal.fitness_delta is None else f"{signal.fitness_delta:+.4f}"
+    return (
+        f"arm '{arm}' cycle {cycle}/{n}: fitness_after={signal.fitness} "
+        f"fitness_delta={delta} held_out={signal.held_out_fitness} {promote} "
+        f"guard={'ok' if guard.ok else 'degenerate'} ({guard.reason})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level campaign
+# ---------------------------------------------------------------------------
+
+
+def run_campaign(
+    *,
+    n: int = DEFAULT_N,
+    k: int = DEFAULT_K,
+    arms: Sequence[str] = DEFAULT_ARMS,
+    max_propose_attempts: int = DEFAULT_MAX_PROPOSE_ATTEMPTS,
+    audit_max_samples: int = DEFAULT_AUDIT_MAX_SAMPLES,
+    audit_max_connections: int = DEFAULT_AUDIT_MAX_CONNECTIONS,
+    dry_run: bool = False,
+    progress_path: Path = PROGRESS_LOG,
+    snapshot_dir: Path = GEN0_SNAPSHOT_DIR,
+    train_runner: Any | None = None,
+    runner_factory: Any | None = None,
+    guard_fn: Any | None = None,
+) -> dict[str, Any]:
+    """Run the full campaign: gen-0 K-repeat baseline → snapshot → 3-arm loop.
+
+    Returns a dict with the noise band + per-arm summaries (for tests + an
+    end-of-run digest). Arms run in the order given (``never → random → gate`` by
+    default, gate LAST). The injected ``train_runner`` / ``runner_factory`` /
+    ``guard_fn`` keep the whole thing unit-testable with NO live audit.
+    """
+    _validate_arms(arms)
+    with ProgressLog(progress_path) as progress:
+        progress.emit(
+            f"campaign start: n={n} k={k} arms={list(arms)} dry_run={dry_run} "
+            f"audit_max_samples={audit_max_samples} audit_max_connections={audit_max_connections}"
+        )
+        band = run_gen0_baseline(
+            k=k,
+            dry_run=dry_run,
+            audit_max_samples=audit_max_samples,
+            audit_max_connections=audit_max_connections,
+            progress=progress,
+            train_runner=train_runner,
+        )
+        snapshot_written = snapshot_sot(snapshot_dir)
+        progress.emit(f"gen-0 SoT snapshot: {len(snapshot_written)} files → {snapshot_dir}")
+        arm_summaries: list[ArmSummary] = []
+        halted = False
+        for arm_index, arm in enumerate(arms):
+            summary = run_arm(
+                arm=arm,
+                arm_index=arm_index,
+                n=n,
+                max_propose_attempts=max_propose_attempts,
+                audit_max_samples=audit_max_samples,
+                audit_max_connections=audit_max_connections,
+                dry_run=dry_run,
+                progress=progress,
+                snapshot_dir=snapshot_dir,
+                runner_factory=runner_factory,
+                guard_fn=guard_fn,
+            )
+            arm_summaries.append(summary)
+            if summary.halted:
+                # A degenerate audit signals a broken setup — stop the WHOLE
+                # campaign (not just this arm) so a broken setup never burns the
+                # remaining arms (campaign-procedure.md §5.6; Codex MCP #3).
+                progress.emit(f"campaign HALT: arm '{arm}' degenerate — stopping remaining arms")
+                halted = True
+                break
+        progress.emit("campaign complete" if not halted else "campaign halted")
+        return {
+            "noise_band": band,
+            "arm_summaries": arm_summaries,
+            "halted": halted,
+            "snapshot_files": [str(p) for p in snapshot_written],
+        }
+
+
+def _validate_arms(arms: Sequence[str]) -> None:
+    valid = {"gate", "random", "never"}
+    bad = [a for a in arms if a not in valid]
+    if bad:
+        raise ValueError(
+            f"unknown arm(s) {bad} — the 3-arm comparison expects a subset of {sorted(valid)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Self-improving campaign driver (docs/self-improving/campaign-procedure.md).",
+    )
+    parser.add_argument("--n", type=int, default=DEFAULT_N, help="cycles per arm (default 10)")
+    parser.add_argument(
+        "--k", type=int, default=DEFAULT_K, help="gen-0 baseline repeats (default 5)"
+    )
+    parser.add_argument(
+        "--arms",
+        type=str,
+        default=",".join(DEFAULT_ARMS),
+        help="comma-separated arm order, gate LAST (default 'never,random,gate')",
+    )
+    parser.add_argument(
+        "--mc",
+        type=int,
+        default=DEFAULT_MAX_PROPOSE_ATTEMPTS,
+        help="max propose-guard re-proposal attempts M (default 8)",
+    )
+    parser.add_argument(
+        "--audit-max-samples",
+        type=int,
+        default=DEFAULT_AUDIT_MAX_SAMPLES,
+        help="GEODE_AUDIT_MAX_SAMPLES export (default 3)",
+    )
+    parser.add_argument(
+        "--audit-max-connections",
+        type=int,
+        default=DEFAULT_AUDIT_MAX_CONNECTIONS,
+        help="GEODE_AUDIT_MAX_CONNECTIONS export (default 8)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="pass --dry-run through to train.py + the runner (synthetic audits, no PAYG/network)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
+    try:
+        _validate_arms(arms)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr, flush=True)
+        return 2
+    run_campaign(
+        n=args.n,
+        k=args.k,
+        arms=arms,
+        max_propose_attempts=args.mc,
+        audit_max_samples=args.audit_max_samples,
+        audit_max_connections=args.audit_max_connections,
+        dry_run=args.dry_run,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry
+    raise SystemExit(main())

--- a/scripts/watch_campaign.py
+++ b/scripts/watch_campaign.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""On-demand digest of a running / finished self-improving campaign.
+
+PR-CAMPAIGN-DRIVER (2026-05-31). The companion to ``scripts/run_campaign.py``.
+Reads the same three SoTs and prints a compact, flushed digest:
+
+* ``autoresearch/state/campaign-progress.log`` — the per-cycle progress lines
+  the driver tees (last N).
+* ``autoresearch/state/mutations.jsonl`` — the mutator-driven ``kind="attribution"``
+  rows (``source="mutator"``), grouped by ``promote_policy`` arm.
+* ``autoresearch/state/baseline_archive.jsonl`` — the ``kind="baseline"`` rows,
+  grouped by baseline epoch (``epoch_label`` / ``be-NNN``).
+
+This is read-only; it never spawns an audit or mutates state. Run it any time
+during a long campaign to see where the held-out fitness curve sits per arm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AUTORESEARCH_STATE_DIR = REPO_ROOT / "autoresearch" / "state"
+PROGRESS_LOG = AUTORESEARCH_STATE_DIR / "campaign-progress.log"
+MUTATIONS_JSONL = AUTORESEARCH_STATE_DIR / "mutations.jsonl"
+BASELINE_ARCHIVE = AUTORESEARCH_STATE_DIR / "baseline_archive.jsonl"
+
+
+def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def tail_progress(path: Path, *, last: int) -> list[str]:
+    """Return the last ``last`` non-blank lines of the progress log."""
+    if not path.exists():
+        return []
+    lines = [ln.rstrip("\n") for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    return lines[-last:]
+
+
+def attribution_by_arm(path: Path) -> dict[str, list[dict[str, Any]]]:
+    """Group the mutator-driven attribution rows by ``promote_policy`` arm.
+
+    Only ``source="mutator"`` rows are kept (the campaign's cycle rows); manual
+    gen-0 baseline rows (``source="manual"``) carry no arm tag and are excluded
+    from the per-arm split.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in _iter_jsonl(path):
+        if row.get("kind") != "attribution":
+            continue
+        if row.get("source") != "mutator":
+            continue
+        arm = str(row.get("promote_policy") or "?")
+        grouped[arm].append(row)
+    return dict(grouped)
+
+
+def baseline_epochs(path: Path) -> dict[str, list[dict[str, Any]]]:
+    """Group ``kind="baseline"`` rows by epoch label (``be-NNN``)."""
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in _iter_jsonl(path):
+        if row.get("kind") != "baseline":
+            continue
+        label = str(row.get("epoch_label") or row.get("epoch_hash") or "?")
+        grouped[label].append(row)
+    return dict(grouped)
+
+
+def _fmt_held_out_curve(rows: list[dict[str, Any]]) -> str:
+    vals: list[float] = [
+        float(v)
+        for r in rows
+        if isinstance((v := r.get("held_out_fitness")), (int, float)) and not isinstance(v, bool)
+    ]
+    if not vals:
+        return "(no held-out values)"
+    return ", ".join(f"{v:.4f}" for v in vals)
+
+
+def build_digest(*, last: int) -> list[str]:
+    """Compose the full digest as a list of lines."""
+    out: list[str] = ["=== campaign digest ==="]
+
+    out.append("")
+    out.append(f"--- progress log (last {last}) ---")
+    progress_lines = tail_progress(PROGRESS_LOG, last=last)
+    out.extend(progress_lines or ["(no campaign-progress.log yet)"])
+
+    out.append("")
+    out.append("--- attribution by arm (source=mutator) ---")
+    grouped = attribution_by_arm(MUTATIONS_JSONL)
+    if not grouped:
+        out.append("(no mutator attribution rows yet)")
+    else:
+        for arm in sorted(grouped):
+            rows = grouped[arm]
+            out.append(f"arm '{arm}': {len(rows)} cycles | held_out: {_fmt_held_out_curve(rows)}")
+
+    out.append("")
+    out.append("--- baseline epochs ---")
+    epochs = baseline_epochs(BASELINE_ARCHIVE)
+    if not epochs:
+        out.append("(no baseline_archive rows yet)")
+    else:
+        for label in sorted(epochs):
+            rows = epochs[label]
+            policies = sorted({str(r.get("promote_policy") or "?") for r in rows})
+            out.append(f"epoch {label}: {len(rows)} baselines | policies={policies}")
+
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--last", type=int, default=20, help="progress-log tail line count (default 20)"
+    )
+    args = parser.parse_args(argv)
+    for line in build_digest(last=args.last):
+        print(line, flush=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry
+    raise SystemExit(main())

--- a/tests/test_run_campaign.py
+++ b/tests/test_run_campaign.py
@@ -1,0 +1,712 @@
+"""Unit tests for the self-improving campaign driver (``scripts/run_campaign.py``).
+
+PR-CAMPAIGN-DRIVER (2026-05-31). NO live audits — every boundary is mocked:
+the mutator ``propose()``, the ``train.py`` subprocess, ``read_eval_log``, and
+the SoT files (via monkeypatched module-level path constants). The tests cover:
+
+* propose-guard: re-proposes on ``RepetitiveMutationError`` + measurement-
+  hyperparam ``ValueError``, accepts a clean proposal, gives up after M.
+* arm loop: correct ``GEODE_PROMOTE_POLICY`` (+ seed for random) +
+  ``commit_enabled`` per arm; gate runs last.
+* SoT snapshot/restore round-trips the policy files + baseline.json.
+* degeneracy guard: HALTs on a fake 0-sample eval, passes on a healthy one.
+* gen-0 K-repeat collects K held-out values + computes the noise band.
+* ``--dry-run`` end-to-end smoke runs without touching PAYG/network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import scripts.run_campaign as rc
+from core.self_improving_loop.mutator_feedback import RepetitionFinding, RepetitiveMutationError
+from core.self_improving_loop.runner import Mutation, Proposal
+
+# ---------------------------------------------------------------------------
+# Fixtures — redirect the module-level SoT paths into tmp dirs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def campaign_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Redirect every SoT path the driver touches into ``tmp_path``."""
+    state_dir = tmp_path / "autoresearch" / "state"
+    policies_dir = state_dir / "policies"
+    policies_dir.mkdir(parents=True)
+    baseline = state_dir / "baseline.json"
+    mutations = state_dir / "mutations.jsonl"
+    progress = state_dir / "campaign-progress.log"
+    snapshot = tmp_path / "state" / "campaign" / "gen-0-snapshot"
+    petri_logs = tmp_path / "petri-logs"
+    petri_logs.mkdir(parents=True)
+
+    monkeypatch.setattr(rc, "AUTORESEARCH_STATE_DIR", state_dir)
+    monkeypatch.setattr(rc, "POLICIES_DIR", policies_dir)
+    monkeypatch.setattr(rc, "BASELINE_JSON", baseline)
+    monkeypatch.setattr(rc, "MUTATIONS_JSONL", mutations)
+    monkeypatch.setattr(rc, "PROGRESS_LOG", progress)
+    monkeypatch.setattr(rc, "GEN0_SNAPSHOT_DIR", snapshot)
+    monkeypatch.setattr(rc, "PETRI_LOGS_DIR", petri_logs)
+    # The snapshot-source tuple is recomputed from the patched POLICIES_DIR so
+    # snapshot_sot reads the tmp policies dir, not the repo one.
+    monkeypatch.setattr(
+        rc,
+        "_SNAPSHOT_SOURCES",
+        ((policies_dir, "*.json"), (policies_dir, "*.jsonl")),
+    )
+    return {
+        "state_dir": state_dir,
+        "policies_dir": policies_dir,
+        "baseline": baseline,
+        "mutations": mutations,
+        "progress": progress,
+        "snapshot": snapshot,
+        "petri_logs": petri_logs,
+    }
+
+
+def _clean_mutation() -> Mutation:
+    return Mutation(
+        target_section="some_section",
+        new_value="a clean new value",
+        rationale="grounded",
+        target_kind="prompt",
+    )
+
+
+def _clean_proposal() -> Proposal:
+    return Proposal(mutation=_clean_mutation())
+
+
+def _repetitive_error() -> RepetitiveMutationError:
+    finding = RepetitionFinding(
+        is_repetitive=True,
+        max_similarity=0.99,
+        matched_mutation_id="m1",
+        matched_target_section="some_section",
+    )
+    return RepetitiveMutationError(finding, threshold=0.85)
+
+
+def _write_attribution(
+    path: Path,
+    *,
+    held_out: float | None,
+    fitness: float | None,
+    delta: float | None = None,
+    promote_policy: str | None = None,
+    source: str = "manual",
+    between_seed_stderr: float | None = 0.05,
+) -> None:
+    row: dict[str, Any] = {"ts": 1.0, "kind": "attribution", "mutation_id": "x", "source": source}
+    if held_out is not None:
+        row["held_out_fitness"] = held_out
+    if fitness is not None:
+        row["fitness_after"] = fitness
+    if delta is not None:
+        row["fitness_delta"] = delta
+    if promote_policy is not None:
+        row["promote_policy"] = promote_policy
+    if between_seed_stderr is not None:
+        row["between_seed_stderr"] = between_seed_stderr
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# propose-guard
+# ---------------------------------------------------------------------------
+
+
+def test_propose_guard_accepts_clean_proposal() -> None:
+    clean = _clean_proposal()
+    runner = SimpleNamespace(propose=lambda: clean)
+    result = rc.propose_with_guard(runner, max_attempts=3)
+    assert result is clean
+
+
+def test_propose_guard_reproposes_on_repetitive_then_accepts() -> None:
+    clean = _clean_proposal()
+    calls = {"n": 0}
+
+    def propose() -> Proposal:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _repetitive_error()
+        return clean
+
+    runner = SimpleNamespace(propose=propose)
+    result = rc.propose_with_guard(runner, max_attempts=5)
+    assert result is clean
+    assert calls["n"] == 2
+
+
+def test_propose_guard_reproposes_on_measurement_hyperparam_valueerror() -> None:
+    clean = _clean_proposal()
+    calls = {"n": 0}
+
+    def propose() -> Proposal:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError(
+                "hyperparam target_section 'seed_limit' is a FIXED audit-measurement parameter"
+            )
+        return clean
+
+    runner = SimpleNamespace(propose=propose)
+    result = rc.propose_with_guard(runner, max_attempts=5)
+    assert result is clean
+    assert calls["n"] == 2
+
+
+def test_propose_guard_gives_up_after_m_attempts() -> None:
+    calls = {"n": 0}
+
+    def propose() -> Proposal:
+        calls["n"] += 1
+        raise _repetitive_error()
+
+    runner = SimpleNamespace(propose=propose)
+    result = rc.propose_with_guard(runner, max_attempts=4)
+    assert result is None
+    assert calls["n"] == 4  # exactly M attempts, no more
+
+
+# ---------------------------------------------------------------------------
+# SoT snapshot / restore round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_restore_round_trips_policies_and_baseline(
+    campaign_state: dict[str, Path],
+) -> None:
+    policies_dir = campaign_state["policies_dir"]
+    baseline = campaign_state["baseline"]
+    (policies_dir / "hyperparam.json").write_text('{"reflection_depth": 3}', encoding="utf-8")
+    (policies_dir / "tool-policy.json").write_text('{"a": "b"}', encoding="utf-8")
+    (policies_dir / "few-shot-pool.jsonl").write_text('{"row": 1}\n', encoding="utf-8")
+    baseline.write_text('{"fitness": 0.5}', encoding="utf-8")
+
+    written = rc.snapshot_sot(campaign_state["snapshot"])
+    assert len(written) == 4  # 3 policy files + baseline.json
+
+    # Mutate the live SoT, then restore.
+    (policies_dir / "hyperparam.json").write_text('{"reflection_depth": 5}', encoding="utf-8")
+    baseline.write_text('{"fitness": 0.9}', encoding="utf-8")
+    (policies_dir / "injected.json").write_text("{}", encoding="utf-8")
+
+    restored = rc.restore_sot(campaign_state["snapshot"])
+    assert (policies_dir / "hyperparam.json").read_text(
+        encoding="utf-8"
+    ) == '{"reflection_depth": 3}'
+    assert baseline.read_text(encoding="utf-8") == '{"fitness": 0.5}'
+    # The snapshot is the canonical set; restored covers exactly the 4 captured files.
+    assert {p.name for p in restored} == {
+        "hyperparam.json",
+        "tool-policy.json",
+        "few-shot-pool.jsonl",
+        "baseline.json",
+    }
+    # Mirror semantics — the orphan file injected after the snapshot is DELETED,
+    # so the next arm starts from an exact matched gen-0 state (Codex MCP #1).
+    assert not (policies_dir / "injected.json").exists()
+
+
+def test_restore_mirror_deletes_orphan_policy_files(
+    campaign_state: dict[str, Path],
+) -> None:
+    policies_dir = campaign_state["policies_dir"]
+    (policies_dir / "hyperparam.json").write_text("{}", encoding="utf-8")
+    rc.snapshot_sot(campaign_state["snapshot"])
+    # An earlier arm inserts a new policy file that gen-0 never had.
+    (policies_dir / "wrapper-sections.json").write_text('{"x": "y"}', encoding="utf-8")
+    rc.restore_sot(campaign_state["snapshot"])
+    assert (policies_dir / "hyperparam.json").exists()
+    assert not (policies_dir / "wrapper-sections.json").exists()
+
+
+def test_restore_missing_snapshot_raises(campaign_state: dict[str, Path]) -> None:
+    with pytest.raises(FileNotFoundError):
+        rc.restore_sot(campaign_state["snapshot"] / "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# degeneracy guard
+# ---------------------------------------------------------------------------
+
+
+def _fake_eval(*, status: str, samples: list[Any]) -> SimpleNamespace:
+    return SimpleNamespace(status=status, samples=samples)
+
+
+def _healthy_sample() -> SimpleNamespace:
+    judge = SimpleNamespace(value={"safety": 3.0, "helpfulness": 2.0})
+    return SimpleNamespace(scores={"audit_judge": judge})
+
+
+@pytest.fixture
+def fake_read_eval_log(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake ``inspect_ai.log.read_eval_log`` into ``sys.modules``.
+
+    The degeneracy guard does ``from inspect_ai.log import read_eval_log`` lazily;
+    ``inspect_ai`` lives behind the ``[audit]`` extra and may be absent in the
+    base test env, so we inject a stub module that returns a caller-supplied eval
+    object. Returns a setter the test calls with the eval to serve.
+    """
+    import sys
+    import types
+
+    served: dict[str, Any] = {}
+
+    def _reader(_path: str) -> Any:
+        return served["eval"]
+
+    inspect_ai_mod = sys.modules.get("inspect_ai") or types.ModuleType("inspect_ai")
+    log_mod = types.ModuleType("inspect_ai.log")
+    log_mod.read_eval_log = _reader  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "inspect_ai", inspect_ai_mod)
+    monkeypatch.setitem(sys.modules, "inspect_ai.log", log_mod)
+
+    def _set(eval_obj: Any) -> None:
+        served["eval"] = eval_obj
+
+    return _set
+
+
+def test_degeneracy_guard_passes_on_healthy_eval(
+    campaign_state: dict[str, Path], fake_read_eval_log: Any
+) -> None:
+    (campaign_state["petri_logs"] / "run.eval").write_bytes(b"")
+    fake_read_eval_log(_fake_eval(status="success", samples=[_healthy_sample()]))
+    result = rc.degeneracy_guard(logs_dir=campaign_state["petri_logs"])
+    assert result.ok
+    assert "samples=1" in result.reason
+
+
+def test_degeneracy_guard_halts_on_zero_sample_eval(
+    campaign_state: dict[str, Path], fake_read_eval_log: Any
+) -> None:
+    (campaign_state["petri_logs"] / "run.eval").write_bytes(b"")
+    fake_read_eval_log(_fake_eval(status="success", samples=[]))
+    result = rc.degeneracy_guard(logs_dir=campaign_state["petri_logs"])
+    assert not result.ok
+    assert "0 samples" in result.reason
+
+
+def test_degeneracy_guard_halts_on_zero_scored_dims(
+    campaign_state: dict[str, Path], fake_read_eval_log: Any
+) -> None:
+    (campaign_state["petri_logs"] / "run.eval").write_bytes(b"")
+    # A sample with no audit_judge score = 0 scored dims.
+    blank = SimpleNamespace(scores={})
+    fake_read_eval_log(_fake_eval(status="success", samples=[blank]))
+    result = rc.degeneracy_guard(logs_dir=campaign_state["petri_logs"])
+    assert not result.ok
+    assert "0 scored dims" in result.reason
+
+
+def test_degeneracy_guard_fallback_on_collapsed_stderr() -> None:
+    # No eval log path + a collapsed between_seed_stderr → degenerate.
+    signal = rc.CycleSignal(
+        held_out_fitness=0.5,
+        fitness=0.5,
+        fitness_delta=0.0,
+        promote_policy="gate",
+        source="mutator",
+        between_seed_stderr=0.001,
+    )
+    result = rc._degeneracy_guard_fallback(signal)
+    assert not result.ok
+    assert "degenerate" in result.reason
+
+
+def test_degeneracy_guard_fallback_ok_with_healthy_stderr() -> None:
+    signal = rc.CycleSignal(
+        held_out_fitness=0.5,
+        fitness=0.5,
+        fitness_delta=0.0,
+        promote_policy="gate",
+        source="mutator",
+        between_seed_stderr=0.08,
+    )
+    result = rc._degeneracy_guard_fallback(signal)
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# gen-0 K-repeat baseline + noise band
+# ---------------------------------------------------------------------------
+
+
+def test_gen0_baseline_collects_k_held_out_and_computes_band(
+    campaign_state: dict[str, Path],
+) -> None:
+    mutations = campaign_state["mutations"]
+    synthetic_held = [0.50, 0.54, 0.52, 0.55, 0.51]
+    calls = {"n": 0}
+
+    def fake_train(*, env: dict[str, str], dry_run: bool) -> SimpleNamespace:
+        # Each "subprocess" appends one synthetic manual attribution row.
+        h = synthetic_held[calls["n"]]
+        _write_attribution(mutations, held_out=h, fitness=h + 0.1, source="manual")
+        calls["n"] += 1
+        return SimpleNamespace(returncode=0)
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        band = rc.run_gen0_baseline(
+            k=5,
+            dry_run=False,
+            audit_max_samples=3,
+            audit_max_connections=8,
+            progress=progress,
+            train_runner=fake_train,
+        )
+
+    assert calls["n"] == 5
+    assert len(band.held_out_values) == 5
+    assert band.held_out_values == tuple(synthetic_held)
+    assert band.mean == pytest.approx(sum(synthetic_held) / 5)
+    assert band.stderr is not None and band.stderr > 0.0
+
+
+def test_compute_noise_band_single_value_zero_stderr() -> None:
+    band = rc.compute_noise_band([0.5], [0.6], k=1)
+    assert band.mean == pytest.approx(0.5)
+    assert band.stderr == 0.0
+
+
+def test_compute_noise_band_empty_is_none() -> None:
+    band = rc.compute_noise_band([], [], k=3)
+    assert band.mean is None
+    assert band.stderr is None
+
+
+# ---------------------------------------------------------------------------
+# arm loop — env + commit_enabled per arm; gate last
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRunner:
+    """A fake runner that records the env / commit_enabled it was built with and
+    succeeds on propose + apply without any network."""
+
+    def __init__(self, *, arm: str, env: dict[str, str], commit_enabled: bool) -> None:
+        self.arm = arm
+        self.env = env
+        self.commit_enabled = commit_enabled
+        self.applied: list[Proposal] = []
+
+    def propose(self) -> Proposal:
+        return _clean_proposal()
+
+    def apply_proposal(self, proposal: Proposal) -> Mutation:
+        self.applied.append(proposal)
+        return proposal.mutation
+
+
+def test_arm_loop_sets_promote_policy_and_seed_and_commit(
+    campaign_state: dict[str, Path],
+) -> None:
+    # Prime a gen-0 snapshot so restore_sot succeeds.
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+    rc.snapshot_sot(campaign_state["snapshot"])
+
+    built: list[_RecordingRunner] = []
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        runner = _RecordingRunner(arm=arm, env=dict(env), commit_enabled=(arm == "gate"))
+        built.append(runner)
+        return runner
+
+    # A healthy signal so the guard never HALTs.
+    _write_attribution(
+        campaign_state["mutations"],
+        held_out=0.5,
+        fitness=0.5,
+        delta=0.01,
+        promote_policy="gate",
+        source="mutator",
+        between_seed_stderr=0.05,
+    )
+
+    def healthy_guard(_signal: rc.CycleSignal | None) -> rc.GuardResult:
+        return rc.GuardResult(ok=True, reason="test ok")
+
+    summaries: list[rc.ArmSummary] = []
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        for arm_index, arm in enumerate(("never", "random", "gate")):
+            summaries.append(
+                rc.run_arm(
+                    arm=arm,
+                    arm_index=arm_index,
+                    n=2,
+                    max_propose_attempts=8,
+                    audit_max_samples=3,
+                    audit_max_connections=8,
+                    dry_run=False,
+                    progress=progress,
+                    snapshot_dir=campaign_state["snapshot"],
+                    runner_factory=factory,
+                    guard_fn=healthy_guard,
+                )
+            )
+
+    # never arm: no seed, commit off.
+    never_runner = built[0]
+    assert never_runner.env["GEODE_PROMOTE_POLICY"] == "never"
+    assert "GEODE_PROMOTE_POLICY_SEED" not in never_runner.env
+    assert never_runner.commit_enabled is False
+
+    # random arm (index 1): deterministic seed = base + 1, commit off.
+    random_runner = built[2]  # built has 2 per arm (n=2); arm boundaries at 0/2/4
+    assert random_runner.env["GEODE_PROMOTE_POLICY"] == "random"
+    assert random_runner.env["GEODE_PROMOTE_POLICY_SEED"] == str(rc.DEFAULT_RANDOM_SEED_BASE + 1)
+    assert random_runner.commit_enabled is False
+
+    # gate arm (index 2, LAST): commit ON.
+    gate_runner = built[4]
+    assert gate_runner.env["GEODE_PROMOTE_POLICY"] == "gate"
+    assert gate_runner.commit_enabled is True
+
+    # gate ran last.
+    assert [s.arm for s in summaries] == ["never", "random", "gate"]
+
+
+def test_arm_loop_halts_on_degenerate_guard(campaign_state: dict[str, Path]) -> None:
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+    rc.snapshot_sot(campaign_state["snapshot"])
+    _write_attribution(
+        campaign_state["mutations"], held_out=0.5, fitness=0.5, delta=0.0, source="mutator"
+    )
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        return _RecordingRunner(arm=arm, env=dict(env), commit_enabled=(arm == "gate"))
+
+    def degenerate_guard(_signal: rc.CycleSignal | None) -> rc.GuardResult:
+        return rc.GuardResult(ok=False, reason="fake degenerate")
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        summary = rc.run_arm(
+            arm="never",
+            arm_index=0,
+            n=10,
+            max_propose_attempts=8,
+            audit_max_samples=3,
+            audit_max_connections=8,
+            dry_run=False,
+            progress=progress,
+            snapshot_dir=campaign_state["snapshot"],
+            runner_factory=factory,
+            guard_fn=degenerate_guard,
+        )
+    assert summary.halted is True
+    assert summary.cycles_run == 1  # halted after the first cycle
+
+
+def test_arm_loop_skips_cycle_when_propose_exhausted(
+    campaign_state: dict[str, Path],
+) -> None:
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+    rc.snapshot_sot(campaign_state["snapshot"])
+
+    class _AlwaysRepetitiveRunner:
+        def __init__(self) -> None:
+            self.applied = 0
+
+        def propose(self) -> Proposal:
+            raise _repetitive_error()
+
+        def apply_proposal(self, proposal: Proposal) -> Mutation:  # pragma: no cover
+            self.applied += 1
+            return proposal.mutation
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _AlwaysRepetitiveRunner:
+        return _AlwaysRepetitiveRunner()
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        summary = rc.run_arm(
+            arm="never",
+            arm_index=0,
+            n=2,
+            max_propose_attempts=3,
+            audit_max_samples=3,
+            audit_max_connections=8,
+            dry_run=False,
+            progress=progress,
+            snapshot_dir=campaign_state["snapshot"],
+            runner_factory=factory,
+            guard_fn=lambda _s: rc.GuardResult(ok=True, reason="ok"),
+        )
+    assert summary.cycles_run == 0
+    assert summary.cycles_skipped == 2
+
+
+# ---------------------------------------------------------------------------
+# env setup
+# ---------------------------------------------------------------------------
+
+
+def test_build_campaign_env_sets_fixed_vars() -> None:
+    env = rc.build_campaign_env(
+        promote_policy="random",
+        promote_policy_seed=424201,
+        audit_max_samples=3,
+        audit_max_connections=8,
+        base_env={"ANTHROPIC_API_KEY": "from-operator-shell"},
+    )
+    assert env["ANTHROPIC_API_KEY"] == "from-operator-shell"
+    assert env["GEODE_CODEX_OAUTH_POLL_DISABLED"] == "1"
+    assert env["AUTORESEARCH_SEED_SELECT"] == str(rc.CYCLE_INPUT_POOL)
+    assert env["GEODE_HELD_OUT_BENCH"] == str(rc.HELD_OUT_BENCH)
+    assert env["GEODE_AUDIT_MAX_SAMPLES"] == "3"
+    assert env["GEODE_AUDIT_MAX_CONNECTIONS"] == "8"
+    assert env["GEODE_PROMOTE_POLICY"] == "random"
+    assert env["GEODE_PROMOTE_POLICY_SEED"] == "424201"
+
+
+def test_build_campaign_env_omits_arm_when_none() -> None:
+    env = rc.build_campaign_env(base_env={})
+    assert "GEODE_PROMOTE_POLICY" not in env
+    assert "GEODE_PROMOTE_POLICY_SEED" not in env
+
+
+def test_build_campaign_env_clears_stale_arm_env(campaign_state: dict[str, Path]) -> None:
+    # A stale arm policy + seed (+ AUTORESEARCH_* aliases) in the base env must be
+    # REMOVED when the caller passes None — gen-0 / gate / never inherit no arm.
+    stale = {
+        "GEODE_PROMOTE_POLICY": "random",
+        "GEODE_PROMOTE_POLICY_SEED": "999",
+        "AUTORESEARCH_PROMOTE_POLICY": "random",
+        "AUTORESEARCH_PROMOTE_POLICY_SEED": "999",
+    }
+    env = rc.build_campaign_env(base_env=stale)
+    assert "GEODE_PROMOTE_POLICY" not in env
+    assert "GEODE_PROMOTE_POLICY_SEED" not in env
+    assert "AUTORESEARCH_PROMOTE_POLICY" not in env
+    assert "AUTORESEARCH_PROMOTE_POLICY_SEED" not in env
+    # gate arm must not inherit the stale seed.
+    env_gate = rc.build_campaign_env(promote_policy="gate", base_env=stale)
+    assert env_gate["GEODE_PROMOTE_POLICY"] == "gate"
+    assert "GEODE_PROMOTE_POLICY_SEED" not in env_gate
+
+
+def test_read_latest_attribution_min_rows_blocks_stale(campaign_state: dict[str, Path]) -> None:
+    mutations = campaign_state["mutations"]
+    _write_attribution(mutations, held_out=0.5, fitness=0.5, source="manual")
+    before = rc.count_attribution_rows(mutations)
+    assert before == 1
+    # No new row appended → min_rows guard returns None (no stale-row reuse).
+    assert rc.read_latest_attribution(mutations, min_rows=before) is None
+    # A new row appended → the guard lets it through.
+    _write_attribution(mutations, held_out=0.6, fitness=0.6, source="manual")
+    signal = rc.read_latest_attribution(mutations, min_rows=before)
+    assert signal is not None
+    assert signal.held_out_fitness == pytest.approx(0.6)
+
+
+def test_campaign_halt_stops_remaining_arms(campaign_state: dict[str, Path]) -> None:
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+    _write_attribution(
+        campaign_state["mutations"], held_out=0.5, fitness=0.5, delta=0.0, source="mutator"
+    )
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        return _RecordingRunner(arm=arm, env=dict(env), commit_enabled=(arm == "gate"))
+
+    def degenerate_guard(_signal: rc.CycleSignal | None) -> rc.GuardResult:
+        return rc.GuardResult(ok=False, reason="fake degenerate")
+
+    result = rc.run_campaign(
+        n=3,
+        k=0,
+        arms=("never", "random", "gate"),
+        dry_run=False,
+        progress_path=campaign_state["progress"],
+        snapshot_dir=campaign_state["snapshot"],
+        train_runner=lambda **_kw: SimpleNamespace(returncode=0),
+        runner_factory=factory,
+        guard_fn=degenerate_guard,
+    )
+    # The first arm halts → the campaign stops; only ONE arm summary exists.
+    assert result["halted"] is True
+    assert len(result["arm_summaries"]) == 1
+    assert result["arm_summaries"][0].arm == "never"
+
+
+# ---------------------------------------------------------------------------
+# end-to-end dry-run smoke (no PAYG / no network)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_end_to_end_smoke(
+    campaign_state: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole campaign runs under --dry-run with synthetic boundaries: the
+    train.py subprocess is stubbed (no network) and the offline runner factory
+    is stubbed so no mutator LLM call fires."""
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text(
+        '{"reflection_depth": 3}', encoding="utf-8"
+    )
+    mutations = campaign_state["mutations"]
+
+    def fake_train(*, env: dict[str, str], dry_run: bool) -> SimpleNamespace:
+        assert dry_run is True  # smoke must pass dry_run through
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        return SimpleNamespace(returncode=0)
+
+    # Offline runner factory — never touches the network.
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        assert dry_run is True
+        return _RecordingRunner(arm=arm, env=dict(env), commit_enabled=False)
+
+    result = rc.run_campaign(
+        n=1,
+        k=1,
+        arms=("never", "random", "gate"),
+        dry_run=True,
+        progress_path=campaign_state["progress"],
+        snapshot_dir=campaign_state["snapshot"],
+        train_runner=fake_train,
+        runner_factory=factory,
+    )
+    band = result["noise_band"]
+    assert band.k == 1
+    assert band.mean == pytest.approx(0.5)
+    assert [s.arm for s in result["arm_summaries"]] == ["never", "random", "gate"]
+    # Snapshot was written (1 policy file + baseline.json if present).
+    assert result["snapshot_files"]
+    # Progress log was flushed to disk.
+    assert campaign_state["progress"].exists()
+    assert "campaign complete" in campaign_state["progress"].read_text(encoding="utf-8")
+
+
+def test_run_campaign_rejects_unknown_arm(campaign_state: dict[str, Path]) -> None:
+    with pytest.raises(ValueError, match="unknown arm"):
+        rc.run_campaign(
+            arms=("never", "bogus"),
+            dry_run=True,
+            progress_path=campaign_state["progress"],
+            snapshot_dir=campaign_state["snapshot"],
+        )
+
+
+def test_read_latest_attribution_picks_newest(campaign_state: dict[str, Path]) -> None:
+    mutations = campaign_state["mutations"]
+    _write_attribution(mutations, held_out=0.40, fitness=0.41, source="manual")
+    _write_attribution(
+        mutations, held_out=0.55, fitness=0.56, delta=0.02, promote_policy="gate", source="mutator"
+    )
+    signal = rc.read_latest_attribution(mutations)
+    assert signal is not None
+    assert signal.held_out_fitness == pytest.approx(0.55)
+    assert signal.fitness == pytest.approx(0.56)
+    assert signal.promote_policy == "gate"
+    assert signal.source == "mutator"
+
+
+def test_read_latest_attribution_none_when_absent(campaign_state: dict[str, Path]) -> None:
+    assert rc.read_latest_attribution(campaign_state["mutations"]) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.101"
+version = "0.99.102"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Build the committed, unit-tested **campaign driver** (`scripts/run_campaign.py`) for the self-improving loop, implementing `docs/self-improving/campaign-procedure.md` exactly: gen-0 K-repeat baseline + noise band → full-SoT snapshot → 3-arm loop (`never → random → gate`, gate LAST, matched gen-0 reset) with a propose-guard, a degeneracy guard, and a flushed progress log.
- Add `scripts/watch_campaign.py` — on-demand digest (progress log + mutator attribution rows split by `promote_policy` + baseline epochs).
- 27 unit tests, every boundary mocked, **NO live audits** (no PAYG).

## Why
The operator needs a single committed entry point to run the 3-arm self-improving campaign (so any observed held-out gain is attributable to the gate, not drift/chance) without re-deriving the procedure by hand each time. The driver sequences existing pieces (`autoresearch/train.py` manual path, `SelfImprovingLoopRunner.propose/apply_proposal`, `GEODE_PROMOTE_POLICY`); it decides no policy of its own.

## Changes
| File | Change |
|------|--------|
| `scripts/run_campaign.py` | New importable module + CLI. gen-0 K-repeat baseline (reads `held_out_fitness`+`fitness` from new `kind="attribution"` rows) + noise band (mean±stderr); full-SoT snapshot/restore (mirror semantics — orphan policy files deleted); 3-arm loop with `GEODE_PROMOTE_POLICY` (+ deterministic `GEODE_PROMOTE_POLICY_SEED=424200+i` for random) and `commit_enabled=(arm=="gate")`; propose-guard (re-propose on `RepetitiveMutationError` + measurement-hyperparam `ValueError`, M=8, skip-as-no-op); degeneracy guard (`inspect_ai.log.read_eval_log` status/samples/scored-dims + `between_seed_stderr` fallback, HALT stops whole campaign); flushed progress-log tee; env setup (`GEODE_CODEX_OAUTH_POLL_DISABLED`, `AUTORESEARCH_SEED_SELECT`, `GEODE_HELD_OUT_BENCH`, `GEODE_AUDIT_MAX_SAMPLES`/`GEODE_AUDIT_MAX_CONNECTIONS`); `--n`/`--k`/`--arms`/`--mc`/`--dry-run` flags. |
| `scripts/watch_campaign.py` | On-demand campaign digest (read-only). |
| `tests/test_run_campaign.py` | 27 unit tests — propose-guard, arm env/commit/order, snapshot/restore round-trip + mirror delete, degeneracy guard (0-sample/0-dim HALT + healthy pass + fallback), gen-0 K-repeat noise band, stale-row guard, campaign HALT, `--dry-run` smoke. |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `README.ko.md`, `pyproject.toml`, `uv.lock` | Version bump 0.99.101 → 0.99.102 (new tooling). |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| gen-0 K-repeat + noise band | Implemented | `run_gen0_baseline` + `compute_noise_band` |
| full-SoT snapshot/restore | Implemented | `snapshot_sot`/`restore_sot` (policies `*.json`/`*.jsonl` + baseline.json) |
| 3-arm loop, gate LAST | Implemented | `run_campaign` iterates `DEFAULT_ARMS=(never,random,gate)` |
| propose-guard | Implemented | `propose_with_guard` |
| degeneracy guard | Implemented | `degeneracy_guard` + `_degeneracy_guard_fallback` |
| flushed progress log + watcher | Implemented | `ProgressLog` + `scripts/watch_campaign.py` |

## Verification
- [x] ruff check clean (scripts/ + test)
- [x] ruff format --check clean
- [x] mypy clean (scripts/run_campaign.py + watch_campaign.py)
- [x] lint-imports clean (4 contracts kept)
- [x] pytest pass (27 tests, no live audits)
- [x] `uv run python scripts/run_campaign.py --dry-run --n 1 --k 1` exits 0 (synthetic, no PAYG; no SoT pollution)
- [x] Codex MCP review — 5 findings addressed

## Reference
Spec: `docs/self-improving/campaign-procedure.md`. Existing pieces: `core/self_improving_loop/runner.py` (`propose`/`apply_proposal`, `RepetitiveMutationError`), `autoresearch/train.py` (`_resolve_promote_policy`, `score_held_out_bench`, attribution writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)