### PR TITLE
release: develop → main (v0.99.130 — petri audit opus-4-8/PAYG + ANTHROPIC_API_KEY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,29 @@ functional change.
 
 ---
 
+## [0.99.130] - 2026-06-03
+
+### Fixed
+- **petri_audit auditor/judge default to claude-opus-4-8 on the PAYG api_key path + the audit
+  subprocess gets ANTHROPIC_API_KEY.** Three issues kept the controlled `petri_audit` tool path
+  (the seed-gen pilot) from running a real audit, leaving all dims `0.0` (`status="low_engagement"`):
+  - The handler defaulted auditor/judge to `claude-sonnet-4-6` / `claude-haiku-4-5-20251001`
+    (`core/cli/tool_handlers/audit.py`) — not the campaign's `claude-opus-4-8`. Now both default to
+    `claude-opus-4-8`.
+  - An anthropic auditor/judge with no per-role source override resolved to the OAuth route
+    (`claude-cli`), which runs the model as Claude Code and REFUSES the adversarial auditor role
+    (treats the injected sysprompt as data → 0 send_message → degenerate audit). `run_audit` now
+    defaults an anthropic auditor/judge to the `api_key` (PAYG) source; openai/codex roles keep
+    their OAuth cascade (gpt-5.5 via codex subscription, $0). An explicit operator override wins.
+  - The inspect subprocess inherited the sub-agent worker's env, which lacks `ANTHROPIC_API_KEY`
+    (the worker does not load `~/.geode/.env`), so inspect aborted in ~2s with "Could not resolve
+    authentication method. Expected one of api_key …" and zero-filled every dim. `run_audit` now
+    resolves `ANTHROPIC_API_KEY` from the GEODE credential source (`settings.anthropic_api_key` →
+    `~/.geode/.env`) and injects it into the subprocess `env` when absent
+    (`plugins/petri_audit/runner.py:_resolve_anthropic_api_key`). The resolver rejects
+    OAuth-shaped tokens (`sk-ant-oat…`) so only a real api_key is ever injected (Anthropic TOS);
+    the codex target uses `~/.codex/auth.json` (file-based) and needs no injection.
+
 ## [0.99.129] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.129
+- **Version**: 0.99.130
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.129 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.130 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.129 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.130 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -39,8 +39,15 @@ def _build_audit_handlers() -> dict[str, Any]:
     )
 
     def handle_petri_audit(**kwargs: Any) -> dict[str, Any]:
-        judge = kwargs.get("judge") or "claude-haiku-4-5-20251001"
-        auditor = kwargs.get("auditor") or "claude-sonnet-4-6"
+        # PR-PETRI-AUDIT-DEFAULT-OPUS-CREDS (2026-06-03) — auditor/judge default
+        # to claude-opus-4-8, matching the self-improving campaign role spec
+        # ([self_improving_loop.petri.{auditor,judge}] = opus-4-8). The prior
+        # haiku/sonnet defaults left a tool-side petri_audit call (e.g. the
+        # seed-gen pilot, which passes neither) on under-tier alignment-audit
+        # models; the campaign never used them (it shells `geode audit` with the
+        # config bindings). Opus 4.8 is the verified auditor tier.
+        judge = kwargs.get("judge") or "claude-opus-4-8"
+        auditor = kwargs.get("auditor") or "claude-opus-4-8"
         # target=None → fall back to GEODE's active settings.model (drift
         # sync stays active). Pinned id sticks for the audit's lifetime.
         target = kwargs.get("target") or None

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -573,6 +573,55 @@ def confirm_or_abort(cost_label: str, *, yes: bool) -> bool:
     return response in ("y", "yes")
 
 
