### PR TITLE
refactor(config): .env = secrets-only — picks persist toml-only + stale-mask cleanup (C-2, v0.99.165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ functional change.
 
 ---
 
+## [0.99.165] - 2026-06-11
+
+### Changed
+- **`.env` is the secrets-only layer (config-unification C-2).** Behavior settings persist to `config.toml` exclusively:
+  - `/model` no longer writes `GEODE_MODEL` / role env vars / `GEODE_AGENTIC_EFFORT` into `.env` — the write landed in the CWD `.env` (not the documented `~/.geode/.env`, hazard H4) and, since the env layer outranks every toml layer, one switch permanently masked all future toml edits (H3); the mutator-role env var additionally had zero readers (H6). Stale lines from earlier releases are auto-cleaned by the picker (`remove_env`: `.env` line + `os.environ`, with a notice).
+  - `/login source` is toml-only, and its `[llm] *_credential_source` rows are now READ (`_TOML_TO_SETTINGS` registration) — hazard H7's dead write closed; the choice survives a `.env` wipe.
+  - API-key writes (onboarding, `/login`) legitimately remain on the `.env` layer; the contract is documented on `upsert_env`. Guards in `tests/core/config/test_c2_env_secrets_only.py`; three old env-write contract pins updated to the new contract.
+
 ## [0.99.164] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.164
+- **Version**: 0.99.165
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8540 (+1 live)
+- **Tests**: 8545 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.164 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.165 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.164 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.165 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/commands/__init__.py
+++ b/core/cli/commands/__init__.py
@@ -46,6 +46,7 @@ from core.cli.commands.schedule import cmd_schedule as cmd_schedule
 # the submodules consume through the deferred ``_pkg.X`` lookup.
 from core.config.env_io import is_glm_key as _is_glm_key
 from core.config.env_io import mask_key as _mask_key
+from core.config.env_io import remove_env as remove_env
 from core.config.env_io import upsert_env as _upsert_env
 from core.ui.console import console as console
 

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -744,8 +744,15 @@ def _persist_credential_source(provider: str, source: str) -> None:
         object.__setattr__(settings, field, source)
     except Exception:
         log.debug("login: settings.%s setattr failed", field, exc_info=True)
-    _pkg._upsert_env(env_var, source)
+    # C-2 (2026-06-11) — credential_source is a behavior setting, not a
+    # secret: toml-only (the toml row is now READ — registered in
+    # _TOML_TO_SETTINGS, closing hazard H7's dead write). Stale env lines
+    # from earlier releases are cleaned so they stop masking the toml.
     upsert_config_toml("llm", field, source)
+    if _pkg.remove_env(env_var):
+        _pkg.console.print(
+            f"  [muted]removed stale {env_var} from .env — config.toml is the durable layer[/muted]"
+        )
 
 
 def _login_source(args: str) -> None:

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -191,25 +191,27 @@ def _apply_model(
                     role_def.settings_field,
                     exc_info=True,
                 )
-        # Durable persistence honours the requested scope. The global
-        # ``~/.geode/.env`` (GEODE_MODEL) write is skipped for a *primary*
-        # **project** switch: writing it leaked the choice to every project
-        # (env outranks the project TOML in the precedence chain) and made
-        # ``_apply_toml_overlay`` skip the project ``primary_model`` on the
-        # next session reload. Non-primary roles (reflection / mutator) are
-        # daemon-global knobs, so they keep their env write; global scope
-        # writes env for every role.
-        if scope == "global" or role_def.name != "primary":
-            _pkg._upsert_env(role_def.env_var, selected.id)
+        # C-2 (2026-06-11) — config.toml is the ONLY durable layer for model
+        # picks; the env write is gone entirely. It used to land in the CWD
+        # ``.env`` (NOT the documented ``~/.geode/.env`` — hazard H4) and,
+        # because the env layer outranks every toml layer, one switch left a
+        # permanent mask over all future toml edits (H3). The mutator-role
+        # env var additionally had zero readers (H6). Stale lines written by
+        # earlier releases are cleaned up below so old masks die too.
         upsert_config_toml(role_def.toml_section, role_def.toml_key, selected.id, scope=scope)
+        if _pkg.remove_env(role_def.env_var):
+            _pkg.console.print(
+                f"  [muted]removed stale {role_def.env_var} from .env — "
+                "config.toml is the durable layer now[/muted]"
+            )
     if role_def.has_effort and effort is not None and effort != old_effort:
         try:
             object.__setattr__(settings, "agentic_effort", effort)
         except Exception:
             log.debug("Could not persist agentic_effort to settings", exc_info=True)
-        if scope == "global":
-            _pkg._upsert_env("GEODE_AGENTIC_EFFORT", effort)
         upsert_config_toml("agentic", "effort", effort, scope=scope)
+        if _pkg.remove_env("GEODE_AGENTIC_EFFORT"):
+            _pkg.console.print("  [muted]removed stale GEODE_AGENTIC_EFFORT from .env[/muted]")
 
     # Model hot-swap is deferred: AgenticLoop._sync_model_from_settings_async()
     # checks settings.model at the start of each round and applies

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -57,6 +57,10 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.plan_model": "plan_model",
     "llm.act_model": "act_model",
     "llm.judge_model": "judge_model",
+    # C-2 (2026-06-11) — H7 fix: /login source was writing these toml rows
+    # but nothing read them back (dead write); now they are part of the cascade.
+    "llm.anthropic_credential_source": "anthropic_credential_source",
+    "llm.openai_credential_source": "openai_credential_source",
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
     "replan.enabled": "replan_enabled",
     "replan.interval": "replan_interval",

--- a/core/config/env_io.py
+++ b/core/config/env_io.py
@@ -23,7 +23,16 @@ def mask_key(key: str) -> str:
 
 
 def upsert_env(var_name: str, value: str) -> None:
-    """Insert or update a variable in .env file. Creates .env if absent."""
+    """Insert or update a variable in the CWD ``.env``. Creates it if absent.
+
+    C-2 contract (config-unification, 2026-06-11): the ``.env`` layer is
+    **secrets-only** — API keys and credentials. Behavior settings (model
+    picks, effort, credential_source) persist to ``config.toml``; tools
+    MUST NOT write them here, because the env layer outranks every toml
+    layer and one written line silently masks all future toml edits
+    (hazards H3/H4). Manual ``GEODE_*`` exports remain a power-user
+    session override — by hand only.
+    """
     env_path = Path(".env")
     lines: list[str] = []
     found = False
@@ -131,3 +140,27 @@ def is_glm_key(value: str) -> bool:
         return False
     # Each segment must be alphanumeric with at least one digit (machine-generated)
     return all(p.isalnum() and any(c.isdigit() for c in p) for p in parts)
+
+
+def remove_env(var_name: str) -> bool:
+    """Remove ``var_name`` from the CWD ``.env`` (and ``os.environ``).
+
+    C-2 stale-mask cleanup: earlier releases' ``/model`` wrote model picks
+    into ``.env``; those lines outrank every toml edit forever. The picker
+    now calls this after its toml write so a tool-created mask is removed
+    by the tool. Returns True when a line was removed.
+    """
+    env_path = Path(".env")
+    removed = False
+    if env_path.exists():
+        kept: list[str] = []
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            if re.match(rf"^{re.escape(var_name)}\s*=", line):
+                removed = True
+                continue
+            kept.append(line)
+        if removed:
+            env_path.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+    if os.environ.pop(var_name, None) is not None:
+        removed = True
+    return removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.164"
+version = "0.99.165"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/cli/test_model_role_tab.py
+++ b/tests/core/cli/test_model_role_tab.py
@@ -153,11 +153,10 @@ def test_apply_model_dispatches_to_reflection_field(
 
     # settings field flipped
     assert settings.cognitive_reflection_model == "claude-haiku-4-5-20251001"
-    # env_io wrote the reflection env + toml keys, NOT GEODE_MODEL /
-    # [llm] primary_model
-    assert ("GEODE_COGNITIVE_REFLECTION_MODEL", "claude-haiku-4-5-20251001") in upsert_env_calls
+    # C-2 (2026-06-11): the toml key is the only durable write — env writes
+    # are gone for every role (hazards H3/H4/H6).
+    assert upsert_env_calls == []
     assert ("cognitive", "reflection_model", "claude-haiku-4-5-20251001") in upsert_toml_calls
-    assert not any(k == "GEODE_MODEL" for k, _v in upsert_env_calls)
     assert not any(s == "llm" for s, _k, _v in upsert_toml_calls)
 
     # Restore
@@ -209,11 +208,12 @@ def test_apply_model_primary_project_scope_skips_global_env(
     assert ("llm", "primary_model", "claude-opus-4-8", "project") in toml_calls
 
 
-def test_apply_model_primary_global_scope_writes_env_and_global(
+def test_apply_model_primary_global_scope_writes_global_toml_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Primary + global scope writes the global config + GEODE_MODEL env so
-    every project without its own override inherits the choice."""
+    """C-2 (2026-06-11): primary + global scope writes the GLOBAL config.toml
+    and nothing else — the env write is gone (it landed in the CWD .env and
+    permanently masked every toml edit; hazards H3/H4)."""
     from core.cli.commands import model as _model_mod
     from core.cli.commands._state import ModelProfile
     from core.config import settings
@@ -229,7 +229,7 @@ def test_apply_model_primary_global_scope_writes_env_and_global(
     finally:
         object.__setattr__(settings, "model", old)
 
-    assert ("GEODE_MODEL", "claude-opus-4-8") in env_calls
+    assert not any(k == "GEODE_MODEL" for k, _v in env_calls)
     assert ("llm", "primary_model", "claude-opus-4-8", "global") in toml_calls
 
 

--- a/tests/core/cli/test_mutator_role_tab.py
+++ b/tests/core/cli/test_mutator_role_tab.py
@@ -118,6 +118,8 @@ def test_apply_model_for_mutator_skips_settings_write(
     # The guard must check role_def.settings_field truthy before the
     # __setattr__ call. Anti-deception pin.
     assert "if role_def.settings_field:" in src
-    # And the env + toml writes happen unconditionally afterwards.
-    assert "_upsert_env(role_def.env_var" in src
+    # C-2 (2026-06-11) — the durable write is toml-only now; the env write
+    # was removed (hazards H3/H4/H6) and stale lines are cleaned up.
+    assert "upsert_config_toml(role_def.toml_section" in src
+    assert "remove_env(role_def.env_var)" in src
     assert "upsert_config_toml(role_def.toml_section, role_def.toml_key" in src

--- a/tests/core/config/test_c2_env_secrets_only.py
+++ b/tests/core/config/test_c2_env_secrets_only.py
@@ -1,0 +1,78 @@
+"""C-2 env=secrets-only guards (2026-06-11).
+
+Pins: model/effort/credential_source picks persist to config.toml ONLY
+(no .env writes — hazards H3/H4/H6), stale env lines are cleaned up by
+the writers, the credential_source toml rows are read back (H7 closed),
+and API-key writes legitimately stay on the .env layer.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from core.config.env_io import remove_env, upsert_env
+
+
+@pytest.fixture()
+def cwd_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path / ".env"
+
+
+def test_remove_env_deletes_line_and_process_env(
+    cwd_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    upsert_env("GEODE_MODEL", "claude-sonnet-4-6")
+    assert "GEODE_MODEL" in cwd_env.read_text()
+    assert os.environ["GEODE_MODEL"] == "claude-sonnet-4-6"
+
+    assert remove_env("GEODE_MODEL") is True
+    assert "GEODE_MODEL" not in cwd_env.read_text()
+    assert "GEODE_MODEL" not in os.environ
+    assert remove_env("GEODE_MODEL") is False  # idempotent
+
+
+def test_remove_env_keeps_other_lines(cwd_env: Path) -> None:
+    upsert_env("ANTHROPIC_API_KEY", "sk-test")
+    upsert_env("GEODE_MODEL", "x")
+    remove_env("GEODE_MODEL")
+    content = cwd_env.read_text()
+    assert "ANTHROPIC_API_KEY=sk-test" in content
+    assert "GEODE_MODEL" not in content
+
+
+def test_model_picker_source_has_no_env_write() -> None:
+    """Source pin — the picker's persistence block must not regrow the
+    env write (config.toml is the only durable layer for model picks)."""
+    src = (
+        Path(__file__).resolve().parents[3] / "core" / "cli" / "commands" / "model.py"
+    ).read_text(encoding="utf-8")
+    assert "_upsert_env(role_def.env_var" not in src
+    assert '_upsert_env("GEODE_AGENTIC_EFFORT"' not in src
+    assert "remove_env(role_def.env_var)" in src  # stale-mask cleanup present
+
+
+def test_login_source_is_toml_only() -> None:
+    src = (
+        Path(__file__).resolve().parents[3] / "core" / "cli" / "commands" / "login.py"
+    ).read_text(encoding="utf-8")
+    assert "_upsert_env(env_var, source)" not in src
+    # API-key write (secrets) must REMAIN on the env layer
+    assert "_upsert_env(env_var, key)" in src
+
+
+def test_credential_source_toml_rows_are_read_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """H7 closed — the rows /login source writes now flow through the cascade."""
+    import core.config as config_mod
+    from core.config import _load_toml_config
+
+    global_toml = tmp_path / "config.toml"
+    global_toml.write_text('[llm]\nanthropic_credential_source = "subscription"\n')
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_PATH", global_toml)
+    monkeypatch.setattr(config_mod, "PROJECT_CONFIG_PATH", tmp_path / "absent.toml")
+    values = _load_toml_config()
+    assert values.get("anthropic_credential_source") == "subscription"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.163"
+version = "0.99.164"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Config-unification C-2: behavior settings (model picks, effort, credential source) persist to `config.toml` ONLY — every tool-driven `.env` write of a behavior setting is removed, and the picker auto-cleans stale masks earlier releases left behind.
- Closes hazards H3 (.env masks toml silently), H4 (`/model global` wrote the CWD `.env`, not the documented `~/.geode/.env`), H6 (mutator env var had zero readers), H7 (`/login source`'s toml row was a dead write — now registered in the cascade).

## Why
The 14-hazard audit's top confusion class: one `.env GEODE_MODEL` line outranks every toml layer forever, and `/model` itself was creating those lines. C-1's `geode config explain` made the masks visible; C-2 stops creating them and removes the existing ones.

## Changes
| File | Change |
|------|--------|
| `core/cli/commands/model.py` | env writes removed for ALL roles + effort; after the toml write, `remove_env(role env var)` cleans stale lines with a notice ("도구가 만든 마스크는 도구가 치운다") |
| `core/config/env_io.py` | `upsert_env` docstring states the secrets-only contract; NEW `remove_env(var)` — deletes the `.env` line + `os.environ` entry, idempotent |
| `core/cli/commands/login.py` | `/login source` toml-only + stale env cleanup; API-KEY writes (secrets) remain on `.env` |
| `core/config/__init__.py` | `_TOML_TO_SETTINGS` += `llm.anthropic_credential_source` / `llm.openai_credential_source` (H7: the rows /login was writing are now read back) |
| `tests/core/config/test_c2_env_secrets_only.py` | NEW 5 guards: remove_env line+process-env+idempotence, other-lines preserved, picker source pin (no env-write regrowth + cleanup present), login toml-only + key-write stays, credential_source cascade read-back |
| `tests/core/cli/test_model_role_tab.py`, `test_mutator_role_tab.py` | 3 old env-write contract pins updated to the toml-only contract |
| stamps | v0.99.165; tests 8545 |

## Verification
- [x] ruff check / format clean (incl. scripts/) · mypy clean (3 known local-venv) · lint-imports 4/4
- [x] cli+config slice 700 passed; full non-live suite failures = the 4 known xdist order-flakes only
- [x] Effective-value semantics preserved: in-process `object.__setattr__(settings, ...)` unchanged; next-session reads flow through the toml cascade (C-1 explain verifies)

## Reference
env/config 14-hazard audit · C-1 (#2094) explain as the verification instrument · frontier consensus already cited on `upsert_config_toml` (Hermes/Codex/Claude Code persist picks to config, not env)