### PR TITLE
fix(cli): /model project-scope no longer leaks globally + add /model global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,28 @@ functional change.
 
 ---
 
+## [0.99.144] - 2026-06-09
+
+### Fixed
+- **`/model` switch no longer leaks a per-project choice to every workspace.**
+  A bare `/model <name>` (project scope) wrote `GEODE_MODEL` to the global
+  `~/.geode/.env` in addition to the project config. Because env outranks the
+  project TOML in the precedence chain (CLI > env > project > global > routing),
+  the choice (a) stuck across every project and (b) shadowed the project
+  `[llm] primary_model` on the next session reload (`_apply_toml_overlay` skips
+  TOML fields that have a `GEODE_*` env). Project scope now persists to the
+  session's `.geode/config.toml` alone. Non-primary roles (reflection / mutator)
+  are daemon-global and keep their env write.
+
+### Added
+- **`/model global <name>` — user-global model switch.** Writes
+  `~/.geode/config.toml` (+ `GEODE_MODEL` env) so every project without its own
+  override inherits it. A bare `/model <name>` is now explicitly project-scoped;
+  the confirmation line prints the scope + target config path and notes the
+  change applies to new sessions. `upsert_config_toml(..., scope=)` selects the
+  project vs global config target. Pinned by
+  `tests/test_model_role_tab.py` (project-no-env / global-env / `global`-token).
+
 ## [0.99.143] - 2026-06-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.143
