### PR TITLE
release: v0.99.176 — /model picker profile hydration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.176] - 2026-06-11
+
+### Fixed
+- **`/model` picker reported "Cancelled" for every switch — thin-CLI profile not hydrated** (operator-reported, the real cause behind "fable 5로 바꿔도 안 먹힘"): the interactive picker runs in the thin CLI process (relayed locally so the terminal keeps stdin), which — unlike the serve daemon — never runs the wiring bootstrap. So `get_profile_store()` was empty and `model_available()` → `resolve_routing()` returned None for EVERY model; the picker treats Enter on an unavailable entry as a blocked-Enter and reports `Cancelled`, so no switch ever landed even though the daemon was authenticated and the current model ran fine. `_interactive_model_picker` / `_interactive_model_picker_for_role` now call `_ensure_profiles_hydrated()` (idempotent `ensure_profile_store()` from `~/.geode/auth.toml`) before evaluating availability. Distinct from and upstream of the v0.99.175 live-session fix — that handled a switch that *landed*; this lets the switch land at all. Guards: `tests/core/cli/test_picker_profile_hydrate.py` (4).
+
 ## [0.99.175] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.175
+- **Version**: 0.99.176
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.175 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.176 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.175 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.176 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -249,6 +249,30 @@ def _apply_model(
     _pkg.console.print()
 
 
+def _ensure_profiles_hydrated() -> None:
+    """Load auth profiles before the thin CLI evaluates ``model_available``.
+
+    The interactive ``/model`` picker runs in the THIN CLI process
+    (``core/cli/__init__.py`` relays it locally so the terminal keeps
+    stdin), which — unlike the serve daemon — never runs the wiring
+    bootstrap. So ``get_profile_store()`` is empty and
+    ``model_available()`` → ``resolve_routing()`` returns None for EVERY
+    model. The picker then treats an Enter on any (apparently
+    unavailable) entry as a blocked-Enter and reports ``Cancelled`` — so
+    no model switch ever lands, even though the daemon is authenticated
+    and the current model runs fine. Operator-reported "fable 5로
+    전환됐지만 Cancelled" (2026-06-11). ``ensure_profile_store`` hydrates
+    from ``~/.geode/auth.toml`` and is idempotent (no-op once built), so
+    availability reflects the real credential state.
+    """
+    import contextlib
+
+    from core.wiring.container import ensure_profile_store
+
+    with contextlib.suppress(Exception):
+        ensure_profile_store()
+
+
 def _interactive_model_picker() -> None:
     """Two-axis interactive picker — model (↑↓) + effort level (←→).
 
@@ -268,6 +292,7 @@ def _interactive_model_picker() -> None:
     from core.cli.effort_picker import pick_model_and_effort
     from core.config import settings
 
+    _ensure_profiles_hydrated()
     profiles = [
         (
             p.id,
@@ -323,6 +348,7 @@ def _interactive_model_picker_for_role(role_def: AgentRole) -> None:
     from core.cli.effort_picker import pick_model_and_effort
     from core.config import settings
 
+    _ensure_profiles_hydrated()
     profiles = [
         (
             p.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.175"
+version = "0.99.176"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/cli/test_picker_profile_hydrate.py
+++ b/tests/core/cli/test_picker_profile_hydrate.py
@@ -1,0 +1,48 @@
+"""Guard: /model picker hydrates auth profiles in the thin CLI (v0.99.176).
+
+The interactive picker runs in the thin CLI process, which never runs the
+wiring bootstrap — so the profile store is empty and ``model_available()``
+returns False for EVERY model. The picker then treats Enter on any entry as
+a blocked-Enter and reports ``Cancelled``, so no switch ever lands even
+though the daemon is authenticated. ``_ensure_profiles_hydrated`` loads
+``~/.geode/auth.toml`` before availability is evaluated.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from core.cli.commands import model as model_mod
+
+
+def test_ensure_profiles_hydrated_calls_ensure_profile_store(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "core.wiring.container.ensure_profile_store",
+        lambda: calls.append("hit"),
+    )
+    model_mod._ensure_profiles_hydrated()
+    assert calls == ["hit"]
+
+
+def test_ensure_profiles_hydrated_is_resilient(monkeypatch) -> None:
+    """A hydration failure must not crash the picker."""
+
+    def _boom() -> None:
+        raise RuntimeError("auth.toml unreadable")
+
+    monkeypatch.setattr("core.wiring.container.ensure_profile_store", _boom)
+    model_mod._ensure_profiles_hydrated()  # must not raise
+
+
+def test_interactive_picker_hydrates_before_availability() -> None:
+    source = inspect.getsource(model_mod._interactive_model_picker)
+    # hydrate must come before the model_available evaluation
+    assert "_ensure_profiles_hydrated()" in source
+    assert source.index("_ensure_profiles_hydrated()") < source.index("model_available(")
+
+
+def test_role_picker_hydrates_before_availability() -> None:
+    source = inspect.getsource(model_mod._interactive_model_picker_for_role)
+    assert "_ensure_profiles_hydrated()" in source
+    assert source.index("_ensure_profiles_hydrated()") < source.index("model_available(")


### PR DESCRIPTION
## Summary
- v0.99.176: `/model` picker hydrates auth profiles in the thin CLI — fixes "Cancelled" on every model switch (PR #2145).

## Verification
- [x] CI green on #2145
- [x] develop → main pass-through