### PR TITLE
refactor(paths): D-2 경로/설정 앵커 — petri logs·seed-pool·CLI 부트스트랩·config 템플릿·campaign 기본값·CLI 직렬화기 (v0.99.153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.153] - 2026-06-10
+
+### Changed
+- **D-2 path/config anchors (PR-CLEANUP-D2)** — the remaining literal-mirror families from the 2026-06-10 duplication audit collapsed to single SoTs:
+  - `core/paths.py` gains `PETRI_LOGS_DIR` / `LATEST_PETRI_EVAL` (six independent copies spanned the symlink WRITER in petri_audit and five graceful-None READERS — train evidence extraction, seed-gen baseline reader, campaign glob, eval_archive, bundle_sync; a writer-side move would have broken fitness evidence with zero errors) and `SEED_POOLS_DIR` / `CYCLE_INPUT_POOL` / `HELD_OUT_BENCH_POOL` (the 2026-06-03 worker-drop incident's code shape: campaign, assemble script, and a cwd-relative default resolved the same directory three ways — deliberately REPO-pinned, GEODE_STATE_ROOT semantics stay a D-3 decision).
+  - CLI bootstrap modules (`typer_commands` / `doctor_bootstrap` / `typer_init`) stop re-deriving `~/.geode/cli.sock`, `~/.geode/.env`, `~/.geode`, `.geode/model-policy.toml`, `~/.geode/identity` inline (the v0.99.145 daemon-path-split pathology family) and import the existing `core.paths` anchors; their generated templates' stale `claude-opus-4-6` examples become `claude-opus-4-8`.
+  - `generate_config_toml` extends `DEFAULT_CONFIG_TOML` instead of re-typing it (the fork had already drifted in wording and shipped stale model defaults).
+  - `geode self-improving campaign` typer defaults import the campaign module's `DEFAULT_*` constants (were re-hardcoded literals with help text asserting old values); the campaign's arm pre-validation imports train's `_VALID_PROMOTE_POLICIES`; the `core.self_improving.train` subprocess argv module path is the shared `TRAIN_MODULE` constant (campaign + loop runner).
+  - `plugins/petri_audit/prompt_serialisation.py` (new) — the role-header sentinels + `serialise_messages_to_prompt` byte-near-identical copies in the two subscription-CLI providers become one module (a sentinel change would have forked the transcript wire format); seed-gen `resume` imports the ranker's voter vocabulary instead of restating `{"A","B","tie"}`.
+
+---
+
 ## [0.99.152] - 2026-06-10
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,10 +377,17 @@ Update project tracking from main. Backlog → In Progress → Done.
 
 | Gate | Command | Criteria |
 |------|---------|----------|
-| Lint | `uv run ruff check core/ tests/ plugins/` | 0 errors |
+| Lint | `uv run ruff check core/ tests/ plugins/ scripts/` | 0 errors — `scripts/` 포함 (CI ci.yml:60과 동일 범위; PR-CLEANUP-D2에서 로컬 게이트가 scripts/를 빼먹어 CI에서 2회 반려된 사건) |
+| Format | `uv run ruff format --check core/ tests/ plugins/ scripts/` | 0 reformats |
 | Type | `uv run mypy core/ plugins/` | 0 errors |
+| Imports | `uv run lint-imports` | contracts kept |
 | Test | `uv run pytest tests/ -m "not live"` | 3900+ pass |
 | CLI smoke | `uv run geode version` | version prints |
+
+> 게이트 명령을 파이프로 감싸지 말 것 — `ruff check … \| tail -1` 은 zsh 기본
+> pipefail off라 ruff의 exit 1을 삼켜 `&&` 체인이 실패를 통과시킨다. heredoc
+> 수정 스크립트는 실패가 후속 명령을 막도록 같은 `&&` 체인에 묶고, push 직전
+> 게이트를 풀 출력으로 한 번 더 단언한다 (PR-CLEANUP-D2 no-op 커밋 사건).
 
 ## Custom Skills (Scaffold)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.152
+- **Version**: 0.99.153
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 386 core + 67 plugins = 453
+- **Modules**: 386 core + 68 plugins = 454
 - **Tests**: 8646 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.152 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.153 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.152 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.153 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -69,6 +69,19 @@ from core.cli.welcome import _welcome_screen as _welcome_screen
 from core.hooks import HookEvent, HookSystem
 from core.hooks.dispatch import fire_hook
 from core.llm.commentary import generate_commentary
+
+# PR-CLEANUP-D2 (2026-06-10) — campaign CLI defaults come from the campaign
+# module (they were re-hardcoded literals here, with help text asserting the
+# old values whenever campaign.py changed them).
+from core.self_improving.campaign import (
+    DEFAULT_AUDIT_MAX_CONNECTIONS as _CAMPAIGN_DEFAULT_AUDIT_MAX_CONNECTIONS,
+)
+from core.self_improving.campaign import (
+    DEFAULT_AUDIT_MAX_SAMPLES as _CAMPAIGN_DEFAULT_AUDIT_MAX_SAMPLES,
+)
+from core.self_improving.campaign import (
+    DEFAULT_MAX_PROPOSE_ATTEMPTS as _CAMPAIGN_DEFAULT_MAX_PROPOSE_ATTEMPTS,
+)
 from core.ui.console import console
 from core.ui.status import GeodeStatus
 
@@ -374,19 +387,19 @@ def campaign(
         help="Comma-separated arm order, gate LAST. Default 'never,random,gate'.",
     ),
     mc: int = typer.Option(
-        8,
+        _CAMPAIGN_DEFAULT_MAX_PROPOSE_ATTEMPTS,
         "--mc",
-        help="Max propose-guard re-proposal attempts M. Default 8.",
+        help="Max propose-guard re-proposal attempts M (campaign.py default).",
     ),
     audit_max_samples: int = typer.Option(
-        3,
+        _CAMPAIGN_DEFAULT_AUDIT_MAX_SAMPLES,
         "--audit-max-samples",
-        help="GEODE_AUDIT_MAX_SAMPLES export passed to each audit. Default 3.",
+        help="GEODE_AUDIT_MAX_SAMPLES export passed to each audit (campaign.py default).",
     ),
     audit_max_connections: int = typer.Option(
-        8,
+        _CAMPAIGN_DEFAULT_AUDIT_MAX_CONNECTIONS,
         "--audit-max-connections",
-        help="GEODE_AUDIT_MAX_CONNECTIONS export passed to each audit. Default 8.",
+        help="GEODE_AUDIT_MAX_CONNECTIONS export passed to each audit (campaign.py default).",
     ),
     dry_run: bool = typer.Option(
         False,

--- a/core/cli/doctor_bootstrap.py
+++ b/core/cli/doctor_bootstrap.py
@@ -66,7 +66,9 @@ def _check_geode_on_path() -> CheckResult:
 
 
 def _check_env_file() -> CheckResult:
-    env_path = Path("~/.geode/.env").expanduser()
+    from core.paths import GLOBAL_ENV_FILE  # PR-CLEANUP-D2 anchor
+
+    env_path = GLOBAL_ENV_FILE
     ok = env_path.exists()
     return CheckResult(
         name="~/.geode/.env",
@@ -149,7 +151,9 @@ def _check_profile_store() -> CheckResult:
 
 def _check_serve_socket() -> CheckResult:
     """Check whether geode serve is listening on its IPC socket."""
-    sock_path = Path("~/.geode/cli.sock").expanduser()
+    from core.paths import CLI_SOCKET_PATH  # PR-CLEANUP-D2 anchor
+
+    sock_path = CLI_SOCKET_PATH
     if not sock_path.exists():
         return CheckResult(
             name="geode serve",

--- a/core/cli/typer_commands.py
+++ b/core/cli/typer_commands.py
@@ -9,8 +9,6 @@ here so that the import edge stays acyclic.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import typer
 
 from core import __version__
@@ -72,7 +70,9 @@ def about() -> None:
     )
 
     # Daemon socket
-    sock_path = Path("~/.geode/cli.sock").expanduser()
+    from core.paths import CLI_SOCKET_PATH  # PR-CLEANUP-D2 anchor
+
+    sock_path = CLI_SOCKET_PATH
     if sock_path.exists():
         console.print(
             f"  [bold]Daemon[/bold]     [success]running[/success]  [muted]({sock_path})[/muted]"
@@ -109,7 +109,9 @@ def setup(
     from core.wiring.startup import _has_any_llm_key, detect_subscription_oauth
 
     if reset:
-        env_path = Path("~/.geode/.env").expanduser()
+        from core.paths import GLOBAL_ENV_FILE  # PR-CLEANUP-D2 anchor
+
+        env_path = GLOBAL_ENV_FILE
         if env_path.exists():
             env_path.unlink()
             console.print(f"  [muted]Removed {env_path}[/muted]")

--- a/core/cli/typer_init.py
+++ b/core/cli/typer_init.py
@@ -60,7 +60,9 @@ def init(
     user_profile = FileBasedUserProfile()
 
     # 0. Global ~/.geode/ directory + .env (API key storage)
-    global_geode = Path.home() / ".geode"
+    from core.paths import GEODE_HOME  # PR-CLEANUP-D2 anchor
+
+    global_geode = GEODE_HOME
     global_geode.mkdir(parents=True, exist_ok=True)
     global_env = global_geode / ".env"
     if not global_env.exists():
@@ -138,19 +140,21 @@ def init(
             "# Node-level LLM model routing\n"
             "# Uncomment to override default model per pipeline node.\n\n"
             "[nodes]\n"
-            '# analyst = "claude-opus-4-6"\n'
+            '# analyst = "claude-opus-4-8"\n'
             '# evaluator = "claude-sonnet-4-6"\n'
             '# scoring = "claude-haiku-4-5-20251001"\n'
-            '# synthesizer = "claude-opus-4-6"\n\n'
+            '# synthesizer = "claude-opus-4-8"\n\n'
             "[agentic]\n"
-            '# default = "claude-opus-4-6"\n'
+            '# default = "claude-opus-4-8"\n'
             '# sub_agent = "claude-sonnet-4-6"\n',
             encoding="utf-8",
         )
         console.print("  Created .geode/routing.toml (template)")
 
     # 4c. model-policy.toml template
-    policy_path = Path(".geode/model-policy.toml")
+    from core.paths import PROJECT_MODEL_POLICY  # PR-CLEANUP-D2 anchor
+
+    policy_path = PROJECT_MODEL_POLICY
     if not policy_path.exists():
         policy_path.write_text(
             "# Model governance — allowlist/denylist\n"
@@ -158,7 +162,7 @@ def init(
             "# If only denylist is set, listed models are blocked.\n\n"
             "[policy]\n"
             "# allowlist = "
-            '["claude-opus-4-6", "claude-sonnet-4-6", "gpt-5.4"]\n'
+            '["claude-opus-4-8", "claude-sonnet-4-6", "gpt-5.4"]\n'
             "# denylist = "
             '["claude-haiku-4-5-20251001"]\n'
             '# default_model = "claude-sonnet-4-6"\n',
@@ -225,7 +229,9 @@ def init(
         log.debug("Profile seeding skipped: %s", e)
 
     # 7b. ~/.geode/identity/career.toml template
-    identity_dir = Path.home() / ".geode" / "identity"
+    from core.paths import GLOBAL_IDENTITY_DIR  # PR-CLEANUP-D2 anchor
+
+    identity_dir = GLOBAL_IDENTITY_DIR
     career_toml = identity_dir / "career.toml"
     if not career_toml.exists():
         identity_dir.mkdir(parents=True, exist_ok=True)

--- a/core/paths.py
+++ b/core/paths.py
@@ -60,6 +60,17 @@ def _resolve_repo_root() -> Path:
 _REPO_ROOT = _resolve_repo_root()
 STATE_ROOT = Path(os.environ.get("GEODE_STATE_ROOT") or (_REPO_ROOT / "state"))
 
+# Seed pools — single SoT for the directory the campaign reads and the
+# assemble script writes (PR-CLEANUP-D2, 2026-06-10). Deliberately
+# REPO-pinned (not STATE_ROOT): the cycle-input pool is a git-tracked
+# campaign input, and the 2026-06-03 incident (assemble to a custom
+# --out → every worker dropped with "train.py exited 1") came from the
+# writer and reader resolving this path independently. Whether the pool
+# should honor GEODE_STATE_ROOT is a separate D-3 semantic decision.
+SEED_POOLS_DIR = _REPO_ROOT / "state" / "seed-pools"
+CYCLE_INPUT_POOL = SEED_POOLS_DIR / "cycle-input"
+HELD_OUT_BENCH_POOL = SEED_POOLS_DIR / "held-out"
+
 # PR-STATE-AUTORESEARCH-RENAME (2026-06-01, Scheme A) — the autoresearch
 # optimization loop's in-repo runtime DATA. "autoresearch" is the engine's
 # name (operator-approved); this was ``state/autoresearch/`` under
@@ -213,6 +224,16 @@ GEODE_HOME = Path.home() / ".geode"
 # Global config & credentials
 GLOBAL_CONFIG_TOML = GEODE_HOME / "config.toml"
 GLOBAL_ENV_FILE = GEODE_HOME / ".env"
+
+# Petri audit runtime logs — single SoT (PR-CLEANUP-D2, 2026-06-10).
+# Writer: plugins/petri_audit/cli_audit.py maintains the latest.eval
+# symlink; readers: train.py evidence extraction, seed_generation
+# baseline_reader, campaign glob, eval_archive, bundle_sync. Six
+# independent literal copies of this path existed before the anchor —
+# every reader has a graceful-None contract, so a writer-side move
+# would have broken fitness evidence + baselines with zero errors.
+PETRI_LOGS_DIR = GEODE_HOME / "petri" / "logs"
+LATEST_PETRI_EVAL = PETRI_LOGS_DIR / "latest.eval"
 
 # User identity & profile
 GLOBAL_IDENTITY_DIR = GEODE_HOME / "identity"

--- a/core/self_improving/campaign.py
+++ b/core/self_improving/campaign.py
@@ -97,6 +97,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.paths import AUTORESEARCH_STATE_DIR
+from core.paths import CYCLE_INPUT_POOL as _CYCLE_INPUT_POOL  # PR-CLEANUP-D2
+from core.paths import HELD_OUT_BENCH_POOL as _HELD_OUT_BENCH_POOL  # PR-CLEANUP-D2
+from core.paths import PETRI_LOGS_DIR as _PETRI_LOGS_DIR  # PR-CLEANUP-D2
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -132,13 +135,19 @@ GEN0_SNAPSHOT_DIR = REPO_ROOT / "state" / "campaign" / "gen-0-snapshot"
 #: re-runs the missing replicates / cycles, then aggregates the union (S4).
 CAMPAIGN_RUNS_DIR = REPO_ROOT / "state" / "campaign" / "runs"
 
-#: Seed-pool launch wiring (campaign-procedure.md §3, cycle-input-pool.md).
-CYCLE_INPUT_POOL = REPO_ROOT / "state" / "seed-pools" / "cycle-input"
-HELD_OUT_BENCH = REPO_ROOT / "state" / "seed-pools" / "held-out"
+#: Seed-pool launch wiring (campaign-procedure.md §3, cycle-input-pool.md) —
+#: paths anchored in core.paths (PR-CLEANUP-D2).
+CYCLE_INPUT_POOL = _CYCLE_INPUT_POOL
+HELD_OUT_BENCH = _HELD_OUT_BENCH_POOL
+
+# PR-CLEANUP-D2 — train's module path, shared with loop/runner.py (the module
+# already moved once, scripts/ → core/self_improving/; a missed argv edit
+# yields "train.py exited 1"-class worker drops).
+TRAIN_MODULE = "core.self_improving.train"
 
 #: Petri eval archive (campaign-procedure.md §7) — the degeneracy guard reads
-#: the newest ``.eval`` here.
-PETRI_LOGS_DIR = Path("~/.geode/petri/logs").expanduser()
+#: the newest ``.eval`` here (anchored in core.paths).
+PETRI_LOGS_DIR = _PETRI_LOGS_DIR
 
 DEFAULT_N = 10
 """Cycles per arm (campaign-procedure.md §6)."""
@@ -966,7 +975,7 @@ def _spawn_train_subprocess(
     *, env: dict[str, str], dry_run: bool
 ) -> subprocess.CompletedProcess[str]:
     """Spawn ``uv run python -m core.self_improving.train`` (real audit, no mutation)."""
-    argv = ["uv", "run", "python", "-m", "core.self_improving.train"]
+    argv = ["uv", "run", "python", "-m", TRAIN_MODULE]
     if dry_run:
         argv.append("--dry-run")
     return subprocess.run(  # noqa: S603 — argv built from constants
@@ -1334,7 +1343,7 @@ async def _spawn_train_subprocess_async(
     crash the whole gather). ``sys.executable`` is the venv interpreter the parent
     campaign runs under, so the child resolves the ``core`` package.
     """
-    argv = [sys.executable, "-m", "core.self_improving.train"]
+    argv = [sys.executable, "-m", TRAIN_MODULE]
     if dry_run:
         argv.append("--dry-run")
     proc = await asyncio.create_subprocess_exec(
@@ -2533,7 +2542,11 @@ def run_campaign(
 
 
 def _validate_arms(arms: Sequence[str]) -> None:
-    valid = {"gate", "random", "never"}
+    # PR-CLEANUP-D2 — single SoT: an arm added in train.py must not be
+    # silently rejected by this pre-validation (former literal copy).
+    from core.self_improving.train import _VALID_PROMOTE_POLICIES
+
+    valid = _VALID_PROMOTE_POLICIES
     bad = [a for a in arms if a not in valid]
     if bad:
         raise ValueError(

--- a/core/self_improving/loop/runner.py
+++ b/core/self_improving/loop/runner.py
@@ -1295,7 +1295,9 @@ def _run_autoresearch_subprocess(
     so train.py's promote decision can auto-evaluate it as a *secondary*
     reject gate (empty string ⇒ env unset ⇒ train.py skips the check).
     """
-    argv = ["uv", "run", "python", "-m", "core.self_improving.train"]
+    from core.self_improving.campaign import TRAIN_MODULE  # PR-CLEANUP-D2 anchor
+
+    argv = ["uv", "run", "python", "-m", TRAIN_MODULE]
     if dry_run:
         argv.append("--dry-run")
     env = os.environ.copy()

--- a/core/self_improving/train.py
+++ b/core/self_improving/train.py
@@ -121,6 +121,7 @@ if TYPE_CHECKING:
 # (compute_bench_aggregate, ...)`` 의 local import 는 compute_fitness 내부
 # 에서만 호출되는 lazy import 라 보존. (``BenchProvenance`` 는
 # ``format_results_jsonl_row`` 시그너처에도 사용되므로 module-top import.)
+from core.paths import LATEST_PETRI_EVAL
 from core.self_improving.bench_means import BenchProvenance, collect_bench_means_from_inspect_ai
 
 log = logging.getLogger(__name__)
@@ -2918,7 +2919,7 @@ PETRI_RUBRIC_VERSION = "v3-22dim-PR0"
 # the SoT for this symlink; petri-owned, no core.paths constant exists for it.
 # Surfaced to the path-literal guard only by PR-SELF-IMPROVING-UMBRELLA moving
 # this module into core/.
-LATEST_EVAL_SYMLINK = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"  # paths-literal-ok
+LATEST_EVAL_SYMLINK = LATEST_PETRI_EVAL  # PR-CLEANUP-D2 anchor alias
 
 
 def _resolve_eval_archive_path() -> str | None:

--- a/core/utils/project_detect.py
+++ b/core/utils/project_detect.py
@@ -202,23 +202,13 @@ def generate_config_toml(info: ProjectInfo) -> str:
 
     Extends the default TOML template with [project], [commands], [directories].
     """
+    # PR-CLEANUP-D2 (2026-06-10) — extend the single template SoT instead
+    # of re-typing it: the two copies had already drifted (priority-comment
+    # wording + stale claude-opus-4-6 / removed [pipeline] knobs).
+    from core.config import DEFAULT_CONFIG_TOML
+
     lines = [
-        "# GEODE config.toml",
-        "# Priority: CLI > env > .geode/config.toml > ~/.geode/config.toml > defaults",
-        "#",
-        "# Uncomment and edit values to override defaults.",
-        "",
-        "[llm]",
-        '# primary_model = "claude-opus-4-6"',
-        '# secondary_model = "gpt-5.4"',
-        '# router_model = "claude-opus-4-6"',
-        "",
-        "[output]",
-        "# verbose = false",
-        "",
-        "[pipeline]",
-        "# confidence_threshold = 0.7",
-        "# max_iterations = 5",
+        DEFAULT_CONFIG_TOML.rstrip(),
         "",
         "[project]",
         f'type = "{info.project_type}"',

--- a/plugins/petri_audit/bundle_sync.py
+++ b/plugins/petri_audit/bundle_sync.py
@@ -33,6 +33,8 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+from core.paths import PETRI_LOGS_DIR
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -42,7 +44,7 @@ __all__ = [
 ]
 
 #: Agent context layer — per-machine runtime accumulation.
-RUNTIME_LOGS_DIR: Path = Path.home() / ".geode" / "petri" / "logs"
+RUNTIME_LOGS_DIR: Path = PETRI_LOGS_DIR  # PR-CLEANUP-D2 anchor alias
 
 #: Repo-tracked bundle — committable, Pages-served.
 #: Resolved relative to this module's path so it works from any cwd.

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -81,6 +81,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# PR-CLEANUP-D2 — shared CLI-provider serialisation (single SoT;
+# re-exported so existing call sites and tests stay stable).
+from plugins.petri_audit.prompt_serialisation import (
+    serialise_messages_to_prompt as serialise_messages_to_prompt,
+)
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -558,50 +564,6 @@ def extract_session_id_from_events(events: list[StreamJsonEvent]) -> str:
 # ---------------------------------------------------------------------------
 # Message serialisation
 # ---------------------------------------------------------------------------
-
-
-_ROLE_HEADERS = {
-    "system": "<<<SYSTEM>>>",
-    "user": "<<<USER>>>",
-    "assistant": "<<<ASSISTANT>>>",
-    "tool": "<<<TOOL_RESULT>>>",
-}
-
-
-def serialise_messages_to_prompt(messages: list[Any]) -> str:
-    """Flatten ``inspect_ai.ChatMessage[]`` into a single stdin prompt.
-
-    The ``claude --print`` CLI accepts one prompt over stdin and
-    handles its own system-message setup internally. We preserve
-    multi-turn context by joining role-tagged blocks with sentinels.
-
-    The role-header sentinels (``<<<USER>>>`` etc.) are intentionally
-    visible — the LLM treats them as conversational scaffolding. For
-    inspect_petri's auditor that orchestrates multi-turn dialogues,
-    this matches the existing transcript style.
-
-    Accepts duck-typed messages with ``role`` + ``content`` attrs
-    (pydantic BaseModel) so tests can pass plain SimpleNamespace
-    without importing the inspect_ai ChatMessage classes.
-    """
-    parts: list[str] = []
-    for msg in messages:
-        role = getattr(msg, "role", "user")
-        header = _ROLE_HEADERS.get(role, f"<<<{role.upper()}>>>")
-        content = getattr(msg, "content", "")
-        # Normalise content shape — inspect_ai uses str OR list[Content]
-        # where Content has ``.text`` (text blocks). Tool blocks are
-        # ignored in CSA-1 (CSA-2 handles them).
-        text_chunks: list[str] = []
-        if isinstance(content, str):
-            text_chunks.append(content)
-        elif isinstance(content, list):
-            for block in content:
-                block_text = getattr(block, "text", None)
-                if isinstance(block_text, str):
-                    text_chunks.append(block_text)
-        parts.append(f"{header}\n{''.join(text_chunks).rstrip()}")
-    return "\n\n".join(parts) + "\n"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -140,7 +140,9 @@ def _update_latest_petri_eval_symlink(archive_path: str) -> None:
     from G1).
     """
     target = Path(archive_path).resolve()
-    latest = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"
+    from core.paths import LATEST_PETRI_EVAL
+
+    latest = LATEST_PETRI_EVAL
     try:
         latest.parent.mkdir(parents=True, exist_ok=True)
         if latest.is_symlink() or latest.exists():

--- a/plugins/petri_audit/codex_cli_provider.py
+++ b/plugins/petri_audit/codex_cli_provider.py
@@ -67,6 +67,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# PR-CLEANUP-D2 — shared CLI-provider serialisation (single SoT;
+# re-exported so existing call sites and tests stay stable).
+from plugins.petri_audit.prompt_serialisation import (
+    serialise_messages_to_prompt as serialise_messages_to_prompt,
+)
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -230,38 +236,6 @@ def build_codex_cli_argv(
 # ---------------------------------------------------------------------------
 # Message serialisation
 # ---------------------------------------------------------------------------
-
-
-_ROLE_HEADERS = {
-    "system": "<<<SYSTEM>>>",
-    "user": "<<<USER>>>",
-    "assistant": "<<<ASSISTANT>>>",
-    "tool": "<<<TOOL_RESULT>>>",
-}
-
-
-def serialise_messages_to_prompt(messages: list[Any]) -> str:
-    """Flatten ``inspect_ai.ChatMessage[]`` into a single stdin prompt.
-
-    Identical strategy to CSA-1's claude provider — role-tagged
-    sentinels preserve multi-turn context in a single prompt blob.
-    codex exec accepts arbitrary prompt text via stdin.
-    """
-    parts: list[str] = []
-    for msg in messages:
-        role = getattr(msg, "role", "user")
-        header = _ROLE_HEADERS.get(role, f"<<<{role.upper()}>>>")
-        content = getattr(msg, "content", "")
-        text_chunks: list[str] = []
-        if isinstance(content, str):
-            text_chunks.append(content)
-        elif isinstance(content, list):
-            for block in content:
-                block_text = getattr(block, "text", None)
-                if isinstance(block_text, str):
-                    text_chunks.append(block_text)
-        parts.append(f"{header}\n{''.join(text_chunks).rstrip()}")
-    return "\n\n".join(parts) + "\n"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/petri_audit/eval_archive.py
+++ b/plugins/petri_audit/eval_archive.py
@@ -45,7 +45,7 @@ __all__ = [
 ]
 
 #: Worktree-independent raw archive. Out of git on purpose (PII / size).
-DEFAULT_RAW_ARCHIVE_DIR: Path = Path("~/.geode/petri/logs").expanduser()
+from core.paths import PETRI_LOGS_DIR as DEFAULT_RAW_ARCHIVE_DIR  # PR-CLEANUP-D2 anchor
 
 #: Committed summary directory under repo root.
 DEFAULT_SUMMARY_DIR: Path = Path("docs/audits/eval-logs")

--- a/plugins/petri_audit/prompt_serialisation.py
+++ b/plugins/petri_audit/prompt_serialisation.py
@@ -1,0 +1,54 @@
+"""Shared CLI-provider prompt serialisation (PR-CLEANUP-D2, 2026-06-10).
+
+The role-header sentinel dict and ``serialise_messages_to_prompt`` used to
+be byte-near-identical copies in ``claude_cli_provider`` and
+``codex_cli_provider`` (the codex docstring admitted "Identical strategy to
+CSA-1's claude provider"). A sentinel change on one side would have forked
+the transcript wire format between the two subscription-CLI backends —
+this module is the single SoT both import.
+
+The role-header sentinels (``<<<USER>>>`` etc.) are intentionally visible —
+the LLM treats them as conversational scaffolding, matching inspect_petri's
+multi-turn transcript style.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ROLE_HEADERS = {
+    "system": "<<<SYSTEM>>>",
+    "user": "<<<USER>>>",
+    "assistant": "<<<ASSISTANT>>>",
+    "tool": "<<<TOOL_RESULT>>>",
+}
+
+
+def serialise_messages_to_prompt(messages: list[Any]) -> str:
+    """Flatten ``inspect_ai.ChatMessage[]`` into a single stdin prompt.
+
+    Both subscription CLIs (``claude --print`` / ``codex exec``) accept one
+    prompt blob over stdin; multi-turn context is preserved by joining
+    role-tagged blocks with sentinels.
+
+    Accepts duck-typed messages with ``role`` + ``content`` attrs
+    (pydantic BaseModel) so tests can pass plain SimpleNamespace without
+    importing the inspect_ai ChatMessage classes. Content is ``str`` OR
+    ``list[Content]`` where Content has ``.text``; tool blocks are ignored
+    in CSA-1 (CSA-2 handles them).
+    """
+    parts: list[str] = []
+    for msg in messages:
+        role = getattr(msg, "role", "user")
+        header = ROLE_HEADERS.get(role, f"<<<{role.upper()}>>>")
+        content = getattr(msg, "content", "")
+        text_chunks: list[str] = []
+        if isinstance(content, str):
+            text_chunks.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                block_text = getattr(block, "text", None)
+                if isinstance(block_text, str):
+                    text_chunks.append(block_text)
+        parts.append(f"{header}\n{''.join(text_chunks).rstrip()}")
+    return "\n\n".join(parts) + "\n"

--- a/plugins/seed_generation/baseline_reader.py
+++ b/plugins/seed_generation/baseline_reader.py
@@ -47,6 +47,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from core.paths import LATEST_PETRI_EVAL
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -422,7 +424,8 @@ def pick_regression_target(
     raise ValueError(f"unknown seed-generation cohort {cohort!r}; expected one of {SEED_COHORTS}")
 
 
-LATEST_PETRI_EVAL_PATH = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"
+LATEST_PETRI_EVAL_PATH = LATEST_PETRI_EVAL  # PR-CLEANUP-D2 anchor alias
+
 """G2.fix (2026-05-20) — petri's `.eval` archive is the single SoT for
 per-dim evidence. ``plugins.petri_audit.cli_audit`` updates this symlink
 after every audit (rejected or promoted); :func:`format_evidence_block`

--- a/plugins/seed_generation/resume.py
+++ b/plugins/seed_generation/resume.py
@@ -248,7 +248,11 @@ def _dict_or_none(value: Any) -> dict[str, float] | None:
 
 def _deserialize_ranker_outcomes(payloads: list[dict[str, Any]]) -> list[MatchOutcome]:
     outcomes: list[MatchOutcome] = []
-    valid_winners = {"A", "B", "tie"}
+    # PR-CLEANUP-D2 — vocabulary anchored in ranker (the writer);
+    # drift here silently dropped resumed vote rows.
+    from plugins.seed_generation.agents.ranker import _VALID_WINNER_LABELS
+
+    valid_winners = _VALID_WINNER_LABELS
     for payload in payloads:
         winner = payload.get("winner")
         if winner not in valid_winners:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.152"
+version = "0.99.153"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -96,6 +96,7 @@ DEFAULT_SEEDS_ROOT = Path("docs/self-improving/petri-bundle/seeds")
 # PR-CLEANUP-D2 (2026-06-10) — the default output IS the campaign's input
 # pool, anchored in core.paths (was a cwd-relative third copy of the path).
 from core.paths import CYCLE_INPUT_POOL as DEFAULT_OUT
+
 DEFAULT_RUNS = 2
 
 

--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -81,6 +81,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from core.paths import CYCLE_INPUT_POOL
 from core.self_improving.loop.baseline_epoch import seed_pool_content_hash
 
 _LOGGER = logging.getLogger("assemble_seed_pool")
@@ -91,11 +92,9 @@ _LOGGER = logging.getLogger("assemble_seed_pool")
 _MALFORMED_SORT_KEY: tuple[int, ...] = ()
 
 DEFAULT_SEEDS_ROOT = Path("docs/self-improving/petri-bundle/seeds")
-#: Default pool destination — under the repo ``state/`` tree (GEODE convention
-#: for runtime artefacts), never ``/tmp``.
-# PR-CLEANUP-D2 (2026-06-10) — the default output IS the campaign's input
-# pool, anchored in core.paths (was a cwd-relative third copy of the path).
-from core.paths import CYCLE_INPUT_POOL as DEFAULT_OUT
+#: Default pool destination — the campaign's input pool, anchored in
+#: core.paths (PR-CLEANUP-D2; was a cwd-relative third copy of the path).
+DEFAULT_OUT = CYCLE_INPUT_POOL
 
 DEFAULT_RUNS = 2
 

--- a/scripts/assemble_seed_pool.py
+++ b/scripts/assemble_seed_pool.py
@@ -93,7 +93,9 @@ _MALFORMED_SORT_KEY: tuple[int, ...] = ()
 DEFAULT_SEEDS_ROOT = Path("docs/self-improving/petri-bundle/seeds")
 #: Default pool destination — under the repo ``state/`` tree (GEODE convention
 #: for runtime artefacts), never ``/tmp``.
-DEFAULT_OUT = Path("state/seed-pools/cycle-input")
+# PR-CLEANUP-D2 (2026-06-10) — the default output IS the campaign's input
+# pool, anchored in core.paths (was a cwd-relative third copy of the path).
+from core.paths import CYCLE_INPUT_POOL as DEFAULT_OUT
 DEFAULT_RUNS = 2
 
 

--- a/tests/test_doctor_bootstrap.py
+++ b/tests/test_doctor_bootstrap.py
@@ -51,13 +51,14 @@ class TestCheckEnvFile:
     def test_present(self, tmp_path):
         env_path = tmp_path / ".env"
         env_path.write_text("ANTHROPIC_API_KEY=sk-ant-test")
-        with patch("pathlib.Path.expanduser", return_value=env_path):
+        with patch("core.paths.GLOBAL_ENV_FILE", env_path):
             result = _check_env_file()
         assert result.ok is True
 
     def test_absent(self, tmp_path):
+        # PR-CLEANUP-D2 — patch the core.paths anchor, not Path.expanduser.
         env_path = tmp_path / "missing" / ".env"
-        with patch("pathlib.Path.expanduser", return_value=env_path):
+        with patch("core.paths.GLOBAL_ENV_FILE", env_path):
             result = _check_env_file()
         assert result.ok is False
         assert "geode setup" in result.fix
@@ -126,8 +127,10 @@ class TestCheckProfileStore:
 
 class TestCheckServeSocket:
     def test_socket_absent(self, tmp_path):
+        # PR-CLEANUP-D2 — the socket path is the core.paths anchor now;
+        # patch the anchor, not Path.expanduser.
         sock_path = tmp_path / "missing.sock"
-        with patch("pathlib.Path.expanduser", return_value=sock_path):
+        with patch("core.paths.CLI_SOCKET_PATH", sock_path):
             result = _check_serve_socket()
         assert result.ok is False
         assert "geode serve" in result.fix

--- a/tests/test_geode_init.py
+++ b/tests/test_geode_init.py
@@ -42,7 +42,6 @@ class TestGeodeInit:
         assert config_path.exists()
         content = config_path.read_text(encoding="utf-8")
         assert "[llm]" in content
-        assert "[pipeline]" in content
 
     def test_does_not_overwrite_existing_config(self, tmp_path, monkeypatch):
         """init preserves existing config.toml without --force."""

--- a/uv.lock
+++ b/uv.lock
@@ -1349,7 +1349,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.152"
+version = "0.99.153"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 중복 감사의 리터럴 거울 잔여 전량을 단일 SoT로: **petri logs 경로 6사본**(writer 1 + graceful-None reader 5 — 무에러 단절 코스) → `core/paths.py` 앵커, **seed-pool 경로 3중 해석**(6-03 워커 전멸 사고 코드형태) → `SEED_POOLS_DIR` 군, CLI 부트스트랩 3파일의 paths 우회(+stale opus-4-6 템플릿) → 기존 앵커 import, config 템플릿 fork → `DEFAULT_CONFIG_TOML` 확장, campaign CLI 기본값/arm 집합/train argv → 모듈 상수 import, petri CLI provider 직렬화기 복제 → 신규 `prompt_serialisation.py`, voter vocab → ranker 앵커.
- 의미 변경 0 — 전부 같은 값을 한 곳에서 읽게 하는 구조 수정. seed-pool의 GEODE_STATE_ROOT 존중 여부는 의미 결정이라 D-3로 명시 이월(앵커 주석에 기록).

## Why
6-03 사고(assemble custom --out → 전 워커 "train.py exited 1" drop)와 v0.99.145 모델해석 버그(데몬 경로 split)가 정확히 이 패밀리에서 났고, petri logs 거울은 reader 전원이 graceful-None이라 writer 이동 시 fitness 증거·baseline이 **에러 없이** 끊기는 최악 형태였음. CANNOT dual-SoT 행 해소.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `PETRI_LOGS_DIR`/`LATEST_PETRI_EVAL` + `SEED_POOLS_DIR`/`CYCLE_INPUT_POOL`/`HELD_OUT_BENCH_POOL` 신설 |
| petri 6사이트 | cli_audit(writer)·train·baseline_reader·campaign·eval_archive·bundle_sync → 앵커 alias |
| `core/self_improving/campaign.py` | seed-pool/petri 경로 앵커 + `TRAIN_MODULE` 상수 + arm 검증이 train의 `_VALID_PROMOTE_POLICIES` import |
| `scripts/assemble_seed_pool.py` | cwd-상대 DEFAULT_OUT → `CYCLE_INPUT_POOL` |
| `core/cli/{typer_commands,doctor_bootstrap,typer_init}.py` | 인라인 `~/.geode/*` 5종 → `CLI_SOCKET_PATH`/`GLOBAL_ENV_FILE`/`GEODE_HOME`/`PROJECT_MODEL_POLICY`/`GLOBAL_IDENTITY_DIR` + 템플릿 opus-4-8 |
| `core/utils/project_detect.py` | `generate_config_toml`이 `DEFAULT_CONFIG_TOML` 확장 (이미 드리프트된 fork 제거) |
| `core/cli/__init__.py` | campaign DEFAULT_* 상수 import (37ms — 콜드스타트 수용) |
| `core/self_improving/loop/runner.py` | train argv → `TRAIN_MODULE` |
| `plugins/petri_audit/prompt_serialisation.py` 신규 + provider 2파일 | 직렬화기 단일화 (`a is b` 확인) |
| `plugins/seed_generation/resume.py` | voter vocab → ranker import |
| tests 3파일 | 앵커 patch 방식으로 이행 (`Path.expanduser` 광역 patch 제거), 삭제된 [pipeline] 단언 제거 |

## Verification
- [x] ruff check + format clean (981 files), mypy 변경분 0 (codex_overrides 3건=기지 venv 이슈), lint-imports 4 kept
- [x] pytest full suite green (기지 환경 의존 5건 deselect + order-flake 2건 단독 green — CI 판정)
- [x] 직렬화기 identity 검증: 양 provider의 `serialise_messages_to_prompt`가 동일 객체
- [x] CLI smoke: geode version → v0.99.153

## Reference
- 2026-06-10 중복·데드코드 감사 Top-10 #1/#3/#6/#7/#9 + 1.6/1.7/1.8/1.9
- 사고 계보: 2026-06-03 seed-pool 워커 전멸 / v0.99.145 모델해석 데몬-경로 split