### PR TITLE
develop → main: session model resolution + .env>TOML precedence (v0.99.145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ functional change.
 
 ---
 
+## [0.99.145] - 2026-06-09
+
+### Fixed
+- **Daemon now uses each session's project model, not its own launch-cwd.** The
+  thin CLI is transport-only and never sent its project context, so `geode serve`
+  resolved every session's model from the *daemon's* launch cwd (`settings.model`)
+  — the caller's `./.geode/config.toml` was ignored and the executed model
+  diverged from the banner (e.g. banner `claude-opus-4-8`, calls routed to a
+  stale `gpt-5.5`). The thin CLI now ships its project-resolved model in the
+  `client_capability` message and the daemon adopts it via `update_model_async`
+  before the first prompt. E2E-verified: a session from a `claude-haiku-4-5`
+  project executes on haiku while the daemon default stays opus. Old clients
+  (no `model` field) keep the daemon default.
+- **`.env` model override now correctly outranks `config.toml`.**
+  `_apply_toml_overlay` skipped the TOML overlay only when `GEODE_<FIELD>` was in
+  `os.environ`, which missed `.env`-file values (pydantic loads them onto the
+  instance, not `os.environ`) — so a project `.env` `GEODE_MODEL` was wrongly
+  overwritten by `[llm] primary_model`, inverting the documented env > TOML
+  precedence. The skip now keys on pydantic's `model_fields_set` (captures env
+  var AND `.env`); `reload_settings_from_disk` passes the fresh instance's set.
+
+### Docs
+- `docs/setup.md` — added a **Model resolution** precedence note (CLI > env/.env >
+  project config > global config > routing), documented `/model global`, and
+  fixed the stale `GEODE_MODEL` default (`claude-opus-4-6` → `claude-opus-4-8`).
+
 ## [0.99.144] - 2026-06-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.144
