### PR TITLE
release: v0.99.151 — drift anchors (develop→main pass-through)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [0.99.151] - 2026-06-10
+
+### Changed
+- **Drift anchors (PR-DRIFT-ANCHORS): two literal-mirror families collapsed to single SoTs.**
+  - `PROVIDER_REGISTRY_NORMALIZATION` + `normalize_registry_provider()` (`core/llm/adapters/registry.py`) replace FOUR independent copies of the legacy→registry provider map (`agent_loop.__init__` + `_model_switching` carried the full dict; `runner._normalize_provider_for_registry` + `_reflection._normalize_provider_for_registry` carried only the openai half, with a comment admitting they were not sync'd). Adding a provider alias is now one edit; the two partial copies gain the `zhipuai → glm` mapping as a side effect (no-op on paths that never see zhipuai).
+  - `core/llm/model_capabilities.py` (new) anchors the Anthropic capability sets (`ANTHROPIC_CONTEXT_MGMT_MODELS` / `ANTHROPIC_ADAPTIVE_MODELS` / `ANTHROPIC_XHIGH_MODELS`); `core/llm/providers/anthropic.py` (request shaping) and `core/cli/effort_picker.py` (knob surfacing) alias the anchor objects instead of maintaining "Keep these in sync" literal copies — the 2026-05-29 opus-4-8 onboarding miss class. `tests/test_drift_anchors.py` pins identity (not equality — a re-introduced copy would be equal today and drift tomorrow), the xhigh ⊆ adaptive ⊆ context-mgmt subset invariants, the absence of literal copies at the four former sites, and the picker↔adapter xhigh agreement.
+
+---
+
 ## [0.99.150] - 2026-06-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.150
+- **Version**: 0.99.151
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 392 core + 70 plugins = 462
-- **Tests**: 8749 (+5 live)
+- **Modules**: 393 core + 70 plugins = 463
+- **Tests**: 8756 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.150 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.151 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.150 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.151 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -42,15 +42,11 @@ def _resolve_path_b_adapter(provider: str, source: str):  # type: ignore[no-unty
     adapter factory used by ``/model`` switching.
     """
     from core.llm.adapters import CONCRETE_SOURCES, resolve_for
+    from core.llm.adapters.registry import normalize_registry_provider
 
     if source not in CONCRETE_SOURCES:
         return None
-    # Legacy ``_resolve_provider`` returns ``openai-codex`` for gpt-5.x
-    # and ``zhipuai`` for GLM models; the Path-B registry uses the
-    # narrower vocabulary (``openai`` / ``glm``).
-    _PROVIDER_NORMALIZATION = {"openai-codex": "openai", "zhipuai": "glm"}
-    registry_provider = _PROVIDER_NORMALIZATION.get(provider, provider)
-    return resolve_for(registry_provider, source)
+    return resolve_for(normalize_registry_provider(provider), source)
 
 
 def _settings_model_target(loop: AgenticLoop) -> str | None:

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -58,25 +58,8 @@ from core.agent.cognitive_state import CognitiveState
 from core.config import _resolve_provider
 from core.llm.adapters import resolve_for
 from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+from core.llm.adapters.registry import normalize_registry_provider
 from core.llm.router import call_with_failover
-
-
-def _normalize_provider_for_registry(provider: str) -> str:
-    """Translate :func:`core.config._resolve_provider` output to the
-    Path-B :func:`~core.llm.adapters.registry.resolve_for` registry's
-    provider-key vocabulary.
-
-    Step J-b.3 (2026-05-23) — duplicates the same translation used by
-    :func:`core.self_improving.loop.runner._normalize_provider_for_registry`.
-    The legacy resolver returns ``"openai-codex"`` for gpt-5.x; the
-    Path-B registry collapses that to ``"openai"`` and lets the
-    ``source`` axis pick between ``payg`` / ``subscription`` /
-    ``adapter``.
-    """
-    if provider == "openai-codex":
-        return "openai"
-    return provider
-
 
 log = logging.getLogger(__name__)
 
@@ -293,7 +276,7 @@ async def reflect_async(
         # credential source as the parent.
         from core.llm.adapters._source_inference import infer_source
 
-        adapter = resolve_for(_normalize_provider_for_registry(provider), infer_source(provider))
+        adapter = resolve_for(normalize_registry_provider(provider), infer_source(provider))
         tool_summary = _summarise_tool_results(tool_results)
         user_prompt = _build_user_prompt(state, tool_summary)
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -429,19 +429,13 @@ class AgenticLoop:
         self._response_schema: dict[str, Any] | None = response_schema
         from core.llm.adapters import resolve_for
 
-        # The Path-B registry uses a narrower provider vocabulary than
-        # ``_resolve_provider``: gpt-5.x models map to ``openai-codex``
-        # in the legacy provider key but collapse to ``openai`` in the
-        # registry (the Codex source is encoded on the ``source`` axis
-        # as ``subscription``).
-        # Related copies in ``runner.py:_normalize_provider_for_registry``
-        # and ``_reflection.py:_normalize_provider_for_registry`` — those
-        # only map ``openai-codex → openai``; this site additionally maps
-        # ``zhipuai → glm``. The three are NOT fully sync'd; align them
-        # if a caller ever surfaces ``zhipuai`` on the reflection /
-        # mutator paths.
-        _PROVIDER_NORMALIZATION = {"openai-codex": "openai", "zhipuai": "glm"}
-        registry_provider = _PROVIDER_NORMALIZATION.get(self._provider, self._provider)
+        # PR-DRIFT-ANCHORS (2026-06-10) — the legacy→registry provider
+        # translation lives in ONE place now
+        # (``core.llm.adapters.registry.PROVIDER_REGISTRY_NORMALIZATION``);
+        # this used to be one of four unsynchronized literal copies.
+        from core.llm.adapters.registry import normalize_registry_provider
+
+        registry_provider = normalize_registry_provider(self._provider)
         # Adapter resolution: direct registry-name lookup first
         # (``codex-oauth`` / ``claude-cli`` / ``openai-payg`` / ...),
         # falling back to the legacy category-axis path for

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -25,6 +25,11 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 
+from core.llm.model_capabilities import (
+    ANTHROPIC_ADAPTIVE_MODELS,
+    ANTHROPIC_XHIGH_MODELS,
+)
+
 # ---------------------------------------------------------------------------
 # Per-provider effort enum table
 # ---------------------------------------------------------------------------
@@ -33,17 +38,12 @@ _ANTHROPIC_ADAPTIVE_EFFORTS = ("low", "medium", "high", "max", "xhigh")
 _OPENAI_REASONING_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
 _GLM_HYBRID_EFFORTS = ("disabled", "enabled")
 
-# Keep these in sync with the adapter capability gates
-# (``core/llm/providers/anthropic.py`` ``_ADAPTIVE_MODELS`` /
-# ``_XHIGH_EFFORT_MODELS``) — the picker only surfaces an effort knob the
-# API will actually accept. Opus 4.8 (claude-opus-4-8) joins 4.7 in both
-# sets: confirmed live by the running harness (Claude Code's /model selector
-# configures claude-opus-4-8 with "xhigh effort"); ctx7 platform docs index
-# only up to the 4.6/4.7 family pages.
-_ANTHROPIC_ADAPTIVE_MODELS = frozenset(
-    {"claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"}
-)
-_ANTHROPIC_XHIGH_MODELS = frozenset({"claude-opus-4-8", "claude-opus-4-7"})
+# PR-DRIFT-ANCHORS (2026-06-10) — the capability sets live in the single
+# SoT ``core/llm/model_capabilities.py`` (the former "Keep these in sync"
+# comment is retired along with the literal copies): the picker surfaces
+# exactly the knobs the adapter request-shaping accepts, by construction.
+_ANTHROPIC_ADAPTIVE_MODELS = ANTHROPIC_ADAPTIVE_MODELS
+_ANTHROPIC_XHIGH_MODELS = ANTHROPIC_XHIGH_MODELS
 
 _OPENAI_RESPONSES_MODELS_PREFIX = ("gpt-5",)
 

--- a/core/llm/adapters/registry.py
+++ b/core/llm/adapters/registry.py
@@ -115,6 +115,29 @@ def adapter_health(name: str) -> EnvironmentReport:
     return get_adapter(name).test_environment()
 
 
+# PR-DRIFT-ANCHORS (2026-06-10) — single SoT for the legacy→registry
+# provider-key translation. ``core.config._resolve_provider`` returns the
+# broader vocabulary (``openai-codex`` for gpt-5.x, ``zhipuai`` for GLM);
+# this registry keys adapters on the narrower ``openai`` / ``glm`` (the
+# Codex distinction rides the ``source`` axis as ``subscription``).
+# Previously FOUR independent copies of this map existed
+# (agent_loop.__init__, _model_switching._resolve_path_b_adapter,
+# runner._normalize_provider_for_registry,
+# _reflection._normalize_provider_for_registry — the last two only
+# carried the openai half), with a comment admitting they were not
+# sync'd. Add new aliases HERE only.
+PROVIDER_REGISTRY_NORMALIZATION: dict[str, str] = {
+    "openai-codex": "openai",
+    "zhipuai": "glm",
+}
+
+
+def normalize_registry_provider(provider: str) -> str:
+    """Translate a legacy ``_resolve_provider`` key to this registry's
+    provider vocabulary (identity for already-narrow keys)."""
+    return PROVIDER_REGISTRY_NORMALIZATION.get(provider, provider)
+
+
 def resolve_for(provider: str, source: str) -> LLMAdapter:
     """Find the unique adapter matching ``(provider, source)``.
 

--- a/core/llm/model_capabilities.py
+++ b/core/llm/model_capabilities.py
@@ -1,0 +1,59 @@
+"""Anthropic model-capability sets — single SoT (PR-DRIFT-ANCHORS, 2026-06-10).
+
+Before this module, the same "which Anthropic models support X" facts were
+hardcoded independently in ``core/llm/providers/anthropic.py`` (adapter
+request shaping) and ``core/cli/effort_picker.py`` (which knobs the picker
+surfaces), with a "Keep these in sync" comment standing in for an actual
+anchor. Model onboarding meant N independent edits and one missed edit
+meant "the new model silently doesn't work on this one surface" — exactly
+the 2026-05-29 incident where the opus-4-8 onboarding missed the
+seed-generation role allowlist ([[reference_model_compat_surfaces]]).
+
+Onboarding a new Anthropic model now means editing THIS file (plus pricing
+TOML); both consumers import from here. The ``model-onboarding`` scaffold
+skill points here.
+
+Capability provenance (doc-before-behaviour, CANNOT §4d): adaptive thinking
++ sampling-parameter removal per the platform 4.6/4.7 model pages; xhigh
+on 4.7/4.8 and opus-4-8 1M/compaction confirmed live by the running
+harness (Claude Code /model configures claude-opus-4-8 with xhigh effort).
+"""
+
+from __future__ import annotations
+
+# Models that support server-side context management + compaction beta
+# (compact-2026-01-12). Haiku 4.5 predates the beta and rejects its header
+# with a 400 whose message contains "context" — misclassified as
+# context_overflow. Only 1M-context models are known to support it.
+ANTHROPIC_CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+    }
+)
+
+# Adaptive-thinking models (Opus 4.6+ / Sonnet 4.6). Sampling parameters
+# (temperature/top_p/top_k) are rejected with 400 from Opus 4.7 and by
+# Opus 4.6 under adaptive thinking — omit them entirely on these models.
+# The effort knob (incl. xhigh) only exists for adaptive models.
+ANTHROPIC_ADAPTIVE_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+    }
+)
+
+# Models that accept ``output_config.effort = "xhigh"`` (one step above
+# high). 4.6 / Sonnet 4.6 reject it with 400.
+ANTHROPIC_XHIGH_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+    }
+)

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -16,6 +16,11 @@ from core.llm.fallback import (
     retry_with_backoff_generic,
     retry_with_backoff_generic_async,
 )
