### PR TITLE
fix(mcp): geode-mcp identity + health honesty + Claude Code registration (v0.99.169)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "geode": {
+      "type": "stdio",
+      "command": "geode-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ functional change.
 
 ---
 
+## [0.99.169] - 2026-06-11
+
+### Fixed
+- **geode-mcp identity + health honesty** (operator-requested MCP exposure audit, live-verified via stdio handshake):
+  - Initialize handshake advertised the mcp SDK's package version ("1.26.0") instead of GEODE's — `create_mcp_server` now sets the wrapped lowlevel server's `version` (the installed SDK's `FastMCP.__init__` exposes no `version` kwarg). Pinned by `test_handshake_advertises_geode_version_not_sdk_version`.
+  - `get_health` `*_configured` only meant "API key present" and read false on OAuth/CLI-lane setups; now also reports `version` + `anthropic_credential_source`/`openai_credential_source`.
+
+### Added
+- Repo-shipped `.mcp.json` registering `geode-mcp` (stdio) for Claude Code sessions opened in this project; README/README.ko gain an "Using GEODE as an MCP server" section with the live verification table (run_agent / propose / apply intentionally not auto-exercised — token cost / mutation side effects).
+
 ## [0.99.168] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.168
+- **Version**: 0.99.169
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.168 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.169 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 
@@ -351,9 +351,25 @@ geode update                  # 소스 체크아웃
 | **3-프로바이더 페일오버** | Anthropic + OpenAI + ZhipuAI. 구독 OAuth (Codex) 자동 감지; 사용량 과금 API 키도 사용 가능; 페일오버는 동일 프로바이더 내에서만 (예상치 못한 vendor 횡단 과금 없음, v0.53.0 거버넌스) |
 | **5-tier 메모리** | SOUL (0) → User Profile (0.5) → Organization (1) → Project (2) → Session (3). 영속화, 데몬 재시작 후에도 유지 |
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` 로 다단계 작업 관리. 디스크 영구화 (`.geode/plans.json`), 재시작 후에도 유지 |
+| **MCP 서버 (`geode-mcp`)** | GEODE 자체를 MCP 서버(stdio)로 노출: `run_agent`, `self_improving_status`, `self_improving_propose`/`apply`(2-step 확인 게이트), `query_memory`, `get_health`. repo의 `.mcp.json`으로 Claude Code에 자동 등록 |
 | **장시간 데몬** | `geode serve` 가 백그라운드로 상주. Slack / Discord / Telegram 폴러 + 스케줄러 tick + thin CLI 용 IPC |
 | **서브에이전트** | 부모 권한 완전 상속, depth/cost 가드, Lane 격리 |
 | **코어 검증** | Guardrails G1-G4 (structural) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal). 전문 편향 / 캘리브레이션 계층은 외부 패키지가 추가 |
+
+
+### GEODE를 MCP 서버로 쓰기
+
+`geode-mcp`(CLI와 함께 설치)는 stdio로 MCP를 말하므로 Claude Code, Claude Desktop, Cursor 등 어떤 MCP 클라이언트든 GEODE를 도구로 부릴 수 있습니다. 이 repo는 `.mcp.json`을 포함하므로 이 프로젝트에서 연 Claude Code 세션은 서버를 자동 인식합니다. 다른 곳에서는 `claude mcp add geode -- geode-mcp`로 등록합니다.
+
+2026-06-11 라이브 런타임 검증(initialize 핸드셰이크, `tools/list`, 도구 호출):
+
+| 점검 | 결과 |
+|------|------|
+| 핸드셰이크 + 도구 6종 노출 | 통과 |
+| `self_improving_status` / `get_health` / `query_memory` | 통과 (라이브 데이터) |
+| 핸드셰이크의 서버 버전 | mcp SDK 버전("1.26.0")으로 오보고되던 것을 GEODE 버전으로 정정 (SDK `FastMCP.__init__`에 `version` kwarg 부재; `tests/core/test_mcp_server_tools.py`로 핀) |
+| `get_health` 자격증명 정직성 | `*_configured`가 API 키 유무만 봐서 OAuth/CLI-lane 환경에서 false로 오보고 — `*_credential_source` 병기로 정정 |
+| `run_agent`, `self_improving_propose`/`apply` | 자동 점검에서 미실행(토큰 비용/변이 부작용); `apply`는 2-step 확인 게이트 뒤 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.168 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.169 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 
@@ -352,9 +352,25 @@ geode update                  # source checkout
 | **3-provider failover** | Anthropic + OpenAI + ZhipuAI. Subscription OAuth (Codex) auto-detected; pay-as-you-go API keys also work; failover is in-provider only (no surprise cross-vendor charges, v0.53.0 governance) |
 | **5-tier memory** | SOUL (0) → User Profile (0.5) → Organization (1) → Project (2) → Session (3). Persistent, survives daemon restarts |
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` for multi-step work. Disk-persistent (`.geode/plans.json`), survives restarts |
+| **MCP server (`geode-mcp`)** | Exposes GEODE itself as an MCP server (stdio): `run_agent`, `self_improving_status`, `self_improving_propose`/`apply` (2-step confirm gate), `query_memory`, `get_health`. Registered for Claude Code via the repo-shipped `.mcp.json` |
 | **Long-running daemon** | `geode serve` runs as background daemon. Slack / Discord / Telegram pollers + scheduler tick + IPC for the thin CLI |
 | **Sub-agents** | Full inheritance of parent capability, depth/cost guards, isolation by Lane |
 | **Core verification** | Guardrails G1-G4 (structural) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal). External packages can add specialized bias / calibration layers |
