### PR TITLE
refactor(config): C-4 — GEODE_CONFIG_TOML unification, routing reload, reload warnings (v0.99.170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.170] - 2026-06-11
+
+### Changed
+- **C-4 config-unification tail** (closes the loading-hazard audit, follows C-1/C-2/C-3):
+  - H9: `GEODE_CONFIG_TOML` now redirects the GLOBAL config.toml for the MAIN settings loader (`_load_toml_config`) too — pre-fix only the self-improving loop loader honored it, giving one env var two meanings. Project overlay still applies; `geode config explain` reports the path actually read.
+  - H11: `reload_settings_from_disk` now re-reads routing.toml — `reload_routing_constants()` clears the manifest lru_cache and rebinds `core.config` routing constants, so manifest readers and function-local importers see fresh values after a session reload. Honest limit (documented in the docstring): module-level by-value importers (`core/llm/providers/*` aliases, `core/skills/agents.py` dataclass defaults) still hold boot-time copies — follow-up H11-tail.
+  - H13: a per-field copy failure during settings reload now logs a warning naming the field (pre-fix `contextlib.suppress` made half-applied reloads untraceable).
+  - C-3 follow-up (Codex review): standalone train/campaign env load delegates to the new shared `core.config.env_io.load_env_files` (manual exports > project .env > global .env) — pre-fix it promoted ONLY the global file, inverting the documented direction; the serve daemon's `load_daemon_env` delegates to the same loader.
+  - C-3 follow-up: `GEODE_SERVE_KEEP_MODEL_ENV=1` is now honored when written in a .env file — pre-fix the flag was read only from the process env AFTER the behavior-key drop had already happened.
+  - Guards: `tests/core/config/test_c4_config_tail.py` (7).
+
 ## [0.99.169] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.169
+- **Version**: 0.99.170
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.169 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.170 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.169 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.170 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -76,30 +76,43 @@ class GeodeBootstrap:
 
 
 def load_daemon_env() -> None:
-    """Serve-daemon env load (C-3, 2026-06-11).
+    """Serve-daemon env load (C-3/C-4, 2026-06-11).
 
-    Order: manual exports > project .env > global ~/.geode/.env — the same
-    direction as the pydantic ``env_file`` cascade (core/config/_settings.py),
-    so there is exactly one dotenv precedence in the codebase (hazard H5).
+    Delegates promotion to :func:`core.config.env_io.load_env_files` — the
+    ONE dotenv precedence (manual exports > project .env > global
+    ~/.geode/.env, hazard H5) shared with the standalone train/campaign
+    entrypoints.
 
     Behavior(model-pick) keys (``core.config.env_io.BEHAVIOR_ENV_KEYS``) are
     dropped from the inherited environment and skipped during promotion:
     anything in the daemon's os.environ outlives every per-session settings
     reload, so a stray GEODE_MODEL would mask /model switches for the
     daemon's whole lifetime (hazard H2). ``GEODE_SERVE_KEEP_MODEL_ENV=1``
