### PR TITLE
docs(scaffold): fix §7 serve-kill — pgrep -f, not ps aux | grep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,8 +344,16 @@ git fetch origin --prune
 After merging to main, rebuild CLI and serve to update the runtime to the latest code.
 
 ```bash
-# 1) Stop geode serve
-kill $(ps aux | grep "geode serve" | grep -v grep | awk '{print $2}')
+# 1) Stop any running geode serve daemon(s). Use `pgrep -f`, NOT
+#    `ps aux | grep "geode serve"` — ps aux truncates the long python path
+#    before "geode serve", so the grep silently matches nothing, the kill is a
+#    no-op, and stale daemons survive a "rebuild" and then fight over
+#    ~/.geode/cli.sock (the multi-serve pathology behind the 2026-06-09
+#    model-resolution bug: banner shows one daemon's model, calls route through
+#    another). `geode serve stop` / `geode doctor` already use pgrep -f
+#    internally (core/cli/cmd_lifecycle.py, core/cli/doctor.py); this manual
+#    line should match.
+pkill -f "geode serve" || true   # no-op if none running; verify: pgrep -f "geode serve"
 
 # 2) Reinstall CLI as editable + sync dependencies.
 #    The [audit] extra (inspect_ai) is REQUIRED — the seed-generation pilot's


### PR DESCRIPTION
## Summary
- CLAUDE.md §7 rebuild step used `kill $(ps aux | grep "geode serve" ...)`, which silently matches nothing (ps aux truncates the long python path before "geode serve"). Switched to `pkill -f "geode serve"`.

## Why
The no-op kill left stale `geode serve` daemons alive across rebuilds. Today three accumulated and two held `~/.geode/cli.sock` simultaneously — the exact multi-serve pathology behind the 2026-06-09 model-resolution bug (banner shows one daemon's model, calls route through another). The code paths already do it right (`pgrep -f "geode serve"` in `core/cli/cmd_lifecycle.py:107`, `core/cli/doctor.py:212`); only the manual doc snippet was fragile.

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` (§7) | `ps aux | grep` → `pkill -f "geode serve"` + rationale comment |

## Verification
- [x] Docs-only (markdown); no code/version/CHANGELOG change (per scope rules)
- [x] Robust pattern matches the in-code `pgrep -f "geode serve"` already used by serve-stop/doctor
- [x] 5-location version unchanged (stays 0.99.146, consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)