### PR TITLE
feat(mcp): geode-mcp --http — remote access with bearer-token auth (v0.99.171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.171] - 2026-06-11
+
+### Added
+- **geode-mcp remote access — streamable-HTTP transport with bearer-token auth** (operator request): `geode-mcp --http [--host] [--port]` serves the existing 6 tools over the MCP streamable-HTTP transport (default stays stdio). Auth = static bearer token from `GEODE_MCP_TOKEN` (secret → `~/.geode/.env`, read via the shared `load_env_files`), wired as `token_verifier` + `auth=AuthSettings` — both are required because the SDK silently skips the auth middleware when `auth` is None (verified in the installed mcp 1.26 source). Fail-loud guard: non-loopback bind without a token exits 2 (`run_agent` is a remote-execution surface); loopback without a token warns. Guards: `tests/core/test_mcp_http_transport.py` (9, incl. live HTTP round-trip — correct token passes initialize+tools/list, wrong/missing token rejected).
+
 ## [0.99.170] - 2026-06-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.170
+- **Version**: 0.99.171
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8558 (+1 live)
+- **Tests**: 8575 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.170 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.171 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 
@@ -370,6 +370,8 @@ geode update                  # 소스 체크아웃
 | 핸드셰이크의 서버 버전 | mcp SDK 버전("1.26.0")으로 오보고되던 것을 GEODE 버전으로 정정 (SDK `FastMCP.__init__`에 `version` kwarg 부재; `tests/core/test_mcp_server_tools.py`로 핀) |
 | `get_health` 자격증명 정직성 | `*_configured`가 API 키 유무만 봐서 OAuth/CLI-lane 환경에서 false로 오보고 — `*_credential_source` 병기로 정정 |
 | `run_agent`, `self_improving_propose`/`apply` | 자동 점검에서 미실행(토큰 비용/변이 부작용); `apply`는 2-step 확인 게이트 뒤 |
