### PR TITLE
fix(usage): has_eval_id scans all month files — date-independent eval-import idempotency (v0.99.109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ functional change.
 
 ---
 
+## [0.99.109] - 2026-06-01
+
+### Fixed
+- **PR-USAGE-EVALID-MONTH (2026-06-01) — `UsageStore.has_eval_id` now scans
+  every month file, not just the current calendar month.** Eval rows are
+  partitioned by the eval's `created` ts (a past month for backfills /
+  month-boundary imports), but the duplicate-detection check only read
+  `date.today()`'s month — so once the wall-clock month rolled past the eval's
+  month, `core.audit.eval_to_jsonl.extract_to_usage_store` re-imported an
+  already-recorded eval (non-idempotent). `has_eval_id` now reads all
+  `YYYY-MM.jsonl` files when `year`/`month` are omitted (new `_read_all_months`
+  helper); pass both to scope to a single month. The companion test helper
+  `tests/audit/test_eval_to_jsonl.py::_read_jsonl` was likewise made
+  date-independent (globs all month files instead of `date.today()`), fixing 4
+  pre-existing date-dependent test failures that surfaced on the develop→main
+  CI once the month rolled to June.
+
 ## [0.99.108] - 2026-06-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.108
+- **Version**: 0.99.109
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.108 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.109 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.108 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.109 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/llm/usage_store.py
+++ b/core/llm/usage_store.py
@@ -174,15 +174,22 @@ class UsageStore:
 
     def has_eval_id(self, eval_id: str, year: int | None = None, month: int | None = None) -> bool:
         """Return True if a record with ``source='petri_eval'`` and the
-        given ``eval_id`` already exists in the month file. Used by
+        given ``eval_id`` already exists. Used by
         :mod:`core.audit.eval_to_jsonl` to skip duplicate extractions.
+
+        When ``year``/``month`` are both omitted, scan EVERY month file
+        rather than just the current calendar month: extraction stamps each
+        row with the eval's ``created`` ts (a past month for backfills or
+        month-boundary imports), so a today-only check would miss it and
+        re-import the eval. Pass both ``year`` and ``month`` to scope the
+        lookup to a single month.
         """
         if not eval_id:
             return False
-        today = date.today()
-        y = year or today.year
-        m = month or today.month
-        records = self._read_month(y, m)
+        if year is not None and month is not None:
+            records = self._read_month(year, month)
+        else:
+            records = self._read_all_months()
         return any(r.eval_id == eval_id and r.source == "petri_eval" for r in records)
 
     def get_monthly_summary(
@@ -325,6 +332,25 @@ class UsageStore:
         except OSError as e:
             log.warning("Failed to read usage file %s: %s", fpath, e)
 
+        return records
+
+    def _read_all_months(self) -> list[UsageRecord]:
+        """Read records across every ``YYYY-MM.jsonl`` file in the store.
+
+        Rows are partitioned by each record's own ``ts`` month (see
+        :meth:`_append`), so a row can live in any past month. Callers that
+        must find a record regardless of the calendar month it was written
+        in (e.g. :meth:`has_eval_id` skip-detection) scan all of them.
+        """
+        if not self._usage_dir.exists():
+            return []
+        records: list[UsageRecord] = []
+        for fpath in sorted(self._usage_dir.glob("[0-9][0-9][0-9][0-9]-[0-9][0-9].jsonl")):
+            try:
+                year, month = int(fpath.stem[:4]), int(fpath.stem[5:7])
+            except ValueError:
+                continue
+            records += self._read_month(year, month)
         return records
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.108"
+version = "0.99.109"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/audit/test_eval_to_jsonl.py
+++ b/tests/audit/test_eval_to_jsonl.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -66,11 +65,18 @@ def _patch_read(monkeypatch: pytest.MonkeyPatch, fake_log: FakeEvalLog) -> None:
 
 
 def _read_jsonl(tmp_path: Path) -> list[dict[str, Any]]:
-    today = date.today()
-    fpath = tmp_path / f"{today.year:04d}-{today.month:02d}.jsonl"
-    if not fpath.exists():
-        return []
-    return [json.loads(line) for line in fpath.read_text(encoding="utf-8").splitlines() if line]
+    # Usage rows are partitioned by the EVAL's ts month (the fixtures'
+    # ``created="2026-05-…"`` → 2026-05.jsonl), NOT today's month. Read every
+    # month file the store actually wrote so the assertions are independent of
+    # the calendar date the test runs on. (Was ``date.today()`` — it broke once
+    # the wall-clock month rolled past the fixture's May, reading an empty
+    # 2026-06.jsonl while the rows sat in 2026-05.jsonl.)
+    rows: list[dict[str, Any]] = []
+    for fpath in sorted(tmp_path.glob("*.jsonl")):
+        rows += [
+            json.loads(line) for line in fpath.read_text(encoding="utf-8").splitlines() if line
+        ]
+    return rows
 
 
 class TestParseEvalTs:


### PR DESCRIPTION
## Summary
- `UsageStore.has_eval_id` now scans **every** `YYYY-MM.jsonl` file (not just `date.today()`'s month) when `year`/`month` are omitted — fixing a latent non-idempotency in petri-eval import.
- Makes the `tests/audit/test_eval_to_jsonl.py::_read_jsonl` helper date-independent, fixing 4 pre-existing date-dependent test failures.

## Why
`core.audit.eval_to_jsonl.extract_to_usage_store` records each usage row under the **eval's** `created` ts month (`_append` partitions by `entry.ts`). But the duplicate-detection guard `has_eval_id(eval_id)` defaulted to `date.today()`'s month. Once the wall-clock month rolled past the eval's month (May→June), the guard read an empty `2026-06.jsonl`, missed the eval_id sitting in `2026-05.jsonl`, and **re-imported the eval** — i.e. import is non-idempotent across a month boundary / for backfills.

This surfaced as a **develop→main CI failure** (PR #1948): `TestExtractToUsageStore` had 4 date-dependent failures. The per-PR "Detect changes" CI scoping had never run these audit tests against unrelated PRs, so the failure was only exposed by the full-suite develop→main run after the month rolled to June. The production code was correct except for this calendar coupling; the test helper had the mirror-image bug (`_read_jsonl` read today's month).

## Changes
| File | Change |
|------|--------|
| `core/llm/usage_store.py` | `has_eval_id` scans all months when `year`/`month` omitted; new `_read_all_months()` helper (globs `YYYY-MM.jsonl`, partitioned by `_append`'s ts month). Pass both `year`+`month` to scope to one month. |
| `tests/audit/test_eval_to_jsonl.py` | `_read_jsonl` globs all month files instead of `date.today()`; removed now-unused `date` import. |
| `CHANGELOG.md`, `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md` | v0.99.108 → v0.99.109 + Fixed entry. |

## Verification
- [x] ruff check clean (core/llm/usage_store.py, core/audit/eval_to_jsonl.py, test file)
- [x] ruff format --check clean
- [x] mypy clean (2 source files)
- [x] pytest: `tests/audit/test_eval_to_jsonl.py` + `tests/test_usage_store.py` → **35 passed** (was 1 failed / 9 passed before this fix; 4 originally-failing date-dependent tests now pass)
- [ ] CI 5/5 green
- [ ] Codex MCP review

## Reference
Unblocks the #1948 develop→main passthrough (CI was red on the pre-existing audit-test date bug). Root cause class = the same calendar-coupling as the test helper; both fixed at the root (scan-all-months) rather than pinning the test clock.