### PR TITLE
fix(cli): hide empty quota bar — remove cold-start "white line" (v0.99.146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ functional change.
 
 ---
 
+## [0.99.146] - 2026-06-09
+
+### Fixed
+- **CLI: removed the cold-start "white line" under the prompt.** The REPL quota
+  banner (`bottom_toolbar`) is drawn by prompt_toolkit with a default `reverse`
+  style in an always-reserved 1-row window, and bar visibility is keyed on the
+  `bottom_toolbar` *attribute* being non-None — not on what the render callable
+  returns — so an empty banner still painted a blank reverse (white) row. The
+  banner is empty because its writer (the Anthropic response hook) fires in the
+  serve daemon while the setter is registered only in the thin-CLI process: a
+  cross-process disconnect that never feeds the banner. The REPL now toggles the
+  attribute per prompt (`_apply_toolbar_visibility`) — the render callable when
+  the banner has content, `None` (bar hidden) when empty. Matches the banner's
+  original "empty on cold start (no flash)" intent and preserves the `reverse`
+  highlight for real quota/abort warnings (no blanket color override). E2E-verified
+  with the real banner: empty → hidden, populated → shown.
+
+---
+
 ## [0.99.145] - 2026-06-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.145
+- **Version**: 0.99.146
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 403 core + 70 plugins = 473
-- **Tests**: 8742 (+5 live)
+- **Tests**: 8745 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.145 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.146 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.145 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.146 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/prompt_session.py
+++ b/core/cli/prompt_session.py
@@ -111,6 +111,14 @@ def _build_prompt_session() -> Any:
     # the self-improving-loop config so prompt_session stays importable when
     # ``core.config.self_improving_loop`` is unavailable (test contexts).
     bottom_toolbar = _make_bottom_toolbar()
+    # Stash the render callable so _apply_toolbar_visibility (run before
+    # each prompt) can show/hide the bar by reassigning the session's
+    # ``bottom_toolbar`` attribute. prompt_toolkit keys bar visibility on
+    # that attribute being non-None — NOT on what the render callable
+    # returns — so an empty render still leaves a 1-row reverse-styled
+    # window (the cold-start "white line"). See _apply_toolbar_visibility.
+    global _toolbar_render
+    _toolbar_render = bottom_toolbar
 
     return PromptSession(
         history=FileHistory(str(history_path)),
@@ -166,7 +174,13 @@ def _make_bottom_toolbar() -> Any:
     def _render() -> Any:
         text = banner.render()
         if not text:
-            return ""
+            # None (not "") signals "no banner content" to
+            # _apply_toolbar_visibility, which then hides the whole bar.
+            # An empty string would still leave a 1-row reverse-styled
+            # window — only un-setting the bottom_toolbar attribute drops
+            # the row. Matches the banner's "empty on cold start (no
+            # flash)" intent (PR-γ1).
+            return None
         return _HTML(text)
 
     return _render
@@ -204,6 +218,36 @@ def _force_select_event_loop() -> None:
 
 # Module-level lazy singleton
 _prompt_session: Any = None
+
+# The bottom_toolbar render callable, stashed by _build_prompt_session so
+# _apply_toolbar_visibility can toggle the bar on/off per prompt.
+_toolbar_render: Any = None
+
+
+def _apply_toolbar_visibility(session: Any) -> None:
+    """Show the quota bar only when the banner has content.
+
+    prompt_toolkit decides bar visibility from whether the
+    ``bottom_toolbar`` *attribute* is non-None (``shortcuts/prompt.py``
+    ConditionalContainer filter), not from what the render callable
+    returns — so an empty render still leaves a 1-row ``reverse``-styled
+    window (the cold-start "white line"). We therefore toggle the
+    attribute itself: the render callable when the banner has content,
+    ``None`` when empty. This hides the empty bar (matching the banner's
+    "no flash" intent) while preserving the reverse highlight for real
+    quota / abort warnings. Note the banner is currently never fed in the
+    thin-CLI process — its writer (the Anthropic response hook) fires in
+    the serve daemon — so in practice the bar stays hidden until that
+    cross-process feed is wired; this keeps the surface honest meanwhile.
+    """
+    render = _toolbar_render
+    if render is None:
+        return
+    try:
+        has_content = render() is not None
+    except Exception:  # pragma: no cover - defensive
+        has_content = False
+    session.bottom_toolbar = render if has_content else None
 
 
 def _get_prompt_session() -> Any:
@@ -244,6 +288,9 @@ def _read_multiline_input(prompt: str) -> str:
             # Restore default SIGINT so prompt_toolkit can handle Ctrl-C internally.
             # Our custom handler interferes with prompt_toolkit's input loop.
             signal.signal(signal.SIGINT, _original_sigint)
+            # Hide the bottom bar when the quota banner has nothing to show
+            # (no empty reverse "white line" on cold start).
+            _apply_toolbar_visibility(session)
             raw: str = str(session.prompt()).strip()
             # Join pasted multi-line text into a single line.
             # Intentional newlines (Esc+Enter) are preserved by the caller

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.145"
+version = "0.99.146"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_prompt_session.py
+++ b/tests/test_prompt_session.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from core.cli.prompt_session import _build_prompt_session
+from core.cli.prompt_session import _apply_toolbar_visibility, _build_prompt_session
 
 
 def _binding_keys(binding: Any) -> tuple[str, ...]:
@@ -121,3 +121,47 @@ def test_prompt_session_any_binding_ignores_non_printable_keys(
 
     current_buffer.insert_text.assert_not_called()
     app.invalidate.assert_not_called()
+
+
+def test_toolbar_hidden_when_banner_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty banner (render -> None) hides the bar by un-setting the attribute.
+
+    prompt_toolkit keys bar visibility on ``bottom_toolbar is not None``,
+    not on the render return, so an empty render must clear the attribute
+    to drop the cold-start "white line" (1-row reverse window).
+    """
+
+    def _empty_render() -> Any:
+        return None
+
+    monkeypatch.setattr("core.cli.prompt_session._toolbar_render", _empty_render)
+    session = SimpleNamespace(bottom_toolbar=_empty_render)
+
+    _apply_toolbar_visibility(session)
+
+    assert session.bottom_toolbar is None
+
+
+def test_toolbar_shown_when_banner_has_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Populated banner (render -> truthy) restores the render callable."""
+
+    def _content_render() -> Any:
+        return "⬤ green"
+
+    monkeypatch.setattr("core.cli.prompt_session._toolbar_render", _content_render)
+    session = SimpleNamespace(bottom_toolbar=None)
+
+    _apply_toolbar_visibility(session)
+
+    assert session.bottom_toolbar is _content_render
+
+
+def test_toolbar_visibility_noop_when_unstashed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No stashed render callable -> leave the attribute untouched (graceful)."""
+    monkeypatch.setattr("core.cli.prompt_session._toolbar_render", None)
+    sentinel = object()
+    session = SimpleNamespace(bottom_toolbar=sentinel)
+
+    _apply_toolbar_visibility(session)
+
+    assert session.bottom_toolbar is sentinel

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.145"
+version = "0.99.146"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- The thin-CLI REPL drew a blank `reverse`-styled 1-row bar (a "white line") under the prompt whenever the quota banner was empty — which is always, in the current architecture.
- Root cause is twofold: (1) prompt_toolkit keys `bottom_toolbar` visibility on the *attribute* being non-None, not on the render return, so an empty render still reserves+styles a 1-row window; (2) the banner is never fed because its writer (the Anthropic response hook) fires in the **serve daemon** while the setter is registered only in the **thin-CLI** process (cross-process disconnect — same two-process split as the v0.99.145 model-resolution fix).
- Fix: toggle the `bottom_toolbar` attribute per prompt (`_apply_toolbar_visibility`) — render callable when the banner has content, `None` (bar hidden) when empty. No blanket color override (which would weaken real quota/abort warnings).

## Why
Operator reported a persistent white line at the bottom of the CLI that "didn't happen before." Git archaeology: the bar was introduced in PR-γ1 (2026-05-19); `render()`/prompt_toolkit (3.0.52) are unchanged since. The line surfaces now because the banner sits permanently in its empty cold-start state — its feed broke when LLM calls moved to the serve daemon (the setter registration stayed in the CLI REPL). A color inversion would only mask the symptom and make a permanently-disconnected banner look "working"; this hides the empty bar honestly while keeping the door open for a future cross-process feed.

## Changes
| File | Change |
|------|--------|
| `core/cli/prompt_session.py` | `_render` returns `None` (not `""`) when empty; stash render callable in `_build_prompt_session`; new `_apply_toolbar_visibility(session)`; call it before each `session.prompt()` |
| `tests/test_prompt_session.py` | 3 tests — empty→hidden, populated→shown, unstashed→no-op |
| `CHANGELOG.md` | `[0.99.146]` Fixed entry |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md` | version 0.99.145 → 0.99.146 (+ CLAUDE.md test count 8742→8745) |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean
- [x] lint-imports 4/4 KEPT (agent-purity contract unaffected)
- [x] pytest 39 passed (`tests/test_prompt_session.py` + `tests/core/cli/test_quota_banner.py`)
- [x] E2E with the **real** banner: cold-start `render()=None`→bar hidden; `set_state(...)`→`render()=HTML`→bar shown; unstashed→no-op
- [x] CLI smoke: `geode version` → GEODE v0.99.146
- [ ] Visual TTY confirm (operator, post-rebuild) — no white row at idle prompt

## Reference
prompt_toolkit `shortcuts/prompt.py:584-597` (ConditionalContainer filter on `self.bottom_toolbar is not None`) + `styles/defaults.py:129` (`("bottom-toolbar", "reverse")`); banner writer `core/llm/providers/anthropic.py:233-240`; setter registration `core/cli/prompt_session.py:162`. Codex MCP review skipped — token expired (operator-authorized); replaced by real-banner E2E + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)