### PR TITLE
fix(agent): system reminder append-only — stop re-keying history prefix every round (v0.99.148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ functional change.
 
 ---
 
+## [0.99.148] - 2026-06-10
+
+### Fixed
+- **Prompt cache: system reminder no longer re-keys the history prefix every round.** `_call_llm` previously inserted the `<system-reminder>` (current date + `Current round: N`) at `messages[0]` and rewrote it in place each round. Prompt caching is a prefix match and messages render after the system blocks, so the entire conversation history was invalidated on every agentic round — the rolling message cache breakpoints (ADR-013 T5, `core/llm/providers/anthropic.py`) could never hit, and the same applied to OpenAI/Codex automatic prefix caching. `prepend_system_reminder` is replaced by `append_system_reminder` (`core/agent/system_injection.py`): the reminder is appended as the **last** message on a per-request copy, the shared history list is never mutated (so the reminder never persists into `ConversationContext`), and a legacy reminder stored at position 0 by the old design is stripped once. The overflow check stays ahead of the copy so emergency prune still mutates the shared list. Pinned by `tests/test_system_injection.py::TestCacheContract` (prefix byte-stability across rounds).
+
+---
+
 ## [0.99.147] - 2026-06-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.147
+- **Version**: 0.99.148
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 403 core + 70 plugins = 473
-- **Tests**: 8745 (+5 live)
+- **Tests**: 8757 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.147 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.148 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.147 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.148 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -2275,13 +2275,21 @@ class AgenticLoop:
         hard-fails on missing registration).
         """
         effective_model = model or self.model
-        # Sandwich injection: prepend system reminder to messages (Claude Code pattern)
-        from core.agent.system_injection import prepend_system_reminder
-
-        prepend_system_reminder(messages, model=effective_model, round_idx=round_idx)
-
-        # Context overflow detection (Karpathy P6 Context Budget)
+        # Context overflow detection (Karpathy P6 Context Budget).
+        # MUST run on the SHARED history list before the reminder copy is
+        # made: emergency prune/compaction mutates ``messages`` in place and
+        # that mutation has to persist via _sync_messages_to_context — on a
+        # per-request copy it would evaporate and re-trigger every round.
         await self._check_context_overflow(system, messages)
+
+        # System reminder appended LAST, on a per-request copy — never at
+        # messages[0] and never into the shared history list. Position and
+        # immutability are load-bearing for prompt caching: the history
+        # prefix must stay byte-stable across rounds or the rolling message
+        # cache breakpoints never hit (see core/agent/system_injection.py).
+        from core.agent.system_injection import append_system_reminder
+
+        messages = append_system_reminder(messages, model=effective_model, round_idx=round_idx)
 
         # WRAP_UP: force text-only when approaching limits
         force_text = False

--- a/core/agent/system_injection.py
+++ b/core/agent/system_injection.py
@@ -1,17 +1,31 @@
 """System injection — XML-tagged context reinforcement for multi-turn conversations.
 
-Inspired by Claude Code's ``prependUserContext()`` pattern (utils/api.ts:449-474),
-this module builds a system reminder that is prepended to the messages array
-before each LLM call. This creates a reminder layer near the active user
-message while keeping the injected content explicitly XML-delimited.
+Inspired by Claude Code's ``<system-reminder>`` pattern: a reminder block is
+attached adjacent to the **latest** user message (appended as the final
+message) before each LLM call, keeping the injected content explicitly
+XML-delimited.
 
 Why: In long multi-turn conversations, instructions in the system prompt drift
 out of the model's attention window. The system reminder reinforces critical
 context (date, active rules, key constraints) at a position closer to the
 latest user message, improving instruction following.
 
