### PR TITLE
fix(model): /model switch lands in live session — thin-CLI↔daemon gap (v0.99.175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.175] - 2026-06-11
+
+### Fixed
+- **`/model` switch ignored inside a live session — thin-CLI ↔ daemon model gap** (operator-reported, recurring): a `/model` issued mid-session relays to the daemon, where `cmd_model` updates `settings.model`/`agentic_effort` + config.toml but never the AgenticLoop the active session runs on (its docstring: "applies to *new* sessions"). The per-turn drift sync that used to re-point the loop was cut to a no-op (PR-DRIFT-CUT, 2026-05-24) because *inferring* drift caused an auto-revert smoke incident — leaving `/model` as the sole explicit entry point, but one that never reached the live loop. `CLIPoller._handle_command_on_server` now calls `_sync_live_loop_to_settings(loop)` after a `/model` command lands: model + provider + identity breadcrumb + context-window adapt + effort axis, using the same synchronous swap helpers `update_model_async` uses (minus the async-only telemetry hook). Fires ONLY on an explicit `/model` command, so it carries operator intent without reintroducing speculative drift. Verify the effective model with `geode about`, not config.toml (`geode config explain model` shows the winning layer). Guards: `tests/core/server/test_model_switch_live_session.py` (5).
+
 ## [0.99.174] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.174
+- **Version**: 0.99.175
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.174 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.175 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.174 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.175 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -894,6 +894,17 @@ class CLIPoller:
                     skill_registry=self._services.skill_registry,
                     mcp_manager=self._services.mcp_manager,
                 )
+            # /model writes config.toml + the daemon's Settings singleton but
+            # cmd_model does NOT touch the live session's AgenticLoop — its
+            # docstring even says "applies to *new* sessions". So a /model
+            # switch inside an interactive REPL was silently ignored until the
+            # session ended: the thin CLI relays /model here, the singleton
+            # flips, but the loop the next prompt runs on keeps its boot-time
+            # model. Operator-reported "fable 5로 바꿔도 opus-4-8로 동작"
+            # (2026-06-11) — the thin-CLI ↔ daemon model gap. Sync the live
+            # loop here so the switch lands in the SAME session.
+            if cmd == "/model" and loop is not None:
+                self._sync_live_loop_to_settings(loop)
             return {
                 "type": "command_result",
                 "cmd": cmd,
@@ -909,6 +920,51 @@ class CLIPoller:
                 "status": "error",
                 "message": str(exc),
             }