+from core.llm.model_capabilities import (
+    ANTHROPIC_ADAPTIVE_MODELS,
+    ANTHROPIC_CONTEXT_MGMT_MODELS,
+    ANTHROPIC_XHIGH_MODELS,
+)
 from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
 if TYPE_CHECKING:
@@ -593,16 +598,10 @@ _API_ALLOWED_KEYS = frozenset(
 # context_overflow.  Only 1M-context models are known to support it.
 # Opus 4.8 (claude-opus-4-8) ships with a 1M context window and Claude Code
 # runs it under server-side compaction, so it inherits the same contract.
-_CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
-    {
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-opus-4-6",
-        "claude-opus-4-5",
-        "claude-sonnet-4-6",
-        "claude-sonnet-4-5",
-    }
-)
+# PR-DRIFT-ANCHORS (2026-06-10) — set contents live in the single SoT
+# ``core/llm/model_capabilities.py``; this alias keeps the local name the
+# rest of this module (and its tests) read.
+_CONTEXT_MGMT_MODELS: frozenset[str] = ANTHROPIC_CONTEXT_MGMT_MODELS
 
 # Adaptive thinking models (Opus 4.6+).  Sampling parameters
 # (temperature/top_p/top_k) are rejected with 400 starting from Opus 4.7
@@ -612,14 +611,7 @@ _CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
 # Opus 4.8 continues the 4.6+ adaptive-thinking contract (the effort knob —
 # incl. ``xhigh`` — only exists for adaptive models, and this session runs
 # claude-opus-4-8 under adaptive thinking; see _XHIGH_EFFORT_MODELS note).