+- **Version**: 0.99.144
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.143 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.144 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.143 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.144 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -83,7 +83,11 @@ def _read_toml_value(section: str, key: str) -> str:
 
 
 def _apply_model(
-    selected: ModelProfile, *, effort: str | None = None, role: str = "primary"
+    selected: ModelProfile,
+    *,
+    effort: str | None = None,
+    role: str = "primary",
+    scope: str = "project",
 ) -> None:
     """Apply a model selection — update settings + .env + config.toml.
 
@@ -96,13 +100,21 @@ def _apply_model(
     leave the existing setting untouched.
 
     PR-A (2026-05-21) — ``role`` selects which agent's model knob is
-    updated. ``"primary"`` (default) preserves the legacy behaviour
-    (writes ``settings.model`` + ``GEODE_MODEL`` env + ``[llm]
-    primary_model``). ``"reflection"`` writes the PR-3 C-2 knob
-    (``settings.cognitive_reflection_model`` + the corresponding env
-    var + ``[cognitive] reflection_model``). Effort is *only* applied
-    when the role declares ``has_effort=True`` — the reflection node
-    has no effort axis.
+    updated. ``"primary"`` (default) writes ``settings.model`` + ``[llm]
+    primary_model``; ``"reflection"`` writes the PR-3 C-2 knob
+    (``settings.cognitive_reflection_model`` + ``[cognitive]
+    reflection_model``). Effort is *only* applied when the role declares
+    ``has_effort=True`` — the reflection node has no effort axis.
+
+    ``scope`` picks the durable config target (precedence: CLI > env >
+    project ``.geode/config.toml`` > global ``~/.geode/config.toml`` >
+    routing default). ``"project"`` (default) persists the *primary*
+    switch to the session's project config **only** — the global
+    ``GEODE_MODEL`` env is intentionally NOT written, since env outranks
+    the project TOML and would leak a per-workspace choice to every
+    project + shadow the project ``primary_model`` on reload. ``"global"``
+    writes ``~/.geode/config.toml`` + ``GEODE_MODEL`` env. Non-primary
+    roles (reflection / mutator) are daemon-global and always write env.
 
     Includes context window guard: blocks downgrade when current context
     exceeds 80% of the target model's window (primary role only —
@@ -179,15 +191,25 @@ def _apply_model(
                     role_def.settings_field,
                     exc_info=True,
                 )
-        _pkg._upsert_env(role_def.env_var, selected.id)
-        upsert_config_toml(role_def.toml_section, role_def.toml_key, selected.id)
+        # Durable persistence honours the requested scope. The global
+        # ``~/.geode/.env`` (GEODE_MODEL) write is skipped for a *primary*
+        # **project** switch: writing it leaked the choice to every project
+        # (env outranks the project TOML in the precedence chain) and made
+        # ``_apply_toml_overlay`` skip the project ``primary_model`` on the
+        # next session reload. Non-primary roles (reflection / mutator) are
+        # daemon-global knobs, so they keep their env write; global scope
+        # writes env for every role.
+        if scope == "global" or role_def.name != "primary":
+            _pkg._upsert_env(role_def.env_var, selected.id)
+        upsert_config_toml(role_def.toml_section, role_def.toml_key, selected.id, scope=scope)
     if role_def.has_effort and effort is not None and effort != old_effort:
         try:
             object.__setattr__(settings, "agentic_effort", effort)
         except Exception:
             log.debug("Could not persist agentic_effort to settings", exc_info=True)
-        _pkg._upsert_env("GEODE_AGENTIC_EFFORT", effort)
-        upsert_config_toml("agentic", "effort", effort)
+        if scope == "global":
+            _pkg._upsert_env("GEODE_AGENTIC_EFFORT", effort)
+        upsert_config_toml("agentic", "effort", effort, scope=scope)
 
     # Model hot-swap is deferred: AgenticLoop._sync_model_from_settings_async()
     # checks settings.model at the start of each round and applies
@@ -197,20 +219,28 @@ def _apply_model(
     # hot-swap plumbing is needed there.
 
     role_tag = "" if role_def.name == "primary" else f"  [muted]({role_def.label})[/muted]"
+    scope_path = "~/.geode/config.toml" if scope == "global" else "./.geode/config.toml"
+    scope_tag = f"  [muted]· {scope} ({scope_path})[/muted]"
     if not same_model and role_def.has_effort and effort is not None:
         _pkg.console.print(
             f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"
-            f"  [muted]({selected.id} · effort={effort})[/muted]{role_tag}"
+            f"  [muted]({selected.id} · effort={effort})[/muted]{role_tag}{scope_tag}"
         )
     elif not same_model:
         _pkg.console.print(
             f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"
-            f"  [muted]({selected.id})[/muted]{role_tag}"
+            f"  [muted]({selected.id})[/muted]{role_tag}{scope_tag}"
         )
     elif role_def.has_effort and effort is not None:
         _pkg.console.print(
             f"  [success]Effort[/success]  {old_effort} → [bold]{effort}[/bold]"
             f"  [muted](model unchanged: {selected.label})[/muted]"
+        )
+    if not same_model:
+        where = "this project" if scope == "project" else "all projects"
+        _pkg.console.print(
+            f"  [muted]Scope: {where}. Applies to new sessions — "
+            "restart `geode` to pick it up.[/muted]"
         )
     _pkg.console.print()
 
@@ -325,17 +355,38 @@ def _interactive_model_picker_for_role(role_def: AgentRole) -> None:
 def cmd_model(args: str) -> None:
     """Handle /model command (OpenClaw Auth Profile Rotation pattern).
 
-    /model                       → interactive arrow-key picker
-                                   (Tab cycles roles: primary / reflection)
-    /model 2                     → select by number (applies to primary)
-    /model gpt-5.4               → select by name (applies to primary)
+    /model                       → interactive picker (this project)
+    /model 2                     → select by number (this project)
+    /model gpt-5.4               → select by name (this project)
+    /model global gpt-5.4        → switch the user-global default (all projects)
     /model reflection            → interactive picker for reflection role
     /model reflection haiku-4.5  → set reflection model by name
     /model reflection 4          → set reflection model by number
