### PR TITLE
feat(seed-gen): default judge panel to PAYG api_key for concurrent voters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.125] - 2026-06-03
+
+### Changed
+- **Seed-generation judge panel defaults to PAYG (`api_key`) HTTP-API paths.** The 3-voter
+  panel flipped from subscription CLI paths (2× `openai-codex` + 1× `claude-cli`) to PAYG
+  `api_key` for all three, so the ranker's 59 matches × 3 voters = 177 voter calls fan out
+  CONCURRENTLY: a PAYG voter rides the `openai_api_lane` / `anthropic_api_lane` (env-tunable
+  via `GEODE_OPENAI_API_LANE_MAX` / `GEODE_ANTHROPIC_API_LANE_MAX`) instead of the
+  `claude-cli` per-process subprocess lane (cap 3) or a throttled subscription bucket — the
+  CLI-path serialization that capped voter throughput. Diversity is preserved: 2 providers
+  (openai + anthropic) + 2 distinct `(provider, source)` pairs. Subscription-path deploys
+  flip back via the **already-wired** `[[seed_generation.judge_panel.voters]]` config override
+  (`picker.pick_bindings` reads `~/.geode/config.toml` over the manifest default — the
+  2026-05-25 "override not wired" note is stale). 2 pinning tests.
+
 ## [0.99.124] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.124
+- **Version**: 0.99.125
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.124 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.125 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.124 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.125 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -207,29 +207,34 @@ queries_per_run = 3
 # at load time, NOT lazily.
 
 [seed_generation.judge_panel]
-# Default voter mix: 2 reviewers on OpenAI gpt-5.5 via openai-codex
-# (ChatGPT subscription / Codex Responses API) + 1 reviewer on
-# Anthropic claude-opus-4-8 via claude-cli (Claude Code Max
-# subscription, top tier; bumped opus-4-7 → opus-4-8 2026-06-01).
+# Default voter mix: 2 reviewers on OpenAI gpt-5.5 via api_key (OpenAI PAYG,
+# Tier 4) + 1 reviewer on Anthropic claude-opus-4-8 via api_key (Anthropic PAYG).
+# PR-VOTER-PAYG-PARALLEL (2026-06-03): the default flipped from subscription CLI
+# paths (openai-codex + claude-cli) to PAYG HTTP-API paths so the ranker's 177
+# voter calls (59 matches × 3 voters) fan out CONCURRENTLY — a PAYG voter rides
+# the ``openai_api_lane`` / ``anthropic_api_lane`` (env-tunable: GEODE_OPENAI_API_LANE_MAX
+# / GEODE_ANTHROPIC_API_LANE_MAX) instead of the claude-cli per-process subprocess
+# lane (cap 3) or a throttled subscription bucket, so concurrency is bounded by the
+# tunable API-lane caps + GEODE_RANKER_MAX_INFLIGHT_MATCHES, not a CLI bottleneck.
 # Both diversity gates are satisfied:
 #   * providers ≥ 2 (openai + anthropic)
-#   * paths ≥ 2 (openai-codex + claude-cli)
-# Every voter rides a subscription path so PAYG credit isn't required.
-# Operators on PAYG-only deploys override via ``~/.geode/config.toml``'s
-# ``[self_improving_loop.seed_generation.judge_panel.voters]`` array.
+#   * (provider, source) pairs ≥ 2 ((openai, api_key) + (anthropic, api_key))
+# Subscription-path deploys override via ``~/.geode/config.toml``'s
+# ``[self_improving_loop.seed_generation.judge_panel.voters]`` array — now WIRED
+# (the picker reads it over this manifest default; see picker.pick_bindings).
 required_diversity_providers = 2
 
 [[seed_generation.judge_panel.voters]]
 model = "gpt-5.5"
 provider = "openai"
-source = "openai-codex"
+source = "api_key"
 
 [[seed_generation.judge_panel.voters]]
 model = "gpt-5.5"
 provider = "openai"
-source = "openai-codex"
+source = "api_key"
 
 [[seed_generation.judge_panel.voters]]
 model = "claude-opus-4-8"
 provider = "anthropic"