-The reminder is injected into a deep-copied messages list (never into the
-stored ConversationContext), so it is ephemeral and regenerated each round.
+Cache contract (PR-CACHE-REMINDER, 2026-06-10): prompt caching is a prefix
+match and messages render after the system blocks. The previous design
+inserted the reminder at ``messages[0]`` and rewrote it per round
+("Current round: N"), which re-keyed the entire history prefix on every
+round — none of the rolling message cache breakpoints
+(core/llm/providers/anthropic.py, ADR-013 T5) could ever hit. The reminder
+therefore MUST stay append-only and MUST stay out of the stored
+ConversationContext:
+
+  - ``append_system_reminder`` returns a NEW list; the caller's history list
+    is never modified, so ``_sync_messages_to_context`` cannot persist the
+    reminder into history as stale mid-prefix bytes.
+  - Per-round variance (round index, date) lands after the last stable
+    history block, so only the reminder itself is uncached each round.
+
+Guard: ``tests/test_system_injection.py::TestCacheContract``.
 """
 
 from __future__ import annotations
@@ -34,7 +48,7 @@ def build_system_reminder(
     round_idx: int = 0,
     extra_context: dict[str, str] | None = None,
 ) -> str:
-    """Build a system reminder string for sandwich injection.
+    """Build a system reminder string for end-adjacent injection.
 
     Assembles a concise context block containing:
       - Current date/time (prevents year hallucination in tool calls)
@@ -80,32 +94,37 @@ def build_system_reminder(
     return body
 
 
-def prepend_system_reminder(
+def append_system_reminder(
     messages: list[dict[str, Any]],
     *,
     model: str = "",
     round_idx: int = 0,
     extra_context: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Prepend a system reminder to the messages list.
+    """Return a new messages list with a system reminder appended last.
 
-    Creates a user message with the system reminder and inserts it at
-    position 0 of the messages list. The messages list is modified
-    **in-place** (caller should pass a deep copy from ``get_messages()``).
+    The input list is NOT modified — the reminder exists only in the
+    per-request copy, never in the stored conversation history (see module
+    docstring for the prompt-cache contract this protects).
 
-    If the first message is already a system-reminder from a previous
-    injection (e.g., stale from a retry), it is replaced rather than
-    stacked.
+    A legacy reminder persisted at position 0 by the pre-2026-06-10 prepend
+    design is stripped, so long-lived sessions converge to a stable prefix
+    after one call.
 
     Args:
-        messages: Deep-copied message list (will be modified in-place).
+        messages: Conversation history (left untouched).
         model: Current model name (for context).
         round_idx: Current round index in the agentic loop.
         extra_context: Additional key-value pairs to include.
 
     Returns:
