### PR TITLE
release: develop → main (v0.99.128 — pilot tool-capable source routing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.128] - 2026-06-03
+
+### Fixed
+- **Seed-generation pilot now binds a tool-capable adapter so it can call `petri_audit`.**
+  The pilot resolved to the `claude-cli` source → `ClaudeCliAdapter`, which declares
+  `supports_tools=False` (`core/llm/adapters/claude_cli.py:327`) and drops `req.tools` — so the
+  pilot's `petri_audit` grant never reached the model. `picker.pick_bindings` now reroutes a
+  tool-requiring role (`_TOOL_REQUIRING_ROLES = {"pilot"}`) off a tool-incapable source
+  (`_TOOL_INCAPABLE_SOURCES = {"claude-cli", "adapter"}` — both spell ClaudeCliAdapter; `openai-codex`
+  → CodexOAuthAdapter is tool-capable) to the provider's PAYG source (`anthropic` → `api_key` →
+  `AnthropicPaygAdapter`, `supports_tools=True`, which translates `req.tools` to the Anthropic
+  Messages API and parses `tool_use` — `core/llm/adapters/_anthropic_common.py:105-109,159-164`).
+  Fires for both the auto-default and an explicit `claude-cli`/`adapter` override (a
+  misconfiguration for the pilot), with a loud WARNING.
+
 ## [0.99.127] - 2026-06-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.127
+- **Version**: 0.99.128
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.127 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.128 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.127 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.128 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/picker.py
+++ b/plugins/seed_generation/picker.py
@@ -112,6 +112,27 @@ _PROVIDER_DEFAULT_PAYG: dict[str, str] = {
     "zhipuai": "api_key",
 }
 
+# PR-SEEDGEN-PILOT-TOOL-CAPABLE-SOURCE (2026-06-03) — picker source-specs whose
+# adapter ignores ``req.tools`` (``supports_tools=False``). Both spell the
+# ClaudeCliAdapter (``core/llm/adapters/claude_cli.py:327``): the legacy
+# ``"claude-cli"`` name and its new-naming alias ``"adapter"`` (see
+# ``binding_to_adapter_source`` — ``claude-cli`` → ``adapter``; the glue test
+# ``test_picker_adapter_glue`` pins ``source="adapter"`` → ClaudeCliAdapter).
+# That adapter runs the model as Claude Code and never serialises the tool
+# schemas, so a tool the model should call simply isn't there. (``openai-codex``
+# → CodexOAuthAdapter is tool-capable; ``codex-cli`` is not a picker source.)
+# Verified by adapter resolution, not assumed.
+_TOOL_INCAPABLE_SOURCES: frozenset[str] = frozenset({"claude-cli", "adapter"})
+
+# Roles that MUST call a GEODE tool: the pilot invokes ``petri_audit`` to run
+# the inner-loop audit. On a tool-incapable source the model never receives
+# ``petri_audit`` and silently degrades to native-CLI Bash improvisation
+# (``geode audit`` shellout) — uncontrolled, contention-prone, and often
+# unparseable. Such roles are rerouted to the provider's tool-capable PAYG
+# source. (Other roles read/emit via native CLI tools, so they tolerate the
+# subprocess adapter.)
+_TOOL_REQUIRING_ROLES: frozenset[str] = frozenset({"pilot"})
+
 
 # Module-level flag so :func:`print_tos_notice` is idempotent across
 # repeated picker calls in the same process (e.g. CLI smoke + CLI run).
@@ -523,6 +544,24 @@ def pick_bindings(
             role_name, override.get("source"), provider, petri_sources
         )
         source = _resolve_source(provider, hint=source_hint, auto_probe=auto_probe)
+        # PR-SEEDGEN-PILOT-TOOL-CAPABLE-SOURCE (2026-06-03) — a tool-requiring
+        # role resolved to a tool-incapable (subprocess) source would never
+        # receive its GEODE tool and would improvise via the native CLI.
+        # Reroute to the provider's tool-capable PAYG source. Fires for both an
+        # auto-resolved and an explicit operator override of ``claude-cli`` on
+        # such a role (the override is a misconfiguration — claude-cli cannot
+        # deliver petri_audit).
+        if role_name in _TOOL_REQUIRING_ROLES and source in _TOOL_INCAPABLE_SOURCES:
+            tool_capable = _PROVIDER_DEFAULT_PAYG.get(provider, "api_key")
+            log.warning(
+                "seed-generation picker: role %r calls a GEODE tool (petri_audit) but "
+                "resolved to tool-incapable source %r (subprocess adapter drops "
+                "req.tools) — rerouting to %r so the model actually receives the tool.",
+                role_name,
+                source,
+                tool_capable,
+            )
+            source = tool_capable
         bindings[role_name] = RoleBinding(
             role=role_name,
             model=model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.127"
+version = "0.99.128"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_picker.py
+++ b/tests/plugins/seed_generation/test_picker.py
@@ -131,10 +131,16 @@ def test_pick_bindings_resolves_all_roles_with_oauth() -> None:
     ):
         result = pick_bindings(manifest=manifest, overrides={})
     assert set(result.bindings) == set(manifest.enabled_roles)
