### PR TITLE
fix(self-improving): gen-0 baseline = K-mean dims + purge inspect cache at real-campaign start (v0.99.104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,41 @@ functional change.
 
 ---
 
+## [0.99.104] - 2026-05-31
+
+### Fixed
+- **PR-CAMPAIGN-GEN0-KMEAN (2026-05-31) — gen-0 baseline = K-mean dims, not the
+  single lucky-outlier bootstrap measure; purge the inspect_ai trajectory cache at
+  real-campaign start.** Two fixes to `scripts/run_campaign.py` (the self-improving
+  campaign driver):
+  - **K-mean baseline (the core fix).** The driver's gen-0 K-repeat left
+    `baseline.json`'s `raw.dim_means` pinned to the SINGLE bootstrap measurement (the
+    1st of K). The Petri audit is stochastic: 3 independent re-measures of the IDENTICAL
+    genesis scaffold gave fitness 0.807 / 0.663 / 0.662 (cache confirmed empty). With the
+    baseline pinned to the lucky-high 0.807, every ~0.66 cycle looked like a −0.14
+    regression, so the promote gate (`current_raw = compute_fitness(cycle_dims)` vs
+    `prior_raw = compute_fitness(baseline_dims)`, both intrinsic) was structurally
+    near-0-approve and the campaign could not test selection. The driver now parses each
+    gen-0 measure's RAW per-dim `dim_means` from `train.py`'s `FITNESS_RESULT:` stdout
+    sentinel, and after the K-repeat overwrites ONLY `baseline.json`'s `raw.dim_means`
+    (→ per-dim K-mean) and `raw.dim_stderr` (→ across-K per-dim sample stderr, the real
+    noise band), preserving the rest of the schema (`schema_version` / `session_id` /
+    `commit` / `ts_utc` / `axes` / `raw.{sample_count, measurement_modality,
+    eval_archive, fitness_stderr, rubric_version, …}`). A dim missing from some measures
+    is averaged over the present ones (partial-coverage logged). Skipped under
+    `--dry-run` (train.py's synthetic `FITNESS_RESULT` dims must not freeze a synthetic
+    baseline) — `write_kmean_baseline` / `aggregate_dim_means` / `parse_fitness_result_dims`.
+  - **inspect cache purge at real-campaign start.** A real (non-`--dry-run`) campaign now
+    calls `plugins.petri_audit.runner.purge_inspect_cache()` (guarded import) before the
+    K gen-0 measures so the identical-scaffold repeats + all cycle audits are INDEPENDENT
+    re-measures, not replays of a stale trajectory cached at
+    `~/Library/Caches/inspect_ai/generate/`. Skipped under `--dry-run`.
+  - **Tests** (`tests/test_run_campaign.py`, +10, all mocked — NO live audit): K-mean
+    baseline write asserts `raw.dim_means` = per-dim mean + `raw.dim_stderr` = across-K
+    stderr with the rest of the schema preserved; `FITNESS_RESULT` parse (incl.
+    non-numeric drop + absent → None); `aggregate_dim_means` mean/stderr + partial
+    coverage; cache purge runs on a real run and NOT on `--dry-run`. 37 tests pass.
+
 ## [0.99.103] - 2026-05-31
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.103
+- **Version**: 0.99.104
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.103 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.104 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.103 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.104 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.103"
+version = "0.99.104"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/run_campaign.py
+++ b/scripts/run_campaign.py
@@ -10,7 +10,14 @@ importable module with a CLI front end. The driver does NOT decide policy — it
   no mutation, ``source="manual"``; the first run bootstrap-establishes
   ``baseline.json``). The campaign spawns it via ``uv run python
   autoresearch/train.py`` and reads each run's ``held_out_fitness`` + ``fitness``
-  from the new ``kind="attribution"`` rows it appends to ``mutations.jsonl``.
+  from the new ``kind="attribution"`` rows it appends to ``mutations.jsonl``,
+  plus each run's RAW per-dim ``dim_means`` from the ``FITNESS_RESULT:`` stdout
+  sentinel. After the K gen-0 repeats it overwrites ``baseline.json``'s
+  ``raw.dim_means`` with the per-dim K-MEAN (and ``raw.dim_stderr`` with the
+  across-K per-dim sample stderr), so the promote gate's ``prior_raw =
+  compute_fitness(mean_dims)`` is a robust central estimate of the stochastic
+  Petri audit — not the single (possibly lucky-outlier) bootstrap measure that
+  would otherwise pin the gate to a structurally near-0-approve state.
 * ``core.self_improving_loop.runner.SelfImprovingLoopRunner`` — one
   ``propose()`` + guard + ``apply_proposal()`` per cycle. The driver wraps
   ``propose()`` in a re-proposal loop (the *propose-guard*) so a
