### PR TITLE
release: v0.99.167 — C-3 config loading unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ functional change.
 
 ---
 
+## [0.99.167] - 2026-06-11
+
+### Changed
+- **C-3 config loading unification — one dotenv precedence, daemon never masked** (config-unification sprint, follows C-1 explain / C-2 secrets-only):
+  - pydantic `env_file` order flipped to `(global ~/.geode/.env, project .env)` so the LATER (project) file wins — pre-fix the order was inverted vs. every other layer's project>global direction (hazard H5, per-process precedence inversion between thin CLI and serve daemon).
+  - Serve daemon `load_daemon_env` (hoisted from the inline `setup_contextvars` block, `core/cli/bootstrap.py`) now **drops behavior(model-pick) env keys** — `GEODE_MODEL`, per-role models, `GEODE_AGENTIC_EFFORT`, credential sources (`core.config.env_io.BEHAVIOR_ENV_KEYS`) — from its inherited environment and skips them during .env promotion, so per-session settings reloads always win (hazard H2: anything promoted into the daemon's `os.environ` outlived every `/model` switch). Escape hatch: `GEODE_SERVE_KEEP_MODEL_ENV=1`.
+  - Promotion precedence normalized: manual exports > project .env > global .env — pre-fix the two files used opposite clobber rules (global never overrode process env, project always did). Secrets still promote (MCP `${VAR}` expansion, subprocess inheritance); empty values still never clobber.
+  - `core/config/explain.py` ladder + `geode config explain` updated to the new order (project .env above global .env).
+  - Guards: `tests/core/config/test_c3_env_loading.py` (8) + flipped `test_project_env_beats_global_env_matching_pydantic_order`.
+
 ## [0.99.166] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.166
+- **Version**: 0.99.167
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8551 (+1 live)
+- **Tests**: 8558 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.166 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.167 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.166 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.167 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -75,6 +75,55 @@ class GeodeBootstrap:
             log.debug("User profile propagation skipped", exc_info=True)
 
 
+def load_daemon_env() -> None:
+    """Serve-daemon env load (C-3, 2026-06-11).
+
+    Order: manual exports > project .env > global ~/.geode/.env — the same
+    direction as the pydantic ``env_file`` cascade (core/config/_settings.py),
+    so there is exactly one dotenv precedence in the codebase (hazard H5).
+
+    Behavior(model-pick) keys (``core.config.env_io.BEHAVIOR_ENV_KEYS``) are
+    dropped from the inherited environment and skipped during promotion:
+    anything in the daemon's os.environ outlives every per-session settings
+    reload, so a stray GEODE_MODEL would mask /model switches for the
+    daemon's whole lifetime (hazard H2). ``GEODE_SERVE_KEEP_MODEL_ENV=1``
+    keeps them for operators who intentionally pin the daemon's model.
+    Secrets still promote — MCP ``${VAR}`` expansion and spawned
+    subprocesses read os.environ.
+    """
+    import os
+    from pathlib import Path
+
+    from dotenv import dotenv_values
+
+    from core.config.env_io import BEHAVIOR_ENV_KEYS
+    from core.paths import GLOBAL_ENV_FILE
+
+    keep_model_env = os.environ.get("GEODE_SERVE_KEEP_MODEL_ENV") == "1"
+    if not keep_model_env:
+        for behavior_key in BEHAVIOR_ENV_KEYS:
+            if behavior_key in os.environ:
+                log.info(
+                    "serve: dropping inherited %s from daemon env "
+                    "(session reloads must win; set "
+                    "GEODE_SERVE_KEEP_MODEL_ENV=1 to keep)",
+                    behavior_key,
+                )
+                os.environ.pop(behavior_key)
+
+    inherited = frozenset(os.environ)
+    for env_file in (GLOBAL_ENV_FILE, Path(".env")):
+        if not env_file.exists():
+            continue
+        for key, val in dotenv_values(str(env_file)).items():
+            # Empty values (e.g. ANTHROPIC_API_KEY=) must NOT clobber
+            if not val or key in inherited:
+                continue
+            if key in BEHAVIOR_ENV_KEYS and not keep_model_env:
+                continue
+            os.environ[key] = val
+
+
 def setup_contextvars(*, load_env: bool = False) -> None:
     """Initialize ContextVars only (memory, profile, env).
 
@@ -82,25 +131,7 @@ def setup_contextvars(*, load_env: bool = False) -> None:
     memory ContextVars are available to all layers.
     """
     if load_env:
-        import os
-        from pathlib import Path
-
-        from dotenv import dotenv_values, load_dotenv
-
-        # 1) Global ~/.geode/.env — baseline for all projects
-        from core.paths import GLOBAL_ENV_FILE
-
-        global_env = GLOBAL_ENV_FILE
-        if global_env.exists():
-            load_dotenv(str(global_env), override=False)
-
-        # 2) Local .env — override only with non-empty values
-        #    Empty values (e.g. ANTHROPIC_API_KEY=) must NOT clobber global keys
-        local_env = Path(".env")
-        if local_env.exists():
-            for key, val in dotenv_values(str(local_env)).items():
-                if val:  # non-empty only
-                    os.environ[key] = val
+        load_daemon_env()
 
     # 1. Memory contextvars
     try:

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -22,8 +22,13 @@ from core.paths import GLOBAL_ENV_FILE
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="GEODE_",
-        # P2 (v0.95.x) — was literal `str(Path.home() / ".geode" / ".env")`
-        env_file=(".env", str(GLOBAL_ENV_FILE)),
+        # C-3 (2026-06-11) — pydantic merges env_file with the LATER file
+        # winning. Pre-fix the order was (".env", global) = GLOBAL beat the
+        # project file, the exact inverse of the project>global convention
+        # every other layer follows (and of the serve daemon's promotion
+        # order — hazard H5, per-process precedence inversion). Order is now
+        # (global, project): one direction everywhere.
+        env_file=(str(GLOBAL_ENV_FILE), ".env"),
         extra="ignore",
     )
 

