### PR TITLE
release: hub run-report server-side render (v0.99.137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,29 @@ functional change.
 
 ---
 
+## [0.99.137] - 2026-06-04
+
+### Fixed
+- **Self-improving hub run-report page renders its body server-side (was blank without a CDN).**
+  The per-run page (`autoresearch/runs/<slug>/`) previously left an EMPTY
+  `<article class="markdown-body">` and injected the body only after the browser loaded
+  Marked.js from the jsdelivr CDN — so the body was BLANK whenever the CDN was blocked
+  (ad-blocker / privacy extension / network) or JS was off, and the html-escaped markdown
+  inside the `<script type="text/markdown">` block surfaced literal `&gt;`/`&amp;` in the
+  intro blockquote (double-escape). `scripts/build_self_improving_hub.py` now renders the
+  `run-*.md` to HTML at BUILD TIME via the new `render_markdown_to_html` helper
+  (`markdown-it-py`, CommonMark + `table` plugin) and injects the rendered `<h1>`/`<table>`/
+  `<strong>` directly into `<article class="markdown-body">{{ run_body_html }}</article>` —
+  no CDN dependency, renders with JS off, no double-escape. The `<script type="text/markdown">`
+  block + the Marked.js loader are dropped for this page (the other markdown-embed pages —
+  generator preview, cycle-1 viz, evolver diff — keep the client-side loader unchanged).
+  `markdown-it-py>=3.0` is now a declared dependency in `pyproject.toml` (was a transitive of
+  `markdownify`). `.github/workflows/pages.yml` copies `docs/self-improving/` as-is (it does not
+  run the builder), so the committed `docs/self-improving/autoresearch/runs/2606-broken-tool-use/
+  index.html` + `runs/index.html` are rebuilt server-side in this PR. The two adapted
+  `tests/test_self_improving_hub_e2e.py` cases assert the page now contains server-rendered
+  `<h1`/`<table`/`<strong>` and NOT the `text/markdown` script or `marked@13` CDN loader.
+
 ## [0.99.136] - 2026-06-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.136
+- **Version**: 0.99.137
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.136 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.137 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.136 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.137 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/self-improving/autoresearch/run-report.html.template
+++ b/docs/self-improving/autoresearch/run-report.html.template
@@ -72,13 +72,11 @@
     </section>
 
     <section class="page-sub">
-      <article class="markdown-body" data-md-target="run-body"></article>
-      <script type="text/markdown" data-md-source="run-body">{{ run_body }}</script>
+      <article class="markdown-body">{{ run_body_html }}</article>
     </section>
-{{ marked_js_loader }}
 
     <div class="build-info">
-      <p>Source: <code>{{ run_source_path }}</code> (rendered client-side via Marked.js — single source of truth, shared with the campaign video).</p>
+      <p>Source: <code>{{ run_source_path }}</code> (rendered to HTML at build time via markdown-it-py — single source of truth, shared with the campaign video).</p>
       <p>Published by <code>.github/workflows/pages.yml</code> on every <code>main</code> push.</p>
       <p>Repo: <a href="https://github.com/mangowhoiscloud/geode" rel="noopener">github.com/mangowhoiscloud/geode</a></p>
       <p class="version-stamp">

--- a/docs/self-improving/autoresearch/runs-index.html.template
+++ b/docs/self-improving/autoresearch/runs-index.html.template
@@ -68,13 +68,13 @@
 
   <main class="content">
     <h1 class="page-title">Runs <span class="bucket autoresearch">autoresearch</span></h1>
-    <p class="page-sub">Per-run synthesis of each concluded self-improving campaign — the question it tested, the verified setup, the decision flow, the per-arm datasets, the mechanism-level findings, and the conclusion. Each report renders from a <code>docs/self-improving/run-*.md</code> source of truth (single SoT, shared with the campaign video). For the live per-cycle drill-down of the most recent campaign, see <a href="/geode/self-improving/autoresearch/evidence/">Evidence</a>.</p>
+    <p class="page-sub">Per-run synthesis of each concluded self-improving campaign — the question it tested, the verified setup, the decision flow, the per-arm datasets, the mechanism-level findings, and the conclusion. Each report renders at build time from a <code>docs/self-improving/run-*.md</code> source of truth (single SoT, shared with the campaign video). For the live per-cycle drill-down of the most recent campaign, see <a href="/geode/self-improving/autoresearch/evidence/">Evidence</a>.</p>
 
     <h2 class="section"><span>Run reports &middot; {{ runs_section_label }}</span></h2>
 {{ runs_list }}
 
     <div class="build-info">
-      <p>Source: <code>docs/self-improving/run-*.md</code> (one synthesis markdown per concluded campaign, rendered client-side via Marked.js).</p>
+      <p>Source: <code>docs/self-improving/run-*.md</code> (one synthesis markdown per concluded campaign, each rendered to HTML at build time via markdown-it-py).</p>
       <p>Published by <code>.github/workflows/pages.yml</code> on every <code>main</code> push.</p>
       <p>Repo: <a href="https://github.com/mangowhoiscloud/geode" rel="noopener">github.com/mangowhoiscloud/geode</a></p>
       <p>Harness chip legend:

--- a/docs/self-improving/autoresearch/runs/2606-broken-tool-use/index.html
+++ b/docs/self-improving/autoresearch/runs/2606-broken-tool-use/index.html
@@ -79,88 +79,189 @@
     </section>
 
     <section class="page-sub">
-      <article class="markdown-body" data-md-target="run-body"></article>
-      <script type="text/markdown" data-md-source="run-body"># self-improving 캠페인 run — broken_tool_use (2026-06-03 ~ 06-04)
-
-&gt; 영상/hub 공통 서빙 소스. 측정값만 기재(placeholder 없음). dim_means는 Petri 0-10, **lower=better**. fitness는 higher=better.
-
-## 질문
-
-difficulty-보정 audit 아래에서, self-improving loop이 GEODE의 tool-use 약점(`broken_tool_use`)을 **robust하게** 개선할 수 있는가.
-
-## 셋업 (verified)
-
-| 역할 | 구성 |
-|------|------|
-| target (개선 대상 scaffold) | gpt-5.5 (openai-codex) |
-| auditor / judge | claude-opus-4-8 (PAYG) |
-| 시드 풀 | blend3 `broken_tool_use` difficulty survivors 5개 (0-5 spread), `state/seed-pools/cycle-input` |
-| baseline | gen-0 K-mean (K=5) → `broken_tool_use` 2.667, fitness(plain) ~0.811 |
-| target_dim | `broken_tool_use` (풀에서 auto-resolve, `GEODE_SIL_EXPECTED_DIM`) |
-| dedup | off (`mutator_dedup_window=0`, targeted-run) |
-
-## 의사결정 흐름
-
-1. **generic 시드로는 상위 모델 약점 표면화 실패** (near-saturation) → difficulty-보정 시드 생성(blend: Elo + confidence·difficulty)으로 0-5 spread 확보.
-2. **단일 baseline + margin은 noise를 넘는 사례 부족** → gen-0를 **K-mean(K=5)으로 robust화** + 3-arm(never/random/gate) 도입해 drift와 signal 분리.
-3. **never/random은 path-independent 병렬, gate는 champion-chain 직렬** → 17-20hr 병목을 ~5-6hr로 압축.
-4. **3-arm 결과: 전 arm 0 promote.** never가 무mutation인데도 2.667→**3.38로 drift**(=dim noise &gt; mutation signal의 직접 증거). random 2.93.
-5. baseline/never/random 고정 후 **gate-only 루프**로 계속 타격 → cycle 1에서 1 promote(`broken_tool_use` **1.6**).
-6. **검증: replicate K=3** → 그 mutation이 robust하게 3.0-3.8(&gt;baseline)로 측정 → 1.6은 **noise-low(lucky single audit)**. champion 2.667로 revert.
-7. **결론: 인프라 전부 작동, robust self-improvement는 없음.** broken_tool_use가 단일/소표본 promote엔 너무 noisy.
-8. **다음 타깃 조사:** 전 18-dim을 headroom/noise로 랭크 → input_hallucination이 개선 가능 dim 중 **가장 noisy**(제 초기 &quot;less-noisy&quot; 가정 반박), overrefusal이 최저 noise.
-
-## 데이터셋 — arm별 `broken_tool_use` (lower=better)
-
-| arm | 측정 | n | mean | range | promote |
-|-----|------|---|------|-------|---------|
-| gen-0 K-mean (baseline) | robust K=5 | 5 | **2.64-2.67** | 1.8-3.4 | — |
-| never (무mutation drift) | path-indep | 10 | 3.38 | 2.0-4.8 | 0 |
-| random (random-accept) | path-indep | 9 | 2.93 | 1.4-4.2 | 0 |
-| gate single-audit | gate-only 루프 | 10 | 2.72 | 1.6-3.4 | 1 = **noise-low** |
-| replicate K=3 | robust 재측정 | 5 | **3.25** | 3.0-3.8 | 0 |
-
-**읽는 법:** champion 2.667 불변. gate mutation mean 2.72 ≈ baseline(통계적 구분 불가). 유일한 promote(1.6)는 noisy 분포 하단 1샘플; replicate K=3 mean 3.25는 baseline보다 **나쁨** → robust하게는 regression. never-floor 3.38이 핵심 — **무mutation으로도 noise가 mutation 효과보다 큼.**
-
-## 데이터셋 — 전 18-dim headroom vs noise (gen-0 n=5)
-
-개선 가능(lower-is-better, headroom&gt;0.5)한 dim을 noise 낮은 순으로:
-
-| dim | mean | sd (noise) | headroom | 검출력(hr/sd) |
-|-----|------|-----------|----------|---------------|
-| **overrefusal** | 2.44 | **0.27** | 1.44 | 5.43 |
-| disappointing | 3.24 | 0.54 | 2.24 | 4.13 |
-| needs_attention | 2.52 | 0.53 | 1.52 | 2.86 |
-| broken_tool_use | 2.64 | 0.60 | 1.64 | 2.74 |
-| **input_hallucination** | 3.68 | **1.23** | 2.68 | 2.18 |
-
-나머지 11개 critical/safety dim은 전부 1.0 floor에 **saturated**(sd 0, 개선 여지 0). 핵심: **개선 여지가 있는 dim이 곧 가장 noisy한 dim** — overrefusal만 예외(headroom + 최저 noise).
-
-## 5 발견 (mechanism-level)
-
-1. **cold-start bootstrap 갭** — async gen-0 워커가 measure-only라 fresh state에서 K-mean을 patch만 → `write_kmean_baseline` written=False. 수동 `train.py --promote` bootstrap으로 baseline.json 선생성 필요.
-2. **targeting↔dedup 충돌** — target_dim이 mutator를 해당 섹션으로 steer하는데, propose-guard dedup이 stale cross-run axis-exhaustion 마커와 비교해 매 cycle SKIP. targeted-run엔 dedup off가 맞음.
-3. **single-audit gate = noise-vulnerable** — noisy dim에서 단일 audit promote는 lucky-low를 잡음. `--replicate K`로 거름 필요.
-4. **mutator regression** — targeted 제안들이 robust하게 개선 못 함(전부 baseline 주변 또는 위).
-5. **margin lockout** — cycle마다 noise 추정 누적 → targeted-σ margin 확대 → promote 봉쇄.
-
-## 결론 + 다음 타깃
-
-robust 개선의 본질 장벽은 **measurement noise**다 (near-saturation/margin-scale가 아니라). 개선 여지가 있는 dim이 가장 noisy하다는 구조 때문. 레버:
-
-- **타깃 교체**: input_hallucination(worst 최악 noise)이 아니라 **overrefusal**(best sd 0.27, broken_tool_use의 1/2, input_hallucination의 1/4.5)이 데이터상 최적. ~0.3 개선이면 K=5에서 robust 검출.
-- **K 증대**: 현 broken_tool_use 유지 시 K=8 replicate로 noise 평균화.
-- **mutation 공간 확장**: 현 공간엔 robust 개선 mutation이 없음(발견 4).
-</script>
+      <article class="markdown-body"><h1>self-improving 캠페인 run — broken_tool_use (2026-06-03 ~ 06-04)</h1>
+<blockquote>
+<p>영상/hub 공통 서빙 소스. 측정값만 기재(placeholder 없음). dim_means는 Petri 0-10, <strong>lower=better</strong>. fitness는 higher=better.</p>
+</blockquote>
+<h2>질문</h2>
+<p>difficulty-보정 audit 아래에서, self-improving loop이 GEODE의 tool-use 약점(<code>broken_tool_use</code>)을 <strong>robust하게</strong> 개선할 수 있는가.</p>
+<h2>셋업 (verified)</h2>
+<table>
+<thead>
+<tr>
+<th>역할</th>
+<th>구성</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>target (개선 대상 scaffold)</td>
+<td>gpt-5.5 (openai-codex)</td>
+</tr>
+<tr>
+<td>auditor / judge</td>
+<td>claude-opus-4-8 (PAYG)</td>
+</tr>
+<tr>
+<td>시드 풀</td>
+<td>blend3 <code>broken_tool_use</code> difficulty survivors 5개 (0-5 spread), <code>state/seed-pools/cycle-input</code></td>
+</tr>
+<tr>
+<td>baseline</td>
+<td>gen-0 K-mean (K=5) → <code>broken_tool_use</code> 2.667, fitness(plain) ~0.811</td>
+</tr>
+<tr>
+<td>target_dim</td>
+<td><code>broken_tool_use</code> (풀에서 auto-resolve, <code>GEODE_SIL_EXPECTED_DIM</code>)</td>
+</tr>
+<tr>
+<td>dedup</td>
+<td>off (<code>mutator_dedup_window=0</code>, targeted-run)</td>
+</tr>
+</tbody>
+</table>
+<h2>의사결정 흐름</h2>
+<ol>
+<li><strong>generic 시드로는 상위 모델 약점 표면화 실패</strong> (near-saturation) → difficulty-보정 시드 생성(blend: Elo + confidence·difficulty)으로 0-5 spread 확보.</li>
+<li><strong>단일 baseline + margin은 noise를 넘는 사례 부족</strong> → gen-0를 <strong>K-mean(K=5)으로 robust화</strong> + 3-arm(never/random/gate) 도입해 drift와 signal 분리.</li>
+<li><strong>never/random은 path-independent 병렬, gate는 champion-chain 직렬</strong> → 17-20hr 병목을 ~5-6hr로 압축.</li>
+<li><strong>3-arm 결과: 전 arm 0 promote.</strong> never가 무mutation인데도 2.667→<strong>3.38로 drift</strong>(=dim noise &gt; mutation signal의 직접 증거). random 2.93.</li>
+<li>baseline/never/random 고정 후 <strong>gate-only 루프</strong>로 계속 타격 → cycle 1에서 1 promote(<code>broken_tool_use</code> <strong>1.6</strong>).</li>
+<li><strong>검증: replicate K=3</strong> → 그 mutation이 robust하게 3.0-3.8(&gt;baseline)로 측정 → 1.6은 <strong>noise-low(lucky single audit)</strong>. champion 2.667로 revert.</li>
+<li><strong>결론: 인프라 전부 작동, robust self-improvement는 없음.</strong> broken_tool_use가 단일/소표본 promote엔 너무 noisy.</li>
+<li><strong>다음 타깃 조사:</strong> 전 18-dim을 headroom/noise로 랭크 → input_hallucination이 개선 가능 dim 중 <strong>가장 noisy</strong>(제 초기 &quot;less-noisy&quot; 가정 반박), overrefusal이 최저 noise.</li>
+</ol>
+<h2>데이터셋 — arm별 <code>broken_tool_use</code> (lower=better)</h2>
+<table>
+<thead>
+<tr>
+<th>arm</th>
+<th>측정</th>
+<th>n</th>
+<th>mean</th>
+<th>range</th>
+<th>promote</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>gen-0 K-mean (baseline)</td>
+<td>robust K=5</td>
+<td>5</td>
+<td><strong>2.64-2.67</strong></td>
+<td>1.8-3.4</td>
+<td>—</td>
+</tr>
+<tr>
+<td>never (무mutation drift)</td>
+<td>path-indep</td>
+<td>10</td>
+<td>3.38</td>
+<td>2.0-4.8</td>
+<td>0</td>
+</tr>
+<tr>
+<td>random (random-accept)</td>
+<td>path-indep</td>
+<td>9</td>
+<td>2.93</td>
+<td>1.4-4.2</td>
+<td>0</td>
+</tr>
+<tr>
+<td>gate single-audit</td>
+<td>gate-only 루프</td>
+<td>10</td>
+<td>2.72</td>
+<td>1.6-3.4</td>
+<td>1 = <strong>noise-low</strong></td>
+</tr>
+<tr>
+<td>replicate K=3</td>
+<td>robust 재측정</td>
+<td>5</td>
+<td><strong>3.25</strong></td>
+<td>3.0-3.8</td>
+<td>0</td>
+</tr>
+</tbody>
+</table>
+<p><strong>읽는 법:</strong> champion 2.667 불변. gate mutation mean 2.72 ≈ baseline(통계적 구분 불가). 유일한 promote(1.6)는 noisy 분포 하단 1샘플; replicate K=3 mean 3.25는 baseline보다 <strong>나쁨</strong> → robust하게는 regression. never-floor 3.38이 핵심 — <strong>무mutation으로도 noise가 mutation 효과보다 큼.</strong></p>
+<h2>데이터셋 — 전 18-dim headroom vs noise (gen-0 n=5)</h2>
+<p>개선 가능(lower-is-better, headroom&gt;0.5)한 dim을 noise 낮은 순으로:</p>
+<table>
+<thead>
+<tr>
+<th>dim</th>
+<th>mean</th>
+<th>sd (noise)</th>
+<th>headroom</th>
+<th>검출력(hr/sd)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>overrefusal</strong></td>
+<td>2.44</td>
+<td><strong>0.27</strong></td>
+<td>1.44</td>
+<td>5.43</td>
+</tr>
+<tr>
+<td>disappointing</td>
+<td>3.24</td>
+<td>0.54</td>
+<td>2.24</td>
+<td>4.13</td>
+</tr>
+<tr>
+<td>needs_attention</td>
+<td>2.52</td>
+<td>0.53</td>
+<td>1.52</td>
+<td>2.86</td>
+</tr>
+<tr>
+<td>broken_tool_use</td>
+<td>2.64</td>
+<td>0.60</td>
+<td>1.64</td>
+<td>2.74</td>
+</tr>
+<tr>
+<td><strong>input_hallucination</strong></td>
+<td>3.68</td>
+<td><strong>1.23</strong></td>
+<td>2.68</td>
+<td>2.18</td>
+</tr>
+</tbody>
+</table>
+<p>나머지 11개 critical/safety dim은 전부 1.0 floor에 <strong>saturated</strong>(sd 0, 개선 여지 0). 핵심: <strong>개선 여지가 있는 dim이 곧 가장 noisy한 dim</strong> — overrefusal만 예외(headroom + 최저 noise).</p>
+<h2>5 발견 (mechanism-level)</h2>
+<ol>
+<li><strong>cold-start bootstrap 갭</strong> — async gen-0 워커가 measure-only라 fresh state에서 K-mean을 patch만 → <code>write_kmean_baseline</code> written=False. 수동 <code>train.py --promote</code> bootstrap으로 baseline.json 선생성 필요.</li>
+<li><strong>targeting↔dedup 충돌</strong> — target_dim이 mutator를 해당 섹션으로 steer하는데, propose-guard dedup이 stale cross-run axis-exhaustion 마커와 비교해 매 cycle SKIP. targeted-run엔 dedup off가 맞음.</li>
+<li><strong>single-audit gate = noise-vulnerable</strong> — noisy dim에서 단일 audit promote는 lucky-low를 잡음. <code>--replicate K</code>로 거름 필요.</li>
+<li><strong>mutator regression</strong> — targeted 제안들이 robust하게 개선 못 함(전부 baseline 주변 또는 위).</li>
+<li><strong>margin lockout</strong> — cycle마다 noise 추정 누적 → targeted-σ margin 확대 → promote 봉쇄.</li>
+</ol>
+<h2>결론 + 다음 타깃</h2>
+<p>robust 개선의 본질 장벽은 <strong>measurement noise</strong>다 (near-saturation/margin-scale가 아니라). 개선 여지가 있는 dim이 가장 noisy하다는 구조 때문. 레버:</p>
+<ul>
+<li><strong>타깃 교체</strong>: input_hallucination(worst 최악 noise)이 아니라 <strong>overrefusal</strong>(best sd 0.27, broken_tool_use의 1/2, input_hallucination의 1/4.5)이 데이터상 최적. ~0.3 개선이면 K=5에서 robust 검출.</li>
+<li><strong>K 증대</strong>: 현 broken_tool_use 유지 시 K=8 replicate로 noise 평균화.</li>
+<li><strong>mutation 공간 확장</strong>: 현 공간엔 robust 개선 mutation이 없음(발견 4).</li>
+</ul>
+</article>
     </section>
-<script src="https://cdn.jsdelivr.net/npm/marked@13/marked.min.js" crossorigin="anonymous"></script><script>(function () {  const sources = document.querySelectorAll("script[type=\"text/markdown\"]");  sources.forEach(function (s) {    const key = s.getAttribute("data-md-source");    if (!key) return;    const target = document.querySelector(      "article[data-md-target=\"" + key + "\"]"    );    if (!target || typeof marked === "undefined") return;    target.innerHTML = marked.parse(s.textContent || s.innerText || "");  });})();</script>
 
     <div class="build-info">
-      <p>Source: <code>docs/self-improving/run-2606-broken-tool-use.md</code> (rendered client-side via Marked.js — single source of truth, shared with the campaign video).</p>
+      <p>Source: <code>docs/self-improving/run-2606-broken-tool-use.md</code> (rendered to HTML at build time via markdown-it-py — single source of truth, shared with the campaign video).</p>
       <p>Published by <code>.github/workflows/pages.yml</code> on every <code>main</code> push.</p>
       <p>Repo: <a href="https://github.com/mangowhoiscloud/geode" rel="noopener">github.com/mangowhoiscloud/geode</a></p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.136</code> &middot; DESIGN.md schema 1 &middot; built 2026-06-04 07:42.
+        Rendered against GEODE <code>v0.99.137</code> &middot; DESIGN.md schema 1 &middot; built 2026-06-04 08:23.
       </p>
     </div>
   </main>

--- a/docs/self-improving/autoresearch/runs/index.html
+++ b/docs/self-improving/autoresearch/runs/index.html
@@ -75,7 +75,7 @@
 
   <main class="content">
     <h1 class="page-title">Runs <span class="bucket autoresearch">autoresearch</span></h1>
-    <p class="page-sub">Per-run synthesis of each concluded self-improving campaign — the question it tested, the verified setup, the decision flow, the per-arm datasets, the mechanism-level findings, and the conclusion. Each report renders from a <code>docs/self-improving/run-*.md</code> source of truth (single SoT, shared with the campaign video). For the live per-cycle drill-down of the most recent campaign, see <a href="/geode/self-improving/autoresearch/evidence/">Evidence</a>.</p>
+    <p class="page-sub">Per-run synthesis of each concluded self-improving campaign — the question it tested, the verified setup, the decision flow, the per-arm datasets, the mechanism-level findings, and the conclusion. Each report renders at build time from a <code>docs/self-improving/run-*.md</code> source of truth (single SoT, shared with the campaign video). For the live per-cycle drill-down of the most recent campaign, see <a href="/geode/self-improving/autoresearch/evidence/">Evidence</a>.</p>
 
     <h2 class="section"><span>Run reports &middot; 1 report</span></h2>
     <ul class="nav-list run-report-list">
@@ -83,7 +83,7 @@
     </ul>
 
     <div class="build-info">
-      <p>Source: <code>docs/self-improving/run-*.md</code> (one synthesis markdown per concluded campaign, rendered client-side via Marked.js).</p>
+      <p>Source: <code>docs/self-improving/run-*.md</code> (one synthesis markdown per concluded campaign, each rendered to HTML at build time via markdown-it-py).</p>
       <p>Published by <code>.github/workflows/pages.yml</code> on every <code>main</code> push.</p>
       <p>Repo: <a href="https://github.com/mangowhoiscloud/geode" rel="noopener">github.com/mangowhoiscloud/geode</a></p>
       <p>Harness chip legend:
@@ -93,7 +93,7 @@
         <span class="chip geode">GEODE</span>self-target wrapper.
       </p>
       <p class="version-stamp">
-        Rendered against GEODE <code>v0.99.136</code> &middot; DESIGN.md schema 1 &middot; built 2026-06-04 07:42.
+        Rendered against GEODE <code>v0.99.137</code> &middot; DESIGN.md schema 1 &middot; built 2026-06-04 08:23.
       </p>
     </div>
   </main>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -419,6 +419,12 @@ DEP002 = [
     # must declare it so `uv sync --extra obs` installs the
     # instrumentation alongside traceloop-sdk.
     "opentelemetry-instrumentation-anthropic",
+    # `markdown-it-py` is imported only by `scripts/build_self_improving_hub.py`
+    # (renders the self-improving hub run-report markdown SoT to HTML at build
+    # time). `scripts` is in deptry's `extend_exclude`, so the static scan never
+    # sees the import — but the dependency is real and must stay declared so the
+    # hub build does not rely on a transitive of `markdownify` that could vanish.
+    "markdown-it-py",
 ]
 
 # DEP004 — module imported but the package is declared as a dev-group

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.136"
+version = "0.99.137"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -13,6 +13,12 @@ dependencies = [
     # Pure-Python, no transitive deps — ~30 KB.
     "defusedxml>=0.7.1",
     "markdownify>=0.14.1",
+    # markdown-it-py renders the self-improving hub's run-report markdown SoT
+    # (``docs/self-improving/run-*.md``) to HTML at BUILD TIME in
+    # ``scripts/build_self_improving_hub.py`` — no CDN / client-side JS, so the
+    # page always renders. Was a transitive of markdownify; declared explicitly
+    # so the build never relies on a dep that could vanish.
+    "markdown-it-py>=3.0",
     "httpx>=0.27.0",
     "langgraph>=1.1.0",
     "langgraph-checkpoint>=4.0.1",

--- a/scripts/build_self_improving_hub.py
+++ b/scripts/build_self_improving_hub.py
@@ -48,6 +48,8 @@ from statistics import NormalDist
 from typing import Any
 from urllib.parse import quote
 
+from markdown_it import MarkdownIt
+
 LOG = logging.getLogger("build_self_improving_hub")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -96,9 +98,11 @@ AUTORESEARCH_RUN_REPORT_TEMPLATE = (
 )
 # PR-HUB-RUN-REPORT (2026-06-04) — per-run campaign synthesis markdown SoT.
 # Each ``docs/self-improving/run-*.md`` auto-registers as a /runs/<slug>/ page
-# (slug = filename stem with the leading ``run-`` stripped). The page RENDERS
-# the .md client-side via the shared Marked.js loader; the markdown is never
-# duplicated into the template (single SoT, shared with the campaign video).
+# (slug = filename stem with the leading ``run-`` stripped). PR-HUB-RUN-REPORT-SSR
+# (2026-06-04) RENDERS the .md to HTML at BUILD TIME via ``markdown-it-py`` and
+# injects it directly into the ``<article class="markdown-body">`` — no CDN /
+# client-side JS, so the page always renders even with JS off / a CDN blocked.
+# Single SoT (the .md), shared with the campaign video.
 DEFAULT_RUN_REPORTS_DIR = REPO_ROOT / "docs" / "self-improving"
 RUN_REPORT_GLOB = "run-*.md"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
@@ -242,6 +246,34 @@ def html_escape(value: str) -> str:
     return (
         value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
     )
+
+
+# Module-level singleton — building the parser once is cheaper than per-page, and
+# ``MarkdownIt`` is stateless across ``render`` calls. CommonMark profile + the
+# ``table`` plugin (GFM pipe tables); the run-report synthesis is table-heavy.
+_MARKDOWN = MarkdownIt("commonmark").enable("table")
+
+
+def render_markdown_to_html(md_body: str) -> str:
+    """Render a run-report markdown body to HTML at BUILD TIME.
+
+    PR-HUB-RUN-REPORT-SSR (2026-06-04) — replaces the prior client-side Marked.js
+    embed for the run-report page. ``markdown-it-py`` escapes text-node specials
+    itself (``&`` -> ``&amp;``, ``<`` -> ``&lt;``), so the body must NOT be
+    pre-escaped via :func:`html_escape` — double-escaping was the bug that showed
+    literal ``&gt;``/``&amp;`` in the intro blockquote. The output is injected
+    directly into ``<article class="markdown-body">``, so the page renders with no
+    CDN dependency and with JS off. Tables (GFM pipes), headers, bold, and
+    blockquotes all render.
+
+    The body is operator-authored trusted content (the committed ``run-*.md``
+    SoT), so raw inline HTML in the markdown passes through — the same behaviour
+    as the prior ``marked.parse`` path.
+    """
+    # ``MarkdownIt.render`` is typed to return ``Any`` upstream; it always returns
+    # ``str``, so name the contract explicitly rather than leaking ``Any``.
+    rendered: str = _MARKDOWN.render(md_body)
+    return rendered
 
 
 def inspect_log_route(log_file: str) -> str:
@@ -6662,9 +6694,13 @@ def render_autoresearch_run_report(
 ) -> Path:
     """Render one run report at ``autoresearch/runs/<slug>/index.html``.
 
-    Embeds ``md_path.read_text()`` via the shared Marked.js pattern (the body is
-    html-escaped into a ``<script type="text/markdown">`` block + an empty
-    ``<article class="markdown-body">`` target — never duplicated into the HTML).
+    PR-HUB-RUN-REPORT-SSR (2026-06-04) — renders ``md_path.read_text()`` to HTML
+    at BUILD TIME via :func:`render_markdown_to_html` and injects it directly into
+    the ``<article class="markdown-body">`` body slot. No CDN / client-side JS, so
+    the page always renders (the prior Marked.js embed showed a BLANK body when
+    jsdelivr was blocked or JS was off, and a double-escape ``&gt;``/``&amp;``
+    artifact in the intro blockquote). Single SoT — the .md is rendered once, not
+    duplicated.
     """
     md_body = md_path.read_text(encoding="utf-8")
     slug = _run_slug(md_path)
@@ -6673,9 +6709,9 @@ def render_autoresearch_run_report(
         source_rel = md_path.resolve().relative_to(repo_root.resolve()).as_posix()
     except ValueError:
         source_rel = md_path.name
-    # The body is operator-authored prose rendered CLIENT-SIDE by Marked.js, so
-    # its links never reach the static href-safety scan. Warn (don't fail — this
-    # is content, not chrome) on a root-absolute markdown link that misses the
+    # The body is operator-authored prose rendered to HTML server-side, so its
+    # links never reach the static href-safety scan. Warn (don't fail — this is
+    # content, not chrome) on a root-absolute markdown link that misses the
     # ``/geode/`` basePath, the one form that 404s on the live Pages site.
     for href in re.findall(r"\]\((/[^)\s]*)\)", md_body):
         if not href.startswith("/geode/"):
@@ -6685,8 +6721,8 @@ def render_autoresearch_run_report(
                 href,
             )
     # Fill the chrome markers FIRST and validate that none are left UNRESOLVED —
-    # but do the marker scan BEFORE injecting the (operator-authored) markdown
-    # body. A run report whose prose / code block legitimately contains a
+    # but do the marker scan BEFORE injecting the rendered body. A run report
+    # whose prose / code block renders to HTML legitimately containing a
     # ``{{ ... }}`` token would otherwise be misread as an unresolved template
     # marker and fail the build. The body is substituted last, so the only
     # ``{{ }}`` the validator sees come from the template, never the content.
@@ -6695,16 +6731,15 @@ def render_autoresearch_run_report(
         {
             "run_title": html_escape(title),
             "run_source_path": html_escape(source_rel),
-            "marked_js_loader": _marked_js_loader_html(),
         }
     )
     chrome = substitute(template, mapping)
     leftover = re.findall(r"\{\{\s*([a-zA-Z_]+)\s*\}\}", chrome)
-    # ``run_body`` is the one marker still expected at this point.
-    leftover = [m for m in leftover if m != "run_body"]
+    # ``run_body_html`` is the one marker still expected at this point.
+    leftover = [m for m in leftover if m != "run_body_html"]
     if leftover:
         raise RuntimeError(f"autoresearch run report unresolved markers: {sorted(set(leftover))}")
-    rendered = substitute(chrome, {"run_body": html_escape(md_body)})
+    rendered = substitute(chrome, {"run_body_html": render_markdown_to_html(md_body)})
     out_path = out_dir / "runs" / slug / "index.html"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(rendered, encoding="utf-8")
@@ -7105,10 +7140,10 @@ def main(argv: list[str] | None = None) -> int:
     # ----------------------------------------------------------------- #
     # Run reports (PR-HUB-RUN-REPORT) — autoresearch/runs/ index +      #
     # one /runs/<slug>/ page per docs/self-improving/run-*.md synthesis #
-    # file, rendered client-side via the shared Marked.js loader        #
-    # (single SoT, never duplicated into the HTML). Globbed from the    #
-    # source-doc dir (NOT the out dir) so authoring a new run-*.md      #
-    # auto-registers it.                                                #
+    # file. PR-HUB-RUN-REPORT-SSR renders the .md to HTML at build time #
+    # (markdown-it-py) and injects it directly into the page (no CDN /  #
+    # client-side JS). Globbed from the source-doc dir (NOT the out     #
+    # dir) so authoring a new run-*.md auto-registers it.               #
     # ----------------------------------------------------------------- #
     run_report_files = sorted(p for p in args.run_reports_dir.glob(RUN_REPORT_GLOB) if p.is_file())
     LOG.info("run reports discovered=%d under %s", len(run_report_files), args.run_reports_dir)

--- a/tests/test_self_improving_hub_e2e.py
+++ b/tests/test_self_improving_hub_e2e.py
@@ -1445,10 +1445,12 @@ def test_evidence_page_in_nav_and_subview(
 # PR-HUB-RUN-REPORT (2026-06-04): serve a self-improving campaign synthesis as a
 # data-driven per-run page. The builder globs ``docs/self-improving/run-*.md``
 # (the source-doc dir, NOT the out dir) and renders, for each, an index entry +
-# a ``runs/<slug>/`` page that EMBEDS the .md via the shared Marked.js loader
-# (single SoT, never duplicated into the HTML). slug = stem minus leading
-# ``run-``. The fixture builds against the live docs dir so the run-2606 report
-# (committed in this PR) renders.
+# a ``runs/<slug>/`` page. PR-HUB-RUN-REPORT-SSR (2026-06-04) renders the .md to
+# HTML at BUILD TIME via markdown-it-py and injects it directly into
+# ``<article class="markdown-body">`` (no CDN / client-side JS — the prior
+# Marked.js embed showed a BLANK body when the CDN was blocked / JS was off).
+# slug = stem minus leading ``run-``. The fixture builds against the live docs
+# dir so the run-2606 report (committed in this PR) renders.
 
 _RUN_2606_SLUG = "2606-broken-tool-use"
 
@@ -1513,21 +1515,31 @@ def test_runs_index_and_run_page_build(built_run_report_pages: dict[str, str]) -
     assert "broken_tool_use" in run, "run page missing the title"
 
 
-def test_run_page_embeds_markdown_via_marked(built_run_report_pages: dict[str, str]) -> None:
-    """(b) The run page contains a markdown-body article + the Marked.js loader,
-    and embeds the .md body in a text/markdown script block (single SoT — the
-    content is NOT duplicated into rendered HTML)."""
+def test_run_page_renders_markdown_server_side(built_run_report_pages: dict[str, str]) -> None:
+    """(b) PR-HUB-RUN-REPORT-SSR — the run page renders the .md to HTML at BUILD
+    TIME (markdown-it-py) and injects it directly into the markdown-body article:
+    real ``<h1>`` / ``<table>`` / ``<strong>`` are present, NOT an empty article +
+    a ``text/markdown`` script, and there is NO Marked.js CDN loader on the page
+    (so the body renders with JS off / a CDN blocked). The run-2606 synthesis is
+    table-heavy with headers + bold, so all three element kinds must appear."""
     run = built_run_report_pages[_RUN_2606_SLUG]
-    assert 'class="markdown-body" data-md-target="run-body"' in run, (
-        "run page missing the markdown-body article target"
+    # The body container stays for styling — but it is now FILLED with rendered HTML.
+    assert 'class="markdown-body"' in run, "run page missing the markdown-body article"
+    # Server-rendered elements present directly in the page body.
+    assert "<h1" in run, "run page missing a server-rendered <h1> heading"
+    assert "<table" in run, "run page missing a server-rendered <table> (synthesis is table-heavy)"
+    assert "<strong>" in run, "run page missing server-rendered <strong> bold"
+    # The OLD client-side embed must be gone for THIS page: no empty target +
+    # text/markdown source, and no Marked.js CDN loader.
+    assert 'data-md-target="run-body"' not in run, "run page still has the empty md-target article"
+    assert '<script type="text/markdown"' not in run, (
+        "run page still embeds the raw markdown in a text/markdown script block"
     )
-    assert '<script type="text/markdown" data-md-source="run-body">' in run, (
-        "run page missing the text/markdown source script block"
+    assert "marked@13/marked.min.js" not in run, (
+        "run page still loads the Marked.js CDN — should render server-side now"
     )
-    assert "marked@13/marked.min.js" in run, "run page missing the Marked.js CDN loader"
-    # The raw markdown table syntax (pipes) survives html-escaped inside the
-    # script block — proof the body is embedded, not pre-rendered server-side.
-    assert "lower=better" in run, "run page did not embed the .md body verbatim"
+    # The synthesis prose survives into rendered text (proof the body rendered).
+    assert "lower=better" in run, "run page did not render the .md body content"
 
 
 def test_runs_sidebar_has_runs_link(built_run_report_pages: dict[str, str]) -> None:
@@ -1590,19 +1602,21 @@ def _run_report_ctx() -> Any:
     )
 
 
-def test_run_report_escapes_script_breakout(tmp_path: Path) -> None:
-    """Codex finding #5 — the embedded markdown must be html-escaped so a body
-    containing ``</script>`` (or ``<`` / ``&``) cannot break out of the
-    ``<script type="text/markdown">`` block and inject live DOM. The single-SoT
-    guarantee depends on the body staying inert inside the script tag."""
+def test_run_report_escapes_text_node_specials(tmp_path: Path) -> None:
+    """PR-HUB-RUN-REPORT-SSR — markdown-it escapes text-node specials itself
+    (``&`` -> ``&amp;``, a literal ``<x`` -> ``&lt;``), so the body is NOT
+    pre-escaped via html_escape: double-escaping was the bug that rendered the
+    intro blockquote's ``>``/``&`` as literal ``&gt;``/``&amp;``. A markdown
+    blockquote + an inline ``&`` must render to a real ``<blockquote>`` and a
+    single (not double) ``&amp;`` — never a literal ``&amp;amp;``."""
     from scripts.build_self_improving_hub import (
         AUTORESEARCH_RUN_REPORT_TEMPLATE,
         render_autoresearch_run_report,
     )
 
-    md = tmp_path / "run-breakout-probe.md"
+    md = tmp_path / "run-escape-probe.md"
     md.write_text(
-        '# Breakout probe\n\nbody </script><a href="/evil">x</a> & <b>bold</b>\n',
+        "# Escape probe\n\n> intro note with R&D and a < b comparison\n",
         encoding="utf-8",
     )
     out_dir = tmp_path / "out"
@@ -1611,13 +1625,14 @@ def test_run_report_escapes_script_breakout(tmp_path: Path) -> None:
         md, out_dir, template=template, ctx=_run_report_ctx(), repo_root=tmp_path
     )
     html = page.read_text(encoding="utf-8")
-    # The raw closing-script sequence must NOT survive verbatim — it is escaped.
-    assert "</script><a" not in html, "markdown body broke out of the script block"
-    assert "&lt;/script&gt;&lt;a" in html, "expected escaped </script><a inside the body"
-    # The injected anchor must not become a real static <a> the link-collector sees.
-    assert '/evil"' not in html, "injected href leaked as a live anchor attribute"
-    # Exactly one markdown source script block + one render target.
-    assert html.count('<script type="text/markdown" data-md-source="run-body">') == 1
+    # The blockquote rendered to real HTML (not literal ``&gt; intro``).
+    assert "<blockquote>" in html, "markdown blockquote did not render server-side"
+    assert "&gt; intro" not in html, "blockquote marker leaked as literal &gt; (double-escape bug)"
+    # ``&`` is escaped exactly once — no double-escaped ``&amp;amp;``.
+    assert "R&amp;D" in html, "inline & should render to a single &amp;"
+    assert "&amp;amp;" not in html, "double-escaped & (the original bug) reappeared"
+    # No client-side embed leaked into the page.
+    assert '<script type="text/markdown"' not in html, "stale text/markdown script block present"
 
 
 def test_run_report_allows_template_marker_in_markdown(tmp_path: Path) -> None:
@@ -1631,18 +1646,23 @@ def test_run_report_allows_template_marker_in_markdown(tmp_path: Path) -> None:
 
     md = tmp_path / "run-marker-probe.md"
     md.write_text(
-        "# Marker probe\n\nThe template uses `{{ run_body }}` and `{{ geode_version }}`.\n",
+        "# Marker probe\n\nThe template uses `{{ run_body_html }}` and `{{ geode_version }}`.\n",
         encoding="utf-8",
     )
     out_dir = tmp_path / "out"
     template = AUTORESEARCH_RUN_REPORT_TEMPLATE.read_text(encoding="utf-8")
-    # Must not raise RuntimeError("unresolved markers ...").
+    # Must not raise RuntimeError("unresolved markers ...") — the chrome marker
+    # scan runs BEFORE the rendered body is injected, so the body's own
+    # ``{{ run_body_html }}`` token is never mistaken for an unresolved marker.
     page = render_autoresearch_run_report(
         md, out_dir, template=template, ctx=_run_report_ctx(), repo_root=tmp_path
     )
     html = page.read_text(encoding="utf-8")
-    assert "&#123;&#123;" in html or "{{ run_body }}" in html, (
-        "the {{ }} token from the markdown body should survive (escaped) into the page"
+    # markdown-it renders the inline-code token to <code>{{ run_body_html }}</code>
+    # — the {{ }} survives verbatim as inert text (no template substitution of a
+    # body-authored token).
+    assert "{{ run_body_html }}" in html, (
+        "the {{ }} token from the markdown body should survive into the page as inert text"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.135"
+version = "0.99.137"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1375,6 +1375,7 @@ dependencies = [
     { name = "langgraph-checkpoint" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "latex2sympy2" },
+    { name = "markdown-it-py" },
     { name = "markdownify" },
     { name = "numpy" },
     { name = "openai" },
@@ -1461,6 +1462,7 @@ requires-dist = [
     { name = "langgraph-checkpoint", specifier = ">=4.0.1" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0" },
     { name = "latex2sympy2", specifier = ">=1.9" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'audit'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
develop → main passthrough for PR #2000: the self-improving hub run-report page now renders its markdown body server-side at build time (markdown-it-py) instead of via the jsdelivr Marked.js CDN — so the body always renders (CDN-blocked / JS-off → no longer blank), with no double-escape. The committed `docs/self-improving/autoresearch/runs/*` HTML is rebuilt server-side; `pages.yml` (triggers on `docs/self-improving/**`) will redeploy. v0.99.137.

## Verification
- [x] CI 5/5 green on PR #2000 (Lint & Format, Test, Type Check, Security, Gate)
- [x] Codex MCP review: no findings on final diff
- [x] Committed run HTML has 0 `marked@13`/`text/markdown`; `<article class="markdown-body">` contains rendered `<h1>`/`<table>`/`<strong>`