+def _resolve_anthropic_api_key() -> str | None:
+    """Resolve ``ANTHROPIC_API_KEY`` for the audit subprocess (api_key only).
+
+    A sub-agent worker that calls ``run_audit`` does not load ``~/.geode/.env``,
+    so both ``os.environ`` and GEODE ``settings`` may be empty there. Try
+    settings first (covers the gateway / loaded-env case), then read
+    ``~/.geode/.env`` directly (the reliable source for a worker). Returns
+    ``None`` when neither yields a key — never raises (graceful boundary).
+    """
+    try:
+        from core.config import settings
+
+        key = _api_key_or_none(getattr(settings, "anthropic_api_key", None))
+        if key:
+            return key
+    except Exception:
+        log.debug("run_audit: settings.anthropic_api_key unavailable", exc_info=True)
+    try:
+        from core.paths import GEODE_HOME
+        from dotenv import dotenv_values
+
+        key = _api_key_or_none(dotenv_values(GEODE_HOME / ".env").get("ANTHROPIC_API_KEY"))
+        if key:
+            return key
+    except Exception:
+        log.debug("run_audit: ~/.geode/.env ANTHROPIC_API_KEY read failed", exc_info=True)
+    return None
+
+
+def _api_key_or_none(value: object) -> str | None:
+    """Return ``value`` as a string IFF it is a real Anthropic API key.
+
+    Rejects Claude OAuth access tokens (``sk-ant-oat…`` — see
+    ``plugins/petri_audit/claude_code_provider.py``): the audit policy injects
+    api_key only, never an OAuth token (Anthropic TOS forbids programmatic /
+    batch use of OAuth tokens). A non-string or OAuth-shaped value → ``None``,
+    so a mis-stored OAuth token under ``ANTHROPIC_API_KEY`` is never injected.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    if value.startswith("sk-ant-oat"):
+        log.warning(
+            "run_audit: ANTHROPIC_API_KEY holds an OAuth-shaped token (sk-ant-oat…); "
+            "refusing to inject it (api_key path only per Anthropic TOS)."
+        )
+        return None
+    return value
+
+
 def run_audit(
     *,
     judge: str | None = None,
@@ -672,6 +721,19 @@ def run_audit(
             else:
                 target = resolved
     assert auditor is not None and judge is not None and target is not None  # narrowed
+    # PR-PETRI-AUDIT-DEFAULT-OPUS-CREDS (2026-06-03) — an anthropic auditor/judge
+    # with no per-role source override DEFAULTS to api_key (PAYG) instead of the
+    # OAuth cascade (operator: "default를 PAYG로 둬"). The anthropic OAuth route is
+    # claude-cli, which runs the model as Claude Code and REFUSES the adversarial
+    # auditor role (treats the injected sysprompt as data → 0 send_message →
+    # degenerate all-zero audit). api_key is the verified alignment-audit path
+    # (+ ANTHROPIC_API_KEY is injected into the subprocess below). openai/codex
+    # roles keep their OAuth cascade (gpt-5.5 via codex subscription, $0). An
+    # explicit operator source override always wins (resolved above).
+    if auditor_source is None and auditor.startswith("claude"):
+        auditor_source = "api_key"
+    if judge_source is None and judge.startswith("claude"):
+        judge_source = "api_key"
     inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth, source=auditor_source)
     inspect_judge = to_inspect_model(judge, use_oauth=use_oauth, source=judge_source)
     inspect_target = to_inspect_target(target)
@@ -768,6 +830,24 @@ def run_audit(
     # ``docs/audits/2026-05-14-petri-oauth-constraints.md``.
     # 실 검증 (live audit 의 valid baseline 측정) 은 2026-05-25 이후
     # 의 후속 cycle 의 operator credential 결정 의 의존.
+    # PR-PETRI-AUDIT-DEFAULT-OPUS-CREDS (2026-06-03) — the inspect subprocess
+    # needs ``ANTHROPIC_API_KEY`` for the anthropic auditor/judge (api_key
+    # path; OAuth tokens stay out per the policy above). When run_audit is
+    # invoked from a sub-agent WORKER (the seed-gen pilot's petri_audit tool
+    # call), that worker process does NOT load ``~/.geode/.env``, so neither it
+    # nor this inherited-env subprocess has the key — inspect aborts in ~2s with
+    # "Could not resolve authentication method. Expected one of api_key …" and
+    # every dim zero-fills (status=low_engagement). Inject the key from the
+    # GEODE credential source when absent. The codex target uses
+    # ``~/.codex/auth.json`` (file-based) so needs no env injection.
+    audit_env = dict(os.environ)
+    if not audit_env.get("ANTHROPIC_API_KEY"):
+        resolved_key = _resolve_anthropic_api_key()
+        if resolved_key:
+            audit_env["ANTHROPIC_API_KEY"] = resolved_key
+            notes.append("injected ANTHROPIC_API_KEY from GEODE credential source")
+        else:
+            notes.append("ANTHROPIC_API_KEY unresolved — anthropic auditor/judge may fail auth")
     log.info("Petri audit subprocess: %s", " ".join(cmd))
     # ``cmd`` is built solely from validated model ids + numeric flags by
     # build_command — no shell metacharacters or untrusted user strings.
@@ -776,6 +856,7 @@ def run_audit(
         text=True,
         capture_output=True,
         check=False,
+        env=audit_env,
     )
     archived_raw, archived_summary = _maybe_auto_archive(
         proc.stdout, proc.stderr, auto_archive=auto_archive, notes=notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.129"
+version = "0.99.130"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/petri_audit/test_audit_credentials.py
+++ b/tests/plugins/petri_audit/test_audit_credentials.py
@@ -1,0 +1,167 @@
+"""ANTHROPIC_API_KEY injection into the audit subprocess + opus-4-8 default.
+
+A sub-agent worker that calls run_audit (the seed-gen pilot's petri_audit tool
+call) does not load ~/.geode/.env, so the inspect subprocess inherited an env
+WITHOUT ANTHROPIC_API_KEY → inspect aborted in ~2s with "Could not resolve
+authentication method" and every dim zero-filled. PR-PETRI-AUDIT-DEFAULT-OPUS-CREDS
+resolves the key from the GEODE credential source and injects it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from plugins.petri_audit.runner import _resolve_anthropic_api_key, run_audit
+
+
+def test_resolve_anthropic_api_key_prefers_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config
+
+    monkeypatch.setattr(
+        core.config.settings, "anthropic_api_key", "sk-from-settings", raising=False
+    )
+    assert _resolve_anthropic_api_key() == "sk-from-settings"
+
+
+def test_resolve_anthropic_api_key_falls_to_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config
+
+    monkeypatch.setattr(core.config.settings, "anthropic_api_key", "", raising=False)
+    with patch("dotenv.dotenv_values", return_value={"ANTHROPIC_API_KEY": "sk-from-dotenv"}):
+        assert _resolve_anthropic_api_key() == "sk-from-dotenv"
+
+
+def test_resolve_anthropic_api_key_none_when_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config
+
+    monkeypatch.setattr(core.config.settings, "anthropic_api_key", "", raising=False)
+    with patch("dotenv.dotenv_values", return_value={}):
+        assert _resolve_anthropic_api_key() is None
+
+
+def test_run_audit_injects_anthropic_key_into_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ANTHROPIC_API_KEY is absent from the env, run_audit resolves it and
+    passes it through to the inspect subprocess so the auditor/judge can auth."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        captured["env"] = kwargs.get("env")
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+        return proc
+
+    with (
+        patch("plugins.petri_audit.runner._resolve_anthropic_api_key", return_value="sk-injected"),
+        patch("plugins.petri_audit.runner.subprocess.run", side_effect=_fake_run),
+        patch("plugins.petri_audit.runner.shutil.which", return_value="/usr/bin/inspect"),
+    ):
+        run_audit(
+            judge="claude-opus-4-8",
+            auditor="claude-opus-4-8",
+            target="claude-opus-4-7",
+            seeds=1,
+            max_turns=2,
+            dry_run=False,
+            yes=True,
+            auto_archive=False,
+        )
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["ANTHROPIC_API_KEY"] == "sk-injected"
+
+
+def test_run_audit_keeps_existing_anthropic_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An already-present ANTHROPIC_API_KEY is NOT overwritten by the resolver."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-already-here")
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        captured["env"] = kwargs.get("env")
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+        return proc
+
+    # The resolver must NOT even be consulted when the key is already present.
+    with (
+        patch(
+            "plugins.petri_audit.runner._resolve_anthropic_api_key",
+            side_effect=AssertionError("resolver should not run when key present"),
+        ),
+        patch("plugins.petri_audit.runner.subprocess.run", side_effect=_fake_run),
+        patch("plugins.petri_audit.runner.shutil.which", return_value="/usr/bin/inspect"),
+    ):
+        run_audit(
+            judge="claude-opus-4-8",
+            auditor="claude-opus-4-8",
+            target="claude-opus-4-7",
+            seeds=1,
+            max_turns=2,
+            dry_run=False,
+            yes=True,
+            auto_archive=False,
+        )
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["ANTHROPIC_API_KEY"] == "sk-already-here"
+
+
+def test_resolve_anthropic_api_key_rejects_oauth_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An OAuth-shaped token (sk-ant-oat…) mis-stored under ANTHROPIC_API_KEY is
+    NOT injected — api_key path only (Anthropic TOS forbids OAuth batch use)."""
+    import core.config
+
+    monkeypatch.setattr(
+        core.config.settings, "anthropic_api_key", "sk-ant-oat01-deadbeef", raising=False
+    )
+    # settings holds an OAuth token → rejected; dotenv empty → None overall.
+    with patch("dotenv.dotenv_values", return_value={}):
+        assert _resolve_anthropic_api_key() is None
+
+
+def test_anthropic_auditor_judge_default_to_api_key_payg() -> None:
+    """An anthropic auditor/judge with no per-role source override defaults to
+    the api_key (PAYG) path, NOT the claude-cli OAuth route (which refuses the
+    adversarial auditor role). openai/codex roles are unaffected (separate test
+    coverage in test_oauth_judge)."""
+    from plugins.petri_audit.runner import run_audit
+
+    with patch("plugins.petri_audit.user_overrides.read_role_override", return_value={}):
+        report = run_audit(
+            judge="claude-opus-4-8",
+            auditor="claude-opus-4-8",
+            target="claude-opus-4-7",
+            seeds=1,
+            max_turns=2,
+            dry_run=True,
+        )
+    joined = " ".join(report.command)
+    assert "auditor=anthropic/claude-opus-4-8" in joined
+    assert "judge=anthropic/claude-opus-4-8" in joined
+    assert "claude-cli/" not in joined  # PAYG api_key path, not OAuth
+
+
+def test_explicit_source_override_wins_over_payg_default() -> None:
+    """An explicit per-role source override is still honored over the api_key
+    default (the default only fills when no override is set)."""
+    from plugins.petri_audit.runner import run_audit
+
+    def _override(role: str) -> dict[str, str]:
+        return {"source": "claude-cli"} if role in ("auditor", "judge") else {}
+
+    with patch("plugins.petri_audit.user_overrides.read_role_override", side_effect=_override):
+        report = run_audit(
+            judge="claude-opus-4-8",
+            auditor="claude-opus-4-8",
+            target="claude-opus-4-7",
+            seeds=1,
+            max_turns=2,
+            dry_run=True,
+        )
+    joined = " ".join(report.command)
+    assert "auditor=claude-cli/claude-opus-4-8" in joined

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -43,7 +43,9 @@ def test_typer_audit_dry_run_prints_command(monkeypatch: pytest.MonkeyPatch) -> 
     assert "Petri audit" in result.output
     assert "inspect eval inspect_petri/audit" in result.output
     # CSA-3 flip — was claude-code/, now claude-cli/.
-    assert "judge=claude-cli/claude-haiku-4-5-20251001" in result.output
+    assert (
+        "judge=anthropic/claude-haiku-4-5-20251001" in result.output
+    )  # PAYG default (anthropic judge)
     assert "target=geode/claude-opus-4-7" in result.output
     assert "seed_instructions=tags:sycophancy" in result.output
     assert "dry-run" in result.output.lower()

--- a/tests/plugins/petri_audit/test_oauth_judge.py
+++ b/tests/plugins/petri_audit/test_oauth_judge.py
@@ -230,7 +230,7 @@ def test_run_audit_uses_oauth_when_token_present() -> None:
     joined = " ".join(report.command)
     # CSA-3 — flipped to paperclip subprocess prefixes.
     assert "judge=codex-cli/gpt-5.5" in joined
-    assert "auditor=claude-cli/claude-sonnet-4-6" in joined
+    assert "auditor=anthropic/claude-sonnet-4-6" in joined  # PAYG default (anthropic auditor)
 
 
 def test_run_audit_no_oauth_flag_forces_per_token() -> None:

--- a/tests/plugins/petri_audit/test_tool_handler.py
+++ b/tests/plugins/petri_audit/test_tool_handler.py
@@ -30,11 +30,22 @@ def test_petri_audit_handler_dry_run_returns_dict() -> None:
 
 
 def test_petri_audit_handler_defaults() -> None:
-    """Handler accepts an empty kwargs dict and falls back to safe defaults."""
+    """Handler accepts an empty kwargs dict and falls back to safe defaults.
+
+    Auditor + judge default to claude-opus-4-8 (PR-PETRI-AUDIT-DEFAULT-OPUS-CREDS)
+    — the campaign auditor tier — not the old haiku/sonnet."""
     handlers = _build_audit_handlers()
     result = handlers["petri_audit"]()
     assert result["status"] == "ok"
     assert result["audit"]["dry_run"] is True
+    cmd = result["audit"]["command"]
+    assert "auditor=anthropic/claude-opus-4-8" in cmd
+    assert "judge=anthropic/claude-opus-4-8" in cmd
+    # The OLD auditor/judge defaults must not appear in those roles (the target
+    # role legitimately carries whatever GEODE's active model is, so assert on
+    # the role-qualified strings, not bare model substrings).
+    assert "auditor=anthropic/claude-sonnet-4-6" not in cmd
+    assert "judge=anthropic/claude-haiku-4-5-20251001" not in cmd
 
 
 def test_petri_audit_handler_unknown_model_returns_error() -> None:


### PR DESCRIPTION
## Summary
Pass-through of v0.99.130 to main: petri_audit auditor/judge default to claude-opus-4-8 on the PAYG api_key path (anthropic OAuth claude-cli refuses the auditor role) + run_audit injects ANTHROPIC_API_KEY into the inspect subprocess (#1986). Completes the controlled-pilot fix chain (toolfix v.128 + seed-staging v.129 + this).

## Verification
- CI 7/7 green on #1986 (develop); ruff/format/mypy clean; petri_audit credential/handler/cli 25 passed; Codex MCP reviewed (OAuth-token-rejection guard added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)