### PR TITLE
feat(config): geode config explain — layer winner/mask visualizer (C-1, v0.99.164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ functional change.
 
 ---
 
+## [0.99.164] - 2026-06-11
+
+### Added
+- **`geode config explain [key]` (config-unification C-1).** Shows every config layer's candidate for a Settings key — os.environ / global `.env` / project `.env` / project `config.toml` / global `config.toml` / code default — with the WINNER and every masked layer, file paths included. Mirrors the real precedence (including pydantic-settings' later-env-file-wins order: global `.env` beats project `.env` for plain `Settings()`). `geode about` now prints a one-line warning when an env-layer model masks a toml pick (the "/model로 바꿨는데 안 바뀜" hazard class). Guards in `tests/core/config/test_config_explain.py`.
+
+### Changed
+- `geode config` is now an explicit subcommand group — the petri-toml migration moved from the flattened form to `geode config migrate-petri-toml` (typer single-command flattening ended when `explain` joined the group).
+
 ## [0.99.163] - 2026-06-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.163
+- **Version**: 0.99.164
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8531 (+1 live)
+- **Tests**: 8540 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.163 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.164 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.163 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.164 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/commands/config.py
+++ b/core/cli/commands/config.py
@@ -250,3 +250,47 @@ def migrate_petri_toml(
         "[muted]Legacy ~/.geode/petri.toml is unchanged — verify the new path "
         "via `geode audit` smoke, then delete the legacy file manually.[/muted]"
     )
