### PR TITLE
feat(self-improving): drop hyperparam from the mutation surface (v0.99.105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,41 @@ functional change.
 
 ---
 
+## [0.99.105] - 2026-05-31
+
+### Removed
+- **PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — remove `hyperparam` from the
+  self-improving loop's mutation surface.** The mutator deterministically fixated
+  on `reflection_depth`: PR-AUDIT-SCAFFOLD-WIRE (#1938) had restricted the mutable
+  `hyperparam` kind to `reflection_depth` ONLY (`max_turns` / `seed_limit` /
+  `dim_set` rejected as audit-measurement params), but `reflection_depth` is an
+  exhausted axis — after ≥3 prior applies the axis-family dedup in
+  `core/self_improving_loop/mutator_feedback.py` (`_AXIS_REPEAT_LIMIT = 3`) rejects
+  every new `reflection_depth` proposal as repetitive (synthetic
+  `axis_family_exhausted_*`, similarity 1.000). With one mutable section left, a
+  live campaign exhausted all 8 propose-guard attempts every cycle → every cycle
+  SKIPped → zero data. `hyperparam` is now removed from
+  `core/self_improving_loop/policies.py::TARGET_KINDS` (the mutable surface is the
+  7 *behaviour* kinds: prompt, tool_policy, tool_descriptions, decomposition,
+  reflection, skill_catalog, agent_contract), so the mutator diversifies. A
+  mutation carrying `target_kind="hyperparam"` is rejected at `parse_mutation` /
+  `apply_mutation` (`runner.py::_reject_hyperparam_mutation`) with a clear message
+  ("hyperparam is not a mutable kind — measurement params are fixed config;
+  reflection_depth axis exhausted"); the PR-AUDIT-SCAFFOLD-WIRE per-section bounds
+  machinery (`_HYPERPARAM_INT_BOUNDS` / `_HYPERPARAM_FIXED_MEASUREMENT_KEYS` /
+  `_HYPERPARAM_CATEGORICAL` / `_validate_hyperparam_bounds`) is removed (no dead
+  branches). The mutator-feedback "Kind × Dim" attribution block is filtered to
+  active `TARGET_KINDS` so a historical `hyperparam` row no longer steers the
+  mutator into a parse-rejection SKIP. The
+  `autoresearch/state/policies/hyperparam.json` SoT and its runtime readers
+  (`autoresearch.train._load_hyperparam_overrides` →
+  seed_limit/max_turns/dim_set/reflection_depth consumed by the audit subprocess +
+  AgenticLoop) are preserved — only the mutation surface is gone; the
+  `_KIND_TO_PATH` mapping is kept (mirroring the deprecated `retrieval` slot) for
+  future re-add. Mutator system-prompt contract text + `autoresearch/program.md`
+  CAN-table updated to list only the 7 behaviour kinds. Docs:
+  `docs/self-improving/campaign-procedure.md` §2.1/§2.2.
+
 ## [0.99.104] - 2026-05-31
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.104
+- **Version**: 0.99.105
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.104 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.105 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 
@@ -37,7 +37,7 @@
 
 ## Self-improving loop
 
-GEODE 는 **non-parametric** 갈래의 자기진화 에이전트입니다. 모델 가중치가 아니라 자신의 scaffold (시스템 프롬프트, 도구 정책, 작업 분해, reflection, 스킬, 에이전트 계약, 도구 설명, 하이퍼파라미터) 를 변이시켜 개선합니다. fitness 는 capability 벤치마크가 아니라 적대적 **안전성** audit 입니다. Petri 급, 다차원이며, critical 안전 차원에는 하드 floor 가 걸려 있어 그 차원을 후퇴시키는 변경은 거부됩니다. **선택** seed 는 함께 진화합니다 — co-scientist 파이프라인이 에이전트와 나란히 적대적 seed 를 키웁니다 — 따라서 이들은 고정된 자가 아니라 움직이는 선택 압력을 가합니다. 세대 간 fitness 는 절대 변이하지 않는 별도의 **버전 고정 held-out 벤치** 위에서 측정합니다. 실제 개선의 증거로 인정되는 것은 그 held-out 곡선뿐입니다.
+GEODE 는 **non-parametric** 갈래의 자기진화 에이전트입니다. 모델 가중치가 아니라 자신의 scaffold (시스템 프롬프트, 도구 정책, 작업 분해, reflection, 스킬, 에이전트 계약, 도구 설명) 를 변이시켜 개선합니다. fitness 는 capability 벤치마크가 아니라 적대적 **안전성** audit 입니다. Petri 급, 다차원이며, critical 안전 차원에는 하드 floor 가 걸려 있어 그 차원을 후퇴시키는 변경은 거부됩니다. **선택** seed 는 함께 진화합니다 — co-scientist 파이프라인이 에이전트와 나란히 적대적 seed 를 키웁니다 — 따라서 이들은 고정된 자가 아니라 움직이는 선택 압력을 가합니다. 세대 간 fitness 는 절대 변이하지 않는 별도의 **버전 고정 held-out 벤치** 위에서 측정합니다. 실제 개선의 증거로 인정되는 것은 그 held-out 곡선뿐입니다.
 
 선택은 정직한 **(1+1) 챔피언 체인**입니다. 변이하고, audit 하고, 실제 이득이 있을 때만 promote 하고, 아니면 revert 합니다. 두 개의 loop 가 함께 돕니다. inner agentic loop 는 작업을 수행하고, outer loop 는 작업을 수행하는 시스템을 다듬습니다. 이 loop 계보 (Promptbreeder, STOP, ADAS, DGM, GEPA) 는 이미 잘 정립돼 있습니다. GEODE 는 그것을 capability 에서 safety 로, 가중치에서 scaffold 로, co-evolved 적대적 seed 위로 다시 겨냥합니다. 새 primitive 가 아니라, 비어 있던 칸을 채우는 재조합입니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.104 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.105 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 
@@ -37,7 +37,7 @@ A general-purpose autonomous agent that also rewrites the scaffolding it runs on
 
 ## The self-improving loop
 
-GEODE is a self-evolving agent on the **non-parametric branch**: it improves by mutating its own scaffolding (system prompt, tool policy, task decomposition, reflection, skills, agent contracts, tool descriptions, hyperparameters), never the model weights. Fitness is an adversarial **safety** audit, not a capability benchmark: Petri-grade, multi-dimensional, with a hard floor on critical safety dimensions, so any change that regresses one is rejected. The **selection** seeds co-evolve — a co-scientist pipeline grows adversarial seeds alongside the agent — so they apply moving selection pressure, not a stable ruler. Cross-generation fitness is measured on a separate **version-frozen held-out bench** that never mutates; only that held-out curve counts as evidence of real improvement.
+GEODE is a self-evolving agent on the **non-parametric branch**: it improves by mutating its own scaffolding (system prompt, tool policy, task decomposition, reflection, skills, agent contracts, tool descriptions), never the model weights. Fitness is an adversarial **safety** audit, not a capability benchmark: Petri-grade, multi-dimensional, with a hard floor on critical safety dimensions, so any change that regresses one is rejected. The **selection** seeds co-evolve — a co-scientist pipeline grows adversarial seeds alongside the agent — so they apply moving selection pressure, not a stable ruler. Cross-generation fitness is measured on a separate **version-frozen held-out bench** that never mutates; only that held-out curve counts as evidence of real improvement.
 
 Selection is an honest **(1+1) champion chain**: mutate, audit, promote on a real gain, otherwise revert. Two loops run together. An inner agentic loop runs a task; an outer loop tunes the system that runs tasks. The loop lineage (Promptbreeder, STOP, ADAS, DGM, GEPA) is well established. GEODE re-aims it from capability to safety, from weights to scaffolding, on co-evolved adversarial seeds. A recombination occupying an empty cell, not a new primitive.
 

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -77,9 +77,9 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
 - Modify `train.py`'s `WRAPPER_PROMPT_SECTIONS` dict. The system
   prompt sections are fair game for wording changes, additions,
   deletions, and reorderings.
-- Mutate any of the **8 policy SoT files** at
+- Mutate any of the **7 behaviour policy SoT files** at
   `autoresearch/state/policies/` (PR-MINIMAL-2 baseline + ADR-012
-  M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE + PR-HYPERPARAM-FOUNDATION):
+  M1/M2 + PR-TOOL-DESCRIPTIONS-MUTATE):
 
   | `target_kind`        | File                       | What it controls                                                |
   |----------------------|----------------------------|-----------------------------------------------------------------|
@@ -90,7 +90,6 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   | `skill_catalog`      | `skill-catalog.json`       | Skill descriptions + `user_invocable` flag (ADR-012 M1)         |
   | `agent_contract`     | `agent-contracts.json`     | Sub-agent role / system_prompt / tools (ADR-012 M2)             |
   | `tool_descriptions`  | `tool-descriptions.json`   | Per-tool `description` + `hints` list (PR-TOOL-DESCRIPTIONS-MUTATE) |
-  | `hyperparam`         | `hyperparam.json`          | Audit-subprocess hyperparameters (PR-HYPERPARAM-FOUNDATION)     |
 
   The four legacy kinds (`prompt` / `tool_policy` / `decomposition` /
   `reflection`) carry a `dict[str, str]` SoT. The three nested kinds
@@ -100,34 +99,29 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   `<tool>.hints`, etc.); `load_policy` / `write_policy` handle the
   conversion. The Mode B runner (`SelfImprovingLoopRunner`) dispatches
   by `Mutation.target_kind` to the matching file; Mode A agents can
-  edit any of the 8 directly via `git`-tracked JSON.
+  edit any of the 7 directly via `git`-tracked JSON.
 
-  `hyperparam` (PR-HYPERPARAM-FOUNDATION, 2026-05-28) is structurally
-  the same `dict[str, str]` schema but semantically distinct: each
-  value is a **string-encoded numeric** that the AgenticLoop runtime
-  converts at consumption time. PR-AUDIT-SCAFFOLD-WIRE (2026-05-31,
-  operator decision) restricted the MUTABLE surface to one section:
-
-  | Section             | Type        | Bounds                  |
-  |---------------------|-------------|-------------------------|
-  | `reflection_depth`  | int         | [1, 5]                  |
-
-  `max_turns` / `seed_limit` / `dim_set` are NO LONGER mutable — they
-  are FIXED audit-MEASUREMENT parameters (turn budget, sample count,
-  judged dim set). Mutating them would change *how / what* the audit
-  measures, confounding the mutated-vs-baseline fitness comparison, so
-  `parse_mutation` + `apply_mutation` REJECT them (fail-closed at two
-  layers, with an explanatory error). They remain readable as
-  operator-set defaults in `hyperparam.json` (consumed by
-  `_build_audit_command`), just not mutator-changeable.
-
-  `parse_mutation` + `apply_mutation` also reject `reflection_depth`
-  values outside [1, 5]. Use a hyperparam (`reflection_depth`) mutation
-  when the regression dim's `measurement_modality` is `tool_log` or
-  `token_count` (programmatic / mechanism-level) and prompt mutations
-  have repeatedly produced `Δ ≈ 0` for the target dim — cycle 1-12
-  (2026-05-26 → 05-28) observed exactly this pattern for
-  `redundant_tool_invocation`, which is what motivates the slot.
+  `hyperparam` (`hyperparam.json`: `seed_limit` / `max_turns` /
+  `dim_set` / `reflection_depth`) is FIXED config, not mutated.
+  PR-HYPERPARAM-FOUNDATION (2026-05-28) opened it as a mutable slot and
+  PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) restricted it to `reflection_depth`
+  only, but PR-DROP-HYPERPARAM-MUTATION (2026-05-31, operator decision)
+  removed the whole kind from `TARGET_KINDS`. Rationale:
+  `seed_limit` / `max_turns` / `dim_set` are audit-MEASUREMENT parameters
+  (sample count, turn budget, judged dim set) — mutating them changes
+  *how / what* the audit measures and confounds the mutated-vs-baseline
+  comparison; and `reflection_depth` is an EXHAUSTED axis — after ≥3
+  prior applies the axis-family dedup (`mutator_feedback.py`,
+  `_AXIS_REPEAT_LIMIT = 3`) rejects every new proposal as repetitive, so
+  a single-section hyperparam surface exhausts the propose-guard every
+  cycle (zero data). A mutation carrying `target_kind="hyperparam"` is
+  REJECTED at `parse_mutation` + `apply_mutation`
+  (`_reject_hyperparam_mutation`, fail-closed at two layers, with an
+  explanatory error). The `hyperparam.json` SoT and its runtime readers
+  (`autoresearch.train._load_hyperparam_overrides`, consumed by
+  `_build_audit_command` + the AgenticLoop) are preserved — only the
+  mutation surface is removed. The mapping in `policies.py:_KIND_TO_PATH`
+  is kept for a future re-introduction.
 
   `retrieval` was deprecated in ADR-012 S0d (2026-05-21) — the reader
   was never wired (PR-AUDIT-5SLOT). The slot is excluded from

