### PR TITLE
feat(llm): Claude Fable 5 support — picker, capability anchors, refusal stop_reason (v0.99.166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ functional change.
 
 ---
 
+## [0.99.166] - 2026-06-11
+
+### Added
+- **Claude Fable 5 support (`claude-fable-5`).** Official-docs-verified (refs cited in every touched module: models overview / introducing page / migration guide):
+  - `/model` picker offers Fable 5 (anthropic, $10/$50 per MTok, 1M ctx, 128k out)
+  - Capability anchors: `ANTHROPIC_ADAPTIVE_MODELS` (adaptive-only thinking — `thinking:{type:"disabled"}` errors, sampling params 400; the existing adaptive request shape applies verbatim), `ANTHROPIC_XHIGH_MODELS`, `ANTHROPIC_CONTEXT_MGMT_MODELS` (compaction)
+  - Pricing + context-window rows; petri (3-role) + seed_generation (9-role) plugin allowlists
+  - **`refusal` stop_reason handling (new)** — Fable 5's safety classifiers decline via `stop_reason:"refusal"` as HTTP 200 (often empty content); the agentic loop previously rendered that as a silent empty turn. `normalize_anthropic` now captures `stop_details`, and the loop maps refusals to `termination_reason="model_refusal"` with an honest message including `stop_details.category` (also benefits Opus 4.7/4.8 where the surface already existed).
+  - Switch-path E2E verified end-to-end in an isolated project: stale `.env` mask removed, toml written, next-session reload + `config explain` winner = project toml, effective model = claude-fable-5.
+
 ## [0.99.165] - 2026-06-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.165
+- **Version**: 0.99.166
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8545 (+1 live)
+- **Tests**: 8551 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.165 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.166 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.165 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.166 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1995,6 +1995,28 @@ class AgenticLoop:
             else:
                 self._consecutive_text_only_rounds = 0
 
+            if response.stop_reason == "refusal":
+                # PR-FABLE5 (2026-06-11) — Fable 5 safety classifiers decline
+                # via stop_reason="refusal" (HTTP 200, often empty content).
+                # Surface it honestly instead of returning a silent empty turn.
+                # ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+                self._op_logger.finalize()
+                self._sync_messages_to_context(messages)
+                stop_details = getattr(response, "stop_details", None)
+                category = stop_details.get("category") if isinstance(stop_details, dict) else None
+                refusal_text = self._extract_text(response).strip() or (
+                    "The model declined this request"
+                    + (f" (safety classifier category: {category})" if category else "")
+                    + ". Rephrase the request or retry on another model via /model."
+                )
+                result = AgenticResult(
+                    text=refusal_text,
+                    tool_calls=self._tool_processor.tool_log,
+                    rounds=round_idx + 1,
+                    termination_reason="model_refusal",
+                )
+                return await self._afinalize_and_return(result, user_input, round_idx + 1)
+
             if response.stop_reason != "tool_use":
                 # end_turn or max_tokens → extract text, done
                 self._op_logger.finalize()

--- a/core/agent/loop/models.py
+++ b/core/agent/loop/models.py
@@ -109,6 +109,8 @@ class AgenticResult:
     # | "llm_error" | "context_exhausted" | "cost_budget_exceeded"
     # | "model_action_required" — LLM error retried up to cap; user must
     #   switch model/provider via /model and re-run. Diagnostic in ``text``.
+    # | "model_refusal" — Fable 5 safety classifier declined (stop_reason
+    #   "refusal", HTTP 200); text carries the category when reported.
     # | "user_clarification_needed" — overthinking detected (consecutive
     #   high-token text-only rounds with no tool use). Loop stops and asks
     #   the user to narrow the request.

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -50,6 +50,10 @@ class ModelProfile:
 # scan when Codex subscription OAuth is registered (v0.52.4 routing policy);
 # otherwise to `openai` PAYG. Both paths visible via /login dashboard.
 MODEL_PROFILES: list[ModelProfile] = [
+    # Fable 5 — Anthropic's most capable widely released model ($10/$50,
+    # 1M ctx, adaptive-only thinking, refusal stop_reason). GA 2026-06-09.
+    # ref: https://platform.claude.com/docs/en/about-claude/models/overview
+    ModelProfile("claude-fable-5", "anthropic", "Fable 5", "$$$$"),
     ModelProfile("claude-opus-4-8", "anthropic", "Opus 4.8", "$$$"),
     ModelProfile("claude-opus-4-7", "anthropic", "Opus 4.7", "$$$"),
     ModelProfile("claude-opus-4-6", "anthropic", "Opus 4.6", "$$$"),

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -88,7 +88,12 @@ class AgenticResponse:
     """
 
     content: list[TextBlock | ToolUseBlock] = field(default_factory=list)
-    stop_reason: str = "end_turn"  # "end_turn" or "tool_use"
+    stop_reason: str = "end_turn"  # "end_turn" / "tool_use" / "refusal" (Fable 5, Opus 4.7+)
+    # PR-FABLE5 (2026-06-11) — refusal metadata. Fable 5's safety
+    # classifiers return stop_reason="refusal" as HTTP 200 with a
+    # stop_details.category ("cyber"/"bio"/"reasoning_extraction"/null).
+    # ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+    stop_details: dict[str, Any] | None = None
     usage: ResponseUsage = field(default_factory=ResponseUsage)
     codex_reasoning_items: list[dict[str, Any]] | None = None
     # v0.57.0 R6 — reasoning summaries for the "live thinking..." UI
@@ -203,11 +208,17 @@ def normalize_anthropic(response: Any) -> AgenticResponse:
             cache_read_tokens=cache_read,
         )
 
+    raw_stop_details = getattr(response, "stop_details", None)
+    if raw_stop_details is not None and not isinstance(raw_stop_details, dict):
+        dump = getattr(raw_stop_details, "model_dump", None)
+        raw_stop_details = dump() if callable(dump) else {"raw": str(raw_stop_details)}
+
     return AgenticResponse(
         content=blocks,
         stop_reason=response.stop_reason,
         usage=usage,
         reasoning_summaries=reasoning_summaries or None,
+        stop_details=raw_stop_details,
     )
 
 

--- a/core/llm/model_capabilities.py
+++ b/core/llm/model_capabilities.py
@@ -27,6 +27,11 @@ from __future__ import annotations
 # context_overflow. Only 1M-context models are known to support it.
 ANTHROPIC_CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
     {
+        # Fable 5 (2026-06-09 GA): 1M ctx + compaction supported; adaptive
+        # thinking always-on (thinking:{type:"disabled"} errors — omit or send
+        # adaptive); sampling params 400; effort incl. xhigh supported.
+        # ref: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -42,6 +47,11 @@ ANTHROPIC_CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
 # The effort knob (incl. xhigh) only exists for adaptive models.
 ANTHROPIC_ADAPTIVE_MODELS: frozenset[str] = frozenset(
     {
+        # Fable 5 (2026-06-09 GA): 1M ctx + compaction supported; adaptive
+        # thinking always-on (thinking:{type:"disabled"} errors — omit or send
+        # adaptive); sampling params 400; effort incl. xhigh supported.
+        # ref: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -53,6 +63,11 @@ ANTHROPIC_ADAPTIVE_MODELS: frozenset[str] = frozenset(
 # high). 4.6 / Sonnet 4.6 reject it with 400.
 ANTHROPIC_XHIGH_MODELS: frozenset[str] = frozenset(
     {
+        # Fable 5 (2026-06-09 GA): 1M ctx + compaction supported; adaptive
+        # thinking always-on (thinking:{type:"disabled"} errors — omit or send
+        # adaptive); sampling params 400; effort incl. xhigh supported.
+        # ref: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
     }

--- a/core/llm/model_pricing.toml
+++ b/core/llm/model_pricing.toml
@@ -23,6 +23,12 @@
 # platform docs index only up to the 4.6/4.7 pages; refresh against the
 # pricing source above on the next quarterly pass if Anthropic publishes a
 # distinct 4.8 rate.
+# Fable 5 — $10/$50 per MTok, 1M ctx, 128k out (GA 2026-06-09).
+# ref: https://platform.claude.com/docs/en/about-claude/models/overview
+[pricing.anthropic."claude-fable-5"]
+input_per_mtok = 10.00
+output_per_mtok = 50.00
+
 [pricing.anthropic."claude-opus-4-8"]
 input_per_mtok = 5.00
 output_per_mtok = 25.00
@@ -135,6 +141,7 @@ output_per_mtok = 0.00  # free tier (limited-time)
 # margin).
 
 [context_windows]
+"claude-fable-5"             = 1000000
 "claude-opus-4-8"            = 1000000
 "claude-opus-4-7"            = 1000000
 "claude-opus-4-6"            = 1000000

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -38,6 +38,7 @@ enabled_roles = ["auditor", "target", "judge"]
 [petri.role.auditor]
 default_model = "claude-opus-4-7"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -53,6 +54,7 @@ role_contract = "roles/auditor.md"
 # LLM GEODE uses internally.
 default_model = "claude-haiku-4-5"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -67,6 +69,7 @@ role_contract = "roles/target.md"
 [petri.role.judge]
 default_model = "claude-sonnet-4-6"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -59,6 +59,7 @@ enabled_roles = [
 [seed_generation.role.generator]
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -80,6 +81,7 @@ default_model = "claude-opus-4-8"
 # subscription can route critic on the strongest available reasoning
 # model when running through ``source = "claude-cli"``.
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -98,6 +100,7 @@ default_model = "claude-opus-4-8"
 # ``claude-opus-4-7`` accepted for the same Claude Code Max routing
 # reason as critic — proximity is also a reasoning-heavy role.
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -117,6 +120,7 @@ role_contract = "plugins/seed_generation/agents/proximity.md"
 # for picker-provenance symmetry with the other roles.
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-haiku-4-5",
@@ -129,6 +133,7 @@ allowed_models = [
 # the panel's voter binding (below) drives actual LLM calls.
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -139,6 +144,7 @@ role_contract = "plugins/seed_generation/agents/ranker.md"
 [seed_generation.role.evolver]
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -149,6 +155,7 @@ role_contract = "plugins/seed_generation/agents/evolver.md"
 [seed_generation.role.meta_reviewer]
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -166,6 +173,7 @@ role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
 [seed_generation.role.supervisor]
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",
@@ -183,6 +191,7 @@ role_contract = "plugins/seed_generation/agents/supervisor.md"
 [seed_generation.role.literature_review]
 default_model = "claude-opus-4-8"
 allowed_models = [
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-4-6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.165"
+version = "0.99.166"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/llm/test_fable5_support.py
+++ b/tests/core/llm/test_fable5_support.py
@@ -1,0 +1,77 @@
+"""Fable 5 support guards (2026-06-11).
+
+Pins the doc-verified surface (refs cited in the production modules):
+capability-anchor membership (adaptive-only thinking / sampling-param
+omission / xhigh effort / 1M-context compaction), picker availability,
+pricing, plugin allowlists, and the refusal stop_reason path.
+
+Official refs:
+- https://platform.claude.com/docs/en/about-claude/models/overview
+- https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+- https://platform.claude.com/docs/en/about-claude/models/migration-guide
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FABLE = "claude-fable-5"
+
+
+def test_capability_anchor_membership() -> None:
+    from core.llm.model_capabilities import (
+        ANTHROPIC_ADAPTIVE_MODELS,
+        ANTHROPIC_CONTEXT_MGMT_MODELS,
+        ANTHROPIC_XHIGH_MODELS,
+    )
+
+    assert FABLE in ANTHROPIC_ADAPTIVE_MODELS  # adaptive-only; sampling params 400
+    assert FABLE in ANTHROPIC_XHIGH_MODELS  # effort xhigh supported
+    assert FABLE in ANTHROPIC_CONTEXT_MGMT_MODELS  # 1M ctx + compaction
+
+
+def test_adapter_request_shape_for_fable() -> None:
+    """The adaptive branch (omit sampling, thinking adaptive, effort) must
+    engage for Fable 5 — the model errors on thinking:{type:"disabled"}
+    and non-default temperature/top_p/top_k."""
+    from core.llm.providers.anthropic import _ADAPTIVE_MODELS
+
+    assert FABLE in _ADAPTIVE_MODELS
+
+
+def test_model_picker_offers_fable() -> None:
+    from core.cli.commands._state import MODEL_PROFILES
+
+    profile = next((p for p in MODEL_PROFILES if p.id == FABLE), None)
+    assert profile is not None
+    assert profile.provider == "anthropic"
+    assert profile.label == "Fable 5"
+
+
+def test_pricing_and_context_window() -> None:
+    data = tomllib.loads((REPO_ROOT / "core" / "llm" / "model_pricing.toml").read_text())
+    row = data["pricing"]["anthropic"][FABLE]
+    assert row["input_per_mtok"] == 10.0 and row["output_per_mtok"] == 50.0
+
+
+def test_plugin_allowlists_include_fable() -> None:
+    for rel in (
+        "plugins/seed_generation/seed_generation.plugin.toml",
+        "plugins/petri_audit/petri.plugin.toml",
+    ):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert FABLE in text, rel
+
+
+def test_refusal_stop_reason_flows_to_result() -> None:
+    """normalize_anthropic carries stop_details; the loop branch exists."""
+    from core.llm.agentic_response import AgenticResponse
+
+    resp = AgenticResponse(stop_reason="refusal", stop_details={"category": "cyber"})
+    assert resp.stop_details == {"category": "cyber"}
+
+    loop_src = (REPO_ROOT / "core" / "agent" / "loop" / "agent_loop.py").read_text(encoding="utf-8")
+    assert 'response.stop_reason == "refusal"' in loop_src
+    assert '"model_refusal"' in loop_src

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.164"
+version = "0.99.165"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `claude-fable-5` available via `/model` (operator request) with the full request-surface compat, doc-before-behaviour verified against official docs (3 pages fetched; URLs cited in every touched module).
- New `refusal` stop_reason handling — Fable 5's safety classifiers return HTTP 200 + `stop_reason:"refusal"`; the loop previously rendered that as a silent empty turn. Now: `stop_details.category` captured, `termination_reason="model_refusal"`, honest user-facing message (benefits Opus 4.7/4.8 too).
- Switch-path E2E executed in an isolated project: stale `.env GEODE_MODEL` mask auto-removed (C-2), toml written, next-session reload effective = fable, `config explain` winner = project toml.

## Why
Operator: "fable 5 지원 추가... /model 입력하면 선택할 수 있게... 요청 표면이 다른 모델과 다른 점 있으니 반드시 공식 문서 확인해서 구현". Verified facts: adaptive-only thinking (`{type:"disabled"}` errors → adaptive/omit), sampling params 400, budget_tokens removed, effort incl. xhigh, 1M ctx/128k out, $10/$50, refusal stop_reason + `fallbacks` beta, ZDR-ineligible (30-day retention).

## Changes
| File | Change |
|------|--------|
| `core/llm/model_capabilities.py` | `claude-fable-5` in ADAPTIVE / XHIGH / CONTEXT_MGMT anchors (doc ref inline) — the adapter's existing adaptive branch (thinking adaptive+summarized, sampling omitted, effort/xhigh) applies verbatim |
| `core/llm/agentic_response.py` | `AgenticResponse.stop_details` field + `normalize_anthropic` capture (pydantic-object-safe) |
| `core/agent/loop/agent_loop.py` | refusal branch before text-exit: `termination_reason="model_refusal"` + honest message with classifier category |
| `core/agent/loop/models.py` | termination_reason doc row |
| `core/llm/model_pricing.toml` | $10/$50 + 1M context-window row |
| `core/cli/commands/_state.py` | `MODEL_PROFILES` top entry — Fable 5 ($$$$) |
| `plugins/{petri_audit,seed_generation}/*.plugin.toml` | 12 allowed_models lists (9-role seedgen trap from the model-compat memory addressed) |
| `tests/core/llm/test_fable5_support.py` | NEW 6 guards: anchor membership, adapter shape engagement, picker, pricing, allowlists, refusal flow |

## Verification
- [x] Official docs fetched + quoted: models/overview · introducing-claude-fable-5-and-claude-mythos-5 · migration-guide (`thinking disabled → error`, `sampling 400`, `refusal HTTP 200 + stop_details.category` exact wording)
- [x] **E2E (isolated tmp project)**: stale `.env GEODE_MODEL=sonnet` + process-env mask → switch to fable → mask removed + API key preserved + toml written → `reload_settings_from_disk` effective = `claude-fable-5` → explain winner = project config.toml, masked = none → PASS
- [x] ruff / format / lint-imports clean; mypy 3 known local-venv only
- [x] full non-live suite: the 4 known xdist order-flakes only; llm/cli/agent slices 1,545 passed
- [x] Live inference call NOT run (cost policy) — switch mechanics were the requested verification; first real fable call will exercise the refusal path organically

## Reference
platform.claude.com 공식 문서 3종 (본문 인용) · C-2 stale-mask cleanup (#2097) · reference_model_compat_surfaces 메모리