### PR TITLE
feat(self-improving): guard seed-pool target_dims against live dim taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ functional change.
 
 ---
 
+## [0.99.121] - 2026-06-03
+
+### Added
+- **PR-POOL-DIM-GUARD (2026-06-03) — seed-pool `target_dims` validation against the
+  live dim taxonomy, wired into `run_campaign` start.** A held-out pool generated
+  before a dim removal (the `redundant_tool_invocation` staleness after
+  PR-DROP-ANALYTICS-DIMS) kept targeting a dim the loop no longer scores: the audits
+  probed a removed dimension, held-out fitness sat pinned near the floor, and the
+  promote gate rejected every cycle for a measurement reason that previously ran
+  silently. `plugins/petri_audit/pool_validation.py::validate_pool_target_dims` reads
+  each seed's frontmatter `target_dims` (reusing `manifest.py`'s `---`/`yaml.safe_load`
+  split — no second parser) and reports any dim not in the live `AXIS_TIERS`. The
+  campaign now HALTs on a stale held-out pool (the comparison ruler is invalid) and
+  warns on a stale selection pool. Verified against the live held-out pool: 10/10
+  seeds flagged (`redundant_tool_invocation`) → HALT. 6 guard tests in
+  `tests/test_pool_validation.py`.
+
+---
+
 ## [0.99.120] - 2026-06-02
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.120
+- **Version**: 0.99.121
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.120 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.121 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.120 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.121 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -1178,6 +1178,33 @@ def run_campaign(
             f"campaign start: n={n} k={k} arms={list(arms)} dry_run={dry_run} "
             f"audit_max_samples={audit_max_samples} audit_max_connections={audit_max_connections}"
         )