--- a/core/self_improving_loop/mutator_feedback.py
+++ b/core/self_improving_loop/mutator_feedback.py
@@ -112,9 +112,22 @@ def format_mutator_feedback_block(
         "",
     ]
 
+    # PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — restrict the rendered kinds
+    # to the *active* mutable surface. The attribution matrix is built from
+    # historical apply/attribution rows, which can include kinds the mutator
+    # can no longer propose (``hyperparam`` was removed; ``retrieval`` was
+    # deprecated). Surfacing a retired kind here — under the "favour kinds
+    # that have moved the regression target_dim historically" guidance below
+    # — would steer the mutator straight into a ``parse_mutation`` rejection
+    # and a wasted SKIP. Filter to ``TARGET_KINDS`` so the feedback only
+    # recommends kinds the mutator can actually dispatch to.
+    from core.self_improving_loop.policies import TARGET_KINDS
+
     if matrix:
         lines.append("Kind x Dim (top dims by absolute attribution per kind):")
         for kind in sorted(matrix):
+            if kind not in TARGET_KINDS:
+                continue
             ranked = rank_dims_by_kind(matrix, kind, limit=_TOP_KINDS_IN_BLOCK)
             if not ranked:
                 continue

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -180,11 +180,30 @@ def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
 # reader-only surface graduates in its own follow-up PR (matching the
 # ADR-012 M1/M2 precedent that opened ``skill_catalog`` and
 # ``agent_contract``). Mutator emitting a ``target_kind`` not in
-# ``TARGET_KINDS`` fails fast at ``parse_mutation`` (``runner.py:914``
+# ``TARGET_KINDS`` fails fast at ``parse_mutation`` (``runner.py``
 # ValueError) — fail-closed by design. The reader-only set is pinned
 # by ``tests/core/self_improving_loop/test_target_kind_surface_doc.py``
 # so a future PR that promotes any of them must remove the entry
 # explicitly rather than silently expanding mutator dispatch.