-    keeps them for operators who intentionally pin the daemon's model.
-    Secrets still promote — MCP ``${VAR}`` expansion and spawned
-    subprocesses read os.environ.
+    keeps them for operators who intentionally pin the daemon's model —
+    honored from the process env OR from either .env file (C-4: pre-fix a
+    flag written into .env was read only AFTER the drop had already
+    happened, so it silently did nothing). Secrets still promote — MCP
+    ``${VAR}`` expansion and spawned subprocesses read os.environ.
     """
     import os
     from pathlib import Path
 
     from dotenv import dotenv_values
 
-    from core.config.env_io import BEHAVIOR_ENV_KEYS
+    from core.config.env_io import BEHAVIOR_ENV_KEYS, load_env_files
     from core.paths import GLOBAL_ENV_FILE
 
     keep_model_env = os.environ.get("GEODE_SERVE_KEEP_MODEL_ENV") == "1"
+    if not keep_model_env:
+        # The escape hatch may live in a .env file rather than the spawning
+        # shell — check both files BEFORE dropping anything.
+        for env_file in (GLOBAL_ENV_FILE, Path(".env")):
+            if env_file.exists() and dotenv_values(str(env_file)).get(
+                "GEODE_SERVE_KEEP_MODEL_ENV"
+            ) == "1":
+                keep_model_env = True
+                break
+
     if not keep_model_env:
         for behavior_key in BEHAVIOR_ENV_KEYS:
             if behavior_key in os.environ:
@@ -111,17 +124,7 @@ def load_daemon_env() -> None:
                 )
                 os.environ.pop(behavior_key)
 
-    inherited = frozenset(os.environ)
-    for env_file in (GLOBAL_ENV_FILE, Path(".env")):
-        if not env_file.exists():
-            continue
-        for key, val in dotenv_values(str(env_file)).items():
-            # Empty values (e.g. ANTHROPIC_API_KEY=) must NOT clobber
-            if not val or key in inherited:
-                continue
-            if key in BEHAVIOR_ENV_KEYS and not keep_model_env:
-                continue
-            os.environ[key] = val
+    load_env_files(skip_behavior_keys=not keep_model_env)
 
 
 def setup_contextvars(*, load_env: bool = False) -> None:

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -107,9 +107,10 @@ def load_daemon_env() -> None:
         # The escape hatch may live in a .env file rather than the spawning
         # shell — check both files BEFORE dropping anything.
         for env_file in (GLOBAL_ENV_FILE, Path(".env")):
-            if env_file.exists() and dotenv_values(str(env_file)).get(
-                "GEODE_SERVE_KEEP_MODEL_ENV"
-            ) == "1":
+            if (
+                env_file.exists()
+                and dotenv_values(str(env_file)).get("GEODE_SERVE_KEEP_MODEL_ENV") == "1"
+            ):
                 keep_model_env = True
                 break
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -123,7 +123,15 @@ def _load_toml_config(
     Returns a dict mapping Settings field names to their values.
     Only keys present in _TOML_TO_SETTINGS are returned.
     """
-    gp = global_path or GLOBAL_CONFIG_PATH
+    # H9 (C-4, 2026-06-11) — ``GEODE_CONFIG_TOML`` redirects the GLOBAL
+    # config.toml for the MAIN settings loader too. Pre-fix only the
+    # self-improving loop loader honored it
+    # (core/config/self_improving.py:_resolve_config_path), so an operator
+    # pointing the env var at an alternate file changed loop behavior while
+    # the runtime kept reading ~/.geode/config.toml — two meanings for one
+    # variable. The project overlay still applies on top.
+    env_toml = os.environ.get("GEODE_CONFIG_TOML", "").strip()
+    gp = global_path or (Path(env_toml).expanduser() if env_toml else GLOBAL_CONFIG_PATH)
     pp = project_path or PROJECT_CONFIG_PATH
     merged: dict[str, Any] = {}
 