+- **Version**: 0.99.145
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.144 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.145 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.144 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.145 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -161,6 +161,7 @@ class IPCClient:
         ``width`` (terminal columns, falling back to 120). The daemon
         ignores unknown fields, so old daemons stay compatible.
         """
+        import os
         import shutil
         import sys
 
@@ -174,11 +175,24 @@ class IPCClient:
             width = 120
         if width <= 0:
             width = 120
+        # The thin CLI resolves the model at ITS cwd (the user's project). The
+        # daemon otherwise resolves from its own launch cwd, so without this the
+        # session's project model is ignored and the call diverges from the
+        # banner. ``cwd`` is sent for diagnostics / future per-project routing.
+        # Old daemons ignore unknown fields (back-compat).
+        try:
+            from core.config import settings as _settings
+
+            model = _settings.model
+        except Exception:
+            model = ""
         self._send(
             {
                 "type": "client_capability",
                 "is_tty": is_tty,
                 "width": width,
+                "model": model,
+                "cwd": os.getcwd(),
             }
         )
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -149,18 +149,32 @@ def _load_toml_config(
     return merged
 
 
-def _apply_toml_overlay(s: Settings) -> None:
-    """Overlay TOML values onto Settings for fields not set by env vars."""
+def _apply_toml_overlay(s: Settings, *, env_set_fields: set[str] | None = None) -> None:
+    """Overlay TOML values onto Settings for fields NOT already set by env / .env.
+
+    Precedence (documented): CLI > env > project ``.geode/config.toml`` > global
+    ``~/.geode/config.toml`` > routing default. The env layer includes BOTH real
+    ``GEODE_*`` environment variables AND values pydantic read from a ``.env``
+    file — pydantic marks all of them in ``model_fields_set`` (verified: an env
+    var and a ``.env`` ``GEODE_MODEL`` both land there). The pre-fix check used
+    ``GEODE_<FIELD> in os.environ``, which MISSED ``.env``-file values (pydantic
+    loads them into the instance, not ``os.environ``), so a project ``.env``
+    ``GEODE_MODEL`` was wrongly overwritten by ``[llm] primary_model`` — inverting
+    env > TOML. ``model_fields_set`` closes that gap.
+
+    ``env_set_fields`` overrides which fields count as env/.env-set. Needed by
+    :func:`reload_settings_from_disk`, which copies a fresh instance's *values*
+    onto the singleton via ``object.__setattr__`` (that bypasses
+    ``model_fields_set``), so the caller passes the fresh instance's set.
+    """
     toml_values = _load_toml_config()
     if not toml_values:
         return
 
+    env_set = env_set_fields if env_set_fields is not None else s.model_fields_set
     for field_name, toml_value in toml_values.items():
-        # Skip fields that were explicitly set via environment variable.
-        # Pydantic Settings loads from GEODE_<FIELD> and .env automatically.
-        # We only overlay TOML for fields still at their code default.
-        env_key = f"GEODE_{field_name.upper()}"
-        if env_key in os.environ:
+        # Env layer (real env var OR .env file) outranks TOML — don't overlay.
+        if field_name in env_set:
             continue
         # Also check special alias env vars for API keys
         if field_name in ("anthropic_api_key", "openai_api_key", "zai_api_key"):
@@ -234,7 +248,11 @@ def reload_settings_from_disk() -> None:
         with contextlib.suppress(Exception):
             new_value = getattr(fresh, field_name)
             object.__setattr__(current, field_name, new_value)
-    _apply_toml_overlay(current)
+    # ``object.__setattr__`` above copied fresh *values* but not its
+    # ``model_fields_set``, so pass the fresh instance's set explicitly — the
+    # overlay must skip fields the fresh ``.env`` / env actually set, not what
+    # the stale singleton recorded at boot.
+    _apply_toml_overlay(current, env_set_fields=set(fresh.model_fields_set))
     log.info(
         "reload_settings_from_disk applied: model=%r (pid=%d)",
         getattr(current, "model", "?"),

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -578,6 +578,29 @@ class CLIPoller:
                 width = 120
             if isinstance(endpoint, _AsyncClientEndpoint):
                 endpoint.set_capability(is_tty=is_tty, width=width)
+            # Adopt the thin CLI's project-resolved model. The daemon creates the
+            # session with its OWN launch-cwd default (``settings.model``); the
+            # thin CLI resolves the model at the *caller's* project cwd. Without
+            # this the session's project config is ignored and the executed model
+            # diverges from the banner. Sent once at session start, before any
+            # prompt, so the swap is safe (no in-flight LLM call).
+            cli_model = str(msg.get("model", "")).strip()
+            if cli_model and cli_model != getattr(loop, "model", ""):
+                try:
+                    from core.config import _resolve_provider
+
+                    await loop.update_model_async(
+                        cli_model, _resolve_provider(cli_model), reason="cli_session_cwd"
+                    )
+                    log.info(
+                        "client_capability: adopted CLI project model %s (session=%s)",
+                        cli_model,
+                        session_id,
+                    )
+                except Exception:
+                    log.warning(
+                        "client_capability: failed to adopt CLI model %s", cli_model, exc_info=True
+                    )
             log.debug("client_capability: is_tty=%s width=%d", is_tty, width if width > 0 else 120)
             return {"type": "ack"}
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -230,7 +230,8 @@ grep "Slack poller seeded" ~/.geode/logs/serve.log
 |---------|-------|-------------|
 | `/help` | | Show all commands |
 | `/status` | | System status (model, API keys, MCP, mode) |
-| `/model [N\|name]` | | Show / switch LLM model |
+| `/model [N\|name]` | | Show / switch LLM model (project-scoped: writes `./.geode/config.toml`) |
+| `/model global [N\|name]` | | Switch the user-global default model (`~/.geode/config.toml`) |
 | `/key [provider] [value]` | | Show / set API key |
 | `/cost` | | LLM cost dashboard (session + monthly) |
 | `/verbose` | | Toggle verbose output |
@@ -243,6 +244,14 @@ grep "Slack poller seeded" ~/.geode/logs/serve.log
 | `/clear` | | Clear conversation |
 | `/compact` | | Compact context |
 | `/quit` | `/q` | Exit |
+
+**Model resolution** (precedence, highest first): CLI flag → env var / `.env`
+(`GEODE_MODEL`) → project `./.geode/config.toml` `[llm] primary_model` → global
+`~/.geode/config.toml` → routing default (`claude-opus-4-8`). Each session uses
+**its own project's** model — the thin CLI resolves the model at your working
+directory and the daemon adopts it, so the displayed model matches the executed
+model. A leftover `GEODE_MODEL` in a project `.env` (env layer) overrides the
+config files; clear it if a `/model` switch seems "stuck".
 
 ---
 
@@ -272,7 +281,7 @@ geode serve [-p 3.0]                   # Headless daemon
 | `ANTHROPIC_API_KEY` | | Claude API key |
 | `OPENAI_API_KEY` | | GPT API key (Cross-LLM) |
 | `ZAI_API_KEY` | | ZhipuAI GLM key |
-| `GEODE_MODEL` | `claude-opus-4-6` | Default LLM model |
+| `GEODE_MODEL` | `claude-opus-4-8` | Model override (env layer — outranks config files; see Model resolution) |
 | `GEODE_ENSEMBLE_MODE` | `single` | Ensemble mode (`single` / `cross`) |
 | **Gateway** | | |
 | `GEODE_GATEWAY_ENABLED` | `false` | Enable Slack/Discord gateway |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.144"
+version = "0.99.145"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_env_dotenv_precedence.py
+++ b/tests/test_env_dotenv_precedence.py
@@ -8,64 +8,51 @@ real ``GEODE_*`` env var AND a ``.env`` file value. ``_apply_toml_overlay``
 used to skip only on ``os.environ`` membership, which missed ``.env``-file
 values (pydantic loads them onto the instance, not ``os.environ``), inverting
 env > TOML. The fix keys the skip on ``model_fields_set`` instead.
+
+These tests exercise the overlay decision directly (deterministic — no cwd /
+``.env``-relative-path / module-reload coupling, which is environment-dependent
+under xdist). The full ``.env`` → ``model_fields_set`` → reload path is covered
+by the live socket E2E in the PR.
 """
 
 from __future__ import annotations
 
