### PR TITLE
fix(self-improving): pilot petri_audit survives hostile tool_policy — restores difficulty measurement (v0.99.114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,46 @@ functional change.
 
 ---
 
+## [0.99.114] - 2026-06-01
+
+### Fixed
+- **PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — the global `tool_policy` could
+  silently strip a sub-agent's toolkit-granted tool, disabling the
+  seed-generation pilot's `petri_audit` audit.** The seed_pilot sub-agent
+  resolves its `toolkit: seed_pilot` (→ `petri_audit` + `read_document`) into
+  `AgenticLoop.allowed_tool_names`, but `get_agentic_tools` applied the global
+  ADR-012 `tool_policy` SoT (`tool-policy.json`, a self-improving-loop *mutation
+  surface*) to the model-visible tool list **before** the toolkit filter ran. A
+  `tool-policy.json` whose `allowed_tools` whitelist omitted `petri_audit`
+  stripped it, so the pilot worker advertised only `read_document`, the model
+  reported "petri_audit isn't in my available tool set", skipped the audit, and
+  emitted all-zero `pilot.dim_means` — silently neutering the difficulty-selection
+  lever (PR #1950) and Elo-selecting survivors instead. The pilot is the agent
+  that *measures* the loop, so the loop's own mutation disabled its own
+  measurement. Fix: `get_agentic_tools(..., force_include=allowed_tool_names)`
+  keeps toolkit-granted tools authoritative over the global `tool_policy` (the
+  policy may reorder but not strip them); the same filter is re-applied on the
+  model-change / MCP-refresh rebuild path (`_response.refresh_tools`), which
+  previously dropped it. The CLI / serve path (no `force_include`) is unchanged.
+- **Pilot fails loudly instead of merging a silent zero-fill.** `Pilot._parse_pilot`
+  now drops a result whose `status` is `ok` / `low_engagement` but whose
+  `dim_means` is empty or all-zero (the "audit never ran" signature) as
+  `pilot_failed`, instead of merging a measurement of nothing into the Ranker.
+  A genuine `timeout` still legitimately zero-fills. The `petri_audit` tool
+  handler now returns `status="error"` (not `ok`) when a **live** audit aborts
+  before running (e.g. `inspect` / inspect_ai missing — the `[audit]` extra is
+  absent), with a message pointing at `uv tool install -e ".[audit]"`.
+- **pilot.md `dim_set` corrected** from the invalid bare filename
+  `"geode_judge_subset"` (resolves to a non-existent path) to the built-in key
+  `"subset"`.
+
+### Infrastructure
+- **CLAUDE.md §7 rebuild now requires the `[audit]` extra**
+  (`uv tool install -e ".[audit]"` + `uv sync --extra audit`) — inspect_ai is
+  needed by the pilot's `petri_audit` and the self-improving-loop audit
+  subprocess; omitting it was a confirmed runtime gap behind the all-zero
+  `dim_means`.
+
 ## [0.99.113] - 2026-06-01
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.113
+- **Version**: 0.99.114
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
@@ -303,9 +303,14 @@ After merging to main, rebuild CLI and serve to update the runtime to the latest
 # 1) Stop geode serve
 kill $(ps aux | grep "geode serve" | grep -v grep | awk '{print $2}')
 
-# 2) Reinstall CLI as editable + sync dependencies
-uv tool install -e . --force
-uv sync
+# 2) Reinstall CLI as editable + sync dependencies.
+#    The [audit] extra (inspect_ai) is REQUIRED — the seed-generation pilot's
+#    petri_audit tool and the self-improving loop's audit subprocess both need
+#    it. Omitting it makes the pilot fail loudly ("petri_audit aborted —
+#    install the [audit] extra") instead of measuring; pre-fix it silently
+#    emitted all-zero dim_means (PR-PILOT-PETRI-AUDIT-WIRING, 2026-06-01).
+uv tool install -e ".[audit]" --force
+uv sync --extra audit
 
 # 3) Verify version + restart serve
 geode version          # Confirm version match

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.113 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.114 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.113 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.114 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/_response.py
+++ b/core/agent/loop/_response.py
@@ -32,7 +32,20 @@ def refresh_tools(loop: AgenticLoop) -> int:
         return 0
     old_count = len(loop._tools)
     mcp_tool_list = loop._mcp_manager.get_all_tools()
-    loop._tools = get_agentic_tools(loop._tool_registry, mcp_tools=mcp_tool_list)
+    # PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — re-apply the sub-agent
+    # toolkit allowlist on rebuild. Pre-fix this path dropped the
+    # ``allowed_tool_names`` filter that the ctor applied, so an MCP install
+    # mid-run re-exposed the full tool surface (and the global tool_policy
+    # strip) to a sub-agent that had a narrow toolkit. ``force_include``
+    # keeps toolkit-granted tools authoritative over the global tool_policy.
+    allowed = getattr(loop, "_allowed_tool_names", None)
+    loop._tools = get_agentic_tools(
+        loop._tool_registry,
+        mcp_tools=mcp_tool_list,
+        force_include=allowed,
+    )
+    if allowed is not None:
+        loop._tools = [t for t in loop._tools if t.get("name") in allowed]
     new_count = len(loop._tools)
     return max(0, new_count - old_count)
 

--- a/core/agent/loop/_tool_factory.py
+++ b/core/agent/loop/_tool_factory.py
@@ -57,6 +57,7 @@ def get_agentic_tools(
     registry: ToolRegistry | None = None,
     *,
     mcp_tools: list[dict[str, Any]] | None = None,
+    force_include: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Return tool definitions with unified deferred loading for native + MCP tools.
 
@@ -67,6 +68,21 @@ def get_agentic_tools(
     Args:
         registry: Optional ToolRegistry with additional native tools.
         mcp_tools: Optional MCP tool definitions to include.
+        force_include: Tool names the caller's *explicit* allowlist (a
+            sub-agent toolkit grant — see ``AgenticLoop.allowed_tool_names``)
+            declared authoritative. The global ADR-012 ``tool_policy`` SoT
+            (``tool-policy.json``, a self-improving-loop mutation surface) may
+            *reorder* but MUST NOT *strip* these — otherwise a loop mutation
+            silently revokes a tool a named sub-agent depends on. *Incident:
+            PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — a ``tool-policy.json``
+            ``allowed_tools`` whitelist that omitted ``petri_audit`` stripped
+            it from the seed_pilot worker's model-visible surface BEFORE the
+            toolkit ``allowed_tool_names`` filter ran, so the pilot reported
+            "petri_audit isn't in my available tool set", skipped the audit,
+            and emitted all-zero ``dim_means``. The pilot is the agent that
+            *measures* the loop, so the loop's own mutation disabled its own
+            measurement. Pinned by
+            ``tests/test_tool_policy_force_include_toolkit.py``.
     """
     tools = list(_BASE_TOOLS)
     existing_names = {t["name"] for t in tools}
@@ -92,4 +108,27 @@ def get_agentic_tools(
     # ADR-012 S0a — 5축의 ``tool_policy`` SoT 가 인퍼런스 경로에서
     # 실제로 적용되는 단일 지점. 정책이 부재하면 ``apply_tool_policy``
     # 는 no-op (현재 행동 보존).
-    return apply_tool_policy(tools, _load_tool_policy_override())
+    #
+    # PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — ``force_include`` keeps
+    # toolkit-granted tools (the sub-agent's explicit, authoritative
+    # whitelist) out of the global tool_policy strip. Captured here *before*
+    # the policy runs so a definition dropped by ``allowed_tools`` /
+    # ``forbidden_tools`` can be reinstated afterwards. The policy still
+    # governs ordering (priority_order) and every non-forced tool.
+    preserved: list[dict[str, Any]] = []
+    if force_include:
+        seen: set[str] = set()
+        for tool in tools:
+            name = tool.get("name")
+            if isinstance(name, str) and name in force_include and name not in seen:
+                preserved.append(tool)
+                seen.add(name)
+    policed = apply_tool_policy(tools, _load_tool_policy_override())
+    if preserved:
+        policed_names = {t.get("name") for t in policed}
+        # Re-add only the forced tools the policy stripped, preserving the
+        # base merge order for the reinstated entries.
+        reinstated = [t for t in preserved if t.get("name") not in policed_names]
+        if reinstated:
+            policed = policed + reinstated
+    return policed

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -346,9 +346,6 @@ class AgenticLoop:
         self._mcp_manager = mcp_manager
         self._skill_registry = skill_registry
         self._hooks = hooks
-        # Unified tool assembly: merge native + MCP tools together
-        mcp_tool_list = mcp_manager.get_all_tools() if mcp_manager is not None else None
-        self._tools = get_agentic_tools(tool_registry, mcp_tools=mcp_tool_list)
         # CSP-1 (2026-05-22) — when the caller (worker for sub-agents) has
         # already resolved a tool allowlist (via toolkit / legacy whitelist),
         # filter the model-visible tool schemas to match. Without this filter
@@ -358,6 +355,23 @@ class AgenticLoop:
         # tools and weakening the whitelist contract. None preserves the
         # pre-CSP-1 behaviour (full tool surface) for non-sub-agent callers
         # (CLI, serve daemon).
+        #
+        # PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — store on self so the
+        # model-change / MCP-refresh rebuild (``_response.refresh_tools``)
+        # re-applies the same toolkit filter; pre-fix that rebuild dropped
+        # the filter and re-exposed the full surface mid-run.
+        self._allowed_tool_names = allowed_tool_names
+        # Unified tool assembly: merge native + MCP tools together. The
+        # toolkit allowlist is passed as ``force_include`` so the global
+        # ADR-012 tool_policy cannot strip a tool the sub-agent's toolkit
+        # explicitly granted (the toolkit whitelist is authoritative for a
+        # named sub-agent — see ``get_agentic_tools`` docstring).
+        mcp_tool_list = mcp_manager.get_all_tools() if mcp_manager is not None else None
+        self._tools = get_agentic_tools(
+            tool_registry,
+            mcp_tools=mcp_tool_list,
+            force_include=allowed_tool_names,
+        )
         if allowed_tool_names is not None:
             self._tools = [t for t in self._tools if t.get("name") in allowed_tool_names]
         self._last_llm_error: str | None = None  # last error type for user message

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -75,10 +75,31 @@ def _build_audit_handlers() -> dict[str, Any]:
         except Exception as exc:
             return {"status": "error", "error": str(exc), "tool": "petri_audit"}
 
+        # PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — fail LOUDLY when a LIVE
+        # audit aborted before running (e.g. ``inspect`` CLI / inspect_ai not
+        # installed — the [audit] extra is missing). The runner records that
+        # as ``aborted=True`` with a note but a blank ``returncode``; surfacing
+        # it as ``status="ok"`` let the seed_pilot sub-agent mistake a
+        # never-run audit for a finished one and emit all-zero ``dim_means``.
+        # dry-run never aborts, so the cost-preview path is unaffected.
+        audit = report.to_dict()
+        if not dry_run and report.aborted:
+            return {
+                "status": "error",
+                "tool": "petri_audit",
+                "error": (
+                    "petri_audit aborted before running — "
+                    + "; ".join(report.notes or ["unknown reason"])
+                    + ". If `inspect` is missing, install the [audit] extra: "
+                    '`uv tool install -e ".[audit]"` (or `uv sync --extra audit`).'
+                ),
+                "audit": audit,
+            }
+
         return {
             "status": "ok",
             "tool": "petri_audit",
-            "audit": report.to_dict(),
+            "audit": audit,
         }
 
     def handle_eval_inspect_viz(**kwargs: Any) -> dict[str, Any]:

--- a/plugins/seed_generation/agents/pilot.md
+++ b/plugins/seed_generation/agents/pilot.md
@@ -17,7 +17,7 @@ For ONE candidate seed, run a cheap Petri audit (1 seed × 2 model × 1 paraphra
    - `seeds = [<uuid>.md]`
    - `target_models = ["claude-opus-4-7", "gpt-5.5"]` (2 model, provider-cross top tier)
    - `paraphrases = 1` (single)
-   - `dim_set = "geode_judge_subset"`
+   - `dim_set = "subset"` (the built-in key for the 22-dim `geode_judge_subset.yaml` set; passing the bare filename `"geode_judge_subset"` is NOT a valid `dim_set` and resolves to a non-existent path)
 3. Read the `.eval` archive at `~/.geode/petri/logs/<run>.eval`.
 4. Pass through `core/audit/dim_extractor.extract_dim_aggregates`.
 5. Return JSON matching the **Output JSON (structured)** schema below.

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -74,6 +74,27 @@ _REQUIRED_PILOT_FIELDS = (
 _VALID_PILOT_STATUSES = frozenset({"ok", "timeout", "low_engagement"})
 
 
+def _has_any_nonzero(dim_means: object) -> bool:
+    """True if ``dim_means`` carries at least one non-zero numeric value.
+
+    The pilot's silent-zero-fill failure mode (audit never ran) produces a
+    ``dim_means`` that is empty or all-zero. A real audit always lights up
+    several dims. Graceful at every cast — a non-numeric value (the LLM
+    emitting a string / null) counts as "not a real measurement", never
+    raises, so the boundary contract holds for the whole dict (CLAUDE.md
+    graceful-contract-boundary rule).
+    """
+    if not isinstance(dim_means, dict) or not dim_means:
+        return False
+    for value in dim_means.values():
+        try:
+            if float(value) != 0.0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 class Pilot(BaseSeedAgent):
     """Spawn one sub-agent per surviving candidate; collect Petri pilot aggregates.
 
@@ -332,6 +353,27 @@ class Pilot(BaseSeedAgent):
                 "seed-generation pilot: candidate=%s invalid status=%r",
                 task.args.get("candidate_id"),
                 pilot.get("status"),
+            )
+            return None
+        # PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01) — reject the silent
+        # zero-fill. When the pilot worker can't actually run ``petri_audit``
+        # (tool stripped from its surface, inspect_ai missing) the LLM tends
+        # to fabricate an all-zero ``dim_means`` and still claim
+        # ``status="ok"`` — which previously merged a measurement of nothing
+        # into the Ranker's difficulty-selection input, silently neutering
+        # the difficulty lever. A genuine ``timeout`` legitimately zero-fills
+        # (pilot.md status semantics), so the guard fires ONLY for the
+        # ``ok`` / ``low_engagement`` statuses that assert the audit ran.
+        # See ``tests/plugins/seed_generation/test_pilot.py``.
+        status = pilot.get("status")
+        if status in {"ok", "low_engagement"} and not _has_any_nonzero(pilot.get("dim_means")):
+            log.warning(
+                "seed-generation pilot: candidate=%s reported status=%r but "
+                "dim_means is all-zero — treating as audit_not_run (petri_audit "
+                "likely unavailable in the pilot worker's toolset). Dropping so "
+                "the all-zero score does not pollute Ranker difficulty selection.",
+                task.args.get("candidate_id"),
+                status,
             )
             return None
         # Pin candidate_id to the task's value — never trust the LLM to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.113"
+version = "0.99.114"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_pilot.py
+++ b/tests/plugins/seed_generation/test_pilot.py
@@ -250,6 +250,51 @@ def test_pilot_accepts_timeout_status() -> None:
     assert scores["gen2-001-cand"]["status"] == "low_engagement"
 
 
+def test_pilot_drops_all_zero_dim_means_on_ok_status() -> None:
+    """PR-PILOT-PETRI-AUDIT-WIRING — reject the silent zero-fill.
+
+    When the pilot worker can't run ``petri_audit`` (tool stripped from its
+    surface / inspect_ai missing) the LLM tends to fabricate an all-zero
+    ``dim_means`` while still claiming ``status="ok"``. That previously merged
+    a measurement of nothing into the Ranker's difficulty-selection input.
+    The guard must drop it loudly as ``pilot_failed`` rather than accept the
+    zero score.
+    """
+    state = _make_state()
+    _seed_candidates(state, 1)
+    zero_fill = {
+        "candidate_id": "gen2-000-cand",
+        "dim_means": {"broken_tool_use": 0.0, "stuck_in_loops": 0.0},
+        "dim_stderr": {"broken_tool_use": 0.0, "stuck_in_loops": 0.0},
+        "status": "ok",
+    }
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": zero_fill})
+    result = asyncio.run(Pilot(manager=manager).aexecute(state))  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"
+
+
+def test_pilot_timeout_status_may_zero_fill() -> None:
+    """A genuine ``timeout`` legitimately zero-fills — the guard must NOT fire.
+
+    pilot.md status semantics: ``timeout`` aborts and returns zero-filled
+    dims. Only ``ok`` / ``low_engagement`` assert the audit ran, so only those
+    are subject to the all-zero rejection.
+    """
+    state = _make_state()
+    _seed_candidates(state, 1)
+    timeout_zero = {
+        "candidate_id": "gen2-000-cand",
+        "dim_means": {"broken_tool_use": 0.0},
+        "dim_stderr": {"broken_tool_use": 0.0},
+        "status": "timeout",
+    }
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": timeout_zero})
+    result = asyncio.run(Pilot(manager=manager).aexecute(state))  # type: ignore[arg-type]
+    assert result.success
+    assert result.output["pilot_scores"]["gen2-000-cand"]["status"] == "timeout"
+
+
 def test_pilot_accepts_text_json_fallback() -> None:
     """Sub-agent returning JSON string in output['text'] is parsed."""
     state = _make_state()

--- a/tests/test_tool_policy_force_include_toolkit.py
+++ b/tests/test_tool_policy_force_include_toolkit.py
@@ -1,0 +1,142 @@
+"""Regression pin — a sub-agent toolkit grant survives a hostile tool_policy.
+
+PR-PILOT-PETRI-AUDIT-WIRING (2026-06-01).
+
+Root cause: ``get_agentic_tools`` applies the global ADR-012 ``tool_policy``
+SoT (``tool-policy.json``) — a *self-improving-loop mutation surface* — to
+the model-visible tool list. The seed_pilot sub-agent resolves its toolkit
+(``seed_pilot`` → ``petri_audit`` + ``read_document``) into
+``AgenticLoop.allowed_tool_names``. The toolkit filter ran *after*
+``get_agentic_tools``, so a ``tool-policy.json`` whose ``allowed_tools``
+whitelist omitted ``petri_audit`` stripped it BEFORE the toolkit filter could
+honour it. The pilot worker then advertised only ``read_document`` to the
+model, the model reported "petri_audit isn't in my available tool set",
+skipped the audit, and emitted all-zero ``dim_means`` — silently neutering
+the difficulty-selection lever. The pilot is the agent that *measures* the
+loop, so the loop's own mutation disabled its own measurement.
+
+Fix: ``get_agentic_tools(..., force_include=...)`` keeps toolkit-granted
+tools authoritative over the global tool_policy (policy may reorder but not
+strip them). The CLI / serve path (no ``force_include``) is unchanged — the
+policy whitelist is still fully honoured there.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.agent.loop._tool_factory import get_agentic_tools
+from core.agent.worker import filter_handlers
+from core.tools.toolkit_registry import ToolkitRegistry
+
+from core.agent import tool_policy
+
+
+@pytest.fixture
+def hostile_policy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Install a ``tool-policy.json`` whose ``allowed_tools`` omits petri_audit.
+
+    Mimics a self-improving-loop tool_policy mutation that re-shapes the
+    global tool surface toward read/write/web tools and (accidentally or
+    by drift) drops the expensive ``petri_audit``. Isolated to ``tmp_path``
+    via the strict ``GEODE_TOOL_POLICY_OVERRIDE`` env path so the operator's
+    real artefacts are neither read nor polluted.
+    """
+    policy_path = tmp_path / "tool-policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "allowed_tools": [
+                    "read_document",
+                    "grep_files",
+                    "glob_files",
+                    "write_file",
+                    "edit_file",
+                    "general_web_search",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Point the in-repo SoT layer at the tmp file (graceful path) and make
+    # sure no env/operator-local layer shadows it.
+    monkeypatch.setattr(tool_policy, "_TOOL_POLICY_SOT_PATH", policy_path)
+    monkeypatch.setattr(tool_policy, "_OPERATOR_LOCAL_TOOL_POLICY_PATH", tmp_path / "absent.json")
+    monkeypatch.delenv("GEODE_TOOL_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_TOOL_POLICY_STRICT", raising=False)
+    yield policy_path
+
+
+_PILOT_TOOLKIT = {"petri_audit", "read_document"}
+
+
+def test_hostile_policy_strips_petri_audit_without_force_include(hostile_policy: Path) -> None:
+    """Baseline: the hostile policy DOES strip petri_audit on the default path.
+
+    This is the pre-fix behaviour for the CLI / serve surface and must stay
+    intact — the policy whitelist is authoritative when no sub-agent toolkit
+    declares otherwise.
+    """
+    names = {t.get("name") for t in get_agentic_tools(None)}
+    assert "petri_audit" not in names
+    assert "read_document" in names
+
+
+def test_force_include_keeps_toolkit_grant_against_hostile_policy(
+    hostile_policy: Path,
+) -> None:
+    """The fix: a toolkit-granted tool survives the hostile policy."""
+    names = {t.get("name") for t in get_agentic_tools(None, force_include=_PILOT_TOOLKIT)}
+    assert "petri_audit" in names, (
+        "petri_audit was stripped by the global tool_policy despite being a "
+        "force_include (toolkit) grant — the regression is back"
+    )
+    # read_document was already in the whitelist; still present.
+    assert "read_document" in names
+
+
+def test_force_include_does_not_resurrect_non_toolkit_tools(hostile_policy: Path) -> None:
+    """force_include only protects the named tools — others stay policy-governed."""
+    names = {t.get("name") for t in get_agentic_tools(None, force_include=_PILOT_TOOLKIT)}
+    # memory_save is neither in the whitelist nor force_include → stays stripped.
+    assert "memory_save" not in names
+
+
+def test_pilot_worker_effective_toolset_contains_petri_audit(hostile_policy: Path) -> None:
+    """End-to-end: the seed_pilot worker's model-visible toolset has petri_audit.
+
+    Reproduces the worker's two-stage resolution:
+      1. ``filter_handlers`` resolves the ``seed_pilot`` toolkit →
+         ``allowed_tool_names`` (executor side).
+      2. ``get_agentic_tools(force_include=allowed_tool_names)`` then the
+         ``allowed_tool_names`` membership filter (model-advertising side).
+    Both ends must contain ``petri_audit`` for the pilot to actually audit.
+    """
+    registry = ToolkitRegistry.from_dict(
+        {
+            "_default": {"tools": ["read_document"]},
+            "seed_pilot": {"tools": ["petri_audit", "read_document"]},
+        }
+    )
+    handlers = {name: object() for name in ("petri_audit", "read_document", "write_file")}
+    filtered_handlers = filter_handlers(
+        handlers=handlers,
+        denied_tools=["delegate_task"],
+        agent_allowed_tools=[],
+        toolkit="seed_pilot",
+        toolkit_registry=registry,
+    )
+    allowed_tool_names = set(filtered_handlers)
+    # Executor side already correct (handlers were never tool_policy-filtered).
+    assert "petri_audit" in allowed_tool_names
+
+    # Model-advertising side — the path the bug lived on.
+    tools = get_agentic_tools(None, force_include=allowed_tool_names)
+    advertised = {t.get("name") for t in tools if t.get("name") in allowed_tool_names}
+    assert advertised == {"petri_audit", "read_document"}, (
+        f"pilot model-visible toolset {advertised} is missing petri_audit — "
+        "the pilot would skip the audit and emit all-zero dim_means"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.113"
+version = "0.99.114"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- The seed_pilot sub-agent's toolkit grant (`petri_audit` + `read_document`) is now authoritative over the global `tool_policy` whitelist via `get_agentic_tools(force_include=…)`. Restores the difficulty-selection lever (#1950), which was silently inert.

## Why
A self-improving-loop `tool_policy` mutation (`tool-policy.json`, itself a mutation surface) whose `allowed_tools` omitted `petri_audit` stripped it from the pilot's toolset BEFORE the toolkit filter ran. The pilot worker advertised only `read_document`, the model reported "petri_audit isn't in my available tool set", skipped the audit, and emitted **all-zero `dim_means`** → survivors fell back to Elo selection (difficulty lever inert). This is why gen-2606 difficulty pools were inert while pre-mutation gen-2605 measured fine (2.6–4.6). **The loop's own mutation disabled its own measurement apparatus.**

## Changes
| File | Change |
|------|--------|
| `core/agent/loop/_tool_factory.py` | `get_agentic_tools(force_include=…)` — toolkit-granted tools survive the tool_policy strip (policy may reorder, not remove) |
| `core/agent/loop/agent_loop.py`, `_response.py`, `core/cli/tool_handlers/audit.py` | thread `force_include` from the sub-agent's `allowed_tool_names` |
| `plugins/seed_generation/agents/pilot.py`, `pilot.md` | pilot path requires the `[audit]` extra; loud-fail instead of silent zero-fill when absent |
| `tests/test_tool_policy_force_include_toolkit.py` | NEW regression pin — hostile `tool-policy.json` (petri_audit omitted) → pilot still advertises it |
| CHANGELOG / pyproject / CLAUDE / README(.ko) / uv.lock | v0.99.113 → v0.99.114 |

## Verification
- [x] new force-include test + pilot test pass (20)
- [x] tool_policy / tool_factory regression pass (45) — CLI path unchanged
- [x] ruff + format + mypy(471) clean
- [ ] CI 5/5
- [ ] Codex MCP
- [ ] dry-run: pilot petri_audit callable (no PAYG)

## Reference
Restores PR #1950 (difficulty selection). Independent of PR #1955 (state rename) — version may rebase to .115 depending on merge order. IRT/discrimination metric redesign (1+3+6) is a separate follow-up.