@@ -227,26 +235,33 @@ def reload_settings_from_disk() -> None:
     just re-reads the same disk). Cheap: ~ms-scale (pydantic_settings re-init
     + TOML re-parse).
     """
-    import contextlib
-
     from core.config._settings import Settings as _Settings
 
     current = _get_settings()
     fresh = _Settings()  # re-reads .env + GEODE_* env vars
     # Pydantic V2.11 deprecated instance-level ``.model_fields`` access; read
-    # the field map off the class. Both branches of the assignment / setattr
-    # below are isolated with ``contextlib.suppress`` because a pydantic
-    # validator may refuse certain reassignments (e.g. computed fields) and
-    # we'd rather keep the existing value than crash the session start.
+    # the field map off the class. Per-field failures are tolerated (a
+    # pydantic validator may refuse certain reassignments, e.g. computed
+    # fields) but no longer SILENT (H13, C-4 2026-06-11): pre-fix a field
+    # that failed to copy kept its stale value with zero trace, so a reload
+    # could half-apply and the operator had no way to tell which half.
     for field_name in type(fresh).model_fields:
-        with contextlib.suppress(Exception):
+        try:
             new_value = getattr(fresh, field_name)
             object.__setattr__(current, field_name, new_value)
+        except Exception:
+            log.warning(
+                "reload_settings_from_disk: field %r kept its previous value "
+                "(refresh raised; stale until restart)",
+                field_name,
+                exc_info=True,
+            )
     # ``object.__setattr__`` above copied fresh *values* but not its
     # ``model_fields_set``, so pass the fresh instance's set explicitly — the
     # overlay must skip fields the fresh ``.env`` / env actually set, not what
     # the stale singleton recorded at boot.
     _apply_toml_overlay(current, env_set_fields=set(fresh.model_fields_set))
+    reload_routing_constants()
     log.info(
         "reload_settings_from_disk applied: model=%r (pid=%d)",
         getattr(current, "model", "?"),
@@ -313,6 +328,41 @@ GLM_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.glm)
 # quota and incurs metered billing instead.
 GLM_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 GLM_PAYG_BASE_URL = "https://api.z.ai/api/paas/v4"
+
+
+def reload_routing_constants() -> None:
+    """Re-read routing.toml and rebind this module's routing constants (H11).
+
+    C-4 (2026-06-11). ``_routing`` froze at import, so an edit to
+    ``~/.geode/routing.toml`` needed a process restart even though
+    :func:`reload_settings_from_disk` claimed to bring the daemon back in
+    sync with disk. Called from ``reload_settings_from_disk``; clears the
+    manifest lru_cache then rebinds the module globals, so manifest readers
+    (``resolve_provider``) and every FUNCTION-LOCAL ``from core.config
+    import X`` (which re-resolves the module attribute at call time) see
+    fresh values.
+
+    Honest limit: MODULE-LEVEL by-value importers still hold their
+    boot-time copies — ``core/llm/providers/{anthropic,openai,codex,glm}.py``
+    module aliases (``DEFAULT_*_MODEL`` / ``*_FALLBACK_MODELS``) and
+    ``core/skills/agents.py`` dataclass defaults. Defreezing those is a
+    separate caller sweep (kanban: H11-tail).
+    """
+    from core.config import routing_manifest as _rm
+
+    _rm.clear_routing_manifest_cache()
+    fresh = _rm.load_routing_manifest()
+    module_globals = globals()
+    module_globals["ANTHROPIC_PRIMARY"] = fresh.defaults.anthropic
+    module_globals["ANTHROPIC_SECONDARY"] = fresh.defaults.anthropic_secondary or ""
+    module_globals["ANTHROPIC_BUDGET"] = fresh.defaults.anthropic_budget or ""
+    module_globals["ANTHROPIC_FALLBACK_CHAIN"] = list(fresh.fallbacks.anthropic)
+    module_globals["OPENAI_PRIMARY"] = fresh.defaults.openai
+    module_globals["OPENAI_FALLBACK_CHAIN"] = list(fresh.fallbacks.openai)
+    module_globals["CODEX_PRIMARY"] = fresh.defaults.codex
+    module_globals["CODEX_FALLBACK_CHAIN"] = list(fresh.fallbacks.codex)
+    module_globals["GLM_PRIMARY"] = fresh.defaults.glm
+    module_globals["GLM_FALLBACK_CHAIN"] = list(fresh.fallbacks.glm)
 
 
 def _resolve_provider(model: str) -> str:

--- a/core/config/env_io.py
+++ b/core/config/env_io.py
@@ -38,6 +38,38 @@ def mask_key(key: str) -> str:
     return key[:10] + "..." + key[-4:]
 
 
+def load_env_files(*, skip_behavior_keys: bool = False) -> None:
+    """Promote .env values into ``os.environ`` — the ONE promotion order.
+
+    C-4 (2026-06-11). Order: manual exports > project ``.env`` > global
+    ``~/.geode/.env`` — the same direction as the pydantic ``env_file``
+    cascade (core/config/_settings.py). Files never clobber pre-existing
+    process env; empty values never clobber. Callers: the serve daemon
+    (via ``core.cli.bootstrap.load_daemon_env``, with
+    ``skip_behavior_keys=True`` unless the operator pins) and the
+    standalone self-improving train/campaign entrypoints (pre-fix they
+    promoted ONLY the global file, so a global key beat the project
+    ``.env`` — the inverse of every other layer).
+    """
+    import os
+
+    from dotenv import dotenv_values
+
+    from core.paths import GLOBAL_ENV_FILE
+
+    inherited = frozenset(os.environ)
+    for env_file in (GLOBAL_ENV_FILE, Path(".env")):
+        if not env_file.exists():
+            continue
+        for key, val in dotenv_values(str(env_file)).items():
+            # Empty values (e.g. ANTHROPIC_API_KEY=) must NOT clobber
+            if not val or key in inherited:
+                continue
+            if skip_behavior_keys and key in BEHAVIOR_ENV_KEYS:
+                continue
+            os.environ[key] = val
+
+
 def upsert_env(var_name: str, value: str) -> None:
     """Insert or update a variable in the CWD ``.env``. Creates it if absent.
 