+#
+# PR-DROP-HYPERPARAM-MUTATION (2026-05-31, operator decision) — ``hyperparam``
+# is REMOVED from the mutable surface. PR-HYPERPARAM-FOUNDATION (2026-05-28)
+# had graduated it, then PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) restricted the
+# mutable section to ``reflection_depth`` ONLY (max_turns/seed_limit/dim_set
+# rejected as measurement params). But ``reflection_depth`` is an EXHAUSTED
+# axis: after ≥3 prior applies the axis-family dedup in
+# ``mutator_feedback.py`` rejects every new ``reflection_depth`` proposal as
+# repetitive (synthetic ``axis_family_exhausted_*``, similarity 1.000), so a
+# campaign exhausts all 8 propose-guard attempts every cycle → all cycles SKIP
+# → zero data. Removing the kind frees the mutator to propose only the 7
+# *behaviour* kinds and diversify. The ``hyperparam.json`` SoT and its RUNTIME
+# readers (seed_limit/max_turns/dim_set/reflection_depth consumed by the audit
+# subprocess + AgenticLoop via ``autoresearch.train._load_hyperparam_overrides``)
+# are PRESERVED — only the MUTATION surface is removed. ``_KIND_TO_PATH`` keeps
+# the ``hyperparam`` mapping (same path-literal guard as the deprecated
+# ``retrieval`` slot) so a future ADR can re-add it to ``TARGET_KINDS`` without
+# re-deriving the path. Rejection message lives in
+# ``runner.py::_reject_hyperparam_mutation``.
 TARGET_KINDS: tuple[str, ...] = (
     "prompt",
     "tool_policy",
@@ -215,26 +234,11 @@ TARGET_KINDS: tuple[str, ...] = (
     # ``_LIST_FIELDS_BY_KIND`` mapping below converts the comma-joined
     # mutation row back to a list on write.
     "tool_descriptions",
-    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — numeric / categorical
-    # hyperparameter mutation slot. Distinct from the 7 text-artifact
-    # kinds above: this slot tunes the audit-subprocess command line
-    # + AgenticLoop runtime configuration directly (max_turns →
-    # ``-T max_turns=<n>``, seed_limit → ``--limit <n>``, dim_set →
-    # ``-T judge_dimensions=<value>``, reflection_depth → AgenticLoop
-    # reflection-iteration cap). Flat ``dict[str, str]`` schema with
-    # string-encoded values (``{"max_turns": "5"}``); runtime readers
-    # convert at the consumption site. Bounds enforced at
-    # ``parse_mutation`` via ``_HYPERPARAM_INT_BOUNDS`` /
-    # ``_HYPERPARAM_CATEGORICAL`` (see ``runner.py``) so a mutator
-    # proposing ``max_turns=999`` fails fast instead of silently
-    # crashing the next audit. Motivated by cycle 1-12 (2026-05-26 →
-    # 05-28) where 11/12 prompt-only mutations could not move
-    # ``redundant_tool_invocation`` (tool_log modality, programmatic
-    # tool-call dedup) — turn-budget mutation is the first surface
-    # the loop has that reaches that mechanism layer. PR-3
-    # (PR-HYPERPARAM-WIRE) lands the audit-subprocess argv builder +
-    # AgenticLoop reader.
-    "hyperparam",
+    # NOTE: ``hyperparam`` was a mutable slot from PR-HYPERPARAM-FOUNDATION
+    # (2026-05-28) through PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) and is REMOVED
+    # by PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — see the block above. The
+    # SoT + runtime readers stay; only the mutation surface is gone. The
+    # remaining 7 entries are all *behaviour* kinds.
 )
 
 # Each kind maps to the SoT file. ``prompt`` re-points to the legacy
@@ -242,6 +246,10 @@ TARGET_KINDS: tuple[str, ...] = (
 #
 # ``retrieval`` 매핑은 S0d 이후 deprecated 상태 — ``TARGET_KINDS`` 에서
 # 제외돼 mutation dispatch 가 발생하지 않지만 path constant 는 보존.
+# ``hyperparam`` 매핑도 PR-DROP-HYPERPARAM-MUTATION (2026-05-31) 이후 동일 —
+# ``TARGET_KINDS`` 에서 제외돼 mutation dispatch 불가하지만, runtime config
+# readers (``autoresearch.train._load_hyperparam_overrides``) 와 미래 ADR
+# 재추가를 위해 path 매핑 보존.
 _KIND_TO_PATH: dict[str, Path] = {
     "prompt": GLOBAL_WRAPPER_SECTIONS_PATH,
     "tool_policy": GLOBAL_TOOL_POLICY_PATH,

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -497,31 +497,22 @@ _MUTATION_CONTRACT_SUFFIX = (
     "next audit.\n"
     "- ``rollback_condition`` is a one-line predicate describing when this "
     'mutation should be reverted (e.g. ``"helpfulness drops below 0.4"``).\n'
-    "- ``target_kind`` selects the policy SoT to mutate. One of "
-    "``prompt`` (default, wrapper-sections.json), ``tool_policy`` "
-    "(tool-policy.json), ``decomposition`` (decomposition.json), "
-    "``reflection`` (reflection.json), ``skill_catalog`` "
-    "(skill-catalog.json), ``agent_contract`` (agent-contracts.json), "
-    "``tool_descriptions`` (tool-descriptions.json — PR-TOOL-DESCRIPTIONS-MUTATE "
-    "graduation, 2026-05-27), or ``hyperparam`` (hyperparam.json — "
-    "PR-HYPERPARAM-FOUNDATION graduation, 2026-05-28: numeric / categorical "
-    "audit-budget tuning). "
+    "- ``target_kind`` selects the policy SoT to mutate. One of the 7 "
+    "behaviour kinds: ``prompt`` (default, wrapper-sections.json), "
+    "``tool_policy`` (tool-policy.json), ``decomposition`` "
+    "(decomposition.json), ``reflection`` (reflection.json), "
+    "``skill_catalog`` (skill-catalog.json), ``agent_contract`` "
+    "(agent-contracts.json), or ``tool_descriptions`` (tool-descriptions.json "
+    "— PR-TOOL-DESCRIPTIONS-MUTATE graduation, 2026-05-27). "
     "Omit for prompt-level mutations. For ``tool_descriptions``, the "
     "``target_section`` uses dotted notation: ``<tool_name>.description`` "
     "(string replacement) or ``<tool_name>.hints`` (comma-separated list "
-    "of hint strings). For ``hyperparam``, the ONLY mutable ``target_section`` "
-    "is ``reflection_depth`` (integer, bounds [1, 5]); ``new_value`` is the "
-    'string-encoded value (``"5"`` not ``5``). The audit-measurement '
-    "parameters ``max_turns`` / ``seed_limit`` / ``dim_set`` are FIXED "
-    "(PR-AUDIT-SCAFFOLD-WIRE, 2026-05-31) and a mutation targeting them is "
-    "REJECTED — they change how/what the audit measures, which would confound "
-    "the mutated-vs-baseline fitness comparison. Use a reflection_depth "
-    "hyperparam mutation when the regression dim's measurement_modality is "
-    "``tool_log`` or ``token_count`` (programmatic / mechanism-level) and "
-    "prompt mutations have repeatedly produced ``Δ ≈ 0`` for the target dim. "
-    "(``retrieval`` "
-    "was deprecated in ADR-012 S0d, 2026-05-21 — see policies.py "
-    "docstring.)\n"
+    "of hint strings). The ``hyperparam`` kind (audit-budget / "
+    "reflection_depth knobs) is NOT mutable (PR-DROP-HYPERPARAM-MUTATION, "
+    "2026-05-31): the measurement params (seed_limit / max_turns / dim_set) "
+    "are fixed audit config and the reflection_depth axis is exhausted, so a "
+    "``hyperparam`` mutation is REJECTED at parse. (``retrieval`` was "
+    "deprecated in ADR-012 S0d, 2026-05-21 — see policies.py docstring.)\n"
     "- **Principle-first (P3-revised, 2026-05-25, SPCT pattern)**: BEFORE "
     "selecting ``target_section`` and writing ``new_value``, explicitly state "
     "the judging principle that motivates this mutation — what specific axis "
@@ -540,13 +531,13 @@ _MUTATION_CONTRACT_SUFFIX = (
     "principle targets redundant_tool_invocation by tightening the LLM's "
     "mental model of when re-querying is justified — the tool_log modality "
     'measures dedup count, so prompt-level dedup discipline is the lever."\n'
-    '  GOOD (398 chars): "redundant_tool_invocation is a tool_log '
-    "measurement: it counts repeated tool calls within an episode. An extra "
-    "reflection pass (reflection_depth) lets the agent re-read its own prior "
-    "tool output and prune a re-query before emitting it, so deepening "
-    "reflection is a direct mechanism-level lever — distinct from the "
-    "prompt-level coaching that cycle 11-14 attempted, and the only mutable "
-    'hyperparam (max_turns / seed_limit / dim_set are fixed measurement)."\n'
+    '  GOOD (412 chars): "redundant_tool_invocation is a tool_log '
+    "measurement: it counts repeated tool calls within an episode. The "
+    "reflection policy (target_kind=reflection) governs whether the agent "
+    "re-reads its own prior tool output before emitting a new call, so "
+    "tightening the reflection policy's re-query discipline is a direct "
+    "mechanism-level lever — distinct from the prompt-level coaching that "
+    'cycle 11-14 attempted."\n'
     "  Both examples are SHORTER than the cap, capture a single causal "
     "anchor, and avoid restating context the user prompt already provides. "
     "Your principle should be NO LONGER than these examples; restating "
@@ -886,93 +877,53 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     return text
 
 
-# PR-HYPERPARAM-FOUNDATION (2026-05-28) — bounds map for the
-# ``hyperparam`` target_kind. Two shapes:
+# PR-DROP-HYPERPARAM-MUTATION (2026-05-31, operator decision) — the
+# ``hyperparam`` target_kind is REMOVED from the mutable surface entirely.
 #
-#   _HYPERPARAM_INT_BOUNDS:   key → (min, max) for integer-valued knobs
-#   _HYPERPARAM_CATEGORICAL:  key → allowed-string set
+# History: PR-HYPERPARAM-FOUNDATION (2026-05-28) opened a numeric / categorical
+# hyperparam mutation slot (max_turns / seed_limit / dim_set / reflection_depth);
+# PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) then restricted it to ``reflection_depth``
+# ONLY (the other three rejected as audit-measurement params that confound the
+# mutated-vs-baseline comparison). But ``reflection_depth`` is an EXHAUSTED axis:
+# after ≥3 prior applies the axis-family dedup in ``mutator_feedback.py``
+# (``_AXIS_REPEAT_LIMIT = 3``) rejects every new ``reflection_depth`` proposal as
+# repetitive (synthetic ``axis_family_exhausted_*``, similarity 1.000). With only
+# one mutable section left, a live campaign exhausts all 8 propose-guard attempts
+# every cycle → every cycle SKIPs → zero data. So the kind is dropped from
+# ``TARGET_KINDS`` (``policies.py``) and the mutator now proposes only the 7
+# behaviour kinds and diversifies.
 #
-# PR-AUDIT-SCAFFOLD-WIRE (2026-05-31, operator decision) — the mutable
-# hyperparam surface is restricted to ``reflection_depth`` ONLY. The other
-# three knobs (``max_turns`` / ``seed_limit`` / ``dim_set``) are MEASUREMENT
-# parameters: they change *how / what* the audit measures (turn budget,
-# sample count, judged dim set), which confounds the fitness comparison
-# between a mutated scaffold and its baseline — a mutation that "improves"
-# fitness merely by shrinking the dim set or the sample fan-out is a
-# measurement artifact, not a real scaffold gain. Those three are now FIXED
-# audit-spec parameters owned by the autoresearch config (and the
-# baseline-epoch spec hash); they are rejected at ``_validate_hyperparam_
-# bounds`` so a mutator cannot propose them. ``reflection_depth`` stays
-# mutable because it is a genuine GEODE *runtime* behaviour knob (AgenticLoop
-# reflection-iteration cap), not an audit-measurement parameter, so tuning it
-# is a legitimate scaffold change whose effect the FIXED measurement captures
-# honestly.
+# The per-section bounds machinery (``_HYPERPARAM_INT_BOUNDS`` /
+# ``_HYPERPARAM_FIXED_MEASUREMENT_KEYS`` / ``_HYPERPARAM_CATEGORICAL``) is now
+# moot — ALL hyperparam mutations are rejected — and is removed rather than
+# left as dead branches. A single clear rejection replaces it.
 #
-# Bounds chosen so a worst-case mutator proposal cannot:
-#   - silently disable reflection (``reflection_depth ≥ 1``)
-#   - explode per-turn latency / cost (``reflection_depth ≤ 5``)
-_HYPERPARAM_INT_BOUNDS: dict[str, tuple[int, int]] = {
-    "reflection_depth": (1, 5),
-}
-_HYPERPARAM_CATEGORICAL: dict[str, frozenset[str]] = {}
-_HYPERPARAM_ALLOWED_KEYS: frozenset[str] = frozenset(
-    list(_HYPERPARAM_INT_BOUNDS.keys()) + list(_HYPERPARAM_CATEGORICAL.keys())
-)
-# Measurement parameters that USED to be mutable (PR-HYPERPARAM-FOUNDATION)
-# but are now FIXED (PR-AUDIT-SCAFFOLD-WIRE). Tracked separately so the
-# rejection error message can explain *why* (confound) rather than just
-# "unknown key", and so a regression test can pin the non-mutability.
-_HYPERPARAM_FIXED_MEASUREMENT_KEYS: frozenset[str] = frozenset(
-    {"max_turns", "seed_limit", "dim_set"}
-)
+# PRESERVED: ``autoresearch/state/policies/hyperparam.json`` and its RUNTIME
+# readers (``autoresearch.train._load_hyperparam_overrides`` →
+# seed_limit/max_turns/dim_set/reflection_depth consumed by the audit subprocess
+# + AgenticLoop). Only the MUTATION surface is gone.
 
 
-def _validate_hyperparam_bounds(section: str, value: str) -> None:
-    """Validate a ``hyperparam`` mutation's ``(target_section, new_value)`` pair.
+def _reject_hyperparam_mutation() -> None:
+    """Reject any ``target_kind="hyperparam"`` mutation.
 
-    Raises :class:`ValueError` if ``section`` is unknown, if a numeric
-    section's ``value`` cannot be cast to int, or if the resulting
-    integer / categorical is outside the documented bounds. The bounds
-    are documented inline in the mutator system-prompt suffix
-    (``_MUTATION_CONTRACT_SUFFIX``) so a fail-closed parse here mirrors
-    what the LLM was told.
+    ``hyperparam`` is no longer a mutable kind (PR-DROP-HYPERPARAM-MUTATION,
+    2026-05-31). It is removed from ``TARGET_KINDS`` so the generic
+    not-in-TARGET_KINDS guard already fails closed, but this dedicated
+    rejection gives the operator a *specific* explanation rather than the
+    generic enumeration — measurement params are fixed config and the
+    ``reflection_depth`` axis is exhausted.
+
+    Always raises :class:`ValueError`.
     """
-    if section in _HYPERPARAM_FIXED_MEASUREMENT_KEYS:
-        raise ValueError(
-            f"hyperparam target_section {section!r} is a FIXED audit-measurement "
-            "parameter and is not mutable (PR-AUDIT-SCAFFOLD-WIRE, 2026-05-31): "
-            "mutating turn budget / sample count / dim set confounds the "
-            "mutated-vs-baseline fitness comparison. Only reflection_depth is "
-            f"mutable; allowed set: {sorted(_HYPERPARAM_ALLOWED_KEYS)!r}."
-        )
-    if section not in _HYPERPARAM_ALLOWED_KEYS:
-        raise ValueError(
-            f"hyperparam target_section {section!r} not in allowed set "
-            f"{sorted(_HYPERPARAM_ALLOWED_KEYS)!r}"
-        )
-    if section in _HYPERPARAM_INT_BOUNDS:
-        lo, hi = _HYPERPARAM_INT_BOUNDS[section]
-        try:
-            n = int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"hyperparam {section} new_value {value!r} must be an integer-convertible string"
-            ) from exc
-        if not (lo <= n <= hi):
-            raise ValueError(f"hyperparam {section}={n} out of bounds [{lo}, {hi}]")
-        return
-    # Categorical branch. ``_HYPERPARAM_CATEGORICAL`` is currently empty
-    # (PR-AUDIT-SCAFFOLD-WIRE removed ``dim_set`` — a measurement param — and
-    # ``reflection_depth`` is integer-valued), so a valid ``section`` always
-    # hits the int branch above and this branch is reserved for a future
-    # categorical knob. Kept (not deleted) so re-adding one only needs a map
-    # entry. ``allowed`` is empty for any section that reaches here, so the
-    # value is rejected — fail-closed.
-    allowed = _HYPERPARAM_CATEGORICAL.get(section, frozenset())
-    if value not in allowed:
-        raise ValueError(
-            f"hyperparam {section} new_value {value!r} must be one of {sorted(allowed)!r}"
-        )
+    raise ValueError(
+        "hyperparam is not a mutable kind — measurement params "
+        "(seed_limit / max_turns / dim_set) are fixed audit config, and the "
+        "reflection_depth axis is exhausted (PR-DROP-HYPERPARAM-MUTATION, "
+        "2026-05-31). Propose one of the 7 behaviour kinds instead "
+        "(prompt / tool_policy / tool_descriptions / decomposition / "
+        "reflection / skill_catalog / agent_contract)."
+    )
 
 
 def parse_mutation(raw: str) -> Mutation:
@@ -1081,16 +1032,16 @@ def parse_mutation(raw: str) -> Mutation:
     if not isinstance(kind_raw, str):
         raise ValueError(f"target_kind must be a string, got {type(kind_raw).__name__}")
     target_kind = kind_raw.strip() or "prompt"
+    # PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — ``hyperparam`` is dropped
+    # from TARGET_KINDS so the generic guard below already fails closed; this
+    # dedicated branch wins first so the mutator gets the *specific* reason
+    # (measurement params fixed + reflection_depth axis exhausted) rather than
+    # the generic enumeration. apply_mutation applies the same gate (boundary
+    # completeness, CLAUDE.md → Wiring Verification → Conditional Read Parity).
+    if target_kind == "hyperparam":
+        _reject_hyperparam_mutation()
     if target_kind not in TARGET_KINDS:
         raise ValueError(f"target_kind {target_kind!r} is not one of {TARGET_KINDS!r}")
-    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam kind 별 bounds
-    # 검사. mutator 가 ``max_turns=999`` 같은 유효 범위 밖 numeric 또는
-    # ``dim_set="bogus"`` 같은 유효 카테고리 밖 값을 propose 시 audit
-    # 시점에 silently crash 하기 전에 parse 시점에 fail-closed.
-    # Boundary completeness rule (CLAUDE.md → CANNOT → Quality):
-    # apply 시점에도 동일 가드를 적용해 두 layer 모두 보호.
-    if target_kind == "hyperparam":
-        _validate_hyperparam_bounds(target_section.strip(), new_value)
     mutation_id_raw = payload.get("mutation_id")
     # Mutation has a default_factory; pass only when the LLM supplied one.
     if isinstance(mutation_id_raw, str) and mutation_id_raw.strip():
@@ -1158,15 +1109,15 @@ def apply_mutation(
         write_wrapper_prompt_sections(sections)
         return sections, previous_value
 
-    # PR-HYPERPARAM-FOUNDATION (2026-05-28) — second-layer bounds gate.
-    # parse_mutation already validates at LLM-response time, but the
-    # apply path is reached from other entrypoints (manual ``apply_mutation``
-    # calls in tests / slash / re-runs of a parsed mutation), so a
-    # ``Mutation`` constructed outside ``parse_mutation`` cannot rely on
-    # the first gate. Defensive depth (CLAUDE.md → Wiring Verification →
-    # Conditional Read Parity).
+    # PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — second-layer rejection.
+    # parse_mutation already rejects at LLM-response time, but the apply path
+    # is reached from other entrypoints (manual ``apply_mutation`` calls in
+    # tests / slash / re-runs of a parsed mutation), so a ``Mutation``
+    # constructed outside ``parse_mutation`` cannot rely on the first gate.
+    # Defensive depth (CLAUDE.md → Wiring Verification → Conditional Read
+    # Parity). ``hyperparam`` is no longer mutable — reject before any write.
     if mutation.target_kind == "hyperparam":
-        _validate_hyperparam_bounds(mutation.target_section, mutation.new_value)
+        _reject_hyperparam_mutation()
 
     # PR-6 policy kinds — tool_policy / decomposition / retrieval /
     # reflection. ``current_sections`` override is honoured for symmetry

--- a/docs/self-improving/campaign-procedure.md
+++ b/docs/self-improving/campaign-procedure.md
@@ -34,7 +34,7 @@ The mutable scaffold is the set of policy artifacts under
 `autoresearch/state/policies/`, dispatched by `mutation.target_kind`
 (`core/self_improving_loop/policies.py::TARGET_KINDS`).
 
-### 2.1 TARGET_KINDS (8 total)
+### 2.1 TARGET_KINDS (7 behaviour kinds)
 
 | target_kind | SoT file | Role |
 |-------------|----------|------|
@@ -45,24 +45,36 @@ The mutable scaffold is the set of policy artifacts under
 | `reflection` | `reflection.json` | Reflection policy |
 | `skill_catalog` | `skill-catalog.json` | Per-skill description + visibility |
 | `agent_contract` | `agent-contracts.json` | Sub-agent contracts |
-| `hyperparam` | `hyperparam.json` | Numeric / categorical knobs |
 
-`retrieval` was deprecated (ADR-012 S0d, 2026-05-21).
+`retrieval` was deprecated (ADR-012 S0d, 2026-05-21). `hyperparam` was a mutable
+slot from PR-HYPERPARAM-FOUNDATION (2026-05-28) through PR-AUDIT-SCAFFOLD-WIRE
+(2026-05-31) but was **removed** from the mutable surface by
+PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — see §2.2.
 
 ### 2.2 Optimizable vs reader-only vs fixed
 
-- **Optimize (mutator may change)**: the 7 active *behaviour* kinds —
+- **Optimize (mutator may change)**: the 7 *behaviour* kinds —
   `prompt`, `tool_policy`, `tool_descriptions`, `decomposition`, `reflection`,
-  `skill_catalog`, `agent_contract` — **plus** the single hyperparam knob
-  `hyperparam.reflection_depth`.
+  `skill_catalog`, `agent_contract`.
 - **Fixed (mutator may NOT change)**:
-  - `hyperparam.seed_limit`, `hyperparam.max_turns`, `hyperparam.dim_set` —
-    these are audit-**measurement** parameters. Changing them changes *how / what*
-    the audit measures (sample count, turn budget, judged dim set), which would
-    confound the mutated-vs-baseline fitness comparison. They are rejected at
-    `parse_mutation` / `apply_mutation` (`_validate_hyperparam_bounds`,
-    PR-AUDIT-SCAFFOLD-WIRE, 2026-05-31; pinned by
-    `tests/test_policy_mutation.py::test_hyperparam_max_turns_seed_limit_dim_set_are_fixed_measurement_params`).
+  - `hyperparam` (`seed_limit` / `max_turns` / `dim_set` / `reflection_depth`)
+    is FIXED config, not mutated. `seed_limit` / `max_turns` / `dim_set` are
+    audit-**measurement** parameters — changing them changes *how / what* the
+    audit measures (sample count, turn budget, judged dim set), which would
+    confound the mutated-vs-baseline fitness comparison. `reflection_depth` is
+    a genuine runtime behaviour knob but its **axis is exhausted**: after ≥3
+    prior applies the axis-family dedup (`mutator_feedback.py`,
+    `_AXIS_REPEAT_LIMIT = 3`) rejects every new `reflection_depth` proposal as
+    repetitive, so a single-section hyperparam surface exhausts the
+    propose-guard every cycle. The whole `hyperparam` kind is therefore removed
+    from `TARGET_KINDS`; a mutation carrying `target_kind="hyperparam"` is
+    rejected at `parse_mutation` / `apply_mutation`
+    (`_reject_hyperparam_mutation`, PR-DROP-HYPERPARAM-MUTATION, 2026-05-31;
+    pinned by
+    `tests/test_policy_mutation.py::test_parse_mutation_rejects_hyperparam_kind_with_clear_message`).
+    The `hyperparam.json` SoT and its runtime readers
+    (`autoresearch.train._load_hyperparam_overrides`) are preserved — only the
+    mutation surface is removed.
   - The `gpt-5.5` target weights (the base model is never trained).
   - The seed pools (cycle-input + held-out) — frozen rulers, see §4.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.104"
+version = "0.99.105"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/self_improving_loop/test_mutator_feedback.py
+++ b/tests/core/self_improving_loop/test_mutator_feedback.py
@@ -86,6 +86,38 @@ def test_feedback_block_renders_matrix_section_when_attribution_present() -> Non
     assert "broken_tool_use" in block
 
 
+def test_feedback_block_excludes_retired_hyperparam_kind() -> None:
+    """PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — a historical ``hyperparam``
+    apply row must NOT be surfaced in the feedback block. The block tells the
+    mutator to "favour kinds that have moved the regression target_dim
+    historically"; if a retired kind appeared there the mutator would propose
+    it and the cycle would SKIP at ``parse_mutation`` rejection. Active kinds
+    in the same matrix are still surfaced."""
+    applies = [
+        _StubApplyRecord(
+            mutation_id="m_hp",
+            target_kind="hyperparam",
+            target_section="reflection_depth",
+        ),
+        _StubApplyRecord(mutation_id="m_p", target_kind="prompt", target_section="lead"),
+    ]
+    attributions = [
+        _StubAttributionRecord(
+            mutation_id="m_hp",
+            observed_dim={"redundant_tool_invocation": -0.5},
+            attribution_score=1.0,
+        ),
+        _StubAttributionRecord(
+            mutation_id="m_p",
+            observed_dim={"safety": 0.4},
+            attribution_score=1.0,
+        ),
+    ]
+    block = format_mutator_feedback_block(applies, attributions)
+    assert "prompt:" in block, "active kind should still be surfaced"
+    assert "hyperparam:" not in block, "retired hyperparam kind must be filtered out"
+
+
 def test_feedback_block_header_counts_match_inputs() -> None:
     """When there is matrix signal the header reports the apply count."""
     applies_signal = [

--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -232,8 +232,9 @@ def test_active_slots_registered_as_mutation_targets() -> None:
     """S0d (2026-05-21) — retrieval deprecated; M1 — skill_catalog 추가;
     M2 (2026-05-21) — agent_contract 추가; PR-TOOL-DESCRIPTIONS-MUTATE
     (2026-05-27, #1779) — tool_descriptions graduated;
-    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam graduated from
-    new numeric / categorical surface → 8 active slot."""
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam graduated, then
+    PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — hyperparam REMOVED from the
+    mutable surface (reflection_depth axis exhausted) → 7 behaviour slots."""
     import importlib
 
     mod = importlib.import_module("core.self_improving_loop.policies")
@@ -246,12 +247,14 @@ def test_active_slots_registered_as_mutation_targets() -> None:
         "reflection",
         "skill_catalog",
         "agent_contract",
-        "hyperparam",
     }
     assert target_kinds == expected, (
-        f"TARGET_KINDS 는 {expected} (post-hyperparam). got={target_kinds}"
+        f"TARGET_KINDS 는 {expected} (post-hyperparam-drop). got={target_kinds}"
     )
     assert "retrieval" not in target_kinds, "retrieval 은 S0d 이후 deprecate 유지"
+    assert "hyperparam" not in target_kinds, (
+        "hyperparam 은 PR-DROP-HYPERPARAM-MUTATION 이후 mutable surface 에서 제거"
+    )
 
 
 def test_retrieval_deprecated_but_path_constant_preserved() -> None:

--- a/tests/test_m2_agent_contract_slot.py
+++ b/tests/test_m2_agent_contract_slot.py
@@ -51,12 +51,12 @@ def test_target_kinds_includes_agent_contract() -> None:
     assert "agent_contract" in pol.TARGET_KINDS
 
 
-def test_target_kinds_count_is_8_post_hyperparam() -> None:
-    """PR-HYPERPARAM-FOUNDATION (2026-05-28) — graduated
-    ``hyperparam`` so the active mutation surface count is now 8
-    (was 7 post-tool_descriptions). Order matters because the
+def test_target_kinds_count_is_7_behaviour_kinds() -> None:
+    """PR-HYPERPARAM-FOUNDATION (2026-05-28) graduated ``hyperparam`` (count 8),
+    then PR-DROP-HYPERPARAM-MUTATION (2026-05-31) REMOVED it again — the mutable
+    surface is now exactly the 7 *behaviour* kinds. Order matters because the
     type-hint enum derives from the tuple."""
-    assert len(pol.TARGET_KINDS) == 8
+    assert len(pol.TARGET_KINDS) == 7
     assert pol.TARGET_KINDS == (
         "prompt",
         "tool_policy",
@@ -65,7 +65,6 @@ def test_target_kinds_count_is_8_post_hyperparam() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
-        "hyperparam",
     )
 
 

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -31,14 +31,14 @@ from core.self_improving_loop import policies as _policies_mod
 # ---------------------------------------------------------------------------
 
 
-def test_target_kinds_contains_active_eight() -> None:
+def test_target_kinds_contains_seven_behaviour_kinds() -> None:
     """ADR-012 S0d — retrieval deprecated. M1 — skill_catalog 추가.
     M2 (2026-05-21) — agent_contract 추가.
     PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — tool_descriptions 추가.
-    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가 (numeric /
-    categorical surface for audit-subprocess command-line knobs +
-    AgenticLoop runtime config).
-    Post-graduation: 8 active mutation targets."""
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가, then
+    PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — hyperparam REMOVED from the
+    mutable surface (reflection_depth axis exhausted; measurement params
+    fixed). The mutable surface is now exactly the 7 *behaviour* kinds."""
     assert set(TARGET_KINDS) == {
         "prompt",
         "tool_policy",
@@ -47,8 +47,11 @@ def test_target_kinds_contains_active_eight() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
-        "hyperparam",
     }
+    assert len(TARGET_KINDS) == 7
+    # hyperparam is no longer a mutable kind.
+    assert "hyperparam" not in TARGET_KINDS
+    assert is_valid_target_kind("hyperparam") is False
 
 
 def test_is_valid_target_kind_accepts_registered_kinds() -> None:
@@ -68,11 +71,12 @@ def test_is_valid_target_kind_rejects_unknown() -> None:
 
 def test_policy_path_returns_distinct_paths() -> None:
     """Distinct SoT per kind so policies evolve independently.
-    PR-HYPERPARAM-FOUNDATION (2026-05-28) — 8 active kinds (prompt /
-    tool_policy / decomposition / reflection / skill_catalog /
-    agent_contract / tool_descriptions / hyperparam) + retrieval
-    (deprecated but path preserved) = 9 distinct paths."""
-    paths = {kind: policy_path(kind) for kind in (*TARGET_KINDS, "retrieval")}
+    PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — 7 active *behaviour* kinds
+    (prompt / tool_policy / decomposition / reflection / skill_catalog /
+    agent_contract / tool_descriptions) + ``retrieval`` and ``hyperparam``
+    (both removed from TARGET_KINDS but path-mapping preserved for runtime
+    readers / future re-add) = 9 distinct paths."""
+    paths = {kind: policy_path(kind) for kind in (*TARGET_KINDS, "retrieval", "hyperparam")}
     assert len(set(paths.values())) == 9
 
 
@@ -512,205 +516,87 @@ def test_global_policy_paths_under_policies_dir() -> None:
 
 
 # ---------------------------------------------------------------------------
-# PR-HYPERPARAM-FOUNDATION (2026-05-28) — bounds validator invariants
+# PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — hyperparam is no longer mutable
 # ---------------------------------------------------------------------------
 
 
-def test_hyperparam_bounds_accepts_valid_int() -> None:
-    """Valid integer-section + in-bounds value → no raise.
-
-    PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) — ``reflection_depth`` is now the
-    ONLY mutable hyperparam knob; ``max_turns`` / ``seed_limit`` moved to the
-    fixed-measurement set (see ``test_hyperparam_*_fixed_measurement_*``).
-    """
-    from core.self_improving_loop.runner import _validate_hyperparam_bounds
-
-    _validate_hyperparam_bounds("reflection_depth", "1")
-    _validate_hyperparam_bounds("reflection_depth", "3")
-    _validate_hyperparam_bounds("reflection_depth", "5")
-
-
-def test_hyperparam_max_turns_seed_limit_dim_set_are_fixed_measurement_params() -> None:
-    """PR-AUDIT-SCAFFOLD-WIRE (2026-05-31, operator decision) — the three
-    audit-MEASUREMENT parameters are NOT mutable: a mutator that changes the
-    turn budget / sample count / dim set would confound the mutated-vs-baseline
-    fitness comparison. They are rejected at the bounds validator with an
-    explanatory error, distinct from the generic 'unknown key' message."""
-    from core.self_improving_loop.runner import _validate_hyperparam_bounds
-
-    for section, value in (("max_turns", "5"), ("seed_limit", "8"), ("dim_set", "subset")):
-        with pytest.raises(ValueError, match="FIXED audit-measurement parameter"):
-            _validate_hyperparam_bounds(section, value)
-
-
-def test_hyperparam_bounds_rejects_unknown_section() -> None:
-    """Section not in the allow-list → ValueError. Defends against
-    mutator inventing knobs the runtime doesn't read."""
-    from core.self_improving_loop.runner import _validate_hyperparam_bounds
-
-    with pytest.raises(ValueError, match="not in allowed set"):
-        _validate_hyperparam_bounds("unknown_section", "5")
-    with pytest.raises(ValueError, match="not in allowed set"):
-        _validate_hyperparam_bounds("BUDGET_MINUTES", "30")
-
-
-def test_hyperparam_bounds_rejects_out_of_range_int() -> None:
-    """Integer-section + value outside [lo, hi] → ValueError."""
-    from core.self_improving_loop.runner import _validate_hyperparam_bounds
-
-    with pytest.raises(ValueError, match="out of bounds"):
-        _validate_hyperparam_bounds("reflection_depth", "0")
-    with pytest.raises(ValueError, match="out of bounds"):
-        _validate_hyperparam_bounds("reflection_depth", "6")
-
-
-def test_hyperparam_bounds_rejects_non_integer_string() -> None:
-    """Integer-section + non-numeric value → ValueError. Defends against
-    mutator emitting ``"5.5"`` or ``"high"`` for an int knob."""
-    from core.self_improving_loop.runner import _validate_hyperparam_bounds
-
-    with pytest.raises(ValueError, match="integer-convertible"):
-        _validate_hyperparam_bounds("reflection_depth", "high")
-    with pytest.raises(ValueError, match="integer-convertible"):
-        _validate_hyperparam_bounds("reflection_depth", "3.5")
-
-
-def test_parse_mutation_hyperparam_kind_valid() -> None:
-    """End-to-end parse path for a valid hyperparam mutation."""
+def test_parse_mutation_rejects_hyperparam_kind_with_clear_message() -> None:
+    """PR-DROP-HYPERPARAM-MUTATION (2026-05-31, operator decision) — a
+    ``hyperparam`` mutation (ANY section, including the formerly-mutable
+    ``reflection_depth``) is REJECTED at parse with a specific explanation:
+    measurement params are fixed config and the reflection_depth axis is
+    exhausted. This is the operator-visible signal, distinct from the generic
+    not-in-TARGET_KINDS enumeration."""
     import json
 
     from core.self_improving_loop.runner import parse_mutation
 
-    payload = json.dumps(
-        {
-            "target_kind": "hyperparam",
-            "target_section": "reflection_depth",
-            "new_value": "3",
-            "rationale": "Try deeper reflection — cycle 1-12 had Δ=0 for redundant_tool_invocation under prompt mutation; an extra reflection pass lets the agent prune redundant tool calls before emitting.",
-            "target_dim": "redundant_tool_invocation",
-            "expected_dim": {"redundant_tool_invocation": -1.0},
-        }
-    )
-    m = parse_mutation(payload)
-    assert m.target_kind == "hyperparam"
-    assert m.target_section == "reflection_depth"
-    assert m.new_value == "3"
-
-
-def test_parse_mutation_hyperparam_kind_rejects_out_of_bounds() -> None:
-    """Mutator proposing ``reflection_depth=999`` is caught at parse, not at
-    audit subprocess invocation. Cycle protection."""
-    import json
-
-    from core.self_improving_loop.runner import parse_mutation
-
-    payload = json.dumps(
-        {
-            "target_kind": "hyperparam",
-            "target_section": "reflection_depth",
-            "new_value": "999",
-            "rationale": "more reflection",
-            "target_dim": "redundant_tool_invocation",
-            "expected_dim": {"redundant_tool_invocation": -0.5},
-        }
-    )
-    with pytest.raises(ValueError, match="out of bounds"):
-        parse_mutation(payload)
-
-
-def test_parse_mutation_hyperparam_rejects_fixed_measurement_sections() -> None:
-    """PR-AUDIT-SCAFFOLD-WIRE (2026-05-31) — a hyperparam mutation targeting a
-    fixed audit-measurement parameter is rejected at parse, before the audit
-    subprocess. Pins the operator decision that only reflection_depth is
-    mutator-tunable."""
-    import json
-
-    from core.self_improving_loop.runner import parse_mutation
-
-    for section, value in (("max_turns", "3"), ("seed_limit", "20"), ("dim_set", "full")):
+    for section in ("reflection_depth", "max_turns", "seed_limit", "dim_set", "anything"):
         payload = json.dumps(
             {
                 "target_kind": "hyperparam",
                 "target_section": section,
-                "new_value": value,
-                "rationale": "attempt to tune the audit measurement surface",
+                "new_value": "3",
+                "rationale": "attempt a hyperparam mutation",
                 "target_dim": "redundant_tool_invocation",
                 "expected_dim": {"redundant_tool_invocation": -0.5},
             }
         )
-        with pytest.raises(ValueError, match="FIXED audit-measurement parameter"):
+        with pytest.raises(ValueError, match="hyperparam is not a mutable kind"):
             parse_mutation(payload)
 
 
-def test_apply_mutation_hyperparam_kind_writes_sot(
+def test_parse_mutation_accepts_all_seven_behaviour_kinds() -> None:
+    """The 7 behaviour kinds remain mutator-dispatchable after the hyperparam
+    drop. Iterates ``TARGET_KINDS`` so the assertion tracks the canonical set;
+    nested-schema kinds use a dotted ``target_section``."""
+    import json
+
+    from core.self_improving_loop.policies import _NESTED_KINDS
+    from core.self_improving_loop.runner import parse_mutation
+
+    for kind in TARGET_KINDS:
+        section = "tool.description" if kind in _NESTED_KINDS else "some_section"
+        payload = json.dumps(
+            {
+                "target_kind": kind,
+                "target_section": section,
+                "new_value": "a new behaviour-policy value",
+                "rationale": "behaviour-kind mutation should parse cleanly",
+                "target_dim": "helpfulness",
+                "expected_dim": {"helpfulness": 0.1},
+            }
+        )
+        m = parse_mutation(payload)
+        assert m.target_kind == kind
+
+
+def test_reject_hyperparam_mutation_helper_always_raises() -> None:
+    """The dedicated rejection helper raises unconditionally with the
+    operator-facing message (pins the message text the contract promises)."""
+    from core.self_improving_loop.runner import _reject_hyperparam_mutation
+
+    with pytest.raises(ValueError, match="reflection_depth axis is exhausted"):
+        _reject_hyperparam_mutation()
+
+
+def test_apply_mutation_rejects_hyperparam_kind(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """apply_mutation routes hyperparam through the generic write_policy
-    path (flat dict[str, str]) — same machinery as the other simple
-    kinds, no special-case writer. Test isolation redirects the SoT
-    path to a tmp file so the canonical
-    ``autoresearch/state/policies/hyperparam.json`` is not mutated."""
+    """Second-layer defense: an externally-constructed ``hyperparam``
+    Mutation that bypassed parse_mutation is still rejected at apply, before
+    any write — the SoT path stays untouched."""
     from core.self_improving_loop.runner import Mutation, apply_mutation
 
     target = tmp_path / "hyperparam.json"
     _redirect_kind(monkeypatch, "hyperparam", target)
-    # The fixed-measurement keys may still sit in the SoT as operator-set
-    # defaults; only reflection_depth is mutator-tunable (PR-AUDIT-SCAFFOLD-WIRE).
-    starting = {"max_turns": "5", "seed_limit": "8", "dim_set": "subset", "reflection_depth": "3"}
-    mutation = Mutation(
+    bad = Mutation(
         target_section="reflection_depth",
         new_value="4",
-        rationale="test apply path",
-        target_kind="hyperparam",
-    )
-    new_sections, previous_value = apply_mutation(mutation, current_sections=starting)
-    assert previous_value == "3"
-    assert new_sections["reflection_depth"] == "4"
-    # The fixed-measurement keys are left untouched by an apply.
-    assert new_sections["max_turns"] == "5"
-    assert new_sections["seed_limit"] == "8"
-    assert new_sections["dim_set"] == "subset"
-
-
-def test_apply_mutation_hyperparam_kind_rejects_out_of_bounds(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Second-layer defense: an externally-constructed Mutation that
-    bypassed parse_mutation cannot still write garbage to the SoT.
-    SoT path redirected for isolation; the raise should happen before
-    any write_policy call, so the tmp file stays untouched as well."""
-    from core.self_improving_loop.runner import Mutation, apply_mutation
-
-    target = tmp_path / "hyperparam.json"
-    _redirect_kind(monkeypatch, "hyperparam", target)
-    bad = Mutation(
-        target_section="reflection_depth",
-        new_value="999",
         rationale="bypass parse",
         target_kind="hyperparam",
     )
-    with pytest.raises(ValueError, match="out of bounds"):
+    with pytest.raises(ValueError, match="hyperparam is not a mutable kind"):
         apply_mutation(bad, current_sections={"reflection_depth": "3"})
-    # Bounds violation must precede the write.
-    assert not target.exists()
-
-
-def test_apply_mutation_hyperparam_rejects_fixed_measurement_section(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """apply_mutation also rejects a fixed-measurement section (defense in
-    depth — an externally-constructed Mutation that bypassed parse_mutation
-    still cannot mutate the audit-measurement surface)."""
-    from core.self_improving_loop.runner import Mutation, apply_mutation
-
-    target = tmp_path / "hyperparam.json"
-    _redirect_kind(monkeypatch, "hyperparam", target)
-    bad = Mutation(
-        target_section="seed_limit",
-        new_value="20",
-        rationale="bypass parse",
-        target_kind="hyperparam",
-    )
-    with pytest.raises(ValueError, match="FIXED audit-measurement parameter"):
-        apply_mutation(bad, current_sections={"seed_limit": "8"})
+    # Rejection must precede the write.
     assert not target.exists()

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -238,9 +238,11 @@ def test_active_slots_registered_as_mutation_targets() -> None:
     M2 (2026-05-21) — agent_contract 추가 → 6 active slot.
     PR-TOOL-DESCRIPTIONS-MUTATE (2026-05-27) — tool_descriptions 추가
     → 7 active slot.
-    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가 → 8 active slot.
-    retrieval 은 명시적 deprecate 유지; path constant + dict 매핑은
-    보존 (별도 ADR 로 RAG 인프라 신설 시 복원 가능)."""
+    PR-HYPERPARAM-FOUNDATION (2026-05-28) — hyperparam 추가 → 8 active slot,
+    PR-DROP-HYPERPARAM-MUTATION (2026-05-31) — hyperparam 제거 → 7 behaviour slot.
+    retrieval 과 hyperparam 모두 TARGET_KINDS 에서 제외; path constant +
+    dict 매핑은 보존 (retrieval=별도 ADR RAG 복원, hyperparam=runtime config
+    reader + 미래 재추가)."""
     import importlib
 
     mod = importlib.import_module("core.self_improving_loop.policies")
@@ -253,14 +255,20 @@ def test_active_slots_registered_as_mutation_targets() -> None:
         "skill_catalog",
         "agent_contract",
         "tool_descriptions",
-        "hyperparam",
     }
     assert target_kinds == expected, (
-        f"TARGET_KINDS 는 정확히 {expected} (post-hyperparam). got={target_kinds}"
+        f"TARGET_KINDS 는 정확히 {expected} (post-hyperparam-drop). got={target_kinds}"
     )
     assert "retrieval" not in target_kinds, "retrieval 은 S0d 이후 deprecate 유지"
-    # path constant 보존 — 미래 복원용
+    assert "hyperparam" not in target_kinds, (
+        "hyperparam 은 PR-DROP-HYPERPARAM-MUTATION 이후 deprecate"
+    )
+    # path constant 보존 — 미래 복원용 + runtime config reader
     src = _read("core/self_improving_loop/policies.py")
     assert '"retrieval": GLOBAL_RETRIEVAL_POLICY_PATH' in src, (
         "GLOBAL_RETRIEVAL_POLICY_PATH 매핑은 deprecate 후에도 보존 필요"
+    )
+    assert '"hyperparam": GLOBAL_HYPERPARAM_POLICY_PATH' in src, (
+        "GLOBAL_HYPERPARAM_POLICY_PATH 매핑은 mutation surface 제거 후에도 "
+        "보존 필요 (runtime config reader + 미래 재추가)"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.104"
+version = "0.99.105"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Remove `hyperparam` from the self-improving loop's mutable surface (`TARGET_KINDS` → 7 behaviour kinds). The mutator now proposes only behaviour kinds and diversifies.
- Reject `target_kind="hyperparam"` at `parse_mutation` + `apply_mutation` with a clear message; remove the now-moot per-section bounds machinery.
- Preserve `hyperparam.json` + its runtime config readers — only the *mutation* surface is removed.

## Why
The mutator deterministically fixated on `reflection_depth`. PR-AUDIT-SCAFFOLD-WIRE (#1938) had restricted the mutable `hyperparam` kind to `reflection_depth` ONLY (`max_turns`/`seed_limit`/`dim_set` rejected as audit-measurement params). But `reflection_depth` is an EXHAUSTED axis: the axis-family dedup in `core/self_improving_loop/mutator_feedback.py` (`_AXIS_REPEAT_LIMIT = 3`) rejects every new `reflection_depth` proposal as repetitive (synthetic `axis_family_exhausted_*`, similarity 1.000) once ≥3 priors exist. With one mutable section left, a live campaign exhausted all 8 propose-guard attempts every cycle → every cycle SKIPped → **zero data**. Operator decision: remove the kind entirely.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/policies.py` | Remove `'hyperparam'` from `TARGET_KINDS` (7 behaviour kinds). Keep `_KIND_TO_PATH['hyperparam']` + `GLOBAL_HYPERPARAM_POLICY_PATH` (like deprecated `retrieval`) for runtime readers + future re-add. |
| `core/self_improving_loop/runner.py` | `parse_mutation` + `apply_mutation` reject `target_kind="hyperparam"` via `_reject_hyperparam_mutation()` (fail-closed at two layers, before any write). Remove moot `_HYPERPARAM_INT_BOUNDS` / `_HYPERPARAM_FIXED_MEASUREMENT_KEYS` / `_HYPERPARAM_CATEGORICAL` / `_validate_hyperparam_bounds`. Mutator contract suffix lists only the 7 behaviour kinds. |
| `core/self_improving_loop/mutator_feedback.py` | Filter the "Kind × Dim" attribution feedback block to active `TARGET_KINDS` so a historical `hyperparam` row no longer steers the mutator into a parse-rejection SKIP. |
| `autoresearch/program.md` | CAN-table → 7 behaviour kinds; "8 policy SoT files" → 7; hyperparam recast as FIXED config. |
| `docs/self-improving/campaign-procedure.md` | §2.1/§2.2 → 7 behaviour kinds; hyperparam = FIXED config (reflection_depth axis exhausted). |
| `README.md` / `README.ko.md` | Drop "hyperparameters" from the mutated-scaffolding list. |
| `tests/test_policy_mutation.py`, `tests/test_adr_012_surface_tiers.py`, `tests/test_m2_agent_contract_slot.py`, `tests/test_self_improving_5_slot_reader_audit.py`, `tests/core/self_improving_loop/test_mutator_feedback.py` | hyperparam mutation now REJECTED; 7 behaviour kinds accepted; `len`/membership invariants → 7; feedback-block filter pinned. |
| `CHANGELOG.md`, `CLAUDE.md`, `pyproject.toml`, `uv.lock` | Version bump 0.99.104 → 0.99.105 (MINOR — mutation-surface change). |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `hyperparam` removed from `TARGET_KINDS` | Implemented | 7 behaviour kinds remain |
| Clear rejection at parse + apply | Implemented | `_reject_hyperparam_mutation()` both layers |
| Dead bounds machinery removed (no dead branches) | Implemented | replaced by single rejection |
| `hyperparam.json` + runtime readers preserved | Verified | `autoresearch.train._load_hyperparam_overrides` untouched |
| program.md CAN-table drift invariant | Implemented | `test_program_md_can_table_matches_target_kinds` green |
| Feedback block surfaces only proposable kinds | Implemented (Codex MCP catch) | new test pins it |

## Verification
- [x] ruff check clean (core/ tests/ plugins/)
- [x] ruff format --check clean
- [x] mypy clean (464 source files)
- [x] lint-imports: 4 kept, 0 broken
- [x] pytest `-m "not live"`: self-improving + campaign sets 459 passed, 1 skipped. The 8 full-suite failures (`test_seed_eval_export` ×4 = `ModuleNotFoundError: inspect_ai` env; `test_oauth_judge` / `test_cli_audit` / `test_m4_4_in_context_wiring`) are pre-existing local flakes (credential-source / oauth / codex-cli / inspect_ai-absent), confirmed failing identically on the baseline with my code stashed — not introduced by this PR.
- [x] CLI smoke: `geode version` → v0.99.105
- [x] Codex MCP review on the diff (4 findings: feedback-block leak fixed; program.md "8"→7 fixed; READMEs hyperparameters dropped; site/sot.ts version is out-of-scope pre-existing stale).

## Reference
Operator decision (2026-05-31). Follows the deprecated-`retrieval` slot precedent (ADR-012 S0d) for keeping the path mapping while removing the mutation surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)