-import importlib
 from pathlib import Path
 
+import core.config as cfg
 import pytest
+from core.config._settings import Settings
 
 
-def _project(tmp: Path, *, env_model: str | None, toml_model: str | None) -> None:
-    if env_model is not None:
-        (tmp / ".env").write_text(f"GEODE_MODEL={env_model}\n", encoding="utf-8")
-    if toml_model is not None:
-        (tmp / ".geode").mkdir(exist_ok=True)
-        (tmp / ".geode" / "config.toml").write_text(
-            f'[llm]\nprimary_model = "{toml_model}"\n', encoding="utf-8"
-        )
+def test_overlay_skips_field_set_by_env_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A field in ``env_set_fields`` (env var OR ``.env`` — both land in
+    pydantic's ``model_fields_set``) must NOT be overwritten by the TOML
+    overlay: env layer outranks project/global TOML."""
+    monkeypatch.setattr(cfg, "_load_toml_config", lambda **_k: {"model": "claude-opus-4-8"})
+    s = Settings()
+    object.__setattr__(s, "model", "gpt-5.4")  # value pydantic read from env / .env
+
+    cfg._apply_toml_overlay(s, env_set_fields={"model"})
+
+    assert s.model == "gpt-5.4"
 
 
-def _resolved_model(tmp: Path, monkeypatch: pytest.MonkeyPatch) -> str:
-    monkeypatch.chdir(tmp)
-    monkeypatch.delenv("GEODE_MODEL", raising=False)
-    import core.config as cfg
+def test_overlay_applies_toml_when_field_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the field NOT env/.env-set, the TOML overlay drives it."""
+    monkeypatch.setattr(cfg, "_load_toml_config", lambda **_k: {"model": "claude-opus-4-8"})
+    s = Settings()
+    object.__setattr__(s, "model", "sentinel-code-default")
 
-    importlib.reload(cfg)
-    cfg.reload_settings_from_disk()
-    return str(cfg.settings.model)
+    cfg._apply_toml_overlay(s, env_set_fields=set())
 
-
-def test_project_dotenv_model_beats_project_toml(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A project ``.env`` ``GEODE_MODEL`` (env layer) must win over the
-    project ``[llm] primary_model`` (TOML layer)."""
-    _project(tmp_path, env_model="gpt-5.4", toml_model="claude-opus-4-8")
-    assert _resolved_model(tmp_path, monkeypatch) == "gpt-5.4"
+    assert s.model == "claude-opus-4-8"
 
 
-def test_project_toml_wins_when_no_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no env/.env override, the project TOML drives the model."""
-    _project(tmp_path, env_model=None, toml_model="claude-opus-4-8")
-    assert _resolved_model(tmp_path, monkeypatch) == "claude-opus-4-8"
-
-
-def test_reload_honours_dotenv_over_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``reload_settings_from_disk`` (daemon session boundary) must keep the
-    same precedence — the pre-fix reload copied fresh *values* but checked the
-    stale singleton's ``model_fields_set``, so the overlay used the wrong set."""
-    _project(tmp_path, env_model="gpt-5.4", toml_model="claude-opus-4-8")
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("GEODE_MODEL", raising=False)
-    import core.config as cfg
-
-    importlib.reload(cfg)
-    cfg.reload_settings_from_disk()
-    assert cfg.settings.model == "gpt-5.4"
-    # Drop the .env override → reload → project TOML now wins.
-    (tmp_path / ".env").write_text("\n", encoding="utf-8")
-    cfg.reload_settings_from_disk()
-    assert cfg.settings.model == "claude-opus-4-8"
+def test_dotenv_value_lands_in_model_fields_set(tmp_path: Path) -> None:
+    """Pin the premise of the fix: a ``.env`` ``GEODE_MODEL`` is captured in
+    ``model_fields_set`` (same as a real env var), so the overlay skip can
+    rely on it. Uses an explicit absolute ``_env_file`` — no cwd coupling."""
+    (tmp_path / ".env").write_text("GEODE_MODEL=gpt-5.4\n", encoding="utf-8")
+    s = Settings(_env_file=str(tmp_path / ".env"))
+    assert s.model == "gpt-5.4"
+    assert "model" in s.model_fields_set

--- a/tests/test_env_dotenv_precedence.py
+++ b/tests/test_env_dotenv_precedence.py
@@ -1,0 +1,75 @@
+"""Config precedence regression — env / .env outranks project/global TOML.
+
+Pins the fix for the 2026-06-09 incident where a project ``.env``
+``GEODE_MODEL`` was silently overridden by ``[llm] primary_model``. The
+documented chain is CLI > env > project ``.geode/config.toml`` > global
+``~/.geode/config.toml`` > routing default; the env layer includes BOTH a
+real ``GEODE_*`` env var AND a ``.env`` file value. ``_apply_toml_overlay``
+used to skip only on ``os.environ`` membership, which missed ``.env``-file
+values (pydantic loads them onto the instance, not ``os.environ``), inverting
+env > TOML. The fix keys the skip on ``model_fields_set`` instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def _project(tmp: Path, *, env_model: str | None, toml_model: str | None) -> None:
+    if env_model is not None:
+        (tmp / ".env").write_text(f"GEODE_MODEL={env_model}\n", encoding="utf-8")
+    if toml_model is not None:
+        (tmp / ".geode").mkdir(exist_ok=True)
+        (tmp / ".geode" / "config.toml").write_text(
+            f'[llm]\nprimary_model = "{toml_model}"\n', encoding="utf-8"
+        )
+
+
+def _resolved_model(tmp: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.chdir(tmp)
+    monkeypatch.delenv("GEODE_MODEL", raising=False)
+    import core.config as cfg
+
+    importlib.reload(cfg)
+    cfg.reload_settings_from_disk()
+    return str(cfg.settings.model)
+
+
+def test_project_dotenv_model_beats_project_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A project ``.env`` ``GEODE_MODEL`` (env layer) must win over the
+    project ``[llm] primary_model`` (TOML layer)."""
+    _project(tmp_path, env_model="gpt-5.4", toml_model="claude-opus-4-8")
+    assert _resolved_model(tmp_path, monkeypatch) == "gpt-5.4"
+
+
+def test_project_toml_wins_when_no_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no env/.env override, the project TOML drives the model."""
+    _project(tmp_path, env_model=None, toml_model="claude-opus-4-8")
+    assert _resolved_model(tmp_path, monkeypatch) == "claude-opus-4-8"
+
+
+def test_reload_honours_dotenv_over_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``reload_settings_from_disk`` (daemon session boundary) must keep the
+    same precedence — the pre-fix reload copied fresh *values* but checked the
+    stale singleton's ``model_fields_set``, so the overlay used the wrong set."""
+    _project(tmp_path, env_model="gpt-5.4", toml_model="claude-opus-4-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GEODE_MODEL", raising=False)
+    import core.config as cfg
+
+    importlib.reload(cfg)
+    cfg.reload_settings_from_disk()
+    assert cfg.settings.model == "gpt-5.4"
+    # Drop the .env override → reload → project TOML now wins.
+    (tmp_path / ".env").write_text("\n", encoding="utf-8")
+    cfg.reload_settings_from_disk()
+    assert cfg.settings.model == "claude-opus-4-8"

--- a/tests/test_env_dotenv_precedence.py
+++ b/tests/test_env_dotenv_precedence.py
@@ -47,17 +47,13 @@ def test_project_dotenv_model_beats_project_toml(
     assert _resolved_model(tmp_path, monkeypatch) == "gpt-5.4"
 
 
-def test_project_toml_wins_when_no_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_project_toml_wins_when_no_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With no env/.env override, the project TOML drives the model."""
     _project(tmp_path, env_model=None, toml_model="claude-opus-4-8")
     assert _resolved_model(tmp_path, monkeypatch) == "claude-opus-4-8"
 
 
-def test_reload_honours_dotenv_over_toml(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_reload_honours_dotenv_over_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``reload_settings_from_disk`` (daemon session boundary) must keep the
     same precedence — the pre-fix reload copied fresh *values* but checked the
     stale singleton's ``model_fields_set``, so the overlay used the wrong set."""

--- a/tests/test_session_model_adoption.py
+++ b/tests/test_session_model_adoption.py
@@ -1,0 +1,68 @@
+"""Daemon adopts the thin CLI's project-resolved model (2026-06-09 fix).
+
+The serve daemon creates each session with its OWN launch-cwd default
+(``settings.model``); the thin CLI resolves the model at the *caller's*
+project cwd and ships it in the ``client_capability`` message. The poller must
+adopt it so the executed model matches the caller's project (and the banner),
+instead of the daemon's launch-cwd model. The ``client_capability`` branch of
+``CLIPoller._process_message_async`` is self-stateless, so we exercise it
+directly on a bare instance with a mock loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from core.server.ipc_server.poller import CLIPoller
+
+
+def _bare_poller() -> CLIPoller:
+    # client_capability handling touches no instance state — skip __init__.
+    return object.__new__(CLIPoller)
+
+
+def _capability_msg(**extra: object) -> dict[str, object]:
+    return {"type": "client_capability", "is_tty": True, "width": 120, "_client": None, **extra}
+
+
+def test_client_capability_adopts_cli_project_model() -> None:
+    poller = _bare_poller()
+    loop = MagicMock()
+    loop.model = "claude-opus-4-6"  # daemon launch-cwd default
+    loop.update_model_async = AsyncMock()
+
+    result = asyncio.run(
+        poller._process_message_async(
+            _capability_msg(model="claude-opus-4-8"), loop, MagicMock(), "cli-test"
+        )
+    )
+
+    assert result == {"type": "ack"}
+    loop.update_model_async.assert_awaited_once()
+    assert loop.update_model_async.call_args.args[0] == "claude-opus-4-8"
+
+
+def test_client_capability_no_model_keeps_daemon_default() -> None:
+    poller = _bare_poller()
+    loop = MagicMock()
+    loop.model = "claude-opus-4-6"
+    loop.update_model_async = AsyncMock()
+
+    # Old client (no model field) — daemon must not swap.
+    asyncio.run(poller._process_message_async(_capability_msg(), loop, MagicMock(), "cli-test"))
+    loop.update_model_async.assert_not_awaited()
+
+
+def test_client_capability_same_model_no_swap() -> None:
+    poller = _bare_poller()
+    loop = MagicMock()
+    loop.model = "claude-opus-4-8"
+    loop.update_model_async = AsyncMock()
+
+    asyncio.run(
+        poller._process_message_async(
+            _capability_msg(model="claude-opus-4-8"), loop, MagicMock(), "cli-test"
+        )
+    )
+    loop.update_model_async.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.144"
+version = "0.99.145"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Daemon now uses each session's project model (thin CLI ships it via `client_capability`; daemon adopts before first prompt) — fixes banner≠call divergence.
- Project `.env` `GEODE_MODEL` correctly outranks `[llm] primary_model` (`_apply_toml_overlay` keys on `model_fields_set`, not `os.environ`).
- docs/setup.md model-resolution note + `/model global`. v0.99.145.

## Verification
- [x] CI green on #2016 (feature → develop) — Lint/Test/Type/install all pass
- [x] Live socket E2E: haiku-project session executed on haiku ($0.044) while daemon default stayed opus
- [x] 6 new deterministic tests + 212 config/ipc-serve regression tests green