-source = "claude-cli"
+source = "api_key"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.124"
+version = "0.99.125"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_picker.py
+++ b/tests/plugins/seed_generation/test_picker.py
@@ -454,3 +454,37 @@ def test_pick_bindings_enforce_diversity_off_allows_collapsed_panel() -> None:
         manifest=manifest, overrides={}, auto_probe=False, enforce_diversity=False
     )
     assert result.diversity_providers == 1
+
+
+def test_default_judge_panel_voters_are_payg_api_key() -> None:
+    """PR-VOTER-PAYG-PARALLEL (2026-06-03) — the manifest default judge panel rides
+    PAYG ``api_key`` HTTP-API paths (not subscription CLI: openai-codex / claude-cli)
+    so the ranker's 59×3=177 voter calls fan out concurrently on the env-tunable
+    ``openai_api_lane`` / ``anthropic_api_lane`` instead of a per-process CLI lane.
+    Diversity is preserved: 2 providers + 2 distinct (provider, source) pairs."""
+    from plugins.seed_generation.manifest import load_manifest
+
+    voters = load_manifest().judge_panel.voters
+    assert [v.source for v in voters] == ["api_key", "api_key", "api_key"]
+    assert {v.provider for v in voters} == {"openai", "anthropic"}
+    pairs = {(v.provider, v.source) for v in voters}
+    assert pairs == {("openai", "api_key"), ("anthropic", "api_key")}
+
+
+def test_config_voter_override_wins_over_manifest_default(tmp_path: Path) -> None:
+    """The ``[[seed_generation.judge_panel.voters]]`` config override IS wired
+    (picker.pick_bindings reads it over the manifest default) — a subscription-path
+    deploy can flip back via config without touching the plugin manifest."""
+    from plugins.seed_generation import picker as pk
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[[seed_generation.judge_panel.voters]]\n"
+        'model = "gpt-5.5"\nprovider = "openai"\nsource = "openai-codex"\n\n'
+        "[[seed_generation.judge_panel.voters]]\n"
+        'model = "claude-opus-4-8"\nprovider = "anthropic"\nsource = "claude-cli"\n',
+        encoding="utf-8",
+    )
+    overridden = pk._load_config_toml_voter_overrides(cfg)
+    assert overridden is not None
+    assert [v.source for v in overridden] == ["openai-codex", "claude-cli"]


### PR DESCRIPTION
## Summary
- Flip the seed-generation judge-panel default from subscription CLI paths (2× openai-codex + 1× claude-cli) to PAYG `api_key` ×3, so the ranker's 59×3=177 voter calls fan out concurrently on the HTTP `openai_api_lane` / `anthropic_api_lane` instead of serializing on the `claude-cli` subprocess lane (cap 3) / a throttled subscription bucket.

## Why
Operator: voter throughput is low because the voters run on CLI-tied paths. The 177-call ranker workload needs the voters off the per-process CLI lane. PAYG `api_key` voters ride the env-tunable API lanes (`GEODE_OPENAI_API_LANE_MAX` / `GEODE_ANTHROPIC_API_LANE_MAX`), removing the CLI serialization.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/seed_generation.plugin.toml` | 3 voters → `source = "api_key"` (PAYG); comment documents the lane rationale |
| `tests/plugins/seed_generation/test_picker.py` | pin the PAYG default (api_key×3 + diversity) + confirm the config override is wired |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| voter PAYG default | Implemented | api_key×3; diversity = 2 providers + 2 (provider,source) pairs |
| config override wiring | Already wired | `picker.pick_bindings:540` `_load_config_toml_voter_overrides` reads config over manifest — the 2026-05-25 "not wired" note is STALE |
| diversity gate | Verified | `pick_bindings(enforce_diversity=True)` passes with api_key×3 |

## Verification
- [x] ruff check + format clean (test file)
- [x] pytest pass — `tests/plugins/seed_generation/` green (exit 0); 2 new pinning tests
- [x] `pick_bindings` resolves api_key×3 + passes runtime diversity (2 distinct (provider,source) pairs)

## Reference
Lane caps env-tunable (`GEODE_OPENAI_API_LANE_MAX` 6→raise, `GEODE_ANTHROPIC_API_LANE_MAX` 50, `GEODE_RANKER_MAX_INFLIGHT_MATCHES` 3→raise) are runtime knobs, set separately at launch.