+
+
+@app.command(name="explain")
+def explain(
+    key: str = typer.Argument("model", help="Settings field to explain (default: model)"),
+) -> None:
+    """Show every config layer's candidate for KEY and which one wins.
+
+    C-1 of the config-unification sprint — the answer to "I changed the
+    config but the model didn't move": the winning layer and everything
+    it masks, with file paths.
+    """
+    from core.config.explain import explain_field
+
+    try:
+        report = explain_field(key)
+    except Exception as exc:
+        typer.echo(f"explain failed for {key!r}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo("")
+    typer.echo(
+        f"  {report.field_name}  (env var {report.env_var}"
+        + (f", toml key {report.toml_key}" if report.toml_key else "")
+        + ")"
+    )
+    typer.echo(f"  effective: {report.effective!r}")
+    typer.echo("")
+    typer.echo(f"  {'layer':22} {'value':28} source")
+    for entry in report.layers:
+        marker = "  WINNER" if entry.is_winner else ("  masked" if entry.is_masked else "")
+        value = "-" if entry.value is None else repr(entry.value)
+        typer.echo(f"  {entry.layer:22} {value:28} {entry.source}{marker}")
+    masked = report.masked_layers
+    typer.echo("")
+    if masked:
+        winner_layer = report.winner.layer if report.winner else "?"
+        typer.echo(
+            f"  {len(masked)} layer(s) masked by {winner_layer}."
+            " Edit the WINNER layer (or remove its line) to change the effective value."
+        )
+    else:
+        typer.echo("  no masking - single layer set.")
+    typer.echo("")

--- a/core/cli/typer_commands.py
+++ b/core/cli/typer_commands.py
@@ -39,6 +39,16 @@ def about() -> None:
     provider = _resolve_provider(model)
     console.print(f"  [bold]Model[/bold]      [value]{model}[/value]  [muted]({provider})[/muted]")
 
+    # C-1 (2026-06-11) — surface the env-masks-toml hazard inline (H3/H4 class).
+    import contextlib
+
+    with contextlib.suppress(Exception):  # about must never fail on diagnostics
+        from core.config.explain import model_mask_warning
+
+        _mask_note = model_mask_warning()
+        if _mask_note:
+            console.print(f"  [warning]{_mask_note}[/warning]")
+
     # Auth profiles (mask all keys)
     try:
         from core.wiring.container import ensure_profile_store

--- a/core/config/explain.py
+++ b/core/config/explain.py
@@ -1,0 +1,167 @@
+"""Config layer explainer — which layer wins, and what it masks.
+
+C-1 of the config-unification sprint (2026-06-11). The override audit
+mapped 14 hazards whose common symptom is "I changed the config but the
+effective value didn't move" — a higher-precedence layer (os.environ, a
+forgotten ``.env`` line, a project-toml pin) silently masks the edit and
+no surface showed the winning layer (hazard H8). This module computes,
+per Settings field, every layer's candidate value and the winner, using
+the SAME precedence the real resolution applies:
+
+    os.environ  >  dotenv layer  >  project config.toml  >  global
+    config.toml  >  code default
+
+Dotenv-layer honesty note: pydantic-settings merges ``env_file=(".env",
+"~/.geode/.env")`` with the LATER file winning, so within the dotenv
+layer the GLOBAL file beats the project file for a plain ``Settings()``
+construction. (The serve daemon's bootstrap loads them in the opposite
+direction — hazard H5; this explainer reports the plain-Settings order
+and flags the key when both files define it.)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dotenv import dotenv_values
+
+from core.config import _TOML_TO_SETTINGS, GLOBAL_CONFIG_PATH, PROJECT_CONFIG_PATH, _flatten_toml
+from core.paths import GLOBAL_ENV_FILE
+
+PROJECT_ENV_FILE = Path(".env")
+
+#: Layer identifiers in precedence order (index 0 = strongest).
+LAYERS: tuple[str, ...] = (
+    "os.environ",
+    "global .env",
+    "project .env",
+    "project config.toml",
+    "global config.toml",
+    "code default",
+)
+
+
+@dataclass
+class LayerValue:
+    layer: str
+    source: str  # file path or "process env" / "Settings default"
+    value: Any | None  # None = not set at this layer
+    is_winner: bool = False
+    is_masked: bool = False
+
+
+@dataclass
+class FieldReport:
+    field_name: str
+    env_var: str
+    toml_key: str | None
+    effective: Any
+    layers: list[LayerValue] = field(default_factory=list)
+
+    @property
+    def winner(self) -> LayerValue | None:
+        return next((entry for entry in self.layers if entry.is_winner), None)
+
+    @property
+    def masked_layers(self) -> list[LayerValue]:
+        return [entry for entry in self.layers if entry.is_masked]
+
+
+_FIELD_TO_TOML: dict[str, str] = {v: k for k, v in _TOML_TO_SETTINGS.items()}
+
+
+def _env_var_for(field_name: str) -> str:
+    return f"GEODE_{field_name.upper()}"
+
+
+def explain_field(field_name: str) -> FieldReport:
+    """Compute the per-layer candidates + winner for one Settings field."""
+    from core.config import settings
+
+    env_var = _env_var_for(field_name)
+    toml_key = _FIELD_TO_TOML.get(field_name)
+
+    candidates: list[LayerValue] = []
+
+    candidates.append(LayerValue("os.environ", "process env", os.environ.get(env_var)))
+
+    # Dotenv layer — pydantic's later-file-wins means GLOBAL beats project
+    # for plain Settings(); report both files separately so a duplicate key
+    # is visible.
+    global_env = dotenv_values(GLOBAL_ENV_FILE) if GLOBAL_ENV_FILE.exists() else {}
+    project_env = dotenv_values(PROJECT_ENV_FILE) if PROJECT_ENV_FILE.exists() else {}
+    candidates.append(LayerValue("global .env", str(GLOBAL_ENV_FILE), global_env.get(env_var)))
+    candidates.append(
+        LayerValue("project .env", str(PROJECT_ENV_FILE.resolve()), project_env.get(env_var))
+    )
+
+    def _toml_value(path: Path) -> Any | None:
+        if toml_key is None or not path.exists():
+            return None
+        import tomllib
+
+        try:
+            with open(path, "rb") as f:
+                flat = _flatten_toml(tomllib.load(f))
+        except Exception:
+            return None
+        return flat.get(toml_key)
+
+    candidates.append(
+        LayerValue(
+            "project config.toml",
+            str(PROJECT_CONFIG_PATH.resolve()),
+            _toml_value(PROJECT_CONFIG_PATH),
+        )
+    )
+    candidates.append(
+        LayerValue("global config.toml", str(GLOBAL_CONFIG_PATH), _toml_value(GLOBAL_CONFIG_PATH))
+    )
+
+    default = (
+        type(settings).model_fields[field_name].default
+        if field_name in type(settings).model_fields
+        else None
+    )
+    candidates.append(LayerValue("code default", "Settings default", default))
+
+    # Winner = first set layer in precedence order.
+    winner_seen = False
+    for entry in candidates:
+        if entry.value is None:
+            continue
+        if not winner_seen:
+            entry.is_winner = True
+            winner_seen = True
+        else:
+            entry.is_masked = True
+
+    return FieldReport(
+        field_name=field_name,
+        env_var=env_var,
+        toml_key=toml_key,
+        effective=getattr(settings, field_name, None),
+        layers=candidates,
+    )
+
+
+def model_mask_warning() -> str | None:
+    """One-line warning when an env-layer model masks a toml pick (H3/H4 class).
+
+    Returns None when nothing is masked. Consumed by ``geode about``.
+    """
+    report = explain_field("model")
+    winner = report.winner
+    if winner is None or winner.layer not in ("os.environ", "global .env", "project .env"):
+        return None
+    masked_toml = [entry for entry in report.masked_layers if entry.layer.endswith("config.toml")]
+    if not masked_toml:
+        return None
+    return (
+        f"{report.env_var} ({winner.layer}) = {winner.value!r} is masking "
+        f"{masked_toml[0].layer} = {masked_toml[0].value!r} — "
+        "run `geode config explain model`"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.163"
+version = "0.99.164"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/cli/test_cmd_config.py
+++ b/tests/core/cli/test_cmd_config.py
@@ -74,7 +74,7 @@ def test_migrate_dry_run_prints_preview_and_does_not_write(
         monkeypatch,
         {"auditor": {"model": "claude-opus-4-7", "source": "claude-cli"}},
     )
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, ["migrate-petri-toml"])
     assert result.exit_code == 0, result.output
     assert "Re-run with --yes" in result.output
     assert "[self_improving_loop.autoresearch.auditor]" in result.output
@@ -95,7 +95,7 @@ def test_migrate_yes_appends_to_config_when_destination_absent(
             "judge": {"model": "claude-sonnet-4-6"},
         },
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 0, result.output
     assert "Appended 2 role(s)" in result.output
     assert target.is_file()
@@ -117,7 +117,7 @@ def test_migrate_yes_preserves_existing_unrelated_sections(
         monkeypatch,
         {"target": {"model": "geode/gpt-5.5", "source": "openai-codex"}},
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 0, result.output
     content = target.read_text(encoding="utf-8")
     # Existing content stays intact + new section appended.
@@ -140,7 +140,7 @@ def test_migrate_yes_refuses_when_destination_already_has_overlapping_section(
         monkeypatch,
         {"auditor": {"model": "claude-opus-4-7"}},
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 1, result.output
     assert "auditor" in result.output
     # Rich may wrap "Refusing to append" across a soft newline at narrow
@@ -162,7 +162,7 @@ def test_migrate_yes_refuses_when_destination_has_broken_toml(
     target.write_text("[broken_toml = unclosed", encoding="utf-8")
     monkeypatch.setattr(core.paths, "GLOBAL_CONFIG_TOML", target)
     _stub_plan(monkeypatch, {"auditor": {"model": "x"}})
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 2, result.output
     assert "not valid TOML" in result.output
 
@@ -173,7 +173,7 @@ def test_migrate_empty_plan_exits_silently(tmp_path: Path, monkeypatch: pytest.M
     target = tmp_path / "config.toml"
     monkeypatch.setattr(core.paths, "GLOBAL_CONFIG_TOML", target)
     _stub_plan(monkeypatch, {})
-    result = runner.invoke(app, [])
+    result = runner.invoke(app, ["migrate-petri-toml"])
     assert result.exit_code == 0, result.output
     assert "nothing to migrate" in result.output.lower()
     assert not target.exists()
@@ -228,7 +228,7 @@ def test_yes_migration_with_embedded_quotes_writes_valid_toml(
         monkeypatch,
         {"target": {"model": 'gpt-5.5 "tactical"', "source": "openai-codex"}},
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 0, result.output
     parsed = tomllib.loads(target.read_text(encoding="utf-8"))
     assert parsed["self_improving_loop"]["autoresearch"]["target"]["model"] == 'gpt-5.5 "tactical"'
@@ -256,7 +256,7 @@ def test_yes_atomic_write_rollback_preserves_existing_config_on_failure(
         raise OSError("simulated disk full")
 
     monkeypatch.setattr(cmd_config, "atomic_write_text", _raise)
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code != 0
     assert target.read_text(encoding="utf-8") == original
 
@@ -274,7 +274,7 @@ def test_yes_accepts_source_only_legacy_entry(
     target = tmp_path / "config.toml"
     monkeypatch.setattr(core.paths, "GLOBAL_CONFIG_TOML", target)
     _stub_plan(monkeypatch, {"judge": {"source": "claude-cli"}})
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 0, result.output
     parsed = tomllib.loads(target.read_text(encoding="utf-8"))
     assert parsed["self_improving_loop"]["autoresearch"]["judge"]["source"] == "claude-cli"
@@ -301,7 +301,7 @@ def test_yes_schema_validation_blocks_invalid_source(
         monkeypatch,
         {"auditor": {"model": "claude-opus-4-7", "source": "bogus"}},
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 3, result.output
     assert "schema validation" in result.output
     # Destination untouched.
@@ -327,7 +327,7 @@ def test_yes_post_render_validation_blocks_corrupt_combined_toml(
         "_render_petri_sections",
         lambda plan: "[self_improving_loop.autoresearch.target]\nmodel = unbalanced\n",
     )
-    result = runner.invoke(app, ["--yes"])
+    result = runner.invoke(app, ["migrate-petri-toml", "--yes"])
     assert result.exit_code == 3, result.output
     assert "refusing to write" in result.output
     assert target.read_text(encoding="utf-8") == original

--- a/tests/core/config/test_config_explain.py
+++ b/tests/core/config/test_config_explain.py
@@ -1,0 +1,92 @@
+"""C-1 config explainer guards (2026-06-11).
+
+Pins the layer ladder's honesty: winner selection follows real precedence
+(os.environ > global .env > project .env > project toml > global toml >
+default — pydantic's later-env-file-wins order for the dotenv layer),
+masked layers are reported, and the `geode about` mask warning fires
+exactly when an env-layer model hides a toml pick (hazard H3/H4 class).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import core.config.explain as explain_mod
+import pytest
+from core.config.explain import explain_field, model_mask_warning
+
+
+@pytest.fixture()
+def isolated_layers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    global_env = tmp_path / "global.env"
+    project_env = tmp_path / "project.env"
+    global_toml = tmp_path / "global-config.toml"
+    project_toml = tmp_path / "project-config.toml"
+    monkeypatch.setattr(explain_mod, "GLOBAL_ENV_FILE", global_env)
+    monkeypatch.setattr(explain_mod, "PROJECT_ENV_FILE", project_env)
+    monkeypatch.setattr(explain_mod, "GLOBAL_CONFIG_PATH", global_toml)
+    monkeypatch.setattr(explain_mod, "PROJECT_CONFIG_PATH", project_toml)
+    monkeypatch.delenv("GEODE_MODEL", raising=False)
+    return {
+        "global_env": global_env,
+        "project_env": project_env,
+        "global_toml": global_toml,
+        "project_toml": project_toml,
+    }
+
+
+def test_default_wins_when_nothing_set(isolated_layers) -> None:
+    report = explain_field("model")
+    assert report.winner is not None
+    assert report.winner.layer == "code default"
+    assert report.masked_layers == []
+
+
+def test_toml_pick_wins_over_default_and_global_over_nothing(isolated_layers) -> None:
+    isolated_layers["global_toml"].write_text('[llm]\nprimary_model = "claude-sonnet-4-6"\n')
+    report = explain_field("model")
+    assert report.winner.layer == "global config.toml"
+    assert report.winner.value == "claude-sonnet-4-6"
+
+
+def test_project_toml_beats_global_toml(isolated_layers) -> None:
+    isolated_layers["global_toml"].write_text('[llm]\nprimary_model = "claude-haiku-4-5"\n')
+    isolated_layers["project_toml"].write_text('[llm]\nprimary_model = "claude-sonnet-4-6"\n')
+    report = explain_field("model")
+    assert report.winner.layer == "project config.toml"
+    assert [entry.layer for entry in report.masked_layers] == ["global config.toml", "code default"]
+
+
+def test_env_file_masks_toml_and_warning_fires(isolated_layers) -> None:
+    isolated_layers["global_env"].write_text("GEODE_MODEL=gpt-5.5\n")
+    isolated_layers["project_toml"].write_text('[llm]\nprimary_model = "claude-sonnet-4-6"\n')
+    report = explain_field("model")
+    assert report.winner.layer == "global .env"
+    masked = {entry.layer for entry in report.masked_layers}
+    assert "project config.toml" in masked
+
+    warning = model_mask_warning()
+    assert warning is not None
+    assert "GEODE_MODEL" in warning and "masking" in warning
+
+
+def test_global_env_beats_project_env_matching_pydantic_order(isolated_layers) -> None:
+    """pydantic-settings: later env_file wins → global .env beats project .env."""
+    isolated_layers["global_env"].write_text("GEODE_MODEL=global-pick\n")
+    isolated_layers["project_env"].write_text("GEODE_MODEL=project-pick\n")
+    report = explain_field("model")
+    assert report.winner.layer == "global .env"
+    assert report.winner.value == "global-pick"
+
+
+def test_os_environ_tops_everything(isolated_layers, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_MODEL", "env-pick")
+    isolated_layers["global_env"].write_text("GEODE_MODEL=file-pick\n")
+    report = explain_field("model")
+    assert report.winner.layer == "os.environ"
+    assert report.winner.value == "env-pick"
+
+
+def test_no_warning_when_no_toml_is_masked(isolated_layers) -> None:
+    isolated_layers["global_env"].write_text("GEODE_MODEL=gpt-5.5\n")
+    assert model_mask_warning() is None


### PR DESCRIPTION
## Summary
- Config-unification sprint C-1 (operator directive: opus-4.8 model-override 혼란): `geode config explain [key]` renders the full 6-layer resolution ladder per Settings key — every layer's candidate value, the WINNER, every masked layer, file paths included.
- `geode about` gains a one-line mask warning when an env-layer model hides a toml pick — the exact "/model로 바꿨는데 안 바뀜" hazard class (H3/H4 from the 14-hazard audit).

## Why
The override audit found no surface showing the winning layer (hazard H8): `geode about` prints only the effective value, so a forgotten `.env GEODE_MODEL` line or a daemon env snapshot masks every toml edit invisibly. C-1 is the observation tool first — it also becomes the verification instrument for C-2..C-4.

## Changes
| File | Change |
|------|--------|
| `core/config/explain.py` | NEW — `explain_field` (per-layer candidates + winner, honest pydantic later-env-file-wins dotenv order documented + pinned), `model_mask_warning` for about |
| `core/cli/commands/config.py` | `geode config explain [key]` (default: model) — ladder table + masked-layer count + edit hint |
| `core/cli/typer_commands.py` | about: mask warning line (suppress-guarded — about never fails on diagnostics) |
| `tests/core/config/test_config_explain.py` | NEW 7 guards: default/toml/project-beats-global/env-masks-toml+warning/global-env-beats-project-env (pydantic order)/os.environ-tops/no-false-warning |
| `tests/core/cli/test_cmd_config.py` | invocations updated to explicit `migrate-petri-toml` subcommand (typer single-command flattening ended when explain joined — CLI surface change recorded in CHANGELOG) |
| stamps | v0.99.164; tests 8540 (+9... measured: +7 new +2 from invocation split) |

## Verification
- [x] ruff check / format clean (incl. scripts/) · mypy clean (3 known local-venv) · lint-imports 4/4
- [x] pytest: config+cli slice 695 passed; full non-live suite failures = the 4 known xdist order-flakes only
- [x] live smoke: `geode config explain model` renders the ladder (cwd-resolved project paths visibly demonstrate hazard H1); `geode about` clean when unmasked

## Reference
env/config 14-hazard audit (2026-06-11 session) · C-1..C-4 unification plan