### PR TITLE
fix(self-improving): campaign auto-resolves targeted-dim from seed pool (gate parity with loop runner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,24 @@ functional change.
 
 ---
 
+## [0.99.134] - 2026-06-04
+
+### Fixed
+- **Campaign harness auto-resolves the targeted promote-gate dim from the seed pool
+  (gate parity with the inner-loop runner).** `core/self_improving/campaign.py`
+  `build_campaign_env` now sets `GEODE_SIL_EXPECTED_DIM` BY DEFAULT, derived from the
+  `CYCLE_INPUT_POOL` seeds' YAML `target_dims` (new `_resolve_pool_target_dims` helper,
+  reusing `plugins.petri_audit.pool_validation._seed_target_dims` — no second YAML
+  parser). Previously the campaign never set this var, so `train.py::_resolve_targeted_dims`
+  returned `None` and the promote gate scored the diluted full 18-dim aggregate — an
+  improvement on the difficulty pool's target dim (e.g. `broken_tool_use`) washed out across
+  17 mostly-saturated dims. The inner-loop runner already env-propagated the targeted dim;
+  the campaign harness now does the parallel wiring. The dim is POOL-DERIVED (no hardcoded
+  constant); an explicit operator-set `GEODE_SIL_EXPECTED_DIM` is respected (never
+  overwritten); an empty / missing / malformed pool leaves the var UNSET → the v1
+  full-aggregate gate (backward-compatible). Closes the gap that required a manual
+  `GEODE_SIL_EXPECTED_DIM` shell export.
+
 ## [0.99.133] - 2026-06-04
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.133
+- **Version**: 0.99.134
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.133 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.134 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.133 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.134 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -214,6 +214,42 @@ def _utc_now_iso() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_pool_target_dims(pool_dir: Path) -> dict[str, float]:
+    """Union the ``target_dims`` declared by a seed pool's seeds.
+
+    PR-CAMPAIGN-TARGET-DIM (2026-06-04). The CYCLE_INPUT_POOL's seeds are
+    difficulty-calibrated to probe a specific judge dim (e.g. ``broken_tool_use``);
+    each seed carries that dim in its YAML front-matter ``target_dims``. This walks
+    every ``*.md`` seed in ``pool_dir``, unions their parsed ``target_dims`` (reusing
+    ``plugins.petri_audit.pool_validation._seed_target_dims`` — the SAME frontmatter
+    parser the pool-dim guard uses, no second YAML reader), and returns
+    ``{dim: 1.0 for dim in sorted(dims)}``.
+
+    The value is a NOMINAL hint only — ``train.py::_resolve_targeted_dims`` reads
+    just the KEYS of ``GEODE_SIL_EXPECTED_DIM`` (intersected with ``DIM_WEIGHTS``)
+    to pick the promote gate's targeted sub-fitness surface; the magnitude is never
+    consulted. The dim set is therefore POOL-DERIVED, never a hardcoded constant.
+
+    Graceful: an empty pool, a missing dir, seeds with no ``target_dims``, or
+    malformed front-matter all yield ``{}`` (``_seed_target_dims`` already swallows
+    a bad seed to ``[]``) — and the import itself is guarded, so a packaged distro
+    without ``plugins.petri_audit`` degrades to ``{}``. Never raises.
+    """
+    try:
+        from plugins.petri_audit.pool_validation import _seed_target_dims
+    except ImportError:
+        return {}
+    if not pool_dir.is_dir():
+        return {}
+    dims: set[str] = set()
+    # ``rglob`` (not ``glob``) — the seed-select contract supports a hierarchical
+    # seed tree, so a nested seed must not hide its target dim (mirrors
+    # ``validate_pool_target_dims``).
+    for seed_md in sorted(pool_dir.rglob("*.md")):
+        dims.update(_seed_target_dims(seed_md))
+    return dict.fromkeys(sorted(dims), 1.0)
+
+
 def build_campaign_env(
     *,
     promote_policy: str | None = None,
@@ -236,6 +272,16 @@ def build_campaign_env(
     ``gate`` / ``never`` arms must inherit NO seed (else `_resolve_promote_policy`
     / `_resolve_promote_policy_seed` would pick up the stale env, which is
     highest-precedence, and the ledger would record a wrong arm / seed).
+
+    ``GEODE_SIL_EXPECTED_DIM`` (PR-CAMPAIGN-TARGET-DIM, 2026-06-04) is auto-resolved
+    BY DEFAULT from the CYCLE_INPUT_POOL's seed ``target_dims`` — gate parity with
+    the inner-loop runner, which already env-propagates the targeted dim so the
+    promote gate scores the TARGETED sub-fitness (``train.py::_resolve_targeted_dims``)
+    on the dim the difficulty pool actually probes, instead of the diluted full
+    18-dim aggregate (near-saturation washout). An EXPLICIT operator-set
+    ``GEODE_SIL_EXPECTED_DIM`` in ``base_env`` is RESPECTED (never overwritten). When
+    the pool yields no target dims (empty / missing / malformed) the var is left
+    UNSET → ``train.py`` falls back to the v1 full-aggregate gate (backward-compatible).
     """
     env = dict(base_env if base_env is not None else os.environ)
     env["GEODE_CODEX_OAUTH_POLL_DISABLED"] = "1"
@@ -255,6 +301,19 @@ def build_campaign_env(
     else:
         env.pop("GEODE_PROMOTE_POLICY_SEED", None)
         env.pop("AUTORESEARCH_PROMOTE_POLICY_SEED", None)
+    # Auto-resolve the targeted dims from the selection pool — gate parity with the
+    # inner-loop runner (``runner.py`` env-propagates ``GEODE_SIL_EXPECTED_DIM``).
+    # Respect an explicit operator override: the mere PRESENCE of the key in
+    # ``base_env`` means the operator set it — never overwrite it, regardless of
+    # value. A deliberately BLANK value is a valid override too (``train.py::
+    # _resolve_targeted_dims`` reads ``"".strip()`` as "no targeting → full
+    # aggregate"), so we must not second-guess it as stale. When the key is absent
+    # we set it from the pool; when the pool yields no dims we leave it UNSET
+    # (graceful full-aggregate fallback).
+    if "GEODE_SIL_EXPECTED_DIM" not in env:
+        target_dims = _resolve_pool_target_dims(CYCLE_INPUT_POOL)
+        if target_dims:
+            env["GEODE_SIL_EXPECTED_DIM"] = json.dumps(target_dims, ensure_ascii=False)
     return env
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.133"
+version = "0.99.134"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_run_campaign.py
+++ b/tests/test_run_campaign.py
@@ -837,6 +837,128 @@ def test_build_campaign_env_clears_stale_arm_env(campaign_state: dict[str, Path]
     assert "GEODE_PROMOTE_POLICY_SEED" not in env_gate
 
 
+# ---------------------------------------------------------------------------
+# build_campaign_env — targeted-dim auto-resolution (PR-CAMPAIGN-TARGET-DIM)
+# ---------------------------------------------------------------------------
+
+
+def _write_seed_with_target_dims(pool_dir: Path, name: str, target_dims: list[str]) -> None:
+    """Write a minimal seed ``.md`` with a ``target_dims`` YAML frontmatter block."""
+    dims_yaml = "\n".join(f"  - {d}" for d in target_dims)
+    pool_dir.mkdir(parents=True, exist_ok=True)
+    (pool_dir / name).write_text(
+        f"---\ntarget_dims:\n{dims_yaml}\n---\n\nseed body\n",
+        encoding="utf-8",
+    )
+
+
+def test_build_campaign_env_auto_resolves_target_dim_from_pool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A CYCLE_INPUT_POOL whose seeds declare ``target_dims: [broken_tool_use]``
+    # auto-resolves GEODE_SIL_EXPECTED_DIM by default — gate parity with the
+    # inner-loop runner. The dim is POOL-DERIVED (the seed's frontmatter), never
+    # a hardcoded constant.
+    pool = tmp_path / "cycle-input"
+    _write_seed_with_target_dims(pool, "s1.md", ["broken_tool_use"])
+    _write_seed_with_target_dims(pool, "s2.md", ["broken_tool_use"])
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    env = rc.build_campaign_env(base_env={})
+
+    assert json.loads(env["GEODE_SIL_EXPECTED_DIM"]) == {"broken_tool_use": 1.0}
+
+
+def test_build_campaign_env_unions_multiple_target_dims_from_pool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Distinct dims across seeds are unioned (value is the nominal 1.0 hint; only
+    # the KEYS feed train.py::_resolve_targeted_dims).
+    pool = tmp_path / "cycle-input"
+    _write_seed_with_target_dims(pool, "s1.md", ["broken_tool_use"])
+    _write_seed_with_target_dims(pool, "s2.md", ["sycophancy"])
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    env = rc.build_campaign_env(base_env={})
+
+    assert json.loads(env["GEODE_SIL_EXPECTED_DIM"]) == {
+        "broken_tool_use": 1.0,
+        "sycophancy": 1.0,
+    }
+
+
+def test_build_campaign_env_respects_explicit_expected_dim_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An operator-set GEODE_SIL_EXPECTED_DIM in base_env is RESPECTED, never
+    # overwritten by the pool-derived value.
+    pool = tmp_path / "cycle-input"
+    _write_seed_with_target_dims(pool, "s1.md", ["broken_tool_use"])
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    override = json.dumps({"sycophancy": 0.3})
+    env = rc.build_campaign_env(base_env={"GEODE_SIL_EXPECTED_DIM": override})
+
+    assert env["GEODE_SIL_EXPECTED_DIM"] == override
+
+
+def test_build_campaign_env_empty_pool_leaves_expected_dim_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An empty pool (no seeds) yields no target dims → GEODE_SIL_EXPECTED_DIM is
+    # left UNSET → train.py falls back to the v1 full-aggregate gate.
+    pool = tmp_path / "cycle-input"
+    pool.mkdir(parents=True)
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    env = rc.build_campaign_env(base_env={})
+
+    assert "GEODE_SIL_EXPECTED_DIM" not in env
+
+
+def test_build_campaign_env_no_target_dims_pool_leaves_expected_dim_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Seeds present but none declaring target_dims (or malformed frontmatter) →
+    # no dims → GEODE_SIL_EXPECTED_DIM absent (graceful full-aggregate fallback).
+    pool = tmp_path / "cycle-input"
+    pool.mkdir(parents=True)
+    (pool / "no_front.md").write_text("just a body, no frontmatter\n", encoding="utf-8")
+    (pool / "empty_dims.md").write_text("---\nname: x\n---\nbody\n", encoding="utf-8")
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    env = rc.build_campaign_env(base_env={})
+
+    assert "GEODE_SIL_EXPECTED_DIM" not in env
+
+
+def test_build_campaign_env_missing_pool_dir_leaves_expected_dim_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A missing pool dir is graceful — no raise, GEODE_SIL_EXPECTED_DIM unset.
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", tmp_path / "does-not-exist")
+
+    env = rc.build_campaign_env(base_env={})
+
+    assert "GEODE_SIL_EXPECTED_DIM" not in env
+
+
+def test_build_campaign_env_respects_blank_explicit_expected_dim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A deliberately BLANK GEODE_SIL_EXPECTED_DIM in base_env is a valid operator
+    # override (train.py::_resolve_targeted_dims reads "".strip() as "no targeting
+    # → full aggregate"). The mere PRESENCE of the key means the operator set it,
+    # so the pool-derived value must NOT overwrite it.
+    pool = tmp_path / "cycle-input"
+    _write_seed_with_target_dims(pool, "s1.md", ["broken_tool_use"])
+    monkeypatch.setattr(rc, "CYCLE_INPUT_POOL", pool)
+
+    env = rc.build_campaign_env(base_env={"GEODE_SIL_EXPECTED_DIM": ""})
+
+    assert env["GEODE_SIL_EXPECTED_DIM"] == ""
+
+
 def test_read_latest_attribution_min_rows_blocks_stale(campaign_state: dict[str, Path]) -> None:
     mutations = campaign_state["mutations"]
     _write_attribution(mutations, held_out=0.5, fitness=0.5, source="manual")

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.133"
+version = "0.99.134"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `core/self_improving/campaign.py::build_campaign_env` now sets `GEODE_SIL_EXPECTED_DIM` **by default**, auto-resolved from the `CYCLE_INPUT_POOL` seeds' YAML `target_dims` front-matter — so a 3-arm campaign's promote gate scores the **targeted sub-fitness** on the dim its difficulty seed pool actually probes, instead of the diluted full 18-dim aggregate.
- New `_resolve_pool_target_dims(pool_dir) -> dict[str, float]` helper unions `plugins.petri_audit.pool_validation._seed_target_dims(md)` over the pool's `*.md` seeds (reuses the existing frontmatter parser — no second YAML reader) and returns `{dim: 1.0 for dim in sorted(dims)}` (nominal hint; `train.py::_resolve_targeted_dims` consumes only the KEYS).
- Closes a wiring gap that previously required a manual `GEODE_SIL_EXPECTED_DIM` shell export to bridge the live campaign.

## Why
Without `GEODE_SIL_EXPECTED_DIM`, `train.py::_resolve_targeted_dims()` returns `None` → the promote gate scores the full-aggregate v1 fitness. An improvement on the difficulty pool's target dim (e.g. `broken_tool_use`) is diluted across 17 mostly-saturated dims → the gate can't detect it (near-saturation washout — the exact problem difficulty-calibrated seeds exist to escape).

The inner-loop runner already does the analogous thing (`core/self_improving/loop/runner.py` env-propagates `GEODE_SIL_EXPECTED_DIM` from `pick_regression_target_dim`). The campaign harness never got the parallel wiring.

## Changes
| File | Change |
|------|--------|
| `core/self_improving/campaign.py` | Add `_resolve_pool_target_dims` helper; `build_campaign_env` auto-sets `GEODE_SIL_EXPECTED_DIM` from the pool by default |
| `tests/test_run_campaign.py` | 7 new tests: pool-derived single/multi dim, explicit override respected (incl. blank), empty / no-target-dims / missing pool → unset |
| `CHANGELOG.md` `pyproject.toml` `CLAUDE.md` `README.md` `README.ko.md` `uv.lock` | PATCH bump 0.99.133 → 0.99.134 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Pool-derived (no hardcoded `broken_tool_use`) | Implemented | unioned from seed frontmatter via `_seed_target_dims` |
| Explicit operator override respected | Implemented | key-presence check (`not in env`) — a deliberate blank `""` is also respected (= full-aggregate; per `train.py`'s `"".strip()` semantics). Codex MCP finding. |
| Graceful empty/missing/malformed → unset | Implemented | `_resolve_pool_target_dims` returns `{}`; var left unset → v1 full-aggregate fallback. Never raises. |

## Verification
- [x] `ruff check core/ tests/` clean
- [x] `ruff format --check` clean
- [x] `mypy core/` clean (403 files)
- [x] `lint-imports` clean (4 kept / 0 broken)
- [x] `pytest tests/test_run_campaign.py` pass (79; +7 new build_campaign_env tests) + `tests/self_improving/test_metric_targeted_irt.py` pass
- [x] Codex MCP review: 1 MAJOR (blank-override) — fixed (key-presence semantics); re-verified clean
- [x] Backward-compatible: a clean checkout's gitignored absent `CYCLE_INPUT_POOL` → var unset → existing tests unchanged

## Reference
Mirrors `core/self_improving/loop/runner.py` `GEODE_SIL_EXPECTED_DIM` env propagation; consumer `core/self_improving/train.py::_resolve_targeted_dims`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)