### PR TITLE
chore(seed-generation): pipeline roles → claude-opus-4-8 (v0.99.111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,27 @@ functional change.
 
 ---
 
+## [0.99.111] - 2026-06-01
+
+### Changed
+- **PR-SEEDGEN-OPUS-4-8 (2026-06-01) — seed-generation pipeline roles bumped
+  claude-opus-4-7 → claude-opus-4-8.** All nine `[seed_generation.role.*]`
+  `default_model` values and the Anthropic judge-panel voter in
+  `seed_generation.plugin.toml`, plus the mirroring per-agent
+  `_DEFAULT_*_MODEL` constructor constants, move to the current Anthropic
+  flagship. The local `claude` CLI (2.1.x) was probe-verified to serve
+  `--model claude-opus-4-8` before the bump, so the `claude-cli`-routed roles
+  resolve cleanly. opus-4-7 stays in every role's `allowed_models` as an
+  operator fallback. The campaign petri auditor/judge were already on
+  opus-4-8 via `[self_improving_loop.petri.*]`; this aligns the seed-generation
+  agents with that flagship tier.
+
 ## [0.99.110] - 2026-06-01
 
 ### Added
 - **PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — difficulty-calibrated
+  survivor selection for the seed-generation pipeline.** The Ranker can now pick
+  survivors by their measured pilot `dim_means[target_dim]` (Petri 1-10,
   survivor selection for the seed-generation pipeline.** The Ranker can now pick
   survivors by their measured pilot `dim_means[target_dim]` (Petri 1-10,
   higher = harder for the target = more headroom) instead of by Elo win-rate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.110
+- **Version**: 0.99.111
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.111 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.111 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -67,7 +67,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Critic"]
 
 
-_DEFAULT_CRITIC_MODEL = "claude-opus-4-7"
+_DEFAULT_CRITIC_MODEL = "claude-opus-4-8"
 _CRITIC_AGENT_NAME = "seed_critic"
 _TASK_TYPE = "seed-critique"
 

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Evolver"]
 
 
-_DEFAULT_EVOLVER_MODEL = "claude-opus-4-7"
+_DEFAULT_EVOLVER_MODEL = "claude-opus-4-8"
 _EVOLVER_AGENT_NAME = "seed_evolver"
 _TASK_TYPE = "seed-evolve"
 

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -70,7 +70,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Generator"]
 
 
-_DEFAULT_GENERATOR_MODEL = "claude-opus-4-7"
+_DEFAULT_GENERATOR_MODEL = "claude-opus-4-8"
 _GENERATOR_AGENT_NAME = "seed_generator"
 _TASK_TYPE = "seed-generation"
 # CSP-13 (2026-05-23) — Loop 2 (debate-turn) sidecar suffix. The

--- a/plugins/seed_generation/agents/literature_review.py
+++ b/plugins/seed_generation/agents/literature_review.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 __all__ = ["LiteratureReview"]
 
 
-_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-opus-4-7"
+_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-opus-4-8"
 _LITERATURE_REVIEW_AGENT_NAME = "seed_literature_review"
 _TASK_TYPE = "seed-literature-review"
 

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -61,7 +61,7 @@ log = logging.getLogger(__name__)
 __all__ = ["MetaReviewer"]
 
 
-_DEFAULT_META_REVIEWER_MODEL = "claude-opus-4-7"
+_DEFAULT_META_REVIEWER_MODEL = "claude-opus-4-8"
 _META_REVIEWER_AGENT_NAME = "seed_meta_reviewer"
 _TASK_TYPE = "seed-meta-review"
 

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Pilot"]
 
 
-_DEFAULT_PILOT_MODEL = "claude-opus-4-7"
+_DEFAULT_PILOT_MODEL = "claude-opus-4-8"
 _PILOT_AGENT_NAME = "seed_pilot"
 _TASK_TYPE = "seed-pilot"
 

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -67,7 +67,7 @@ __all__ = ["HIGH_SIMILARITY_DEGREE", "Proximity"]
 
 HIGH_SIMILARITY_DEGREE = "high"
 
-_DEFAULT_PROXIMITY_MODEL = "claude-opus-4-7"
+_DEFAULT_PROXIMITY_MODEL = "claude-opus-4-8"
 _PROXIMITY_AGENT_NAME = "seed_proximity"
 _TASK_TYPE = "seed-proximity"
 

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -76,7 +76,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Ranker"]
 
 
-_DEFAULT_RANKER_MODEL = "claude-opus-4-7"
+_DEFAULT_RANKER_MODEL = "claude-opus-4-8"
 _TASK_TYPE = "seed-ranker-vote"
 _PARTIAL_CHECKPOINT_EVERY_MATCHES = 10
 _PARTIAL_CHECKPOINT_EVERY_SECONDS = 120.0

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -81,7 +81,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Supervisor"]
 
 
-_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"
+_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-8"
 _SUPERVISOR_AGENT_NAME = "seed_supervisor"
 _TASK_TYPE = "seed-supervisor"
 

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -109,9 +109,10 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 
 [seed_generation.role.pilot]
 # Pilot orchestrates a Petri inner-loop audit per candidate. Default
-# tier moved to ``claude-opus-4-7`` (PR-UPGRADE-ROLES-TOP-TIER,
-# 2026-05-26) under operator directive that all role LLMs run on the
-# Anthropic top tier — see CHANGELOG. The 90s wall-time cap in
+# tier is ``claude-opus-4-8`` (PR-UPGRADE-ROLES-TOP-TIER 2026-05-26 set
+# opus-4-7; PR-SEEDGEN-OPUS-4-8 2026-06-01 bumped it) under operator
+# directive that all role LLMs run on the Anthropic top tier — see
+# CHANGELOG. The 90s wall-time cap in
 # pilot.md is unchanged; operators tightening the per-candidate
 # budget can override the model via
 # ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -57,7 +57,7 @@ enabled_roles = [
 # ── Roles ────────────────────────────────────────────────────────────────────
 
 [seed_generation.role.generator]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -75,7 +75,7 @@ role_contract = "plugins/seed_generation/agents/generator.md"
 num_turns = 0
 
 [seed_generation.role.critic]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # ``claude-opus-4-7`` accepted so operators on the Claude Code Max
 # subscription can route critic on the strongest available reasoning
 # model when running through ``source = "claude-cli"``.
@@ -94,7 +94,7 @@ role_contract = "plugins/seed_generation/agents/critic.md"
 # (paper §3). Pre-CSP-8 was an embedding call to text-embedding-3-small;
 # now an LLM completion call like every other role. CSP-10 dropped the
 # ``kind`` field from the schema (every role is completion now).
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # ``claude-opus-4-7`` accepted for the same Claude Code Max routing
 # reason as critic — proximity is also a reasoning-heavy role.
 allowed_models = [
@@ -115,7 +115,7 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 # pilot.md is unchanged; operators tightening the per-candidate
 # budget can override the model via
 # ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # Override paths: operators can pin a faster/cheaper model via the
 # allowlist below when the 90s wall-time becomes a bottleneck.
 allowed_models = [
@@ -130,7 +130,7 @@ role_contract = "plugins/seed_generation/agents/pilot.md"
 [seed_generation.role.ranker]
 # 3-judge panel orchestrator. Its own default_model is a placeholder —
 # the panel's voter binding (below) drives actual LLM calls.
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -140,7 +140,7 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/ranker.md"
 
 [seed_generation.role.evolver]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -150,7 +150,7 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/evolver.md"
 
 [seed_generation.role.meta_reviewer]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -161,13 +161,13 @@ role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
 
 # PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor role spec section.
 # Defaults mirror ``plugins/seed_generation/agents/supervisor.py``'s
-# ``_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"`` (per the role
+# ``_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-8"`` (per the role
 # docstring: "Run-level strategy synthesis. Dispatches ONE Opus
 # sub-agent" — Opus chosen because supervisor's output gates the
 # value of every downstream call). Allowed list mirrors meta_reviewer
 # (same single-shot, run-level analyst pattern).
 [seed_generation.role.supervisor]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -184,7 +184,7 @@ role_contract = "plugins/seed_generation/agents/supervisor.md"
 # in ``~/.geode/config.toml`` to opt into the external arxiv fetch +
 # git-tracked snapshot loop.
 [seed_generation.role.literature_review]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -207,8 +207,8 @@ queries_per_run = 3
 [seed_generation.judge_panel]
 # Default voter mix: 2 reviewers on OpenAI gpt-5.5 via openai-codex
 # (ChatGPT subscription / Codex Responses API) + 1 reviewer on
-# Anthropic claude-opus-4-7 via claude-cli (Claude Code Max
-# subscription, top tier per PR-UPGRADE-ROLES-TOP-TIER 2026-05-26).
+# Anthropic claude-opus-4-8 via claude-cli (Claude Code Max
+# subscription, top tier; bumped opus-4-7 → opus-4-8 2026-06-01).
 # Both diversity gates are satisfied:
 #   * providers ≥ 2 (openai + anthropic)
 #   * paths ≥ 2 (openai-codex + claude-cli)
@@ -228,6 +228,6 @@ provider = "openai"
 source = "openai-codex"
 
 [[seed_generation.judge_panel.voters]]
-model = "claude-opus-4-7"
+model = "claude-opus-4-8"
 provider = "anthropic"
 source = "claude-cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.110"
+version = "0.99.111"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -238,7 +238,7 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
     clear_manifest_cache()
     manifest = load_manifest()
     proximity = manifest.get_role("proximity")
-    assert proximity.default_model == "claude-opus-4-7"
+    assert proximity.default_model == "claude-opus-4-8"
 
     toml_body = (
         Path(__file__).resolve().parents[3]
@@ -257,14 +257,12 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
 
 
 def test_bundled_manifest_all_role_defaults_top_tier() -> None:
-    """PR-UPGRADE-ROLES-TOP-TIER (2026-05-26) regression pin — every
-    role default in the shipped TOML must be ``claude-opus-4-7``
-    (the Anthropic top tier per GEODE's spec registry). The judge
-    panel must keep 2× gpt-5.5 codex voters + 1× claude-opus-4-7
-    voter (provider-diversity gate). Prior to this PR roles split
-    across ``claude-sonnet-4-6`` (generator/critic/proximity/ranker/
-    evolver/literature_review) and ``claude-haiku-4-5`` (pilot's
-    cheap-fast slot); meta_reviewer + supervisor were already opus."""
+    """PR-UPGRADE-ROLES-TOP-TIER (2026-05-26) regression pin, bumped by
+    PR-SEEDGEN-OPUS-4-8 (2026-06-01) — every role default in the shipped
+    TOML must be ``claude-opus-4-8`` (the current Anthropic top tier). The
+    judge panel must keep 2× gpt-5.5 codex voters + 1× claude-opus-4-8
+    voter (provider-diversity gate). The flagship moved opus-4-7 → opus-4-8
+    once the local claude CLI was probe-verified to serve it."""
     clear_manifest_cache()
     manifest = load_manifest()
     role_names = (
@@ -280,14 +278,14 @@ def test_bundled_manifest_all_role_defaults_top_tier() -> None:
     )
     for name in role_names:
         role = manifest.get_role(name)
-        assert role.default_model == "claude-opus-4-7", (
+        assert role.default_model == "claude-opus-4-8", (
             f"role {name!r} default_model={role.default_model!r}; "
-            "PR-UPGRADE-ROLES-TOP-TIER requires opus-4-7"
+            "PR-SEEDGEN-OPUS-4-8 requires opus-4-8"
         )
     voters = manifest.judge_panel.voters
     voter_models = sorted(v.model for v in voters)
-    assert voter_models == ["claude-opus-4-7", "gpt-5.5", "gpt-5.5"], (
-        f"judge panel voter models {voter_models!r}; expected [claude-opus-4-7, gpt-5.5, gpt-5.5]"
+    assert voter_models == ["claude-opus-4-8", "gpt-5.5", "gpt-5.5"], (
+        f"judge panel voter models {voter_models!r}; expected [claude-opus-4-8, gpt-5.5, gpt-5.5]"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.110"
+version = "0.99.111"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump all 9 `[seed_generation.role.*]` `default_model` + the Anthropic judge-panel voter in `seed_generation.plugin.toml` from `claude-opus-4-7` → `claude-opus-4-8`, plus the mirroring per-agent `_DEFAULT_*_MODEL` constructor constants.
- `opus-4-7` stays in every role's `allowed_models` as a fallback.

## Why
Operator directive: run all seed-generation role LLMs on the current Anthropic flagship (opus-4-8), aligning the pipeline with the campaign's petri auditor/judge (already opus-4-8 via `[self_improving_loop.petri.*]`). Verified before bumping: the local `claude` CLI (2.1.154) serves `--model claude-opus-4-8` (probe returned OK), so the `claude-cli`-routed roles resolve cleanly — no version mismatch.

**Important runtime note:** the operative per-role binding is the operator's `~/.geode/seed-generation.toml` (legacy) or `~/.geode/config.toml [seed_generation.role.*]`; the manifest `default_model` is only the fallback. The stale operator file (pinned opus-4-7 from a 2026-05-24 smoke) is synced to opus-4-8 separately, out-of-repo. This PR keeps the repo manifest + code defaults consistent with that flagship.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/seed_generation.plugin.toml` | 9 role `default_model` + judge voter → opus-4-8; 2 stale comments fixed |
| `plugins/seed_generation/agents/*.py` (9) | `_DEFAULT_*_MODEL` constants → opus-4-8 |
| `tests/plugins/seed_generation/test_manifest.py` | top-tier regression pins 4-7 → 4-8 |
| CHANGELOG / pyproject / CLAUDE / README(.ko) | v0.99.110 → v0.99.111 |

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] ruff format --check clean
- [x] mypy core/ plugins/ clean (471 files)
- [x] pytest tests/plugins/seed_generation/ → 693 passed, 3 skipped
- [ ] CI 5/5 green
- [ ] Codex MCP

## Reference
Lever-1 (difficulty-calibrated seed generation) setup, on top of #1950. Operator decision: pipeline → opus-4-8; pilot inner-audit auditor/judge kept on PAYG opus-4-8 (out-of-repo `~/.geode/petri.toml`).