--- a/core/config/env_io.py
+++ b/core/config/env_io.py
@@ -14,6 +14,22 @@ import os
 import re
 from pathlib import Path
 
+# C-3 (2026-06-11) — behavior(model-pick) env keys. These are SESSION-scoped
+# manual overrides only: tools never write them (C-2), the serve daemon drops
+# them from its inherited os.environ at startup (so per-session disk reloads
+# always win — hazard H2), and the bootstrap .env promotion skips them.
+BEHAVIOR_ENV_KEYS: tuple[str, ...] = (
+    "GEODE_MODEL",
+    "GEODE_PLAN_MODEL",
+    "GEODE_ACT_MODEL",
+    "GEODE_JUDGE_MODEL",
+    "GEODE_COGNITIVE_REFLECTION_MODEL",
+    "GEODE_LEARNING_EXTRACT_MODEL",
+    "GEODE_AGENTIC_EFFORT",
+    "GEODE_ANTHROPIC_CREDENTIAL_SOURCE",
+    "GEODE_OPENAI_CREDENTIAL_SOURCE",
+)
+
 
 def mask_key(key: str) -> str:
     """Mask an API key for display: show first 10 + last 4 chars."""

--- a/core/config/explain.py
+++ b/core/config/explain.py
@@ -11,12 +11,13 @@ the SAME precedence the real resolution applies:
     os.environ  >  dotenv layer  >  project config.toml  >  global
     config.toml  >  code default
 
-Dotenv-layer honesty note: pydantic-settings merges ``env_file=(".env",
-"~/.geode/.env")`` with the LATER file winning, so within the dotenv
-layer the GLOBAL file beats the project file for a plain ``Settings()``
-construction. (The serve daemon's bootstrap loads them in the opposite
-direction — hazard H5; this explainer reports the plain-Settings order
-and flags the key when both files define it.)
+Dotenv-layer order (C-3, 2026-06-11): one direction everywhere —
+project ``.env`` beats global ``~/.geode/.env``. pydantic-settings
+merges ``env_file=(global, ".env")`` with the LATER file winning, and
+the serve daemon's bootstrap promotion follows the same order, so the
+per-process inversion (hazard H5) is gone. Behavior(model-pick) keys
+additionally never survive into the daemon's os.environ (hazard H2,
+``core.config.env_io.BEHAVIOR_ENV_KEYS``).
 """
 
 from __future__ import annotations
@@ -36,8 +37,8 @@ PROJECT_ENV_FILE = Path(".env")
 #: Layer identifiers in precedence order (index 0 = strongest).
 LAYERS: tuple[str, ...] = (
     "os.environ",
-    "global .env",
     "project .env",
+    "global .env",
     "project config.toml",
     "global config.toml",
     "code default",
@@ -88,15 +89,15 @@ def explain_field(field_name: str) -> FieldReport:
 
     candidates.append(LayerValue("os.environ", "process env", os.environ.get(env_var)))
 
-    # Dotenv layer — pydantic's later-file-wins means GLOBAL beats project
-    # for plain Settings(); report both files separately so a duplicate key
-    # is visible.
+    # Dotenv layer — env_file=(global, project) with later-file-wins, so
+    # the PROJECT file beats global (C-3); report both files separately so
+    # a duplicate key is visible.
     global_env = dotenv_values(GLOBAL_ENV_FILE) if GLOBAL_ENV_FILE.exists() else {}
     project_env = dotenv_values(PROJECT_ENV_FILE) if PROJECT_ENV_FILE.exists() else {}
-    candidates.append(LayerValue("global .env", str(GLOBAL_ENV_FILE), global_env.get(env_var)))
     candidates.append(
         LayerValue("project .env", str(PROJECT_ENV_FILE.resolve()), project_env.get(env_var))
     )
+    candidates.append(LayerValue("global .env", str(GLOBAL_ENV_FILE), global_env.get(env_var)))
 
     def _toml_value(path: Path) -> Any | None:
         if toml_key is None or not path.exists():
@@ -155,7 +156,7 @@ def model_mask_warning() -> str | None:
     """
     report = explain_field("model")
     winner = report.winner