+
+    Scope (config precedence: CLI > env > project ``.geode/config.toml`` >
+    global ``~/.geode/config.toml`` > routing default):
+      * default (no ``global`` token) → writes the *project* config, so the
+        switch is scoped to the current workspace.
+      * ``/model global <name>`` → writes ``~/.geode/config.toml``, inherited
+        by every project without its own override.
+    Either way the change applies to *new* sessions (restart ``geode``).
     """
     from core.cli import commands as _pkg
 
     arg = args.strip()
+
+    # ``/model global <…>`` — switch the user-global default instead of the
+    # session's project config. Parsed before the role token (order:
+    # ``/model global <role> <name>``). Default scope is "project" so a bare
+    # ``/model <name>`` no longer leaks the choice to every workspace via the
+    # global env (the pre-fix behaviour that made project switches stick
+    # globally and shadowed the project TOML).
+    scope = "project"
+    if arg:
+        first, _, rest = arg.partition(" ")
+        if first == "global":
+            scope = "global"
+            arg = rest.strip()
 
     # PR-A — explicit role prefix: ``/model <role>`` or
     # ``/model <role> <picker-arg>``. The role token must match a
@@ -348,6 +399,14 @@ def cmd_model(args: str) -> None:
             role_name = first
             arg = rest.strip()
     role_def = role_by_name(role_name)
+
+    # ``/model global`` with no model — the interactive picker applies to the
+    # project scope, so global needs an explicit model id/number.
+    if scope == "global" and not arg:
+        _pkg.console.print("  [warning]Global scope needs an explicit model.[/warning]")
+        _pkg.console.print("  [muted]Usage: /model global <number> | /model global <name>[/muted]")
+        _pkg.console.print()
+        return
 
     # /model (no args, primary role) → interactive picker (requires tty)
     # /model reflection → interactive picker focused on reflection tab
@@ -438,4 +497,4 @@ def cmd_model(args: str) -> None:
         _pkg.console.print()
         return
 
-    _apply_model(selected, role=role_def.name)
+    _apply_model(selected, role=role_def.name, scope=scope)

--- a/core/utils/env_io.py
+++ b/core/utils/env_io.py
@@ -46,8 +46,8 @@ def upsert_env(var_name: str, value: str) -> None:
     os.environ[var_name] = value
 
 
-def upsert_config_toml(section: str, key: str, value: str) -> None:
-    """Insert or update ``[section] key = "value"`` in ``.geode/config.toml``.
+def upsert_config_toml(section: str, key: str, value: str, *, scope: str = "project") -> None:
+    """Insert or update ``[section] key = "value"`` in a ``config.toml``.
 
     Creates the file (and ``[section]`` heading) if absent. Mirrors the
     write semantics of ``upsert_env``: durable layer for picker choices
@@ -57,12 +57,22 @@ def upsert_config_toml(section: str, key: str, value: str) -> None:
     Code project + global config) — chosen settings persist to the
     config layer, not just the env layer.
 
+    ``scope`` picks the durable target, matching the config precedence
+    (CLI > env > project ``.geode/config.toml`` > global
+    ``~/.geode/config.toml`` > routing default):
+
+    * ``"project"`` (default) — the *session's* project config,
+      ``PROJECT_CONFIG_TOML`` (``.geode/config.toml`` relative to the
+      thin-CLI cwd). Scoped to the current workspace only.
+    * ``"global"`` — the user-global ``~/.geode/config.toml``, inherited
+      by every project that has no project-level override.
+
     Section headings use ``[section.subsection]`` notation per TOML.
     """
-    from core.paths import PROJECT_CONFIG_TOML
+    from core.paths import GLOBAL_CONFIG_TOML, PROJECT_CONFIG_TOML
 
     # P2 (v0.95.x) — was literal `Path(".geode") / "config.toml"`
-    config_path = PROJECT_CONFIG_TOML
+    config_path = GLOBAL_CONFIG_TOML if scope == "global" else PROJECT_CONFIG_TOML
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     target_line = f'{key} = "{value}"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.143"
+version = "0.99.144"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_compact_clear.py
+++ b/tests/test_compact_clear.py
@@ -253,12 +253,14 @@ class TestModelSwitchGuard:
 
         mock_env.assert_not_called()
 
