### PR TITLE
feat(cli+mcp): /recall slash surface + geode-mcp first-class entry point (v0.99.155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [0.99.155] - 2026-06-10
+
+### Added
+- **`/recall` slash command (D-3 (3), PR-D3B)** — operator surface for the memory-recall pool that the OL-C3 writer promised but never shipped: `save` (writes a frontmatter MD via `core/memory/recall_writer.write_recall_entry`, interactive prompts for missing fields on a TTY, fail-loud without one), `list` (dense table rendered through the M4.4.1 reader's own parser — one schema, one parser), `show` (verbatim entry). Registered across `COMMAND_REGISTRY` (THIN) / `COMMAND_MAP` / dispatcher / help.
+- **`geode-mcp` first-class entry point (D-3 (4), PR-D3B)** — `core/mcp_server.py` promoted from a 2-tool analysis shell to GEODE's MCP surface (console script `geode-mcp`, FastMCP server renamed `geode-analysis` → `geode`): `run_agent` (agentic one-shot via the shared minimal stack), `self_improving_status` (promoted baseline + mutation-ledger tail), and `self_improving_propose` / `self_improving_apply` (two-step contract — the MCP client is the confirmation gate, mirroring the slash's y/N prompt; apply refuses unknown `mutation_id`).
+
+### Changed
+- `core.cli.bootstrap._build_agentic_stack_minimal` promoted to public `run_agentic_oneshot(prompt, *, quiet, time_budget_s)` — context:fork skill execution and the `geode-mcp` `run_agent` tool share one stack (callers migrated in the same PR).
+
 ## [0.99.154] - 2026-06-10
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.154
+- **Version**: 0.99.155
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 375 core + 67 plugins = 442
-- **Tests**: 8504 (+5 live)
+- **Modules**: 376 core + 67 plugins = 443
+- **Tests**: 8515 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.154 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.155 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.154 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.155 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -187,11 +187,19 @@ def bootstrap_geode(
     )
 
 
-def _build_agentic_stack_minimal(prompt: str, *, quiet: bool = True) -> Any:
-    """Build a minimal isolated AgenticLoop and run a prompt (for context:fork skills).
+def run_agentic_oneshot(
+    prompt: str,
+    *,
+    quiet: bool = True,
+    time_budget_s: float = 60.0,
+) -> Any:
+    """Build a minimal isolated AgenticLoop and run a prompt one-shot.
 
     Returns AgenticResult.  Inline construction — no SharedServices overhead.
-    Fork is a lightweight one-shot execution, not a session mode.
+    One-shot execution, not a session mode. Callers: context:fork skill
+    execution (``cmd_skill_invoke``) and the ``geode-mcp`` ``run_agent``
+    tool (D-3 ④, 2026-06-10 — promoted from the private
+    ``_build_agentic_stack_minimal`` so both surfaces share one stack).
     """
     from core.agent.conversation import ConversationContext
     from core.agent.loop import AgenticLoop
@@ -209,7 +217,7 @@ def _build_agentic_stack_minimal(prompt: str, *, quiet: bool = True) -> Any:
         model=_stk_settings.model,
         provider=_resolve_provider(_stk_settings.model),
         quiet=quiet,
-        time_budget_s=60.0,
+        time_budget_s=time_budget_s,
         max_rounds=0,
     )
     return run_process_coroutine(loop.arun(prompt))

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -223,6 +223,7 @@ COMMAND_MAP: dict[str, str] = {
     "/petri": "petri",
     "/self-improving": "self-improving",
     "/sil": "self-improving",
+    "/recall": "recall",
 }
 
 
@@ -252,6 +253,7 @@ def show_help() -> None:
     console.print("  [label]/context[/label]            — Show assembled context tiers")
     console.print("  [label]/apply[/label]              — Manage job applications")
     console.print("  [label]/tasks[/label]              — Show task list")
+    console.print("  [label]/recall[/label]             — Memory-recall pool (list/show/save)")
     console.print("  [label]/compact[/label]            — Compact conversation context")
     console.print("  [label]/clear[/label]              — Clear conversation history")
     console.print("  [label]/help[/label]               — Show this help")

--- a/core/cli/commands/recall.py
+++ b/core/cli/commands/recall.py
@@ -1,0 +1,223 @@
+"""``/recall`` REPL slash command — operator surface for the memory-recall pool.
+
+D-3 decision ③ (2026-06-10) — OL-C3 shipped the *writer*
+(``core/memory/recall_writer.write_recall_entry``) as a pure utility whose
+docstring promised "operator calls ``write_recall_entry(...)`` via CLI /
+REPL slash", but no slash existed. The M4.4.1 *reader*
+(``core/self_improving/loop/memory_recall.py``, injected through
+``in_context_wiring``) has been live the whole time, so the pool's only
+write path was hand-editing ``~/.geode/memory/recall/*.md``. This module
+closes that loop.
+
+Sub-actions:
+
+  /recall                       list (default)
+  /recall list                  dense table — name / type / description
+  /recall show <name>           print one entry verbatim
+  /recall save <name> [--type t] [--desc "..."] [--body "..."] [--overwrite]
+                                write one entry; missing --desc/--body are
+                                prompted interactively when a TTY is attached
+
+Read-write parity: ``list`` / ``show`` resolve the pool directory through
+the same env override (``$GEODE_MEMORY_RECALL_DIR``) the reader and writer
+share, and ``list`` parses entries with the reader's own parser
+(``load_memory_entries``) — one frontmatter schema, one parser.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+from core.ui.console import console
+
+__all__ = ["cmd_recall"]
+
+_VALID_TYPES_HINT = "user / feedback / project / reference"
+
+
+def cmd_recall(args: str) -> None:
+    """Dispatch the ``/recall`` sub-action. Empty args → ``list``."""
+    try:
+        parts = shlex.split(args) if args else []
+    except ValueError as exc:
+        console.print(f"  [warning]argument parse failed: {exc}[/warning]")
+        return
+    action = parts[0] if parts else "list"
+
+    if action == "list":
+        _cmd_list()
+        return
+    if action == "show":
+        _cmd_show(parts[1:])
+        return
+    if action == "save":
+        _cmd_save(parts[1:])
+        return
+
+    console.print()
+    console.print(f"  [warning]Unknown action: /recall {action}[/warning]")
+    console.print("  [muted]Available: list / show <name> / save <name> [flags][/muted]")
+    console.print()
+
+
+def _cmd_list() -> None:
+    """Render the recall pool as a dense table (reader's parser = one schema)."""
+    from core.memory.recall_writer import resolve_recall_dir
+    from core.self_improving.loop.memory_recall import load_memory_entries
+
+    entries = load_memory_entries()
+    console.print()
+    console.print("  [header]Memory recall pool[/header]")
+    console.print(f"  [muted]{resolve_recall_dir()}[/muted]")
+    console.print()
+    if not entries:
+        console.print("    [muted]no entries — /recall save <name> writes the first one[/muted]")
+        console.print()
+        return
+    name_width = max(len(e.name) for e in entries)
+    type_width = max((len(e.type) for e in entries if e.type), default=4)
+    for entry in sorted(entries, key=lambda e: e.name):
+        type_label = entry.type or "-"
+        console.print(
+            f"    {entry.name:<{name_width}}  [muted]{type_label:<{type_width}}[/muted]  "
+            f"{_clip(entry.description, 80)}"
+        )
+    console.print()
+    console.print(f"  [muted]{len(entries)} entries · /recall show <name> for full body[/muted]")
+    console.print()
+
+
+def _cmd_show(opts: list[str]) -> None:
+    """Print one entry's file verbatim (frontmatter + body)."""
+    from core.memory.recall_writer import resolve_recall_dir
+
+    if not opts:
+        console.print("  [warning]show: needs an entry name — /recall show <name>[/warning]")
+        return
+    name = opts[0]
+    file_path = resolve_recall_dir() / f"{name}.md"
+    if not file_path.is_file():
+        console.print()
+        console.print(f"  [warning]no entry named {name!r}[/warning] [muted]({file_path})[/muted]")
+        console.print("  [muted]/recall list shows available names[/muted]")
+        console.print()
+        return
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        console.print(f"  [warning]read failed:[/warning] {exc}")
+        return
+    console.print()
+    console.print(f"  [muted]{file_path}[/muted]")
+    console.print()
+    console.print(content)
+
+
+def _cmd_save(opts: list[str]) -> None:
+    """Write one entry via ``write_recall_entry``.
+
+    Positional ``<name>`` is required. ``--desc`` / ``--body`` fall back
+    to interactive prompts on a TTY; without a TTY they are required flags
+    so scripted callers fail loudly instead of writing empty fields.
+    """
+    from core.memory.recall_writer import (
+        RECALL_TYPE_FEEDBACK,
+        VALID_RECALL_TYPES,
+        write_recall_entry,
+    )
+
+    name = ""
+    type_label = RECALL_TYPE_FEEDBACK
+    description = ""
+    body = ""
+    overwrite = False
+    i = 0
+    while i < len(opts):
+        tok = opts[i]
+        if tok == "--overwrite":
+            overwrite = True
+        elif tok in {"--type", "--desc", "--body"}:
+            if i + 1 >= len(opts):
+                console.print(f"  [warning]{tok} requires a value[/warning]")
+                return
+            value = opts[i + 1]
+            if tok == "--type":
+                type_label = value
+            elif tok == "--desc":
+                description = value
+            else:
+                body = value
+            i += 1
+        elif tok.startswith("--"):
+            console.print(f"  [warning]unknown flag: {tok!r}[/warning]")
+            return
+        elif not name:
+            name = tok
+        else:
+            console.print(f"  [warning]unexpected extra argument: {tok!r}[/warning]")
+            return
+        i += 1
+
+    if not name:
+        console.print(
+            "  [warning]save: needs a name — "
+            '/recall save <name> [--type t] [--desc "..."] [--body "..."][/warning]'
+        )
+        return
+    if type_label not in VALID_RECALL_TYPES:
+        console.print(
+            f"  [warning]invalid type: {type_label!r} (valid: {_VALID_TYPES_HINT})[/warning]"
+        )
+        return
+
+    if not description:
+        prompted_desc = _prompt_field("description (one line)", flag="--desc")
+        if prompted_desc is None:
+            return
+        description = prompted_desc
+    if not body:
+        prompted_body = _prompt_field("body", flag="--body")
+        if prompted_body is None:
+            return
+        body = prompted_body
+    if not description or not body:
+        console.print("  [warning]save: description and body must be non-empty[/warning]")
+        return
+
+    written_path = write_recall_entry(
+        name=name,
+        description=description,
+        body=body,
+        type_label=type_label,
+        overwrite=overwrite,
+    )
+    console.print()
+    if written_path is None:
+        console.print(
+            f"  [warning]not written[/warning] — entry {name!r} already exists "
+            "(re-run with --overwrite) or the write failed (see log)"
+        )
+    else:
+        console.print(f"  [success]saved[/success]  {written_path}")
+        console.print(f"    type {type_label} · injected by memory-recall on keyword match")
+    console.print()
+
+
+def _prompt_field(label: str, *, flag: str) -> str | None:
+    """Interactive fallback for a missing field. ``None`` = abort."""
+    if not sys.stdin.isatty():
+        console.print(f"  [warning]save: {flag} is required without a TTY[/warning]")
+        return None
+    try:
+        return str(console.input(f"  {label}: ")).strip()
+    except (EOFError, KeyboardInterrupt):
+        console.print()
+        console.print("  [muted]aborted[/muted]")
+        return None
+
+
+def _clip(s: str, n: int) -> str:
+    if len(s) <= n:
+        return s
+    return s[: n - 1] + "…"

--- a/core/cli/commands/skills.py
+++ b/core/cli/commands/skills.py
@@ -121,10 +121,10 @@ def cmd_skill_invoke(skill_registry: _Any, arg: str, *, agentic_ref: _Any = None
     if skill.context_fork:
         # Fork execution: run in isolated subagent
         _pkg.console.print(f"  [dim]Skill '{name}' → forked subagent[/dim]")
-        from core.cli.bootstrap import _build_agentic_stack_minimal
+        from core.cli.bootstrap import run_agentic_oneshot
 
         try:
-            result = _build_agentic_stack_minimal(rendered, quiet=True)
+            result = run_agentic_oneshot(rendered, quiet=True)
             status = "ok" if result and not getattr(result, "error", False) else "err"
             summary = getattr(result, "text", "")[:200] if result else "(no output)"
             _pkg.console.print(f"  [dim]skill:{name} → {status}[/dim]")

--- a/core/cli/dispatcher.py
+++ b/core/cli/dispatcher.py
@@ -163,6 +163,10 @@ def _handle_command(
         from core.cli.commands.self_improving import cmd_self_improving
 
         cmd_self_improving(args)
+    elif action == "recall":
+        from core.cli.commands.recall import cmd_recall
+
+        cmd_recall(args)
     elif action == "stop":
         # v0.63.0 — Hermes-style daemon shutdown (`hermes stop`).
         # Args: ``/stop --force`` for SIGKILL, optional ``--timeout=N``.

--- a/core/cli/routing.py
+++ b/core/cli/routing.py
@@ -109,6 +109,12 @@ COMMAND_REGISTRY: dict[str, CommandSpec] = {
         description="Self-improving loop status (PR-OPS-1 — run/history/rollback deferred)",
         handler_path="core.cli.commands.self_improving:cmd_self_improving",
     ),
+    "/recall": CommandSpec(
+        name="/recall",
+        location=RunLocation.THIN,
+        description="Memory-recall pool — list/show/save persistent memory entries",
+        handler_path="core.cli.commands.recall:cmd_recall",
+    ),
     # ────────── DAEMON_RPC — short read-only daemon queries ──────────
     # Phase 4에서 core/server/handlers/ 로 이동 후 handler_path 갱신.
     # 현재는 cli/__init__.py:_handle_command 가 IPC RPC로 위임 (호환).

--- a/core/mcp_server.py
+++ b/core/mcp_server.py
@@ -1,8 +1,23 @@
-"""GEODE MCP Server — expose generic GEODE tools.
+"""GEODE MCP Server — expose GEODE's agentic + self-improving surface.
 
-This module keeps the FastMCP server shell, the two domain-agnostic tools
-(``query_memory``, ``get_health``), the ``geode://soul`` resource, and the
-``main()`` stdio entry point.
+D-3 decision ④ (2026-06-10) promoted this module from a 2-tool analysis
+shell (``query_memory`` / ``get_health``) to a first-class entry point —
+``geode-mcp`` console script (stdio transport). Any MCP host (Claude Code,
+Codex CLI, claude.ai connectors) can:
+
+* ``run_agent`` — execute a GEODE agentic one-shot (same minimal stack as
+  context:fork skill execution, ``core.cli.bootstrap.run_agentic_oneshot``).
+* ``self_improving_status`` — read the promoted baseline + recent mutation
+  ledger rows (same SoTs as the ``/self-improving status`` slash).
+* ``self_improving_propose`` / ``self_improving_apply`` — drive the
+  mutator's propose → confirm → apply cycle. Two separate tools on
+  purpose: the MCP client *is* the confirmation gate (mirrors the slash's
+  interactive y/N prompt), so a propose result must be explicitly echoed
+  back via its ``mutation_id`` before anything is written.
+
+Register in an MCP host (example, Claude Code):
+
+    claude mcp add geode -- geode-mcp
 """
 
 from __future__ import annotations
@@ -18,12 +33,71 @@ _MCP_TOOLS_PATH = Path(__file__).resolve().parent / "tools" / "mcp_tools.json"
 with _MCP_TOOLS_PATH.open(encoding="utf-8") as _f:
     _TOOL_DESCRIPTIONS: dict[str, str] = json.load(_f)
 
+_STATUS_RECENT_N = 5
+
+
+def _self_improving_status_payload() -> dict[str, Any]:
+    """Read-only loop status — promoted baseline + recent mutation rows.
+
+    Reads the same two SoTs as ``/self-improving status``: the *promoted*
+    ``baseline.json`` (updated only when a mutation passes the gate — not
+    a "latest measurement" file) and the tail of ``mutations.jsonl``.
+    Missing files yield ``None`` / ``[]`` rather than raising so an MCP
+    client can poll on a fresh clone.
+    """
+    from core.paths import MUTATION_AUDIT_LOG_PATH
+
+    audit_path = Path(MUTATION_AUDIT_LOG_PATH)
+    baseline_path = audit_path.parent / "baseline.json"
+
+    baseline: dict[str, Any] | None = None
+    if baseline_path.is_file():
+        try:
+            parsed = json.loads(baseline_path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                baseline = {
+                    "fitness": parsed.get("fitness"),
+                    "ts_utc": parsed.get("ts_utc") or parsed.get("timestamp"),
+                    "session_id": parsed.get("session_id"),
+                    "schema_version": parsed.get("schema_version"),
+                }
+        except (OSError, json.JSONDecodeError):
+            baseline = None
+
+    recent: list[dict[str, Any]] = []
+    if audit_path.is_file():
+        try:
+            lines = audit_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            lines = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                recent.append(
+                    {
+                        "ts": row.get("ts") or row.get("timestamp"),
+                        "kind": row.get("kind") or "applied",
+                        "mutation_id": row.get("mutation_id") or row.get("id"),
+                        "target_kind": row.get("target_kind"),
+                        "target_section": row.get("target_section"),
+                    }
+                )
+        recent = recent[-_STATUS_RECENT_N:]
+
+    return {"baseline": baseline, "recent_mutations": recent}
+
 
 def create_mcp_server() -> Any:
     """Create and configure the GEODE MCP server.
 
-    Returns a FastMCP Server instance with the generic core tools/resources
-    registered.
+    Returns a FastMCP Server instance with the agentic, self-improving,
+    and memory tools/resources registered.
 
     Requires the ``mcp`` package to be installed.
     """
@@ -34,10 +108,67 @@ def create_mcp_server() -> Any:
             "MCP server requires the 'mcp' package. Install with: uv add mcp"
         ) from None
 
-    mcp = FastMCP("geode-analysis")
+    mcp = FastMCP("geode")
 
     # Shared ProjectMemory instance (created once per server lifetime)
     _project_memory: Any = None
+    # Pending mutator proposals — propose() parks here keyed by mutation_id;
+    # apply() consumes. The two-step contract is the MCP confirmation gate.
+    _pending_proposals: dict[str, tuple[Any, Any]] = {}
+
+    @mcp.tool(description=_TOOL_DESCRIPTIONS["run_agent"])
+    def run_agent(prompt: str, time_budget_s: float = 120.0) -> dict[str, Any]:
+        """Run one GEODE agentic one-shot and return the result."""
+        from core.cli.bootstrap import run_agentic_oneshot
+
+        result = run_agentic_oneshot(prompt, quiet=True, time_budget_s=time_budget_s)
+        return {
+            "text": getattr(result, "text", ""),
+            "rounds": getattr(result, "rounds", 0),
+            "termination_reason": getattr(result, "termination_reason", "unknown"),
+            "error": getattr(result, "error", None),
+        }
+
+    @mcp.tool(description=_TOOL_DESCRIPTIONS["self_improving_status"])
+    def self_improving_status() -> dict[str, Any]:
+        """Promoted baseline + recent mutation ledger rows."""
+        return _self_improving_status_payload()
+
+    @mcp.tool(description=_TOOL_DESCRIPTIONS["self_improving_propose"])
+    def self_improving_propose() -> dict[str, Any]:
+        """Propose one scaffold mutation — nothing is written yet."""
+        from core.self_improving.loop.runner import SelfImprovingLoopRunner
+
+        runner = SelfImprovingLoopRunner(rerun_enabled=False, commit_enabled=True)
+        proposal = runner.propose()
+        mutation = proposal.mutation
+        _pending_proposals[mutation.mutation_id] = (runner, proposal)
+        return {
+            "mutation_id": mutation.mutation_id,
+            "target_kind": mutation.target_kind,
+            "target_section": mutation.target_section,
+            "previous_value": proposal.target_sections.get(mutation.target_section, ""),
+            "new_value": mutation.new_value,
+            "rationale": mutation.rationale,
+            "baseline_fitness": proposal.baseline_fitness,
+            "next_step": "call self_improving_apply with this mutation_id to write it",
+        }
+
+    @mcp.tool(description=_TOOL_DESCRIPTIONS["self_improving_apply"])
+    def self_improving_apply(mutation_id: str) -> dict[str, Any]:
+        """Apply a previously proposed mutation (confirmation step)."""
+        entry = _pending_proposals.pop(mutation_id, None)
+        if entry is None:
+            return {
+                "applied": False,
+                "error": (
+                    f"no pending proposal {mutation_id!r} in this server session — "
+                    "call self_improving_propose first"
+                ),
+            }
+        runner, proposal = entry
+        runner.apply_proposal(proposal)
+        return {"applied": True, "mutation_id": mutation_id}
 
     @mcp.tool(description=_TOOL_DESCRIPTIONS["query_memory"])
     def query_memory(query: str) -> dict[str, Any]:
@@ -75,7 +206,7 @@ def create_mcp_server() -> Any:
 
 
 def main() -> None:
-    """Entry point for running the MCP server."""
+    """Entry point for running the MCP server (``geode-mcp`` console script)."""
     import sys
 
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)

--- a/core/tools/mcp_tools.json
+++ b/core/tools/mcp_tools.json
@@ -1,4 +1,8 @@
 {
   "query_memory": "Search GEODE memory across tiers (session, project, organization).",
-  "get_health": "Get GEODE pipeline health status and component stats."
+  "get_health": "Get GEODE pipeline health status and component stats.",
+  "run_agent": "Run one GEODE agentic one-shot: plan/act/observe rounds with GEODE's tool set until the prompt is answered or time_budget_s expires. Returns the final text, round count, and termination reason.",
+  "self_improving_status": "Read-only self-improving loop status: the promoted baseline (fitness, timestamp) and the most recent mutation ledger rows (applied / rejected / rolled_back).",
+  "self_improving_propose": "Propose ONE scaffold mutation via the self-improving mutator LLM. Nothing is written — review the returned diff (previous_value vs new_value, rationale), then confirm with self_improving_apply.",
+  "self_improving_apply": "Apply a mutation previously returned by self_improving_propose, identified by mutation_id. This writes the scaffold SoT and appends to the mutation ledger. Proposals are held only for the current server session."
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.154"
+version = "0.99.155"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -46,6 +46,9 @@ dependencies = [
 
 [project.scripts]
 geode = "core.cli:app"
+# D-3 (4) 2026-06-10 — first-class MCP entry point: agentic one-shot +
+# self-improving propose/apply + memory tools over stdio.
+geode-mcp = "core.mcp_server:main"
 
 # inspect_ai discovers third-party model providers via the `inspect_ai`
 # entry-point group (importlib.metadata). When the [audit] extra is

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -430,15 +430,15 @@ class TestAgenticLoop:
     def test_internal_sync_entrypoints_bridge_to_arun_not_run(self) -> None:
         """Production entrypoints should not route through AgenticLoop.run()."""
         from core.agent.worker import _run_agentic
-        from core.cli.bootstrap import _build_agentic_stack_minimal
+        from core.cli.bootstrap import run_agentic_oneshot
         from core.cli.commands.skills import cmd_skill_invoke
         from core.cli.scheduler_drain import drain_scheduler_queue
         from core.cli.typer_serve import serve
         from core.server.ipc_server.poller import CLIPoller
 
         forbidden = {
-            "_build_agentic_stack_minimal": (
-                inspect.getsource(_build_agentic_stack_minimal),
+            "run_agentic_oneshot": (
+                inspect.getsource(run_agentic_oneshot),
                 ["return loop.run("],
             ),
             "drain_scheduler_queue": (

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -1,0 +1,112 @@
+"""``geode-mcp`` server surface — D-3 decision ④ (2026-06-10).
+
+Pins the promotion from a 2-tool analysis shell to the first-class entry
+point: server identity, the agentic + self-improving tool registration,
+the propose→apply two-step confirmation contract, and the read-only
+status payload's graceful empty states.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from core.mcp_server import _self_improving_status_payload, create_mcp_server
+
+EXPECTED_TOOLS = {
+    "run_agent",
+    "self_improving_status",
+    "self_improving_propose",
+    "self_improving_apply",
+    "query_memory",
+    "get_health",
+}
+
+
+def test_server_identity_and_tool_surface() -> None:
+    server = create_mcp_server()
+    assert server.name == "geode"
+    tools = asyncio.run(server.list_tools())
+    names = {tool.name for tool in tools}
+    assert names >= EXPECTED_TOOLS
+
+
+def test_tool_descriptions_sourced_from_json() -> None:
+    """Every registered core tool keeps its description in mcp_tools.json."""
+    descriptions_path = Path("core/tools/mcp_tools.json")
+    described = set(json.loads(descriptions_path.read_text(encoding="utf-8")))
+    assert described >= EXPECTED_TOOLS
+
+
+def test_apply_without_propose_is_refused() -> None:
+    """Two-step contract — apply must not write without a parked proposal."""
+    server = create_mcp_server()
+    result = asyncio.run(server.call_tool("self_improving_apply", {"mutation_id": "nope"}))
+    payload = result[1] if isinstance(result, tuple) else result
+    text = json.dumps(payload, default=str)
+    assert "no pending proposal" in text
+
+
+def test_status_payload_graceful_on_missing_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import core.paths as core_paths
+
+    monkeypatch.setattr(
+        core_paths, "MUTATION_AUDIT_LOG_PATH", tmp_path / "state" / "mutations.jsonl"
+    )
+    payload = _self_improving_status_payload()
+    assert payload == {"baseline": None, "recent_mutations": []}
+
+
+def test_status_payload_reads_baseline_and_ledger_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import core.paths as core_paths
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    audit_path = state_dir / "mutations.jsonl"
+    monkeypatch.setattr(core_paths, "MUTATION_AUDIT_LOG_PATH", audit_path)
+
+    (state_dir / "baseline.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "fitness": 0.7915,
+                "ts_utc": "2026-06-10T00:00:00Z",
+                "session_id": "s-test",
+            }
+        ),
+        encoding="utf-8",
+    )
+    ledger_rows = [
+        {
+            "ts": float(i),
+            "kind": "applied",
+            "mutation_id": f"m{i}",
+            "target_kind": "identity",
+            "target_section": "core",
+        }
+        for i in range(8)
+    ]
+    audit_path.write_text(
+        "\n".join(json.dumps(row) for row in ledger_rows) + "\nnot-json\n", encoding="utf-8"
+    )
+
+    payload = _self_improving_status_payload()
+    assert payload["baseline"] == {
+        "fitness": 0.7915,
+        "ts_utc": "2026-06-10T00:00:00Z",
+        "session_id": "s-test",
+        "schema_version": 2,
+    }
+    recent = payload["recent_mutations"]
+    assert len(recent) == 5  # tail only
+    assert recent[-1]["mutation_id"] == "m7"
+    assert recent[0]["mutation_id"] == "m3"

--- a/tests/test_recall_command.py
+++ b/tests/test_recall_command.py
@@ -1,0 +1,103 @@
+"""``/recall`` slash command — D-3 decision ③ (2026-06-10).
+
+The OL-C3 writer (``core/memory/recall_writer``) promised a CLI/REPL
+surface in its docstring while the M4.4.1 reader was already live; these
+tests pin the slash that closes the loop: save writes a frontmatter MD
+the reader can parse, list renders via the reader's own parser
+(one schema, one parser), and the no-TTY save path fails loudly instead
+of writing empty fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.cli.commands.recall import cmd_recall
+from core.memory.recall_writer import GEODE_MEMORY_RECALL_DIR_ENV
+
+
+@pytest.fixture()
+def recall_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    pool_dir = tmp_path / "recall"
+    pool_dir.mkdir()
+    monkeypatch.setenv(GEODE_MEMORY_RECALL_DIR_ENV, str(pool_dir))
+    return pool_dir
+
+
+def test_save_writes_reader_parseable_entry(
+    recall_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cmd_recall('save quota-pref --type project --desc "Sonnet on quota" --body "Switch model."')
+
+    entry_file = recall_dir / "quota-pref.md"
+    assert entry_file.is_file()
+    content = entry_file.read_text(encoding="utf-8")
+    assert "name: quota-pref" in content
+    assert "type: project" in content
+    assert content.rstrip().endswith("Switch model.")
+    assert "saved" in capsys.readouterr().out
+
+    # Read-write parity — the M4.4.1 reader must parse what save wrote.
+    from core.self_improving.loop.memory_recall import load_memory_entries
+
+    entries = load_memory_entries()
+    assert [e.name for e in entries] == ["quota-pref"]
+    assert entries[0].type == "project"
+    assert entries[0].description == "Sonnet on quota"
+
+
+def test_save_refuses_duplicate_without_overwrite(
+    recall_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cmd_recall('save dup --desc "first" --body "first body"')
+    cmd_recall('save dup --desc "second" --body "second body"')
+    out = capsys.readouterr().out
+    assert "not written" in out
+    assert "first body" in (recall_dir / "dup.md").read_text(encoding="utf-8")
+
+    cmd_recall('save dup --desc "second" --body "second body" --overwrite')
+    assert "second body" in (recall_dir / "dup.md").read_text(encoding="utf-8")
+
+
+def test_save_rejects_invalid_type(recall_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_recall('save bad --type nonsense --desc "d" --body "b"')
+    assert "invalid type" in capsys.readouterr().out
+    assert not (recall_dir / "bad.md").exists()
+
+
+def test_save_without_body_and_no_tty_fails_loudly(
+    recall_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # pytest's captured stdin is not a TTY — the interactive fallback must
+    # refuse rather than write an empty field.
+    cmd_recall('save no-body --desc "d"')
+    assert "required without a TTY" in capsys.readouterr().out
+    assert not (recall_dir / "no-body.md").exists()
+
+
+def test_list_and_show_roundtrip(recall_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_recall('save alpha --type user --desc "alpha desc" --body "alpha body"')
+    capsys.readouterr()
+
+    cmd_recall("list")
+    listed = capsys.readouterr().out
+    assert "alpha" in listed
+    assert "alpha desc" in listed
+    assert "1 entries" in listed
+
+    cmd_recall("show alpha")
+    shown = capsys.readouterr().out
+    assert "alpha body" in shown
+
+
+def test_show_unknown_name_hints(recall_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_recall("show missing")
+    assert "no entry named" in capsys.readouterr().out
+
+
+def test_unknown_action_hints(capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_recall("frobnicate")
+    out = capsys.readouterr().out
+    assert "Unknown action" in out
+    assert "save" in out

--- a/uv.lock
+++ b/uv.lock
@@ -1349,7 +1349,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.154"
+version = "0.99.155"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- D-3 operator decision ③ — ship the missing `/recall` slash surface over the memory-recall pool: `save` (OL-C3 writer `write_recall_entry`), `list` (rendered via the M4.4.1 reader's own parser — one schema, one parser), `show` (verbatim entry).
- D-3 operator decision ④ — promote `core/mcp_server.py` to a first-class `geode-mcp` entry point (console script, server renamed `geode-analysis` → `geode`) exposing GEODE's agentic + self-improving surface to any MCP host.
- `_build_agentic_stack_minimal` promoted to public `run_agentic_oneshot(prompt, *, quiet, time_budget_s)` — fork-skill execution and the MCP `run_agent` tool share one stack.

## Why
The duplication/dead-code audit (2026-06-10) found the recall pool half-disconnected: the reader (`core/self_improving/loop/memory_recall.py`, injected via `in_context_wiring`) is live, but the writer's promised CLI/REPL surface never shipped — the only write path was hand-editing `~/.geode/memory/recall/*.md`. Separately, `core/mcp_server.py` was a 2-tool analysis shell with no entry point. Operator picks: ③ "a로 진행해" (ship the surface), ④ "a로 수행해. GEODE 에이전틱 + self-improving 가능하도록".

## Changes
| File | Change |
|------|--------|
| `core/cli/commands/recall.py` | NEW — `/recall list/show/save` handler; interactive prompts for missing fields on a TTY, fail-loud without one; invalid type rejected against `VALID_RECALL_TYPES` |
| `core/cli/routing.py` | `/recall` `CommandSpec` (THIN, `core.cli.commands.recall:cmd_recall`) |
| `core/cli/commands/_state.py` | `COMMAND_MAP["/recall"]` + help line |
| `core/cli/dispatcher.py` | `recall` action branch |
| `core/mcp_server.py` | server `geode-analysis` → `geode`; new tools `run_agent`, `self_improving_status`, `self_improving_propose`/`self_improving_apply` (two-step contract — MCP client is the confirmation gate, mirrors the slash y/N prompt; apply refuses unknown `mutation_id`); `_self_improving_status_payload` reads the *promoted* baseline + ledger tail (same SoTs as `/self-improving status`) |
| `core/tools/mcp_tools.json` | descriptions for the 4 new tools |
| `pyproject.toml` | `geode-mcp = "core.mcp_server:main"` console script; version 0.99.155 |
| `core/cli/bootstrap.py` | `run_agentic_oneshot` (public, `time_budget_s` parameterized) replaces `_build_agentic_stack_minimal`; caller `core/cli/commands/skills.py` + test reference migrated in the same PR |
| `tests/test_recall_command.py` | NEW — save→reader read-write parity, duplicate/overwrite, invalid type, no-TTY fail-loud, list/show roundtrip |
| `tests/test_mcp_server_tools.py` | NEW — server identity + tool surface, descriptions sourced from JSON, apply-without-propose refused, status payload graceful empty states + ledger tail |
| `CHANGELOG.md` / `CLAUDE.md` / `README*.md` | v0.99.155 stamp; measured metrics 376 core + 67 plugins = 443 modules, 8515 tests (+1 live — the old "+5 live" was stale) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| recall writer | Already exists | `write_recall_entry` reused as-is — only the surface shipped |
| recall reader parity | Implemented | `list` parses via `load_memory_entries` (reader's parser), pinned by parity test |
| MCP agentic tool | Implemented | shared `run_agentic_oneshot` — no second loop construction |
| MCP self-improving apply gate | Implemented | propose→apply two-step; no auto-apply path |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ scripts/, unpiped)
- [x] ruff format --check clean (989 files)
- [x] mypy clean (443 files; 3 pre-existing local-venv-only `codex_overrides.py` errors appear only with [audit] extra installed — CI clean)
- [x] lint-imports 4/4 kept
- [x] pytest non-live suite: 4 failures = known xdist order-flake family (api-lane/ranker singleton env-leak), all pass isolated (27/27)
- [x] `geode version` prints v0.99.155; `create_mcp_server().name == "geode"`; `geode-mcp` console_scripts entry point resolves

## Reference
D-3 decision menu (2026-06-10 session) · OL-C3 writer docstring contract · M4.4.1 reader (PR #1436)