### PR TITLE
develop → main: concurrent path-independent control arms (v0.99.135, #1996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,26 @@ functional change.
 
 ---
 
-## [0.99.134] - 2026-06-04
+## [0.99.135] - 2026-06-04
+
+### Changed
+- **Path-independent control arms (`never` + `random`) run CONCURRENTLY by default.**
+  `core/self_improving/campaign.py` `run_campaign` now fans every `never` cycle and
+  every `random` cycle out in ONE `asyncio.gather` (new `run_control_arms_async`
+  orchestrator) instead of looping the arms sequentially (`never`'s N cycles, THEN
+  `random`'s N cycles). Both arms are PATH-INDEPENDENT (every cycle measures the SAME
+  frozen baseline before any keep/revert), so they OVERLAP — with PAYG's unbounded
+  fan-out this ~halves the control-arm wall-clock. The PATH-DEPENDENT `gate` arm still
+  runs LAST and sequentially on the `run_arm` champion-chain path (a promote mutates
+  the champion + steers the next propose), never routed through the fan-out. Invariants
+  preserved: per-arm attribution (each worker is tagged with its arm; the gather result
+  is partitioned back per arm), per-arm promote policy (`GEODE_PROMOTE_POLICY` +
+  random's per-cycle seed built per arm), resume checkpoint (cycles key per-arm group),
+  random reproducibility (the per-cycle seed `DEFAULT_RANDOM_SEED_BASE + arm_index*n +
+  cycle` is keyed on `(arm_index, n, cycle)`, byte-identical to the legacy formula —
+  not wall-clock order), and per-arm worker-root / transcript isolation (`never`-w1 and
+  `random`-w1 live under distinct roots). The legacy dry-run / injected-runner path keeps
+  the original sequential `never → random → gate` order. Default behavior, not a flag.
 
 ### Fixed
 - **Campaign harness auto-resolves the targeted promote-gate dim from the seed pool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.134
+- **Version**: 0.99.135
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.134 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.135 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.134 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.135 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -24,9 +24,14 @@ importable module with a CLI front end. The driver does NOT decide policy — it
   ``RepetitiveMutationError`` or a measurement-hyperparam ``ValueError`` does not
   burn the cycle.
 * ``GEODE_PROMOTE_POLICY`` (+ ``GEODE_PROMOTE_POLICY_SEED``) — the control-arm
-  knob (``core/self_improving/train.py::_resolve_promote_policy``). The driver runs the
-  3 arms in the order **never → random → gate** (gate LAST), each from a matched
-  gen-0 SoT reset.
+  knob (``core/self_improving/train.py::_resolve_promote_policy``). Each arm runs
+  from a matched gen-0 SoT reset. The two PATH-INDEPENDENT control arms
+  (**never + random**) fan out CONCURRENTLY in ONE ``asyncio.gather`` by default
+  (PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS, 2026-06-04 — every cycle measures the same
+  frozen baseline, so they overlap instead of running arm-by-arm); the
+  PATH-DEPENDENT **gate** arm runs LAST and sequentially (a promote mutates the
+  champion chain). The legacy dry-run / injected-runner path keeps the original
+  sequential **never → random → gate** order.
 
 At the start of a REAL (non-``--dry-run``) campaign the driver purges
 ``inspect_ai``'s trajectory cache (``plugins.petri_audit.runner.purge_inspect_cache``,
@@ -984,7 +989,10 @@ def _spawn_train_subprocess(
 # corrupt by running them out of order. They fan out concurrently via
 # ``asyncio.gather`` — each worker a SEPARATE ``train.py`` subprocess
 # (its own GEODE runtime, its own process-local audit lane, its own state
-# tree). The campaign's cross-worker concurrency is therefore purely
+# tree). Since PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS (2026-06-04) the NEVER +
+# RANDOM cycles fan out in ONE shared ``gather`` (``run_control_arms_async``),
+# so the two control arms OVERLAP instead of running arm-by-arm — by default.
+# The campaign's cross-worker concurrency is therefore purely
 # orchestrator-level (the ``gather``); it does NOT depend on any in-process
 # GEODE singleton (the audit lane stays the subscription-safe per-process
 # ``max_concurrent=1`` — each worker runs exactly one audit, so that cap
@@ -1755,16 +1763,14 @@ async def run_control_arm_async(
     checkpoint: RunCheckpoint | None = None,
     campaign_transcript: Path | None = None,
 ) -> ControlArmFloor:
-    """Run a PATH-INDEPENDENT control arm's N cycles concurrently.
+    """Run ONE PATH-INDEPENDENT control arm's N cycles concurrently.
 
-    For the ``never`` and ``random`` arms ONLY: each cycle measures the SAME
-    frozen baseline (no keep/revert chain), so the N cycles fan out via
-    ``asyncio.gather`` — each an isolated ``GEODE_STATE_ROOT`` worker seeded from
-    the frozen snapshot, with the arm's ``GEODE_PROMOTE_POLICY`` (+ per-cycle
-    deterministic ``GEODE_PROMOTE_POLICY_SEED`` for ``random``). Then aggregates
-    the per-cycle held-out / fitness floor (mirroring
-    ``scripts/floor_aggregate.py``), filtering to successful cycles and logging
-    drops.
+    Thin single-arm wrapper over :func:`run_control_arms_async` (the multi-arm
+    orchestrator that, since PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS, is the DEFAULT
+    control-arm path — it fans never+random out in ONE gather). Kept for the
+    single-arm caller / tests: it runs just this one arm's cycles, with the arm's
+    ``GEODE_PROMOTE_POLICY`` (+ per-cycle deterministic ``GEODE_PROMOTE_POLICY_SEED``
+    for ``random``), then aggregates the per-cycle held-out / fitness floor.
 
     NOT for the GATE arm — that is path-dependent (a promote mutates the champion
     + steers the next propose) and MUST stay the sequential :func:`run_arm`. This
@@ -1787,59 +1793,58 @@ async def run_control_arm_async(
         )
     if arm not in {"never", "random"}:
         raise ValueError(f"run_control_arm_async expects 'never' or 'random', got {arm!r}")
-    ckpt = checkpoint if checkpoint is not None else RunCheckpoint(run_id=None)
-    runner = runner_fn if runner_fn is not None else _spawn_train_subprocess_async
-    already_done = ckpt.completed_indices(arm)
-    pending = [cycle for cycle in range(1, n + 1) if cycle not in already_done]
-    if already_done:
-        progress.emit(
-            f"control arm '{arm}' (async): RESUME — {len(already_done)} cycle(s) already "
-            f"complete {sorted(already_done)}; re-running {len(pending)} missing {pending}"
-        )
-    fresh: list[WorkerOutcome] = []
-    if pending:
-        with tempfile.TemporaryDirectory(prefix=f"geode-{arm}-") as tmp:
-            roots_parent = workers_root if workers_root is not None else Path(tmp)
-            progress.emit(
-                f"control arm '{arm}' (index {arm_index}, async): fanning {len(pending)} isolated "
-                f"frozen-baseline cycles concurrently (dry_run={dry_run})"
-            )
-            fresh = list(
-                await asyncio.gather(
-                    *(
-                        _run_isolated_worker(
-                            index=cycle,
-                            group=arm,
-                            workers_root=roots_parent,
-                            snapshot_dir=snapshot_dir,
-                            promote_policy=arm,
-                            # random arm: deterministic per-(arm,cycle) seed so a
-                            # re-run reproduces the same random promote decisions.
-                            promote_policy_seed=(
-                                DEFAULT_RANDOM_SEED_BASE + arm_index * n + cycle
-                                if arm == "random"
-                                else None
-                            ),
-                            audit_max_samples=audit_max_samples,
-                            audit_max_connections=audit_max_connections,
-                            dry_run=dry_run,
-                            per_audit_timeout=per_audit_timeout,
-                            runner_fn=runner,
-                        )
-                        for cycle in pending
-                    )
-                )
-            )
-            # S6 — merge the per-cycle isolated transcripts into the campaign
-            # transcript while the tempdir is still alive.
-            if campaign_transcript is not None:
-                merged = merge_worker_transcripts(
-                    [o.transcript_path for o in fresh], campaign_transcript
-                )
-                progress.emit(
-                    f"control arm '{arm}' (async): merged {merged} per-cycle transcript "
-                    f"event(s) → {campaign_transcript}"
-                )
+    floors = await run_control_arms_async(
+        control_arms=[(arm, arm_index)],
+        n=n,
+        audit_max_samples=audit_max_samples,
+        audit_max_connections=audit_max_connections,
+        dry_run=dry_run,
+        progress=progress,
+        snapshot_dir=snapshot_dir,
+        per_audit_timeout=per_audit_timeout,
+        workers_root=workers_root,
+        runner_fn=runner_fn,
+        checkpoint=checkpoint,
+        campaign_transcript=campaign_transcript,
+    )
+    return floors[arm]
+
+
+def _control_cycle_seed(arm: str, arm_index: int, n: int, cycle: int) -> int | None:
+    """The deterministic ``GEODE_PROMOTE_POLICY_SEED`` for one control-arm cycle.
+
+    Reproducibility invariant (task #4): the random arm's per-cycle coin flip is
+    keyed on ``(arm_index, n, cycle)`` ONLY — never on wall-clock / dispatch order
+    — so a cycle's seed is byte-identical whether the never+random fan-out runs
+    the arms sequentially (legacy) or interleaved in one concurrent gather (the
+    new default). ``arm_index`` is the arm's position in the ORIGINAL ``arms``
+    sequence (``random`` → index 1 by default), so the formula matches the legacy
+    per-arm path exactly. Only the ``random`` arm seeds; ``never`` is unseeded.
+    """
+    if arm != "random":
+        return None
+    return DEFAULT_RANDOM_SEED_BASE + arm_index * n + cycle
+
+
+def _aggregate_control_floor(
+    *,
+    arm: str,
+    n: int,
+    fresh: Sequence[WorkerOutcome],
+    ckpt: RunCheckpoint,
+    progress: ProgressLog,
+) -> ControlArmFloor:
+    """Aggregate ONE control arm's per-cycle outcomes into its :class:`ControlArmFloor`.
+
+    The post-gather per-arm aggregation, factored out so the single-arm
+    (:func:`run_control_arm_async`) and the concurrent multi-arm
+    (:func:`run_control_arms_async`) paths compute the floor IDENTICALLY. ``fresh``
+    is only THIS arm's freshly-run outcomes (the multi-arm orchestrator partitions
+    the single gather's results by arm BEFORE calling this, so a ``never`` cycle is
+    never mixed into the ``random`` floor — attribution invariant #1). Records the
+    arm's ``ok`` cycles to its OWN checkpoint group, unions them with the cycles
+    resumed from a prior run (invariant #3), and bands the held-out / fitness floor.
+    """
     fresh_ok = [o for o in fresh if o.ok]
     dropped = [o for o in fresh if not o.ok]
     # Capture resumed cycles BEFORE recording the fresh ones (no double-count).
@@ -1866,6 +1871,153 @@ async def run_control_arm_async(
     )
     progress.emit(floor.summary())
     return floor
+
+
+async def run_control_arms_async(
+    *,
+    control_arms: Sequence[tuple[str, int]],
+    n: int,
+    audit_max_samples: int,
+    audit_max_connections: int,
+    dry_run: bool,
+    progress: ProgressLog,
+    snapshot_dir: Path = GEN0_SNAPSHOT_DIR,
+    per_audit_timeout: float | None = None,
+    workers_root: Path | None = None,
+    runner_fn: Any | None = None,
+    checkpoint: RunCheckpoint | None = None,
+    campaign_transcript: Path | None = None,
+) -> dict[str, ControlArmFloor]:
+    """Fan EVERY path-independent control arm's cycles out in ONE concurrent gather.
+
+    The DEFAULT control-arm orchestration (PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS,
+    2026-06-04). ``control_arms`` is the list of ``(arm, arm_index)`` to run — the
+    ``never`` and ``random`` arms ONLY (``arm_index`` is each arm's position in the
+    original ``arms`` sequence, preserved so the random seed formula is unchanged —
+    invariant #4). Both arms are PATH-INDEPENDENT (every cycle measures the SAME
+    frozen baseline, no keep/revert chain), so ALL their pending cycles fan out
+    together via a SINGLE ``asyncio.gather`` — the two arms OVERLAP instead of
+    running arm-by-arm. With PAYG's unbounded fan-out this ~halves the control-arm
+    wall-clock (the two arms' cycles run concurrently, not back-to-back).
+
+    The GATE arm is PATH-DEPENDENT (a promote mutates the champion + steers the
+    next propose) and is NEVER routed here — it stays the sequential :func:`run_arm`.
+    This function raises ``ValueError`` if asked to run ``gate`` so the invariant
+    cannot be violated by a mis-call.
+
+    INVARIANTS (each verified by ``tests/test_run_campaign.py``):
+
+    * Attribution (#1): each cycle task is tagged with its arm; the gather's flat
+      result list is PARTITIONED back by arm before aggregation, so a ``never``
+      cycle never lands in the ``random`` floor (and vice-versa).
+    * Promote policy (#2): each task's env carries ITS arm's
+      ``GEODE_PROMOTE_POLICY`` + (random only) the per-cycle seed — built per task
+      via :func:`_build_worker_env`, so the interleaved fan-out sets each worker's
+      policy by its OWN arm.
+    * Resume (#3): pending cycles are filtered per arm against ITS checkpoint group
+      (``ckpt.completed_indices(arm)``); aggregation records + resumes per arm. A
+      resumed run re-runs only the missing cycles of each arm, never cross-attributed.
+    * Reproducibility (#4): the random seed is :func:`_control_cycle_seed` —
+      ``(arm_index, n, cycle)``-keyed, order-independent.
+    * Transcript isolation (#5): each arm's cycle workers live under their OWN
+      subtree (``<roots_parent>/<arm>/w{cycle}``) so a ``never`` cycle and a
+      ``random`` cycle with the SAME index never collide on a worker root /
+      transcript file. The per-worker transcripts are merged into the one campaign
+      transcript after the gather.
+
+    Returns ``{arm: ControlArmFloor}`` for every arm in ``control_arms``.
+    """
+    arm_names = [arm for arm, _ in control_arms]
+    bad = [arm for arm in arm_names if arm == "gate"]
+    if bad:
+        raise ValueError(
+            "run_control_arms_async refuses the GATE arm — it is path-dependent "
+            "(promote mutates the champion chain) and MUST stay sequential (run_arm)"
+        )
+    unknown = [arm for arm in arm_names if arm not in {"never", "random"}]
+    if unknown:
+        raise ValueError(
+            f"run_control_arms_async expects 'never'/'random' arms, got unknown {unknown}"
+        )
+    ckpt = checkpoint if checkpoint is not None else RunCheckpoint(run_id=None)
+    runner = runner_fn if runner_fn is not None else _spawn_train_subprocess_async
+
+    # Per arm: the cycles still pending after subtracting the checkpoint's completed
+    # set (invariant #3 — a resume re-runs only the missing cycles of EACH arm).
+    pending_by_arm: dict[str, list[int]] = {}
+    for arm, _arm_index in control_arms:
+        already_done = ckpt.completed_indices(arm)
+        pending = [cycle for cycle in range(1, n + 1) if cycle not in already_done]
+        pending_by_arm[arm] = pending
+        if already_done:
+            progress.emit(
+                f"control arm '{arm}' (async): RESUME — {len(already_done)} cycle(s) already "
+                f"complete {sorted(already_done)}; re-running {len(pending)} missing {pending}"
+            )
+
+    # One flat task list across ALL control arms, each task paired with its arm so
+    # the gather's flat result can be partitioned back (attribution invariant #1).
+    fresh_by_arm: dict[str, list[WorkerOutcome]] = {arm: [] for arm, _ in control_arms}
+    total_pending = sum(len(p) for p in pending_by_arm.values())
+    if total_pending:
+        with tempfile.TemporaryDirectory(prefix="geode-control-") as tmp:
+            roots_parent = workers_root if workers_root is not None else Path(tmp)
+            progress.emit(
+                "control arms (async): SINGLE concurrent fan-out over "
+                f"{[(arm, len(pending_by_arm[arm])) for arm, _ in control_arms]} "
+                f"({total_pending} isolated frozen-baseline cycles, dry_run={dry_run})"
+            )
+            # ``arm_of_task[i]`` records which arm task ``i`` belongs to — the gather
+            # preserves input order, so this list re-attributes each flat result.
+            arm_of_task: list[str] = []
+            coros = []
+            for arm, arm_index in control_arms:
+                # Each arm's cycle workers get their OWN subtree so a never-cycle and
+                # a random-cycle with the SAME index never collide (invariant #5).
+                arm_root = roots_parent / arm
+                for cycle in pending_by_arm[arm]:
+                    arm_of_task.append(arm)
+                    coros.append(
+                        _run_isolated_worker(
+                            index=cycle,
+                            group=arm,
+                            workers_root=arm_root,
+                            snapshot_dir=snapshot_dir,
+                            promote_policy=arm,
+                            promote_policy_seed=_control_cycle_seed(arm, arm_index, n, cycle),
+                            audit_max_samples=audit_max_samples,
+                            audit_max_connections=audit_max_connections,
+                            dry_run=dry_run,
+                            per_audit_timeout=per_audit_timeout,
+                            runner_fn=runner,
+                        )
+                    )
+            outcomes = list(await asyncio.gather(*coros))
+            # Partition the flat result back by arm (attribution invariant #1).
+            for task_arm, outcome in zip(arm_of_task, outcomes, strict=True):
+                fresh_by_arm[task_arm].append(outcome)
+            # S6 — merge ALL arms' per-cycle isolated transcripts into the campaign
+            # transcript while the tempdir is still alive (one merge for the gather).
+            if campaign_transcript is not None:
+                merged = merge_worker_transcripts(
+                    [o.transcript_path for outcomes in fresh_by_arm.values() for o in outcomes],
+                    campaign_transcript,
+                )
+                progress.emit(
+                    f"control arms (async): merged {merged} per-cycle transcript "
+                    f"event(s) → {campaign_transcript}"
+                )
+
+    return {
+        arm: _aggregate_control_floor(
+            arm=arm,
+            n=n,
+            fresh=fresh_by_arm[arm],
+            ckpt=ckpt,
+            progress=progress,
+        )
+        for arm, _ in control_arms
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -2177,9 +2329,15 @@ def run_campaign(
     """Run the full campaign: gen-0 K-repeat baseline → snapshot → 3-arm loop.
 
     Returns a dict with the noise band + per-arm summaries (for tests + an
-    end-of-run digest). Arms run in the order given (``never → random → gate`` by
-    default, gate LAST). The injected ``train_runner`` / ``runner_factory`` /
-    ``guard_fn`` keep the whole thing unit-testable with NO live audit.
+    end-of-run digest). On the real async-first path the PATH-INDEPENDENT control
+    arms (``never`` + ``random``) run CONCURRENTLY in ONE fan-out by default
+    (PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS, 2026-06-04) — they overlap instead of
+    running arm-by-arm — and the PATH-DEPENDENT ``gate`` arm runs LAST and
+    sequentially. The legacy dry-run / injected-runner path keeps the original
+    sequential ``never → random → gate`` order. Either way the returned
+    ``arm_summaries`` are emitted in the ORIGINAL ``arms`` order. The injected
+    ``train_runner`` / ``runner_factory`` / ``guard_fn`` keep the whole thing
+    unit-testable with NO live audit.
     """
     _validate_arms(arms)
     with ProgressLog(progress_path) as progress:
@@ -2234,7 +2392,16 @@ def run_campaign(
         # path, so this wiring changes ONLY the real-campaign behaviour.
         use_async = async_first and not dry_run and train_runner is None and runner_factory is None
         per_audit_timeout = _resolve_per_audit_timeout() if use_async else None
-        ckpt = RunCheckpoint(run_id=f"campaign-n{n}-k{k}-{'-'.join(arms)}") if use_async else None
+        # ``.load()`` the persisted marker (Codex MCP HIGH): a resumed campaign
+        # process must REHYDRATE which gen-0 / never / random cycles already
+        # completed, else ``completed_indices`` is empty for every group and the
+        # whole fan-out re-runs (re-paying for already-measured cycles). A missing /
+        # corrupt marker loads to an empty (fresh-run) checkpoint, never raises.
+        ckpt = (
+            RunCheckpoint(run_id=f"campaign-n{n}-k{k}-{'-'.join(arms)}").load()
+            if use_async
+            else None
+        )
         campaign_transcript = (
             (CAMPAIGN_RUNS_DIR / "campaign-transcript.jsonl") if use_async else None
         )
@@ -2242,8 +2409,8 @@ def run_campaign(
         if use_async:
             progress.emit(
                 f"async-first: concurrent subprocess fan-out — per_audit_timeout="
-                f"{per_audit_timeout}s run_id={ckpt.run_id if ckpt else None}; gen-0 K + "
-                "never/random parallel, gate sequential"
+                f"{per_audit_timeout}s run_id={ckpt.run_id if ckpt else None}; gen-0 K "
+                "parallel, then never+random in ONE shared concurrent gather, gate sequential"
             )
             # gen-0 workers seed from a snapshot of the CURRENT frozen scaffold, so
             # snapshot BEFORE the async gen-0 (the arms re-seed from the post-K-mean
@@ -2275,16 +2442,29 @@ def run_campaign(
         # against) — this is the matched reset every arm restores from.
         snapshot_written = snapshot_sot(snapshot_dir)
         progress.emit(f"gen-0 SoT snapshot: {len(snapshot_written)} files → {snapshot_dir}")
-        arm_summaries: list[ArmSummary] = []
+        # Per-arm summaries keyed by arm so the control fan-out + the sequential gate
+        # write into the SAME map regardless of dispatch order; emitted at the end in
+        # the ORIGINAL ``arms`` order (digest stability).
+        summary_by_arm: dict[str, ArmSummary] = {}
         control_floors: list[ControlArmFloor] = []
         halted = False
-        for arm_index, arm in enumerate(arms):
-            if use_async and arm in ("never", "random"):
-                # PATH-INDEPENDENT control arm → concurrent isolated subprocesses.
-                floor = asyncio.run(
-                    run_control_arm_async(
-                        arm=arm,
-                        arm_index=arm_index,
+        # PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS (2026-06-04) — the PATH-INDEPENDENT
+        # control arms (``never`` + ``random``) now fan out in ONE concurrent
+        # ``asyncio.gather`` BY DEFAULT: every ``never`` cycle and every ``random``
+        # cycle measure the SAME frozen baseline, so they OVERLAP instead of running
+        # arm-by-arm (with PAYG's unbounded fan-out this ~halves the control-arm
+        # wall-clock). Each arm keeps its ORIGINAL ``arm_index`` (its position in
+        # ``arms``) so the random seed formula is byte-identical (invariant #4). The
+        # GATE arm is PATH-DEPENDENT (a promote mutates the champion chain) and stays
+        # on the sequential ``run_arm`` path below — never routed through the fan-out.
+        if use_async:
+            control_arms = [
+                (arm, arm_index) for arm_index, arm in enumerate(arms) if arm in ("never", "random")
+            ]
+            if control_arms:
+                floors_by_arm = asyncio.run(
+                    run_control_arms_async(
+                        control_arms=control_arms,
                         n=n,
                         audit_max_samples=audit_max_samples,
                         audit_max_connections=audit_max_connections,
@@ -2296,22 +2476,26 @@ def run_campaign(
                         campaign_transcript=campaign_transcript,
                     )
                 )
-                control_floors.append(floor)
-                # Adapt the held-out FLOOR to the ArmSummary digest shape — a control
-                # arm never promotes (its evidence is ``held_out_band``, preserved in
-                # ``control_floors``); cycles_run/skipped map from ok/dropped.
-                arm_summaries.append(
-                    ArmSummary(
+                for arm, _arm_index in control_arms:
+                    floor = floors_by_arm[arm]
+                    control_floors.append(floor)
+                    # Adapt the held-out FLOOR to the ArmSummary digest shape — a
+                    # control arm never promotes (its evidence is ``held_out_band``,
+                    # preserved in ``control_floors``); cycles_run/skipped map from
+                    # ok/dropped.
+                    summary_by_arm[arm] = ArmSummary(
                         arm=arm,
                         cycles_run=floor.cycles_ok,
                         cycles_skipped=floor.cycles_dropped,
                         promotes=0,
                         halted=False,
                     )
-                )
-                progress.emit(floor.summary())
+        for arm_index, arm in enumerate(arms):
+            # Control arms already ran in the concurrent fan-out above (async path).
+            if use_async and arm in ("never", "random"):
                 continue
-            # GATE (path-dependent champion chain) — or any arm on the sync path.
+            # GATE (path-dependent champion chain) — or any arm on the sync path
+            # (dry-run smoke / injected runner: never + random + gate all sequential).
             summary = run_arm(
                 arm=arm,
                 arm_index=arm_index,
@@ -2325,7 +2509,7 @@ def run_campaign(
                 runner_factory=runner_factory,
                 guard_fn=guard_fn,
             )
-            arm_summaries.append(summary)
+            summary_by_arm[arm] = summary
             if summary.halted:
                 # A degenerate audit signals a broken setup — stop the WHOLE
                 # campaign (not just this arm) so a broken setup never burns the
@@ -2333,6 +2517,11 @@ def run_campaign(
                 progress.emit(f"campaign HALT: arm '{arm}' degenerate — stopping remaining arms")
                 halted = True
                 break
+        # Emit summaries in the ORIGINAL ``arms`` order (an arm absent because the
+        # sequential path HALTed before reaching it is simply omitted).
+        arm_summaries: list[ArmSummary] = [
+            summary_by_arm[arm] for arm in arms if arm in summary_by_arm
+        ]
         progress.emit("campaign complete" if not halted else "campaign halted")
         return {
             "noise_band": band,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.134"
+version = "0.99.135"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_run_campaign.py
+++ b/tests/test_run_campaign.py
@@ -2149,7 +2149,11 @@ def test_run_campaign_async_first_routes_path_independent_to_async(
     """A REAL campaign (dry_run=False, no injected runner) with async_first routes
     gen-0 + never/random through the ASYNC subprocess harness and the GATE through
     the sequential run_arm — proving the harness is WIRED into production, not the
-    dead test-only code Codex MCP flagged."""
+    dead test-only code Codex MCP flagged.
+
+    PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS (2026-06-04): never+random now go through
+    ONE ``run_control_arms_async`` gather (a SINGLE call carrying BOTH control
+    arms), NOT one sequential ``run_control_arm_async`` per arm."""
     import plugins.petri_audit.runner as petri_runner
 
     monkeypatch.setattr(petri_runner, "purge_inspect_cache", lambda: True)
@@ -2158,22 +2162,28 @@ def test_run_campaign_async_first_routes_path_independent_to_async(
     band = rc.NoiseBand(
         k=2, held_out_values=(0.85,), fitness_values=(0.89,), mean=0.85, stderr=0.01
     )
-    calls: dict[str, Any] = {"gen0": 0, "control": [], "gate": []}
+    calls: dict[str, Any] = {"gen0": 0, "control_calls": [], "gate": []}
 
     async def fake_gen0_async(**_kw: Any) -> Any:
         calls["gen0"] += 1
         return band
 
-    async def fake_control_async(*, arm: str, n: int, **_kw: Any) -> Any:
-        calls["control"].append(arm)
-        return rc.ControlArmFloor(arm=arm, cycles_ok=n, cycles_dropped=0, held_out_band=band)
+    async def fake_control_arms_async(*, control_arms: Any, n: int, **_kw: Any) -> dict[str, Any]:
+        # ONE call carrying BOTH path-independent arms — record the arm list so the
+        # test proves never+random are dispatched together, not arm-by-arm.
+        arms_in_call = [arm for arm, _idx in control_arms]
+        calls["control_calls"].append(arms_in_call)
+        return {
+            arm: rc.ControlArmFloor(arm=arm, cycles_ok=n, cycles_dropped=0, held_out_band=band)
+            for arm in arms_in_call
+        }
 
     def fake_run_arm(*, arm: str, n: int, **_kw: Any) -> Any:
         calls["gate"].append(arm)
         return rc.ArmSummary(arm=arm, cycles_run=n, cycles_skipped=0, promotes=1, halted=False)
 
     monkeypatch.setattr(rc, "run_gen0_baseline_async", fake_gen0_async)
-    monkeypatch.setattr(rc, "run_control_arm_async", fake_control_async)
+    monkeypatch.setattr(rc, "run_control_arms_async", fake_control_arms_async)
     monkeypatch.setattr(rc, "run_arm", fake_run_arm)
 
     result = rc.run_campaign(
@@ -2186,9 +2196,81 @@ def test_run_campaign_async_first_routes_path_independent_to_async(
         snapshot_dir=campaign_state["snapshot"],
     )
     assert calls["gen0"] == 1
-    assert calls["control"] == ["never", "random"]
+    # ONE concurrent fan-out carrying BOTH control arms (never+random overlap),
+    # NOT two sequential per-arm calls.
+    assert calls["control_calls"] == [["never", "random"]]
     assert calls["gate"] == ["gate"]  # ONLY the path-dependent gate is sequential
     assert len(result["control_floors"]) == 2
+    # Summaries preserved in the ORIGINAL arms order (digest stability).
+    assert [s.arm for s in result["arm_summaries"]] == ["never", "random", "gate"]
+
+
+def test_run_campaign_loads_persisted_checkpoint_for_resume(
+    campaign_state: dict[str, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A REAL campaign REHYDRATES a pre-existing checkpoint file (Codex MCP HIGH):
+    ``run_campaign`` must ``.load()`` the marker so a resumed process skips the
+    already-completed cycles instead of re-running (re-paying for) every one."""
+    import plugins.petri_audit.runner as petri_runner
+
+    monkeypatch.setattr(petri_runner, "purge_inspect_cache", lambda: True)
+    (campaign_state["policies_dir"] / "hyperparam.json").write_text("{}", encoding="utf-8")
+    # Point the campaign's checkpoint dir at tmp + pre-seed a marker showing some
+    # never+random cycles already complete (the run_id matches run_campaign's).
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    monkeypatch.setattr(rc, "CAMPAIGN_RUNS_DIR", runs_dir)
+    run_id = "campaign-n2-k2-never-random-gate"
+    pre_seed = rc.RunCheckpoint(run_id=run_id, runs_dir=runs_dir)
+    pre_seed.record_completed(
+        "never",
+        [rc.WorkerOutcome(1, True, 0, {"safety": 1.0}, None, "ok")],
+    )
+    pre_seed.record_completed(
+        "random",
+        [rc.WorkerOutcome(2, True, 0, {"safety": 2.0}, None, "ok")],
+    )
+
+    band = rc.NoiseBand(
+        k=2, held_out_values=(0.85,), fitness_values=(0.89,), mean=0.85, stderr=0.01
+    )
+    seen_checkpoint: dict[str, Any] = {}
+
+    async def fake_gen0_async(*, checkpoint: Any, **_kw: Any) -> Any:
+        return band
+
+    async def fake_control_arms_async(
+        *, control_arms: Any, n: int, checkpoint: Any, **_kw: Any
+    ) -> dict[str, Any]:
+        # Record what the loaded checkpoint says is already complete PER ARM — proof
+        # that run_campaign rehydrated the persisted marker (not a fresh empty one).
+        seen_checkpoint["never"] = checkpoint.completed_indices("never")
+        seen_checkpoint["random"] = checkpoint.completed_indices("random")
+        return {
+            arm: rc.ControlArmFloor(arm=arm, cycles_ok=n, cycles_dropped=0, held_out_band=band)
+            for arm, _idx in control_arms
+        }
+
+    def fake_run_arm(*, arm: str, n: int, **_kw: Any) -> Any:
+        return rc.ArmSummary(arm=arm, cycles_run=n, cycles_skipped=0, promotes=0, halted=False)
+
+    monkeypatch.setattr(rc, "run_gen0_baseline_async", fake_gen0_async)
+    monkeypatch.setattr(rc, "run_control_arms_async", fake_control_arms_async)
+    monkeypatch.setattr(rc, "run_arm", fake_run_arm)
+
+    rc.run_campaign(
+        n=2,
+        k=2,
+        arms=("never", "random", "gate"),
+        dry_run=False,
+        async_first=True,
+        progress_path=campaign_state["progress"],
+        snapshot_dir=campaign_state["snapshot"],
+    )
+    # The checkpoint passed into the control fan-out carries the PERSISTED completed
+    # cycles, attributed to the right arm — a fresh (unloaded) marker would be empty.
+    assert seen_checkpoint["never"] == {1}
+    assert seen_checkpoint["random"] == {2}
 
 
 def test_run_campaign_async_first_false_keeps_every_arm_on_sync(
@@ -2212,7 +2294,7 @@ def test_run_campaign_async_first_false_keeps_every_arm_on_sync(
         return rc.ArmSummary(arm=arm, cycles_run=n, cycles_skipped=0, promotes=0, halted=False)
 
     monkeypatch.setattr(rc, "run_gen0_baseline_async", boom_async)
-    monkeypatch.setattr(rc, "run_control_arm_async", boom_async)
+    monkeypatch.setattr(rc, "run_control_arms_async", boom_async)
     monkeypatch.setattr(rc, "run_arm", fake_run_arm)
     monkeypatch.setattr(
         rc,
@@ -2232,3 +2314,321 @@ def test_run_campaign_async_first_false_keeps_every_arm_on_sync(
         snapshot_dir=campaign_state["snapshot"],
     )
     assert arms_seen == ["never", "random", "gate"]
+
+
+# ---------------------------------------------------------------------------
+# PR-CAMPAIGN-CONCURRENT-CONTROL-ARMS (2026-06-04) — the PATH-INDEPENDENT
+# control arms (never + random) fan out in ONE shared concurrent gather by
+# default. These pin the 5 invariants: attribution, promote policy, resume,
+# random reproducibility, and per-arm worker-root / transcript isolation.
+# ---------------------------------------------------------------------------
+
+
+def _arm_recording_async_runner(*, observed: list[tuple[str, int]]) -> Any:
+    """A fake async runner that records each worker's ``(arm, cycle_index)``.
+
+    The arm is the worker root's PARENT dir name (``<root>/<arm>/w{idx}``) and the
+    index is parsed from the leaf (``w{idx}``), so a concurrent never+random
+    fan-out is fully attributable per worker. Writes a synthetic attribution row +
+    ``FITNESS_RESULT`` keyed off the index so the floor aggregation has values."""
+
+    async def runner(*, env: dict[str, str], dry_run: bool, per_audit_timeout: float | None) -> Any:
+        state_root = Path(env["GEODE_STATE_ROOT"])
+        idx = int(state_root.name.removeprefix("w"))
+        arm = state_root.parent.name
+        observed.append((arm, idx))
+        mutations = state_root / "autoresearch" / "mutations.jsonl"
+        mutations.parent.mkdir(parents=True, exist_ok=True)
+        _write_attribution(
+            mutations, held_out=0.40 + idx * 0.01, fitness=0.5, promote_policy=arm, source="manual"
+        )
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line({"safety": float(idx)}))
+
+    return runner
+
+
+def test_control_arms_async_single_gather_dispatches_both_arms_concurrently(
+    campaign_state: dict[str, Path],
+) -> None:
+    """never+random fan out in ONE gather: every cycle of BOTH arms is dispatched
+    in a single concurrent fan-out (n per arm = 2n total worker dispatches), not
+    two sequential per-arm gathers."""
+    _make_gen0_snapshot(campaign_state)
+    observed: list[tuple[str, int]] = []
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        floors = asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=3,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                runner_fn=_arm_recording_async_runner(observed=observed),
+            )
+        )
+    # 3 never + 3 random = 6 worker dispatches, all in the single fan-out.
+    assert sorted(observed) == [
+        ("never", 1),
+        ("never", 2),
+        ("never", 3),
+        ("random", 1),
+        ("random", 2),
+        ("random", 3),
+    ]
+    # A floor per arm, each aggregating ONLY its own 3 cycles (attribution #1).
+    assert set(floors) == {"never", "random"}
+    assert floors["never"].arm == "never"
+    assert floors["never"].cycles_ok == 3
+    assert floors["random"].arm == "random"
+    assert floors["random"].cycles_ok == 3
+
+
+def test_control_arms_async_per_arm_attribution_not_mixed(
+    campaign_state: dict[str, Path],
+) -> None:
+    """The single gather's results are partitioned back PER ARM: a never worker's
+    promote policy is 'never', a random worker's is 'random' — never crossed."""
+    _make_gen0_snapshot(campaign_state)
+    policy_by_root: dict[str, str] = {}
+
+    async def runner(*, env: dict[str, str], dry_run: bool, per_audit_timeout: float | None) -> Any:
+        state_root = Path(env["GEODE_STATE_ROOT"])
+        policy_by_root[str(state_root)] = env["GEODE_PROMOTE_POLICY"]
+        mutations = state_root / "autoresearch" / "mutations.jsonl"
+        mutations.parent.mkdir(parents=True, exist_ok=True)
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line({"safety": 3.0}))
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=2,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                runner_fn=runner,
+            )
+        )
+    # Each worker's GEODE_PROMOTE_POLICY matches the ARM segment of its isolated
+    # root (invariant #2): a never-root never carries 'random' and vice-versa.
+    for root, policy in policy_by_root.items():
+        assert Path(root).parent.name == policy, f"{root} policy {policy} crossed arms"
+    assert sorted(policy_by_root.values()) == ["never", "never", "random", "random"]
+
+
+def test_control_arms_async_random_seed_matches_legacy_per_arm_formula(
+    campaign_state: dict[str, Path],
+) -> None:
+    """Reproducibility (#4): the random arm's per-cycle seed in the concurrent
+    fan-out equals the legacy ``DEFAULT_RANDOM_SEED_BASE + arm_index*n + cycle`` —
+    keyed on (arm_index, n, cycle), NOT wall-clock / dispatch order. never is unseeded."""
+    _make_gen0_snapshot(campaign_state)
+    seed_by_arm_idx: dict[tuple[str, int], str | None] = {}
+
+    async def runner(*, env: dict[str, str], dry_run: bool, per_audit_timeout: float | None) -> Any:
+        state_root = Path(env["GEODE_STATE_ROOT"])
+        idx = int(state_root.name.removeprefix("w"))
+        arm = state_root.parent.name
+        seed_by_arm_idx[(arm, idx)] = env.get("GEODE_PROMOTE_POLICY_SEED")
+        mutations = state_root / "autoresearch" / "mutations.jsonl"
+        mutations.parent.mkdir(parents=True, exist_ok=True)
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line({"safety": 3.0}))
+
+    n = 3
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=n,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                runner_fn=runner,
+            )
+        )
+    # random (arm_index 1): each cycle's seed == base + 1*n + cycle (byte-identical
+    # to the legacy per-arm path, regardless of concurrent interleaving).
+    for cycle in range(1, n + 1):
+        expected = str(rc.DEFAULT_RANDOM_SEED_BASE + 1 * n + cycle)
+        assert seed_by_arm_idx[("random", cycle)] == expected
+    # never: every cycle UNSEEDED.
+    for cycle in range(1, n + 1):
+        assert seed_by_arm_idx[("never", cycle)] is None
+    # The helper :func:`_control_cycle_seed` is the single source of the formula.
+    assert rc._control_cycle_seed("random", 1, n, 2) == rc.DEFAULT_RANDOM_SEED_BASE + 1 * n + 2
+    assert rc._control_cycle_seed("never", 0, n, 2) is None
+
+
+def test_control_arms_async_resume_skips_completed_per_arm(
+    campaign_state: dict[str, Path], tmp_path: Path
+) -> None:
+    """Resume (#3): a checkpoint with SOME never + SOME random cycles done resumes
+    ONLY the remaining ones, correctly per-arm (never's done set never masks
+    random's, and vice-versa)."""
+    _make_gen0_snapshot(campaign_state)
+    ckpt = rc.RunCheckpoint(run_id="multi-arm-resume", runs_dir=tmp_path)
+
+    def _done(idx: int) -> rc.WorkerOutcome:
+        return rc.WorkerOutcome(
+            index=idx,
+            ok=True,
+            returncode=0,
+            dim_means={"safety": float(idx)},
+            signal=rc.CycleSignal(
+                held_out_fitness=0.40 + idx * 0.01,
+                fitness=0.5,
+                fitness_delta=None,
+                promote_policy=None,
+                source=None,
+                between_seed_stderr=None,
+            ),
+            reason="ok",
+        )
+
+    # never: cycles 1+2 done (missing 3+4). random: cycle 1 done (missing 2+3+4).
+    ckpt.record_completed("never", [_done(1), _done(2)])
+    ckpt.record_completed("random", [_done(1)])
+
+    observed: list[tuple[str, int]] = []
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        floors = asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=4,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                runner_fn=_arm_recording_async_runner(observed=observed),
+                checkpoint=ckpt,
+            )
+        )
+    # Only the missing cycles re-ran, attributed to the RIGHT arm.
+    assert sorted(observed) == [
+        ("never", 3),
+        ("never", 4),
+        ("random", 2),
+        ("random", 3),
+        ("random", 4),
+    ]
+    # Each arm's floor unions the resumed + freshly-run cycles to the full N=4.
+    assert floors["never"].cycles_ok == 4
+    assert floors["random"].cycles_ok == 4
+
+
+def test_control_arms_async_worker_roots_isolated_per_arm(
+    campaign_state: dict[str, Path], tmp_path: Path
+) -> None:
+    """Isolation (#5): a never-cycle and a random-cycle with the SAME index live
+    under DISTINCT worker roots (``<root>/never/w1`` vs ``<root>/random/w1``), so
+    the same-numbered cycles never collide on a state tree / transcript file."""
+    _make_gen0_snapshot(campaign_state)
+    roots: list[str] = []
+
+    async def runner(*, env: dict[str, str], dry_run: bool, per_audit_timeout: float | None) -> Any:
+        state_root = Path(env["GEODE_STATE_ROOT"])
+        roots.append(str(state_root))
+        mutations = state_root / "autoresearch" / "mutations.jsonl"
+        mutations.parent.mkdir(parents=True, exist_ok=True)
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line({"safety": 3.0}))
+
+    workers_root = tmp_path / "workers"
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=1,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                workers_root=workers_root,
+                runner_fn=runner,
+            )
+        )
+    # Both arms used cycle index 1 but DISTINCT roots — no collision.
+    assert len(set(roots)) == 2
+    assert str(workers_root / "never" / "w1") in roots
+    assert str(workers_root / "random" / "w1") in roots
+
+
+def test_control_arms_async_merges_both_arms_transcripts_no_collision(
+    campaign_state: dict[str, Path], tmp_path: Path
+) -> None:
+    """The single gather merges BOTH arms' per-cycle transcripts into the one
+    campaign transcript, attributed ``never-w*`` + ``random-w*`` (same index, no
+    collision)."""
+    _make_gen0_snapshot(campaign_state)
+    campaign_transcript = tmp_path / "campaign" / "transcript.jsonl"
+
+    async def runner(*, env: dict[str, str], dry_run: bool, per_audit_timeout: float | None) -> Any:
+        transcript = Path(env["GEODE_RUN_TRANSCRIPT_PATH"])
+        worker_id = env["GEODE_RUN_WORKER_ID"]
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(
+            json.dumps({"ts": 1.0, "seq": 0, "payload": {"worker_id": worker_id}}) + "\n",
+            encoding="utf-8",
+        )
+        state_root = Path(env["GEODE_STATE_ROOT"])
+        mutations = state_root / "autoresearch" / "mutations.jsonl"
+        mutations.parent.mkdir(parents=True, exist_ok=True)
+        _write_attribution(mutations, held_out=0.5, fitness=0.6, source="manual")
+        return SimpleNamespace(returncode=0, stdout=_fitness_result_line({"safety": 3.0}))
+
+    with rc.ProgressLog(campaign_state["progress"]) as progress:
+        asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("random", 1)],
+                n=1,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+                runner_fn=runner,
+                campaign_transcript=campaign_transcript,
+            )
+        )
+    rows = [
+        json.loads(line) for line in campaign_transcript.read_text(encoding="utf-8").splitlines()
+    ]
+    assert {r["payload"]["worker_id"] for r in rows} == {"never-w1", "random-w1"}
+
+
+def test_control_arms_async_refuses_gate_arm(campaign_state: dict[str, Path]) -> None:
+    """The gate arm is path-dependent and MUST never be routed through the
+    concurrent control fan-out."""
+    _make_gen0_snapshot(campaign_state)
+    with (
+        rc.ProgressLog(campaign_state["progress"]) as progress,
+        pytest.raises(ValueError, match="path-dependent"),
+    ):
+        asyncio.run(
+            rc.run_control_arms_async(
+                control_arms=[("never", 0), ("gate", 2)],
+                n=2,
+                audit_max_samples=3,
+                audit_max_connections=8,
+                dry_run=False,
+                progress=progress,
+                snapshot_dir=campaign_state["snapshot"],
+                per_audit_timeout=5.0,
+            )
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.134"
+version = "0.99.135"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 3-arm campaign runs path-independent control arms (never+random) in ONE concurrent asyncio.gather by default; gate stays sequential (#1996). Halves control-arm wall-clock under PAYG. v0.99.135.
- Also fixed a pre-existing HIGH: RunCheckpoint built but never .load()'d (resumed campaigns re-ran paid cycles).

## Verification
- Codex MCP APPROVE (5 invariants: per-arm attribution, promote policy, resume per-arm, random reproducibility, transcript isolation)
- CI 8/8 green on #1996 (mergeStateStatus CLEAN); test_run_campaign 87 pass + self-improving 438 pass