+        # PR-POOL-DIM-GUARD (2026-06-03) — fail loud on a seed pool that targets a
+        # dim no longer in the live taxonomy. The held-out pool is the ruler the
+        # gate is judged against; if it targets a removed dim (the
+        # ``redundant_tool_invocation`` staleness after PR-DROP-ANALYTICS-DIMS),
+        # the audits probe a dimension the loop no longer scores, the held-out
+        # fitness sits pinned near the floor, and the gate rejects every cycle for
+        # a measurement reason — an invalid experiment that previously ran
+        # silently. A stale HELD-OUT HALTs (regenerate before measuring); a stale
+        # SELECTION only warns (the optimizer wastes effort on a dead dim, but the
+        # comparison ruler is still sound).
+        from plugins.petri_audit.pool_validation import validate_pool_target_dims
+        from core.self_improving.train import AXIS_TIERS
+
+        _live_dims = frozenset(AXIS_TIERS)
+        _held_stale = validate_pool_target_dims(HELD_OUT_BENCH, _live_dims)
+        if _held_stale:
+            raise RuntimeError(
+                f"held-out pool {HELD_OUT_BENCH} targets non-live dims {_held_stale} — "
+                "stale bench (the ruler probes a removed/unknown dim). Regenerate the "
+                "held-out pool against the live dim taxonomy before running. HALT."
+            )
+        _sel_stale = validate_pool_target_dims(CYCLE_INPUT_POOL, _live_dims)
+        if _sel_stale:
+            progress.emit(
+                f"WARN: selection pool {CYCLE_INPUT_POOL} targets non-live dims "
+                f"{_sel_stale} (stale targeting — optimizer effort wasted on a dead dim)"
+            )
         # FIX 2 — purge inspect_ai's trajectory cache at the start of a REAL
         # campaign so the K gen-0 measures + all cycle audits are independent
         # re-measures, not replays of a stale cached trajectory (the cache at

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -1189,6 +1189,7 @@ def run_campaign(
         # SELECTION only warns (the optimizer wastes effort on a dead dim, but the
         # comparison ruler is still sound).
         from plugins.petri_audit.pool_validation import validate_pool_target_dims
+
         from core.self_improving.train import AXIS_TIERS
 
         _live_dims = frozenset(AXIS_TIERS)

--- a/plugins/petri_audit/pool_validation.py
+++ b/plugins/petri_audit/pool_validation.py
@@ -1,0 +1,87 @@
+"""Validate that a seed pool's ``target_dims`` reference only LIVE judge dims.
+
+Why this exists: a seed pool generated against an older dim taxonomy can keep
+targeting a dimension that has since been removed (e.g.
+``redundant_tool_invocation`` after PR-DROP-ANALYTICS-DIMS). Nothing previously
+caught that — the stale scenarios were audited silently, the removed dim was
+never scored, and the held-out fitness sat pinned near the floor because the
+ruler probed a dimension the loop no longer measures. The campaign then read a
+*structurally immovable* held-out and rejected every cycle for a measurement
+reason, not a behaviour one.
+
+This module makes the drift loud: it reads each seed's ``target_dims`` from the
+YAML frontmatter (same ``--- ... ---`` split + ``yaml.safe_load`` that
+``manifest.py`` uses — no second parser) and reports any dim that is not in the
+caller-supplied LIVE dim set. The campaign HALTs on a stale held-out pool and
+warns on a stale selection pool.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+
+def _seed_target_dims(seed_md: Path) -> list[str]:
+    """Parse one seed's ``target_dims`` from its YAML frontmatter.
+
+    Mirrors ``manifest.py``'s frontmatter read: split on ``---`` and
+    ``yaml.safe_load`` the first block. Returns ``[]`` when the file has no
+    frontmatter, no ``target_dims`` key, or a malformed block (a bad seed must
+    not crash validation — it is simply reported as carrying no targeted dims).
+    """
+    try:
+        text = seed_md.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    parts = text.split("---")
+    # Anchor: frontmatter must open the file. If anything precedes the first
+    # ``---`` then the ``---`` are body separators, not a frontmatter fence, and
+    # the YAML-like block between them must not be mistaken for frontmatter
+    # (Codex MCP review).
+    if len(parts) < 3 or parts[0].strip():
+        return []
+    try:
+        front = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return []
+    if not isinstance(front, dict):
+        return []
+    raw = front.get("target_dims") or []
+    if isinstance(raw, str):
+        raw = [raw]
+    elif not isinstance(raw, (list, tuple)):
+        # A YAML scalar (e.g. ``target_dims: 123``) is malformed — a bad seed
+        # must not crash validation, so treat it as carrying no targeted dims.
+        return []
+    return [str(d).strip() for d in raw if str(d).strip()]
+
+
+def validate_pool_target_dims(
+    pool_dir: Path | str, live_dims: Iterable[str]
+) -> dict[str, list[str]]:
+    """Return ``{seed_filename: [offending dims]}`` for seeds whose
+    ``target_dims`` reference a dim NOT in ``live_dims``.
+
+    An empty result means the pool is aligned with the live taxonomy. ``live_dims``
+    is the authoritative current judge/fitness dim set (the caller supplies it so
+    this stays decoupled from any one dim-source module). A missing/unreadable
+    pool dir yields ``{}`` (nothing to flag) — the path-existence check is the
+    caller's separate concern (``_validate_seed_select_path``).
+    """
+    live = frozenset(live_dims)
+    pool = Path(pool_dir)
+    offending: dict[str, list[str]] = {}
+    if not pool.is_dir():
+        return offending
+    # ``rglob`` (not ``glob``) so a hierarchical seed tree — which the seed-select
+    # contract supports via ``flatten_for_inspect_petri`` — cannot hide a stale
+    # seed in a subdir and bypass the guard (Codex MCP review). The relative path
+    # is the key so nested seeds stay distinguishable.
+    for seed_md in sorted(pool.rglob("*.md")):
+        stale = [d for d in _seed_target_dims(seed_md) if d not in live]
+        if stale:
+            offending[str(seed_md.relative_to(pool))] = stale
+    return offending

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.120"
+version = "0.99.121"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_pool_validation.py
+++ b/tests/test_pool_validation.py
@@ -1,0 +1,76 @@
+"""Guard tests for :func:`plugins.petri_audit.pool_validation.validate_pool_target_dims`.
+
+Pins the invariant that a seed pool may only target LIVE judge dims, so a future
+dim removal that orphans a pool (the ``redundant_tool_invocation`` incident,
+2026-06-03) fails loudly instead of silently auditing a removed dim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.petri_audit.pool_validation import validate_pool_target_dims
+
+LIVE = frozenset({"stuck_in_loops", "input_hallucination", "broken_tool_use"})
+
+
+def _seed(pool: Path, name: str, target_dims: str) -> None:
+    pool.joinpath(name).write_text(
+        f"---\nname: {name}\ntarget_dims: {target_dims}\n---\nscenario body\n",
+        encoding="utf-8",
+    )
+
+
+def test_aligned_pool_passes(tmp_path: Path) -> None:
+    _seed(tmp_path, "a.md", "[stuck_in_loops]")
+    _seed(tmp_path, "b.md", "[input_hallucination]")
+    assert validate_pool_target_dims(tmp_path, LIVE) == {}
+
+
+def test_removed_dim_flagged(tmp_path: Path) -> None:
+    _seed(tmp_path, "stale.md", "[redundant_tool_invocation]")
+    _seed(tmp_path, "ok.md", "[stuck_in_loops]")
+    assert validate_pool_target_dims(tmp_path, LIVE) == {"stale.md": ["redundant_tool_invocation"]}
+
+
+def test_string_form_target_dims(tmp_path: Path) -> None:
+    _seed(tmp_path, "s.md", "redundant_tool_invocation")
+    assert validate_pool_target_dims(tmp_path, LIVE) == {"s.md": ["redundant_tool_invocation"]}
+
+
+def test_no_frontmatter_is_safe(tmp_path: Path) -> None:
+    tmp_path.joinpath("plain.md").write_text("no frontmatter at all", encoding="utf-8")
+    assert validate_pool_target_dims(tmp_path, LIVE) == {}
+
+
+def test_missing_dir_is_safe(tmp_path: Path) -> None:
+    assert validate_pool_target_dims(tmp_path / "does-not-exist", LIVE) == {}
+
+
+def test_multiple_dims_partial_offending(tmp_path: Path) -> None:
+    _seed(tmp_path, "mix.md", "[stuck_in_loops, verbose_padding]")
+    assert validate_pool_target_dims(tmp_path, LIVE) == {"mix.md": ["verbose_padding"]}
+
+
+def test_nested_pool_is_scanned(tmp_path: Path) -> None:
+    # rglob: a stale seed in a subdir must NOT bypass the guard (Codex MCP).
+    sub = tmp_path / "tier" / "dim"
+    sub.mkdir(parents=True)
+    _seed(sub, "deep.md", "[redundant_tool_invocation]")
+    out = validate_pool_target_dims(tmp_path, LIVE)
+    assert out == {"tier/dim/deep.md": ["redundant_tool_invocation"]}
+
+
+def test_body_separators_not_misread_as_frontmatter(tmp_path: Path) -> None:
+    # `---` appearing in the BODY (no opening fence) must not be parsed as
+    # frontmatter and trigger a false stale flag.
+    tmp_path.joinpath("body.md").write_text(
+        "scenario intro\n---\ntarget_dims: [redundant_tool_invocation]\n---\nmore body\n",
+        encoding="utf-8",
+    )
+    assert validate_pool_target_dims(tmp_path, LIVE) == {}
+
+
+def test_scalar_target_dims_does_not_crash(tmp_path: Path) -> None:
+    _seed(tmp_path, "scalar.md", "123")  # YAML int scalar, not a list/str
+    assert validate_pool_target_dims(tmp_path, LIVE) == {}


### PR DESCRIPTION
## Summary
- New `validate_pool_target_dims` flags seeds whose frontmatter `target_dims` reference a dim not in the live `AXIS_TIERS`, wired into `run_campaign` start.
- Held-out pool stale → **HALT** (the ruler is invalid); selection pool stale → **WARN**.

## Why
A held-out pool generated before a dim removal kept targeting `redundant_tool_invocation` (dropped in PR-DROP-ANALYTICS-DIMS). The held-out audits probed a removed dim, held-out fitness sat pinned near the floor, and the promote gate rejected every cycle for a **measurement** reason — silently. The campaign's comparison ruler was invalid and nothing caught it. (Diagnosed 2026-06-03 mid-campaign; the live held-out pool flags 10/10 seeds.)

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/pool_validation.py` | NEW — `validate_pool_target_dims(pool_dir, live_dims)`; frontmatter parse reuses `manifest.py`'s `---`/`yaml.safe_load` split; `rglob` for nested pools; frontmatter anchored to file start; scalar `target_dims` handled without crashing |
| `core/self_improving/campaign.py` | `run_campaign` start: HALT on stale held-out, WARN on stale selection |
| `tests/test_pool_validation.py` | NEW — 9 tests (aligned/removed-dim/string/scalar/no-frontmatter/missing-dir/partial/nested/body-separators) |
| `CHANGELOG.md` + 4 version files | 0.99.120 → 0.99.121 |

## Verification
- [x] ruff check clean (isolated)
- [x] mypy clean
- [x] pytest 9/9 pass
- [x] verified live held-out pool → 10/10 seeds flagged → HALT
- [x] Codex MCP review (3 findings: nested-pool glob→rglob, frontmatter anchor, scalar TypeError — all fixed)

## Reference
Mid-campaign diagnosis 2026-06-03 — held-out↔live-dim drift (measurement-validity, distinct from F16 near-saturation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)