### PR TITLE
fix(campaign): load ~/.geode/.env at audit entry — PAYG auditor/judge auth (v0.99.118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,28 @@ functional change.
 
 ---
 
+## [0.99.118] - 2026-06-02
+
+### Fixed
+- **PR-CAMPAIGN-LOAD-ENV (2026-06-02) — the campaign/audit subprocess chain now
+  loads `~/.geode/.env`, so the PAYG `ANTHROPIC_API_KEY` reaches the petri
+  auditor/judge.** Only `geode serve` + the REPL called
+  `setup_contextvars(load_env=True)`; the campaign chain
+  (`campaign.py` → `train.py` → `geode audit` → `inspect eval`) never loaded the
+  env file, so the api_key-sourced anthropic auditor/judge
+  (`[self_improving_loop.petri.{auditor,judge}] source=api_key`) found no
+  credential and inspect_ai's native anthropic provider raised "Could not
+  resolve authentication method" during the auditor's token-count step → every
+  cycle audit errored → degenerate gen-0 baseline (2 dims, no fitness). The
+  seed-generation **pilot** path was unaffected because it runs INSIDE the serve
+  daemon, whose `os.environ` already had the key — which is why pilot audits
+  succeeded while campaign cycle audits failed with the identical role binding.
+  New `core.self_improving.train._load_global_env()` (shared by `train.main` +
+  `campaign.main`) loads the global env with `override=False` (an
+  already-exported shell key still wins). The stale campaign docstring that made
+  this the operator's shell responsibility is corrected. Pinned by
+  `tests/test_autoresearch_train.py::test_load_global_env_*`.
+
 ## [0.99.117] - 2026-06-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.117
+- **Version**: 0.99.118
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.117 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.118 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.117 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.118 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -42,10 +42,14 @@ every boundary with mocks and NO live audit / network / PAYG spend. ``--dry-run`
 passes the flag through to ``train.py`` AND to the runner (``rerun_dry_run=True``)
 so the whole chain can be smoke-tested end-to-end with synthetic audits.
 
-ENV SETUP (operator handoff)
-----------------------------
-The operator's shell wrapper is responsible for exporting ``ANTHROPIC_API_KEY``
-(the driver cannot source ``~/.geode/.env`` from inside Python). The driver sets,
+ENV SETUP
+---------
+PR-CAMPAIGN-LOAD-ENV (2026-06-02): the driver now loads ``~/.geode/.env`` itself
+(``main`` → ``train._load_global_env``), so ``ANTHROPIC_API_KEY`` reaches the
+spawned audit subprocesses without the operator's shell having to export it.
+(Pre-fix this was the operator's responsibility; a forgotten export silently
+broke every cycle audit with an anthropic auth error → degenerate baseline.) An
+already-exported shell key still wins (``override=False``). The driver also sets,
 in the env it passes to each subprocess:
 
 * ``GEODE_CODEX_OAUTH_POLL_DISABLED=1`` — bypass GEODE's pre-emptive 5-hour
@@ -1282,6 +1286,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    # PR-CAMPAIGN-LOAD-ENV (2026-06-02) — load ~/.geode/.env so the spawned
+    # train.py audit subprocesses inherit the PAYG ANTHROPIC_API_KEY. train.py's
+    # own main() also loads it (defence in depth for direct ``python -m
+    # core.self_improving.train`` runs), but loading at the driver too means the
+    # key is present from the first gen-0 spawn without relying on the operator's
+    # shell having exported it.
+    from core.self_improving.train import _load_global_env
+
+    _load_global_env()
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
     arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())

--- a/core/self_improving/train.py
+++ b/core/self_improving/train.py
@@ -205,6 +205,29 @@ Resolved by :func:`_resolve_target_effect_size`."""
 WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 
 
+def _load_global_env() -> bool:
+    """Load ``~/.geode/.env`` into ``os.environ`` (``override=False``).
+
+    PR-CAMPAIGN-LOAD-ENV (2026-06-02). The campaign/audit entry points run as
+    standalone subprocesses that never went through ``geode serve`` / the REPL
+    bootstrap (the only callers of ``setup_contextvars(load_env=True)``), so the
+    PAYG ``ANTHROPIC_API_KEY`` used by the api_key-sourced petri auditor/judge
+    was absent and inspect_ai's anthropic provider raised "Could not resolve
+    authentication method". Loading the global env file here gives the audit
+    subprocess the same credential the serve daemon already has.
+    ``override=False`` so a key already exported in the launching shell wins.
+    Returns whether the file was found (for the dry-run log line).
+    """
+    from core.paths import GLOBAL_ENV_FILE
+
+    if not GLOBAL_ENV_FILE.exists():
+        return False
+    from dotenv import load_dotenv
+
+    load_dotenv(str(GLOBAL_ENV_FILE), override=False)
+    return True
+
+
 def _get_autoresearch_config() -> Any:
     """Lazily load ``[self_improving_loop.autoresearch]`` from ``~/.geode/config.toml``.
 
@@ -4043,6 +4066,20 @@ def _revert_sot_after_reject(
 
 
 def main() -> int:
+    # PR-CAMPAIGN-LOAD-ENV (2026-06-02) — load ~/.geode/.env into os.environ at the
+    # campaign/audit entry point. Only ``geode serve`` + the REPL called
+    # ``setup_contextvars(load_env=True)``; the campaign chain
+    # (``campaign.py`` → ``train.py`` → ``geode audit`` → ``inspect eval``) never
+    # did, so the PAYG ``ANTHROPIC_API_KEY`` (config ``[self_improving_loop.petri.
+    # {auditor,judge}] source=api_key``) was absent in the spawned audit
+    # subprocess → inspect_ai's native anthropic provider raised "Could not
+    # resolve authentication method" → every cycle audit errored → degenerate
+    # baseline. The pilot path worked only because it runs INSIDE the serve
+    # daemon, whose os.environ already had the key. ``override=False`` so an
+    # already-exported shell key still wins; loading ``.env`` directly (not the
+    # full ``setup_contextvars``) avoids its unrelated memory/contextvar setup.
+    _load_global_env()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--dry-run",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.117"
+version = "0.99.118"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -2422,3 +2422,39 @@ def test_results_paths_follow_baseline_path_monkeypatch(
     tsv_path, jsonl_path = auto_train._results_paths()
     assert tsv_path == state_dir / "results.tsv"
     assert jsonl_path == state_dir / "results.jsonl"
+
+
+def test_load_global_env_populates_os_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-CAMPAIGN-LOAD-ENV: the campaign/audit entry loads ~/.geode/.env so the
+    PAYG ANTHROPIC_API_KEY reaches the spawned audit subprocess (the bug that made
+    every cycle audit error → degenerate baseline). ``override=False`` so an
+    already-exported shell key wins."""
+    import os
+
+    import core.paths as core_paths
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("ANTHROPIC_API_KEY=sk-ant-from-env-file\n", encoding="utf-8")
+    monkeypatch.setattr(core_paths, "GLOBAL_ENV_FILE", env_file)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    assert auto_train._load_global_env() is True
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-from-env-file"
+
+    # override=False — a key already in the shell env is NOT clobbered.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-shell")
+    auto_train._load_global_env()
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-from-shell"
+
+
+def test_load_global_env_missing_file_is_false_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ~/.geode/.env → returns False, no raise (a fresh box without the file
+    still runs; the key may come from the shell env instead)."""
+    import core.paths as core_paths
+
+    monkeypatch.setattr(core_paths, "GLOBAL_ENV_FILE", tmp_path / "nonexistent.env")
+    assert auto_train._load_global_env() is False

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.117"
+version = "0.99.118"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- The self-improving campaign's audit subprocess chain now loads `~/.geode/.env` (shared `_load_global_env()`, called by `train.main` + `campaign.main`), so the PAYG `ANTHROPIC_API_KEY` reaches the api_key-sourced petri auditor/judge.

## Why
A diagnostic campaign produced cycle audit `.eval`s with `status=error`: `"Could not resolve authentication method"` (auditor=anthropic/claude-opus-4-8), model_usage empty → degenerate gen-0 baseline (2 dims, no fitness). The seed-generation **pilot** (same machine/session, same role binding) SUCCEEDED. **Two independent agents (a diagnosis agent + a raw-evidence agent reading `.eval`/config blind) converged with no discrepancy**: only `geode serve` + the REPL call `setup_contextvars(load_env=True)`; the campaign chain (`campaign.py` → `train.py` → `geode audit` → `inspect eval`) never loaded the env file, so the anthropic auditor had no key in the spawned subprocess. The pilot worked only because it runs INSIDE the serve daemon (env already in `os.environ`). `--use-oauth` was a red herring — the per-role `source=api_key` correctly overrides it; the key was simply absent.

## Changes
| File | Change |
|------|--------|
| `core/self_improving/train.py` | new `_load_global_env()` helper + call at `main()` entry |
| `core/self_improving/campaign.py` | `main()` calls `_load_global_env()`; stale "operator must export" docstring corrected |
| `tests/test_autoresearch_train.py` | `test_load_global_env_*` (populates os.environ; override=False; missing-file no-op) |
| CHANGELOG / pyproject / CLAUDE / README(.ko) | v0.99.117 → v0.99.118 |

## Verification
- [x] ruff check core/tests/plugins/scripts clean; ruff format --check clean; mypy 471 clean
- [x] new env-load tests pass; full test_autoresearch_train.py green
- [ ] CI 5/5 green + Codex MCP
- [ ] post-merge: campaign re-launch produces non-degenerate gen-0 (cycle .eval status=success, dim_means populated)

## Reference
2-agent cross-check (report+inspect) per operator's anti-deception directive. The degenerate baseline + all-error cycle .evals from the diagnostic run were the symptom.