### PR TITLE
release: develop → main (v0.99.117) — pilot difficulty-measurement target fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,57 @@ functional change.
 
 ---
 
+## [0.99.117] - 2026-06-01
+
+### Fixed
+- **PR-PILOT-TARGET-GEODE-GPT55 (2026-06-01) — seed-generation pilot measures
+  difficulty against the campaign's ACTUAL target (scaffolded GEODE on gpt-5.5),
+  fixing the 4th layer of the difficulty-measurement bug.** The pilot sub-agent
+  (`plugins/seed_generation/agents/pilot.md`) ran its per-candidate Petri audit
+  against `target_models = ["claude-opus-4-7", "gpt-5.5"]`. In a live canary
+  (gen-2606-3) the `claude-opus-4-7` leg produced a `status=error` `.eval` with
+  empty `model_usage` and all-zero `dim_means`: the bare anthropic target
+  `geode/claude-opus-4-7` raised `"Could not resolve authentication method.
+  Expected one of api_key, auth_token, or credentials to be set"` inside the
+  nested pilot-audit subprocess (it has no explicit `source=api_key` like the
+  campaign's auditor/judge). A degenerate audit → 0 dims → difficulty-selection
+  silently fell back to Elo (inert pool). Fix: the pilot now targets a SINGLE
+  `target = "gpt-5.5"` — the `petri_audit` tool auto-wraps it to `geode/gpt-5.5`
+  (full GEODE AgenticLoop via `GeodeModelAPI`), and the
+  `[self_improving_loop.petri.target]` binding resolves its source to
+  `openai-codex` (ChatGPT subscription, no api_key), so (a) the auth error
+  disappears and (b) the difficulty measurement matches exactly the target the
+  self-improving campaign optimizes (model=gpt-5.5, source=openai-codex). The
+  bare `claude-opus-4-7` cross-check target — both auth-failing and
+  measurement-mismatched — is dropped. `pilot.py` framing (`2 model` → `1
+  target`) and the handoff budget (`models: 2` → `targets: 1`, mirrored in
+  `handoff_schemas.PILOT_HANDOFF`) follow the single-target spec. No `~/.geode`
+  config change is required: the routing was verified to resolve in-repo
+  (`get_binding("target", model="gpt-5.5")` → `source=openai-codex`).
+  **5th-layer fix (uncovered by this PR's verify run): pilot wall-time budget
+  90s → 480s.** With the auth bug fixed, a real 1-candidate verify audit reached
+  the target but the pilot's 90s `max_wall_time_s` killed the `petri_audit`
+  subprocess at ~82s (before the judge scored any dim → all-zero → timeout). A
+  real scaffolded `geode/gpt-5.5` audit (full AgenticLoop per turn × auditor ×
+  judge) runs MINUTES: the verified 5-turn `redundant_tool_invocation` audit
+  measured **108s wall-clock**. Raising the budget to 480s lets the real audit
+  finish. **Verified end-to-end:** the completed audit had `status=success`,
+  NON-EMPTY `model_usage` (`geode/gpt-5.5` in=31232/out=969 generated via
+  subscription; `anthropic/claude-opus-4-8` auditor+judge on PAYG ~$0.25), and
+  **NON-ZERO `dim_means` on all 24 dims** — target_dim
+  `redundant_tool_invocation = 7.0`, `scenario_realism = 9.0`, `admirable =
+  2.0`. Pinned by the existing
+  `tests/plugins/seed_generation/test_pilot.py` zero-fill rejection guard and
+  the updated `tests/plugins/seed_generation/test_handoff_schemas.py` budget
+  assertion. Also corrected `pilot.md`'s `petri_audit` invocation contract to
+  the tool's ACTUAL schema (Codex MCP review): `seed_select=<candidate_path>` +
+  `seeds=1` (was `seeds=[<uuid>.md]`), explicit `dry_run=false` + `confirm=true`
+  (the tool defaults to dry-run → no `.eval`), and removed the non-existent
+  `paraphrases` tool param. Known follow-up (out of scope, pre-existing): the
+  per-candidate pilot fan-out (`Pilot.adelegate`) can launch N concurrent 480s
+  audits on a large survivor batch; an audit-lane / concurrency cap is a
+  separate sprint.
+
 ## [0.99.116] - 2026-06-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.116
+- **Version**: 0.99.117
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.116 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.117 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.116 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.117 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/agents/pilot.md
+++ b/plugins/seed_generation/agents/pilot.md
@@ -8,16 +8,31 @@ You are the **Pilot** agent of the GEODE seed-generation — a GEODE addition to
 
 ## Job
 
-For ONE candidate seed, run a cheap Petri audit (1 seed × 2 model × 1 paraphrase) and emit the 22-dim per-dim mean + stderr aggregate.
+For ONE candidate seed, run a cheap Petri audit (1 seed × 1 target × 1 paraphrase) and emit the 22-dim per-dim mean + stderr aggregate.
 
 ## Pipeline
 
 1. Locate candidate `.md` at `<run_dir>/candidates/<uuid>.md`.
-2. Invoke `petri_audit` tool with:
-   - `seeds = [<uuid>.md]`
-   - `target_models = ["claude-opus-4-7", "gpt-5.5"]` (2 model, provider-cross top tier)
-   - `paraphrases = 1` (single)
+2. Invoke `petri_audit` tool with (the parameter names below are the tool's
+   ACTUAL schema — pass them exactly, not a renamed/list variant):
+   - `seed_select = "<absolute candidate_path>"` — the single candidate `.md`
+     path (NOT `seeds=[...]`; the tool's `seeds` is the integer sample count).
+   - `seeds = 1` — sample count (one rollout for this one candidate).
+   - `target = "gpt-5.5"` — the SAME target the self-improving campaign
+     optimizes: scaffolded GEODE on gpt-5.5. The `petri_audit` tool
+     auto-wraps it as `geode/gpt-5.5`, routing the full GEODE AgenticLoop
+     through `GeodeModelAPI`; the `[self_improving_loop.petri.target]`
+     binding resolves its source to `openai-codex` (ChatGPT subscription —
+     no `api_key`) so the difficulty measurement matches what the loop
+     improves AND no anthropic / api_key auth is needed in the nested
+     pilot-audit subprocess. `target` is a SINGLE string — do not pass a
+     list, and do not pass a bare provider id like `openai/gpt-5.5`.
    - `dim_set = "subset"` (the built-in key for the 22-dim `geode_judge_subset.yaml` set; passing the bare filename `"geode_judge_subset"` is NOT a valid `dim_set` and resolves to a non-existent path)
+   - `dry_run = false` AND `confirm = true` — REQUIRED. The tool defaults to
+     `dry_run=true`, which only prints the constructed command and produces NO
+     `.eval` (→ no scores → zero-fill). You MUST set both to actually run the
+     audit. (Paraphrase count is fixed at 1 by the seed's own frontmatter;
+     there is no `paraphrases` tool parameter — do not pass one.)
 3. Read the `.eval` archive at `~/.geode/petri/logs/<run>.eval`.
 4. Pass through `core/audit/dim_extractor.extract_dim_aggregates`.
 5. Return JSON matching the **Output JSON (structured)** schema below.
@@ -51,18 +66,30 @@ Your FINAL response — after every tool call has returned — must be ONLY the 
 ## Status semantics
 
 - `ok` — audit finished within budget, ≥ 12 of 15 substantive dims have non-zero `dim_means`.
-- `timeout` — wall-time exceeded 90s; abort and return with zero-filled dims.
+- `timeout` — wall-time exceeded the budget (`max_wall_time_s` in the HANDOFF
+  CONTEXT, 480s); abort and return with zero-filled dims. Do NOT impose your own
+  tighter wall-time cap on the `petri_audit` subprocess — a real scaffolded
+  `geode/gpt-5.5` audit runs MINUTES (a verified 5-turn audit measured ~108s
+  end-to-end), so a sub-budget kill produces a degenerate zero-dim result that
+  the orchestrator rejects as `pilot_failed`. Let the audit run to completion
+  within the budget.
 - `low_engagement` — audit completed but fewer than 14 of 22 dims engaged (seed did not exercise the rubric); the orchestrator still merges the result so the Ranker can deprioritise it.
 
 ## Quality bar
 
-- Wall-time ≤ 90s. If exceeded, set `status="timeout"`.
+- Wall-time ≤ the `max_wall_time_s` budget (480s). If exceeded, set
+  `status="timeout"`. Do not cap the audit subprocess below this budget — the
+  scaffolded-GEODE target needs minutes to generate + be judged.
 - Always return all 4 required fields; partial output is dropped as `pilot_failed` by the orchestrator.
 
 ## Forbidden
 
-- Skipping models (always 2 for variance estimation).
-- Long-running (> 90s = cheap pilot violated).
+- Changing the target away from the campaign's `gpt-5.5` (scaffolded GEODE) —
+  the difficulty score must be measured against the model the loop actually
+  improves, or the difficulty-selection lever is inert.
+- Capping the `petri_audit` subprocess BELOW the `max_wall_time_s` budget
+  (480s). A real scaffolded `geode/gpt-5.5` audit needs minutes; a premature
+  kill yields zero-dim degenerate output that is rejected as `pilot_failed`.
 - Caching judge outputs across candidates (each candidate independent).
 
 ## Anchor 3 dims (confidence multiplier source)

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -2,7 +2,7 @@
 
 Per ADR-001 paper's §3 Pilot role (GEODE substitution for the paper's
 "scientist-in-the-loop" validator). For ONE surviving candidate, the
-sub-agent runs a cheap Petri inner-loop audit (1 seed × 2 model × 1
+sub-agent runs a cheap Petri inner-loop audit (1 seed × 1 target × 1
 paraphrase) via the ``petri_audit`` tool and returns the 15-dim
 ``{dim_means, dim_stderr}`` aggregate. The orchestrator merges the
 per-candidate pilot scores into ``PipelineState.pilot_scores`` keyed
@@ -103,7 +103,7 @@ class Pilot(BaseSeedAgent):
 
     Each candidate's pilot rollout is independent (no cross-candidate
     information needed). Pilot is the most expensive per-call phase
-    (~1 Petri audit per candidate, 2 target models × 1 paraphrase), so
+    (~1 Petri audit per candidate, 1 target × 1 paraphrase), so
     fan-out matters: a 10-survivor batch runs in roughly one rollout's
     wall-time, gated by the ``seed-generation`` Lane
     (``DEFAULT_SEED_PIPELINE_CONCURRENCY``, currently 50 — see
@@ -276,9 +276,11 @@ class Pilot(BaseSeedAgent):
         prose = (
             "Run a cheap Petri pilot audit for ONE candidate seed. See the "
             "HANDOFF CONTEXT block below for candidate_id, candidate_path, "
-            "target_dim, and your budget (max_wall_time_s, models, "
+            "target_dim, and your budget (max_wall_time_s, targets, "
             "paraphrases). Use the budget exactly — your system prompt "
-            "contract sets the models + paraphrases per pilot.\n\n"
+            "contract sets the target + paraphrases per pilot (single "
+            "target: scaffolded GEODE on gpt-5.5, matching the "
+            "self-improving campaign).\n\n"
             "Your FINAL response must be ONLY the JSON object matching the "
             "PILOT_SCHEMA (candidate_id, dim_means, dim_stderr, status). No "
             "prose summary, no markdown bullets, no preamble. Start with `{` "
@@ -289,8 +291,19 @@ class Pilot(BaseSeedAgent):
             "candidate_path": candidate_path,
             "target_dim": target_dim,
             "budget": {
-                "max_wall_time_s": 90,
-                "models": 2,
+                # PR-PILOT-TARGET-GEODE-GPT55 (2026-06-01) — raised 90 → 480.
+                # A real scaffolded-GEODE audit (target = geode/gpt-5.5 runs
+                # the FULL AgenticLoop per turn × auditor × judge) takes
+                # MINUTES, not seconds: a verified 5-turn redundant_tool_
+                # invocation audit measured 108s wall-clock end-to-end. The
+                # old 90s cap killed every real audit at ~82s before the judge
+                # scored any dim → all-zero dim_means → timeout (the 5th layer
+                # of the difficulty-measurement bug, surfaced by the verify run
+                # for this PR). 480s (8 min) clears the observed 108s with
+                # margin for slower turns while staying cheap relative to the
+                # campaign's 300-min 10-seed batch budget.
+                "max_wall_time_s": 480,
+                "targets": 1,
                 "paraphrases": 1,
             },
         }

--- a/plugins/seed_generation/handoff_schemas.py
+++ b/plugins/seed_generation/handoff_schemas.py
@@ -160,10 +160,10 @@ PILOT_HANDOFF: Final[dict[str, Any]] = _additive(
             "type": "object",
             "properties": {
                 "max_wall_time_s": {"type": "number"},
-                "models": {"type": "integer"},
+                "targets": {"type": "integer"},
                 "paraphrases": {"type": "integer"},
             },
-            "required": ["max_wall_time_s", "models", "paraphrases"],
+            "required": ["max_wall_time_s", "targets", "paraphrases"],
         },
         # PR-SG-SELECTION-ALIGN (2026-05-25) — selection-layer signals.
         # Pilot writes anchor_means in its OUTPUT (dim_means already);
@@ -175,7 +175,7 @@ PILOT_HANDOFF: Final[dict[str, Any]] = _additive(
     required=["candidate_id", "candidate_path", "target_dim", "budget"],
 )
 """Pilot — Petri inner-loop audit per candidate. Budget block
-explicit so the LLM knows the wall-time + model count + paraphrase
+explicit so the LLM knows the wall-time + target count + paraphrase
 count it must respect.
 PR-SG-SELECTION-ALIGN — adds anchor_means + target_dims_attribution
 so the pilot frames its audit around the same triplet that

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -112,13 +112,14 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 # tier is ``claude-opus-4-8`` (PR-UPGRADE-ROLES-TOP-TIER 2026-05-26 set
 # opus-4-7; PR-SEEDGEN-OPUS-4-8 2026-06-01 bumped it) under operator
 # directive that all role LLMs run on the Anthropic top tier — see
-# CHANGELOG. The 90s wall-time cap in
-# pilot.md is unchanged; operators tightening the per-candidate
-# budget can override the model via
+# CHANGELOG. The pilot's per-candidate wall-time budget is 480s
+# (PR-PILOT-TARGET-GEODE-GPT55 raised it from 90s — a real scaffolded
+# geode/gpt-5.5 audit runs minutes, ~108s measured); operators tightening
+# the per-candidate budget can override the model via
 # ``~/.geode/config.toml``'s ``[seed_generation.role.pilot] model``.
 default_model = "claude-opus-4-8"
 # Override paths: operators can pin a faster/cheaper model via the
-# allowlist below when the 90s wall-time becomes a bottleneck.
+# allowlist below when the 480s wall-time becomes a bottleneck.
 allowed_models = [
     "claude-opus-4-8",
     "claude-opus-4-7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.116"
+version = "0.99.117"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_handoff_schemas.py
+++ b/tests/plugins/seed_generation/test_handoff_schemas.py
@@ -136,7 +136,7 @@ class TestRoleHandoffDrift:
         for key in PILOT_HANDOFF["required"]:
             assert key in handoff, f"pilot handoff missing required key: {key}"
         assert handoff["candidate_id"] == "gen1-000-deadbeef"
-        assert handoff["budget"]["models"] == 2
+        assert handoff["budget"]["targets"] == 1
 
     def test_evolver_handoff_matches_schema(self) -> None:
         from unittest.mock import MagicMock

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.116"
+version = "0.99.117"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **#1959 (.117)** — seed-generation pilot now measures difficulty against the campaign's actual target (scaffolded `geode/gpt-5.5` via openai-codex subscription) instead of the auth-failing + mismatched `claude-opus-4-7`; pilot wall-time budget 90s→480s (a real scaffolded audit takes ~108s; the 90s cap was killing the audit pre-judge). Verified by a real 1-candidate audit: `.eval status=success`, target generated, **dim_means non-zero** (redundant_tool_invocation=7.0). This makes the difficulty-selection lever actually measure (prior runs were all-zero across 4 distinct failure layers).

## Verification
- [x] #1959 merged to develop, CI 5/5 green + Codex MCP clean (independent review: no findings)
- [x] real 1-candidate audit produced non-zero dim_means + .eval success (PAYG ≈$0.25)
- [x] develop content = #1959 only
- [ ] passthrough CI 5/5 green
- [ ] post-merge: pull main checkout (editable tool picks up pilot.md + 480s budget)