+
+
+### Using GEODE as an MCP server
+
+`geode-mcp` (installed with the CLI) speaks MCP over stdio, so any MCP client — Claude Code, Claude Desktop, Cursor — can drive GEODE as a tool. This repo ships `.mcp.json`, so Claude Code sessions opened in this project pick the server up automatically; elsewhere register it with `claude mcp add geode -- geode-mcp`.
+
+Verified 2026-06-11 against the live runtime (initialize handshake, `tools/list`, tool calls):
+
+| Check | Result |
+|-------|--------|
+| Handshake + 6 tools listed | pass |
+| `self_improving_status` / `get_health` / `query_memory` | pass (live data) |
+| Server version in handshake | was the mcp SDK's "1.26.0" — now reports GEODE's version (the SDK's `FastMCP.__init__` exposes no `version` kwarg; pinned by `tests/core/test_mcp_server_tools.py`) |
+| `get_health` credential honesty | `*_configured` only meant "API key present" and read false on OAuth/CLI-lane setups — now also reports `*_credential_source` |
+| `run_agent`, `self_improving_propose`/`apply` | not exercised in the automated check (token cost / mutation side effects); `apply` is gated behind a 2-step proposal confirm |
 
 ---
 

--- a/core/mcp_server.py
+++ b/core/mcp_server.py
@@ -108,6 +108,15 @@ def create_mcp_server() -> Any:
         ) from None
 
     mcp = FastMCP("geode")
+    # Report GEODE's own version in the initialize handshake. The installed
+    # mcp SDK's FastMCP.__init__ (1.26.x) exposes no ``version`` kwarg even
+    # though the wrapped lowlevel ``Server(name, version, ...)`` accepts one,
+    # so without this the handshake advertises the SDK's package version
+    # ("1.26.0") instead of GEODE's. Verified against the installed SDK:
+    # mcp.server.fastmcp.FastMCP -> self._mcp_server.version (None by default).
+    from core import __version__ as _geode_version
+
+    mcp._mcp_server.version = _geode_version
 
     # Shared ProjectMemory instance (created once per server lifetime)
     _project_memory: Any = None
@@ -183,13 +192,23 @@ def create_mcp_server() -> Any:
     @mcp.tool(description=_TOOL_DESCRIPTIONS["get_health"])
     def get_health() -> dict[str, Any]:
         """Get pipeline health status."""
+        from core import __version__
         from core.config import settings
 
