### PR TITLE
release: openai_source single entry point → main (v0.99.122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,20 +49,31 @@ functional change.
 
 ### Added
 - **PR-OPENAI-SOURCE-SINGLE-ENTRY (2026-06-03) — single `[self_improving_loop] openai_source`
-  knob for the OpenAI-role credential lane.** The OpenAI surface of the self-improving loop
-  spans three sources that each drive a distinct consumer — `autoresearch.source` (the
-  `geode audit` subprocess's `--use-oauth` flag, `core/self_improving/train.py`),
-  `autoresearch.target.source` (the petri `target` adapter via
-  `plugins.petri_audit.registry.get_binding`), and `autoresearch.mutator.source` (the
-  in-process mutator LLM, `core/self_improving/loop/runner.py`). Keeping the three in sync by
-  hand is a silent-drift trap, so `SelfImprovingLoopConfig.openai_source` fans one value out
-  to all three at config-load time (`_propagate_openai_source`): `"openai-codex"` → ChatGPT
-  subscription OAuth (per-minute rate-limited), `"api_key"` → OpenAI PAYG (api.openai.com, no
-  per-minute cap). Anthropic roles (`auditor` / `judge`) are never touched. A per-role
-  `source` explicitly set to a *different* value raises (ambiguous config — fail loud, not
-  silent divergence). 8 tests including a cross-module parity test that drives
-  `read_role_override("target")` end-to-end so the knob can never become a half-disconnected
-  config field.
+  knob for the OpenAI credential lane.** Moving the self-improving loop's OpenAI roles between
+  the ChatGPT subscription (per-minute rate-limited) and OpenAI PAYG (api.openai.com, no
+  per-minute cap) used to mean editing three scattered `source` fields that each feed a
+  different consumer — `autoresearch.source` (the `geode audit` subprocess's `--use-oauth`
+  flag, `core/self_improving/train.py`), `autoresearch.target.source` (the petri `target`
+  adapter via `plugins.petri_audit.registry.get_binding`), and `autoresearch.mutator.source`
+  (the in-process mutator LLM, `core/self_improving/loop/runner.py`). `SelfImprovingLoopConfig.openai_source`
+  fans one value out to all three at config-load time (`_propagate_openai_source`); accepted
+  values are restricted to `"openai-codex"` / `"api_key"` (`_openai_source_is_openai_lane`).
+  It is **authoritative** — an explicit per-role `source` set to a different value is
+  superseded with a `UserWarning` (not a swallowed `ValidationError`), so the resolved lane is
+  deterministic even on the `read_role_override` path that gracefully degrades on validation
+  errors. **Scope**: the three autoresearch roles only — Anthropic `auditor` / `judge` carry
+  their own source, and the `[self_improving_loop.seed_generation]` voters pin theirs in the
+  seed-generation manifest (separate surfaces by design).
+
+### Fixed
+- **Mutator dispatch now honours an explicit `api_key` source.** `core/self_improving/loop/runner.py:_default_llm_call`'s
+  API path called `infer_source(provider)` unconditionally (PR-SOURCE-ROUTING, 2026-05-28), so
+  an explicit `api_key` mutator source was silently re-derived back to the subscription lane
+  whenever an OpenAI OAuth profile was present — half-defeating the `openai_source` knob for the
+  mutator. An explicit `api_key` now maps to `SOURCE_PAYG` directly; `auto` still defers to
+  `infer_source`. 9 tests incl. a cross-module parity test driving `read_role_override("target")`
+  and a mutator-dispatch regression test (`infer_source` returning subscription while the
+  explicit `api_key` still routes PAYG).
 
 ## [0.99.121] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ functional change.
 
 ---
 
+## [0.99.122] - 2026-06-03
+
+### Added
+- **PR-OPENAI-SOURCE-SINGLE-ENTRY (2026-06-03) — single `[self_improving_loop] openai_source`
+  knob for the OpenAI-role credential lane.** The OpenAI surface of the self-improving loop
+  spans three sources that each drive a distinct consumer — `autoresearch.source` (the
+  `geode audit` subprocess's `--use-oauth` flag, `core/self_improving/train.py`),
+  `autoresearch.target.source` (the petri `target` adapter via
+  `plugins.petri_audit.registry.get_binding`), and `autoresearch.mutator.source` (the
+  in-process mutator LLM, `core/self_improving/loop/runner.py`). Keeping the three in sync by
+  hand is a silent-drift trap, so `SelfImprovingLoopConfig.openai_source` fans one value out
+  to all three at config-load time (`_propagate_openai_source`): `"openai-codex"` → ChatGPT
+  subscription OAuth (per-minute rate-limited), `"api_key"` → OpenAI PAYG (api.openai.com, no
+  per-minute cap). Anthropic roles (`auditor` / `judge`) are never touched. A per-role
+  `source` explicitly set to a *different* value raises (ambiguous config — fail loud, not
+  silent divergence). 8 tests including a cross-module parity test that drives
+  `read_role_override("target")` end-to-end so the knob can never become a half-disconnected
+  config field.
+
 ## [0.99.121] - 2026-06-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.121
+- **Version**: 0.99.122
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.121 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.122 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.121 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.122 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -577,6 +577,30 @@ class SelfImprovingLoopConfig(BaseModel):
     default) aborts with an actionable error. Codex CLI's
     ``forced_login_method`` pattern."""
 
+    openai_source: Source | None = None
+    """Single entry point for the credential lane of every OpenAI-provider
+    self-improving role.
+
+    The OpenAI lane is split across three sub-fields that each drive a distinct
+    consumer: ``autoresearch.source`` (the ``geode audit`` subprocess's
+    ``--use-oauth`` flag, ``core/self_improving/train.py``), ``autoresearch.target.source``
+    (the petri ``target`` adapter via ``plugins.petri_audit.registry.get_binding``),
+    and ``autoresearch.mutator.source`` (the in-process mutator LLM via
+    ``core/self_improving/loop/runner.py:_default_llm_call``). Keeping them in
+    sync by hand is the kind of three-place edit that silently drifts, so this
+    field is the ONE knob an operator flips to move the whole OpenAI surface
+    between subscription and PAYG:
+
+    - ``"openai-codex"`` → ChatGPT subscription OAuth (per-minute rate-limited)
+    - ``"api_key"``      → OpenAI PAYG (api.openai.com, no per-minute cap)
+
+    When set, ``_propagate_openai_source`` fills the three sub-fields. Anthropic
+    roles (``auditor`` / ``judge``) carry their own ``source`` and are never
+    touched. ``None`` (default) → no propagation; each role keeps its own
+    ``source`` (full back-compat). A per-role ``source`` that is *explicitly* set
+    to a value different from ``openai_source`` raises (ambiguous config — fail
+    loud, not silent-divergence)."""
+
     warn_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
     """Quota usage ratio above which the FE banner turns yellow."""
 
@@ -662,6 +686,47 @@ class SelfImprovingLoopConfig(BaseModel):
                 f"abort_threshold ({self.abort_threshold}) must be greater than "
                 f"warn_threshold ({self.warn_threshold})"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _propagate_openai_source(self) -> SelfImprovingLoopConfig:
+        """Fan the single ``openai_source`` knob out to the three OpenAI-role sources.
+
+        Runs after the legacy-namespace migration (``mode="before"``) has already
+        grafted ``[petri.*]`` / ``[mutator]`` into ``autoresearch``, so the three
+        sub-models are fully populated and their ``model_fields_set`` faithfully
+        reflects what the operator pinned explicitly.
+
+        A sub-field that the operator set explicitly to a DIFFERENT value raises
+        (ambiguous — the operator should drop the per-role pin or align it). An
+        explicit pin equal to ``openai_source`` is allowed (redundant, harmless).
+        Anything left at its schema default is overwritten with ``openai_source``.
+        """
+        if self.openai_source is None:
+            return self
+        lane = self.openai_source
+        ar = self.autoresearch
+
+        def _resolve(current: Source, explicit: bool, path: str) -> Source:
+            if explicit and current != lane:
+                raise ValueError(
+                    f"[self_improving_loop] openai_source={lane.value!r} conflicts with an "
+                    f"explicit {path}={current.value!r}. Remove the per-role source pin "
+                    f"(openai_source is the single entry point) or set it to the same value."
+                )
+            return lane
+
+        # Direct per-field assignment (not a heterogeneous loop) so each owner is
+        # concretely typed and carries its own ``source`` attribute.
+        ar.source = _resolve(ar.source, "source" in ar.model_fields_set, "autoresearch.source")
+        ar.target.source = _resolve(
+            ar.target.source, "source" in ar.target.model_fields_set, "autoresearch.target.source"
+        )
+        ar.mutator.source = _resolve(
+            ar.mutator.source,
+            "source" in ar.mutator.model_fields_set,
+            "autoresearch.mutator.source",
+        )
         return self
 
 

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -50,7 +50,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from core.config.credential_source import CredentialSource
 from core.paths import GLOBAL_CONFIG_TOML
@@ -578,28 +578,36 @@ class SelfImprovingLoopConfig(BaseModel):
     ``forced_login_method`` pattern."""
 
     openai_source: Source | None = None
-    """Single entry point for the credential lane of every OpenAI-provider
-    self-improving role.
+    """Single entry point for the OpenAI credential lane of the **autoresearch
+    audit subprocess, target, and mutator** roles.
 
-    The OpenAI lane is split across three sub-fields that each drive a distinct
-    consumer: ``autoresearch.source`` (the ``geode audit`` subprocess's
+    That OpenAI surface is split across three sub-fields that each drive a
+    distinct consumer: ``autoresearch.source`` (the ``geode audit`` subprocess's
     ``--use-oauth`` flag, ``core/self_improving/train.py``), ``autoresearch.target.source``
     (the petri ``target`` adapter via ``plugins.petri_audit.registry.get_binding``),
     and ``autoresearch.mutator.source`` (the in-process mutator LLM via
     ``core/self_improving/loop/runner.py:_default_llm_call``). Keeping them in
     sync by hand is the kind of three-place edit that silently drifts, so this
-    field is the ONE knob an operator flips to move the whole OpenAI surface
-    between subscription and PAYG:
+    field is the ONE knob an operator flips to move those three between
+    subscription and PAYG:
 
     - ``"openai-codex"`` → ChatGPT subscription OAuth (per-minute rate-limited)
     - ``"api_key"``      → OpenAI PAYG (api.openai.com, no per-minute cap)
 
-    When set, ``_propagate_openai_source`` fills the three sub-fields. Anthropic
-    roles (``auditor`` / ``judge``) carry their own ``source`` and are never
-    touched. ``None`` (default) → no propagation; each role keeps its own
-    ``source`` (full back-compat). A per-role ``source`` that is *explicitly* set
-    to a value different from ``openai_source`` raises (ambiguous config — fail
-    loud, not silent-divergence)."""
+    Only those two values are accepted (``_openai_source_is_openai_lane``); it is
+    an OpenAI-lane knob, not a general source default. **Scope** — it does NOT
+    reach the Anthropic ``auditor`` / ``judge`` roles (they carry their own
+    ``source``) nor the ``[self_improving_loop.seed_generation]`` voters (those
+    pin their own source in the seed-generation manifest); those are separate
+    surfaces by design.
+
+    When set, ``_propagate_openai_source`` fills the three sub-fields and is
+    **authoritative** — a per-role ``source`` that was *explicitly* set to a
+    different value is superseded with a ``UserWarning`` (visible, but not a
+    swallowed ``ValidationError`` — so the chosen lane is deterministic even on
+    the petri-CLI ``read_role_override`` path that gracefully degrades on
+    validation errors). ``None`` (default) → no propagation; each role keeps its
+    own ``source`` (full back-compat)."""
 
     warn_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
     """Quota usage ratio above which the FE banner turns yellow."""
@@ -707,27 +715,56 @@ class SelfImprovingLoopConfig(BaseModel):
         lane = self.openai_source
         ar = self.autoresearch
 
-        def _resolve(current: Source, explicit: bool, path: str) -> Source:
+        def _apply(current: Source, explicit: bool, path: str) -> Source:
+            # Authoritative: openai_source supersedes an explicit per-role pin, but
+            # WARNS (not raises) so the resolved lane is deterministic even on the
+            # ``read_role_override`` path that swallows ValidationError for graceful
+            # petri-CLI degradation. A swallowed conflict-raise there would let the
+            # target silently fall back to the manifest cascade — the warn+overwrite
+            # avoids that entirely.
             if explicit and current != lane:
-                raise ValueError(
-                    f"[self_improving_loop] openai_source={lane.value!r} conflicts with an "
-                    f"explicit {path}={current.value!r}. Remove the per-role source pin "
-                    f"(openai_source is the single entry point) or set it to the same value."
+                warnings.warn(
+                    f"[self_improving_loop] openai_source={lane.value!r} supersedes the "
+                    f"explicit {path}={current.value!r} (openai_source is the single entry "
+                    f"point for the OpenAI credential lane). Remove the per-role source pin "
+                    f"to silence this.",
+                    UserWarning,
+                    stacklevel=2,
                 )
             return lane
 
         # Direct per-field assignment (not a heterogeneous loop) so each owner is
         # concretely typed and carries its own ``source`` attribute.
-        ar.source = _resolve(ar.source, "source" in ar.model_fields_set, "autoresearch.source")
-        ar.target.source = _resolve(
+        ar.source = _apply(ar.source, "source" in ar.model_fields_set, "autoresearch.source")
+        ar.target.source = _apply(
             ar.target.source, "source" in ar.target.model_fields_set, "autoresearch.target.source"
         )
-        ar.mutator.source = _resolve(
+        ar.mutator.source = _apply(
             ar.mutator.source,
             "source" in ar.mutator.model_fields_set,
             "autoresearch.mutator.source",
         )
         return self
+
+    @field_validator("openai_source")
+    @classmethod
+    def _openai_source_is_openai_lane(cls, value: Source | None) -> Source | None:
+        """Restrict the knob to the two OpenAI credential lanes.
+
+        ``openai_source`` is an OpenAI-lane selector, not a general source default —
+        ``auto`` / ``claude-cli`` would propagate to the OpenAI roles (e.g. route the
+        mutator through Claude CLI), which is never what an OpenAI-lane knob should do.
+        """
+        if value is not None and value not in (
+            CredentialSource.OPENAI_CODEX,
+            CredentialSource.API_KEY,
+        ):
+            raise ValueError(
+                f"openai_source must be 'openai-codex' (subscription) or 'api_key' (PAYG), "
+                f"got {value.value!r}. It selects only the OpenAI credential lane; Anthropic "
+                f"roles carry their own source."
+            )
+        return value
 
 
 def _resolve_config_path(path: Path | str | None) -> Path:

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -705,10 +705,12 @@ class SelfImprovingLoopConfig(BaseModel):
         sub-models are fully populated and their ``model_fields_set`` faithfully
         reflects what the operator pinned explicitly.
 
-        A sub-field that the operator set explicitly to a DIFFERENT value raises
-        (ambiguous — the operator should drop the per-role pin or align it). An
-        explicit pin equal to ``openai_source`` is allowed (redundant, harmless).
-        Anything left at its schema default is overwritten with ``openai_source``.
+        ``openai_source`` is authoritative: a sub-field the operator set explicitly
+        to a DIFFERENT value is overwritten and a ``UserWarning`` is emitted (visible,
+        but not a ``ValidationError`` that ``read_role_override`` would swallow — so
+        the resolved lane stays deterministic on that path). An explicit pin equal to
+        ``openai_source`` overwrites silently (no-op, no warning); anything left at its
+        schema default is overwritten with ``openai_source``.
         """
         if self.openai_source is None:
             return self

--- a/core/self_improving/loop/runner.py
+++ b/core/self_improving/loop/runner.py
@@ -809,14 +809,19 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     from core.config import settings as _settings
     from core.llm.adapters import resolve_for
     from core.llm.adapters._source_inference import infer_source
-    from core.llm.adapters.base import AdapterCallRequest, Message
+    from core.llm.adapters.base import SOURCE_PAYG, AdapterCallRequest, Message
     from core.llm.router import call_with_failover
 
-    # PR-SOURCE-ROUTING (2026-05-28) — mutator dispatch used to hard-code
-    # ``"payg"`` so subscription-only Pattern B sent every mutator turn
-    # to the depleted PAYG endpoint. ``infer_source`` mirrors the
-    # AgenticLoop main-path resolution.
-    adapter = resolve_for(_normalize_provider_for_registry(provider), infer_source(provider))
+    # PR-SOURCE-ROUTING (2026-05-28) — for the unpinned ``auto`` source, mirror the
+    # AgenticLoop main-path resolution via ``infer_source`` (subscription-first when
+    # an OAuth profile is present) instead of the old hard-coded ``"payg"`` that sent
+    # every mutator turn to the depleted PAYG endpoint.
+    # PR-OPENAI-SOURCE-SINGLE-ENTRY (2026-06-03) — but an EXPLICIT ``api_key`` (e.g.
+    # set via the ``[self_improving_loop] openai_source`` single entry point) must
+    # route to PAYG; ``infer_source`` would otherwise re-derive subscription from a
+    # present OAuth profile and silently ignore the operator's explicit lane choice.
+    resolved_source = SOURCE_PAYG if source == "api_key" else infer_source(provider)
+    adapter = resolve_for(_normalize_provider_for_registry(provider), resolved_source)
     mutator_temperature = _settings.temperature_self_improving_mutation
 
     async def _do_call(m: str) -> object:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.121"
+version = "0.99.122"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -17,6 +17,7 @@ Pins:
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -264,9 +265,9 @@ def test_default_llm_call_normalizes_openai_codex_provider(
     monkeypatch.setattr("core.llm.adapters.resolve_for", _capture_resolve)
 
     async def _fake_failover(
-        models: list[str], do_call: object, **kwargs: object
+        models: list[str], do_call: Callable[[str], Awaitable[object]], **kwargs: object
     ) -> tuple[object, str]:
-        result_obj = await do_call(models[0])  # type: ignore[operator]
+        result_obj = await do_call(models[0])
         return (result_obj, models[0])
 
     monkeypatch.setattr("core.llm.router.call_with_failover", _fake_failover)
@@ -327,9 +328,9 @@ def test_default_llm_call_api_key_path_unchanged(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("core.llm.adapters.resolve_for", _capture_resolve)
 
     async def _fake_failover(
-        models: list[str], do_call: object, **kwargs: object
+        models: list[str], do_call: Callable[[str], Awaitable[object]], **kwargs: object
     ) -> tuple[object, str]:
-        result_obj = await do_call(models[0])  # type: ignore[operator]
+        result_obj = await do_call(models[0])
         return (result_obj, models[0])
 
     monkeypatch.setattr("core.llm.router.call_with_failover", _fake_failover)
@@ -525,9 +526,9 @@ def test_default_llm_call_explicit_api_key_routes_payg_not_inferred_subscription
     monkeypatch.setattr("core.llm.adapters.resolve_for", _capture_resolve)
 
     async def _fake_failover(
-        models: list[str], do_call: object, **kwargs: object
+        models: list[str], do_call: Callable[[str], Awaitable[object]], **kwargs: object
     ) -> tuple[object, str]:
-        result_obj = await do_call(models[0])  # type: ignore[operator]
+        result_obj = await do_call(models[0])
         return (result_obj, models[0])
 
     monkeypatch.setattr("core.llm.router.call_with_failover", _fake_failover)

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -479,3 +479,60 @@ def test_persist_full_config_uses_plural_roles_path(
     cfg = load_self_improving_loop_config()
     assert "miner" in cfg.seed_generation.roles
     assert cfg.seed_generation.roles["miner"].source == "claude-cli"
+
+
+def test_default_llm_call_explicit_api_key_routes_payg_not_inferred_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR-OPENAI-SOURCE-SINGLE-ENTRY (2026-06-03) — an EXPLICIT ``api_key`` mutator
+    source must route to PAYG even when ``infer_source`` would re-derive subscription
+    from a present OAuth profile. Proves the ``[self_improving_loop] openai_source``
+    single entry point actually reaches the mutator (regression guard for the
+    half-honored knob: pre-fix the API branch discarded ``source`` and used
+    ``infer_source(provider)`` unconditionally)."""
+    from core.self_improving.loop import runner
+
+    cfg_mock = MagicMock()
+    cfg_mock.autoresearch.mutator.default_model = "gpt-5.5"
+    cfg_mock.autoresearch.mutator.source = "api_key"
+    cfg_mock.autoresearch.mutator.max_tokens = 1024
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: cfg_mock,
+    )
+    monkeypatch.setattr("core.config._resolve_provider", lambda m: "openai-codex")
+    # infer_source WOULD say subscription (OAuth profile present). The fix must NOT
+    # consult it for an explicit api_key — otherwise the operator's PAYG choice is
+    # silently reverted to the rate-limited subscription lane.
+    monkeypatch.setattr(
+        "core.llm.adapters._source_inference.infer_source", lambda _p: "openai-codex"
+    )
+
+    captured: dict[str, object] = {"provider": None, "source": None}
+
+    def _capture_resolve(provider: str, source: str) -> MagicMock:
+        captured["provider"] = provider
+        captured["source"] = source
+        stub = MagicMock()
+        stub.name = "openai-payg"
+
+        async def _acomplete(req: object) -> object:
+            return _stub_adapter_call_result("from openai-payg")
+
+        stub.acomplete = _acomplete
+        return stub
+
+    monkeypatch.setattr("core.llm.adapters.resolve_for", _capture_resolve)
+
+    async def _fake_failover(
+        models: list[str], do_call: object, **kwargs: object
+    ) -> tuple[object, str]:
+        result_obj = await do_call(models[0])  # type: ignore[operator]
+        return (result_obj, models[0])
+
+    monkeypatch.setattr("core.llm.router.call_with_failover", _fake_failover)
+
+    result = runner._default_llm_call("SYS", "USR")
+    assert result == "from openai-payg"
+    # explicit api_key → SOURCE_PAYG ("payg"), NOT infer_source's "openai-codex"
+    assert captured == {"provider": "openai", "source": "payg"}

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -633,3 +633,96 @@ def test_step_j_b1_clean_input_emits_no_deprecation() -> None:
         "Step J-b.1 regressed: clean (new-style) input should not emit any "
         "petri/mutator DeprecationWarning."
     )
+
+
+# ── openai_source single entry point (PR-OPENAI-SOURCE-SINGLE-ENTRY) ──────────
+
+
+def test_openai_source_none_leaves_per_role_defaults() -> None:
+    """Default (openai_source unset) → no propagation, full back-compat."""
+    cfg = SelfImprovingLoopConfig()
+    assert cfg.openai_source is None
+    # the three OpenAI-role sources keep their own schema defaults
+    assert cfg.autoresearch.source.value == "claude-cli"
+    assert cfg.autoresearch.target.source.value == "claude-cli"
+    assert cfg.autoresearch.mutator.source.value == "auto"
+
+
+def test_openai_source_fans_out_to_three_roles() -> None:
+    """openai_source fills audit-subprocess + target + mutator in one knob."""
+    cfg = SelfImprovingLoopConfig.model_validate({"openai_source": "api_key"})
+    assert cfg.autoresearch.source.value == "api_key"
+    assert cfg.autoresearch.target.source.value == "api_key"
+    assert cfg.autoresearch.mutator.source.value == "api_key"
+
+
+def test_openai_source_subscription_value_also_fans_out() -> None:
+    """The knob works both directions — subscription is equally a single flip."""
+    cfg = SelfImprovingLoopConfig.model_validate({"openai_source": "openai-codex"})
+    assert cfg.autoresearch.source.value == "openai-codex"
+    assert cfg.autoresearch.target.source.value == "openai-codex"
+    assert cfg.autoresearch.mutator.source.value == "openai-codex"
+
+
+def test_openai_source_does_not_touch_anthropic_roles() -> None:
+    """auditor / judge carry their own source and are never propagated to."""
+    cfg = SelfImprovingLoopConfig.model_validate(
+        {
+            "openai_source": "api_key",
+            "autoresearch": {
+                "auditor": {"source": "claude-cli"},
+                "judge": {"source": "claude-cli"},
+            },
+        }
+    )
+    assert cfg.autoresearch.auditor.source.value == "claude-cli"
+    assert cfg.autoresearch.judge.source.value == "claude-cli"
+    # OpenAI roles still moved
+    assert cfg.autoresearch.target.source.value == "api_key"
+
+
+def test_openai_source_explicit_matching_per_role_is_allowed() -> None:
+    """An explicit per-role source equal to openai_source is redundant, not an error."""
+    cfg = SelfImprovingLoopConfig.model_validate(
+        {"openai_source": "api_key", "autoresearch": {"target": {"source": "api_key"}}}
+    )
+    assert cfg.autoresearch.target.source.value == "api_key"
+
+
+def test_openai_source_conflicting_per_role_raises() -> None:
+    """A different explicit per-role source is ambiguous → fail loud, not silent."""
+    with pytest.raises(ValueError, match=r"single entry point|conflicts"):
+        SelfImprovingLoopConfig.model_validate(
+            {"openai_source": "api_key", "autoresearch": {"source": "openai-codex"}}
+        )
+
+
+def test_openai_source_conflict_detected_after_legacy_migration() -> None:
+    """Legacy [petri.target] is migrated into autoresearch BEFORE the conflict check,
+    so a legacy-layout pin that disagrees with openai_source still fails loud."""
+    with (
+        pytest.warns(DeprecationWarning),
+        pytest.raises(ValueError, match=r"single entry point|conflicts"),
+    ):
+        SelfImprovingLoopConfig.model_validate(
+            {"openai_source": "api_key", "petri": {"target": {"source": "openai-codex"}}}
+        )
+
+
+def test_openai_source_reaches_petri_target_binding(tmp_path: Path, monkeypatch) -> None:
+    """Cross-module parity: the single openai_source knob is what
+    ``plugins.petri_audit.user_overrides.read_role_override`` surfaces for the
+    petri ``target`` role — proving the propagation is not a half-disconnected
+    config field but actually steers the audit target's credential lane."""
+    from plugins.petri_audit.user_overrides import read_role_override
+
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        '[self_improving_loop]\nopenai_source = "api_key"\n',
+    )
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(path))
+    override = read_role_override("target")
+    # "api_key" is not a known-default, so it surfaces as the source override
+    # that get_binding feeds into resolve_credential_source → openai-payg.
+    assert str(override.get("source")) == "api_key" or override.get("source") == "api_key"

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -689,24 +689,35 @@ def test_openai_source_explicit_matching_per_role_is_allowed() -> None:
     assert cfg.autoresearch.target.source.value == "api_key"
 
 
-def test_openai_source_conflicting_per_role_raises() -> None:
-    """A different explicit per-role source is ambiguous → fail loud, not silent."""
-    with pytest.raises(ValueError, match=r"single entry point|conflicts"):
-        SelfImprovingLoopConfig.model_validate(
+def test_openai_source_supersedes_conflicting_per_role_with_warning() -> None:
+    """A different explicit per-role source is superseded (authoritative) + WARNS —
+    deterministically, not via a ValidationError that read_role_override would swallow."""
+    with pytest.warns(UserWarning, match=r"single entry point|supersedes"):
+        cfg = SelfImprovingLoopConfig.model_validate(
             {"openai_source": "api_key", "autoresearch": {"source": "openai-codex"}}
         )
+    # openai_source wins — the lane is deterministic
+    assert cfg.autoresearch.source.value == "api_key"
 
 
-def test_openai_source_conflict_detected_after_legacy_migration() -> None:
-    """Legacy [petri.target] is migrated into autoresearch BEFORE the conflict check,
-    so a legacy-layout pin that disagrees with openai_source still fails loud."""
-    with (
-        pytest.warns(DeprecationWarning),
-        pytest.raises(ValueError, match=r"single entry point|conflicts"),
-    ):
-        SelfImprovingLoopConfig.model_validate(
+def test_openai_source_supersedes_after_legacy_migration() -> None:
+    """Legacy [petri.target] is migrated into autoresearch BEFORE propagation, so a
+    legacy-layout pin that disagrees with openai_source is also superseded + warned."""
+    with pytest.warns((DeprecationWarning, UserWarning)):
+        cfg = SelfImprovingLoopConfig.model_validate(
             {"openai_source": "api_key", "petri": {"target": {"source": "openai-codex"}}}
         )
+    assert cfg.autoresearch.target.source.value == "api_key"
+
+
+def test_openai_source_rejects_non_openai_lane() -> None:
+    """The knob is an OpenAI-lane selector — auto / claude-cli are rejected so it can
+    never route an OpenAI role through Claude CLI or the manifest cascade."""
+    from pydantic import ValidationError
+
+    for bad in ("auto", "claude-cli"):
+        with pytest.raises(ValidationError, match=r"openai-codex.*api_key|OpenAI credential lane"):
+            SelfImprovingLoopConfig.model_validate({"openai_source": bad})
 
 
 def test_openai_source_reaches_petri_target_binding(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Pass-through of PR #1971: `[self_improving_loop] openai_source` single entry point for the OpenAI credential lane (3 autoresearch roles), + mutator-dispatch explicit-`api_key`→PAYG fix.

## Verification
- [x] CI 8/8 green on #1971 (Lint&Format, Test, Type, Security, macos, ubuntu, Gate, Detect)
- [x] Codex MCP verified — 4 prior issues + 2 LOW all FIXED
- [x] version develop 0.99.122 > main 0.99.121