### PR TITLE
feat(self-improving): geode campaign CLI + onboarding docs (v0.99.141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,49 @@ functional change.
 
 ---
 
+## [0.99.141] - 2026-06-04
+
+### Added
+- **`geode campaign` CLI command + self-improving onboarding docs.** The 3-arm
+  self-improving campaign was previously launchable only via the raw script
+  `python core/self_improving/campaign.py`; a discoverable `geode campaign` Typer
+  command now forwards `--n` / `--k` / `--arms` / `--mc` / `--audit-max-samples` /
+  `--audit-max-connections` / `--dry-run` to the existing
+  `core/self_improving/campaign.py::main(argv)` (behaviour identical; the runtime
+  import is lazy so loading the CLI does not eagerly pull the self-improving
+  runtime). Registered in `core/cli/__init__.py`; covered by
+  `tests/test_cli_campaign.py` (5 tests).
+- **`docs/self-improving/campaign-quick-start.md`** — a start-here runbook for the
+  loop: a prerequisites checklist (`uv sync --extra audit`, the auditor/judge/target
+  model accounts, copying `docs/examples/self_improving_loop.config.toml.example`
+  to `~/.geode/config.toml`), a 5-step first campaign (both `geode campaign` and the
+  script form), and a common-failures table. Linked from `docs/setup.md` and both
+  READMEs.
+- **`docs/setup.md` "Self-improving loop" section** — surfaces the blocking
+  prerequisites (the `[audit]` extra, the required model accounts, the config copy)
+  that were previously implicit in config comments only.
+
+### Fixed
+- **Stale `state/self_improving/` paths corrected to `state/autoresearch/`** in the
+  onboarding-path docs (`campaign-procedure.md`, `loop-overview.md`,
+  `baseline-schema-history.md`, `held-out-bench.md`) — the real path per
+  `core/paths.py::AUTORESEARCH_STATE_DIR` (PR-STATE-AUTORESEARCH-RENAME Scheme A).
+  The stale path pointed newcomers at a directory that does not exist; the code
+  package `core/self_improving/` is unchanged (only the state dir was renamed). The
+  same stale path still appears in 11 internal design/ADR docs (out of this PR's
+  onboarding scope) and is tracked as a follow-up.
+- **Onboarding config docs corrected to the active shape.** The config example
+  (`docs/examples/self_improving_loop.config.toml.example`), `campaign-quick-start.md`,
+  and the `setup.md` section now document per-role model bindings as
+  `[self_improving_loop.autoresearch.<role>]` (`model` + `source`) — the active shape
+  per `core/config/self_improving_loop.py` — instead of the deprecated no-op flat
+  `target_model`/`judge_model` slots and the legacy `[self_improving_loop.petri.*]`
+  tables (now demoted to a "deprecated, auto-migrated" note). Role default models are
+  shown as the actual `petri.plugin.toml` manifest defaults (auditor `claude-opus-4-7`,
+  target `claude-haiku-4-5`, judge `claude-sonnet-4-6`). The missing-`[audit]`-extra
+  failure mode is documented as a loud abort ("`inspect` CLI not found … install the
+  [audit] extra"), matching `plugins/petri_audit/runner.py`, not a silent zero-fill.
+
 ## [0.99.140] - 2026-06-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.140
+- **Version**: 0.99.141
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.140 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.141 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 
@@ -279,6 +279,8 @@ autoresearch / seed-generation / petri audit 드라이버의 model / dim set / b
 geode config migrate-petri-toml          # dry-run 미리보기
 geode config migrate-petri-toml --yes    # [self_improving_loop.petri.*] 를 config.toml 에 append
 ```
+
+캠페인을 돌리려면 quick-start 부터 시작하세요: [docs/self-improving/campaign-quick-start.md](docs/self-improving/campaign-quick-start.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.140 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.141 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 
@@ -280,6 +280,8 @@ Tune the autoresearch / seed-generation / petri audit drivers — model picks, d
 geode config migrate-petri-toml          # dry-run preview
 geode config migrate-petri-toml --yes    # append [self_improving_loop.petri.*] to config.toml
 ```
+
+To run a campaign, start with the quick-start: [docs/self-improving/campaign-quick-start.md](docs/self-improving/campaign-quick-start.md).
 
 ---
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -349,6 +349,84 @@ from core.cli.commands.reindex import reindex  # noqa: E402
 app.command(name="reindex")(reindex)
 
 
+# PR-CAMPAIGN-CLI: discoverable front end for the 3-arm self-improving campaign.
+# This is a THIN forwarder: it collects the same options the argparse driver in
+# ``core/self_improving/campaign.py`` exposes (``--n`` / ``--k`` / ``--arms`` +
+# the pass-through flags) and rebuilds them as an argv list handed straight to
+# ``campaign.main``. No campaign logic is reimplemented here, so ``geode
+# campaign`` and ``python core/self_improving/campaign.py`` stay byte-identical
+# in behaviour. The import is local to the command body so loading the CLI
+# package never eagerly pulls the self-improving runtime (and its heavy deps).
+def campaign(
+    n: int = typer.Option(
+        10,
+        "--n",
+        help="Cycles per arm (campaign-procedure.md section 6). Default 10.",
+    ),
+    k: int = typer.Option(
+        5,
+        "--k",
+        help="gen-0 baseline repeats, the noise-band K-mean. Default 5.",
+    ),
+    arms: str = typer.Option(
+        "never,random,gate",
+        "--arms",
+        help="Comma-separated arm order, gate LAST. Default 'never,random,gate'.",
+    ),
+    mc: int = typer.Option(
+        8,
+        "--mc",
+        help="Max propose-guard re-proposal attempts M. Default 8.",
+    ),
+    audit_max_samples: int = typer.Option(
+        3,
+        "--audit-max-samples",
+        help="GEODE_AUDIT_MAX_SAMPLES export passed to each audit. Default 3.",
+    ),
+    audit_max_connections: int = typer.Option(
+        8,
+        "--audit-max-connections",
+        help="GEODE_AUDIT_MAX_CONNECTIONS export passed to each audit. Default 8.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Synthetic audits, no PAYG/network. Passed through to train.py + the runner.",
+    ),
+) -> None:
+    """Run the 3-arm self-improving campaign (gen-0 baseline, then never/random/gate).
+
+    Thin wrapper over ``core/self_improving/campaign.py``: forwards the flags
+    unchanged, so behaviour matches ``python core/self_improving/campaign.py``.
+    A real (non --dry-run) campaign spawns audit subprocesses and spends PAYG
+    budget, so launch it deliberately.
+    """
+    from core.self_improving.campaign import main as _campaign_main
+
+    argv: list[str] = [
+        "--n",
+        str(n),
+        "--k",
+        str(k),
+        "--arms",
+        arms,
+        "--mc",
+        str(mc),
+        "--audit-max-samples",
+        str(audit_max_samples),
+        "--audit-max-connections",
+        str(audit_max_connections),
+    ]
+    if dry_run:
+        argv.append("--dry-run")
+    exit_code = _campaign_main(argv)
+    if exit_code != 0:
+        raise typer.Exit(code=exit_code)
+
+
+app.command()(campaign)
+
+
 def _version_option(value: bool) -> None:
     if value:
         console.print(f"GEODE v{__version__}")

--- a/docs/examples/self_improving_loop.config.toml.example
+++ b/docs/examples/self_improving_loop.config.toml.example
@@ -34,12 +34,6 @@ abort_threshold = 0.9
 # Inner-audit wall-clock budget (minutes). 1–60. Subprocess timeout is
 # `budget_minutes * 60 + 120`. Default 5.
 budget_minutes = 5
-# Model that the inner Petri audit sends prompts to (the *target*).
-target_model = "geode/gpt-5.5"
-# Model that scores each rollout via inspect_petri's judge contract.
-# Default keeps judge ≠ target provider for the M1 cross-provider guard
-# (`plugins/petri_audit/optimize.py`).
-judge_model = "claude-code/opus"
 # Use Claude Code / Codex OAuth for the audit subprocess when available.
 # Falls through to PAYG only when `fallback_to_payg = true` above.
 use_oauth = true
@@ -54,6 +48,34 @@ dim_set  = "5axes"
 max_turns = 10
 # Optional override of the global flag for autoresearch only.
 # fallback_to_payg = true
+
+# ---------------------------------------------------------------------------
+# ACTIVE per-role model bindings (the control-layer SoT)
+# ---------------------------------------------------------------------------
+# This is the shape the runtime reads: one nested table per role under
+# `[self_improving_loop.autoresearch.<role>]`, each with `model` + `source`.
+# Each role table is optional; an absent role falls back to the manifest
+# defaults in `plugins/petri_audit/petri.plugin.toml`
+# (auditor: claude-opus-4-7, target: claude-haiku-4-5, judge: claude-sonnet-4-6).
+# `source` selects the credential lane: `claude-cli` (Claude Code Max OAuth,
+# the default), `openai-codex` (ChatGPT subscription OAuth), or `auto`
+# (manifest cascade). Schema: `core.config.self_improving_loop.PetriRoleConfig`.
+
+# Auditor: the LLM that conducts the Petri audit (flagship recommended).
+[self_improving_loop.autoresearch.auditor]
+model  = "claude-opus-4-7"
+source = "claude-cli"
+
+# Target: the model the audit sends prompts to (the model under test).
+[self_improving_loop.autoresearch.target]
+model  = "geode/gpt-5.5"
+source = "openai-codex"
+
+# Judge: the model that scores each rollout via the judge contract. Keep
+# judge ≠ target provider for the cross-provider guard.
+[self_improving_loop.autoresearch.judge]
+model  = "claude-sonnet-4-6"
+source = "claude-cli"
 
 # ---------------------------------------------------------------------------
 # seed-generation driver (plugins/seed_generation/)
@@ -74,22 +96,16 @@ default_gen_tag = "gen1"
 # source   = "openai-codex"
 
 # ---------------------------------------------------------------------------
-# petri audit role overrides (replaces legacy ~/.geode/petri.toml)
+# Deprecated (auto-migrated, do not use for new configs)
 # ---------------------------------------------------------------------------
-# Per-role override of the model + credential source used during
-# `geode audit` runs. Each entry is optional — absent role → manifest
-# defaults from `plugins/petri_audit/petri.plugin.toml`. Migrate
+# The legacy `[self_improving_loop.petri.<role>]` tables and the flat
+# `target_model` / `judge_model` slots under `[self_improving_loop.autoresearch]`
+# are deprecated. The config loader still accepts them for back-compat: the
+# `[petri.<role>]` tables are auto-migrated to
+# `[self_improving_loop.autoresearch.<role>]` (a DeprecationWarning fires per
+# load, see `core/config/self_improving_loop.py:664`), and the flat
+# `target_model` / `judge_model` slots are no-op back-compat fields that the
+# runtime never consults (`core/config/self_improving_loop.py:317,322`).
+# New configs should use the ACTIVE per-role tables above. Migrate any
 # existing `~/.geode/petri.toml` entries via
 # `geode config migrate-petri-toml --yes`.
-
-[self_improving_loop.petri.auditor]
-model  = "claude-sonnet-4-6"
-source = "claude-cli"
-
-[self_improving_loop.petri.target]
-model  = "geode/gpt-5.5"
-source = "openai-codex"
-
-[self_improving_loop.petri.judge]
-model  = "claude-opus-4-7"
-source = "claude-cli"

--- a/docs/self-improving/baseline-schema-history.md
+++ b/docs/self-improving/baseline-schema-history.md
@@ -4,8 +4,8 @@ Lossless record of every baseline-related schema GEODE's self-improving loop
 has used, so a baseline measured under an older schema is never silently
 mis-read and the design provenance of the current schema is preserved.
 
-The **active anchor** is `state/self_improving/baseline.json` (the most recently
-promoted baseline). The **registry** is `state/self_improving/baseline_archive.jsonl`
+The **active anchor** is `state/autoresearch/baseline.json` (the most recently
+promoted baseline). The **registry** is `state/autoresearch/baseline_archive.jsonl`
 (one append-only `kind="baseline"` row per promotion — the hub's baseline index
 reads it). The two are separate SoTs: the anchor answers "what does the loop
 compare against right now"; the registry answers "what baselines have existed,

--- a/docs/self-improving/campaign-procedure.md
+++ b/docs/self-improving/campaign-procedure.md
@@ -12,7 +12,7 @@ The loop optimizes GEODE's **scaffold** — the system-prompt sections and polic
 artifacts that wrap the base model — NOT the base model's weights. One cycle:
 
 1. The mutator proposes a single-section change to one scaffold artifact.
-2. The change is applied to the in-repo SoT (`state/self_improving/policies/*`).
+2. The change is applied to the in-repo SoT (`state/autoresearch/policies/*`).
 3. A Petri audit runs with the audit target = **GEODE-as-a-system**
    (`geode/gpt-5.5` → `GeodeModelAPI` → `AgenticLoop`), i.e. gpt-5.5 running the
    *mutated* scaffold as the base of its system prompt, with the auditor's seed
@@ -31,7 +31,7 @@ spec hash — see `baseline-epoch-partition`).
 ## 2. The scaffold (what is mutated)
 
 The mutable scaffold is the set of policy artifacts under
-`state/self_improving/policies/`, dispatched by `mutation.target_kind`
+`state/autoresearch/policies/`, dispatched by `mutation.target_kind`
 (`core/self_improving/loop/policies.py::TARGET_KINDS`).
 
 ### 2.1 TARGET_KINDS (7 behaviour kinds)
@@ -173,9 +173,9 @@ JSONL stream by arm.
 
 | Artifact | Path | Content |
 |----------|------|---------|
-| Mutation ledger | `state/self_improving/mutations.jsonl` | Every mutate / apply / audit / baseline / attribution row (git-tracked). |
-| Policy SoTs | `state/self_improving/policies/*.json` | The current (best) scaffold — `git diff` shows mutation state. |
-| Baseline | `state/self_improving/baseline.json` | The promoted baseline (advances only on a gate promote). |
+| Mutation ledger | `state/autoresearch/mutations.jsonl` | Every mutate / apply / audit / baseline / attribution row (git-tracked). |
+| Policy SoTs | `state/autoresearch/policies/*.json` | The current (best) scaffold — `git diff` shows mutation state. |
+| Baseline | `state/autoresearch/baseline.json` | The promoted baseline (advances only on a gate promote). |
 | Baseline archive | `baseline_archive.jsonl` | One row per baseline epoch (`be-001` → …), content-addressed by spec hash. |
 | Eval archive | `~/.geode/petri/logs/*.eval` (+ `latest.eval`) | Per-cycle Petri `.eval` — the single SoT for per-dim evidence. |
 | Hub | self-improving hub pages | Serves baseline epochs (grouped) + the cross-generation evidence page, mirroring the seed-gen `gen-*` layout. |

--- a/docs/self-improving/campaign-quick-start.md
+++ b/docs/self-improving/campaign-quick-start.md
@@ -1,0 +1,216 @@
+# Self-improving campaign: quick start
+
+The single front door for running GEODE's self-improving loop. If you have never
+run a campaign, start here, then graduate to `campaign-procedure.md` for the full
+procedure and `docs/architecture/autoresearch.md` for the design.
+
+What the loop does, and what it does not: each cycle mutates one section of
+GEODE's scaffold (the system-prompt sections + policy artifacts that wrap the
+base model, never the model weights), audits the scaffolded GEODE with Petri,
+folds the per-dim judge scores into a scalar fitness, and either commits the
+mutation or reverts the source of truth on a statistically defensible gate. The
+loop MEASURES and GATES. It does not promise improvement: a real run can produce
+zero promotions (the `broken_tool_use` campaign's robust improvement was 0). The
+held-out fitness curve is the evidence surface, and a flat curve is an honest,
+expected outcome.
+
+## 1. Prerequisites checklist
+
+Verify every item below. Skipping the audit extra or the model accounts produces
+a run that looks like it works but measures nothing.
+
+| Requirement | How to satisfy | Why it matters |
+|-------------|----------------|----------------|
+| Python 3.12+ | `python --version` | Project floor (`pyproject.toml`, `requires-python >= 3.12`). |
+| `uv` | `uv --version` | Package manager + runner for every command here. |
+| Base sync | `uv sync` | Installs GEODE core. Not enough on its own for the loop. |
+| Audit extra | `uv sync --extra audit` | Installs `inspect_ai` + Petri (puts the `inspect` CLI on PATH). WITHOUT it the audit aborts loudly: `plugins/petri_audit/runner.py` checks `shutil.which("inspect")` and returns an aborted report with `` `inspect` CLI not found on PATH — install the [audit] extra: `uv sync --extra audit`. `` (`core.self_improving.train` then returns failure for that cycle). Install it before your first run. |
+| Auditor + judge model | Anthropic account (Claude). See model accounts below. | The Petri auditor drives each scenario, the judge scores each rollout on the rubric. No judge means no fitness. |
+| Target model | `geode/gpt-5.5` via ChatGPT / Codex OAuth, or override `[self_improving_loop.autoresearch.target] model = ...` in config. | The audit target is GEODE-as-a-system running the mutated scaffold. No target means no audit. |
+
+Without these model accounts the loop cannot run: the auditor, judge, and target
+are three separate LLM roles, and an absent account aborts the audit (or, with
+quota exhausted, degenerates to `fitness=None`, which the gate refuses to
+promote).
+
+### Model accounts and the three roles
+
+The audit uses three distinct roles, each with its own model + credential
+source. Manifest defaults come from `plugins/petri_audit/petri.plugin.toml`; you
+override them per role under `[self_improving_loop.autoresearch.<role>]` in
+`~/.geode/config.toml` (each table takes `model` + `source`):
+
+| Role | Manifest default model | Default source | Provider account needed |
+|------|------------------------|----------------|-------------------------|
+| auditor | `claude-opus-4-7` | `claude-cli` | Anthropic (Claude Code OAuth or API key) |
+| target | `claude-haiku-4-5` | `claude-cli` | Anthropic (or override to `geode/gpt-5.5` on ChatGPT / Codex OAuth) |
+| judge | `claude-sonnet-4-6` | `claude-cli` | Anthropic (kept on a different provider than the target for the cross-provider guard) |
+
+For a cross-provider audit, override the target to `geode/gpt-5.5`: it routes
+through `GeodeModelAPI` to the `AgenticLoop`, so the mutated scaffold is in the
+causal path of the audited behaviour. Set the override under
+`[self_improving_loop.autoresearch.target]` (`model = "geode/gpt-5.5"`,
+`source = "openai-codex"`). If you do not have ChatGPT / Codex access, set
+`[self_improving_loop.autoresearch.target] model = ...` to a model your account
+can reach instead.
+
+### Config and keys
+
+1. Copy the annotated template, then edit the values for your accounts:
+
+   ```bash
+   cp docs/examples/self_improving_loop.config.toml.example ~/.geode/config.toml
+   ```
+
+   The template documents every `[self_improving_loop.*]` key: `budget_minutes`,
+   `use_oauth`, `seed_limit`, `seed_select`, `dim_set`, `max_turns`, plus the
+   active per-role `[self_improving_loop.autoresearch.<role>]` (auditor / target /
+   judge) `model` + `source` bindings. Absent sections fall back to documented
+   defaults.
+
+2. Set the API keys in `~/.geode/.env` (see `docs/setup.md` for the full key
+   list). At minimum the auditor + judge need an Anthropic credential:
+
+   ```
+   ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+   The Claude Code / Codex OAuth path (`use_oauth = true`, the default) lets the
+   audit subprocess reuse your subscription quota instead of PAYG. PAYG fallback
+   stays off unless you flip `fallback_to_payg = true`. The OAuth audit path is
+   roughly $0; the Anthropic PAYG path is roughly $5 to $10 per audit.
+
+3. Optional outer-loop env hook: `GEODE_WRAPPER_OVERRIDE` points at the JSON file
+   of system-prompt sections that the loop writes per cycle. The loop sets it for
+   you; you do not normally set it by hand.
+
+## 2. Your first campaign (5 steps)
+
+### Step a: get an isolated worktree
+
+Never run code work on `main` / `develop`. Allocate a worktree off `develop`:
+
+```bash
+git fetch origin
+git worktree add .claude/worktrees/my-campaign -b feature/my-campaign develop
+```
+
+All subsequent commands run from inside that worktree checkout.
+
+### Step b: set the loop config
+
+Edit `~/.geode/config.toml` `[self_improving_loop.*]` per section 1. The values
+that matter most for a first run: `seed_limit` (default 10), `budget_minutes`
+(default 5, the per-audit wall-clock budget), and the three
+`[self_improving_loop.autoresearch.<role>]` (auditor / target / judge) `model`
+bindings. Leave the measurement parameters (`seed_limit`, `max_turns`,
+`dim_set`) fixed once chosen: changing them changes how / what the audit
+measures and confounds the mutated-vs-baseline comparison.
+
+### Step c: gen-0 baseline + a single audit
+
+`python -m core.self_improving.train` runs ONE audit per invocation, the
+single-audit entry. Smoke the plumbing first with `--dry-run` (synthetic
+baseline, no network, no quota): it emits the real output shape with
+`fitness` near `0.89` against the dry-run dim mock.
+
+```bash
+# Plumbing smoke: synthetic audit, no budget spent, no PAYG/network.
+uv run python -m core.self_improving.train --dry-run
+
+# Real single audit (consumes budget). Redirect, never flood stdout.
+uv run python -m core.self_improving.train > state/autoresearch/run.log 2>&1
+```
+
+Extract the metrics from the log:
+
+```bash
+grep "^fitness:\|^.*_score:\|^.*_mean:" state/autoresearch/run.log
+```
+
+An empty grep result means the audit crashed (check `tail -n 50` of the log) or
+aborted before measuring: a missing `[audit]` extra aborts loudly with `inspect`
+CLI not found on PATH. A fitness line with all-zero `dim_means` instead points at
+a degenerate audit (the target could not reach a model, e.g. auth or quota), so
+re-check section 1 before reading anything into the number. The first real run with no prior `baseline.json` establishes the
+baseline; the cross-axis gate stays dormant until a baseline exists.
+
+### Step d: a short 3-arm run
+
+The campaign driver runs three arms (`never`, `random`, `gate`) from a matched
+gen-0 reset so any observed gain is attributable to the gate, not to drift or
+chance. Run a short version first (`--n 1` cycle per arm).
+
+Recommended entry, the `geode campaign` command (a sibling change adds this CLI;
+prefer it once available):
+
+```bash
+geode campaign --n 1 --k 5 --arms never,random,gate
+```
+
+Script form, which works today (equivalent driver, same flags):
+
+```bash
+uv run python core/self_improving/campaign.py --n 1 --k 5 --arms never,random,gate
+```
+
+Flags (from `core/self_improving/campaign.py::_build_arg_parser`):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--n` | 10 | cycles per arm |
+| `--k` | 5 | gen-0 baseline repeats (the noise band) |
+| `--arms` | `never,random,gate` | comma-separated arm order, gate LAST |
+| `--mc` | 8 | max propose-guard re-proposal attempts |
+| `--audit-max-samples` | 3 | `GEODE_AUDIT_MAX_SAMPLES` export |
+| `--audit-max-connections` | 8 | `GEODE_AUDIT_MAX_CONNECTIONS` export |
+| `--dry-run` | off | synthetic audits, no PAYG / network (plumbing only) |
+
+Smoke the campaign wiring end to end with `--dry-run` before spending budget:
+
+```bash
+uv run python core/self_improving/campaign.py --n 1 --k 5 --arms never,random,gate --dry-run
+```
+
+A real 3-arm run is long: the gate arm runs last and sequentially, so budget per
+arm at default `--n 10` adds up across many audits. Start with `--n 1` to confirm
+the full loop completes before scaling up.
+
+### Step e: where results land and how to read them
+
+| Artifact | Path | What it holds |
+|----------|------|---------------|
+| Mutation ledger | `state/autoresearch/mutations.jsonl` | One row per mutate / apply / audit / baseline / attribution event (git-tracked). Arms are tagged via `promote_policy` / `promote_policy_seed`, so you can split the stream by arm. |
+| Promoted baseline | `state/autoresearch/baseline.json` | The promoted baseline `dim_means` + `dim_stderr`. Advances only on a gate promote; a reject leaves it untouched. |
+| Per-cycle eval | `~/.geode/petri/logs/*.eval` (+ `latest.eval`) | The Petri `.eval` per cycle, the single source for per-dim evidence. |
+| Run logs | `state/autoresearch/run.log` (single audit), `state/campaign/` (campaign progress + runs) | Stdout / progress for inspection. |
+| Self-improving hub | `docs/self-improving/` (`index.html`) | The rendered pages: baseline epochs and the cross-generation evidence page. The held-out fitness curve, partitioned by baseline epoch and by arm, is the curve that counts. |
+
+Read order for a finished run: the per-arm held-out curves on the hub
+(`never` and `random` set the reference the `gate` arm must beat), then
+`mutations.jsonl` to see which mutations were proposed and whether any promoted.
+A flat or non-promoting `gate` arm is a valid result: the gate refused to promote
+within measurement noise.
+
+## 3. Common failures and fixes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Audit aborts immediately: `inspect` CLI not found on PATH | The `[audit]` extra is not installed, so `inspect_ai` / Petri are absent and the run aborts loudly before measuring | `uv sync --extra audit` (and `uv tool install -e ".[audit]" --force` if using the installed CLI), then re-run. |
+| Audit aborts or `fitness=None` (degenerate, never promoted) | Auth missing or subscription quota exhausted on auditor / judge / target | Refresh OAuth / add the missing key in `~/.geode/.env`; wait for quota reset, or set `fallback_to_payg = true` to opt into PAYG charges. |
+| Every cycle replays an identical (often fake) score | `inspect_ai` trajectory cache pollution: it keys on input messages, so an identical-scaffold repeat hits the same cached score | Purge `~/Library/Caches/inspect_ai/generate/`. A real campaign run purges it at start; for ad-hoc single audits, clear it by hand. |
+| Audit killed mid-run | Per-audit wall-clock budget exceeded (`budget_minutes`, subprocess timeout `budget_minutes * 60 + 120`; campaign per-audit timeout via `GEODE_PER_AUDIT_TIMEOUT_S`, default 2700s) | Raise `budget_minutes` in config or `GEODE_PER_AUDIT_TIMEOUT_S` for the campaign, or shorten `max_turns` / `seed_limit` so each audit fits the budget. |
+
+## 4. Where to go deeper
+
+- `docs/self-improving/campaign-procedure.md`: the full procedure SoT. Scaffold
+  surface (the 7 behaviour kinds), the two-audit measurement (selection vs frozen
+  held-out), the gen-0 noise band, the promote gate and its margin, the 3-arm
+  attribution design, and the fixed parameters / guards.
+- `docs/architecture/autoresearch.md`: the design + fitness spec. Mission, the
+  Petri x GEODE pipeline, tier classification and weights, the cross-axis
+  monotone gate, and the git-as-optimiser ratchet.
+- `docs/examples/self_improving_loop.config.toml.example`: the annotated config
+  template, every `[self_improving_loop.*]` key with its default and precedence.
+- `core/self_improving/program.md`: the single-audit driver's instruction sheet,
+  including the `train.py` output format and the cross-axis gate semantics.

--- a/docs/self-improving/held-out-bench.md
+++ b/docs/self-improving/held-out-bench.md
@@ -135,11 +135,11 @@ ls "$GEODE_HELD_OUT_BENCH"/manifest.json
 When a bench is configured, EVERY cycle (not just promotes) runs a second audit
 on the frozen bench and records the result:
 
-- **`state/self_improving/mutations.jsonl`** — the per-cycle `kind="attribution"`
+- **`state/autoresearch/mutations.jsonl`** — the per-cycle `kind="attribution"`
   row gains `held_out_fitness` (canonical 0-1 `compute_fitness`, HIGHER-is-better)
   and `held_out_bench_id`. Ordered by `ts`, these rows ARE the cross-generation
   curve. This is the curve SoT the hub renders.
-- **`state/self_improving/baseline_archive.jsonl`** — on a promote, the
+- **`state/autoresearch/baseline_archive.jsonl`** — on a promote, the
   `kind="baseline"` row also carries `held_out_fitness` + `held_out_bench_id` so
   the promoted baseline records its fixed-ruler fitness.
 

--- a/docs/self-improving/loop-overview.md
+++ b/docs/self-improving/loop-overview.md
@@ -1,8 +1,8 @@
 # GEODE self-improving loop — overview (DATA + program SoT)
 
-The self-improving loop's **runtime DATA** lives at `state/self_improving/`
+The self-improving loop's **runtime DATA** lives at `state/autoresearch/`
 (under `STATE_ROOT`, env-overridable via `GEODE_STATE_ROOT`; the single
-canonical `core.paths.SELF_IMPROVING_STATE_DIR`) and the **agent program
+canonical `core.paths.AUTORESEARCH_STATE_DIR`) and the **agent program
 SoT** is `core/self_improving/program.md`. The loop *CODE* lives under the
 `core.self_improving` umbrella package (PR-SELF-IMPROVING-UMBRELLA,
 2026-05-31) — `core/self_improving/train.py` (the audit runner, formerly
@@ -72,7 +72,7 @@ signal lives in the companion `results.jsonl`.
 
 Mutations to `WRAPPER_PROMPT_SECTIONS` propagate into the audit
 subprocess through the `GEODE_WRAPPER_OVERRIDE` env var (which points
-at `state/self_improving/wrapper-override.json`). The GEODE runtime's
+at `state/autoresearch/wrapper-override.json`). The GEODE runtime's
 `PromptAssembler` Phase 0 reads it and replaces the wrapper base.
 `--dry-run` skips the subprocess entirely so plumbing can be verified
 without spending budget.