-_ADAPTIVE_MODELS: frozenset[str] = frozenset(
-    {
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
-    }
-)
+_ADAPTIVE_MODELS: frozenset[str] = ANTHROPIC_ADAPTIVE_MODELS
 
 # v0.56.0 R4-mini — Opus 4.7 supports the new ``xhigh`` effort level (one
 # step above ``high``); 4.6 / Sonnet 4.6 reject it with 400. Mirrors
@@ -633,7 +625,7 @@ _ADAPTIVE_MODELS: frozenset[str] = frozenset(
 # emits it). ctx7 platform docs only index up to the 4.6/4.7 family pages, so
 # the 4.8-specific acceptance is grounded by the running harness rather than a
 # doc page.
-_XHIGH_EFFORT_MODELS: frozenset[str] = frozenset({"claude-opus-4-8", "claude-opus-4-7"})
+_XHIGH_EFFORT_MODELS: frozenset[str] = ANTHROPIC_XHIGH_MODELS
 
 
 def _supports_xhigh_effort(model: str) -> bool:

--- a/core/self_improving/loop/runner.py
+++ b/core/self_improving/loop/runner.py
@@ -704,27 +704,6 @@ def _consume_last_llm_call_usage() -> dict[str, Any]:
     return snapshot
 
 
-def _normalize_provider_for_registry(provider: str) -> str:
-    """Translate :func:`core.config._resolve_provider` output to the
-    Path-B registry's provider key vocabulary.
-
-    Step J-b.2 (2026-05-23, Codex MCP HIGH fix-up) —
-    :func:`_resolve_provider` returns the broader provider keys
-    (``anthropic`` / ``openai`` / ``openai-codex`` / ``glm``). The
-    Path-B :func:`~core.llm.adapters.registry.resolve_for` registry uses
-    a narrower set: ``anthropic`` / ``openai`` / ``glm``. The Codex
-    distinction is encoded on the ``source`` axis instead (``CodexOAuthAdapter``
-    lives at ``provider="openai"`` ``source="subscription"``).
-
-    For a gpt-5.x model the legacy resolver returns ``"openai-codex"``;
-    the Path-B mutator collapses that to ``"openai"`` and lets the
-    source axis pick between ``payg`` / ``subscription`` / ``adapter``.
-    """
-    if provider == "openai-codex":
-        return "openai"
-    return provider
-
-
 def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     """Mutator LLM call.
 
@@ -808,6 +787,7 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     from core.llm.adapters import resolve_for
     from core.llm.adapters._source_inference import infer_source
     from core.llm.adapters.base import SOURCE_PAYG, AdapterCallRequest, Message
+    from core.llm.adapters.registry import normalize_registry_provider
     from core.llm.router import call_with_failover
 
     # PR-SOURCE-ROUTING (2026-05-28) — for the unpinned ``auto`` source, mirror the
@@ -819,7 +799,7 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     # route to PAYG; ``infer_source`` would otherwise re-derive subscription from a
     # present OAuth profile and silently ignore the operator's explicit lane choice.
     resolved_source = SOURCE_PAYG if source == "api_key" else infer_source(provider)
-    adapter = resolve_for(_normalize_provider_for_registry(provider), resolved_source)
+    adapter = resolve_for(normalize_registry_provider(provider), resolved_source)
     mutator_temperature = _settings.temperature_self_improving_mutation
 
     async def _do_call(m: str) -> object:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.150"
+version = "0.99.151"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_drift_anchors.py
+++ b/tests/test_drift_anchors.py
@@ -1,0 +1,107 @@
+"""PR-DRIFT-ANCHORS (2026-06-10) — single-SoT guards for former literal mirrors.
+
+Two families used to drift:
+
+1. ``_PROVIDER_NORMALIZATION`` — the legacy→registry provider map existed
+   as FOUR independent copies (two full dict literals, two partial
+   functions that only mapped the openai half, with a comment admitting
+   they were not sync'd). Anchor:
+   ``core.llm.adapters.registry.PROVIDER_REGISTRY_NORMALIZATION``.
+
+2. Anthropic model-capability sets — adapter request shaping
+   (``core/llm/providers/anthropic.py``) and the CLI effort picker
+   (``core/cli/effort_picker.py``) each hardcoded the same model sets
+   with a "Keep these in sync" comment. Anchor:
+   ``core.llm.model_capabilities``.
+
+These tests pin the anchor's content invariants AND that the consumers
+alias the anchor objects (identity, not copies) — a re-introduced literal
+copy fails the identity assertions.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+class TestProviderNormalizationAnchor:
+    def test_map_contents(self) -> None:
+        from core.llm.adapters.registry import PROVIDER_REGISTRY_NORMALIZATION
+
+        assert PROVIDER_REGISTRY_NORMALIZATION == {
+            "openai-codex": "openai",
+            "zhipuai": "glm",
+        }
+
+    def test_normalize_passthrough_and_mapping(self) -> None:
+        from core.llm.adapters.registry import normalize_registry_provider
+
+        assert normalize_registry_provider("openai-codex") == "openai"
+        assert normalize_registry_provider("zhipuai") == "glm"
+        assert normalize_registry_provider("anthropic") == "anthropic"
+        assert normalize_registry_provider("glm") == "glm"
+
+    def test_no_literal_copies_at_former_sites(self) -> None:
+        """The four former copy sites must call the anchor, not re-declare
+        the dict. Source-scan guard (same style as TestCacheContract)."""
+        import core.agent.loop._model_switching as model_switching
+        import core.agent.loop._reflection as reflection
+        from core.agent.loop.agent_loop import AgenticLoop
+
+        from core.self_improving.loop import runner
+
+        for src in (
+            inspect.getsource(AgenticLoop.__init__),
+            inspect.getsource(model_switching._resolve_path_b_adapter),
+            inspect.getsource(reflection),
+            inspect.getsource(runner),
+        ):
+            assert "_PROVIDER_NORMALIZATION = {" not in src
+            assert "_normalize_provider_for_registry" not in src
+        assert "normalize_registry_provider" in inspect.getsource(AgenticLoop.__init__)
+
+
+class TestModelCapabilityAnchor:
+    def test_capability_subset_invariants(self) -> None:
+        """xhigh ⊆ adaptive ⊆ context-mgmt — a model cannot accept the
+        xhigh effort knob without being adaptive, and every adaptive
+        model in the catalog is a 1M/compaction model."""
+        from core.llm.model_capabilities import (
+            ANTHROPIC_ADAPTIVE_MODELS,
+            ANTHROPIC_CONTEXT_MGMT_MODELS,
+            ANTHROPIC_XHIGH_MODELS,
+        )
+
+        assert ANTHROPIC_XHIGH_MODELS <= ANTHROPIC_ADAPTIVE_MODELS
+        assert ANTHROPIC_ADAPTIVE_MODELS <= ANTHROPIC_CONTEXT_MGMT_MODELS
+
+    def test_adapter_aliases_are_anchor_objects(self) -> None:
+        """Identity, not equality — a re-introduced literal copy would be
+        equal today and silently drift tomorrow."""
+        from core.llm.providers import anthropic as anthropic_provider
+
+        from core.llm import model_capabilities as caps
+
+        assert anthropic_provider._CONTEXT_MGMT_MODELS is caps.ANTHROPIC_CONTEXT_MGMT_MODELS
+        assert anthropic_provider._ADAPTIVE_MODELS is caps.ANTHROPIC_ADAPTIVE_MODELS
+        assert anthropic_provider._XHIGH_EFFORT_MODELS is caps.ANTHROPIC_XHIGH_MODELS
+
+    def test_effort_picker_aliases_are_anchor_objects(self) -> None:
+        from core.cli import effort_picker
+        from core.llm import model_capabilities as caps
+
+        assert effort_picker._ANTHROPIC_ADAPTIVE_MODELS is caps.ANTHROPIC_ADAPTIVE_MODELS
+        assert effort_picker._ANTHROPIC_XHIGH_MODELS is caps.ANTHROPIC_XHIGH_MODELS
+
+    def test_picker_surfaces_match_adapter_acceptance(self) -> None:
+        """End-to-end invariant the anchor exists to guarantee: the picker
+        offers xhigh exactly for the models the adapter will accept it on."""
+        from core.cli.effort_picker import supported_efforts
+        from core.llm.model_capabilities import (
+            ANTHROPIC_ADAPTIVE_MODELS,
+            ANTHROPIC_XHIGH_MODELS,
+        )
+
+        for model in ANTHROPIC_ADAPTIVE_MODELS:
+            efforts = supported_efforts(model, "anthropic")
+            assert ("xhigh" in efforts) == (model in ANTHROPIC_XHIGH_MODELS)

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -281,15 +281,16 @@ def test_default_llm_call_normalizes_openai_codex_provider(
 
 
 def test_normalize_provider_for_registry_passes_through_known_keys() -> None:
-    """Non-codex provider keys pass through ``_normalize_provider_for_registry``
-    unchanged so the helper is conservative."""
-    from core.self_improving.loop.runner import _normalize_provider_for_registry
+    """Non-codex provider keys pass through ``normalize_registry_provider``
+    unchanged so the helper is conservative. PR-DRIFT-ANCHORS — the
+    runner's local copy was replaced by the shared anchor."""
+    from core.llm.adapters.registry import normalize_registry_provider
 
-    assert _normalize_provider_for_registry("anthropic") == "anthropic"
-    assert _normalize_provider_for_registry("openai") == "openai"
-    assert _normalize_provider_for_registry("glm") == "glm"
+    assert normalize_registry_provider("anthropic") == "anthropic"
+    assert normalize_registry_provider("openai") == "openai"
+    assert normalize_registry_provider("glm") == "glm"
     # Legacy Codex provider key collapses to the Path-B registry key.
-    assert _normalize_provider_for_registry("openai-codex") == "openai"
+    assert normalize_registry_provider("openai-codex") == "openai"
 
 
 def test_default_llm_call_api_key_path_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.150"
+version = "0.99.151"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.151: provider 정규화 4사본 + Anthropic capability 거울 5세트를 단일 SoT 앵커로 통합 (PR #2042).
- develop→main 패스스루.

## Verification
- [x] PR #2042 CI 8/8 green
- [x] develop은 main 완전 포함