+
+    def _sync_live_loop_to_settings(self, loop: Any) -> None:
+        """Re-point the live session loop at the daemon's current settings.
+
+        Called right after a ``/model`` command lands on the daemon. The
+        command updated ``settings.model`` (+ ``settings.agentic_effort``)
+        but not the AgenticLoop the active session runs on. This mirrors the
+        ``client_capability`` adoption path (which only fires once at session
+        start) for the mid-session case, using the same synchronous swap
+        helpers ``update_model_async`` uses internally — model + provider +
+        identity breadcrumb + context-window adapt — minus the async-only
+        ``MODEL_SWITCHED`` hook (telemetry, not behaviour). The effort axis is
+        re-pointed directly, matching ``services.create_session``'s
+        constructor bridge.
+
+        Why an explicit sync rather than the old per-turn drift sync:
+        ``_model_switching.sync_model_from_settings_async`` was cut to a
+        no-op (PR-DRIFT-CUT, 2026-05-24) because *inferring* drift from
+        ``settings.model`` between rounds caused an auto-revert smoke
+        incident. The cut left ``/model`` as the operator's sole explicit
+        entry point — so the switch must be pushed at the command boundary,
+        not inferred. This is that push: it fires ONLY on an explicit
+        ``/model`` command, so it carries the operator's intent without
+        reintroducing speculative drift.
+        """
+        from core.agent.loop import _model_switching
+        from core.config import _resolve_provider, settings
+
+        target = (settings.model or "").strip()
+        if target and target != getattr(loop, "model", ""):
+            try:
+                old_model, changed = _model_switching._apply_model_update(
+                    loop, target, _resolve_provider(target)
+                )
+                if changed:
+                    _model_switching._inject_model_switch_breadcrumb(loop, old_model, target)
+                    loop._adapt_context_for_model(target)
+                    log.info("model command: live session loop synced to %s", target)
+            except Exception:
+                log.warning("model command: live loop model sync failed", exc_info=True)
+
+        new_effort = (getattr(settings, "agentic_effort", "") or "").strip()
+        if new_effort and getattr(loop, "_effort", None) != new_effort:
+            loop._effort = new_effort
+            log.info("model command: live session effort synced to %s", new_effort)
 
     def _handle_resume(
         self,

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -882,6 +882,22 @@ class CLIPoller:
         """
         cmd = msg.get("cmd", "")
         args = msg.get("args", "")
+        # Capture the primary model + effort BEFORE the command so the live-loop
+        # sync below fires only when THIS /model actually changed the primary
+        # axis. A role-specific switch (``/model reflection X`` writes
+        # ``cognitive_reflection_model``), an unknown/login-blocked/list/
+        # already-current ``/model``, or ``/model`` with no primary change must
+        # NOT touch the live loop — otherwise it would clobber the model the
+        # client_capability path adopted at session start (which moves
+        # ``loop.model`` WITHOUT moving ``settings.model``). See Codex review,
+        # 2026-06-11.
+        model_before = ""
+        effort_before = ""
+        if cmd == "/model" and loop is not None:
+            from core.config import settings as _pre_settings
+
+            model_before = (getattr(_pre_settings, "model", "") or "").strip()
+            effort_before = (getattr(_pre_settings, "agentic_effort", "") or "").strip()
         try:
             from core.cli import _handle_command
             from core.ui.console import capture_output
@@ -904,7 +920,7 @@ class CLIPoller:
             # (2026-06-11) — the thin-CLI ↔ daemon model gap. Sync the live
             # loop here so the switch lands in the SAME session.
             if cmd == "/model" and loop is not None:
-                self._sync_live_loop_to_settings(loop)
+                self._sync_live_loop_to_settings(loop, model_before, effort_before)
             return {
                 "type": "command_result",
                 "cmd": cmd,
@@ -921,8 +937,8 @@ class CLIPoller:
                 "message": str(exc),
             }
 
-    def _sync_live_loop_to_settings(self, loop: Any) -> None:
-        """Re-point the live session loop at the daemon's current settings.
+    def _sync_live_loop_to_settings(self, loop: Any, model_before: str, effort_before: str) -> None:
+        """Re-point the live session loop after a ``/model`` changed the primary.
 
         Called right after a ``/model`` command lands on the daemon. The
         command updated ``settings.model`` (+ ``settings.agentic_effort``)
@@ -935,6 +951,17 @@ class CLIPoller:
         re-pointed directly, matching ``services.create_session``'s
         constructor bridge.
 
+        Gated on ``settings.model != model_before`` (the value captured before
+        the command ran), NOT on ``settings.model != loop.model``. Only a
+        command that *actually moved the primary axis* should touch the live
+        loop: a role-specific ``/model reflection X`` moves
+        ``cognitive_reflection_model`` and leaves ``settings.model`` untouched,
+        and an unknown/blocked/list ``/model`` moves nothing — in both cases
+        ``loop.model`` may legitimately differ from ``settings.model`` because
+        the ``client_capability`` path adopted the thin CLI's project model
+        without moving the singleton. Gating on the singleton delta keeps those
+        cases from clobbering the live loop. (Codex review, 2026-06-11.)
+
         Why an explicit sync rather than the old per-turn drift sync:
         ``_model_switching.sync_model_from_settings_async`` was cut to a
         no-op (PR-DRIFT-CUT, 2026-05-24) because *inferring* drift from
@@ -942,14 +969,16 @@ class CLIPoller:
         incident. The cut left ``/model`` as the operator's sole explicit
         entry point — so the switch must be pushed at the command boundary,
         not inferred. This is that push: it fires ONLY on an explicit
-        ``/model`` command, so it carries the operator's intent without
-        reintroducing speculative drift.
+        ``/model`` command that moved the primary axis, so it carries the
+        operator's intent without reintroducing speculative drift.
         """
         from core.agent.loop import _model_switching
         from core.config import _resolve_provider, settings
 
         target = (settings.model or "").strip()
-        if target and target != getattr(loop, "model", ""):
+        # Only sync when this command moved the primary axis AND the live loop
+        # hasn't already caught up.
+        if target and target != model_before and target != getattr(loop, "model", ""):
             try:
                 old_model, changed = _model_switching._apply_model_update(
                     loop, target, _resolve_provider(target)
@@ -962,7 +991,11 @@ class CLIPoller:
                 log.warning("model command: live loop model sync failed", exc_info=True)
 
         new_effort = (getattr(settings, "agentic_effort", "") or "").strip()
-        if new_effort and getattr(loop, "_effort", None) != new_effort:
+        if (
+            new_effort
+            and new_effort != effort_before
+            and getattr(loop, "_effort", None) != new_effort
+        ):
             loop._effort = new_effort
             log.info("model command: live session effort synced to %s", new_effort)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.174"
+version = "0.99.175"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/server/test_model_switch_live_session.py
+++ b/tests/core/server/test_model_switch_live_session.py
@@ -1,0 +1,98 @@
+"""Guard: /model switch lands in the SAME interactive session (v0.99.175).
+
+The thin CLI relays a mid-session ``/model`` to the daemon, where
+``cmd_model`` updates ``settings.model`` + config.toml but NOT the live
+AgenticLoop the session runs on (its docstring says "applies to *new*
+sessions"). Operator-reported "fable 5로 바꿔도 opus-4-8로 동작" — the
+thin-CLI ↔ daemon model gap. ``CLIPoller._sync_live_loop_to_settings``
+re-points the live loop after a ``/model`` command lands.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from core.server.ipc_server.poller import CLIPoller
+
+
+class _FakeLoop:
+    def __init__(self) -> None:
+        self.model = "claude-opus-4-8"
+        self._provider = "anthropic"
+        self._tool_processor = type("_TP", (), {"_model": "claude-opus-4-8"})()
+        self._new_adapter = None
+        self._prompt_dirty = False
+        self._effort = "high"
+        self.adapted_to: str | None = None
+
+    def _adapt_context_for_model(self, target: str) -> None:
+        self.adapted_to = target
+
+
+class _FakeSettings:
+    model = "claude-fable-5"
+    agentic_effort = "xhigh"
+
+
+@pytest.fixture()
+def poller(monkeypatch) -> CLIPoller:
+    # The identity breadcrumb touches loop.context internals covered by the
+    # _model_switching tests; stub it here so these guards isolate the
+    # model/effort re-point behaviour.
+    monkeypatch.setattr(
+        "core.agent.loop._model_switching._inject_model_switch_breadcrumb",
+        lambda *_a, **_k: 0,
+    )
+    return CLIPoller.__new__(CLIPoller)  # bypass __init__ — only the method is under test
+
+
+def test_sync_repoints_live_loop_model(poller: CLIPoller, monkeypatch) -> None:
+    monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
+    loop = _FakeLoop()
+    poller._sync_live_loop_to_settings(loop)
+    assert loop.model == "claude-fable-5"
+    assert loop._provider == "anthropic"
+    assert loop.adapted_to == "claude-fable-5"
+
+
+def test_sync_repoints_effort(poller: CLIPoller, monkeypatch) -> None:
+    monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
+    loop = _FakeLoop()
+    poller._sync_live_loop_to_settings(loop)
+    assert loop._effort == "xhigh"
+
+
+def test_sync_noop_when_already_current(poller: CLIPoller, monkeypatch) -> None:
+    class _SameSettings:
+        model = "claude-opus-4-8"
+        agentic_effort = "high"
+
+    monkeypatch.setattr("core.config.settings", _SameSettings(), raising=False)
+    loop = _FakeLoop()
+    poller._sync_live_loop_to_settings(loop)
+    # unchanged model → no context re-adapt fired
+    assert loop.adapted_to is None
+    assert loop.model == "claude-opus-4-8"
+
+
+def test_handle_command_on_server_syncs_after_model(poller: CLIPoller, monkeypatch) -> None:
+    """The /model command path must call the live-loop sync; other commands
+    must not."""
+    source = inspect.getsource(CLIPoller._handle_command_on_server)
+    assert 'cmd == "/model"' in source
+    assert "_sync_live_loop_to_settings(loop)" in source
+
+
+def test_sync_survives_apply_failure(poller: CLIPoller, monkeypatch) -> None:
+    """A swap failure must not crash command handling — effort still syncs."""
+
+    def _boom(*_a: Any, **_k: Any) -> tuple[str, bool]:
+        raise RuntimeError("adapter resolution failed")
+
+    monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
+    monkeypatch.setattr("core.agent.loop._model_switching._apply_model_update", _boom)
+    loop = _FakeLoop()
+    poller._sync_live_loop_to_settings(loop)  # must not raise
+    assert loop._effort == "xhigh"  # effort axis still applied

--- a/tests/core/server/test_model_switch_live_session.py
+++ b/tests/core/server/test_model_switch_live_session.py
@@ -51,7 +51,8 @@ def poller(monkeypatch) -> CLIPoller:
 def test_sync_repoints_live_loop_model(poller: CLIPoller, monkeypatch) -> None:
     monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
     loop = _FakeLoop()
-    poller._sync_live_loop_to_settings(loop)
+    # primary moved: model_before is the old value, settings.model is the new
+    poller._sync_live_loop_to_settings(loop, "claude-opus-4-8", "high")
     assert loop.model == "claude-fable-5"
     assert loop._provider == "anthropic"
     assert loop.adapted_to == "claude-fable-5"
@@ -60,8 +61,25 @@ def test_sync_repoints_live_loop_model(poller: CLIPoller, monkeypatch) -> None:
 def test_sync_repoints_effort(poller: CLIPoller, monkeypatch) -> None:
     monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
     loop = _FakeLoop()
-    poller._sync_live_loop_to_settings(loop)
+    poller._sync_live_loop_to_settings(loop, "claude-opus-4-8", "high")
     assert loop._effort == "xhigh"
+
+
+def test_sync_noop_when_primary_unchanged(poller: CLIPoller, monkeypatch) -> None:
+    """A /model command that did NOT move settings.model (role switch, unknown
+    model, list) must not touch the live loop — even if loop.model already
+    differs from settings.model (client_capability adopted a project model).
+    This is the Codex-flagged role-clobber regression."""
+    monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
+    loop = _FakeLoop()
+    # loop adopted fable-5 at session start via client_capability; settings.model
+    # is the daemon's stale opus-4-8. A `/model reflection X` leaves
+    # settings.model == model_before (= "claude-fable-5" here as the captured
+    # pre-command value), so nothing should move.
+    loop.model = "claude-fable-5"
+    poller._sync_live_loop_to_settings(loop, model_before="claude-fable-5", effort_before="xhigh")
+    assert loop.model == "claude-fable-5"  # NOT clobbered back to settings.model
+    assert loop.adapted_to is None
 
 
 def test_sync_noop_when_already_current(poller: CLIPoller, monkeypatch) -> None:
@@ -71,8 +89,8 @@ def test_sync_noop_when_already_current(poller: CLIPoller, monkeypatch) -> None:
 
     monkeypatch.setattr("core.config.settings", _SameSettings(), raising=False)
     loop = _FakeLoop()
-    poller._sync_live_loop_to_settings(loop)
-    # unchanged model → no context re-adapt fired
+    # primary "changed" to the value the loop already holds → no re-adapt
+    poller._sync_live_loop_to_settings(loop, "claude-haiku-4-5", "high")
     assert loop.adapted_to is None
     assert loop.model == "claude-opus-4-8"
 
@@ -82,7 +100,9 @@ def test_handle_command_on_server_syncs_after_model(poller: CLIPoller, monkeypat
     must not."""
     source = inspect.getsource(CLIPoller._handle_command_on_server)
     assert 'cmd == "/model"' in source
-    assert "_sync_live_loop_to_settings(loop)" in source
+    assert "_sync_live_loop_to_settings(loop, model_before, effort_before)" in source
+    # gated on the pre-command primary value, not loop.model
+    assert "model_before" in source
 
 
 def test_sync_survives_apply_failure(poller: CLIPoller, monkeypatch) -> None:
@@ -94,5 +114,5 @@ def test_sync_survives_apply_failure(poller: CLIPoller, monkeypatch) -> None:
     monkeypatch.setattr("core.config.settings", _FakeSettings(), raising=False)
     monkeypatch.setattr("core.agent.loop._model_switching._apply_model_update", _boom)
     loop = _FakeLoop()
-    poller._sync_live_loop_to_settings(loop)  # must not raise
+    poller._sync_live_loop_to_settings(loop, "claude-opus-4-8", "high")  # must not raise
     assert loop._effort == "xhigh"  # effort axis still applied

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.174"
+version = "0.99.175"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.173"
+version = "0.99.174"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- A `/model` switch issued inside a live interactive session was ignored until the session ended — the operator's recurring "fable 5로 바꿔도 opus-4-8로 동작" thin-CLI ↔ daemon gap.
- Root cause: the thin CLI relays `/model` to the daemon, where `cmd_model` updates `settings.model`/`agentic_effort` + config.toml but never the AgenticLoop the active session runs on. The per-turn drift sync that used to re-point the loop was cut to a no-op (PR-DRIFT-CUT, 2026-05-24) to avoid auto-revert — leaving `/model` as the sole explicit entry point, but one that never reached the live loop.

## Why
`cmd_model._apply_model` writes the daemon's Settings singleton + config.toml (its docstring: "applies to *new* sessions"); the `client_capability` adoption path only fires once at session start. So mid-session switches had no path to the running loop. Verified by reading the daemon model-resolution wiring end to end (services.create_session reload, client_capability adoption, drift-sync no-op).

## Changes
| File | Change |
|------|--------|
| `core/server/ipc_server/poller.py` | `_handle_command_on_server` captures the primary model + effort before a `/model` command, then calls new `_sync_live_loop_to_settings(loop, model_before, effort_before)` — re-points model/provider/breadcrumb/context-window/effort via the same sync helpers `update_model_async` uses (minus the async-only telemetry hook). Covers both the async and sync IPC dispatch paths (shared handler). |
| `tests/core/server/test_model_switch_live_session.py` | 6 guards |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Mid-session primary `/model` reaches live loop | Implemented | model+provider+breadcrumb+context+effort |
| Role-specific `/model reflection X` must NOT clobber primary | Implemented | Codex review caught this — sync gated on `settings.model != model_before` (pre-command value), not `!= loop.model`, so role/unknown/list commands that leave the primary axis untouched don't override the client_capability-adopted model |
| Both IPC paths covered | Verified | shared `_handle_command_on_server`; interactive REPL uses the async server |

## Verification
- [x] ruff check + format clean (scripts/ included)
- [x] mypy clean (450 files)
- [x] lint-imports 4 contracts kept
- [x] pytest test_model_switch_live_session (6) + test_phase3_ipc: 0 failed
- [x] Codex MCP review (gpt-5.5): flagged the role-clobber risk → fixed + regression-pinned; re-confirmed both IPC paths covered, helper sequence complete, effort consumed per-call, concurrency safe (loop idle during command handling)

## Reference
Operator live session cli-52254326 (check_status showed opus-4-8 after a fable-5 switch attempt). Daemon wiring: services.py:200 reload, poller.py:587 client_capability, _model_switching.py:77 drift-sync no-op (PR-DRIFT-CUT).