### PR TITLE
release: develop → main (v0.99.111) — seed-gen difficulty selection + opus-4-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,27 @@ functional change.
 
 ---
 
+## [0.99.111] - 2026-06-01
+
+### Changed
+- **PR-SEEDGEN-OPUS-4-8 (2026-06-01) — seed-generation pipeline roles bumped
+  claude-opus-4-7 → claude-opus-4-8.** All nine `[seed_generation.role.*]`
+  `default_model` values and the Anthropic judge-panel voter in
+  `seed_generation.plugin.toml`, plus the mirroring per-agent
+  `_DEFAULT_*_MODEL` constructor constants, move to the current Anthropic
+  flagship. The local `claude` CLI (2.1.x) was probe-verified to serve
+  `--model claude-opus-4-8` before the bump, so the `claude-cli`-routed roles
+  resolve cleanly. opus-4-7 stays in every role's `allowed_models` as an
+  operator fallback. The campaign petri auditor/judge were already on
+  opus-4-8 via `[self_improving_loop.petri.*]`; this aligns the seed-generation
+  agents with that flagship tier.
+
 ## [0.99.110] - 2026-06-01
 
 ### Added
 - **PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — difficulty-calibrated
+  survivor selection for the seed-generation pipeline.** The Ranker can now pick
+  survivors by their measured pilot `dim_means[target_dim]` (Petri 1-10,
   survivor selection for the seed-generation pipeline.** The Ranker can now pick
   survivors by their measured pilot `dim_means[target_dim]` (Petri 1-10,
   higher = harder for the target = more headroom) instead of by Elo win-rate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,26 @@ functional change.
 
 ---
 
+## [0.99.110] - 2026-06-01
+
+### Added
+- **PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — difficulty-calibrated
+  survivor selection for the seed-generation pipeline.** The Ranker can now pick
+  survivors by their measured pilot `dim_means[target_dim]` (Petri 1-10,
+  higher = harder for the target = more headroom) instead of by Elo win-rate.
+  Elo does not prefer hard seeds (gen-2605-3: the elo-1084 seed elicits 4.2 on
+  the target dim while the elo-1094 seed elicits only 2.8), so the
+  tournament was systematically discarding the hard seeds the saturated
+  self-improving metric needs. New `tournament.select_survivors` /
+  `rank_by_difficulty` pure functions rank ALL rated candidates hardest-first
+  (tie-break: Elo descending, then candidate id) and truncate to K; a survivor
+  with no usable pilot signal sorts last and never crashes the path. The mode is
+  OPT-IN via `GEODE_SEED_SURVIVOR_SELECTION=difficulty` (resolved by
+  `resolve_survivor_selection` and wired through `_registry_builder` into the
+  production `Ranker`); the default stays `elo`, so existing runs are unchanged.
+  A misconfigured difficulty request (no `target_dim` / empty `pilot_means`)
+  degrades to Elo rather than returning an arbitrary order.
+
 ## [0.99.109] - 2026-06-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.110
+- **Version**: 0.99.111
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.109
+- **Version**: 0.99.110
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.111 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.109 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.111 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.109 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.110 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -214,12 +214,20 @@ def populate_registry(
                     manifest_role_dict[field_name] = getattr(manifest_role, field_name)
 
         if role_name == "ranker":
+            # PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — resolve the
+            # survivor-selection mode from the operator env knob
+            # (``GEODE_SEED_SURVIVOR_SELECTION``). Default "elo" keeps the
+            # production path unchanged; "difficulty" re-ranks survivors by
+            # measured pilot target_dim elicitation (hardest first).
+            from plugins.seed_generation.tournament import resolve_survivor_selection
+
             agent: BaseSeedAgent = Ranker(
                 manager,
                 list(picker_result.voters),
                 model=binding.model if binding else _DEFAULT_FALLBACK_MODEL,
                 source=binding.source if binding else "auto",
                 manifest_role=manifest_role_dict,
+                selection=resolve_survivor_selection(),
             )
         else:
             cls = _ROLE_TO_CLASS.get(role_name)

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -67,7 +67,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Critic"]
 
 
-_DEFAULT_CRITIC_MODEL = "claude-opus-4-7"
+_DEFAULT_CRITIC_MODEL = "claude-opus-4-8"
 _CRITIC_AGENT_NAME = "seed_critic"
 _TASK_TYPE = "seed-critique"
 

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Evolver"]
 
 
-_DEFAULT_EVOLVER_MODEL = "claude-opus-4-7"
+_DEFAULT_EVOLVER_MODEL = "claude-opus-4-8"
 _EVOLVER_AGENT_NAME = "seed_evolver"
 _TASK_TYPE = "seed-evolve"
 

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -70,7 +70,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Generator"]
 
 
-_DEFAULT_GENERATOR_MODEL = "claude-opus-4-7"
+_DEFAULT_GENERATOR_MODEL = "claude-opus-4-8"
 _GENERATOR_AGENT_NAME = "seed_generator"
 _TASK_TYPE = "seed-generation"
 # CSP-13 (2026-05-23) — Loop 2 (debate-turn) sidecar suffix. The

--- a/plugins/seed_generation/agents/literature_review.py
+++ b/plugins/seed_generation/agents/literature_review.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 __all__ = ["LiteratureReview"]
 
 
-_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-opus-4-7"
+_DEFAULT_LITERATURE_REVIEW_MODEL = "claude-opus-4-8"
 _LITERATURE_REVIEW_AGENT_NAME = "seed_literature_review"
 _TASK_TYPE = "seed-literature-review"
 

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -61,7 +61,7 @@ log = logging.getLogger(__name__)
 __all__ = ["MetaReviewer"]
 
 
-_DEFAULT_META_REVIEWER_MODEL = "claude-opus-4-7"
+_DEFAULT_META_REVIEWER_MODEL = "claude-opus-4-8"
 _META_REVIEWER_AGENT_NAME = "seed_meta_reviewer"
 _TASK_TYPE = "seed-meta-review"
 

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Pilot"]
 
 
-_DEFAULT_PILOT_MODEL = "claude-opus-4-7"
+_DEFAULT_PILOT_MODEL = "claude-opus-4-8"
 _PILOT_AGENT_NAME = "seed_pilot"
 _TASK_TYPE = "seed-pilot"
 

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -67,7 +67,7 @@ __all__ = ["HIGH_SIMILARITY_DEGREE", "Proximity"]
 
 HIGH_SIMILARITY_DEGREE = "high"
 
-_DEFAULT_PROXIMITY_MODEL = "claude-opus-4-7"
+_DEFAULT_PROXIMITY_MODEL = "claude-opus-4-8"
 _PROXIMITY_AGENT_NAME = "seed_proximity"
 _TASK_TYPE = "seed-proximity"
 

--- a/plugins/seed_generation/agents/ranker.md
+++ b/plugins/seed_generation/agents/ranker.md
@@ -26,7 +26,14 @@ Voters' `provider` must span ≥ 2 (per manifest `required_diversity_providers =
 ## Output (orchestrator state merge)
 
 - `elo_ratings: {candidate_id: rating}` final state.
-- `survivors: [candidate_id]` — top-K by Elo (K=5 default).
+- `survivors: [candidate_id]` — top-K (K=5 default). Selection mode is
+  resolved from `GEODE_SEED_SURVIVOR_SELECTION` (default `elo`):
+  - `elo` — top-K by descending Elo rating (tournament win-rate).
+  - `difficulty` — top-K by descending measured pilot
+    `dim_means[target_dim]` (hardest first; higher Petri elicitation =
+    harder for the target = more headroom). Keeps the seeds the target
+    struggles most with, which Elo can discard. Falls back to Elo when no
+    pilot signal is available.
 - Match-by-match log to `<run_dir>/elo_log.tsv` (commit-friendly).
 
 ## Forbidden

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -76,7 +76,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Ranker"]
 
 
-_DEFAULT_RANKER_MODEL = "claude-opus-4-7"
+_DEFAULT_RANKER_MODEL = "claude-opus-4-8"
 _TASK_TYPE = "seed-ranker-vote"
 _PARTIAL_CHECKPOINT_EVERY_MATCHES = 10
 _PARTIAL_CHECKPOINT_EVERY_SECONDS = 120.0

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -57,13 +57,15 @@ from plugins.seed_generation.orchestrator import PipelineState
 from plugins.seed_generation.picker import VoterBinding
 from plugins.seed_generation.tournament import (
     DEFAULT_K_FACTOR,
+    DEFAULT_SURVIVOR_SELECTION,
     DEFAULT_TOP_K,
     MatchOutcome,
     MatchPlan,
+    SurvivorSelection,
     apply_match,
     majority_winner,
     plan_matches,
-    top_k,
+    select_survivors,
 )
 
 if TYPE_CHECKING:
@@ -183,6 +185,7 @@ class Ranker(BaseSeedAgent):
         manifest_role: dict[str, object] | None = None,
         k_factor: float = DEFAULT_K_FACTOR,
         survivors_k: int = DEFAULT_TOP_K,
+        selection: SurvivorSelection = DEFAULT_SURVIVOR_SELECTION,
         rng: random.Random | None = None,
     ) -> None:
         super().__init__(
@@ -199,6 +202,12 @@ class Ranker(BaseSeedAgent):
         self._voters = voters
         self._k_factor = k_factor
         self._survivors_k = survivors_k
+        # PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — survivor selection
+        # mode. ``"elo"`` (default) is unchanged top-K-by-rating; ``"difficulty"``
+        # keeps the seeds the target struggles most with (highest pilot
+        # target_dim elicitation). The orchestrator wires this from
+        # ``resolve_survivor_selection()`` (env knob) so it is OPT-IN.
+        self._selection: SurvivorSelection = selection
         self._rng = rng
 
     async def aexecute(self, state: PipelineState) -> SeedAgentResult:
@@ -383,13 +392,28 @@ class Ranker(BaseSeedAgent):
                 )
                 match_details.append(detail)
 
-        survivors = top_k(ratings, k=self._survivors_k)
+        # PR-SEEDGEN-DIFFICULTY-SELECTION (2026-06-01) — survivor pick honours
+        # the resolved selection mode. ``"elo"`` is the historical top-K-by-rating
+        # path; ``"difficulty"`` re-ranks ALL rated candidates by their measured
+        # pilot ``dim_means[target_dim]`` (hardest first) so the pool keeps the
+        # seeds the target struggles most with — the high-elicitation seeds Elo
+        # would otherwise discard (gen-2605-3: elo 1084 / target_dim 4.2 ranked
+        # below elo 1094 / target_dim 2.8). Difficulty degrades to Elo when no
+        # pilot signal is available (``pilot_means`` carries it, keyed per cid).
+        survivors = select_survivors(
+            ratings,
+            k=self._survivors_k,
+            selection=self._selection,
+            pilot_means=pilot_means,
+            target_dim=state.target_dim,
+        )
         self._emit_elo_log(state, outcomes, ratings)
         self._persist_tournament_log(state, match_details)
         log.info(
-            "seed-generation ranker: %d/%d matches counted, survivors=%s",
+            "seed-generation ranker: %d/%d matches counted, selection=%s, survivors=%s",
             len(outcomes),
             len(match_plan),
+            self._selection,
             survivors[:3],
         )
 

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -81,7 +81,7 @@ log = logging.getLogger(__name__)
 __all__ = ["Supervisor"]
 
 
-_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"
+_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-8"
 _SUPERVISOR_AGENT_NAME = "seed_supervisor"
 _TASK_TYPE = "seed-supervisor"
 

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -109,9 +109,10 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 
 [seed_generation.role.pilot]
 # Pilot orchestrates a Petri inner-loop audit per candidate. Default
-# tier moved to ``claude-opus-4-7`` (PR-UPGRADE-ROLES-TOP-TIER,
-# 2026-05-26) under operator directive that all role LLMs run on the
-# Anthropic top tier — see CHANGELOG. The 90s wall-time cap in
+# tier is ``claude-opus-4-8`` (PR-UPGRADE-ROLES-TOP-TIER 2026-05-26 set
+# opus-4-7; PR-SEEDGEN-OPUS-4-8 2026-06-01 bumped it) under operator
+# directive that all role LLMs run on the Anthropic top tier — see
+# CHANGELOG. The 90s wall-time cap in
 # pilot.md is unchanged; operators tightening the per-candidate
 # budget can override the model via
 # ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -57,7 +57,7 @@ enabled_roles = [
 # ── Roles ────────────────────────────────────────────────────────────────────
 
 [seed_generation.role.generator]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -75,7 +75,7 @@ role_contract = "plugins/seed_generation/agents/generator.md"
 num_turns = 0
 
 [seed_generation.role.critic]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # ``claude-opus-4-7`` accepted so operators on the Claude Code Max
 # subscription can route critic on the strongest available reasoning
 # model when running through ``source = "claude-cli"``.
@@ -94,7 +94,7 @@ role_contract = "plugins/seed_generation/agents/critic.md"
 # (paper §3). Pre-CSP-8 was an embedding call to text-embedding-3-small;
 # now an LLM completion call like every other role. CSP-10 dropped the
 # ``kind`` field from the schema (every role is completion now).
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # ``claude-opus-4-7`` accepted for the same Claude Code Max routing
 # reason as critic — proximity is also a reasoning-heavy role.
 allowed_models = [
@@ -115,7 +115,7 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 # pilot.md is unchanged; operators tightening the per-candidate
 # budget can override the model via
 # ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 # Override paths: operators can pin a faster/cheaper model via the
 # allowlist below when the 90s wall-time becomes a bottleneck.
 allowed_models = [
@@ -130,7 +130,7 @@ role_contract = "plugins/seed_generation/agents/pilot.md"
 [seed_generation.role.ranker]
 # 3-judge panel orchestrator. Its own default_model is a placeholder —
 # the panel's voter binding (below) drives actual LLM calls.
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -140,7 +140,7 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/ranker.md"
 
 [seed_generation.role.evolver]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -150,7 +150,7 @@ allowed_models = [
 role_contract = "plugins/seed_generation/agents/evolver.md"
 
 [seed_generation.role.meta_reviewer]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -161,13 +161,13 @@ role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
 
 # PR-SUPERVISOR-ENABLE (2026-05-26) — supervisor role spec section.
 # Defaults mirror ``plugins/seed_generation/agents/supervisor.py``'s
-# ``_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"`` (per the role
+# ``_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-8"`` (per the role
 # docstring: "Run-level strategy synthesis. Dispatches ONE Opus
 # sub-agent" — Opus chosen because supervisor's output gates the
 # value of every downstream call). Allowed list mirrors meta_reviewer
 # (same single-shot, run-level analyst pattern).
 [seed_generation.role.supervisor]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -184,7 +184,7 @@ role_contract = "plugins/seed_generation/agents/supervisor.md"
 # in ``~/.geode/config.toml`` to opt into the external arxiv fetch +
 # git-tracked snapshot loop.
 [seed_generation.role.literature_review]
-default_model = "claude-opus-4-7"
+default_model = "claude-opus-4-8"
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",
@@ -207,8 +207,8 @@ queries_per_run = 3
 [seed_generation.judge_panel]
 # Default voter mix: 2 reviewers on OpenAI gpt-5.5 via openai-codex
 # (ChatGPT subscription / Codex Responses API) + 1 reviewer on
-# Anthropic claude-opus-4-7 via claude-cli (Claude Code Max
-# subscription, top tier per PR-UPGRADE-ROLES-TOP-TIER 2026-05-26).
+# Anthropic claude-opus-4-8 via claude-cli (Claude Code Max
+# subscription, top tier; bumped opus-4-7 → opus-4-8 2026-06-01).
 # Both diversity gates are satisfied:
 #   * providers ≥ 2 (openai + anthropic)
 #   * paths ≥ 2 (openai-codex + claude-cli)
@@ -228,6 +228,6 @@ provider = "openai"
 source = "openai-codex"
 
 [[seed_generation.judge_panel.voters]]
-model = "claude-opus-4-7"
+model = "claude-opus-4-8"
 provider = "anthropic"
 source = "claude-cli"

--- a/plugins/seed_generation/tournament.py
+++ b/plugins/seed_generation/tournament.py
@@ -30,22 +30,29 @@ P1-P7 prevention checklist application:
 from __future__ import annotations
 
 import math
+import os
 import random
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Literal
 
 __all__ = [
     "DEFAULT_K_FACTOR",
+    "DEFAULT_SURVIVOR_SELECTION",
     "DEFAULT_TOP_K",
     "INITIAL_RATING",
+    "SURVIVOR_SELECTION_ENV",
     "MatchOutcome",
     "MatchPlan",
+    "SurvivorSelection",
     "apply_match",
     "expected_score",
     "initial_ratings",
     "outcome_score",
     "plan_matches",
+    "rank_by_difficulty",
+    "resolve_survivor_selection",
+    "select_survivors",
     "top_k",
 ]
 
@@ -53,6 +60,30 @@ __all__ = [
 INITIAL_RATING: float = 1000.0
 DEFAULT_K_FACTOR: float = 32.0
 DEFAULT_TOP_K: int = 5
+
+
+SurvivorSelection = Literal["elo", "difficulty"]
+"""How the Ranker picks survivors from the rated candidate set.
+
+- ``"elo"`` (default, unchanged behaviour) — top-K by descending Elo
+  rating (tournament win-rate via the 3-judge panel).
+- ``"difficulty"`` — top-K by descending measured pilot
+  ``dim_means[target_dim]`` (Petri 1-10, HIGHER = more misbehaviour
+  elicited = HARDER for the target = LOWER target fitness = MORE
+  headroom for a mutation to improve). Selects the seeds the target
+  struggles most with, instead of the ones the panel rated "best".
+"""
+
+DEFAULT_SURVIVOR_SELECTION: SurvivorSelection = "elo"
+"""Default survivor selection mode — Elo, so existing runs are unchanged
+unless the operator opts in to difficulty-calibrated selection."""
+
+SURVIVOR_SELECTION_ENV = "GEODE_SEED_SURVIVOR_SELECTION"
+"""Operator override — set to ``difficulty`` to pick the hardest seeds
+(highest pilot target_dim elicitation) instead of the top-Elo seeds.
+Any unrecognised / empty value falls back to
+:data:`DEFAULT_SURVIVOR_SELECTION` (the knob must never harden into an
+invalid mode from a typo)."""
 
 
 WinnerLabel = Literal["A", "B", "tie"]
@@ -200,6 +231,124 @@ def top_k(
     """
     ranked = sorted(ratings.items(), key=lambda kv: (-kv[1], kv[0]))
     return [cid for cid, _ in ranked[:k]]
+
+
+def resolve_survivor_selection() -> SurvivorSelection:
+    """Resolve the effective survivor-selection mode from the environment.
+
+    Reads :data:`SURVIVOR_SELECTION_ENV`. Recognises ``"elo"`` /
+    ``"difficulty"`` (case-insensitive, surrounding whitespace stripped);
+    any other value — including an empty string or a typo — falls back to
+    :data:`DEFAULT_SURVIVOR_SELECTION` so the knob can never harden into an
+    invalid mode mid-run.
+    """
+    raw = os.environ.get(SURVIVOR_SELECTION_ENV, "").strip().lower()
+    if raw == "difficulty":
+        return "difficulty"
+    if raw == "elo":
+        return "elo"
+    return DEFAULT_SURVIVOR_SELECTION
+
+
+def _difficulty_signal(
+    pilot_means: Mapping[str, Mapping[str, object]],
+    candidate_id: str,
+    target_dim: str,
+) -> float | None:
+    """Return the candidate's pilot ``dim_means[target_dim]`` as a float.
+
+    Graceful contract at every schema-typed boundary: a missing candidate,
+    a non-mapping pilot entry, a missing ``target_dim`` key, a non-numeric
+    value, or a non-finite float (``NaN`` / ``inf``) all resolve to ``None``
+    (sorts last in the difficulty ranking) rather than raising. ``bool`` is
+    rejected explicitly so a stray ``True`` cannot masquerade as ``1.0``.
+    The non-finite guard matters because pilot ``dim_means`` arrives via
+    ``json.loads``, which parses ``NaN`` / ``Infinity`` — ``NaN`` would make
+    the sort insertion-dependent and ``inf`` would always rank first,
+    silently overriding a measured-hard seed.
+    """
+    means = pilot_means.get(candidate_id)
+    if not isinstance(means, Mapping):
+        return None
+    value = means.get(target_dim)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    signal = float(value)
+    if not math.isfinite(signal):
+        return None
+    return signal
+
+
+def rank_by_difficulty(
+    ratings: Mapping[str, float],
+    pilot_means: Mapping[str, Mapping[str, object]],
+    target_dim: str,
+) -> list[str]:
+    """Rank every rated candidate hardest-first by pilot ``target_dim`` elicitation.
+
+    The sort key per candidate is ``(-difficulty, -elo_rating, candidate_id)``:
+
+    1. **difficulty** — the pilot's measured ``dim_means[target_dim]``
+       (Petri 1-10, HIGHER = harder). Descending, so the seed the target
+       struggles most with leads.
+    2. **elo_rating** — descending Elo as a deterministic tie-break when
+       two candidates elicited the same difficulty (the harder-AND-better
+       seed wins the tie).
+    3. **candidate_id** — lexicographic, the final tie-break so the order
+       is stable across re-runs (matters for the survivors.json / pool
+       content-hash determinism downstream).
+
+    A candidate with no usable difficulty signal (missing / non-numeric
+    pilot ``dim_means[target_dim]``) sorts AFTER every candidate that has
+    one — it is never crashed on and never promoted above a measured-hard
+    seed. ``ratings`` defines the candidate universe (one entry per rated
+    candidate); ``pilot_means`` is the read-only difficulty source.
+    """
+
+    # Candidates with a signal sort before those without; ``has_signal`` is
+    # the primary key (False sorts last under reverse-of-(-x) ordering, so
+    # we encode it as 0/1 and negate alongside the difficulty value).
+    def _sort_key(candidate_id: str) -> tuple[int, float, float, str]:
+        signal = _difficulty_signal(pilot_means, candidate_id, target_dim)
+        has_signal = 1 if signal is not None else 0
+        difficulty = signal if signal is not None else 0.0
+        elo = ratings.get(candidate_id, INITIAL_RATING)
+        # Negate has_signal + difficulty + elo for descending; id ascending.
+        return (-has_signal, -difficulty, -elo, candidate_id)
+
+    return sorted(ratings.keys(), key=_sort_key)
+
+
+def select_survivors(
+    ratings: Mapping[str, float],
+    *,
+    k: int = DEFAULT_TOP_K,
+    selection: SurvivorSelection = DEFAULT_SURVIVOR_SELECTION,
+    pilot_means: Mapping[str, Mapping[str, object]] | None = None,
+    target_dim: str | None = None,
+) -> list[str]:
+    """Pick the top-``k`` survivors under the chosen selection mode.
+
+    - ``selection="elo"`` (default) — delegates to :func:`top_k`; identical
+      to the historical behaviour (top-K by descending Elo).
+    - ``selection="difficulty"`` — ranks ALL rated candidates by measured
+      pilot ``dim_means[target_dim]`` (hardest first via
+      :func:`rank_by_difficulty`), then truncates to ``k``. This keeps the
+      seeds the target struggles most with, which Elo would otherwise
+      discard (a high-elicitation seed can carry a lower Elo than an easy
+      one — see gen-2605-3). Falls back to Elo when ``target_dim`` is
+      absent / blank or ``pilot_means`` is empty, so a misconfigured
+      difficulty request degrades to the safe default rather than
+      returning an arbitrary order.
+    """
+    if selection != "difficulty":
+        return top_k(dict(ratings), k=k)
+    if not target_dim or not pilot_means:
+        # Difficulty requested but no usable signal source — degrade to
+        # Elo so the run still produces a deterministic survivor set.
+        return top_k(dict(ratings), k=k)
+    ranked = rank_by_difficulty(ratings, pilot_means, target_dim)
+    return ranked[:k]
 
 
 def majority_winner(votes: tuple[WinnerLabel, ...]) -> WinnerLabel:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.109"
+version = "0.99.110"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.110"
+version = "0.99.111"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -238,7 +238,7 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
     clear_manifest_cache()
     manifest = load_manifest()
     proximity = manifest.get_role("proximity")
-    assert proximity.default_model == "claude-opus-4-7"
+    assert proximity.default_model == "claude-opus-4-8"
 
     toml_body = (
         Path(__file__).resolve().parents[3]
@@ -257,14 +257,12 @@ def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
 
 
 def test_bundled_manifest_all_role_defaults_top_tier() -> None:
-    """PR-UPGRADE-ROLES-TOP-TIER (2026-05-26) regression pin — every
-    role default in the shipped TOML must be ``claude-opus-4-7``
-    (the Anthropic top tier per GEODE's spec registry). The judge
-    panel must keep 2× gpt-5.5 codex voters + 1× claude-opus-4-7
-    voter (provider-diversity gate). Prior to this PR roles split
-    across ``claude-sonnet-4-6`` (generator/critic/proximity/ranker/
-    evolver/literature_review) and ``claude-haiku-4-5`` (pilot's
-    cheap-fast slot); meta_reviewer + supervisor were already opus."""
+    """PR-UPGRADE-ROLES-TOP-TIER (2026-05-26) regression pin, bumped by
+    PR-SEEDGEN-OPUS-4-8 (2026-06-01) — every role default in the shipped
+    TOML must be ``claude-opus-4-8`` (the current Anthropic top tier). The
+    judge panel must keep 2× gpt-5.5 codex voters + 1× claude-opus-4-8
+    voter (provider-diversity gate). The flagship moved opus-4-7 → opus-4-8
+    once the local claude CLI was probe-verified to serve it."""
     clear_manifest_cache()
     manifest = load_manifest()
     role_names = (
@@ -280,14 +278,14 @@ def test_bundled_manifest_all_role_defaults_top_tier() -> None:
     )
     for name in role_names:
         role = manifest.get_role(name)
-        assert role.default_model == "claude-opus-4-7", (
+        assert role.default_model == "claude-opus-4-8", (
             f"role {name!r} default_model={role.default_model!r}; "
-            "PR-UPGRADE-ROLES-TOP-TIER requires opus-4-7"
+            "PR-SEEDGEN-OPUS-4-8 requires opus-4-8"
         )
     voters = manifest.judge_panel.voters
     voter_models = sorted(v.model for v in voters)
-    assert voter_models == ["claude-opus-4-7", "gpt-5.5", "gpt-5.5"], (
-        f"judge panel voter models {voter_models!r}; expected [claude-opus-4-7, gpt-5.5, gpt-5.5]"
+    assert voter_models == ["claude-opus-4-8", "gpt-5.5", "gpt-5.5"], (
+        f"judge panel voter models {voter_models!r}; expected [claude-opus-4-8, gpt-5.5, gpt-5.5]"
     )
 
 

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -830,3 +830,126 @@ def test_ranker_voter_task_ids_match_mutation_eval_shape() -> None:
         f"Ranker task_id shape drifted from mutation_eval — "
         f"got {tasks[0].task_id!r}, expected {expected_first!r}."
     )
+
+
+# ── PR-SEEDGEN-DIFFICULTY-SELECTION — difficulty-calibrated survivor pick ──
+
+
+def _state_with_pilot_difficulty(n: int, hard_idx: int) -> PipelineState:
+    """A candidate state where ``c-{hard_idx}`` has the HIGHEST pilot
+    target_dim elicitation (hardest seed) regardless of how the Elo
+    tournament shakes out. All other candidates carry low target_dim
+    elicitation. ``target_dim`` is ``broken_tool_use`` (see
+    ``_state_with_candidates``).
+    """
+    state = _state_with_candidates(n)
+    state.pilot_scores = {}
+    for i in range(n):
+        # The hard candidate elicits 9.0; everyone else a low 1.0.
+        target_mean = 9.0 if i == hard_idx else 1.0
+        state.pilot_scores[f"c-{i:02d}"] = {
+            "candidate_id": f"c-{i:02d}",
+            "dim_means": {"broken_tool_use": target_mean},
+            "dim_stderr": {"broken_tool_use": 0.1},
+            "status": "ok",
+        }
+    return state
+
+
+def test_ranker_difficulty_mode_picks_hardest_seed_first() -> None:
+    """Difficulty mode surfaces the high-elicitation seed as the #1
+    survivor even when Elo would not rank it first."""
+    hard_idx = 5
+    state = _state_with_pilot_difficulty(8, hard_idx=hard_idx)
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=cast(Any, manager),
+        voters=_voters(),
+        selection="difficulty",
+        rng=random.Random(0),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+    assert result.success
+    survivors = result.output["survivors"]
+    assert survivors[0] == f"c-{hard_idx:02d}", (
+        f"difficulty mode must rank the hardest seed (pilot target_dim 9.0) "
+        f"first; got survivors={survivors}"
+    )
+
+
+def test_ranker_difficulty_mode_can_invert_elo_order() -> None:
+    """On the SAME final ratings, elo and difficulty modes disagree:
+    elo picks its top-rated seed, difficulty picks the high-elicitation
+    seed — confirming the modes are genuinely different selection paths."""
+    hard_idx = 5
+    state_elo = _state_with_pilot_difficulty(8, hard_idx=hard_idx)
+    state_diff = _state_with_pilot_difficulty(8, hard_idx=hard_idx)
+
+    elo_ranker = Ranker(
+        manager=cast(Any, _AlwaysAWinsManager()),
+        voters=_voters(),
+        selection="elo",
+        rng=random.Random(0),
+    )
+    diff_ranker = Ranker(
+        manager=cast(Any, _AlwaysAWinsManager()),
+        voters=_voters(),
+        selection="difficulty",
+        rng=random.Random(0),
+    )
+    elo_result = asyncio.run(elo_ranker.aexecute(state_elo))
+    diff_result = asyncio.run(diff_ranker.aexecute(state_diff))
+
+    # Same RNG + same manager → identical Elo ratings in both runs.
+    assert elo_result.output["elo_ratings"] == diff_result.output["elo_ratings"]
+    # Difficulty always leads with the hardest seed; elo leads with its
+    # top-Elo seed. The hard seed need not be elo's top, so the two
+    # survivor lists differ here (the whole point of the feature).
+    assert diff_result.output["survivors"][0] == f"c-{hard_idx:02d}"
+    assert elo_result.output["survivors"] != diff_result.output["survivors"]
+
+
+def test_ranker_difficulty_missing_pilot_does_not_crash() -> None:
+    """A candidate with no pilot score must not crash difficulty mode and
+    must sort after candidates that DO have a difficulty signal."""
+    state = _state_with_candidates(4)
+    # Only c-01 has a pilot dim_means for the target_dim.
+    state.pilot_scores = {
+        "c-01": {
+            "candidate_id": "c-01",
+            "dim_means": {"broken_tool_use": 7.0},
+            "dim_stderr": {"broken_tool_use": 0.1},
+            "status": "ok",
+        }
+    }
+    ranker = Ranker(
+        manager=cast(Any, _AlwaysAWinsManager()),
+        voters=_voters(),
+        selection="difficulty",
+        rng=random.Random(0),
+    )
+    result = asyncio.run(ranker.aexecute(state))
+    assert result.success
+    # The only candidate with a usable difficulty signal leads.
+    assert result.output["survivors"][0] == "c-01"
+
+
+def test_ranker_default_selection_is_elo() -> None:
+    """Default (no ``selection`` arg) keeps the historical Elo-only path,
+    so the survivor list matches an explicit elo-mode run."""
+    state_default = _state_with_pilot_difficulty(6, hard_idx=3)
+    state_elo = _state_with_pilot_difficulty(6, hard_idx=3)
+    default_ranker = Ranker(
+        manager=cast(Any, _AlwaysAWinsManager()),
+        voters=_voters(),
+        rng=random.Random(7),
+    )
+    elo_ranker = Ranker(
+        manager=cast(Any, _AlwaysAWinsManager()),
+        voters=_voters(),
+        selection="elo",
+        rng=random.Random(7),
+    )
+    default_result = asyncio.run(default_ranker.aexecute(state_default))
+    elo_result = asyncio.run(elo_ranker.aexecute(state_elo))
+    assert default_result.output["survivors"] == elo_result.output["survivors"]

--- a/tests/plugins/seed_generation/test_tournament.py
+++ b/tests/plugins/seed_generation/test_tournament.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import random
 
+import pytest
 from plugins.seed_generation.tournament import (
     DEFAULT_K_FACTOR,
+    DEFAULT_SURVIVOR_SELECTION,
     INITIAL_RATING,
+    SURVIVOR_SELECTION_ENV,
     MatchOutcome,
     MatchPlan,
     apply_match,
@@ -15,6 +18,9 @@ from plugins.seed_generation.tournament import (
     majority_winner,
     outcome_score,
     plan_matches,
+    rank_by_difficulty,
+    resolve_survivor_selection,
+    select_survivors,
     top_k,
 )
 
@@ -226,3 +232,161 @@ def test_match_plan_is_frozen() -> None:
 def test_default_k_factor_pinned() -> None:
     """Sprint plan §13 default K=32 — regression guard."""
     assert DEFAULT_K_FACTOR == 32.0
+
+
+# ── PR-SEEDGEN-DIFFICULTY-SELECTION — difficulty-calibrated survivor pick ──
+
+
+def test_default_survivor_selection_is_elo() -> None:
+    """Default must stay Elo so existing runs are unchanged unless opted in."""
+    assert DEFAULT_SURVIVOR_SELECTION == "elo"
+
+
+def test_resolve_selection_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SURVIVOR_SELECTION_ENV, raising=False)
+    assert resolve_survivor_selection() == "elo"
+
+
+def test_resolve_selection_difficulty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SURVIVOR_SELECTION_ENV, "difficulty")
+    assert resolve_survivor_selection() == "difficulty"
+
+
+def test_resolve_selection_case_and_whitespace_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SURVIVOR_SELECTION_ENV, "  Difficulty  ")
+    assert resolve_survivor_selection() == "difficulty"
+
+
+def test_resolve_selection_typo_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo must never harden the knob into an invalid mode."""
+    monkeypatch.setenv(SURVIVOR_SELECTION_ENV, "difculty")
+    assert resolve_survivor_selection() == "elo"
+
+
+def test_rank_by_difficulty_hardest_first() -> None:
+    """The high-elicitation seed leads even when its Elo is lower.
+
+    Mirrors the gen-2605-3 finding: elo 1094 / target_dim 2.8 vs
+    elo 1084 / target_dim 4.2 — difficulty must rank the 4.2 seed first.
+    """
+    ratings = {"easy_high_elo": 1094.0, "hard_low_elo": 1084.0}
+    pilot_means = {
+        "easy_high_elo": {"broken_tool_use": 2.8},
+        "hard_low_elo": {"broken_tool_use": 4.2},
+    }
+    ranked = rank_by_difficulty(ratings, pilot_means, "broken_tool_use")
+    assert ranked == ["hard_low_elo", "easy_high_elo"]
+
+
+def test_rank_by_difficulty_missing_pilot_sorts_last() -> None:
+    ratings = {"with_signal": 1000.0, "no_pilot": 2000.0}
+    pilot_means = {"with_signal": {"broken_tool_use": 1.0}}
+    # ``no_pilot`` has the higher Elo but no difficulty signal → sorts last.
+    ranked = rank_by_difficulty(ratings, pilot_means, "broken_tool_use")
+    assert ranked == ["with_signal", "no_pilot"]
+
+
+def test_rank_by_difficulty_non_numeric_signal_sorts_last() -> None:
+    ratings = {"numeric": 1000.0, "stringy": 1000.0, "booly": 1000.0}
+    pilot_means = {
+        "numeric": {"broken_tool_use": 3.0},
+        "stringy": {"broken_tool_use": "high"},
+        "booly": {"broken_tool_use": True},  # bool must NOT count as 1.0
+    }
+    ranked = rank_by_difficulty(ratings, pilot_means, "broken_tool_use")
+    # Only ``numeric`` has a usable signal; the other two sort last by id.
+    assert ranked[0] == "numeric"
+    assert set(ranked[1:]) == {"booly", "stringy"}
+
+
+def test_rank_by_difficulty_non_finite_signal_sorts_last() -> None:
+    """``NaN`` / ``inf`` arrive via json.loads — they must NOT count as a
+    difficulty signal (``inf`` would always rank first; ``NaN`` would make
+    the sort insertion-dependent), so they sort behind the measured seed."""
+    ratings = {"measured": 1000.0, "infs": 1000.0, "nans": 1000.0}
+    pilot_means = {
+        "measured": {"broken_tool_use": 3.0},
+        "infs": {"broken_tool_use": float("inf")},
+        "nans": {"broken_tool_use": float("nan")},
+    }
+    ranked = rank_by_difficulty(ratings, pilot_means, "broken_tool_use")
+    assert ranked[0] == "measured"
+    assert set(ranked[1:]) == {"infs", "nans"}
+
+
+def test_rank_by_difficulty_elo_tie_break() -> None:
+    """Equal difficulty → higher Elo wins the tie, then lexicographic id."""
+    ratings = {"a": 1100.0, "b": 1200.0, "c": 1200.0}
+    pilot_means = {
+        "a": {"d": 5.0},
+        "b": {"d": 5.0},
+        "c": {"d": 5.0},
+    }
+    ranked = rank_by_difficulty(ratings, pilot_means, "d")
+    # b/c share Elo 1200 (b<c lexicographic), a is 1100.
+    assert ranked == ["b", "c", "a"]
+
+
+def test_select_survivors_elo_mode_matches_top_k() -> None:
+    ratings = {"a": 1100.0, "b": 1050.0, "c": 1200.0, "d": 1000.0}
+    assert select_survivors(ratings, k=2, selection="elo") == top_k(ratings, k=2)
+
+
+def test_select_survivors_difficulty_inverts_elo() -> None:
+    ratings = {"easy": 1094.0, "hard": 1084.0}
+    pilot_means = {
+        "easy": {"broken_tool_use": 2.8},
+        "hard": {"broken_tool_use": 4.2},
+    }
+    # Elo would pick "easy" first; difficulty picks "hard".
+    elo_pick = select_survivors(ratings, k=1, selection="elo")
+    difficulty_pick = select_survivors(
+        ratings,
+        k=1,
+        selection="difficulty",
+        pilot_means=pilot_means,
+        target_dim="broken_tool_use",
+    )
+    assert elo_pick == ["easy"]
+    assert difficulty_pick == ["hard"]
+
+
+def test_select_survivors_difficulty_truncates_to_k() -> None:
+    ratings = {"a": 1000.0, "b": 1000.0, "c": 1000.0, "d": 1000.0}
+    pilot_means = {
+        "a": {"d": 1.0},
+        "b": {"d": 4.0},
+        "c": {"d": 3.0},
+        "d": {"d": 2.0},
+    }
+    picked = select_survivors(
+        ratings, k=2, selection="difficulty", pilot_means=pilot_means, target_dim="d"
+    )
+    assert picked == ["b", "c"]
+
+
+def test_select_survivors_difficulty_without_target_dim_falls_back_to_elo() -> None:
+    ratings = {"easy": 1094.0, "hard": 1084.0}
+    pilot_means = {"easy": {"d": 2.8}, "hard": {"d": 4.2}}
+    # No target_dim → degrade to Elo (deterministic) rather than guess.
+    picked = select_survivors(
+        ratings, k=1, selection="difficulty", pilot_means=pilot_means, target_dim=None
+    )
+    assert picked == ["easy"]
+
+
+def test_select_survivors_difficulty_without_pilot_means_falls_back_to_elo() -> None:
+    ratings = {"easy": 1094.0, "hard": 1084.0}
+    picked = select_survivors(
+        ratings, k=1, selection="difficulty", pilot_means=None, target_dim="d"
+    )
+    assert picked == ["easy"]
+
+
+def test_select_survivors_empty_ratings() -> None:
+    assert select_survivors({}, k=5, selection="elo") == []
+    assert select_survivors({}, k=5, selection="difficulty", pilot_means={}, target_dim="d") == []

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.110"
+version = "0.99.111"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.108"
+version = "0.99.110"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- #1950 — difficulty-calibrated survivor selection for seed generation (opt-in `GEODE_SEED_SURVIVOR_SELECTION=difficulty`, v0.99.110).
- #1951 — seed-generation pipeline roles bumped claude-opus-4-7 → claude-opus-4-8 (v0.99.111).

## Verification
- [x] both PRs merged to develop with CI 5/5 green + Codex MCP clean
- [x] develop content = #1950 + #1951 only (verified via diff --stat)
- [ ] passthrough CI 5/5 green