-    if winner is None or winner.layer not in ("os.environ", "global .env", "project .env"):
+    if winner is None or winner.layer not in ("os.environ", "project .env", "global .env"):
         return None
     masked_toml = [entry for entry in report.masked_layers if entry.layer.endswith("config.toml")]
     if not masked_toml:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.166"
+version = "0.99.167"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/config/test_c3_env_loading.py
+++ b/tests/core/config/test_c3_env_loading.py
@@ -1,0 +1,128 @@
+"""C-3 guards — one dotenv precedence + daemon behavior-env drop.
+
+Config-unification sprint, 2026-06-11. Pins:
+
+1. pydantic ``env_file`` order is (global, project) so the LATER (project)
+   file wins — pre-fix it was (".env", global) = global beat project, the
+   inverse of every other layer's project>global direction (hazard H5).
+2. The serve daemon's ``load_daemon_env`` drops behavior(model-pick) keys
+   from its inherited os.environ and never promotes them from .env files,
+   so per-session settings reloads always win (hazard H2) — with the
+   ``GEODE_SERVE_KEEP_MODEL_ENV=1`` escape hatch.
+3. Files never clobber manual exports (env > files), and secrets still
+   promote for MCP ``${VAR}`` expansion / subprocess inheritance.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+from core.cli.bootstrap import load_daemon_env
+from core.config.env_io import BEHAVIOR_ENV_KEYS
+
+
+def test_settings_env_file_order_is_global_then_project() -> None:
+    """Later file wins in pydantic — project must come AFTER global."""
+    import core.config._settings as settings_mod
+
+    source = inspect.getsource(settings_mod)
+    assert 'env_file=(str(GLOBAL_ENV_FILE), ".env")' in source
+
+
+def test_behavior_keys_cover_all_model_pick_surfaces() -> None:
+    expected = {
+        "GEODE_MODEL",
+        "GEODE_PLAN_MODEL",
+        "GEODE_ACT_MODEL",
+        "GEODE_JUDGE_MODEL",
+        "GEODE_COGNITIVE_REFLECTION_MODEL",
+        "GEODE_LEARNING_EXTRACT_MODEL",
+        "GEODE_AGENTIC_EFFORT",
+        "GEODE_ANTHROPIC_CREDENTIAL_SOURCE",
+        "GEODE_OPENAI_CREDENTIAL_SOURCE",
+    }
+    assert set(BEHAVIOR_ENV_KEYS) == expected
+
+
+@pytest.fixture()
+def daemon_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolated global .env + project .env + cwd for load_daemon_env."""
+    import core.cli.bootstrap as bootstrap_mod
+
+    global_env_file = tmp_path / "global.env"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    monkeypatch.setattr("core.paths.GLOBAL_ENV_FILE", global_env_file, raising=True)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("GEODE_SERVE_KEEP_MODEL_ENV", raising=False)
+    for behavior_key in BEHAVIOR_ENV_KEYS:
+        monkeypatch.delenv(behavior_key, raising=False)
+    monkeypatch.delenv("C3_TEST_SECRET", raising=False)
+    return {
+        "module": bootstrap_mod,
+        "global_env": global_env_file,
+        "project_env": project_dir / ".env",
+    }
+
+
+def test_daemon_drops_inherited_behavior_env(daemon_env, monkeypatch) -> None:
+    import os
+
+    monkeypatch.setenv("GEODE_MODEL", "stale-shell-pick")
+    monkeypatch.setenv("GEODE_AGENTIC_EFFORT", "low")
+    load_daemon_env()
+    assert "GEODE_MODEL" not in os.environ
+    assert "GEODE_AGENTIC_EFFORT" not in os.environ
+
+
+def test_daemon_never_promotes_behavior_keys_from_env_files(daemon_env, monkeypatch) -> None:
+    import os
+
+    daemon_env["global_env"].write_text("GEODE_MODEL=global-pick\nC3_TEST_SECRET=g\n")
+    daemon_env["project_env"].write_text("GEODE_JUDGE_MODEL=project-pick\n")
+    load_daemon_env()
+    assert "GEODE_MODEL" not in os.environ
+    assert "GEODE_JUDGE_MODEL" not in os.environ
+    # secrets still promote
+    assert os.environ.get("C3_TEST_SECRET") == "g"
+    monkeypatch.delenv("C3_TEST_SECRET", raising=False)
+
+
+def test_keep_model_env_escape_hatch(daemon_env, monkeypatch) -> None:
+    import os
+
+    monkeypatch.setenv("GEODE_SERVE_KEEP_MODEL_ENV", "1")
+    monkeypatch.setenv("GEODE_MODEL", "pinned-pick")
+    load_daemon_env()
+    assert os.environ.get("GEODE_MODEL") == "pinned-pick"
+
+
+def test_project_env_beats_global_env_in_promotion(daemon_env, monkeypatch) -> None:
+    import os
+
+    daemon_env["global_env"].write_text("C3_TEST_SECRET=from-global\n")
+    daemon_env["project_env"].write_text("C3_TEST_SECRET=from-project\n")
+    load_daemon_env()
+    assert os.environ.get("C3_TEST_SECRET") == "from-project"
+    monkeypatch.delenv("C3_TEST_SECRET", raising=False)
+
+
+def test_files_never_clobber_manual_exports(daemon_env, monkeypatch) -> None:
+    import os
+
+    monkeypatch.setenv("C3_TEST_SECRET", "manual-export")
+    daemon_env["global_env"].write_text("C3_TEST_SECRET=from-global\n")
+    daemon_env["project_env"].write_text("C3_TEST_SECRET=from-project\n")
+    load_daemon_env()
+    assert os.environ.get("C3_TEST_SECRET") == "manual-export"
+
+
+def test_empty_values_do_not_clobber(daemon_env, monkeypatch) -> None:
+    import os
+
+    monkeypatch.setenv("C3_TEST_SECRET", "real-value")
+    daemon_env["project_env"].write_text("C3_TEST_SECRET=\n")
+    load_daemon_env()
+    assert os.environ.get("C3_TEST_SECRET") == "real-value"

