### PR TITLE
fix(petri-audit): wire GEODE_AUDIT_MAX_CONNECTIONS/_MAX_SAMPLES env knobs (v0.99.103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,24 @@ functional change.
 
 ---
 
+## [0.99.103] - 2026-05-31
+
+### Fixed
+- **PR-AUDIT-CONCURRENCY-KNOB (2026-05-31) — make the audit-concurrency env knobs
+  actually take effect.** `plugins/petri_audit/runner.py` `build_command()` hardcoded
+  `--max-connections 1` + `--max-samples 1` (the single-OAuth ~5 req/s safe pin from
+  PR-OL-AUDIT-BURST-FIX). PR-CAMPAIGN-DRIVER's `scripts/run_campaign.py` already exports
+  `GEODE_AUDIT_MAX_CONNECTIONS` / `GEODE_AUDIT_MAX_SAMPLES` (default 8/3) for a
+  higher-limit lane (PAYG `api_key` auditor/judge, or a multi-account pool), but those
+  reads were silently no-op'd in the runner, so parallel audits were impossible and
+  audit wall-clock stayed serial. `build_command()` now reads both caps from the
+  environment via a `_cap()` helper that defaults to 1, clamps to a minimum of 1, and
+  falls back to 1 on a missing or non-integer value (graceful boundary) — so the
+  single-OAuth path is byte-identical to the prior hardcoded behaviour. Pinned by four
+  new tests in `tests/test_ol_audit_burst_fix.py` (unset → 1/1, override → 8/3,
+  non-integer → 1/1, sub-1 → clamped to 1); the two pre-existing default-pin tests now
+  clear the env so an ambient export can't flake them.
+
 ## [0.99.102] - 2026-05-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.102
+- **Version**: 0.99.103
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.102 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.103 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.102 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.103 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -243,6 +243,7 @@ def build_command(
     _validate_seed_select_path(seed_select)
 
     cmd: list[str] = ["inspect", "eval", "inspect_petri/audit"]
+
     # PR-OL-AUDIT-BURST-FIX (2026-05-22) FIX-1+2 — serialise inspect_ai's
     # per-provider connection pool (default 10) and per-sample
     # parallelism (default also 10) down to 1 each. Matches Paperclip's
@@ -256,8 +257,19 @@ def build_command(
     # of fan-out parallel. Trade: actually completing > 0 samples.
     # Operators with a multi-account pool (future AccountPool sprint)
     # can lift these caps; the single-OAuth default stays at 1.
-    cmd.extend(["--max-connections", "1"])
-    cmd.extend(["--max-samples", "1"])
+    #
+    # An operator on a higher-limit lane (PAYG api_key, or a multi-account
+    # pool) lifts these via GEODE_AUDIT_MAX_CONNECTIONS / _MAX_SAMPLES. A
+    # missing or non-integer value falls back to 1 (graceful boundary), so
+    # the single-OAuth path is byte-identical to the original behaviour.
+    def _cap(env_name: str) -> int:
+        try:
+            return max(1, int(os.environ.get(env_name, "1")))
+        except (TypeError, ValueError):
+            return 1
+
+    cmd.extend(["--max-connections", str(_cap("GEODE_AUDIT_MAX_CONNECTIONS"))])
+    cmd.extend(["--max-samples", str(_cap("GEODE_AUDIT_MAX_SAMPLES"))])
     if seeds > 0:
         cmd.extend(["--limit", str(seeds)])
     cmd.extend(["--model-role", f"auditor={auditor}"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.102"
+version = "0.99.103"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_ol_audit_burst_fix.py
+++ b/tests/test_ol_audit_burst_fix.py
@@ -5,10 +5,12 @@ when Anthropic Max OAuth subscription is shared between host Claude
 Code + audit subprocess + inspect_ai's 10-default-connection burst):
 
 FIX-1 — ``_build_audit_command`` argv pins ``--max-connections 1``
-        (inspect_ai default is 10 per provider).
+        by default (inspect_ai default is 10 per provider). An operator
+        on a higher-limit lane lifts it via GEODE_AUDIT_MAX_CONNECTIONS.
 
-FIX-2 — same argv pins ``--max-samples 1`` (serialises inspect_ai's
-        per-sample parallelism on top of per-connection).
+FIX-2 — same argv pins ``--max-samples 1`` by default (serialises
+        inspect_ai's per-sample parallelism on top of per-connection);
+        lifted via GEODE_AUDIT_MAX_SAMPLES.
 
 FIX-3 — ``core/llm/audit_lane.py`` module-level Lane (max_concurrent=1,
         15-min timeout) wraps the ``subprocess.run`` call so cron +
@@ -60,8 +62,15 @@ def _build_inspect_cmd() -> list[str]:
     )
 
 
-def test_inspect_cmd_pins_max_connections_one() -> None:
-    """FIX-1 — ``--max-connections 1`` is in the `inspect eval` argv."""
+def test_inspect_cmd_pins_max_connections_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIX-1 — ``--max-connections 1`` is in the `inspect eval` argv.
+
+    Clear the env knob so an ambient ``GEODE_AUDIT_MAX_CONNECTIONS`` on the
+    dev/CI host can't flake this default-pin assertion.
+    """
+    monkeypatch.delenv("GEODE_AUDIT_MAX_CONNECTIONS", raising=False)
     cmd = _build_inspect_cmd()
     assert "--max-connections" in cmd, (
         "OL-AUDIT-BURST-FIX FIX-1 regressed: --max-connections missing — "
@@ -71,8 +80,15 @@ def test_inspect_cmd_pins_max_connections_one() -> None:
     assert cmd[idx + 1] == "1"
 
 
-def test_inspect_cmd_pins_max_samples_one() -> None:
-    """FIX-2 — ``--max-samples 1`` is in the `inspect eval` argv."""
+def test_inspect_cmd_pins_max_samples_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIX-2 — ``--max-samples 1`` is in the `inspect eval` argv.
+
+    Clear the env knob so an ambient ``GEODE_AUDIT_MAX_SAMPLES`` on the
+    dev/CI host can't flake this default-pin assertion.
+    """
+    monkeypatch.delenv("GEODE_AUDIT_MAX_SAMPLES", raising=False)
     cmd = _build_inspect_cmd()
     assert "--max-samples" in cmd, (
         "OL-AUDIT-BURST-FIX FIX-2 regressed: --max-samples missing — "
@@ -80,6 +96,54 @@ def test_inspect_cmd_pins_max_samples_one() -> None:
     )
     idx = cmd.index("--max-samples")
     assert cmd[idx + 1] == "1"
+
+
+def test_inspect_cmd_caps_default_to_one_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the env knobs unset the OAuth-safe 1/1 default holds — byte-
+    identical to the pre-knob hardcoded behaviour."""
+    monkeypatch.delenv("GEODE_AUDIT_MAX_CONNECTIONS", raising=False)
+    monkeypatch.delenv("GEODE_AUDIT_MAX_SAMPLES", raising=False)
+    cmd = _build_inspect_cmd()
+    assert cmd[cmd.index("--max-connections") + 1] == "1"
+    assert cmd[cmd.index("--max-samples") + 1] == "1"
+
+
+def test_inspect_cmd_caps_honour_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A higher-limit lane (PAYG api_key / multi-account pool) lifts the
+    caps via GEODE_AUDIT_MAX_CONNECTIONS / _MAX_SAMPLES."""
+    monkeypatch.setenv("GEODE_AUDIT_MAX_CONNECTIONS", "8")
+    monkeypatch.setenv("GEODE_AUDIT_MAX_SAMPLES", "3")
+    cmd = _build_inspect_cmd()
+    assert cmd[cmd.index("--max-connections") + 1] == "8"
+    assert cmd[cmd.index("--max-samples") + 1] == "3"
+
+
+def test_inspect_cmd_caps_fall_back_on_non_integer_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-integer env value falls back to 1 (graceful boundary) rather
+    than crashing build_command — keeps the OAuth path safe under typos."""
+    monkeypatch.setenv("GEODE_AUDIT_MAX_CONNECTIONS", "x")
+    monkeypatch.setenv("GEODE_AUDIT_MAX_SAMPLES", "")
+    cmd = _build_inspect_cmd()
+    assert cmd[cmd.index("--max-connections") + 1] == "1"
+    assert cmd[cmd.index("--max-samples") + 1] == "1"
+
+
+def test_inspect_cmd_caps_clamp_below_one_to_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 0 / negative env value clamps up to 1 — inspect_ai requires >= 1
+    and a 0-connection pool would deadlock the audit."""
+    monkeypatch.setenv("GEODE_AUDIT_MAX_CONNECTIONS", "0")
+    monkeypatch.setenv("GEODE_AUDIT_MAX_SAMPLES", "-4")
+    cmd = _build_inspect_cmd()
+    assert cmd[cmd.index("--max-connections") + 1] == "1"
+    assert cmd[cmd.index("--max-samples") + 1] == "1"
 
 
 def test_inspect_cmd_burst_flags_before_model_role() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.102"
+version = "0.99.103"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/runner.py` `build_command()` now reads `--max-connections` / `--max-samples` from `GEODE_AUDIT_MAX_CONNECTIONS` / `GEODE_AUDIT_MAX_SAMPLES` (was hardcoded `1`/`1`), defaulting to 1, clamping to min 1, falling back to 1 on missing/non-integer (graceful boundary).
- The single-OAuth path stays byte-identical (envs unset → `--max-connections 1 --max-samples 1`); a higher-limit lane (PAYG `api_key`, multi-account pool) can now lift the caps.

## Why
PR-CAMPAIGN-DRIVER (#1941, v0.99.102) shipped `scripts/run_campaign.py`, which exports `GEODE_AUDIT_MAX_CONNECTIONS` / `GEODE_AUDIT_MAX_SAMPLES` (default 8/3) for the PAYG `api_key` auditor/judge lane and needs parallel audits (mc=3) for feasible wall-clock. But `runner.py` hardcoded `--max-connections 1` + `--max-samples 1` (the single-OAuth ~5 req/s safe pin from PR-OL-AUDIT-BURST-FIX), so those exports were silently a no-op — parallel audits were impossible and audit wall-clock stayed serial. PR-CAMPAIGN-DRIVER's own CHANGELOG noted the knob was "forward-looking" because "the single-OAuth `petri_audit/runner.py` lane still pins `--max-samples 1 --max-connections 1`". This PR makes the knob effective.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/runner.py` | `build_command()` reads both caps via a local `_cap()` helper (`max(1, int(os.environ.get(env, "1")))`, ValueError/TypeError → 1); kept the PR-OL-AUDIT-BURST-FIX comment block (default-1 claim still accurate) |
| `tests/test_ol_audit_burst_fix.py` | +4 env-knob tests (unset → 1/1, override → 8/3, non-integer `"x"`/`""` → 1/1, sub-1 `"0"`/`"-4"` → clamped to 1); the two pre-existing default-pin tests now `monkeypatch.delenv` so an ambient host export can't flake them; FIX-1/FIX-2 docstring updated |
| `CHANGELOG.md` | 0.99.103 entry |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md`, `uv.lock` | version 0.99.102 → 0.99.103 |

## Verification
- [x] ruff check clean (`plugins/petri_audit/runner.py`, `tests/test_ol_audit_burst_fix.py`)
- [x] ruff format --check clean
- [x] mypy clean (`runner.py`)
- [x] lint-imports clean (4 contracts kept, 0 broken)
- [x] pytest: 14 burst-fix + 43 runner + 27 campaign-driver tests pass; verified isolation holds with ambient `GEODE_AUDIT_MAX_CONNECTIONS=8 GEODE_AUDIT_MAX_SAMPLES=3` exported
- [x] CLI smoke: `geode version` → v0.99.103
- [x] Codex MCP review (1 catch applied: pre-existing default-pin tests needed env isolation)
- [x] 3 pre-existing failures (`test_codex_cli_provider`, `test_oauth_judge`) confirmed present on clean origin/develop — unrelated to this change

## Reference
PR-CAMPAIGN-DRIVER (#1941) export sites: `scripts/run_campaign.py:199-200`. Pin: `tests/test_ol_audit_burst_fix.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)