### PR TITLE
release: develop → main (v0.99.129 — single-seed staging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ functional change.
 
 ---
 
+## [0.99.129] - 2026-06-03
+
+### Fixed
+- **Petri audit stages a single candidate `.md` `seed_select` as a directory of N copies** (was
+  splitlines-shredded into empty seeds). When the seed-gen pilot calls `petri_audit` with a lone
+  `.md` path + `seeds=N`, inspect-petri's `seeds_dataset` treated the path as newline-delimited
+  seed instructions — `resource(path).splitlines()` turned front-matter lines into garbage one-line
+  "seeds", so the actual scenario was never delivered, the target never engaged, and every dim
+  scored 0 (`status="low_engagement"` → `malformed_pilot`). This surfaced once the pilot started
+  calling the controlled `petri_audit` tool (v0.99.128); the prior improvised `geode audit` path
+  had hand-staged copies to avoid it. `seed_tree.flatten_for_inspect_petri(seed_select, samples=N)`
+  now stages a lone `.md` into `<GEODE_HOME>/petri-audit/single-seed-stage/<stem>-<hash>-x<N>/` with
+  N distinct-named copies (content-addressed, idempotent) so `read_seed_directory` delivers the real
+  candidate as N independent rollouts; `runner.build_command` passes `samples=seeds`.
+  (`project_seedgen_pilot_seed_delivery_bug`.)
+
 ## [0.99.128] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.128
+- **Version**: 0.99.129
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.128 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.129 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.128 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.129 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -281,9 +281,13 @@ def build_command(
         # PR 0 — when seed_select is a hierarchical tree (tier/dim/...),
         # flatten to a content-addressed symlink stage so inspect-petri's
         # flat ``directory.glob("*.md")`` loader sees every seed.
+        # PR-PETRI-SINGLE-SEED-STAGING (2026-06-03) — a single candidate ``.md``
+        # is staged as ``seeds`` distinct-named copies (passed via ``samples``)
+        # so it delivers ``seeds`` real rollouts instead of being splitlines-
+        # shredded into empty seeds (project_seedgen_pilot_seed_delivery_bug).
         from plugins.petri_audit.seed_tree import flatten_for_inspect_petri
 
-        resolved_seed_path = flatten_for_inspect_petri(seed_select)
+        resolved_seed_path = flatten_for_inspect_petri(seed_select, samples=seeds)
         cmd.extend(["-T", f"seed_instructions={resolved_seed_path}"])
     elif tags:
         cmd.extend(["-T", f"seed_instructions=tags:{tags}"])

--- a/plugins/petri_audit/seed_tree.py
+++ b/plugins/petri_audit/seed_tree.py
@@ -124,7 +124,36 @@ def _populate_stage(tree_root: Path, stage: Path) -> None:
             link_path.write_bytes(md_path.read_bytes())
 
 
-def flatten_for_inspect_petri(seed_select: str | Path) -> str | Path:
+def _stage_single_seed(md_path: Path, samples: int) -> Path:
+    """Stage a single candidate ``.md`` as a directory of ``samples`` copies.
+
+    Returns ``<GEODE_HOME>/petri-audit/single-seed-stage/<stem>-<hash>-x<n>/``
+    containing ``samples`` distinct-named copies of the candidate. Content-
+    addressed (sha256 of the body + n) so re-runs reuse the stage; idempotent.
+
+    Why copies, not a lone file: inspect-petri's ``seeds_dataset`` treats a
+    lone ``.md`` *path* as newline-delimited seed instructions
+    (``resource(path).splitlines()``), shredding the candidate into garbage
+    one-line "seeds". A *directory* is read by ``read_seed_directory`` as one
+    Sample per ``*.md`` file, so ``samples`` distinct-named copies yield
+    ``samples`` independent rollouts of the real candidate
+    (``project_seedgen_pilot_seed_delivery_bug``).
+    """
+    n = max(1, samples)
+    body = md_path.read_bytes()
+    digest = hashlib.sha256(body + str(n).encode()).hexdigest()[:16]
+    stage = GEODE_HOME / "petri-audit" / "single-seed-stage" / f"{md_path.stem}-{digest}-x{n}"
+    stage.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        # Distinct stems → distinct Sample ids → independent rollouts.
+        dest = stage / f"{md_path.stem}__s{i + 1}.md"
+        if not dest.exists():
+            dest.write_bytes(body)
+    log.info("seed_tree: staged single seed %s → %s (%d copies)", md_path, stage, n)
+    return stage
+
+
+def flatten_for_inspect_petri(seed_select: str | Path, *, samples: int = 1) -> str | Path:
     """Return a value inspect-petri can resolve to seeds.
 
     When ``seed_select`` is a hierarchical seed tree, populate (or
@@ -133,6 +162,14 @@ def flatten_for_inspect_petri(seed_select: str | Path) -> str | Path:
     not a hierarchical tree, return the input unchanged so
     inspect-petri's native handling kicks in.
 
+    When ``seed_select`` is a single ``.md`` file (the seed-generation
+    pilot's per-candidate audit), stage it as a directory of ``samples``
+    copies via :func:`_stage_single_seed` — a lone ``.md`` path is otherwise
+    splitlines-shredded into empty/garbage seeds by inspect-petri's
+    ``seeds_dataset``, so the target never engages and every dim scores 0
+    (``status="low_engagement"``). This is ``project_seedgen_pilot_seed_delivery_bug``;
+    the remediation the pilot used to apply by hand now applies for any caller.
+
     Strings stay strings; paths stay paths — the caller renders the
     final value via f-string for the inspect eval CLI.
     """
@@ -140,6 +177,8 @@ def flatten_for_inspect_petri(seed_select: str | Path) -> str | Path:
     if isinstance(seed_select, str) and seed_select.startswith(("id:", "tags:")):
         return seed_select
     path = Path(seed_select).expanduser()
+    if path.is_file() and path.suffix == ".md":
+        return _stage_single_seed(path.resolve(), samples)
     if not path.exists() or not is_hierarchical_seed_tree(path):
         # Pass through unchanged — non-existent paths fail at
         # inspect-petri's boundary with a clearer error message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.128"
+version = "0.99.129"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/petri_audit/test_seed_tree.py
+++ b/tests/plugins/petri_audit/test_seed_tree.py
@@ -103,3 +103,55 @@ def test_flatten_for_inspect_petri_symlink_content_preserved(
         out = flatten_for_inspect_petri(tree)
     target = out / "critical__broken_tool_use__01_base.md"
     assert target.read_text(encoding="utf-8") == seed_body
+
+
+# ── single .md staging (project_seedgen_pilot_seed_delivery_bug) ──────────────
+
+
+def test_flatten_single_md_stages_n_copies(tmp_path: Path, monkeypatch: object) -> None:
+    """A lone candidate .md is staged into a directory of `samples` distinct
+    copies (so inspect-petri's directory loader reads it as N real seeds,
+    instead of splitlines-shredding the lone file into empty seeds)."""
+    cand = tmp_path / "cand.md"
+    cand.write_text("---\nname: c\n---\nscenario body", encoding="utf-8")
+    stage_root = tmp_path / "stage_root"
+    with patch("plugins.petri_audit.seed_tree.GEODE_HOME", stage_root):
+        out = flatten_for_inspect_petri(cand, samples=3)
+    assert isinstance(out, Path) and out.is_dir()
+    mds = sorted(p.name for p in out.glob("*.md"))
+    assert mds == ["cand__s1.md", "cand__s2.md", "cand__s3.md"]
+    # Every copy preserves the candidate body verbatim.
+    for p in out.glob("*.md"):
+        assert p.read_text(encoding="utf-8") == "---\nname: c\n---\nscenario body"
+
+
+def test_flatten_single_md_default_one_copy(tmp_path: Path, monkeypatch: object) -> None:
+    cand = tmp_path / "cand.md"
+    cand.write_text("body", encoding="utf-8")
+    stage_root = tmp_path / "stage_root"
+    with patch("plugins.petri_audit.seed_tree.GEODE_HOME", stage_root):
+        out = flatten_for_inspect_petri(cand)  # samples defaults to 1
+    assert isinstance(out, Path) and out.is_dir()
+    assert [p.name for p in out.glob("*.md")] == ["cand__s1.md"]
+
+
+def test_flatten_single_md_idempotent(tmp_path: Path, monkeypatch: object) -> None:
+    cand = tmp_path / "cand.md"
+    cand.write_text("body", encoding="utf-8")
+    stage_root = tmp_path / "stage_root"
+    with patch("plugins.petri_audit.seed_tree.GEODE_HOME", stage_root):
+        out1 = flatten_for_inspect_petri(cand, samples=2)
+        out2 = flatten_for_inspect_petri(cand, samples=2)
+    assert out1 == out2  # content-addressed → same stage reused
+
+
+def test_flatten_single_md_distinct_stage_per_sample_count(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    cand = tmp_path / "cand.md"
+    cand.write_text("body", encoding="utf-8")
+    stage_root = tmp_path / "stage_root"
+    with patch("plugins.petri_audit.seed_tree.GEODE_HOME", stage_root):
+        out2 = flatten_for_inspect_petri(cand, samples=2)
+        out3 = flatten_for_inspect_petri(cand, samples=3)
+    assert out2 != out3  # the copy count is part of the content address


### PR DESCRIPTION
## Summary
Pass-through of v0.99.129 to main: `petri_audit` stages a single candidate `.md` `seed_select` as a directory of N copies so it delivers the real scenario (N rollouts) instead of being splitlines-shredded into empty seeds (#1984). Completes the pilot difficulty-measurement fix chain (toolfix v0.99.128 + this).

## Verification
- CI 8/8 green on #1984 (develop); ruff/format/mypy clean; test_seed_tree 12 passed; Codex MCP — no correctness findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)