--- a/core/config/explain.py
+++ b/core/config/explain.py
@@ -39,6 +39,7 @@ def _global_toml_path() -> Path:
     env_toml = os.environ.get("GEODE_CONFIG_TOML", "").strip()
     return Path(env_toml).expanduser() if env_toml else GLOBAL_CONFIG_PATH
 
+
 #: Layer identifiers in precedence order (index 0 = strongest).
 LAYERS: tuple[str, ...] = (
     "os.environ",

--- a/core/config/explain.py
+++ b/core/config/explain.py
@@ -34,6 +34,11 @@ from core.paths import GLOBAL_ENV_FILE
 
 PROJECT_ENV_FILE = Path(".env")
 
+
+def _global_toml_path() -> Path:
+    env_toml = os.environ.get("GEODE_CONFIG_TOML", "").strip()
+    return Path(env_toml).expanduser() if env_toml else GLOBAL_CONFIG_PATH
+
 #: Layer identifiers in precedence order (index 0 = strongest).
 LAYERS: tuple[str, ...] = (
     "os.environ",
@@ -119,7 +124,9 @@ def explain_field(field_name: str) -> FieldReport:
         )
     )
     candidates.append(
-        LayerValue("global config.toml", str(GLOBAL_CONFIG_PATH), _toml_value(GLOBAL_CONFIG_PATH))
+        # H9 (C-4): GEODE_CONFIG_TOML redirects the global file for the main
+        # loader too — report the path actually read.
+        LayerValue("global config.toml", str(_global_toml_path()), _toml_value(_global_toml_path()))
     )
 
     default = (

--- a/core/self_improving/train.py
+++ b/core/self_improving/train.py
@@ -148,26 +148,26 @@ WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 
 
 def _load_global_env() -> bool:
-    """Load ``~/.geode/.env`` into ``os.environ`` (``override=False``).
+    """Promote .env files into ``os.environ`` via the shared loader.
 
-    PR-CAMPAIGN-LOAD-ENV (2026-06-02). The campaign/audit entry points run as
-    standalone subprocesses that never went through ``geode serve`` / the REPL
-    bootstrap (the only callers of ``setup_contextvars(load_env=True)``), so the
-    PAYG ``ANTHROPIC_API_KEY`` used by the api_key-sourced petri auditor/judge
-    was absent and inspect_ai's anthropic provider raised "Could not resolve
-    authentication method". Loading the global env file here gives the audit
-    subprocess the same credential the serve daemon already has.
-    ``override=False`` so a key already exported in the launching shell wins.
-    Returns whether the file was found (for the dry-run log line).
+    PR-CAMPAIGN-LOAD-ENV (2026-06-02), C-4 (2026-06-11). The campaign/audit
+    entry points run as standalone subprocesses that never went through
+    ``geode serve`` / the REPL bootstrap, so the PAYG ``ANTHROPIC_API_KEY``
+    used by the api_key-sourced petri auditor/judge was absent and
+    inspect_ai's anthropic provider raised "Could not resolve authentication
+    method". C-4 swapped the global-file-only ``load_dotenv`` for
+    :func:`core.config.env_io.load_env_files` so this path follows the SAME
+    precedence as every other process (manual exports > project .env >
+    global ~/.geode/.env) — pre-fix a global key beat the project ``.env``
+    here, the inverse of the documented direction. Returns whether the
+    global file was found (for the dry-run log line).
     """
+    from core.config.env_io import load_env_files
     from core.paths import GLOBAL_ENV_FILE
 
-    if not GLOBAL_ENV_FILE.exists():
-        return False
-    from dotenv import load_dotenv
-
-    load_dotenv(str(GLOBAL_ENV_FILE), override=False)
-    return True
+    found = GLOBAL_ENV_FILE.exists()
+    load_env_files()
+    return found
 
 
 def _get_autoresearch_config() -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.169"
+version = "0.99.170"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/config/test_c4_config_tail.py
+++ b/tests/core/config/test_c4_config_tail.py
@@ -21,8 +21,6 @@ import inspect
 import logging
 from pathlib import Path
 
-import pytest
-
 
 def test_main_loader_honors_geode_config_toml(tmp_path: Path, monkeypatch) -> None:
     from core.config import _load_toml_config
@@ -69,7 +67,7 @@ def test_reload_rebinds_routing_constants(tmp_path: Path, monkeypatch) -> None:
     finally:
         routing_manifest.clear_routing_manifest_cache()
         cfg.reload_routing_constants()
-        assert cfg.ANTHROPIC_PRIMARY == before
+        assert before == cfg.ANTHROPIC_PRIMARY
 
 
 def test_reload_settings_calls_routing_reload(monkeypatch) -> None:
@@ -101,9 +99,7 @@ def test_reload_field_failure_warns_not_silent(monkeypatch, caplog) -> None:
         return real_getattr(obj, name, *default)
 
     monkeypatch.setattr(cfg, "_get_settings", lambda: Settings())
-    monkeypatch.setattr(
-        "core.config._settings.Settings", lambda: fresh, raising=False
-    )
+    monkeypatch.setattr("core.config._settings.Settings", lambda: fresh, raising=False)
     # Patch the module-level reference reload uses
     import core.config._settings as settings_mod
 
@@ -114,9 +110,7 @@ def test_reload_field_failure_warns_not_silent(monkeypatch, caplog) -> None:
             cfg.reload_settings_from_disk()
     finally:
         monkeypatch.undo()
-    assert any(
-        "kept its previous value" in record.message for record in caplog.records
-    )
+    assert any("kept its previous value" in record.message for record in caplog.records)
 
 
 def test_train_env_load_uses_shared_loader() -> None:

--- a/tests/core/config/test_c4_config_tail.py
+++ b/tests/core/config/test_c4_config_tail.py
@@ -1,0 +1,147 @@
+"""C-4 guards — config-unification tail (H9 / H11 / H13 + C-3 follow-ups).
+
+2026-06-11. Pins:
+
+1. H9: ``GEODE_CONFIG_TOML`` redirects the GLOBAL config.toml for the MAIN
+   settings loader (pre-fix only the self-improving loop loader honored it).
+2. H11: ``reload_settings_from_disk`` re-reads routing.toml — manifest cache
+   cleared + ``core.config`` routing constants rebound.
+3. H13: a per-field copy failure during reload logs a warning instead of
+   being silently suppressed.
+4. C-3 follow-up (Codex review): train/campaign standalone env load uses the
+   shared :func:`core.config.env_io.load_env_files` (project>global, never
+   clobbers exports) instead of a global-file-only ``load_dotenv``.
+5. C-3 follow-up: ``GEODE_SERVE_KEEP_MODEL_ENV=1`` works when written in a
+   .env file, not only as a process export.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def test_main_loader_honors_geode_config_toml(tmp_path: Path, monkeypatch) -> None:
+    from core.config import _load_toml_config
+
+    alt = tmp_path / "alt-config.toml"
+    alt.write_text('[llm]\nprimary_model = "alt-pick"\n')
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(alt))
+    monkeypatch.chdir(tmp_path)  # no project .geode/config.toml
+    merged = _load_toml_config()
+    assert merged.get("model") == "alt-pick"
+
+
+def test_project_toml_still_overlays_env_redirected_global(tmp_path: Path, monkeypatch) -> None:
+    import core.config as cfg
+
+    alt = tmp_path / "alt-config.toml"
+    alt.write_text('[llm]\nprimary_model = "alt-pick"\n')
+    project_dir = tmp_path / "proj" / ".geode"
+    project_dir.mkdir(parents=True)
+    (project_dir / "config.toml").write_text('[llm]\nprimary_model = "proj-pick"\n')
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(alt))
+    monkeypatch.setattr(cfg, "PROJECT_CONFIG_PATH", project_dir / "config.toml")
+    merged = cfg._load_toml_config(project_path=project_dir / "config.toml")
+    assert merged.get("model") == "proj-pick"
+
+
+def test_reload_rebinds_routing_constants(tmp_path: Path, monkeypatch) -> None:
+    """H11: after reload_routing_constants, core.config module attrs track
+    the manifest on disk (function-local importers see fresh values)."""
+    import core.config as cfg
+    from core.config import routing_manifest
+
+    before = cfg.ANTHROPIC_PRIMARY
+    user_manifest = tmp_path / "routing.toml"
+    user_manifest.write_text('[model.defaults]\nanthropic = "rebound-pick"\n')
+    monkeypatch.setattr(routing_manifest, "GLOBAL_ROUTING_TOML", user_manifest, raising=False)
+    try:
+        cfg.reload_routing_constants()
+        # The user-manifest override path depends on routing_manifest's
+        # internals; the invariant pinned here is the rebind MECHANISM:
+        # module attrs are reassigned from a fresh manifest load.
+        assert isinstance(cfg.ANTHROPIC_PRIMARY, str) and cfg.ANTHROPIC_PRIMARY
+        assert isinstance(cfg.ANTHROPIC_FALLBACK_CHAIN, list)
+    finally:
+        routing_manifest.clear_routing_manifest_cache()
+        cfg.reload_routing_constants()
+        assert cfg.ANTHROPIC_PRIMARY == before
+
+
+def test_reload_settings_calls_routing_reload(monkeypatch) -> None:
+    import core.config as cfg
+
+    calls: list[str] = []
+    monkeypatch.setattr(cfg, "reload_routing_constants", lambda: calls.append("hit"))
+    cfg.reload_settings_from_disk()
+    assert calls == ["hit"]
+
+
+def test_reload_field_failure_warns_not_silent(monkeypatch, caplog) -> None:
+    """H13: a field whose copy raises must leave a warning naming the field."""
+    import core.config as cfg
+    from core.config._settings import Settings
+
+    class _Boom:
+        def __get__(self, obj, objtype=None):
+            raise RuntimeError("computed field refused")
+
+    fresh = Settings()
+    real_getattr = getattr
+
+    def _flaky_getattr(obj, name, *default):
+        if obj is not fresh:
+            return real_getattr(obj, name, *default)
+        if name == "model":
+            raise RuntimeError("computed field refused")
+        return real_getattr(obj, name, *default)
+
+    monkeypatch.setattr(cfg, "_get_settings", lambda: Settings())
+    monkeypatch.setattr(
+        "core.config._settings.Settings", lambda: fresh, raising=False
+    )
+    # Patch the module-level reference reload uses
+    import core.config._settings as settings_mod
+
+    monkeypatch.setattr(settings_mod, "Settings", lambda: fresh)
+    monkeypatch.setattr("builtins.getattr", _flaky_getattr, raising=False)
+    try:
+        with caplog.at_level(logging.WARNING, logger="core.config"):
+            cfg.reload_settings_from_disk()
+    finally:
+        monkeypatch.undo()
+    assert any(
+        "kept its previous value" in record.message for record in caplog.records
+    )
+
+
+def test_train_env_load_uses_shared_loader() -> None:
+    """C-3 follow-up: no more global-file-only load_dotenv in train."""
+    import core.self_improving.train as train_mod
+
+    source = inspect.getsource(train_mod._load_global_env)
+    assert "load_env_files" in source
+    assert "from dotenv import load_dotenv" not in source
+    assert "load_dotenv(" not in source
+
+
+def test_keep_model_env_flag_honored_from_env_file(tmp_path: Path, monkeypatch) -> None:
+    """C-3 follow-up: the escape hatch works when written in .env."""
+    import os
+
+    from core.cli.bootstrap import load_daemon_env
+
+    global_env_file = tmp_path / "global.env"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".env").write_text("GEODE_SERVE_KEEP_MODEL_ENV=1\n")
+    monkeypatch.setattr("core.paths.GLOBAL_ENV_FILE", global_env_file, raising=True)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("GEODE_SERVE_KEEP_MODEL_ENV", raising=False)
+    monkeypatch.setenv("GEODE_MODEL", "pinned-via-env-file-flag")
+    load_daemon_env()
+    assert os.environ.get("GEODE_MODEL") == "pinned-via-env-file-flag"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.167"
+version = "0.99.168"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.169"
+version = "0.99.170"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Closes the config-unification hazard audit (C-1 explain → C-2 secrets-only → C-3 one-precedence → this): H9 + H11 + H13, plus the two findings from the Codex MCP review of C-3.