+    @patch("core.utils.env_io.upsert_config_toml")
     @patch("core.cli.commands._upsert_env")
     @patch("core.cli.commands._check_provider_key")
     def test_downgrade_allowed_when_fits(
         self,
         mock_key: MagicMock,
         mock_env: MagicMock,
+        mock_toml: MagicMock,
     ):
         from core.cli.commands import (
             _apply_model,
@@ -274,14 +276,20 @@ class TestModelSwitchGuard:
             profile = self._make_profile("glm-5", "GLM-5")
             _apply_model(profile)
 
-        mock_env.assert_called_once()
+        # Default scope is project — the switch persists to the project config
+        # (proves it was allowed, not blocked by the context guard) and no
+        # longer writes the global GEODE_MODEL env (the pre-fix leak).
+        mock_toml.assert_called()
+        mock_env.assert_not_called()
 
+    @patch("core.utils.env_io.upsert_config_toml")
     @patch("core.cli.commands._upsert_env")
     @patch("core.cli.commands._check_provider_key")
     def test_upgrade_always_allowed(
         self,
         mock_key: MagicMock,
         mock_env: MagicMock,
+        mock_toml: MagicMock,
     ):
         from core.cli.commands import (
             _apply_model,
@@ -297,7 +305,8 @@ class TestModelSwitchGuard:
             profile = self._make_profile("claude-opus-4-6", "Opus 4.6")
             _apply_model(profile)
 
-        mock_env.assert_called_once()
+        mock_toml.assert_called()
+        mock_env.assert_not_called()
 
     @patch("core.cli.commands._upsert_env")
     @patch("core.cli.commands._check_provider_key")

--- a/tests/test_model_role_tab.py
+++ b/tests/test_model_role_tab.py
@@ -137,7 +137,9 @@ def test_apply_model_dispatches_to_reflection_field(
     monkeypatch.setattr(
         _env_io,
         "upsert_config_toml",
-        lambda section, key, value: upsert_toml_calls.append((section, key, value)),
+        lambda section, key, value, *, scope="project": upsert_toml_calls.append(
+            (section, key, value)
+        ),
     )
 
     # Snapshot the current reflection model so we can restore + verify.
@@ -162,6 +164,99 @@ def test_apply_model_dispatches_to_reflection_field(
 
     # Restore
     object.__setattr__(settings, "cognitive_reflection_model", old_reflection)
+
+
+def _capture_apply_io(monkeypatch: pytest.MonkeyPatch):
+    """Shared stub: capture _upsert_env + upsert_config_toml(scope=…) calls."""
+    from core.cli import commands as _pkg
+    from core.utils import env_io as _env_io
+
+    monkeypatch.setattr(_pkg, "_check_provider_key", lambda _p: None)
+    monkeypatch.setattr(_pkg, "get_conversation_context", lambda: None)
+    env_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(_pkg, "_upsert_env", lambda k, v: env_calls.append((k, v)))
+    toml_calls: list[tuple[str, str, str, str]] = []
+    monkeypatch.setattr(
+        _env_io,
+        "upsert_config_toml",
+        lambda section, key, value, *, scope="project": toml_calls.append(
+            (section, key, value, scope)
+        ),
+    )
+    return env_calls, toml_calls
+
+
+def test_apply_model_primary_project_scope_skips_global_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Primary + project scope persists to the project config only — never
+    the global GEODE_MODEL env, the pre-fix leak that made a project switch
+    stick across every workspace and shadow the project TOML on reload."""
+    from core.cli.commands._state import ModelProfile
+    from core.config import settings
+
+    from core.cli.commands import model as _model_mod
+
+    env_calls, toml_calls = _capture_apply_io(monkeypatch)
+    old = settings.model
+    object.__setattr__(settings, "model", "claude-opus-4-7")
+    try:
+        target = ModelProfile(
+            id="claude-opus-4-8", provider="anthropic", label="Opus 4.8", cost="$$$"
+        )
+        _model_mod._apply_model(target, role="primary", scope="project")
+    finally:
+        object.__setattr__(settings, "model", old)
+
+    assert not any(k == "GEODE_MODEL" for k, _v in env_calls)
+    assert ("llm", "primary_model", "claude-opus-4-8", "project") in toml_calls
+
+
+def test_apply_model_primary_global_scope_writes_env_and_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Primary + global scope writes the global config + GEODE_MODEL env so
+    every project without its own override inherits the choice."""
+    from core.cli.commands._state import ModelProfile
+    from core.config import settings
+
+    from core.cli.commands import model as _model_mod
+
+    env_calls, toml_calls = _capture_apply_io(monkeypatch)
+    old = settings.model
+    object.__setattr__(settings, "model", "claude-opus-4-7")
+    try:
+        target = ModelProfile(
+            id="claude-opus-4-8", provider="anthropic", label="Opus 4.8", cost="$$$"
+        )
+        _model_mod._apply_model(target, role="primary", scope="global")
+    finally:
+        object.__setattr__(settings, "model", old)
+
+    assert ("GEODE_MODEL", "claude-opus-4-8") in env_calls
+    assert ("llm", "primary_model", "claude-opus-4-8", "global") in toml_calls
+
+
+def test_cmd_model_global_token_routes_to_global_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/model global <name>`` dispatches with scope='global'; a bare
+    ``/model <name>`` stays project-scoped."""
+    from core.cli.commands import model as _model_mod
+
+    monkeypatch.setattr(_model_mod, "model_available", lambda _id: True)
+    captured: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        _model_mod,
+        "_apply_model",
+        lambda selected, *, role="primary", scope="project", effort=None: captured.append(
+            (selected.id, scope)
+        ),
+    )
+    _model_mod.cmd_model("global claude-opus-4-8")
+    _model_mod.cmd_model("claude-opus-4-8")
+    assert ("claude-opus-4-8", "global") in captured
+    assert ("claude-opus-4-8", "project") in captured
 
 
 def test_apply_model_primary_skips_effort_for_reflection_role(

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.143"
+version = "0.99.144"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Fix the `/model` switch bug: a bare `/model <name>` (project scope) was leaking the choice to **every** workspace via the global `GEODE_MODEL` env, which also shadowed the project `[llm] primary_model` on reload.
- Make scope explicit: `/model <name>` = **project**, `/model global <name>` = **global**. The confirmation line prints the scope + config path.

## Why
Operator reported `/model 4.8` not taking effect. The session ran at `~/workspace/resume` with `[llm] primary_model = "gpt-5.5"` in its project config. `/model` (RunLocation.THIN) runs at the session cwd, so its project-config write was already correct — but `_apply_model` ALSO wrote `GEODE_MODEL` to the **global** `~/.geode/.env`. Since the precedence chain is **CLI > env > project TOML > global TOML > routing**, the env write (a) stuck across every project and (b) made `core/config/__init__.py:_apply_toml_overlay` skip the project `primary_model` on the next session reload. So a "project switch" behaved globally and self-shadowed.

## Changes
| File | Change |
|------|--------|
| `core/utils/env_io.py` | `upsert_config_toml(..., scope="project"\|"global")` → `PROJECT_CONFIG_TOML` vs `GLOBAL_CONFIG_TOML` |
| `core/cli/commands/model.py` | `_apply_model(..., scope=)`: scoped config write; `GEODE_MODEL` env fires only when `scope=="global" or role!="primary"` (primary+project = config-only; reflection/mutator stay daemon-global). `cmd_model` parses a leading `global` token, guards bare `/model global`, prints scope + path + "applies to new sessions" |
| `tests/test_model_role_tab.py` | + project-no-env / global-env / `global`-token guards; reflection stub gains `scope` kwarg |
| CHANGELOG / README×2 / CLAUDE.md / pyproject | v0.99.143 → **v0.99.144** |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Precedence verified (operator ask #3) | Done | CLI > env > project > global > routing; removing the primary+project env write lets the project TOML apply via `_apply_toml_overlay` (`core/config/__init__.py:163`) |
| `_apply_model` call sites | All correct | interactive pickers (`model.py:306/352`) stay project-scoped by design; direct `/model` (`:500`) threads scope |
| `upsert_config_toml` callers | No regression | `login.py:748` defaults to project = its prior behavior |
| Mid-session vs new-session | Documented | model is resolved at session start (`services.py:reload_settings_from_disk`); confirmation line tells the user to restart `geode` |

## Verification
- [x] ruff / ruff format --check / mypy / lint-imports clean
- [x] 226 model/config/cli/startup tests green (incl. 3 new scope guards)
- [x] `geode version` → v0.99.144
- [ ] Codex MCP — unavailable this run (its codex OAuth token is expired, the same auth failure that triggered this bug report); rigorous self-review of call sites + precedence done in place

## Reference
Operator bug report 2026-06-09 ("model을 4.8로 전환했음에도 반영이 되지 않는 버그 … '/model'로 아무 명령어 없이 전환했을 때 프로젝트 레벨임을 명시하고 슬래시로 global을 수행했을 때 global 모델로 전환 … 우선순위가 맞는지도 파악해").