### PR TITLE
release: v0.99.172 — geode-mcp run_agent adapter bootstrap fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.172] - 2026-06-11
+
+### Fixed
+- **geode-mcp `run_agent` adapter bootstrap** — the first live `run_agent` call over the new HTTP transport failed with `AdapterNotFoundError "Known pairs: []"`: `run_agentic_oneshot` assumed the adapter registry was populated by `GeodeRuntime.create`, which geode-mcp (and any standalone caller) never runs. Now self-bootstraps via `bootstrap_builtins()` (idempotent; same pattern as `core/agent/worker.py`). Latent since v0.99.155 — the stdio-era audit intentionally skipped exercising `run_agent` (token cost), so the defect surfaced only on the operator's live remote test. Guard: `test_run_agentic_oneshot_bootstraps_adapters`.
+
 ## [0.99.171] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.171
+- **Version**: 0.99.172
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.171 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.172 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.171 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.172 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -242,6 +242,14 @@ def run_agentic_oneshot(
     from core.async_runtime import run_process_coroutine
     from core.config import _resolve_provider
     from core.config import settings as _stk_settings
+    from core.llm.adapters.registry import bootstrap_builtins
+
+    # geode-mcp (and any caller that never went through GeodeRuntime.create)
+    # has an EMPTY adapter registry — the first live run_agent over MCP
+    # failed with AdapterNotFoundError "Known pairs: []" (2026-06-11).
+    # Same pattern as core/agent/worker.py:858. Idempotent: already-
+    # registered adapters are skipped.
+    bootstrap_builtins()
 
     conversation = ConversationContext()
     handlers = _build_tool_handlers_for_fork()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.171"
+version = "0.99.172"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/test_mcp_server_tools.py
+++ b/tests/core/test_mcp_server_tools.py
@@ -145,3 +145,15 @@ def test_status_payload_reads_baseline_and_ledger_tail(
     assert len(recent) == 5  # tail only
     assert recent[-1]["mutation_id"] == "m7"
     assert recent[0]["mutation_id"] == "m3"
+
+
+def test_run_agentic_oneshot_bootstraps_adapters() -> None:
+    """geode-mcp's run_agent path must self-bootstrap the adapter registry —
+    it never goes through GeodeRuntime.create. First live MCP run_agent
+    failed with AdapterNotFoundError "Known pairs: []" (2026-06-11)."""
+    import inspect
+
+    from core.cli.bootstrap import run_agentic_oneshot
+
+    source = inspect.getsource(run_agentic_oneshot)
+    assert "bootstrap_builtins()" in source


### PR DESCRIPTION
## Summary
- v0.99.172: run_agentic_oneshot self-bootstraps the adapter registry — first live HTTP run_agent failed with AdapterNotFoundError "Known pairs: []" (PR #2123).

## Verification
- [x] CI green on #2123
- [x] develop → main pass-through