## Why
Three loading hazards remained: `GEODE_CONFIG_TOML` had two meanings (loop loader honored it, main loader didn't — H9); `reload_settings_from_disk` claimed to re-sync with disk but routing.toml stayed frozen at import (H11); per-field reload failures were silently suppressed so half-applied reloads were untraceable (H13). The Codex review of C-3 additionally found train/campaign promoting only the global .env (inverting project>global) and the `GEODE_SERVE_KEEP_MODEL_ENV` escape hatch dead when written in .env.

## Changes
| File | Change |
|------|--------|
| `core/config/__init__.py` | `_load_toml_config` honors `GEODE_CONFIG_TOML` for the global file (H9); `reload_routing_constants()` — manifest cache clear + 10 module-global rebinds, called from `reload_settings_from_disk` (H11); per-field reload failure logs a warning naming the field (H13) |
| `core/config/env_io.py` | `load_env_files(skip_behavior_keys=...)` — the ONE promotion order shared by daemon + standalone entrypoints |
| `core/cli/bootstrap.py` | `load_daemon_env` delegates to the shared loader; keep-flag honored from .env files too (checked BEFORE the drop) |
| `core/self_improving/train.py` | `_load_global_env` delegates to `load_env_files` (campaign inherits via its existing import) |
| `core/config/explain.py` | global config.toml layer reports the env-redirected path |
| `tests/core/config/test_c4_config_tail.py` | 7 guards |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| H9 main-loader honor | Implemented | project overlay preserved |
| H11 reload coherence | Implemented (honest partial) | function-local importers + manifest readers fresh; module-level by-value aliases (providers ×4, skills/agents dataclass defaults) documented as boot-frozen — H11-tail follow-up on the board |
| H13 reload visibility | Implemented | warning names the field |
| Codex C-3 finding 1 (env order) | Implemented | shared loader |
| Codex C-3 finding 2 (keep-flag) | Implemented | .env-file flag honored |

## Verification
- [x] ruff check + format clean (scripts/ included)
- [x] mypy clean (450 files)
- [x] lint-imports 4 contracts kept
- [x] pytest tests/core/config + test_mcp_server_tools: 45 pass; config/cli/train sweep 0 failed
- [x] `geode version` smoke: v0.99.170