--- a/tests/core/config/test_config_explain.py
+++ b/tests/core/config/test_config_explain.py
@@ -70,13 +70,13 @@ def test_env_file_masks_toml_and_warning_fires(isolated_layers) -> None:
     assert "GEODE_MODEL" in warning and "masking" in warning
 
 
-def test_global_env_beats_project_env_matching_pydantic_order(isolated_layers) -> None:
-    """pydantic-settings: later env_file wins → global .env beats project .env."""
+def test_project_env_beats_global_env_matching_pydantic_order(isolated_layers) -> None:
+    """C-3: env_file=(global, project), later wins → project .env beats global."""
     isolated_layers["global_env"].write_text("GEODE_MODEL=global-pick\n")
     isolated_layers["project_env"].write_text("GEODE_MODEL=project-pick\n")
     report = explain_field("model")
-    assert report.winner.layer == "global .env"
-    assert report.winner.value == "global-pick"
+    assert report.winner.layer == "project .env"
+    assert report.winner.value == "project-pick"
 
 
 def test_os_environ_tops_everything(isolated_layers, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.165"
+version = "0.99.167"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- C-3 config loading unification: one dotenv precedence (project .env wins), serve daemon drops behavior(model-pick) env keys at startup so per-session reloads always win (PR #2105, v0.99.167).

## Verification
- [x] CI 8/8 green on #2105
- [x] develop → main pass-through (no extra commits)