-    # All Claude-* roles resolve to claude-cli when OAuth is available.
-    for role in ("generator", "critic", "pilot", "ranker", "evolver", "meta_reviewer"):
+    # Non-tool Claude-* roles resolve to claude-cli when OAuth is available.
+    # The pilot is EXCLUDED — it calls petri_audit, which the claude-cli
+    # subprocess adapter cannot deliver, so it reroutes to api_key
+    # (PR-SEEDGEN-PILOT-TOOL-CAPABLE-SOURCE).
+    for role in ("generator", "critic", "ranker", "evolver", "meta_reviewer"):
         assert result.bindings[role].provider == "anthropic"
         assert result.bindings[role].source == "claude-cli"
+    # Pilot reroutes to the tool-capable PAYG source even with OAuth available.
+    assert result.bindings["pilot"].provider == "anthropic"
+    assert result.bindings["pilot"].source == "api_key"
     # Proximity now runs claude-sonnet completion (CSP-8 LLM-clustering
     # revert, paper §3); CSP-10 dropped the embedding kind plumbing.
     assert result.bindings["proximity"].provider == "anthropic"
@@ -158,13 +164,36 @@ def test_pick_bindings_no_probe_uses_payg() -> None:
 
 def test_pick_bindings_user_override_source() -> None:
     manifest = _make_manifest()
-    overrides = {"generator": {"source": "api_key"}, "pilot": {"source": "claude-cli"}}
+    # A claude-cli override on a NON-tool role (critic) is honored; the same
+    # override on the pilot is rerouted to api_key (claude-cli cannot deliver
+    # petri_audit — PR-SEEDGEN-PILOT-TOOL-CAPABLE-SOURCE).
+    overrides = {"generator": {"source": "api_key"}, "critic": {"source": "claude-cli"}}
     with patch("plugins.seed_generation.picker._probe_oauth", return_value=True):
         result = pick_bindings(manifest=manifest, overrides=overrides)
     assert result.bindings["generator"].source == "api_key"
-    assert result.bindings["pilot"].source == "claude-cli"
-    # Critic was NOT overridden → still claude-cli (OAuth probe = True).
     assert result.bindings["critic"].source == "claude-cli"
+
+
+def test_pick_bindings_pilot_reroutes_off_tool_incapable_source() -> None:
+    """The pilot calls petri_audit, so it must never bind a tool-incapable
+    (claude-cli subprocess) source — even when explicitly overridden to it or
+    when OAuth would otherwise default it there. It reroutes to api_key."""
+    manifest = _make_manifest()
+    with patch("plugins.seed_generation.picker._probe_oauth", return_value=True):
+        # (a) explicit claude-cli override on the pilot → rerouted.
+        forced = pick_bindings(manifest=manifest, overrides={"pilot": {"source": "claude-cli"}})
+        assert forced.bindings["pilot"].source == "api_key"
+        # (b) auto-default (OAuth available) would pick claude-cli → rerouted.
+        auto = pick_bindings(manifest=manifest, overrides={})
+        assert auto.bindings["pilot"].source == "api_key"
+        # (c) the new-naming alias "adapter" also maps to ClaudeCliAdapter
+        # (tool-incapable) → rerouted.
+        aliased = pick_bindings(manifest=manifest, overrides={"pilot": {"source": "adapter"}})
+        assert aliased.bindings["pilot"].source == "api_key"
+    # A tool-capable explicit source on the pilot is left untouched.
+    with patch("plugins.seed_generation.picker._probe_oauth", return_value=True):
+        explicit = pick_bindings(manifest=manifest, overrides={"pilot": {"source": "api_key"}})
+        assert explicit.bindings["pilot"].source == "api_key"
 
 
 def test_pick_bindings_user_override_model() -> None:


### PR DESCRIPTION
## Summary
Pass-through of v0.99.128 to main: the seed-generation pilot now reroutes off the tool-incapable `claude-cli` source to a tool-capable PAYG adapter so it can actually call `petri_audit` (#1982), instead of improvising the audit via a Bash shellout.

## Verification
- CI 8/8 green on #1982 (develop)
- ruff / format / mypy clean; seed_generation 715 passed; Codex MCP reviewed (`"adapter"` alias + CHANGELOG parity addressed)
- Live-validated: pilot emits `tool_call` → `tool_result` for `petri_audit`; N=12 re-run had malformed_pilot=0 (vs 3 before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)