@@ -21,12 +28,19 @@ importable module with a CLI front end. The driver does NOT decide policy — it
   3 arms in the order **never → random → gate** (gate LAST), each from a matched
   gen-0 SoT reset.
 
+At the start of a REAL (non-``--dry-run``) campaign the driver purges
+``inspect_ai``'s trajectory cache (``plugins.petri_audit.runner.purge_inspect_cache``,
+the cache at ``~/Library/Caches/inspect_ai/generate/``) so the K gen-0 measures
++ all cycle audits are INDEPENDENT re-measures, not replays of a stale cached
+trajectory for an identical seed. Skipped under ``--dry-run`` (synthetic audits
+never touch the cache).
+
 The campaign is split into pure, testable units (snapshot/restore, the
-propose-guard, the degeneracy guard, the gen-0 noise-band collection) so the
-unit suite in ``tests/test_run_campaign.py`` can exercise every boundary with
-mocks and NO live audit / network / PAYG spend. ``--dry-run`` passes the flag
-through to ``train.py`` AND to the runner (``rerun_dry_run=True``) so the whole
-chain can be smoke-tested end-to-end with synthetic audits.
+propose-guard, the degeneracy guard, the gen-0 noise-band collection + K-mean
+baseline write) so the unit suite in ``tests/test_run_campaign.py`` can exercise
+every boundary with mocks and NO live audit / network / PAYG spend. ``--dry-run``
+passes the flag through to ``train.py`` AND to the runner (``rerun_dry_run=True``)
+so the whole chain can be smoke-tested end-to-end with synthetic audits.
 
 ENV SETUP (operator handoff)
 ----------------------------
@@ -58,6 +72,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import shutil
 import statistics
@@ -385,12 +400,71 @@ def _as_float(value: object) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
+        num = float(value)
+        # Reject non-finite (NaN / ±Inf): not a valid measurement, and json.dumps
+        # would otherwise write non-standard JSON into baseline.json (Codex MCP
+        # finding — graceful boundary at the schema-typed cast).
+        return num if math.isfinite(num) else None
     return None
 
 
 def _as_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+# ---------------------------------------------------------------------------
