### PR TITLE
fix(mcp): run_agent event-loop conflict — async oneshot core (v0.99.174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.174] - 2026-06-11
+
+### Fixed
+- **geode-mcp `run_agent` event-loop conflict** — second live HTTP defect: FastMCP executes tool handlers inside the server's event loop, where the sync `run_agentic_oneshot` wrapper's `run_process_coroutine` raises "cannot be called from an active event loop". `run_agentic_oneshot` split into async core `arun_agentic_oneshot` (carrying the adapter bootstrap from v0.99.172) + thin sync wrapper; the MCP `run_agent` tool is now `async def` awaiting the core directly. Fork-skill caller keeps the sync wrapper. Guards: `test_run_agent_tool_is_async_and_awaits_async_core`, `test_sync_oneshot_wrapper_delegates_to_async_core`.
+
 ## [0.99.173] - 2026-06-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.173
+- **Version**: 0.99.174
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.173 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.174 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.173 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.174 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -222,24 +222,23 @@ def bootstrap_geode(
     )
 
 
-def run_agentic_oneshot(
+async def arun_agentic_oneshot(
     prompt: str,
     *,
     quiet: bool = True,
     time_budget_s: float = 60.0,
 ) -> Any:
-    """Build a minimal isolated AgenticLoop and run a prompt one-shot.
+    """Async core of :func:`run_agentic_oneshot` — await inside a running loop.
 
-    Returns AgenticResult.  Inline construction — no SharedServices overhead.
-    One-shot execution, not a session mode. Callers: context:fork skill
-    execution (``cmd_skill_invoke``) and the ``geode-mcp`` ``run_agent``
-    tool (D-3 ④, 2026-06-10 — promoted from the private
-    ``_build_agentic_stack_minimal`` so both surfaces share one stack).
+    geode-mcp executes tools INSIDE the server's event loop, where the sync
+    wrapper's ``run_process_coroutine`` raises ("cannot be called from an
+    active event loop" — first live HTTP ``run_agent``, 2026-06-11). MCP
+    tool handlers await this directly; sync callers (fork skill) keep the
+    wrapper below.
     """
     from core.agent.conversation import ConversationContext
     from core.agent.loop import AgenticLoop
     from core.agent.tool_executor import ToolExecutor
-    from core.async_runtime import run_process_coroutine
     from core.config import _resolve_provider
     from core.config import settings as _stk_settings
     from core.llm.adapters.registry import bootstrap_builtins
@@ -263,7 +262,27 @@ def run_agentic_oneshot(
         time_budget_s=time_budget_s,
         max_rounds=0,
     )
-    return run_process_coroutine(loop.arun(prompt))
+    return await loop.arun(prompt)
+
+
+def run_agentic_oneshot(
+    prompt: str,
+    *,
+    quiet: bool = True,
+    time_budget_s: float = 60.0,
+) -> Any:
+    """Build a minimal isolated AgenticLoop and run a prompt one-shot.
+
+    Returns AgenticResult.  Inline construction — no SharedServices overhead.
+    One-shot execution, not a session mode. Callers: context:fork skill
+    execution (``cmd_skill_invoke``); the ``geode-mcp`` ``run_agent`` tool
+    awaits :func:`arun_agentic_oneshot` directly (running-loop context).
+    """
+    from core.async_runtime import run_process_coroutine
+
+    return run_process_coroutine(
+        arun_agentic_oneshot(prompt, quiet=quiet, time_budget_s=time_budget_s)
+    )
 
 
 def _build_tool_handlers_for_fork() -> dict[str, Any]:

--- a/core/mcp_server.py
+++ b/core/mcp_server.py
@@ -177,11 +177,11 @@ def create_mcp_server(
     _pending_proposals: dict[str, tuple[Any, Any]] = {}
 
     @mcp.tool(description=_TOOL_DESCRIPTIONS["run_agent"])
-    def run_agent(prompt: str, time_budget_s: float = 120.0) -> dict[str, Any]:
+    async def run_agent(prompt: str, time_budget_s: float = 120.0) -> dict[str, Any]:
         """Run one GEODE agentic one-shot and return the result."""
-        from core.cli.bootstrap import run_agentic_oneshot
+        from core.cli.bootstrap import arun_agentic_oneshot
 
-        result = run_agentic_oneshot(prompt, quiet=True, time_budget_s=time_budget_s)
+        result = await arun_agentic_oneshot(prompt, quiet=True, time_budget_s=time_budget_s)
         return {
             "text": getattr(result, "text", ""),
             "rounds": getattr(result, "rounds", 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.173"
+version = "0.99.174"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/test_mcp_server_tools.py
+++ b/tests/core/test_mcp_server_tools.py
@@ -153,7 +153,31 @@ def test_run_agentic_oneshot_bootstraps_adapters() -> None:
     failed with AdapterNotFoundError "Known pairs: []" (2026-06-11)."""
     import inspect
 
-    from core.cli.bootstrap import run_agentic_oneshot
+    from core.cli.bootstrap import arun_agentic_oneshot
 
-    source = inspect.getsource(run_agentic_oneshot)
+    source = inspect.getsource(arun_agentic_oneshot)
     assert "bootstrap_builtins()" in source
+
+
+def test_run_agent_tool_is_async_and_awaits_async_core() -> None:
+    """FastMCP executes tools inside the server's event loop — a sync tool
+    calling run_process_coroutine raises "cannot be called from an active
+    event loop" (second live HTTP run_agent failure, 2026-06-11). The tool
+    must be async and await arun_agentic_oneshot."""
+    import inspect
+
+    import core.mcp_server as mod
+
+    source = inspect.getsource(mod.create_mcp_server)
+    assert "async def run_agent(" in source
+    assert "await arun_agentic_oneshot(" in source
+
+
+def test_sync_oneshot_wrapper_delegates_to_async_core() -> None:
+    import inspect
+
+    from core.cli.bootstrap import arun_agentic_oneshot, run_agentic_oneshot
+
+    assert inspect.iscoroutinefunction(arun_agentic_oneshot)
+    source = inspect.getsource(run_agentic_oneshot)
+    assert "arun_agentic_oneshot(" in source


### PR DESCRIPTION
## Summary
- Second live HTTP `run_agent` defect: FastMCP runs tool handlers inside the server's event loop, where the sync wrapper's `run_process_coroutine` raises "cannot be called from an active event loop".
- `run_agentic_oneshot` split into async core `arun_agentic_oneshot` (keeps the v0.99.172 adapter bootstrap) + thin sync wrapper; MCP `run_agent` is now `async def` awaiting the core.

## Why
The stdio-era audit never exercised `run_agent` live (token cost), so both this and the adapter-registry defect surfaced only on the operator's remote test. Fork-skill (sync CLI context) keeps the wrapper — one stack, two entry shapes.

## Changes
| File | Change |
|------|--------|
| `core/cli/bootstrap.py` | `arun_agentic_oneshot` async core + `run_agentic_oneshot` sync wrapper delegation |
| `core/mcp_server.py` | `run_agent` tool `async def`, awaits the core |
| `tests/core/test_mcp_server_tools.py` | 2 new guards + bootstrap guard retargeted to the async core |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (450 files)
- [x] lint-imports 4 contracts kept
- [x] pytest test_mcp_server_tools (10) + test_mcp_http_transport (9): 0 failed
- [ ] live HTTP run_agent retest after rebuild (post-merge)