+        # ``*_configured`` historically meant "API key present", which
+        # under-reports health for OAuth/CLI-lane setups (the common case:
+        # both read false while the agent runs fine on subscription auth).
+        # Keep the legacy keys but scope them honestly as api_key bits, and
+        # add the effective credential-source picks so a client can tell
+        # "no API key" apart from "not authenticated at all".
         return {
+            "version": __version__,
             "model": settings.model,
             "ensemble_mode": settings.ensemble_mode,
             "anthropic_configured": bool(settings.anthropic_api_key),
             "openai_configured": bool(settings.openai_api_key),
+            "anthropic_credential_source": settings.anthropic_credential_source,
+            "openai_credential_source": settings.openai_credential_source,
         }
 
     @mcp.resource("geode://soul")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.168"
+version = "0.99.169"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/test_mcp_server_tools.py
+++ b/tests/core/test_mcp_server_tools.py
@@ -36,6 +36,41 @@ def test_server_identity_and_tool_surface() -> None:
     assert names >= EXPECTED_TOOLS
 
 
+def test_handshake_advertises_geode_version_not_sdk_version() -> None:
+    """The initialize handshake must carry GEODE's version. The installed
+    mcp SDK's FastMCP exposes no ``version`` kwarg, so create_mcp_server
+    sets it on the wrapped lowlevel server — without that, clients see the
+    SDK package version (e.g. "1.26.0")."""
+    from core import __version__
+
+    server = create_mcp_server()
+    assert server._mcp_server.version == __version__
+    init_options = server._mcp_server.create_initialization_options()
+    assert init_options.server_version == __version__
+
+
+def test_get_health_reports_credential_sources() -> None:
+    """``*_configured`` alone under-reports OAuth/CLI-lane setups; health
+    must also expose the effective credential-source picks + version."""
+    server = create_mcp_server()
+
+    async def _call() -> dict:
+        result = await server.call_tool("get_health", {})
+        return result[1] if isinstance(result, tuple) else result
+
+    payload = asyncio.run(_call())
+    if isinstance(payload, dict) and "result" in payload:
+        payload = payload["result"]
+    for key in (
+        "version",
+        "anthropic_credential_source",
+        "openai_credential_source",
+        "anthropic_configured",
+        "openai_configured",
+    ):
+        assert key in payload, key
+
+
 def test_tool_descriptions_sourced_from_json() -> None:
     """Every registered core tool keeps its description in mcp_tools.json."""
     descriptions_path = Path("core/tools/mcp_tools.json")

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.167"
+version = "0.99.169"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Live MCP exposure audit (operator request): stdio handshake + tools/list + read-only tool calls against the production runtime — 2 quality defects found and fixed.
- Handshake advertised the mcp SDK's package version ("1.26.0") instead of GEODE's; `get_health` under-reported OAuth/CLI-lane setups (api-key-only bools).
- Repo-shipped `.mcp.json` so Claude Code sessions in this project pick up `geode-mcp` automatically; README/README.ko record the verification results.

## Why
GEODE has been a first-class MCP server since v0.99.155 but was never registered for Claude Code nor live-verified end-to-end. The audit (initialize → tools/list → self_improving_status / get_health / query_memory) passed functionally but exposed the two identity/honesty defects above.

## Changes
| File | Change |
|------|--------|
| `core/mcp_server.py` | set lowlevel server `version` to GEODE's (installed SDK `FastMCP.__init__` has no `version` kwarg — verified); `get_health` adds `version` + `anthropic/openai_credential_source` |
| `.mcp.json` | new — registers `geode-mcp` (stdio) project-scope for Claude Code |
| `tests/core/test_mcp_server_tools.py` | +2 guards (handshake version, health keys) |
| `README.md` / `README.ko.md` | feature row + "Using GEODE as an MCP server" section with live verification table |

## Verification
- [x] ruff check + format clean (scripts/ included)
- [x] mypy clean (450 files)
- [x] lint-imports 4 contracts kept
- [x] pytest test_mcp_server_tools (7) + tests/core/config: all pass
- [x] live stdio handshake: SERVER geode / 6 tools / status+health+query_memory OK (run_agent / propose / apply intentionally not auto-exercised — token cost / mutation side effects)