+# FITNESS_RESULT stdout parse (gen-0 per-measure raw dim_means)
+# ---------------------------------------------------------------------------
+
+#: The structured stdout sentinel ``autoresearch/train.py`` emits on the success
+#: path (``train.py`` ~L4786): ``FITNESS_RESULT: {"fitness": ..., "dim_means":
+#: {...}, "dim_stderr": {...}, "audit_run_id": ...}``. The campaign tail-parses
+#: it to recover each gen-0 measure's RAW per-dim ``dim_means`` (the attribution
+#: row in ``mutations.jsonl`` carries only the baseline-relative ``observed_dim``
+#: delta, not the raw means), so the gen-0 K-mean can be computed from the
+#: identical-scaffold repeats.
+_FITNESS_RESULT_PREFIX = "FITNESS_RESULT: "
+
+
+def parse_fitness_result_dims(stdout: str | None) -> dict[str, float] | None:
+    """Parse the ``dim_means`` dict from a ``train.py`` ``FITNESS_RESULT:`` line.
+
+    Takes the LAST ``FITNESS_RESULT:``-prefixed line (a single ``train.py`` run
+    emits exactly one on success; keying on the *last* one keeps the contract
+    "last sentinel wins" robust to interleaved log noise) and returns its
+    ``dim_means`` as a ``{dim: float}`` dict. Returns ``None`` when no sentinel
+    line exists, the last one is not parseable JSON / has no ``dim_means`` dict,
+    or no numeric dim survives (a ``--dry-run`` / failed run emits none) — so a
+    caller skips that measure rather than fold a phantom zero-dim row into the
+    K-mean. A later malformed sentinel is NOT silently masked by an earlier valid
+    one (Codex MCP finding): the last sentinel line is authoritative. Non-numeric
+    / non-finite dim values are dropped (graceful per the contract-boundary rule —
+    every schema-typed cast is guarded, not just the outer parse).
+    """
+    if not stdout:
+        return None
+    last_payload: str | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if line.startswith(_FITNESS_RESULT_PREFIX):
+            last_payload = line[len(_FITNESS_RESULT_PREFIX) :].strip()
+    if last_payload is None:
+        return None
+    try:
+        obj = json.loads(last_payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    dim_means_raw = obj.get("dim_means")
+    if not isinstance(dim_means_raw, dict):
+        return None
+    parsed: dict[str, float] = {}
+    for key, value in dim_means_raw.items():
+        num = _as_float(value)
+        if isinstance(key, str) and num is not None:
+            parsed[key] = num
+    return parsed or None
 
 
 # ---------------------------------------------------------------------------
@@ -583,6 +657,95 @@ def compute_noise_band(
     return NoiseBand(k=k, held_out_values=held, fitness_values=fit, mean=mean, stderr=stderr)
 
 
+def aggregate_dim_means(
+    per_measure_dim_means: Sequence[dict[str, float]],
+) -> tuple[dict[str, float], dict[str, float], dict[str, int]]:
+    """Per-dim mean + across-K sample stderr over the K gen-0 measures.
+
+    Each element of ``per_measure_dim_means`` is one gen-0 measure's RAW
+    ``dim_means`` (parsed from its ``FITNESS_RESULT:`` stdout line). For every dim
+    that appears in AT LEAST ONE measure, the mean is taken over the measures
+    where the dim is PRESENT (a dim missing from some measures is averaged over
+    the present ones, not treated as zero — keep it simple + correct). The stderr
+    is the sample stderr ``stdev(present_values) / sqrt(n_present)`` when
+    ``n_present >= 2``, else ``0.0`` (a single observation has no measurable
+    band). Returns ``(mean_dims, stderr_dims, present_count_dims)``; the third
+    dict records how many of the K measures contributed to each dim so the caller
+    can log a partial-coverage warning.
+
+    This is the CORE fix: ``baseline.json``'s ``raw.dim_means`` must be a robust
+    central estimate across the K identical-scaffold repeats, not the single
+    (possibly lucky-high / lucky-low) bootstrap measure — otherwise every cycle's
+    ``compute_fitness(cycle_dims)`` vs ``compute_fitness(baseline_dims)`` gate
+    compares against an outlier and the campaign is structurally near-0-approve.
+    """
+    dims: set[str] = set()
+    for measure in per_measure_dim_means:
+        dims.update(measure.keys())
+    mean_dims: dict[str, float] = {}
+    stderr_dims: dict[str, float] = {}
+    present_count: dict[str, int] = {}
+    for dim in sorted(dims):
+        present = [m[dim] for m in per_measure_dim_means if dim in m]
+        if not present:  # pragma: no cover — dims came from the measures
+            continue
+        present_count[dim] = len(present)
+        mean_dims[dim] = statistics.fmean(present)
+        stderr_dims[dim] = (
+            statistics.stdev(present) / (len(present) ** 0.5) if len(present) >= 2 else 0.0
+        )
+    return mean_dims, stderr_dims, present_count
+
+
+def write_kmean_baseline(
+    mean_dims: dict[str, float],
+    stderr_dims: dict[str, float],
+    *,
+    baseline_path: Path | None = None,
+) -> bool:
+    """Overwrite ``baseline.json``'s ``raw.dim_means`` + ``raw.dim_stderr`` with
+    the K-aggregate, preserving the rest of the schema.
+
+    The bootstrap ``train.py`` run already wrote ``baseline.json`` from its SINGLE
+    measure (1st of K). This rewrites ONLY ``raw.dim_means`` (→ K-mean) and
+    ``raw.dim_stderr`` (→ across-K per-dim sample stderr, the real noise band),
+    leaving every other field intact: top-level ``schema_version`` / ``session_id``
+    / ``commit`` / ``ts_utc``, ``axes``, and the rest of ``raw``
+    (``sample_count`` / ``measurement_modality`` / ``eval_archive`` /
+    ``fitness_stderr`` / ``rubric_version`` / …). So the promote gate's
+    ``prior_raw = compute_fitness(raw.dim_means)`` reads the robust central
+    estimate.
+
+    Returns ``True`` when the rewrite landed, ``False`` when there is no
+    ``baseline.json`` to patch (the bootstrap never established one — e.g. all K
+    runs failed) or no aggregate dims were collected (nothing to write).
+    """
+    target = baseline_path if baseline_path is not None else BASELINE_JSON
+    if not mean_dims:
+        return False
+    if not target.exists():
+        return False
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    raw_block = payload.get("raw")
+    if not isinstance(raw_block, dict):
+        # A bootstrap baseline.json with no (or a non-dict) ``raw`` block is
+        # malformed — the bootstrap train.py run did not establish the expected
+        # schema. Refuse to fabricate a ``raw`` block (that would violate the
+        # "overwrite ONLY raw.dim_means + raw.dim_stderr" contract and mask the
+        # broken bootstrap); return False so the caller logs written=False
+        # (Codex MCP finding — preserve-only contract).
+        return False
+    raw_block["dim_means"] = {dim: float(v) for dim, v in mean_dims.items()}
+    raw_block["dim_stderr"] = {dim: float(v) for dim, v in stderr_dims.items()}
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
 def run_gen0_baseline(
     *,
     k: int,
@@ -606,6 +769,11 @@ def run_gen0_baseline(
     runner_fn = train_runner if train_runner is not None else _spawn_train_subprocess
     held_out_values: list[float] = []
     fitness_values: list[float] = []
+    # Each gen-0 measure's RAW per-dim ``dim_means`` (parsed from its
+    # ``FITNESS_RESULT:`` stdout line) — the K-mean of these replaces
+    # ``baseline.json``'s single-bootstrap ``raw.dim_means`` so the promote gate
+    # compares cycles against a robust central estimate, not a lucky outlier.
+    per_measure_dim_means: list[dict[str, float]] = []
     for i in range(1, k + 1):
         env = build_campaign_env(
             audit_max_samples=audit_max_samples,
@@ -620,6 +788,10 @@ def run_gen0_baseline(
                 f"{getattr(result, 'returncode', '?')} — skipping signal read"
             )
             continue
+        # Recover this measure's raw dim_means from the FITNESS_RESULT sentinel.
+        measure_dims = parse_fitness_result_dims(getattr(result, "stdout", None))
+        if measure_dims:
+            per_measure_dim_means.append(measure_dims)
         # Require a NEW attribution row from THIS run (no stale-row reuse).
         signal = read_latest_attribution(min_rows=rows_before)
         if signal is None:
@@ -634,10 +806,40 @@ def run_gen0_baseline(
             fitness_values.append(signal.fitness)
         progress.emit(
             f"gen-0 baseline repeat {i}/{k}: held_out={signal.held_out_fitness} "
-            f"fitness={signal.fitness} source={signal.source}"
+            f"fitness={signal.fitness} source={signal.source} "
+            f"dims_parsed={len(measure_dims) if measure_dims else 0}"
         )
     band = compute_noise_band(held_out_values, fitness_values, k=k)
     progress.emit(band.summary())
+    # CORE FIX — rewrite baseline.json's raw.dim_means to the K-mean dims (and
+    # raw.dim_stderr to the across-K per-dim sample stderr), so prior_raw =
+    # compute_fitness(mean_dims) is a robust central estimate, not the single
+    # lucky-high/low bootstrap measure (every other field is preserved).
+    #
+    # Under --dry-run the K-mean write is SKIPPED: train.py --dry-run emits a
+    # FITNESS_RESULT line with SYNTHETIC dims (so per_measure_dim_means is
+    # populated), but persisting those would freeze a synthetic baseline — the
+    # same reason train.py short-circuits its own promote gate on dry-run. The
+    # smoke must leave baseline.json untouched.
+    if dry_run:
+        progress.emit(
+            f"gen-0 K-mean baseline: dry-run — skipped baseline.json rewrite "
+            f"(parsed {len(per_measure_dim_means)}/{k} synthetic FITNESS_RESULT measures)"
+        )
+    elif per_measure_dim_means:
+        mean_dims, stderr_dims, present_count = aggregate_dim_means(per_measure_dim_means)
+        wrote = write_kmean_baseline(mean_dims, stderr_dims)
+        partial = sorted(d for d, c in present_count.items() if c < len(per_measure_dim_means))
+        progress.emit(
+            f"gen-0 K-mean baseline: collected {len(per_measure_dim_means)}/{k} measures, "
+            f"{len(mean_dims)} dims; baseline.json raw.dim_means←K-mean "
+            f"(written={wrote})" + (f"; partial-coverage dims={partial}" if partial else "")
+        )
+    else:
+        progress.emit(
+            f"gen-0 K-mean baseline: no FITNESS_RESULT dims parsed from {k} measures "
+            "(all failed) — baseline.json raw.dim_means left as bootstrap"
+        )
     return band
 
 
@@ -898,6 +1100,35 @@ def _cycle_line(
 
 
 # ---------------------------------------------------------------------------
+# inspect_ai trajectory-cache purge (FIX 2 — real-campaign start)
+# ---------------------------------------------------------------------------
+
+
+def _purge_inspect_cache_at_start(progress: ProgressLog) -> bool:
+    """Call ``plugins.petri_audit.runner.purge_inspect_cache`` at real-campaign
+    start, logging the outcome.
+
+    The import is GUARDED: ``plugins.petri_audit`` pulls in ``inspect_ai`` (the
+    ``[audit]`` extra), which is absent in a base ``uv sync`` env. When the import
+    fails the purge is a logged no-op (``False``) rather than a crash, so a
+    non-audit invocation of the driver still runs. ``purge_inspect_cache`` itself
+    is graceful for the same reason (returns ``False`` when ``inspect_ai`` is
+    unavailable), so this is belt-and-braces.
+    """
+    try:
+        from plugins.petri_audit.runner import purge_inspect_cache
+    except ImportError as exc:
+        progress.emit(f"inspect cache purge: skipped (petri_audit/inspect_ai unavailable — {exc})")
+        return False
+    purged = purge_inspect_cache()
+    progress.emit(
+        f"inspect cache purge: ran at real-campaign start (purged={purged}) — "
+        "K gen-0 measures + cycle audits are independent re-measures, not cache replays"
+    )
+    return purged
+
+
+# ---------------------------------------------------------------------------
 # Top-level campaign
 # ---------------------------------------------------------------------------
 
@@ -930,6 +1161,15 @@ def run_campaign(
             f"campaign start: n={n} k={k} arms={list(arms)} dry_run={dry_run} "
             f"audit_max_samples={audit_max_samples} audit_max_connections={audit_max_connections}"
         )
+        # FIX 2 — purge inspect_ai's trajectory cache at the start of a REAL
+        # campaign so the K gen-0 measures + all cycle audits are independent
+        # re-measures, not replays of a stale cached trajectory (the cache at
+        # ``~/Library/Caches/inspect_ai/generate/`` keys on the input messages, so
+        # an identical-scaffold gen-0 repeat would otherwise hit the same cached
+        # score K times). Skipped under --dry-run (synthetic audits never touch
+        # the cache).
+        if not dry_run:
+            _purge_inspect_cache_at_start(progress)
         band = run_gen0_baseline(
             k=k,
             dry_run=dry_run,

--- a/tests/test_run_campaign.py
+++ b/tests/test_run_campaign.py
@@ -386,6 +386,218 @@ def test_compute_noise_band_empty_is_none() -> None:
 
 
 # ---------------------------------------------------------------------------
+# FITNESS_RESULT stdout parse + K-mean baseline (the core fix)
+# ---------------------------------------------------------------------------
+
+
+def _fitness_result_line(dim_means: dict[str, float], *, fitness: float = 0.7) -> str:
+    return "FITNESS_RESULT: " + json.dumps(
+        {"fitness": fitness, "audit_run_id": "abc", "dim_means": dim_means, "dim_stderr": {}}
+    )
+
+
+def test_parse_fitness_result_dims_extracts_dim_means() -> None:
+    stdout = "noise\n" + _fitness_result_line({"safety": 2.0, "scenario_realism": 8.0}) + "\nmore\n"
+    parsed = rc.parse_fitness_result_dims(stdout)
+    assert parsed == {"safety": 2.0, "scenario_realism": 8.0}
+
+
+def test_parse_fitness_result_dims_none_when_absent() -> None:
+    assert rc.parse_fitness_result_dims("just logs, no sentinel\n") is None
+    assert rc.parse_fitness_result_dims(None) is None
+    # Non-numeric dim values are dropped; an all-bad payload yields None.
+    bad = "FITNESS_RESULT: " + json.dumps({"dim_means": {"safety": "oops"}})
+    assert rc.parse_fitness_result_dims(bad) is None
+
+
+def test_parse_fitness_result_dims_drops_non_finite() -> None:
+    # NaN / Infinity are not valid measurements; json emits them as bare tokens.
+    bad = 'FITNESS_RESULT: {"dim_means": {"safety": NaN, "realism": Infinity, "ok": 3.0}}'
+    assert rc.parse_fitness_result_dims(bad) == {"ok": 3.0}
+
+
+def test_parse_fitness_result_dims_last_sentinel_wins_even_if_malformed() -> None:
+    # An earlier VALID sentinel must NOT mask a later malformed one — the last
+    # FITNESS_RESULT line is authoritative, so a trailing broken sentinel → None.
+    stdout = _fitness_result_line({"safety": 2.0}) + "\nFITNESS_RESULT: {not json\n"
+    assert rc.parse_fitness_result_dims(stdout) is None
+    # And a later VALID sentinel overrides an earlier one.
+    stdout2 = _fitness_result_line({"safety": 2.0}) + "\n" + _fitness_result_line({"safety": 9.0})
+    assert rc.parse_fitness_result_dims(stdout2) == {"safety": 9.0}
+
+
+def test_aggregate_dim_means_mean_and_stderr() -> None:
+    measures = [
+        {"safety": 2.0, "realism": 8.0},
+        {"safety": 4.0, "realism": 8.0},
+    ]
+    mean_dims, stderr_dims, present = rc.aggregate_dim_means(measures)
+    assert mean_dims["safety"] == pytest.approx(3.0)  # (2+4)/2
+    assert mean_dims["realism"] == pytest.approx(8.0)
+    # stderr = stdev([2,4]) / sqrt(2) = sqrt(2) / sqrt(2) = 1.0
+    assert stderr_dims["safety"] == pytest.approx(1.0)
+    assert stderr_dims["realism"] == pytest.approx(0.0)  # identical values
+    assert present == {"safety": 2, "realism": 2}
+
+
+def test_aggregate_dim_means_partial_coverage_averages_present_only() -> None:
+    # 'extra' appears in only one of two measures → averaged over the present one.
+    measures = [{"a": 1.0, "extra": 5.0}, {"a": 3.0}]
+    mean_dims, stderr_dims, present = rc.aggregate_dim_means(measures)
+    assert mean_dims["a"] == pytest.approx(2.0)
+    assert mean_dims["extra"] == pytest.approx(5.0)  # only the one present value
+    assert present == {"a": 2, "extra": 1}
+    assert stderr_dims["extra"] == 0.0  # single observation → no band
+
+
+def test_write_kmean_baseline_overwrites_dims_preserving_schema(
+    campaign_state: dict[str, Path],
+) -> None:
+    baseline = campaign_state["baseline"]
+    # The bootstrap train.py run wrote baseline.json from a SINGLE lucky measure.
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "boot-1",
+                "commit": "deadbeef",
+                "ts_utc": "2026-05-31T00:00:00Z",
+                "raw": {
+                    "dim_means": {"safety": 8.0, "realism": 1.0},  # the lucky outlier
+                    "dim_stderr": {"safety": 0.0, "realism": 0.0},
+                    "sample_count": {"safety": 3},
+                    "measurement_modality": {"safety": "transcript"},
+                    "eval_archive": "boot.eval",
+                    "rubric_version": "v3-22dim-PR0",
+                    "fitness_stderr": 0.02,
+                },
+                "axes": {"admire_means": None, "bench_means": {"x": 1.0}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    wrote = rc.write_kmean_baseline(
+        {"safety": 3.0, "realism": 7.0},
+        {"safety": 1.0, "realism": 0.5},
+        baseline_path=baseline,
+    )
+    assert wrote is True
+    payload = json.loads(baseline.read_text(encoding="utf-8"))
+    # Only raw.dim_means + raw.dim_stderr overwritten with the K-aggregate.
+    assert payload["raw"]["dim_means"] == {"safety": 3.0, "realism": 7.0}
+    assert payload["raw"]["dim_stderr"] == {"safety": 1.0, "realism": 0.5}
+    # Everything else preserved byte-for-byte (schema, provenance, axes).
+    assert payload["schema_version"] == 2
+    assert payload["session_id"] == "boot-1"
+    assert payload["commit"] == "deadbeef"
+    assert payload["raw"]["sample_count"] == {"safety": 3}
+    assert payload["raw"]["measurement_modality"] == {"safety": "transcript"}
+    assert payload["raw"]["eval_archive"] == "boot.eval"
+    assert payload["raw"]["fitness_stderr"] == 0.02
+    assert payload["axes"] == {"admire_means": None, "bench_means": {"x": 1.0}}
+
+
+def test_write_kmean_baseline_no_file_returns_false(campaign_state: dict[str, Path]) -> None:
+    # No bootstrap baseline.json on disk → nothing to patch.
+    assert not campaign_state["baseline"].exists()
+    assert rc.write_kmean_baseline({"safety": 3.0}, {"safety": 1.0}) is False
+
+
+def test_write_kmean_baseline_empty_dims_returns_false(campaign_state: dict[str, Path]) -> None:
+    campaign_state["baseline"].write_text('{"raw": {"dim_means": {}}}', encoding="utf-8")
+    assert rc.write_kmean_baseline({}, {}) is False
+
+
+def test_write_kmean_baseline_malformed_raw_returns_false(
+    campaign_state: dict[str, Path],
+) -> None:
+    # A bootstrap baseline.json with no (or a non-dict) raw block is malformed —
+    # the writer refuses to fabricate a raw block (preserve-only contract).
+    baseline = campaign_state["baseline"]
+    baseline.write_text('{"schema_version": 2, "raw": "not-a-dict"}', encoding="utf-8")
+    assert (
+        rc.write_kmean_baseline({"safety": 3.0}, {"safety": 1.0}, baseline_path=baseline) is False
+    )
+    # The malformed file is left untouched (no fabricated raw.dim_means).
+    assert json.loads(baseline.read_text(encoding="utf-8")) == {
+        "schema_version": 2,
+        "raw": "not-a-dict",
+    }
+    # Missing raw block entirely → also False.
+    baseline.write_text('{"schema_version": 2}', encoding="utf-8")
+    assert (
+        rc.write_kmean_baseline({"safety": 3.0}, {"safety": 1.0}, baseline_path=baseline) is False
+    )
+
+
+def test_gen0_baseline_sets_baseline_to_k_mean_dims(
+    campaign_state: dict[str, Path],
+) -> None:
+    """The CORE fix: after the K-repeat, baseline.json's raw.dim_means equals the
+    per-dim mean across the K measures' FITNESS_RESULT dims, and raw.dim_stderr
+    the across-K per-dim sample stderr; the rest of the schema is preserved."""
+    mutations = campaign_state["mutations"]
+    baseline = campaign_state["baseline"]
+    # The 1st (bootstrap) measure wrote baseline.json with its lucky-high dims +
+    # the full schema. The K-mean must overwrite ONLY the two dim sub-fields.
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "boot",
+                "raw": {
+                    "dim_means": {"safety": 8.0, "realism": 2.0},
+                    "dim_stderr": {},
+                    "rubric_version": "v3-22dim-PR0",
+                },
+                "axes": {"bench_means": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Three identical-scaffold measures with KNOWN, varying dims (the stochastic
+    # Petri re-measure spread) → the gen-0 noise the fix is meant to capture.
+    measure_dims = [
+        {"safety": 2.0, "realism": 6.0},
+        {"safety": 3.0, "realism": 7.0},
+        {"safety": 4.0, "realism": 8.0},
+    ]
+    calls = {"n": 0}
+
+    def fake_train(*, env: dict[str, str], dry_run: bool) -> SimpleNamespace:
+        dims = measure_dims[calls["n"]]
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        calls["n"] += 1
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line(dims))
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        rc.run_gen0_baseline(
+            k=3,
+            dry_run=False,
+            audit_max_samples=3,
+            audit_max_connections=8,
+            progress=progress,
+            train_runner=fake_train,
+        )
+
+    payload = json.loads(baseline.read_text(encoding="utf-8"))
+    # raw.dim_means = per-dim mean across the 3 measures.
+    assert payload["raw"]["dim_means"]["safety"] == pytest.approx(3.0)  # (2+3+4)/3
+    assert payload["raw"]["dim_means"]["realism"] == pytest.approx(7.0)  # (6+7+8)/3
+    # raw.dim_stderr = across-K per-dim sample stderr (stdev/sqrt(3)).
+    import statistics as _stats
+
+    assert payload["raw"]["dim_stderr"]["safety"] == pytest.approx(
+        _stats.stdev([2.0, 3.0, 4.0]) / (3**0.5)
+    )
+    # The rest of the schema is preserved (not the lucky bootstrap dims).
+    assert payload["schema_version"] == 2
+    assert payload["session_id"] == "boot"
+    assert payload["raw"]["rubric_version"] == "v3-22dim-PR0"
+    assert payload["axes"] == {"bench_means": None}
+
+
+# ---------------------------------------------------------------------------
 # arm loop — env + commit_enabled per arm; gate last
 # ---------------------------------------------------------------------------
 
@@ -682,6 +894,79 @@ def test_dry_run_end_to_end_smoke(
     # Progress log was flushed to disk.
     assert campaign_state["progress"].exists()
     assert "campaign complete" in campaign_state["progress"].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# inspect-cache purge — real campaign purges, --dry-run does NOT
+# ---------------------------------------------------------------------------
+
+
+def test_real_campaign_purges_inspect_cache(
+    campaign_state: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real (non-dry-run) campaign calls purge_inspect_cache at start so the K
+    gen-0 measures + cycle audits are independent re-measures, not cache hits."""
+    import plugins.petri_audit.runner as petri_runner
+
+    calls = {"n": 0}
+
+    def fake_purge() -> bool:
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(petri_runner, "purge_inspect_cache", fake_purge)
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        return _RecordingRunner(arm=arm, env=dict(env), commit_enabled=(arm == "gate"))
+
+    rc.run_campaign(
+        n=1,
+        k=0,
+        arms=("never",),
+        dry_run=False,  # real campaign
+        progress_path=campaign_state["progress"],
+        snapshot_dir=campaign_state["snapshot"],
+        train_runner=lambda **_kw: SimpleNamespace(returncode=0, stdout=""),
+        runner_factory=factory,
+        guard_fn=lambda _s: rc.GuardResult(ok=True, reason="ok"),
+    )
+    assert calls["n"] == 1
+    assert "inspect cache purge: ran at real-campaign start" in campaign_state[
+        "progress"
+    ].read_text(encoding="utf-8")
+
+
+def test_dry_run_campaign_does_not_purge_inspect_cache(
+    campaign_state: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--dry-run never touches the trajectory cache (synthetic audits)."""
+    import plugins.petri_audit.runner as petri_runner
+
+    calls = {"n": 0}
+
+    def fake_purge() -> bool:
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(petri_runner, "purge_inspect_cache", fake_purge)
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+
+    def factory(*, arm: str, env: dict[str, str], dry_run: bool) -> _RecordingRunner:
+        return _RecordingRunner(arm=arm, env=dict(env), commit_enabled=False)
+
+    rc.run_campaign(
+        n=1,
+        k=1,
+        arms=("never",),
+        dry_run=True,
+        progress_path=campaign_state["progress"],
+        snapshot_dir=campaign_state["snapshot"],
+        train_runner=lambda **_kw: SimpleNamespace(returncode=0, stdout=""),
+        runner_factory=factory,
+    )
+    assert calls["n"] == 0
+    assert "inspect cache purge" not in campaign_state["progress"].read_text(encoding="utf-8")
 
 
 def test_run_campaign_rejects_unknown_arm(campaign_state: dict[str, Path]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.103"
+version = "0.99.104"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **Core fix**: the gen-0 K-repeat in `scripts/run_campaign.py` left `baseline.json`'s `raw.dim_means` pinned to the SINGLE bootstrap (1st of K) Petri measurement. The Petri audit is stochastic (3 re-measures of the identical genesis scaffold gave fitness 0.807 / 0.663 / 0.662, cache confirmed empty), so the lucky-high 0.807 bootstrap made every ~0.66 cycle look like a −0.14 regression → the promote gate was structurally near-0-approve and the campaign could not test selection. Now the driver computes the K-mean dims and writes them back.
- **Fix 2**: purge the `inspect_ai` trajectory cache at the start of a real (non-`--dry-run`) campaign so the K gen-0 measures + cycle audits are independent re-measures, not cache replays.

## Why
The promote gate compares `current_raw = compute_fitness(cycle_dims)` vs `prior_raw = compute_fitness(baseline_dims)` (both intrinsic, same formula — `autoresearch/train.py:3435-3450`). `baseline.json` stores `raw.dim_means` (not a fitness scalar; fitness is computed on demand). With the baseline pinned to one lucky-high outlier, `prior_raw` is biased high and no cycle can clear the gate — the 10-cycle 0-approve risk is structural, not a selection result. A robust central estimate (K-mean) is required before the campaign can measure whether selection works. Separately, an identical-scaffold gen-0 repeat would hit the same `~/Library/Caches/inspect_ai/generate/` trajectory K times unless the cache is purged first.

## Changes
| File | Change |
|------|--------|
| `scripts/run_campaign.py` | `parse_fitness_result_dims()` parses each gen-0 measure's RAW per-dim `dim_means` from `train.py`'s `FITNESS_RESULT:` stdout sentinel (last sentinel authoritative; non-numeric/non-finite dropped). `aggregate_dim_means()` computes per-dim mean + across-K sample stderr (partial-coverage: a dim present in only some measures is averaged over the present ones). `write_kmean_baseline()` overwrites ONLY `raw.dim_means` + `raw.dim_stderr`, preserving the rest of the schema; returns False on missing/malformed `raw` (no fabrication) / no file / no dims. `run_gen0_baseline()` collects the per-measure dims + writes the K-mean (skipped under `--dry-run`). `run_campaign()` calls `_purge_inspect_cache_at_start()` (guarded import of `plugins.petri_audit.runner.purge_inspect_cache`) on a real run, skipped under `--dry-run`. `_as_float()` now rejects non-finite. |
| `tests/test_run_campaign.py` | +13 mocked tests (NO live audit): K-mean baseline write + schema preservation; malformed/missing `raw` → False; `FITNESS_RESULT` parse incl. non-finite drop + last-sentinel-wins; `aggregate_dim_means` mean/stderr + partial coverage; cache purge runs on real run and NOT on `--dry-run`. 40 total pass. |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `README.ko.md`, `pyproject.toml`, `uv.lock` | version 0.99.103 → 0.99.104 (PATCH) + CHANGELOG entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| FITNESS_RESULT sentinel carries raw dim_means | Already exists | `autoresearch/train.py` ~L4786, success-path only. Attribution row in mutations.jsonl carries only baseline-relative `observed_dim` delta, not raw means — so stdout parse is required. |
| `purge_inspect_cache()` | Already exists | `plugins/petri_audit/runner.py:309`, graceful when `inspect_ai` absent. Wired here at real-campaign start. |
| baseline.json schema | Preserved | `schema_version` / `session_id` / `commit` / `ts_utc` / `axes` / `raw.{sample_count, measurement_modality, eval_archive, fitness_stderr, rubric_version}` all untouched; only `raw.dim_means` + `raw.dim_stderr` rewritten. |

## Verification
- [x] ruff check clean (`scripts/run_campaign.py` + `tests/` + `core/` + `plugins/`)
- [x] ruff format --check clean
- [x] mypy clean (`scripts/run_campaign.py`)
- [x] lint-imports clean (4 contracts kept)
- [x] pytest `tests/test_run_campaign.py` 40 pass
- [x] `uv run python scripts/run_campaign.py --dry-run --n 1 --k 2` exits 0; K-mean log line shown; cache purge + baseline rewrite both skipped under dry-run
- [x] Codex MCP reviewed the diff — 1 MED + 2 LOW findings all addressed (malformed-raw → False; non-finite drop; last-sentinel-wins)

## Reference
Source: operator handoff (PR-CAMPAIGN-GEN0-KMEAN). Empirical: 3 independent re-measures of the identical genesis scaffold (0.807/0.663/0.662, cache empty). Builds on PR-CAMPAIGN-DRIVER (#1941) + PR-AUDIT-CONCURRENCY-KNOB (#1942).

🤖 Generated with [Claude Code](https://claude.com/claude-code)