-        The same messages list (for chaining convenience).
+        A new list ``[*history, reminder]`` — or the input list unchanged
+        when there is nothing to inject.
     """
+    base = messages
+    if base and _is_system_reminder(base[0]):
+        base = base[1:]
+
     reminder = build_system_reminder(
         model=model,
         round_idx=round_idx,
@@ -113,24 +132,18 @@ def prepend_system_reminder(
     )
 
     if not reminder:
-        return messages
+        return base
 
     reminder_message: dict[str, Any] = {
         "role": "user",
         "content": f"<{_REMINDER_TAG}>\n{reminder}\n</{_REMINDER_TAG}>",
     }
 
-    # Replace stale reminder if present (idempotent injection)
-    if messages and _is_system_reminder(messages[0]):
-        messages[0] = reminder_message
-    else:
-        messages.insert(0, reminder_message)
-
-    return messages
+    return [*base, reminder_message]
 
 
 def _is_system_reminder(message: dict[str, Any]) -> bool:
-    """Check if a message is a system reminder (for dedup)."""
+    """Check if a message is a system reminder (for legacy-prefix strip)."""
     if message.get("role") != "user":
         return False
     content = message.get("content", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.147"
+version = "0.99.148"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_prompt_audit_2026_05_12.py
+++ b/tests/test_prompt_audit_2026_05_12.py
@@ -14,7 +14,7 @@ Each test pins a specific behaviour discovered or established by the audit:
 from __future__ import annotations
 
 import pytest
-from core.agent.system_injection import prepend_system_reminder
+from core.agent.system_injection import append_system_reminder
 from core.agent.system_prompt import (
     _audit_mode_active,
     _persona_on,
@@ -127,12 +127,12 @@ def test_wrapper_fallback_role_is_generic_not_geode_persona() -> None:
     assert "autonomous execution agent" in role
 
 
-def test_sandwich_system_reminder_uses_xml_tags() -> None:
+def test_system_reminder_uses_xml_tags() -> None:
     messages = [{"role": "user", "content": "hello"}]
-    out = prepend_system_reminder(messages, round_idx=1)
-    assert out[0]["content"].startswith("<system-reminder>")
-    assert out[0]["content"].endswith("</system-reminder>")
-    assert "[system-reminder]" not in out[0]["content"]
+    out = append_system_reminder(messages, round_idx=1)
+    assert out[-1]["content"].startswith("<system-reminder>")
+    assert out[-1]["content"].endswith("</system-reminder>")
+    assert "[system-reminder]" not in out[-1]["content"]
 
 
 def test_math_formatting_instruction_reaches_agentic_system_prompt(

--- a/tests/test_system_injection.py
+++ b/tests/test_system_injection.py
@@ -2,8 +2,11 @@
 
 Covers:
   1. build_system_reminder: content assembly, budget enforcement
-  2. prepend_system_reminder: injection, idempotency, empty-case
-  3. _is_system_reminder: tag detection
+  2. append_system_reminder: end-adjacent injection, input immutability,
+     legacy-prefix strip
+  3. TestCacheContract: prompt-cache prefix stability guard
+     (PR-CACHE-REMINDER, 2026-06-10)
+  4. _is_system_reminder: tag detection
 """
 
 from __future__ import annotations
@@ -15,8 +18,8 @@ from core.agent.system_injection import (
     _MAX_REMINDER_CHARS,
     _REMINDER_TAG,
     _is_system_reminder,
+    append_system_reminder,
     build_system_reminder,
-    prepend_system_reminder,
 )
 
 # ---------------------------------------------------------------------------
@@ -68,58 +71,98 @@ class TestBuildSystemReminder:
 
 
 # ---------------------------------------------------------------------------
-# prepend_system_reminder
+# append_system_reminder
 # ---------------------------------------------------------------------------
 
 
-class TestPrependSystemReminder:
-    """Tests for prepend_system_reminder()."""
+class TestAppendSystemReminder:
+    """Tests for append_system_reminder()."""
 
-    def test_prepends_to_empty_messages(self) -> None:
+    def test_appends_to_empty_messages(self) -> None:
         """Injection into empty messages list."""
         messages: list[dict[str, Any]] = []
-        result = prepend_system_reminder(messages)
+        result = append_system_reminder(messages)
         assert len(result) == 1
         assert result[0]["role"] == "user"
         assert f"<{_REMINDER_TAG}>" in result[0]["content"]
         assert f"</{_REMINDER_TAG}>" in result[0]["content"]
 
-    def test_prepends_before_user_message(self) -> None:
-        """Reminder appears before the first user message."""
+    def test_appends_after_latest_user_message(self) -> None:
+        """Reminder is the LAST message, after all history."""
         messages = [{"role": "user", "content": "Hello"}]
-        result = prepend_system_reminder(messages)
+        result = append_system_reminder(messages)
         assert len(result) == 2
-        assert _is_system_reminder(result[0])
-        assert result[1]["content"] == "Hello"
-
-    def test_idempotent_no_stacking(self) -> None:
-        """Calling twice replaces rather than stacking reminders."""
-        messages = [{"role": "user", "content": "Hello"}]
-        prepend_system_reminder(messages, round_idx=0)
-        assert len(messages) == 2
-
-        prepend_system_reminder(messages, round_idx=1)
-        assert len(messages) == 2  # replaced, not stacked
-        assert "Current round: 2" in messages[0]["content"]
-
-    def test_modifies_in_place(self) -> None:
-        """Messages list modified in-place (returns same reference)."""
-        messages = [{"role": "user", "content": "test"}]
-        result = prepend_system_reminder(messages)
-        assert result is messages
+        assert result[0]["content"] == "Hello"
+        assert _is_system_reminder(result[1])
 
     def test_preserves_existing_messages(self) -> None:
-        """Original messages preserved after injection."""
+        """Full history preserved in order, reminder appended last."""
         messages = [
             {"role": "user", "content": "first"},
             {"role": "assistant", "content": "reply"},
             {"role": "user", "content": "second"},
         ]
-        prepend_system_reminder(messages)
-        assert len(messages) == 4
-        assert messages[1]["content"] == "first"
-        assert messages[2]["content"] == "reply"
-        assert messages[3]["content"] == "second"
+        result = append_system_reminder(messages)
+        assert len(result) == 4
+        assert [m["content"] for m in result[:3]] == ["first", "reply", "second"]
+        assert _is_system_reminder(result[3])
+
+    def test_strips_legacy_position0_reminder(self) -> None:
+        """A reminder persisted at [0] by the old prepend design is dropped."""
+        legacy = f"<{_REMINDER_TAG}>\nCurrent date: stale\n</{_REMINDER_TAG}>"
+        messages = [
+            {"role": "user", "content": legacy},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = append_system_reminder(messages)
+        assert len(result) == 2
+        assert result[0]["content"] == "Hello"
+        assert _is_system_reminder(result[1])
+        assert "stale" not in result[1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Cache contract — prefix stability (PR-CACHE-REMINDER, 2026-06-10)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheContract:
+    """Prompt-cache guards: history prefix must stay byte-stable across rounds.
+
+    The pre-2026-06-10 design inserted the reminder at messages[0] and
+    rewrote it per round, invalidating the entire message-prefix cache on
+    every agentic round. These tests pin the append-only contract.
+    """
+
+    def test_input_list_not_mutated(self) -> None:
+        """The caller's history list is never modified."""
+        messages = [{"role": "user", "content": "Hello"}]
+        snapshot = [dict(m) for m in messages]
+        result = append_system_reminder(messages, round_idx=2)
+        assert messages == snapshot
+        assert result is not messages
+
+    def test_history_prefix_stable_across_rounds(self) -> None:
+        """Round-varying reminder bytes land ONLY in the final message.
+
+        result[:-1] must be identical across rounds — that is the cacheable
+        prefix. Only the appended reminder may differ.
+        """
+        history = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "working"},
+        ]
+        round1 = append_system_reminder(history, round_idx=1)
+        round2 = append_system_reminder(history, round_idx=2)
+        assert round1[:-1] == round2[:-1] == history
+        assert round1[-1] != round2[-1]  # round counter differs, as intended
+
+    def test_reminder_never_first_message(self) -> None:
+        """With non-empty history the reminder must not occupy messages[0]."""
+        messages = [{"role": "user", "content": "Hello"}]
+        result = append_system_reminder(messages, round_idx=1)
+        assert not _is_system_reminder(result[0])
+        assert _is_system_reminder(result[-1])
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +192,7 @@ class TestIsSystemReminder:
 
 
 # ---------------------------------------------------------------------------
-# Integration: AgenticLoop wiring (mock-based)
+# Integration: AgenticLoop wiring (source-based)
 # ---------------------------------------------------------------------------
 
 
@@ -158,15 +201,23 @@ class TestAgenticLoopIntegration:
 
     def test_import_succeeds(self) -> None:
         """Module imports cleanly from the agentic loop's call site."""
-        from core.agent.system_injection import prepend_system_reminder
+        from core.agent.system_injection import append_system_reminder
 
-        assert callable(prepend_system_reminder)
+        assert callable(append_system_reminder)
 
     def test_injection_in_call_path(self) -> None:
-        """Verify _call_llm source references system_injection."""
+        """_call_llm appends the reminder and does so AFTER the overflow check.
+
+        Order is load-bearing: the overflow check must see (and prune) the
+        shared history list; the per-request reminder copy is made afterwards.
+        """
         import inspect
 
         from core.agent.loop import AgenticLoop
 
         source = inspect.getsource(AgenticLoop._call_llm)
-        assert "prepend_system_reminder" in source
+        assert "append_system_reminder" in source
+        assert "prepend_system_reminder" not in source
+        assert source.index("_check_context_overflow") < source.index(
+            "append_system_reminder(messages"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.147"
+version = "0.99.148"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `<system-reminder>` 주입을 `messages[0]` 삽입(in-place)에서 **마지막 메시지 append(per-request 복사본)** 로 전환 — 히스토리 prefix를 라운드마다 재키잉하던 prompt-cache 브레이커 제거.
- 공유 히스토리 리스트 불변 보장(reminder가 ConversationContext로 영속되지 않음) + 구버전이 [0]에 영속시킨 legacy reminder 1회 strip.
- `TestCacheContract`로 prefix byte-안정성 핀.

## Why
Prompt caching은 prefix 일치이고 messages는 system 블록 뒤에 렌더된다. 기존 `prepend_system_reminder`는 `Current round: N`이 포함된 reminder를 `messages[0]`에 두고 매 라운드 재작성 → 대화 히스토리 전체가 **매 에이전틱 라운드 캐시 미스**. rolling message breakpoint 3개(ADR-013 T5, `core/llm/providers/anthropic.py:872-887`)가 한 번도 히트할 수 없었고, OpenAI/Codex 자동 prefix 캐싱도 동일하게 무효화됐다 (히스토리 재처리 비용 ~10×: Anthropic 캐시 읽기 0.1×, Codex cached input 10%). system static 블록은 messages 앞이라 계속 히트해 `cache_read_input_tokens`가 0이 아니었던 탓에 증상이 가려져 있었다.

frontier 정합: Claude Code는 reminder를 최신 user 턴 인접(끝)에 부착, Codex CLI는 append-only 루프를 공식 설계 원칙으로 문서화 (Prompt Caching 201 cookbook).

## Changes
| File | Change |
|------|--------|
| `core/agent/system_injection.py` | `prepend_system_reminder` → `append_system_reminder` (새 리스트 반환, 입력 불변, legacy [0] strip), 모듈 docstring에 캐시 계약 명시 |
| `core/agent/loop/agent_loop.py` | `_call_llm`: overflow 검사(공유 리스트, in-place prune 영속) → reminder append(복사본) 순서 고정 + 근거 주석 |
| `tests/test_system_injection.py` | append 의미론 + `TestCacheContract`(입력 불변/라운드 간 prefix 안정/[0] 금지) + 호출부 순서 가드 |
| `tests/test_prompt_audit_2026_05_12.py` | append 참조·last-position 단언으로 갱신 |
| `CHANGELOG.md` 외 4 | v0.99.148 PATCH, Tests 메트릭 8757 실측 동기 |

## Verification
- [x] ruff check clean + ruff format --check clean
- [x] mypy clean (changed files)
- [x] pytest: test_system_injection + test_prompt_audit + test_agentic_loop + test_anthropic_messages_cache + test_arun_llm_dispatch + test_context_manager 전부 green (183)
- [x] lint-imports: Contracts 4 kept, 0 broken
- [x] CLI smoke: geode version OK

## Reference
- Anthropic prompt caching 공식 문서 (prefix match, render order tools→system→messages, breakpoint 의미론)
- OpenAI Prompt Caching 201 cookbook — Codex CLI의 append-only + byte-identical prefix 규율
- 이전 설계의 docstring이 인용한 Claude Code 패턴의 실제 위치(최신 턴 인접)와의 불일치 교정