+
+**원격 접근 (v0.99.171):** `geode-mcp --http [--host H] [--port P]`가 같은 도구를 MCP streamable-HTTP 전송으로 서빙합니다. 인증은 `GEODE_MCP_TOKEN` bearer 토큰(시크릿 — `~/.geode/.env`에 기재), 클라이언트는 `Authorization: Bearer <token>` 헤더를 보냅니다. 토큰 없이 비-루프백 바인드는 시작 시 거부됩니다 — `run_agent`가 GEODE 전체 도구면에 닿으므로 무인증 개방은 원격 실행 표면입니다. 개인 기기 간 사용이면 SSH가 무설정 대안입니다: `claude mcp add geode -- ssh <host> geode-mcp`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.170 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.171 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 
@@ -371,6 +371,8 @@ Verified 2026-06-11 against the live runtime (initialize handshake, `tools/list`
 | Server version in handshake | was the mcp SDK's "1.26.0" — now reports GEODE's version (the SDK's `FastMCP.__init__` exposes no `version` kwarg; pinned by `tests/core/test_mcp_server_tools.py`) |
 | `get_health` credential honesty | `*_configured` only meant "API key present" and read false on OAuth/CLI-lane setups — now also reports `*_credential_source` |
 | `run_agent`, `self_improving_propose`/`apply` | not exercised in the automated check (token cost / mutation side effects); `apply` is gated behind a 2-step proposal confirm |
+
+**Remote access (v0.99.171):** `geode-mcp --http [--host H] [--port P]` serves the same tools over the MCP streamable-HTTP transport. Auth is a bearer token from `GEODE_MCP_TOKEN` (a secret — put it in `~/.geode/.env`); clients pass `Authorization: Bearer <token>`. A non-loopback bind without a token is refused at startup — `run_agent` reaches GEODE's full tool surface, so an open bind is a remote-execution surface. For personal cross-device use, SSH needs no setup at all: `claude mcp add geode -- ssh <host> geode-mcp`.
 
 ---
 

--- a/core/mcp_server.py
+++ b/core/mcp_server.py
@@ -23,8 +23,11 @@ Register in an MCP host (example, Claude Code):
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # Load core-generic MCP tool descriptions from centralized JSON.
 # Plugin-specific descriptions live alongside their plugin module.
@@ -92,7 +95,35 @@ def _self_improving_status_payload() -> dict[str, Any]:
     return {"baseline": baseline, "recent_mutations": recent}
 
 
-def create_mcp_server() -> Any:
+class _StaticTokenVerifier:
+    """Constant-time bearer-token check for the HTTP transport.
+
+    The MCP SDK's auth stack is OAuth-shaped; for a single-operator remote
+    setup a static shared secret is the honest fit. ``verify_token`` is the
+    SDK's :class:`~mcp.server.auth.provider.TokenVerifier` protocol
+    (verified against the installed mcp 1.26 source — Protocol with one
+    async method returning ``AccessToken | None``).
+    """
+
+    def __init__(self, expected_token: str) -> None:
+        self._expected = expected_token
+
+    async def verify_token(self, token: str) -> Any | None:
+        import hmac
+
+        from mcp.server.auth.provider import AccessToken
+
+        if not hmac.compare_digest(token, self._expected):
+            return None
+        return AccessToken(token=token, client_id="geode-mcp-static", scopes=[], expires_at=None)
+
+
+def create_mcp_server(
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    auth_token: str | None = None,
+) -> Any:
     """Create and configure the GEODE MCP server.
 
     Returns a FastMCP Server instance with the agentic, self-improving,
@@ -107,7 +138,28 @@ def create_mcp_server() -> Any:
             "MCP server requires the 'mcp' package. Install with: uv add mcp"
         ) from None
 
-    mcp = FastMCP("geode")
+    server_kwargs: dict[str, Any] = {}
+    if host is not None:
+        server_kwargs["host"] = host
+    if port is not None:
+        server_kwargs["port"] = port
+    if auth_token:
+        # SDK contract (verified in the installed mcp 1.26 source): passing
+        # ``token_verifier`` WITHOUT ``auth=AuthSettings(...)`` silently
+        # skips the auth middleware — ``streamable_http_app`` gates the
+        # BearerAuthBackend on ``self.settings.auth``. Both must be set or
+        # the server is open despite the token.
+        from mcp.server.auth.settings import AuthSettings
+
+        base_url = f"http://{host or '127.0.0.1'}:{port or 8765}"
+        server_kwargs["token_verifier"] = _StaticTokenVerifier(auth_token)
+        server_kwargs["auth"] = AuthSettings(
+            issuer_url=base_url,
+            resource_server_url=f"{base_url}/mcp",
+            required_scopes=[],
+        )
+
+    mcp = FastMCP("geode", **server_kwargs)
     # Report GEODE's own version in the initialize handshake. The installed
     # mcp SDK's FastMCP.__init__ (1.26.x) exposes no ``version`` kwarg even
     # though the wrapped lowlevel ``Server(name, version, ...)`` accepts one,
@@ -223,13 +275,78 @@ def create_mcp_server() -> Any:
     return mcp
 
 
+def _is_loopback(host: str) -> bool:
+    return host in ("127.0.0.1", "::1", "localhost")
+
+
 def main() -> None:
-    """Entry point for running the MCP server (``geode-mcp`` console script)."""
+    """Entry point for running the MCP server (``geode-mcp`` console script).
+
+    Default transport is stdio (the MCP client spawns this process — local
+    only). ``--http`` switches to the SDK's streamable-http transport for
+    remote access; the bearer token comes from ``GEODE_MCP_TOKEN`` (a
+    secret, so it lives in ``~/.geode/.env`` per the C-2 contract — the
+    shared :func:`core.config.env_io.load_env_files` promotion runs first
+    so a token written there is found).
+
+    Fail-loud guard: binding to a NON-loopback host without a token is
+    refused — ``run_agent`` reaches GEODE's full tool surface (bash, file
+    ops) and ``self_improving_apply`` mutates the scaffold, so an open
+    network bind is a remote-execution surface, not a convenience.
+    Loopback HTTP without a token is allowed (same trust boundary as
+    stdio) but logged as a warning.
+    """
+    import argparse
+    import os
+    import sys
+
     from core.observability.logging_config import configure_logging
 
+    parser = argparse.ArgumentParser(prog="geode-mcp")
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        help="serve over streamable HTTP instead of stdio (remote access)",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP bind host")
+    parser.add_argument("--port", type=int, default=8765, help="HTTP bind port")
+    args = parser.parse_args()
+
     configure_logging("mcp")
-    server = create_mcp_server()
-    server.run()
+
+    if not args.http:
+        server = create_mcp_server()
+        server.run()
+        return
+
+    from core.config.env_io import load_env_files
+
+    load_env_files()
+    auth_token = (os.environ.get("GEODE_MCP_TOKEN") or "").strip()
+
+    if not auth_token and not _is_loopback(args.host):
+        print(
+            f"geode-mcp: refusing to bind {args.host}:{args.port} without "
+            "GEODE_MCP_TOKEN — a tokenless non-loopback bind exposes "
+            "run_agent (full tool surface) to the network. Set "
+            "GEODE_MCP_TOKEN in ~/.geode/.env or the environment.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if not auth_token:
+        log.warning(
+            "geode-mcp: HTTP on loopback without GEODE_MCP_TOKEN — local "
+            "processes can call all tools (same trust as stdio)."
+        )
+
+    server = create_mcp_server(host=args.host, port=args.port, auth_token=auth_token or None)
+    log.info(
+        "geode-mcp: streamable HTTP on %s:%d (auth=%s)",
+        args.host,
+        args.port,
+        "bearer-token" if auth_token else "none/loopback",
+    )
+    server.run(transport="streamable-http")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.170"
+version = "0.99.171"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/test_mcp_http_transport.py
+++ b/tests/core/test_mcp_http_transport.py
@@ -1,0 +1,186 @@
+"""geode-mcp HTTP transport guards (v0.99.171).
+
+Pins:
+1. Default transport stays stdio — ``--http`` is opt-in.
+2. Non-loopback bind without GEODE_MCP_TOKEN is refused (exit 2) — fail-loud,
+   not an open remote-execution surface.
+3. SDK contract: when a token is configured, ``auth=AuthSettings`` is passed
+   alongside ``token_verifier`` — the installed mcp SDK silently SKIPS the
+   auth middleware if ``auth`` is None (streamable_http_app gates
+   BearerAuthBackend on ``settings.auth``).
+4. ``_StaticTokenVerifier`` accepts the exact token, rejects others
+   (constant-time compare).
+5. Live HTTP round-trip on a loopback port: wrong/no token rejected (401),
+   correct token completes initialize + tools/list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from core.mcp_server import _is_loopback, _StaticTokenVerifier, create_mcp_server
+
+
+def test_default_transport_is_stdio_and_http_is_optin() -> None:
+    import inspect
+
+    import core.mcp_server as mod
+
+    source = inspect.getsource(mod.main)
+    assert 'parser.add_argument(\n        "--http"' in source or '"--http"' in source
+    assert 'server.run(transport="streamable-http")' in source
+    # stdio default: the no-http branch calls run() with no transport arg
+    assert "server.run()" in source
+
+
+def test_nonloopback_bind_without_token_refused(monkeypatch, capsys) -> None:
+    import sys
+
+    import core.mcp_server as mod
+
+    monkeypatch.delenv("GEODE_MCP_TOKEN", raising=False)
+    monkeypatch.setattr("core.config.env_io.load_env_files", lambda **_kw: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["geode-mcp", "--http", "--host", "0.0.0.0"],  # noqa: S104 — guard-under-test
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main()
+    assert excinfo.value.code == 2
+    assert "GEODE_MCP_TOKEN" in capsys.readouterr().err
+
+
+def test_loopback_detection() -> None:
+    assert _is_loopback("127.0.0.1")
+    assert _is_loopback("localhost")
+    assert _is_loopback("::1")
+    assert not _is_loopback("0.0.0.0")  # noqa: S104 — the value being classified
+    assert not _is_loopback("192.168.0.10")
+
+
+def test_token_configured_server_carries_auth_settings() -> None:
+    server = create_mcp_server(host="127.0.0.1", port=39999, auth_token="sekrit")
+    assert server.settings.auth is not None
+    assert server._token_verifier is not None
+
+
+def test_tokenless_server_has_no_auth_settings() -> None:
+    server = create_mcp_server(host="127.0.0.1", port=39998)
+    assert server.settings.auth is None
+
+
+def test_static_verifier_accepts_exact_rejects_other() -> None:
+    verifier = _StaticTokenVerifier("sekrit")
+    ok = asyncio.run(verifier.verify_token("sekrit"))
+    bad = asyncio.run(verifier.verify_token("not-it"))
+    assert ok is not None and ok.client_id == "geode-mcp-static"
+    assert bad is None
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture()
+def http_server_with_token():
+    """Run the streamable-http app with a token on a loopback port."""
+    import uvicorn
+
+    port = _free_port()
+    server = create_mcp_server(host="127.0.0.1", port=port, auth_token="sekrit")
+    app = server.streamable_http_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    uv_server = uvicorn.Server(config)
+    thread = threading.Thread(target=uv_server.run, daemon=True)
+    thread.start()
+    deadline = 50
+    while not uv_server.started and deadline:
+        deadline -= 1
+        import time
+
+        time.sleep(0.1)
+    assert uv_server.started, "uvicorn did not start"
+    yield f"http://127.0.0.1:{port}/mcp"
+    uv_server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_http_roundtrip_auth(http_server_with_token) -> None:
+    url = http_server_with_token
+
+    async def _with_token() -> list[str]:
+        from mcp.client.streamable_http import streamablehttp_client
+
+        from mcp import ClientSession
+
+        async with (
+            streamablehttp_client(url, headers={"Authorization": "Bearer sekrit"}) as (
+                read,
+                write,
+                _get_sid,
+            ),
+            ClientSession(read, write) as session,
+        ):
+            await asyncio.wait_for(session.initialize(), timeout=15)
+            tools = await asyncio.wait_for(session.list_tools(), timeout=10)
+            return [tool.name for tool in tools.tools]
+
+    names = asyncio.run(_with_token())
+    assert "run_agent" in names and "get_health" in names
+
+    async def _wrong_token_rejected() -> bool:
+        from mcp.client.streamable_http import streamablehttp_client
+
+        try:
+            async with streamablehttp_client(url, headers={"Authorization": "Bearer wrong"}) as (
+                read,
+                write,
+                _get_sid,
+            ):
+                from mcp import ClientSession
+
+                async with ClientSession(read, write) as session:
+                    await asyncio.wait_for(session.initialize(), timeout=10)
+            return False
+        except BaseException:
+            return True
+
+    assert asyncio.run(_wrong_token_rejected())
+
+    async def _no_token_rejected() -> bool:
+        from mcp.client.streamable_http import streamablehttp_client
+
+        try:
+            async with streamablehttp_client(url) as (read, write, _get_sid):
+                from mcp import ClientSession
+
+                async with ClientSession(read, write) as session:
+                    await asyncio.wait_for(session.initialize(), timeout=10)
+            return False
+        except BaseException:
+            return True
+
+    assert asyncio.run(_no_token_rejected())
+
+
+def test_http_mode_loads_env_files_for_token(monkeypatch) -> None:
+    """The token is a secret → lives in .env; main() must run the shared
+    loader before reading GEODE_MCP_TOKEN."""
+    import inspect
+
+    import core.mcp_server as mod
+
+    source = inspect.getsource(mod.main)
+    assert "load_env_files()" in source
+    token_read = 'os.environ.get("GEODE_MCP_TOKEN")'
+    assert token_read in source
+    assert source.index("load_env_files()") < source.index(token_read)

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.170"
+version = "0.99.171"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `geode-mcp --http [--host] [--port]` serves the existing 6 tools over the MCP streamable-HTTP transport for remote clients; default remains stdio (operator-approved option 2 of the remote-access plan).
- Auth = static bearer token from `GEODE_MCP_TOKEN` (secret → `~/.geode/.env`, promoted via the shared `load_env_files`); constant-time verify.
- Fail-loud: non-loopback bind without a token is refused at startup (exit 2) — `run_agent` reaches GEODE's full tool surface, so a tokenless open bind is a remote-execution surface.

## Why
geode-mcp was stdio-only — MCP clients had to spawn it as a local child process, so other machines could not reach GEODE as an MCP server. Operator requested network exposure with authentication.

## Changes
| File | Change |
|------|--------|
| `core/mcp_server.py` | `_StaticTokenVerifier` (SDK TokenVerifier protocol, hmac.compare_digest); `create_mcp_server(host, port, auth_token)` wiring `token_verifier` + `auth=AuthSettings` — both required, the SDK skips the auth middleware entirely when `auth` is None (verified in the installed mcp 1.26 source: `streamable_http_app` gates `BearerAuthBackend` on `settings.auth`); `main()` argparse `--http/--host/--port`, env-file token load, non-loopback guard |
| `tests/core/test_mcp_http_transport.py` | 9 guards incl. live HTTP round-trip: correct token completes initialize+tools/list, wrong/missing token rejected; non-loopback refusal; auth-settings parity pins |
| `README.md` / `README.ko.md` | remote-access paragraph in the MCP section (token setup, refusal semantics, SSH alternative) |

## Verification
- [x] ruff check + format clean (scripts/ included)
- [x] mypy: core/mcp_server.py clean (3 remaining = known local-only codex_overrides artifact with [audit] extra; CI clean)
- [x] lint-imports 4 contracts kept
- [x] pytest test_mcp_http_transport (9) + test_mcp_server_tools (7) + tests/core/config: 0 failed
- [x] `geode version` smoke: v0.99.171

## Reference
Installed mcp SDK 1.26 source (FastMCP.run transports, TokenVerifier protocol, AuthSettings required fields, streamable_http_app auth gating) — doc-before-behaviour attestation in docstrings.