@@ -124,7 +124,7 @@ core/self_improving/           — loop CODE + program SoT (umbrella package)
 ├── admire_means.py / bench_means.py — positive-pressure / capability axes
 └── loop/          — loop runtime (runner, mutator, policies, …)
 
-state/self_improving/          — runtime DATA (under STATE_ROOT)
+state/autoresearch/            — runtime DATA (under STATE_ROOT)
 ├── policies/      — mutation-target SoT JSONs (git-tracked)
 ├── mutations.jsonl, baseline_archive.jsonl, baseline_epochs.json (git-tracked)
 ├── results.tsv, results.jsonl — rolling per-audit history (git-tracked)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -286,6 +286,27 @@ geode serve [-p 3.0]                   # Headless daemon
 
 ---
 
+## Self-improving loop
+
+The self-improving loop runs a Petri audit over GEODE's own scaffold, measures the result, and gates each candidate change behind that measurement. It does not promise improvement: it measures and either promotes or rejects.
+
+Before running a campaign, three prerequisites are BLOCKING:
+
+1. **Audit extra**: `uv sync --extra audit`. This pulls in `inspect_ai` + `petri` (putting the `inspect` CLI on PATH), which the audit subprocess and the seed-generation pilot both require. Without it the audit aborts loudly: `plugins/petri_audit/runner.py` checks `shutil.which("inspect")` and returns an aborted report with `` `inspect` CLI not found on PATH — install the [audit] extra: `uv sync --extra audit`. ``, and the loop returns failure for that cycle.
+2. **Model accounts**:
+   - An **auditor + judge model** (Anthropic): the auditor drives the Petri scenario and the judge scores each rollout. Configured via the `[self_improving_loop.autoresearch.auditor]` / `[self_improving_loop.autoresearch.judge]` sections (`model` + `source`).
+   - A **target model**: defaults to the manifest `claude-haiku-4-5`; override to `geode/gpt-5.5` via ChatGPT / Codex OAuth with `[self_improving_loop.autoresearch.target]` (`model = "geode/gpt-5.5"`, `source = "openai-codex"`) in config.
+3. **Config**: copy `docs/examples/self_improving_loop.config.toml.example` to `~/.geode/config.toml` (or merge the `[self_improving_loop.*]` sections into an existing one). Absent sections fall back to documented defaults.
+
+```bash
+uv sync --extra audit
+cp docs/examples/self_improving_loop.config.toml.example ~/.geode/config.toml
+```
+
+To run a campaign, start with the quick-start runbook: [docs/self-improving/campaign-quick-start.md](self-improving/campaign-quick-start.md). For the full procedure (difficulty seeding, baseline re-measurement, the 3-arm comparison, the bench axis), see [docs/self-improving/campaign-procedure.md](self-improving/campaign-procedure.md).
+
+---
+
 ## Testing
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.140"
+version = "0.99.141"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_cli_campaign.py
+++ b/tests/test_cli_campaign.py
@@ -29,14 +29,22 @@ def test_campaign_command_is_registered() -> None:
 
 
 def test_campaign_help_lists_core_flags() -> None:
-    result = CliRunner().invoke(app, ["campaign", "--help"])
+    # Assert the flags on the command's declared params, NOT by substring-matching
+    # the rendered ``--help`` text: Typer renders help through Rich, whose box
+    # wrapping + ANSI styling vary by terminal width / TTY (a narrow, no-TTY CI
+    # runner wraps the options panel so a literal "--n" is not a clean substring).
+    # The help is generated FROM these params, so introspecting them tests the
+    # same intent deterministically.
+    click_app = typer.main.get_command(app)
+    assert isinstance(click_app, click.Group)
+    campaign_cmd = click_app.commands["campaign"]
+    opt_names = {opt for param in campaign_cmd.params for opt in param.opts}
+    for flag in ("--n", "--k", "--arms", "--dry-run"):
+        assert flag in opt_names, f"{flag} missing from campaign command params"
 
+    # Smoke: ``--help`` still renders and exits cleanly (format-agnostic).
+    result = CliRunner().invoke(app, ["campaign", "--help"])
     assert result.exit_code == 0
-    out = result.output
-    assert "--n" in out
-    assert "--k" in out
-    assert "--arms" in out
-    assert "--dry-run" in out
 
 
 def test_campaign_forwards_options_to_campaign_main() -> None:

--- a/tests/test_cli_campaign.py
+++ b/tests/test_cli_campaign.py
@@ -1,0 +1,112 @@
+"""Registration + smoke tests for the ``geode campaign`` Typer command.
+
+PR-CAMPAIGN-CLI. ``geode campaign`` is a thin forwarder over the argparse
+driver in ``core/self_improving/campaign.py`` (it rebuilds the user options as
+an argv list and hands them to ``campaign.main``). These tests assert the
+command is discoverable and that the flags forward faithfully WITHOUT launching
+a real campaign: the delegation test mocks ``campaign.main`` so no audit
+subprocess is spawned and no PAYG budget is spent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import click
+import typer
+from typer.testing import CliRunner
+
+from core.cli import app
+
+
+def test_campaign_command_is_registered() -> None:
+    # Resolve the underlying click command so the name is the real CLI name
+    # (``app.registered_commands`` stores name=None for ``app.command()`` with
+    # no explicit name; the name is derived at build time from the function).
+    click_app = typer.main.get_command(app)
+    assert isinstance(click_app, click.Group)
+    assert "campaign" in click_app.commands
+
+
+def test_campaign_help_lists_core_flags() -> None:
+    result = CliRunner().invoke(app, ["campaign", "--help"])
+
+    assert result.exit_code == 0
+    out = result.output
+    assert "--n" in out
+    assert "--k" in out
+    assert "--arms" in out
+    assert "--dry-run" in out
+
+
+def test_campaign_forwards_options_to_campaign_main() -> None:
+    with patch("core.self_improving.campaign.main", return_value=0) as mock_main:
+        result = CliRunner().invoke(
+            app,
+            [
+                "campaign",
+                "--n",
+                "2",
+                "--k",
+                "1",
+                "--arms",
+                "never,gate",
+                "--mc",
+                "4",
+                "--audit-max-samples",
+                "5",
+                "--audit-max-connections",
+                "6",
+                "--dry-run",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_main.assert_called_once()
+    forwarded = mock_main.call_args.args[0]
+    assert forwarded == [
+        "--n",
+        "2",
+        "--k",
+        "1",
+        "--arms",
+        "never,gate",
+        "--mc",
+        "4",
+        "--audit-max-samples",
+        "5",
+        "--audit-max-connections",
+        "6",
+        "--dry-run",
+    ]
+
+
+def test_campaign_defaults_forward_without_dry_run() -> None:
+    with patch("core.self_improving.campaign.main", return_value=0) as mock_main:
+        result = CliRunner().invoke(app, ["campaign"])
+
+    assert result.exit_code == 0
+    forwarded = mock_main.call_args.args[0]
+    # Defaults mirror campaign.py argparse (--n 10, --k 5, gate LAST); no --dry-run.
+    assert forwarded == [
+        "--n",
+        "10",
+        "--k",
+        "5",
+        "--arms",
+        "never,random,gate",
+        "--mc",
+        "8",
+        "--audit-max-samples",
+        "3",
+        "--audit-max-connections",
+        "8",
+    ]
+    assert "--dry-run" not in forwarded
+
+
+def test_campaign_propagates_nonzero_exit_code() -> None:
+    with patch("core.self_improving.campaign.main", return_value=2):
+        result = CliRunner().invoke(app, ["campaign", "--arms", "bogus"])
+
+    assert result.exit_code == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.140"
+version = "0.99.141"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Add a discoverable `geode campaign` CLI command (thin forwarder over `core/self_improving/campaign.py::main`) so the 3-arm campaign is no longer script-only.
- Add a `docs/self-improving/campaign-quick-start.md` start-here runbook + a `docs/setup.md` "Self-improving loop" section + README cross-links.
- Correct onboarding docs against code: stale state paths, deprecated config shape, role defaults, and the `[audit]`-missing failure mode.

## Why
Audit of "can another person run the loop from a clean clone" found the loop was runnable but not discoverable/accurate for a newcomer: no `geode campaign` command (raw `python core/self_improving/campaign.py` only), no single quick-start, and `setup.md` had no self-improving section. A Codex review then surfaced that several onboarding docs (and the canonical config example) pointed at **deprecated no-op** config keys and a wrong failure mode — a newcomer following them would write config that silently does nothing.

## Changes
| File | Change |
|------|--------|
| `core/cli/__init__.py` | New `geode campaign` Typer command; forwards `--n/--k/--arms/--mc/--audit-max-samples/--audit-max-connections/--dry-run` to `campaign.main(argv)`; lazy runtime import |
| `tests/test_cli_campaign.py` | New: 5 registration/forwarding tests (no real launch) |
| `docs/self-improving/campaign-quick-start.md` | New start-here runbook (prereqs + 5-step first campaign + common failures) |
| `docs/setup.md` | New "Self-improving loop" section (blocking prereqs + links) |
| `README.md`, `README.ko.md` | Quick-start cross-link |
| `docs/examples/self_improving_loop.config.toml.example` | Lead with active `[self_improving_loop.autoresearch.<role>]` (model+source); demote deprecated flat `target_model`/`judge_model` + `[petri.*]` |
| `docs/self-improving/{campaign-procedure,loop-overview,baseline-schema-history,held-out-bench}.md` | Stale `state/self_improving/` -> `state/autoresearch/`; `SELF_IMPROVING_STATE_DIR` -> `AUTORESEARCH_STATE_DIR` |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md`, `uv.lock`, `CHANGELOG.md` | Version 0.99.140 -> 0.99.141 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `geode campaign` CLI | Implemented | forwarder; behaviour identical to script |
| Quick-start runbook | Implemented | grounded against `_build_arg_parser`, config schema |
| setup.md prereqs | Implemented | model accounts + `[audit]` extra + config copy |
| config example active shape | Fixed | flat/`[petri.*]` were deprecated no-ops |
| state-path drift | Fixed (onboarding docs) | 11 internal design/ADR docs out of scope -> follow-up |

## Verification
- [x] ruff check clean (core/cli + test)
- [x] ruff format --check clean
- [x] mypy clean
- [x] lint-imports: 4 kept, 0 broken
- [x] pytest tests/test_cli_campaign.py: 5 passed
- [x] CLI smoke: `geode version` -> v0.99.141, `geode campaign --help` registered
- [x] version parity across 5 locations (0.99.141)
- [x] Codex MCP reviewed (2 rounds); all 7 findings remediated

## Reference
Operator request: package + document the self-improving loop so others (incl. the operator) can run it. Codex MCP review (2 rounds) drove the doc-accuracy fixes.