### PR TITLE
feat(seed-generation): pilot 3-sample difficulty (rank by mean not variance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.120] - 2026-06-02
+
+### Changed
+- **PR-PILOT-MULTISAMPLE (2026-06-02) — the seed-generation difficulty pilot now
+  measures `seeds = 3` (3 rollouts per candidate) instead of 1.** `rank_by_difficulty`
+  was ranking candidates by a single-sample draw, so it selected high-VARIANCE seeds
+  (lucky tails) rather than high-MEAN ones — gen-2606-i1-012 read 7 on its one pilot
+  sample but averaged 2.4±0.98 over a 5-sample re-measure. Ranking by a 3-sample mean
+  selects genuinely-hard scenarios. The pilot wall-time budget (`pilot.py`
+  `max_wall_time_s`) is raised 480→960s to fit the 3 sequential rollouts
+  (~3×108s + judge) at `max_connections=1`.
+
 ## [0.99.119] - 2026-06-02
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.119
+- **Version**: 0.99.120
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.119 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.120 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.119 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.120 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/agents/pilot.md
+++ b/plugins/seed_generation/agents/pilot.md
@@ -17,7 +17,9 @@ For ONE candidate seed, run a cheap Petri audit (1 seed × 1 target × 1 paraphr
    ACTUAL schema — pass them exactly, not a renamed/list variant):
    - `seed_select = "<absolute candidate_path>"` — the single candidate `.md`
      path (NOT `seeds=[...]`; the tool's `seeds` is the integer sample count).
-   - `seeds = 1` — sample count (one rollout for this one candidate).
+   - `seeds = 3` — sample count (THREE rollouts for this one candidate, so the
+     reported `dim_means` is a 3-sample mean, not a single high-variance draw;
+     `rank_by_difficulty` must rank by the central estimate, not a lucky tail).
    - `target = "gpt-5.5"` — the SAME target the self-improving campaign
      optimizes: scaffolded GEODE on gpt-5.5. The `petri_audit` tool
      auto-wraps it as `geode/gpt-5.5`, routing the full GEODE AgenticLoop

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -299,10 +299,18 @@ class Pilot(BaseSeedAgent):
                 # old 90s cap killed every real audit at ~82s before the judge
                 # scored any dim → all-zero dim_means → timeout (the 5th layer
                 # of the difficulty-measurement bug, surfaced by the verify run
-                # for this PR). 480s (8 min) clears the observed 108s with
-                # margin for slower turns while staying cheap relative to the
-                # campaign's 300-min 10-seed batch budget.
-                "max_wall_time_s": 480,
+                # for this PR).
+                #
+                # PR-PILOT-MULTISAMPLE (2026-06-02) — raised 480 → 960. The
+                # pilot now measures ``seeds = 3`` (pilot.md) so
+                # ``rank_by_difficulty`` ranks candidates by a 3-sample MEAN
+                # rather than a single-sample draw — a single N=1 pilot ranked
+                # by a lucky high-variance tail (gen-2606-i1-012 read 7 on its
+                # one sample but averaged 2.4±0.98 over 5). At max_connections=1
+                # the 3 samples run sequentially (~3 × 108s ≈ 324s + judge), so
+                # the cap is tripled-with-margin to 960s (16 min); still cheap
+                # vs the campaign's 300-min batch budget.
+                "max_wall_time_s": 960,
                 "targets": 1,
                 "paraphrases": 1,
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.119"
+version = "0.99.120"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Seed-gen difficulty pilot now measures `seeds = 3` (was 1), so `rank_by_difficulty` ranks candidates by a 3-sample MEAN instead of a single high-variance draw.
- Pilot wall-time budget 480→960s to fit 3 sequential rollouts.

## Why
The i1-012 canary exposed the flaw: it read `broken=7 / input=6` on its single pilot sample but a 5-sample re-measure gave `2.4±0.98 / 3.0±1.26` — the pilot was selecting variance tails as "hard" seeds. Ranking by a 3-sample mean fixes the selection signal before the (가) harder-seed-generation run.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/agents/pilot.md` | `seeds = 1` → `seeds = 3` + rationale |
| `plugins/seed_generation/agents/pilot.py` | `max_wall_time_s` 480 → 960 (3 sequential rollouts) |

## Verification
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/plugins/seed_generation/` — 695 passed, 3 skipped (test_pilot 16/16)
- [x] No test pinned seeds=1 / 480

## Reference
i1-012 reproducibility canary (2026-06-02); difficulty-selection #1950.
🤖 Generated with [Claude Code](https://claude.com/claude-code)