### PR TITLE
fix(residuals): recover mutator-CLI resilience guard + sync geode_hero to 18-dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ functional change.
 
 ---
 
+## [0.99.124] - 2026-06-03
+
+### Fixed
+- **Recover the mutator-CLI resilience guard in `propose_with_guard`.** A prior-session
+  uncommitted patch (stashed, recovered here) — when the mutator CLI (codex) fails on a
+  transient blip OR a subscription usage-limit, `propose_with_guard` now catches
+  `CliInvocationError`, backs off + retries, and (on exhaustion) logs a no-op SKIP instead of
+  crashing the whole arm and forfeiting the cycles already run. Still load-bearing whenever the
+  mutator routes through the codex CLI rather than the `openai_source` PAYG API path.
+- **Sync `geode_hero` to the live 18-dim taxonomy.** The hero visualization's `auxiliary_dims`
+  still listed the two removed script-computed analytics dims (`verbose_padding` /
+  `redundant_tool_invocation`, dropped in PR-DROP-ANALYTICS-DIMS) — it would render a 12-aux
+  tier card instead of the live 10. Removed both so the scene matches `AXIS_TIERS` (5 critical +
+  10 aux + 3 info = 18). The layout-ratchet baseline regen + EN/KO re-render are a follow-up on
+  a manim-KO-render-capable environment (this session's manim could not render the KO glyph
+  clusters); the `--static-check` CI gate stays green against the existing baseline.
+
 ## [0.99.123] - 2026-06-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.123
+- **Version**: 0.99.124
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.123 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.124 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.123 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.124 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -628,6 +628,9 @@ def propose_with_guard(
     distinctly, then the broad ``ValueError`` for measurement-hyperparam /
     malformed-JSON rejections.
     """
+    import time
+
+    from core.self_improving.loop.cli_subprocess import CliInvocationError
     from core.self_improving.loop.mutator_feedback import RepetitiveMutationError
 
     for attempt in range(1, max_attempts + 1):
@@ -636,6 +639,20 @@ def propose_with_guard(
         except RepetitiveMutationError as exc:
             if progress is not None:
                 progress.emit(f"propose-guard attempt {attempt}/{max_attempts}: repetitive — {exc}")
+        except CliInvocationError as exc:
+            # PR-GATE-RESILIENCE — the mutator CLI (codex) failing (transient blip OR
+            # subscription usage-limit) must NOT crash the whole arm and forfeit the
+            # cycles already run. Back off + retry; if every attempt fails the cycle
+            # becomes a logged no-op SKIP, identical to a propose-guard exhaustion, so
+            # the arm keeps its prior-cycle evidence. (Recovered from a prior-session
+            # stash; still load-bearing whenever the mutator routes through the codex
+            # CLI rather than the openai_source PAYG API path.)
+            if progress is not None:
+                progress.emit(
+                    f"propose-guard attempt {attempt}/{max_attempts}: mutator CLI failed — "
+                    f"{str(exc)[:160]}"
+                )
+            time.sleep(15.0)
         except ValueError as exc:
             if progress is not None:
                 progress.emit(f"propose-guard attempt {attempt}/{max_attempts}: rejected — {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.123"
+version = "0.99.124"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/visualizations/geode_hero.py
+++ b/scripts/visualizations/geode_hero.py
@@ -1313,8 +1313,6 @@ class GeodeSelfImprovingHero(Scene):
             "stuck_in_loops",
             "stale_context_recall",
             "context_attribution",
-            "verbose_padding",
-            "redundant_tool_invocation",
         )
         info_dims = (
             "unprompted_initiative",


### PR DESCRIPTION
## Summary
- Recover a prior-session stashed `propose_with_guard` resilience guard (catch mutator-CLI `CliInvocationError` → backoff/retry → no-op SKIP, not an arm crash) and land it durably.
- Sync `geode_hero` `auxiliary_dims` to the live taxonomy — drop the 2 removed analytics dims so the hero scene renders 10 aux (18 total), not 12.

## Why
Two leftovers surfaced during the async-first / dim-removal work: (1) a mutator-CLI resilience patch was uncommitted in a fragile stash (operator asked to recover + archive it); (2) `geode_hero` still listed `verbose_padding` / `redundant_tool_invocation` (removed in PR-DROP-ANALYTICS-DIMS), so it would render a wrong 12-aux tier card.

## Changes
| File | Change |
|------|--------|
| `core/self_improving/campaign.py` | `propose_with_guard` catches `CliInvocationError` (backoff 15s + retry; no-op SKIP on exhaustion) |
| `scripts/visualizations/geode_hero.py` | remove `verbose_padding` + `redundant_tool_invocation` from `auxiliary_dims` (12→10) |

## Verification
- [x] ruff check + format clean; mypy clean (campaign.py)
- [x] pytest pass — test_run_campaign (propose/guard/campaign) green
- [x] verify_hero_layout `--static-check` green (existing baseline)
- [ ] geode_hero layout-baseline regen + EN/KO re-render — DEFERRED to a manim-KO-render-capable env (this session's manim could not render KO glyph clusters despite fonts installed); `test_hero_frame_ratchet` is SKIPPED without rendered frames so CI is unaffected.

## Reference
Operator residual cleanup ("복구해서 아카이빙"). resilience patch = recovered from stash@{0}; geode_hero = task #37 (viz-sync) geode_hero portion (critical_floor / autoresearch_compare do not reference these dims).