### PR TITLE
docs(3d): Config 8페이지 재생성 + 문체 검수 + README Site 링크 제거

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -16,8 +16,6 @@
 </p>
 
 <p align="center">
-  <a href="https://mangowhoiscloud.github.io/geode/">사이트</a>
-  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">문서</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving 허브</a>

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 </p>
 
 <p align="center">
-  <a href="https://mangowhoiscloud.github.io/geode/">Site</a>
-  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">Docs</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving hub</a>

--- a/site/src/app/docs/config/basics/page.tsx
+++ b/site/src/app/docs/config/basics/page.tsx
@@ -8,203 +8,358 @@ export default function Page() {
       slug="config/basics"
       title="Configuration basics"
       titleKo="설정 기초"
-      summary="Where configuration lives, how it loads, and how overrides resolve."
-      summaryKo="설정이 어디에 있고, 어떻게 로드되고, override가 어떻게 결정되는지 설명합니다."
+      summary="File roles after the config unification: .env for secrets, config.toml for behavior, one resolution ladder, and geode config explain as the debugging flow."
+      summaryKo="config 통합 이후의 파일 역할입니다. .env는 시크릿, config.toml은 동작 설정, 해석 사다리는 하나, 디버깅은 geode config explain으로 합니다."
     >
       <Bi
         ko={
           <>
-            <h2>왜 이 페이지를 먼저 읽나</h2>
             <p>
-              GEODE는 코드를 고치지 않고 동작을 바꿀 수 있어야 합니다. 모델, 예산,
-              메신저 바인딩 같은 값은 설정에서 옵니다. 그래서 키 하나하나를 외우기
-              전에, 설정이 어디에 살고 어떤 순서로 합쳐지는지부터 잡아야 합니다.
-              전체 키 목록은 <a href="/geode/docs/config/reference">config.toml 레퍼런스</a>에
-              있습니다. 이 페이지는 그 레퍼런스를 읽기 위한 지도입니다.
+              GEODE 설정의 규칙은 한 줄입니다. 시크릿은 <code>.env</code>에,
+              동작은 <code>config.toml</code>에 둡니다. 같은 키가 여러 층에
+              있으면 더 가까운 층이 이기고, 어느 층이 이겼는지는
+              <code>geode config explain</code>이 보여줍니다.
             </p>
 
-            <h2>설정이 사는 곳</h2>
+            <h2>파일과 역할</h2>
+            <table>
+              <thead>
+                <tr><th>파일</th><th>역할</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>~/.geode/.env</code></td>
+                  <td>전역 시크릿 층. API 키와 자격 증명이 들어갑니다. 온보딩과 <code>/login</code>의 키 기록이 여기로 갑니다.</td>
+                </tr>
+                <tr>
+                  <td>프로젝트 <code>.env</code> (cwd)</td>
+                  <td>프로젝트 시크릿 층. 전역 <code>.env</code>보다 우선합니다.</td>
+                </tr>
+                <tr>
+                  <td><code>~/.geode/config.toml</code></td>
+                  <td>전역 동작 설정. <code>[self_improving_loop.*]</code> 섹션도 이 파일에 삽니다.</td>
+                </tr>
+                <tr>
+                  <td><code>.geode/config.toml</code></td>
+                  <td>프로젝트 동작 설정. 전역 toml을 덮습니다. <code>/model</code>의 기본 저장 위치입니다.</td>
+                </tr>
+                <tr>
+                  <td><code>core/config/routing.toml</code></td>
+                  <td>출하되는 라우팅 매니페스트. 모델 기본값, provider prefix, 자격 패턴. <code>~/.geode/routing.toml</code>이 섹션 단위로 덮습니다.</td>
+                </tr>
+              </tbody>
+            </table>
             <p>
-              GEODE는 네 곳에서 설정을 읽습니다. 같은 키가 여러 곳에 있으면, 더 가까운
-              곳이 이깁니다.
+              시크릿 전용 <code>.env</code>는 도구가 지키는 계약입니다.
+              <code>/model</code>은 더 이상 <code>GEODE_MODEL</code>을
+              <code>.env</code>에 쓰지 않고 <code>config.toml</code>에만
+              기록합니다. 과거 릴리스가 남긴 <code>.env</code>의 모델 줄은
+              피커가 toml을 쓴 직후 자동으로 지우고 알림을 출력합니다
+              (<code>core/config/env_io.py</code>의 <code>remove_env</code>).
+              toml 매핑이 없는 env 전용 키
+              (<code>GEODE_GATEWAY_ENABLED</code> 등)를 손으로
+              <code>.env</code>에 적는 것은 여전히 유효한 운영 방법입니다.
             </p>
+
+            <h2>해석 사다리</h2>
+            <p>
+              모든 Settings 필드는 같은 사다리를 탑니다. 위가 이깁니다
+              (<code>core/config/explain.py</code>의 <code>LAYERS</code>).
+            </p>
+            <pre>{`1. os.environ            셸 export. 세션 한정 수동 override
+2. 프로젝트 .env          cwd의 .env
+3. 전역 .env             ~/.geode/.env
+4. 프로젝트 config.toml   .geode/config.toml
+5. 전역 config.toml      ~/.geode/config.toml
+6. 코드 기본값`}</pre>
+            <p>
+              모델 해석으로 좁히면 같은 사다리가 이렇게 읽힙니다. CLI 인자 &gt;
+              env 층(os.environ + .env 파일들) &gt; 프로젝트 toml &gt; 전역
+              toml &gt; routing 기본값. env 층이 toml 전부를 이기므로, 잊힌
+              <code>.env</code> 줄 하나가 이후의 모든 toml 편집을 가립니다.
+              이 구조의 대표 함정입니다.
+            </p>
+            <p>
+              <code>GEODE_CONFIG_TOML</code> env 변수는 전역
+              <code>config.toml</code>의 경로를 바꿉니다. C-4부터 메인 설정
+              로더(<code>core/config/__init__.py</code>)와 self-improving
+              로더(<code>core/config/self_improving.py</code>)가 같은 경로를
+              읽습니다. 프로젝트 toml은 그 위에 그대로 얹힙니다.
+            </p>
+
+            <h2>geode config explain</h2>
+            <p>
+              &quot;설정을 바꿨는데 실효값이 안 움직인다&quot;의 표준 진단
+              플로우입니다. 키마다 층별 후보 표를 출력하고, 정확히 하나의
+              층을 <code>WINNER</code>로, 그 아래 설정된 층을
+              <code>masked</code>로 표시합니다. 파일 경로까지 같이 나오므로
+              어느 줄을 고치거나 지워야 하는지 바로 보입니다.
+            </p>
+            <pre>{`geode config explain model     # 키 생략 시 model
+geode about                    # 실효 모델 + 마스크 경고 한 줄`}</pre>
+            <p>
+              검증은 항상 실효값으로 합니다. <code>geode about</code>이
+              보여주는 모델이 실제로 호출되는 모델이고, env 층이 toml 선택을
+              가리고 있으면 같은 화면에 경고가 뜹니다. config.toml 내용을
+              읽는 것으로 검증을 끝내면 안 됩니다.
+            </p>
+
+            <h2>리로드 시맨틱</h2>
+            <p>
+              세션 경계에서 <code>reload_settings_from_disk()</code>가
+              <code>.env</code>, <code>GEODE_*</code> env, config.toml을 살아
+              있는 싱글톤에 다시 읽어 들입니다. 필드 복사가 실패하면 해당
+              필드명을 적은 경고를 남기므로 반쯤 적용된 리로드가 조용히
+              지나가지 않습니다. 리로드는
+              <code>reload_routing_constants()</code>도 호출해 routing
+              매니페스트 캐시를 비우고 <code>core.config</code>의 라우팅
+              상수를 다시 묶습니다. 한계도 명시합니다. 모듈 로드 시점에 값을
+              복사해 간 importer는 부트 시점 복사본을 계속 들고 있으므로,
+              그 경로까지 갱신하려면 프로세스를 재시작해야 합니다.
+            </p>
+
+            <h2>데몬과 모델 env 키</h2>
+            <p>
+              serve 데몬은 시작할 때 상속받은 환경에서 동작(모델 선택) 계열
+              env 키를 떨어뜨리고, <code>.env</code> 승격에서도 건너뜁니다
+              (<code>core/cli/bootstrap.py</code>의
+              <code>load_daemon_env</code>). 데몬 환경에 승격된 모델 키가
+              모든 <code>/model</code> 전환보다 오래 살아남던 문제의
+              수정입니다. 대상 키 목록은 <code>core/config/env_io.py</code>의
+              <code>BEHAVIOR_ENV_KEYS</code>입니다.
+            </p>
+            <pre>{`GEODE_MODEL  GEODE_PLAN_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
+GEODE_COGNITIVE_REFLECTION_MODEL  GEODE_LEARNING_EXTRACT_MODEL
+GEODE_AGENTIC_EFFORT
+GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
+            <p>
+              데몬의 모델을 env로 일부러 고정하고 싶다면
+              <code>GEODE_SERVE_KEEP_MODEL_ENV=1</code>을 켭니다. C-4부터 이
+              플래그는 프로세스 env뿐 아니라 양쪽 <code>.env</code> 파일에서도
+              읽힙니다. 승격 우선순위는 수동 export &gt; 프로젝트
+              <code>.env</code> &gt; 전역 <code>.env</code>이고, 파일은 이미
+              존재하는 프로세스 env를 덮지 않으며 빈 값도 덮지 않습니다.
+            </p>
+
+            <h2>실패 모드</h2>
+            <table>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>/model</code>로 바꿨는데 그대로</td>
+                  <td>env 층의 모델 줄이 toml을 마스크</td>
+                  <td><code>geode config explain model</code>로 WINNER 층과 파일을 찾고 그 줄을 지웁니다. 최신 버전 피커는 다음 toml 기록 때 자동 정리합니다.</td>
+                </tr>
+                <tr>
+                  <td>thin CLI는 새 모델, 데몬만 옛 모델</td>
+                  <td><code>GEODE_SERVE_KEEP_MODEL_ENV=1</code>이 켜져 있거나 C-3 이전 데몬</td>
+                  <td>플래그를 끄거나 데몬을 재시작합니다. <code>pkill -f &quot;geode serve&quot;</code> 후 재진입.</td>
+                </tr>
+                <tr>
+                  <td><code>~/.geode/routing.toml</code>을 고쳤는데 반영 안 됨</td>
+                  <td>부트 시점 복사본을 든 모듈 경로</td>
+                  <td>세션 리로드로 매니페스트 독자는 갱신됩니다. 그래도 남으면 프로세스를 재시작합니다.</td>
+                </tr>
+                <tr>
+                  <td>프로젝트 <code>.env</code>가 전역에 짐</td>
+                  <td>C-3 이전 버전의 역전된 dotenv 순서</td>
+                  <td>업그레이드합니다. 현재 계약은 프로젝트 <code>.env</code>가 전역을 이깁니다.</td>
+                </tr>
+                <tr>
+                  <td><code>GEODE_CONFIG_TOML</code>이 일부 로더에만 적용</td>
+                  <td>C-4 이전에는 self-improving 로더만 인식</td>
+                  <td>업그레이드합니다. <code>geode config explain</code>이 실제로 읽은 경로를 보고합니다.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
             <ul>
-              <li><strong>CLI 인자</strong>. 한 번의 실행에만 적용됩니다.</li>
-              <li><strong>환경 변수와 <code>.env</code></strong>. 모든 변수는 <code>GEODE_</code> 접두사를 씁니다. 예를 들어 <code>GEODE_MODEL</code>이 <code>model</code> 키를 덮습니다. <code>.env</code> 파일은 현재 디렉터리의 <code>.env</code>와 <code>~/.geode/.env</code> 두 곳에서 읽습니다.</li>
-              <li><strong>프로젝트 TOML</strong>. <code>.geode/config.toml</code>. 워크스페이스마다 다른 설정을 둘 때 씁니다.</li>
-              <li><strong>전역 TOML</strong>. <code>~/.geode/config.toml</code>. 모든 프로젝트에 공통으로 적용할 기본값입니다.</li>
-            </ul>
-            <p>
-              어느 파일도 필수가 아닙니다. 넷 다 없으면 GEODE는 코드 안의 기본값으로
-              동작합니다.
-            </p>
-
-            <h2>해석 순서</h2>
-            <p>
-              우선순위는 높은 것부터 낮은 것까지 다음과 같습니다.
-            </p>
-            <pre>{`CLI 인자
-  > 환경 변수 / .env (GEODE_*)
-    > 프로젝트 .geode/config.toml
-      > 전역 ~/.geode/config.toml
-        > 코드 기본값`}</pre>
-            <p>
-              읽는 방식이 두 갈래라는 점이 중요합니다. 환경 변수와 <code>.env</code>는
-              설정 객체를 만들 때 곧바로 로드됩니다. TOML 값은 그 뒤에 얹히되,
-              <strong>환경 변수로 이미 정해진 키는 건너뜁니다</strong>. 그래서 환경
-              변수가 항상 TOML보다 셉니다. 환경 변수로 모델을 고정해 두면 <code>config.toml</code>의
-              모델 값은 무시됩니다.
-            </p>
-            <p>
-              TOML에서 코드가 모르는 키는 조용히 무시됩니다. 매핑된 키만 적용되므로,
-              오타가 난 키는 효과 없이 지나갑니다. 레퍼런스에 적힌 이름을 그대로
-              쓰세요.
-            </p>
-
-            <h2>로드 시점</h2>
-            <p>
-              설정은 싱글턴입니다. 처음 누군가 설정을 요청할 때 한 번 만들어지고,
-              그 뒤로는 같은 객체가 재사용됩니다. 무거운 의존성을 미루기 위해 이렇게
-              지연 로드합니다. 디스크가 바뀌면 <code>reload_settings_from_disk()</code>가
-              <code>.env</code>와 <code>config.toml</code>을 다시 읽어 살아 있는 싱글턴을
-              제자리에서 갱신합니다. <code>geode serve</code> 데몬이 세션 경계에서 이
-              경로를 타기 때문에, CLI에서 모델을 바꿔도 데몬이 디스크와 다시 맞춰집니다.
-            </p>
-
-            <h2>config.toml 첫 모양</h2>
-            <p>
-              값은 영역별 테이블로 묶입니다. 바꾸고 싶은 줄의 주석만 풀면 됩니다.
-            </p>
-            <pre>{`[llm]
-primary_model = "claude-opus-4-7"
-secondary_model = "gpt-5.4"
-
-[pipeline]
-confidence_threshold = 0.7
-max_iterations = 5
-
-[gateway]
-time_budget_s = 300
-
-[[gateway.bindings.rules]]
-channel = "slack"
-channel_id = "C12345"
-auto_respond = true`}</pre>
-            <p>
-              <code>[[gateway.bindings.rules]]</code>는 메신저 채널 하나를 세션으로
-              라우팅하는 규칙입니다. <code>channel_id</code>가 비면 그 규칙은 안전을 위해
-              건너뜁니다. 빈 id는 모든 채널을 받는 위험한 catch-all이 되기 때문입니다.
-              바인딩을 더 다루려면{" "}
-              <a href="/geode/docs/guides/binding">바인딩 설정</a> 가이드를 보세요.
-            </p>
-
-            <h2>다음으로</h2>
-            <ul>
-              <li><a href="/geode/docs/config/reference">config.toml 레퍼런스</a>. 영역별 전체 키.</li>
-              <li><a href="/geode/docs/run/providers">프로바이더 설정</a>. 키를 어디에 두는지.</li>
-              <li><a href="/geode/docs/runtime/auth">인증과 OAuth</a>. 자격 증명 소스.</li>
+              <li><a href="/geode/docs/config/reference">config.toml 레퍼런스</a>. 전체 키 목록입니다.</li>
+              <li><a href="/geode/docs/runtime/auth">인증과 OAuth</a>. 시크릿 층에 무엇이 들어가는지 다룹니다.</li>
+              <li><a href="/geode/docs/runtime/llm/providers">LLM 라우팅</a>. routing.toml이 소비되는 곳입니다.</li>
             </ul>
           </>
         }
         en={
           <>
-            <h2>Why read this first</h2>
             <p>
-              GEODE has to change behaviour without editing code. Values like the
-              model, the budgets, and messaging bindings all come from
-              configuration. So before memorising individual keys, get the shape
-              right. Where configuration lives, and in what order the sources
-              merge. The full key list is in the{" "}
-              <a href="/geode/docs/config/reference">config.toml reference</a>.
-              This page is the map for reading that reference.
+              GEODE configuration follows one rule. Secrets live in
+              <code>.env</code>, behavior lives in <code>config.toml</code>.
+              When the same key exists in several layers, the closer layer
+              wins, and <code>geode config explain</code> shows you which one
+              won.
             </p>
 
-            <h2>Where configuration lives</h2>
+            <h2>Files and roles</h2>
+            <table>
+              <thead>
+                <tr><th>File</th><th>Role</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>~/.geode/.env</code></td>
+                  <td>Global secrets layer. API keys and credentials. Onboarding and <code>/login</code> write keys here.</td>
+                </tr>
+                <tr>
+                  <td>Project <code>.env</code> (cwd)</td>
+                  <td>Project secrets layer. Beats the global <code>.env</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>~/.geode/config.toml</code></td>
+                  <td>Global behavior settings. Also hosts the <code>[self_improving_loop.*]</code> sections.</td>
+                </tr>
+                <tr>
+                  <td><code>.geode/config.toml</code></td>
+                  <td>Project behavior settings. Outranks the global toml. Default write target of <code>/model</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>core/config/routing.toml</code></td>
+                  <td>Shipped routing manifest: model defaults, provider prefixes, credential patterns. <code>~/.geode/routing.toml</code> overrides it section by section.</td>
+                </tr>
+              </tbody>
+            </table>
             <p>
-              GEODE reads configuration from four places. When the same key
-              appears in more than one, the closer source wins.
+              &quot;Secrets-only <code>.env</code>&quot; is a contract the
+              tools keep. <code>/model</code> no longer writes
+              <code>GEODE_MODEL</code> to <code>.env</code>; it persists to
+              <code>config.toml</code> only. Model lines left behind by older
+              releases are auto-removed right after the picker&apos;s toml
+              write, with a printed notice (<code>remove_env</code> in
+              <code>core/config/env_io.py</code>). Hand-writing env-only keys
+              that have no toml mapping (<code>GEODE_GATEWAY_ENABLED</code>
+              and friends) into <code>.env</code> remains a valid operator
+              move.
             </p>
+
+            <h2>The resolution ladder</h2>
+            <p>
+              Every Settings field rides the same ladder. Higher wins
+              (<code>LAYERS</code> in <code>core/config/explain.py</code>).
+            </p>
+            <pre>{`1. os.environ            shell exports. session-scoped manual override
+2. project .env          .env in the cwd
+3. global .env           ~/.geode/.env
+4. project config.toml   .geode/config.toml
+5. global config.toml    ~/.geode/config.toml
+6. code default`}</pre>
+            <p>
+              Narrowed to model resolution, the same ladder reads: CLI args
+              &gt; env layer (os.environ plus both .env files) &gt; project
+              toml &gt; global toml &gt; routing default. Because the env
+              layer outranks every toml, a single forgotten <code>.env</code>
+              line masks all future toml edits. That is the classic trap this
+              design removes from the tools and leaves only to deliberate
+              hands.
+            </p>
+            <p>
+              The <code>GEODE_CONFIG_TOML</code> env var redirects the global
+              <code>config.toml</code> path. Since C-4 both the main settings
+              loader (<code>core/config/__init__.py</code>) and the
+              self-improving loader
+              (<code>core/config/self_improving.py</code>) honor it, so the
+              variable has one meaning. The project toml still overlays on
+              top.
+            </p>
+
+            <h2>geode config explain</h2>
+            <p>
+              The standard diagnosis for &quot;I changed the config but the
+              effective value did not move&quot;. For a key it prints a
+              per-layer candidate table, marks exactly one layer as
+              <code>WINNER</code> and every set lower layer as
+              <code>masked</code>, with file paths, so you see exactly which
+              line to edit or remove.
+            </p>
+            <pre>{`geode config explain model     # key defaults to model
+geode about                    # effective model + one-line mask warning`}</pre>
+            <p>
+              Always verify against the effective state. The model
+              <code>geode about</code> reports is the model that gets called,
+              and the same screen warns when an env layer masks a toml pick.
+              Reading config.toml content is not verification.
+            </p>
+
+            <h2>Reload semantics</h2>
+            <p>
+              At session boundaries <code>reload_settings_from_disk()</code>
+              re-reads <code>.env</code>, <code>GEODE_*</code> env, and
+              config.toml into the live singleton. A per-field copy failure
+              logs a warning naming the field, so a half-applied reload never
+              passes silently. The reload also calls
+              <code>reload_routing_constants()</code>, clearing the
+              routing-manifest cache and rebinding the routing constants on
+              <code>core.config</code>. The honest limit: importers that
+              copied values at module load time still hold boot-time copies.
+              Restart the process to refresh those paths.
+            </p>
+
+            <h2>The daemon and model env keys</h2>
+            <p>
+              At startup the serve daemon drops behavior (model-pick) env
+              keys from its inherited environment and skips them during
+              <code>.env</code> promotion (<code>load_daemon_env</code> in
+              <code>core/cli/bootstrap.py</code>). This fixes the failure
+              where a model key promoted into the daemon&apos;s environment
+              outlived every <code>/model</code> switch. The key list is
+              <code>BEHAVIOR_ENV_KEYS</code> in
+              <code>core/config/env_io.py</code>.
+            </p>
+            <pre>{`GEODE_MODEL  GEODE_PLAN_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
+GEODE_COGNITIVE_REFLECTION_MODEL  GEODE_LEARNING_EXTRACT_MODEL
+GEODE_AGENTIC_EFFORT
+GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
+            <p>
+              To pin the daemon&apos;s model via env on purpose, set
+              <code>GEODE_SERVE_KEEP_MODEL_ENV=1</code>. Since C-4 the flag is
+              honored from the process env or from either <code>.env</code>
+              file. Promotion precedence is manual exports &gt; project
+              <code>.env</code> &gt; global <code>.env</code>; files never
+              clobber pre-existing process env, and empty values never
+              clobber anything.
+            </p>
+
+            <h2>Failure modes</h2>
+            <table>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>/model</code> switch does not stick</td>
+                  <td>A model line in the env layer masks the toml</td>
+                  <td>Run <code>geode config explain model</code>, find the WINNER layer and file, remove the line. Current pickers also auto-clean it on the next toml write.</td>
+                </tr>
+                <tr>
+                  <td>Thin CLI sees the new model, the daemon keeps the old one</td>
+                  <td><code>GEODE_SERVE_KEEP_MODEL_ENV=1</code> is set, or a pre-C-3 daemon</td>
+                  <td>Unset the flag or restart the daemon: <code>pkill -f &quot;geode serve&quot;</code>, then re-enter.</td>
+                </tr>
+                <tr>
+                  <td>Edits to <code>~/.geode/routing.toml</code> do not land</td>
+                  <td>A module path holding a boot-time copy</td>
+                  <td>Session reload refreshes manifest readers. If a path still lags, restart the process.</td>
+                </tr>
+                <tr>
+                  <td>Project <code>.env</code> loses to the global one</td>
+                  <td>Pre-C-3 versions had the dotenv order inverted</td>
+                  <td>Upgrade. The current contract is project <code>.env</code> beats global.</td>
+                </tr>
+                <tr>
+                  <td><code>GEODE_CONFIG_TOML</code> only applies to some loaders</td>
+                  <td>Before C-4 only the self-improving loader honored it</td>
+                  <td>Upgrade. <code>geode config explain</code> reports the path actually read.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
             <ul>
-              <li><strong>CLI arguments</strong>. Apply to a single run.</li>
-              <li><strong>Environment variables and <code>.env</code></strong>. Every variable uses the <code>GEODE_</code> prefix. For example, <code>GEODE_MODEL</code> overrides the <code>model</code> key. The <code>.env</code> file is read from both the current directory <code>.env</code> and <code>~/.geode/.env</code>.</li>
-              <li><strong>Project TOML</strong>. <code>.geode/config.toml</code>. Use it when a workspace needs settings different from the rest.</li>
-              <li><strong>Global TOML</strong>. <code>~/.geode/config.toml</code>. Defaults shared across every project.</li>
-            </ul>
-            <p>
-              None of these files is required. With all four absent, GEODE runs on
-              its code defaults.
-            </p>
-
-            <h2>How overrides resolve</h2>
-            <p>
-              Priority runs from highest to lowest as follows.
-            </p>
-            <pre>{`CLI arguments
-  > environment variables / .env (GEODE_*)
-    > project .geode/config.toml
-      > global ~/.geode/config.toml
-        > code defaults`}</pre>
-            <p>
-              The read happens in two passes, and that matters. Environment
-              variables and <code>.env</code> load first, when the settings object
-              is built. TOML values are layered on afterwards, but{" "}
-              <strong>any key already set by an environment variable is skipped</strong>.
-              That is why an environment variable always beats TOML. Pin the model
-              through an environment variable and the model value in{" "}
-              <code>config.toml</code> is ignored.
-            </p>
-            <p>
-              A TOML key the code does not recognise is silently ignored. Only
-              mapped keys are applied, so a typo passes through with no effect.
-              Use the names exactly as the reference spells them.
-            </p>
-
-            <h2>When it loads</h2>
-            <p>
-              Settings are a singleton. They are built once on first request and
-              the same object is reused after that. The load is lazy to defer
-              heavy dependencies. When the disk changes,{" "}
-              <code>reload_settings_from_disk()</code> re-reads <code>.env</code>{" "}
-              and <code>config.toml</code> and refreshes the live singleton in
-              place. The <code>geode serve</code> daemon takes this path at a
-              session boundary, so changing the model from the CLI brings the
-              daemon back in sync with disk.
-            </p>
-
-            <h2>A first config.toml</h2>
-            <p>
-              Values are grouped into per-area tables. Uncomment only the lines
-              you want to change.
-            </p>
-            <pre>{`[llm]
-primary_model = "claude-opus-4-7"
-secondary_model = "gpt-5.4"
-
-[pipeline]
-confidence_threshold = 0.7
-max_iterations = 5
-
-[gateway]
-time_budget_s = 300
-
-[[gateway.bindings.rules]]
-channel = "slack"
-channel_id = "C12345"
-auto_respond = true`}</pre>
-            <p>
-              <code>[[gateway.bindings.rules]]</code> is a rule that routes one
-              messaging channel to a session. A rule with an empty{" "}
-              <code>channel_id</code> is skipped for safety, since an empty id
-              would be an unsafe catch-all that accepts every channel. For more
-              on bindings, see the{" "}
-              <a href="/geode/docs/guides/binding">Configure a binding</a> guide.
-            </p>
-
-            <h2>Where to go next</h2>
-            <ul>
-              <li><a href="/geode/docs/config/reference">config.toml reference</a>. Every key, grouped by area.</li>
-              <li><a href="/geode/docs/run/providers">Configure providers</a>. Where keys go.</li>
-              <li><a href="/geode/docs/runtime/auth">Auth and OAuth</a>. Credential sources.</li>
+              <li><a href="/geode/docs/config/reference">config.toml reference</a>. The full key inventory.</li>
+              <li><a href="/geode/docs/runtime/auth">Auth and OAuth</a>. What goes into the secrets layer.</li>
+              <li><a href="/geode/docs/runtime/llm/providers">LLM routing</a>. Where routing.toml is consumed.</li>
             </ul>
           </>
         }

--- a/site/src/app/docs/config/reference/page.tsx
+++ b/site/src/app/docs/config/reference/page.tsx
@@ -8,350 +8,737 @@ export default function Page() {
       slug="config/reference"
       title="config.toml reference"
       titleKo="config.toml 레퍼런스"
-      summary="Every configuration key, grouped by area, marked stable or experimental."
-      summaryKo="영역별로 묶은 모든 설정 키입니다. stable과 experimental을 표시합니다."
+      summary="The exhaustive key reference: Settings fields with their toml mappings, the routing.toml manifest, and the self-improving loop sections."
+      summaryKo="전체 키 레퍼런스입니다. toml 매핑이 붙은 Settings 필드, routing.toml 매니페스트, self-improving 루프 섹션을 다룹니다."
     >
       <Bi
         ko={
           <>
-            <h2>읽는 법</h2>
             <p>
-              아래 표는 코드의 설정 모델에서 검증한 키만 담습니다. 각 키는 환경 변수
-              <code>GEODE_</code> 접두사로도 설정할 수 있습니다. 예를 들어 <code>model</code>은
-              <code>GEODE_MODEL</code>입니다. 일부 키는 <code>config.toml</code>의 점 표기
-              경로로만 매핑됩니다. 그 경로는 별도로 적었습니다. 우선순위와 로드 방식은{" "}
-              <a href="/geode/docs/config/basics">설정 기초</a>를 먼저 보세요.
+              이 페이지는 설정 키의 단일 목록입니다. 키가 어디서 어떤 순서로
+              읽히는지는 <a href="/geode/docs/config/basics">설정 기초</a>가
+              다룹니다. 키는 세 무리로 나뉩니다. Settings 필드
+              (<code>core/config/_settings.py</code>), 라우팅 매니페스트
+              (<code>core/config/routing.toml</code>), self-improving 루프
+              섹션(<code>core/config/self_improving.py</code>).
             </p>
             <p>
-              실험 단계로 표시된 키는 동작이 바뀔 수 있습니다. 빈 문자열 기본값은
-              대개 다른 값으로 폴백한다는 뜻입니다. 표의 설명에 폴백 대상을 적었습니다.
+              모든 Settings 필드는 <code>GEODE_</code> 접두사를 붙인 env
+              변수로 덮을 수 있습니다. <code>model</code>은
+              <code>GEODE_MODEL</code>, <code>agentic_effort</code>는
+              <code>GEODE_AGENTIC_EFFORT</code>가 됩니다. toml 키 열이 비어
+              있으면 그 필드는 env 또는 코드 기본값으로만 설정합니다. toml
+              매핑의 SoT는 <code>core/config/__init__.py</code>의
+              <code>_TOML_TO_SETTINGS</code>이고, 매핑에 없는 toml 키는
+              조용히 무시됩니다.
             </p>
 
-            <h2>LLM과 모델</h2>
-            <p><code>config.toml</code> 경로: <code>[llm]</code> 테이블.</p>
+            <h2>Settings: toml 매핑 필드</h2>
+
+            <h3>[llm]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>model</code> (<code>llm.primary_model</code>)</td><td>주 모델. REPL과 agentic 루프가 씁니다.</td><td><code>claude-opus-4-7</code></td></tr>
-                <tr><td><code>default_secondary_model</code> (<code>llm.secondary_model</code>)</td><td>Cross-LLM 검증의 2차 모델.</td><td><code>gpt-5.4</code></td></tr>
-                <tr><td><code>router_model</code> (<code>llm.router_model</code>)</td><td>라우팅 결정을 내리는 모델.</td><td><code>claude-opus-4-7</code></td></tr>
-                <tr><td><code>plan_model</code> (<code>llm.plan_model</code>)</td><td>계획 단계 모델. 빈 값이면 <code>model</code>로 폴백합니다.</td><td>빈 문자열</td></tr>
-                <tr><td><code>act_model</code> (<code>llm.act_model</code>)</td><td>행동 루프 모델. 빈 값이면 <code>model</code>로 폴백합니다.</td><td>빈 문자열</td></tr>
-                <tr><td><code>judge_model</code> (<code>llm.judge_model</code>)</td><td>턴별 verify 판정 모델. 빈 값이면 <code>model</code>로 폴백합니다.</td><td>빈 문자열</td></tr>
-                <tr><td><code>learning_extract_model</code> (<code>llm.learning_extract_model</code>)</td><td>학습 추출 훅이 쓰는 저비용 모델.</td><td><code>glm-4.7-flash</code></td></tr>
-                <tr><td><code>agreement_threshold</code></td><td>Cross-LLM 합의 통과 임계값.</td><td><code>0.67</code></td></tr>
-                <tr><td><code>forced_login_method</code></td><td>프로바이더별 인증 모드 강제. 예: <code>{`{"openai":"apikey"}`}</code>.</td><td>빈 dict</td></tr>
+                <tr><td><code>model</code></td><td><code>llm.primary_model</code></td><td>str = <code>&quot;claude-opus-4-8&quot;</code></td><td>기본 모델. 기본값은 routing.toml의 anthropic 기본값을 따라갑니다.</td></tr>
+                <tr><td><code>plan_model</code></td><td><code>llm.plan_model</code></td><td>str = <code>&quot;&quot;</code></td><td>플래닝 단계 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
+                <tr><td><code>act_model</code></td><td><code>llm.act_model</code></td><td>str = <code>&quot;&quot;</code></td><td>액션 루프 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
+                <tr><td><code>judge_model</code></td><td><code>llm.judge_model</code></td><td>str = <code>&quot;&quot;</code></td><td>턴 단위 verify judge 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
+                <tr><td><code>learning_extract_model</code></td><td><code>llm.learning_extract_model</code></td><td>str = <code>&quot;glm-4.7-flash&quot;</code></td><td>learning 추출 훅용 무료 티어 GLM 모델.</td></tr>
+                <tr><td><code>anthropic_credential_source</code></td><td><code>llm.anthropic_credential_source</code></td><td>str = <code>&quot;auto&quot;</code></td><td>Anthropic 자격 경로. <code>CredentialSource</code> 값 + <code>oauth</code> 별칭 + <code>none</code>.</td></tr>
+                <tr><td><code>openai_credential_source</code></td><td><code>llm.openai_credential_source</code></td><td>str = <code>&quot;auto&quot;</code></td><td>OpenAI 자격 경로. 같은 검증을 거칩니다.</td></tr>
               </tbody>
             </table>
 
-            <h2>LLM 연결</h2>
-            <p>httpx 풀과 재시도. 기본값으로 충분한 고급 키입니다.</p>
+            <h3>[agentic]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>llm_max_connections</code></td><td>풀의 최대 연결 수.</td><td><code>20</code></td></tr>
-                <tr><td><code>llm_read_timeout</code></td><td>응답 읽기 타임아웃(초). 1M 컨텍스트를 위해 큽니다.</td><td><code>300.0</code></td></tr>
-                <tr><td><code>llm_connect_timeout</code></td><td>TCP 연결 타임아웃(초).</td><td><code>5.0</code></td></tr>
-                <tr><td><code>llm_max_retries</code></td><td>모델별 최대 재시도 횟수.</td><td><code>3</code></td></tr>
-                <tr><td><code>llm_max_fallback_cost_ratio</code></td><td>폴백 비용 비율 상한. <code>0</code>은 무제한.</td><td><code>0.0</code></td></tr>
+                <tr><td><code>agentic_effort</code></td><td><code>agentic.effort</code></td><td>str = <code>&quot;high&quot;</code></td><td><code>low</code>/<code>medium</code>/<code>high</code>/<code>max</code>/<code>xhigh</code>. Anthropic <code>output_config.effort</code>, OpenAI <code>reasoning.effort</code>로 전달됩니다. xhigh는 Opus 4.7 이상과 Fable 5 전용.</td></tr>
+                <tr><td><code>agentic_loop_time_budget</code></td><td><code>agentic.time_budget</code></td><td>float = 0.0</td><td>벽시계 초 단위 예산. 0이면 무제한.</td></tr>
+                <tr><td><code>agentic_thinking_budget</code></td><td><code>agentic.thinking_budget</code></td><td>int = 0</td><td>레거시 thinking 토큰 예산. 0이면 비활성.</td></tr>
               </tbody>
             </table>
 
-            <h2>예산과 비용</h2>
+            <h3>[replan]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>cost_limit_usd</code></td><td>세션 비용 상한(USD). 80%에서 경고, 100%에서 초과 이벤트. <code>0</code>은 무제한.</td><td><code>0.0</code></td></tr>
-                <tr><td><code>agentic_loop_time_budget</code> (<code>agentic.time_budget</code>)</td><td>agentic 루프 벽시계 예산(초). <code>0</code>은 무제한.</td><td><code>0.0</code></td></tr>
-                <tr><td><code>agentic_effort</code> (<code>agentic.effort</code>)</td><td>thinking depth. <code>low</code> / <code>medium</code> / <code>high</code> / <code>max</code> / <code>xhigh</code>.</td><td><code>high</code></td></tr>
-                <tr><td><code>max_tool_result_tokens</code></td><td>도구 결과 절단 임계 토큰. <code>0</code>은 무제한.</td><td><code>25000</code></td></tr>
-                <tr><td><code>tool_offload_threshold</code></td><td>큰 결과를 디스크로 내리는 토큰 임계값. <code>0</code>은 비활성.</td><td><code>15000</code></td></tr>
-                <tr><td><code>pipeline_timeout_s</code></td><td>파이프라인 타임아웃(초). <code>0</code>은 무제한.</td><td><code>600.0</code></td></tr>
+                <tr><td><code>replan_enabled</code></td><td><code>replan.enabled</code></td><td>bool = true</td><td>리플랜 활성화.</td></tr>
+                <tr><td><code>replan_interval</code></td><td><code>replan.interval</code></td><td>int = 5</td><td>리플랜 주기. 0이면 주기 비활성.</td></tr>
+                <tr><td><code>replan_max_attempts</code></td><td><code>replan.max_attempts</code></td><td>int = 3</td><td>리플랜 시도 상한.</td></tr>
               </tbody>
             </table>
 
-            <h2>파이프라인과 오케스트레이션</h2>
-            <p><code>config.toml</code> 경로: <code>[pipeline]</code> 테이블 (앞 두 키).</p>
+            <h3>[cognitive]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>confidence_threshold</code> (<code>pipeline.confidence_threshold</code>)</td><td>이 값 아래면 루프백.</td><td><code>0.7</code></td></tr>
-                <tr><td><code>max_iterations</code> (<code>pipeline.max_iterations</code>)</td><td>최대 파이프라인 반복.</td><td><code>5</code></td></tr>
-                <tr><td><code>max_subagent_depth</code></td><td>서브에이전트 최대 재귀 깊이.</td><td><code>1</code></td></tr>
-                <tr><td><code>max_total_subagents</code></td><td>세션 내 최대 서브에이전트 수.</td><td><code>15</code></td></tr>
-                <tr><td><code>subagent_max_tokens</code></td><td>서브에이전트 출력 토큰 제한.</td><td><code>32768</code></td></tr>
-                <tr><td><code>ensemble_mode</code></td><td><code>single</code> 또는 <code>cross</code>(다중 LLM).</td><td><code>single</code></td></tr>
+                <tr><td><code>cognitive_reflection_enabled</code></td><td><code>cognitive.reflection_enabled</code></td><td>bool = true</td><td>인지 리플렉션 활성화.</td></tr>
+                <tr><td><code>cognitive_reflection_model</code></td><td><code>cognitive.reflection_model</code></td><td>str = <code>&quot;claude-haiku-4-5-20251001&quot;</code></td><td>리플렉션 모델.</td></tr>
+                <tr><td><code>cognitive_reflection_max_tokens</code></td><td><code>cognitive.reflection_max_tokens</code></td><td>int = 512</td><td>리플렉션 출력 토큰 상한.</td></tr>
+                <tr><td><code>cognitive_reflection_interval</code></td><td><code>cognitive.reflection_interval</code></td><td>int = 1</td><td>몇 라운드마다 리플렉션할지. 1이면 매 라운드.</td></tr>
               </tbody>
             </table>
 
-            <h2>게이트웨이와 바인딩</h2>
-            <p><code>config.toml</code> 경로: <code>[gateway]</code> 테이블과 <code>[[gateway.bindings.rules]]</code> 배열.</p>
+            <h3>[sandbox]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>gateway_enabled</code></td><td>인바운드 메시지 게이트웨이 활성. <code>GEODE_GATEWAY_ENABLED=true</code>.</td><td><code>false</code></td></tr>
-                <tr><td><code>gateway_poll_interval_s</code></td><td>게이트웨이 폴링 간격(초).</td><td><code>3.0</code></td></tr>
-                <tr><td><code>gateway_max_concurrent</code></td><td>동시에 처리하는 게이트웨이 메시지 수.</td><td><code>4</code></td></tr>
-                <tr><td><code>gateway.time_budget_s</code></td><td>바인딩이 상속하는 게이트웨이 기본 시간 예산.</td><td>해당 없음</td></tr>
-                <tr><td><code>gateway.max_turns</code></td><td>게이트웨이 세션 턴 상한. <code>0</code>은 무제한.</td><td><code>0</code></td></tr>
-              </tbody>
-            </table>
-            <p><code>[[gateway.bindings.rules]]</code> 규칙 하나의 필드:</p>
-            <table>
-              <thead><tr><th>필드</th><th>하는 일</th><th>기본값</th></tr></thead>
-              <tbody>
-                <tr><td><code>channel</code></td><td>메신저 종류. 예: <code>slack</code>. 필수.</td><td>해당 없음</td></tr>
-                <tr><td><code>channel_id</code></td><td>채널 식별자. 비면 그 규칙은 건너뜁니다.</td><td>해당 없음</td></tr>
-                <tr><td><code>auto_respond</code></td><td>자동 응답 여부.</td><td><code>true</code></td></tr>
-                <tr><td><code>require_mention</code></td><td>멘션이 있을 때만 응답.</td><td><code>false</code></td></tr>
-                <tr><td><code>allowed_tools</code></td><td>이 바인딩에서 허용할 도구 목록.</td><td>빈 목록</td></tr>
-                <tr><td><code>time_budget_s</code></td><td>이 바인딩의 시간 예산(초). 없으면 게이트웨이 기본값.</td><td>게이트웨이 기본값</td></tr>
+                <tr><td><code>sandbox_max_file_size_bytes</code></td><td><code>sandbox.max_file_size_bytes</code></td><td>int = 262144</td><td>파일 읽기 바이트 상한.</td></tr>
+                <tr><td><code>sandbox_max_read_tokens</code></td><td><code>sandbox.max_read_tokens</code></td><td>int = 25000</td><td>읽기 결과 토큰 상한.</td></tr>
+                <tr><td><code>sandbox_max_glob_results</code></td><td><code>sandbox.max_glob_results</code></td><td>int = 100</td><td>glob 결과 개수 상한.</td></tr>
+                <tr><td><code>sandbox_max_grep_results</code></td><td><code>sandbox.max_grep_results</code></td><td>int = 50</td><td>grep 결과 개수 상한.</td></tr>
+                <tr><td><code>sandbox_max_grep_line_chars</code></td><td><code>sandbox.max_grep_line_chars</code></td><td>int = 200</td><td>grep 라인 문자 상한.</td></tr>
               </tbody>
             </table>
 
-            <h2>스케줄러와 자동화</h2>
+            <h3>[output]</h3>
             <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
+              <thead>
+                <tr><th>필드</th><th>toml 키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>scheduler_auto_start</code></td><td>부트 시 스케줄러 자동 시작.</td><td><code>true</code></td></tr>
-                <tr><td><code>scheduler_interval_s</code></td><td>스케줄러 체크 간격(초).</td><td><code>1.0</code></td></tr>
-                <tr><td><code>scheduler_jitter_enabled</code></td><td>잡별 결정적 jitter 적용.</td><td><code>true</code></td></tr>
-                <tr><td><code>scheduler_max_jitter_ms</code></td><td>jitter 상한(밀리초).</td><td><code>900000.0</code></td></tr>
-                <tr><td><code>outcome_tracking_enabled</code></td><td>결과 추적 활성 (실험).</td><td><code>true</code></td></tr>
-                <tr><td><code>drift_scan_cron</code></td><td>drift 스캔 cron 식 (실험).</td><td><code>0 */6 * * *</code></td></tr>
+                <tr><td><code>verbose</code></td><td><code>output.verbose</code></td><td>bool = false</td><td>상세 출력. <code>/verbose</code>로 세션 중 토글합니다.</td></tr>
               </tbody>
             </table>
 
-            <h2>메모리와 세션</h2>
-            <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
-              <tbody>
-                <tr><td><code>session_ttl_hours</code></td><td>세션 idle TTL(시간).</td><td><code>4.0</code></td></tr>
-                <tr><td><code>session_storage_dir</code></td><td>파일 백업 디렉터리. 비면 메모리만 사용.</td><td>빈 문자열</td></tr>
-                <tr><td><code>compact_keep_recent</code></td><td>압축 시 보존할 최근 메시지 수.</td><td><code>10</code></td></tr>
-                <tr><td><code>checkpoint_db</code></td><td>체크포인트 DB 파일.</td><td><code>geode_checkpoints.db</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>샌드박스 (파일 도구 가드)</h2>
-            <p><code>config.toml</code> 경로: <code>[sandbox]</code> 테이블.</p>
-            <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
-              <tbody>
-                <tr><td><code>sandbox_max_file_size_bytes</code> (<code>sandbox.max_file_size_bytes</code>)</td><td>읽기 전 파일 크기 가드(바이트).</td><td><code>262144</code></td></tr>
-                <tr><td><code>sandbox_max_read_tokens</code> (<code>sandbox.max_read_tokens</code>)</td><td>읽은 뒤 토큰 추정 가드.</td><td><code>25000</code></td></tr>
-                <tr><td><code>sandbox_max_glob_results</code> (<code>sandbox.max_glob_results</code>)</td><td>Glob 도구 최대 결과.</td><td><code>100</code></td></tr>
-                <tr><td><code>sandbox_max_grep_results</code> (<code>sandbox.max_grep_results</code>)</td><td>Grep 도구 최대 파일 수.</td><td><code>50</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>승인과 알림</h2>
-            <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
-              <tbody>
-                <tr><td><code>hitl_level</code></td><td>휴먼 인 더 루프 단계. <code>0</code> 자율, <code>1</code> 쓰기만 확인, <code>2</code> 전부 확인.</td><td><code>2</code></td></tr>
-                <tr><td><code>plan_auto_execute</code></td><td>계획 자동 실행. <code>GEODE_PLAN_AUTO_EXECUTE=true</code>.</td><td><code>false</code></td></tr>
-                <tr><td><code>computer_use_enabled</code></td><td>데스크탑 자동화 활성.</td><td><code>true</code></td></tr>
-                <tr><td><code>notification_channel</code></td><td>기본 알림 채널.</td><td><code>slack</code></td></tr>
-                <tr><td><code>notification_on_pipeline_error</code></td><td>파이프라인 오류 시 알림.</td><td><code>true</code></td></tr>
-                <tr><td><code>webhook_enabled</code></td><td>웹훅 엔드포인트 활성. <code>GEODE_WEBHOOK_ENABLED=true</code>.</td><td><code>false</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>자격 증명 소스</h2>
-            <table>
-              <thead><tr><th>키</th><th>하는 일</th><th>기본값</th></tr></thead>
-              <tbody>
-                <tr><td><code>anthropic_credential_source</code></td><td>Anthropic 자격 증명 소스. <code>auto</code> / <code>api_key</code> / <code>claude-cli</code> / <code>oauth</code> / <code>none</code>.</td><td><code>auto</code></td></tr>
-                <tr><td><code>openai_credential_source</code></td><td>OpenAI 자격 증명 소스. 같은 집합.</td><td><code>auto</code></td></tr>
-                <tr><td><code>anthropic_api_key</code></td><td>Anthropic 키. <code>ANTHROPIC_API_KEY</code> 별칭 가능.</td><td>빈 문자열</td></tr>
-                <tr><td><code>openai_api_key</code></td><td>OpenAI 키. <code>OPENAI_API_KEY</code> 별칭 가능.</td><td>빈 문자열</td></tr>
-                <tr><td><code>zai_api_key</code></td><td>ZhipuAI(GLM) 키. <code>ZAI_API_KEY</code> 별칭 가능.</td><td>빈 문자열</td></tr>
-              </tbody>
-            </table>
-
-            <h2>참고</h2>
+            <h2>Settings: env 전용 필드</h2>
             <p>
-              이 목록은 코드의 설정 모델에서 직접 검증한 키만 담습니다. 모델 기본값과
-              폴백 체인은 <code>routing.toml</code>이라는 별도 매니페스트에서 오므로 여기
-              표에 없습니다. 모델별 라우팅을 바꾸려면{" "}
-              <a href="/geode/docs/runtime/llm/providers">LLM 라우팅</a>을 보세요.
-              자격 증명 흐름은 <a href="/geode/docs/runtime/auth">인증과 OAuth</a>에
-              있습니다.
+              아래 무리는 toml 매핑이 없습니다. <code>GEODE_*</code> env
+              변수나 <code>.env</code>로만 설정합니다.
             </p>
+
+            <h3>시크릿과 프로바이더</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>anthropic_api_key</code> / <code>openai_api_key</code> / <code>zai_api_key</code></td><td>str = <code>&quot;&quot;</code></td><td><code>ANTHROPIC_API_KEY</code> / <code>OPENAI_API_KEY</code> / <code>ZAI_API_KEY</code>로 별칭됩니다. 시크릿이므로 <code>.env</code> 층에 둡니다.</td></tr>
+                <tr><td><code>ensemble_mode</code></td><td>str = <code>&quot;single&quot;</code></td><td><code>single</code> 또는 <code>cross</code> 멀티 LLM 모드.</td></tr>
+                <tr><td><code>forced_login_method</code></td><td>dict = {`{}`}</td><td>프로바이더별 인증 방식 강제(<code>{`{"openai": "apikey"}`}</code>). 기본은 구독 우선.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Temperature (0.0-2.0)</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>temperature_agent_loop</code></td><td>1.0</td><td>에이전트 루프 호출.</td></tr>
+                <tr><td><code>temperature_reflection</code></td><td>1.0</td><td>리플렉션 호출.</td></tr>
+                <tr><td><code>temperature_verification</code></td><td>0.0</td><td>verify 호출. cross-LLM 합의를 위한 결정성.</td></tr>
+                <tr><td><code>temperature_commentary</code></td><td>1.0</td><td>커멘터리 호출.</td></tr>
+                <tr><td><code>temperature_self_improving_mutation</code></td><td>1.0</td><td>변이 제안 호출.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>서브에이전트</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>max_subagent_depth</code></td><td>1</td><td>중첩 위임 깊이 상한.</td></tr>
+                <tr><td><code>max_total_subagents</code></td><td>15</td><td>총 서브에이전트 상한.</td></tr>
+                <tr><td><code>subagent_max_rounds</code></td><td>0</td><td>서브에이전트 라운드 상한. 0이면 무제한.</td></tr>
+                <tr><td><code>subagent_max_tokens</code></td><td>32768</td><td>서브에이전트 출력 토큰 상한.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>토큰 가드와 오프로딩</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>max_tool_result_tokens</code></td><td>25000</td><td>도구 결과 토큰 상한. 0이면 무제한.</td></tr>
+                <tr><td><code>tool_offload_threshold</code></td><td>15000</td><td>이 토큰을 넘는 결과는 디스크로 오프로드됩니다. 0이면 비활성.</td></tr>
+                <tr><td><code>tool_offload_ttl_hours</code></td><td>4.0</td><td>오프로드 보관 시간.</td></tr>
+                <tr><td><code>observation_mask_keep_rounds</code></td><td>3</td><td>관측 마스킹 전 유지 라운드.</td></tr>
+                <tr><td><code>compact_keep_recent</code></td><td>10</td><td>컴팩션 시 보존할 최근 메시지 수.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>스케줄러와 트리거</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>trigger_scheduler_interval_s</code></td><td>60.0</td><td>트리거 스케줄러 폴 간격.</td></tr>
+                <tr><td><code>scheduler_interval_s</code></td><td>1.0</td><td>스케줄러 틱 간격.</td></tr>
+                <tr><td><code>scheduler_auto_start</code></td><td>true</td><td>serve와 함께 스케줄러 자동 시작.</td></tr>
+                <tr><td><code>scheduler_jitter_enabled</code></td><td>true</td><td>예약 실행에 지터 적용.</td></tr>
+                <tr><td><code>scheduler_max_jitter_ms</code></td><td>900000.0</td><td>지터 상한. 15분입니다.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>메모리와 세션</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>session_ttl_hours</code></td><td>4.0</td><td>세션 보존 시간.</td></tr>
+                <tr><td><code>session_storage_dir</code></td><td><code>&quot;&quot;</code></td><td>세션 저장 디렉터리. 비우면 인메모리.</td></tr>
+                <tr><td><code>redis_url</code> / <code>postgres_url</code></td><td><code>&quot;&quot;</code></td><td>외부 스토어 연결 문자열.</td></tr>
+                <tr><td><code>organization_fixture_dir</code></td><td><code>&quot;&quot;</code></td><td>조직 메모리 픽스처 경로.</td></tr>
+                <tr><td><code>user_profile_dir</code></td><td><code>&quot;&quot;</code></td><td>비우면 <code>~/.geode/user_profile</code>.</td></tr>
+                <tr><td><code>checkpoint_db</code></td><td><code>&quot;geode_checkpoints.db&quot;</code></td><td>체크포인트 DB 파일명.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>게이트웨이, 알림, 웹훅</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>gateway_enabled</code></td><td>false</td><td>메신저 게이트웨이. <code>geode serve</code>의 전제 조건입니다.</td></tr>
+                <tr><td><code>gateway_poll_interval_s</code></td><td>3.0</td><td>게이트웨이 폴 간격.</td></tr>
+                <tr><td><code>gateway_max_concurrent</code></td><td>4</td><td>동시 처리 상한.</td></tr>
+                <tr><td><code>notification_channel</code></td><td><code>&quot;slack&quot;</code></td><td>알림 채널 종류.</td></tr>
+                <tr><td><code>notification_recipient</code></td><td><code>&quot;#geode-alerts&quot;</code></td><td>알림 수신처.</td></tr>
+                <tr><td><code>webhook_enabled</code></td><td>false</td><td>웹훅 HTTP 엔드포인트.</td></tr>
+                <tr><td><code>webhook_port</code></td><td>8765</td><td>웹훅 포트.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>HITL, 플랜, 비용, 데스크탑</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>hitl_level</code></td><td>2</td><td>2면 모두 확인, 1이면 쓰기만 확인, 0이면 자율.</td></tr>
+                <tr><td><code>plan_auto_execute</code></td><td>false</td><td>플랜 자동 실행.</td></tr>
+                <tr><td><code>cost_limit_usd</code></td><td>0.0</td><td>비용 상한. 0이면 무제한, 80%에서 경고.</td></tr>
+                <tr><td><code>computer_use_enabled</code></td><td>true</td><td>데스크탑 자동화 도구.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>LLM 커넥션 풀</h3>
+            <table>
+              <thead>
+                <tr><th>필드</th><th>기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>llm_max_connections</code></td><td>20</td><td>최대 연결 수.</td></tr>
+                <tr><td><code>llm_max_keepalive_connections</code></td><td>5</td><td>keepalive 연결 상한.</td></tr>
+                <tr><td><code>llm_keepalive_expiry</code></td><td>30.0</td><td>keepalive 만료 초.</td></tr>
+                <tr><td><code>llm_connect_timeout</code></td><td>5.0</td><td>연결 타임아웃.</td></tr>
+                <tr><td><code>llm_read_timeout</code></td><td>300.0</td><td>읽기 타임아웃.</td></tr>
+                <tr><td><code>llm_write_timeout</code></td><td>30.0</td><td>쓰기 타임아웃.</td></tr>
+                <tr><td><code>llm_pool_timeout</code></td><td>10.0</td><td>풀 대기 타임아웃.</td></tr>
+                <tr><td><code>llm_retry_base_delay</code></td><td>2.0</td><td>재시도 기본 지연.</td></tr>
+                <tr><td><code>llm_retry_max_delay</code></td><td>30.0</td><td>재시도 최대 지연.</td></tr>
+                <tr><td><code>llm_max_retries</code></td><td>3</td><td>재시도 횟수.</td></tr>
+                <tr><td><code>llm_max_fallback_cost_ratio</code></td><td>0.0</td><td>폴백 비용 비율 상한. 0이면 무제한.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>routing.toml</h2>
+            <p>
+              출하본은 <code>core/config/routing.toml</code>이고, 사용자
+              override <code>~/.geode/routing.toml</code>이 섹션 단위로
+              병합됩니다(<code>core/config/routing_manifest.py</code>).
+            </p>
+            <table>
+              <thead>
+                <tr><th>섹션</th><th>키</th><th>내용</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>[model.defaults]</code></td><td><code>anthropic</code>, <code>anthropic_secondary</code>, <code>anthropic_budget</code>, <code>openai</code>, <code>codex</code>, <code>glm</code></td><td><code>claude-opus-4-8</code> / <code>claude-sonnet-4-6</code> / <code>claude-haiku-4-5-20251001</code> / <code>gpt-5.5</code> / <code>gpt-5.5</code> / <code>glm-5.1</code>. <code>core.config.ANTHROPIC_PRIMARY</code> 등으로 export됩니다.</td></tr>
+                <tr><td><code>[model.fallbacks]</code></td><td>프로바이더별 리스트 4개</td><td>기본은 전부 빈 리스트입니다. 같은 프로바이더 묵시적 폴백 체인은 출하되지 않고, 기본 모델 실패는 예외를 던지며 사용자가 <code>/model</code>로 고릅니다. 폴백은 <code>~/.geode/routing.toml</code>에서 옵트인합니다.</td></tr>
+                <tr><td><code>[routing.prefixes]</code></td><td><code>claude-</code>, <code>glm-</code>, <code>gpt-</code>, <code>o3-</code>, <code>o3</code>, <code>o4-</code>, <code>o4-mini</code>, <code>gemini-</code>, <code>deepseek-</code>, <code>llama-</code>, <code>qwen-</code>, <code>qwen3</code></td><td>모델 id 접두사를 프로바이더로 매핑합니다. 첫 매치가 이깁니다.</td></tr>
+                <tr><td><code>[routing]</code></td><td><code>codex_only_models</code>, <code>codex_suffixes</code>, <code>fallback_provider</code></td><td><code>gpt-5.5</code>/<code>gpt-5.5-pro</code>는 접두사보다 먼저 검사되어 openai-codex로 라우팅됩니다. <code>-codex</code>/<code>-codex-max</code>/<code>-codex-mini</code> 접미사도 codex. 미해석 시 <code>openai</code>.</td></tr>
+                <tr><td><code>[nodes]</code></td><td><code>analyst</code>, <code>evaluator</code>, <code>scoring</code>, <code>synthesizer</code></td><td>파이프라인 노드 모델. 전부 <code>claude-opus-4-8</code> 고정이라 노드가 REPL 모델을 상속하지 않습니다. 조회 순서는 프로젝트 <code>.geode/routing.toml</code>, 매니페스트, 없으면 <code>settings.model</code>.</td></tr>
+                <tr><td><code>[credentials.patterns]</code></td><td><code>sk-ant-</code>, <code>sk-proj-</code>, <code>sk-</code></td><td>키 모양에서 프로바이더를 추정합니다. GLM 키({`{id}.{secret}`} 모양)는 <code>core.config.env_io.is_glm_key</code>가 감지합니다.</td></tr>
+                <tr><td><code>[credentials.env_vars]</code></td><td>3개</td><td>anthropic은 <code>ANTHROPIC_API_KEY</code>, openai는 <code>OPENAI_API_KEY</code>, glm은 <code>ZAI_API_KEY</code>.</td></tr>
+                <tr><td><code>[credentials.keychain]</code></td><td>1개</td><td>anthropic은 <code>&quot;Claude Code-credentials&quot;</code>(macOS). 프로세스 단위 override는 <code>GEODE_&lt;PROVIDER&gt;_KEYCHAIN_SERVICE</code>.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>[self_improving_loop.*]</h2>
+            <p>
+              <code>~/.geode/config.toml</code>(또는
+              <code>GEODE_CONFIG_TOML</code>)에서
+              <code>load_self_improving_loop_config</code>가 읽습니다.
+              Settings와 분리된 별도 로더입니다. 옵트인 기능이라 lazy하게
+              두어 cold start를 가볍게 유지합니다. 파일이나 섹션이 없으면
+              전부 기본값으로 동작하고, 섹션이 있는데 키가 틀리면 큰 소리로
+              ValueError를 냅니다(<code>extra=&quot;forbid&quot;</code>).
+            </p>
+
+            <h3>[self_improving_loop]</h3>
+            <table>
+              <thead>
+                <tr><th>키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>fallback_to_payg</code></td><td>bool = false</td><td>구독 소진 시 소스 해석이 <code>api_key</code>로 흘러내릴 수 있는지.</td></tr>
+                <tr><td><code>openai_source</code></td><td>None</td><td><code>&quot;openai-codex&quot;</code> 또는 <code>&quot;api_key&quot;</code>만 허용. autoresearch의 source, target.source, mutator.source로 팬아웃되는 단일 노브. 충돌 시 UserWarning과 함께 이 키가 권위입니다.</td></tr>
+                <tr><td><code>warn_threshold</code></td><td>float = 0.5</td><td>예산 경고 임계.</td></tr>
+                <tr><td><code>abort_threshold</code></td><td>float = 0.9</td><td>중단 임계. warn보다 커야 합니다.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>[self_improving_loop.autoresearch]</h3>
+            <table>
+              <thead>
+                <tr><th>키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>budget_minutes</code></td><td>int = 5 (1-600)</td><td>사이클 시간 예산.</td></tr>
+                <tr><td><code>mutator_feedback_window</code></td><td>int = 20 (0-200)</td><td>변이 제안에 주는 최근 이력 창.</td></tr>
+                <tr><td><code>mutator_dedup_window</code></td><td>int = 20</td><td>중복 변이 검사 창.</td></tr>
+                <tr><td><code>mutator_dedup_threshold</code></td><td>float = 0.85</td><td>중복 판정 유사도.</td></tr>
+                <tr><td><code>anchor_confidence_mode</code></td><td>bool = false</td><td>anchor 신뢰도 모드.</td></tr>
+                <tr><td><code>source</code></td><td><code>claude-cli</code></td><td>역할 공통 기본 자격 소스.</td></tr>
+                <tr><td><code>seed_limit</code></td><td>int = 10 (5-1000)</td><td>감사당 seed 수.</td></tr>
+                <tr><td><code>seed_select</code></td><td><code>&quot;plugins/petri_audit/seeds&quot;</code></td><td>공진화 seed 풀 경로.</td></tr>
+                <tr><td><code>held_out_bench</code></td><td>None</td><td>고정 자 역할의 frozen seed 디렉터리.</td></tr>
+                <tr><td><code>promote_policy</code></td><td><code>&quot;gate&quot;</code></td><td><code>gate</code> / <code>random</code> / <code>never</code>.</td></tr>
+                <tr><td><code>promote_policy_seed</code></td><td>int = 0</td><td>random 정책의 시드.</td></tr>
+                <tr><td><code>replicate</code></td><td>int = 1 (1-20)</td><td>감사 반복 횟수.</td></tr>
+                <tr><td><code>target_effect_size</code></td><td>float = 0.02</td><td>승격에 요구하는 효과 크기.</td></tr>
+                <tr><td><code>dim_set</code></td><td><code>&quot;subset&quot;</code></td><td>측정 dim 세트.</td></tr>
+                <tr><td><code>max_turns</code></td><td>int = 10 (1-200)</td><td>감사당 턴 상한.</td></tr>
+                <tr><td><code>target_model</code> / <code>judge_model</code></td><td>deprecated</td><td>no-op 슬롯. 역할 서브섹션을 쓰세요.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              역할 서브섹션
+              <code>[self_improving_loop.autoresearch.target|judge|auditor]</code>는
+              <code>model</code>(기본 <code>&quot;&quot;</code>)과
+              <code>source</code>(기본 <code>claude-cli</code>)를 받고,
+              mutator 서브섹션은 <code>default_model</code>(None이면
+              <code>Settings.model</code> 상속),
+              <code>source</code>(<code>auto</code>),
+              <code>max_tokens</code>(1024)를 받습니다. 레거시
+              <code>[self_improving_loop.petri.*]</code>와
+              <code>[self_improving_loop.mutator]</code>는 DeprecationWarning과
+              함께 자동 이전됩니다. <code>geode audit</code>의 역할 해석
+              순서는 argv, 역할 서브섹션, 매니페스트 기본값 순입니다.
+            </p>
+            <p>
+              env 사이드 채널이 키 몇 개에 붙어 있습니다.
+              <code>GEODE_HELD_OUT_BENCH</code>,
+              <code>GEODE_PROMOTE_POLICY</code>,
+              <code>GEODE_AUDIT_REPLICATE</code>,
+              <code>GEODE_TARGET_EFFECT_SIZE</code>이고 각각
+              <code>AUTORESEARCH_*</code> 별칭을 동반합니다. 해석 순서는 env,
+              CLI 플래그, config 필드, 기본값 순입니다.
+            </p>
+
+            <h3>[self_improving_loop.seed_generation]</h3>
+            <table>
+              <thead>
+                <tr><th>키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>candidates_default</code></td><td>int = 15 (1-100)</td><td>세대당 후보 수 기본값.</td></tr>
+                <tr><td><code>default_gen_tag</code></td><td><code>&quot;gen1&quot;</code></td><td>기본 세대 태그.</td></tr>
+                <tr><td><code>roles</code></td><td>dict</td><td>역할별 서브섹션마다 <code>model</code>, <code>source</code>, <code>num_turns</code>(0 또는 2-6), <code>max_papers</code>(0-20), <code>queries_per_run</code>(1-10).</td></tr>
+              </tbody>
+            </table>
+
+            <h3>[self_improving_loop.scheduler]</h3>
+            <table>
+              <thead>
+                <tr><th>키</th><th>타입 / 기본값</th><th>용도</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>enabled</code></td><td>bool = false</td><td>auto-trigger 옵트인.</td></tr>
+                <tr><td><code>cron</code></td><td><code>&quot;0 */6 * * *&quot;</code></td><td>발화 cron.</td></tr>
+                <tr><td><code>min_interval_minutes</code></td><td>int = 60 (1-1440)</td><td>최소 발화 간격.</td></tr>
+                <tr><td><code>max_generation</code></td><td>int = 0</td><td>세대 상한. 0이면 무제한.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
+            <ul>
+              <li><a href="/geode/docs/config/basics">설정 기초</a>. 층과 해석 순서.</li>
+              <li><a href="/geode/docs/capabilities/outer-loop">아우터 루프 설정</a>. self-improving 섹션의 동작 맥락.</li>
+              <li><a href="/geode/docs/runtime/llm/providers">LLM 라우팅</a>. routing.toml의 소비처.</li>
+            </ul>
           </>
         }
         en={
           <>
-            <h2>How to read this</h2>
             <p>
-              The tables below contain only keys verified against the code's
-              settings model. Each key can also be set through an environment
-              variable with the <code>GEODE_</code> prefix. For example,{" "}
-              <code>model</code> is <code>GEODE_MODEL</code>. Some keys are mapped
-              only through a dotted <code>config.toml</code> path, which is noted
-              alongside the key. For priority and load order, read{" "}
-              <a href="/geode/docs/config/basics">Configuration basics</a> first.
+              This page is the single inventory of configuration keys. For
+              where keys live and in what order they resolve, read
+              <a href="/geode/docs/config/basics"> Configuration basics</a>.
+              The keys fall into three groups: Settings fields
+              (<code>core/config/_settings.py</code>), the routing manifest
+              (<code>core/config/routing.toml</code>), and the self-improving
+              loop sections (<code>core/config/self_improving.py</code>).
             </p>
             <p>
-              Keys marked experimental may change behaviour. An empty-string
-              default usually means the value falls back to another key, named in
-              the description.
+              Every Settings field can be overridden by an env var with the
+              <code>GEODE_</code> prefix: <code>model</code> becomes
+              <code>GEODE_MODEL</code>, <code>agentic_effort</code> becomes
+              <code>GEODE_AGENTIC_EFFORT</code>. An empty toml-key column
+              means the field is env-or-default only. The mapping SoT is
+              <code>_TOML_TO_SETTINGS</code> in
+              <code>core/config/__init__.py</code>; unmapped TOML keys are
+              silently ignored.
             </p>
 
-            <h2>LLM and models</h2>
-            <p><code>config.toml</code> path: <code>[llm]</code> table.</p>
+            <h2>Settings: toml-mapped fields</h2>
+
+            <h3>[llm]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>model</code> (<code>llm.primary_model</code>)</td><td>Primary model. Used by the REPL and the agentic loop.</td><td><code>claude-opus-4-7</code></td></tr>
-                <tr><td><code>default_secondary_model</code> (<code>llm.secondary_model</code>)</td><td>Secondary model for cross-LLM verification.</td><td><code>gpt-5.4</code></td></tr>
-                <tr><td><code>router_model</code> (<code>llm.router_model</code>)</td><td>Model that makes routing decisions.</td><td><code>claude-opus-4-7</code></td></tr>
-                <tr><td><code>plan_model</code> (<code>llm.plan_model</code>)</td><td>Planning-step model. Empty falls back to <code>model</code>.</td><td>empty string</td></tr>
-                <tr><td><code>act_model</code> (<code>llm.act_model</code>)</td><td>Action-loop model. Empty falls back to <code>model</code>.</td><td>empty string</td></tr>
-                <tr><td><code>judge_model</code> (<code>llm.judge_model</code>)</td><td>Per-turn verify judge model. Empty falls back to <code>model</code>.</td><td>empty string</td></tr>
-                <tr><td><code>learning_extract_model</code> (<code>llm.learning_extract_model</code>)</td><td>Low-cost model used by the learning-extraction hook.</td><td><code>glm-4.7-flash</code></td></tr>
-                <tr><td><code>agreement_threshold</code></td><td>Cross-LLM consensus pass threshold.</td><td><code>0.67</code></td></tr>
-                <tr><td><code>forced_login_method</code></td><td>Force the auth mode per provider. For example, <code>{`{"openai":"apikey"}`}</code>.</td><td>empty dict</td></tr>
+                <tr><td><code>model</code></td><td><code>llm.primary_model</code></td><td>str = <code>&quot;claude-opus-4-8&quot;</code></td><td>Primary model. The default mirrors the anthropic default in routing.toml.</td></tr>
+                <tr><td><code>plan_model</code></td><td><code>llm.plan_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Planning-step model. Empty falls back to <code>model</code>.</td></tr>
+                <tr><td><code>act_model</code></td><td><code>llm.act_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Action-loop model. Empty falls back to <code>model</code>.</td></tr>
+                <tr><td><code>judge_model</code></td><td><code>llm.judge_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Per-turn verify judge model. Empty falls back to <code>model</code>.</td></tr>
+                <tr><td><code>learning_extract_model</code></td><td><code>llm.learning_extract_model</code></td><td>str = <code>&quot;glm-4.7-flash&quot;</code></td><td>Free-tier GLM model for the learning-extract hook.</td></tr>
+                <tr><td><code>anthropic_credential_source</code></td><td><code>llm.anthropic_credential_source</code></td><td>str = <code>&quot;auto&quot;</code></td><td>Anthropic credential lane. Validated against <code>CredentialSource</code> plus the <code>oauth</code> alias and the <code>none</code> sentinel.</td></tr>
+                <tr><td><code>openai_credential_source</code></td><td><code>llm.openai_credential_source</code></td><td>str = <code>&quot;auto&quot;</code></td><td>OpenAI credential lane. Same validation.</td></tr>
               </tbody>
             </table>
 
-            <h2>LLM connection</h2>
-            <p>httpx pool and retries. Advanced keys that the defaults usually cover.</p>
+            <h3>[agentic]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>llm_max_connections</code></td><td>Maximum connections in the pool.</td><td><code>20</code></td></tr>
-                <tr><td><code>llm_read_timeout</code></td><td>Response read timeout in seconds. Large for 1M context.</td><td><code>300.0</code></td></tr>
-                <tr><td><code>llm_connect_timeout</code></td><td>TCP connect timeout in seconds.</td><td><code>5.0</code></td></tr>
-                <tr><td><code>llm_max_retries</code></td><td>Maximum retry attempts per model.</td><td><code>3</code></td></tr>
-                <tr><td><code>llm_max_fallback_cost_ratio</code></td><td>Fallback cost ratio cap. <code>0</code> is unlimited.</td><td><code>0.0</code></td></tr>
+                <tr><td><code>agentic_effort</code></td><td><code>agentic.effort</code></td><td>str = <code>&quot;high&quot;</code></td><td><code>low</code>/<code>medium</code>/<code>high</code>/<code>max</code>/<code>xhigh</code>, forwarded as Anthropic <code>output_config.effort</code> or OpenAI <code>reasoning.effort</code>. xhigh is Opus 4.7+ and Fable 5 only.</td></tr>
+                <tr><td><code>agentic_loop_time_budget</code></td><td><code>agentic.time_budget</code></td><td>float = 0.0</td><td>Wall-clock seconds. 0 means no limit.</td></tr>
+                <tr><td><code>agentic_thinking_budget</code></td><td><code>agentic.thinking_budget</code></td><td>int = 0</td><td>Legacy thinking-token budget. 0 disables.</td></tr>
               </tbody>
             </table>
 
-            <h2>Budgets and cost</h2>
+            <h3>[replan]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>cost_limit_usd</code></td><td>Session cost cap in USD. Warns at 80 percent, fires an exceeded event at 100 percent. <code>0</code> is unlimited.</td><td><code>0.0</code></td></tr>
-                <tr><td><code>agentic_loop_time_budget</code> (<code>agentic.time_budget</code>)</td><td>Agentic-loop wall-clock budget in seconds. <code>0</code> is unlimited.</td><td><code>0.0</code></td></tr>
-                <tr><td><code>agentic_effort</code> (<code>agentic.effort</code>)</td><td>Thinking depth. <code>low</code> / <code>medium</code> / <code>high</code> / <code>max</code> / <code>xhigh</code>.</td><td><code>high</code></td></tr>
-                <tr><td><code>max_tool_result_tokens</code></td><td>Tool-result truncation threshold in tokens. <code>0</code> is unlimited.</td><td><code>25000</code></td></tr>
-                <tr><td><code>tool_offload_threshold</code></td><td>Token threshold for offloading large results to disk. <code>0</code> disables.</td><td><code>15000</code></td></tr>
-                <tr><td><code>pipeline_timeout_s</code></td><td>Pipeline timeout in seconds. <code>0</code> is unlimited.</td><td><code>600.0</code></td></tr>
+                <tr><td><code>replan_enabled</code></td><td><code>replan.enabled</code></td><td>bool = true</td><td>Enable replanning.</td></tr>
+                <tr><td><code>replan_interval</code></td><td><code>replan.interval</code></td><td>int = 5</td><td>Replan cadence. 0 turns the cadence off.</td></tr>
+                <tr><td><code>replan_max_attempts</code></td><td><code>replan.max_attempts</code></td><td>int = 3</td><td>Replan attempt cap.</td></tr>
               </tbody>
             </table>
 
-            <h2>Pipeline and orchestration</h2>
-            <p><code>config.toml</code> path: <code>[pipeline]</code> table for the first two keys.</p>
+            <h3>[cognitive]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>confidence_threshold</code> (<code>pipeline.confidence_threshold</code>)</td><td>Loop back below this value.</td><td><code>0.7</code></td></tr>
-                <tr><td><code>max_iterations</code> (<code>pipeline.max_iterations</code>)</td><td>Maximum pipeline iterations.</td><td><code>5</code></td></tr>
-                <tr><td><code>max_subagent_depth</code></td><td>Maximum sub-agent recursion depth.</td><td><code>1</code></td></tr>
-                <tr><td><code>max_total_subagents</code></td><td>Maximum sub-agents within a session.</td><td><code>15</code></td></tr>
-                <tr><td><code>subagent_max_tokens</code></td><td>Sub-agent output token limit.</td><td><code>32768</code></td></tr>
-                <tr><td><code>ensemble_mode</code></td><td><code>single</code> or <code>cross</code> for multi-LLM.</td><td><code>single</code></td></tr>
+                <tr><td><code>cognitive_reflection_enabled</code></td><td><code>cognitive.reflection_enabled</code></td><td>bool = true</td><td>Enable cognitive reflection.</td></tr>
+                <tr><td><code>cognitive_reflection_model</code></td><td><code>cognitive.reflection_model</code></td><td>str = <code>&quot;claude-haiku-4-5-20251001&quot;</code></td><td>Reflection model.</td></tr>
+                <tr><td><code>cognitive_reflection_max_tokens</code></td><td><code>cognitive.reflection_max_tokens</code></td><td>int = 512</td><td>Reflection output cap.</td></tr>
+                <tr><td><code>cognitive_reflection_interval</code></td><td><code>cognitive.reflection_interval</code></td><td>int = 1</td><td>Reflect every N rounds. 1 means every round.</td></tr>
               </tbody>
             </table>
 
-            <h2>Gateway and bindings</h2>
-            <p><code>config.toml</code> path: <code>[gateway]</code> table and the <code>[[gateway.bindings.rules]]</code> array.</p>
+            <h3>[sandbox]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>gateway_enabled</code></td><td>Enable the inbound message gateway. <code>GEODE_GATEWAY_ENABLED=true</code>.</td><td><code>false</code></td></tr>
-                <tr><td><code>gateway_poll_interval_s</code></td><td>Gateway poll interval in seconds.</td><td><code>3.0</code></td></tr>
-                <tr><td><code>gateway_max_concurrent</code></td><td>Gateway messages handled at once.</td><td><code>4</code></td></tr>
-                <tr><td><code>gateway.time_budget_s</code></td><td>Gateway default time budget that bindings inherit.</td><td>not set</td></tr>
-                <tr><td><code>gateway.max_turns</code></td><td>Gateway session turn cap. <code>0</code> is unlimited.</td><td><code>0</code></td></tr>
-              </tbody>
-            </table>
-            <p>Fields on a single <code>[[gateway.bindings.rules]]</code> rule:</p>
-            <table>
-              <thead><tr><th>Field</th><th>What it does</th><th>Default</th></tr></thead>
-              <tbody>
-                <tr><td><code>channel</code></td><td>Messenger kind, for example <code>slack</code>. Required.</td><td>not set</td></tr>
-                <tr><td><code>channel_id</code></td><td>Channel identifier. The rule is skipped when empty.</td><td>not set</td></tr>
-                <tr><td><code>auto_respond</code></td><td>Whether to respond automatically.</td><td><code>true</code></td></tr>
-                <tr><td><code>require_mention</code></td><td>Respond only when mentioned.</td><td><code>false</code></td></tr>
-                <tr><td><code>allowed_tools</code></td><td>Tools allowed for this binding.</td><td>empty list</td></tr>
-                <tr><td><code>time_budget_s</code></td><td>Time budget for this binding in seconds. Falls back to the gateway default.</td><td>gateway default</td></tr>
+                <tr><td><code>sandbox_max_file_size_bytes</code></td><td><code>sandbox.max_file_size_bytes</code></td><td>int = 262144</td><td>File-read byte cap.</td></tr>
+                <tr><td><code>sandbox_max_read_tokens</code></td><td><code>sandbox.max_read_tokens</code></td><td>int = 25000</td><td>Read-result token cap.</td></tr>
+                <tr><td><code>sandbox_max_glob_results</code></td><td><code>sandbox.max_glob_results</code></td><td>int = 100</td><td>Glob result cap.</td></tr>
+                <tr><td><code>sandbox_max_grep_results</code></td><td><code>sandbox.max_grep_results</code></td><td>int = 50</td><td>Grep result cap.</td></tr>
+                <tr><td><code>sandbox_max_grep_line_chars</code></td><td><code>sandbox.max_grep_line_chars</code></td><td>int = 200</td><td>Grep line-length cap.</td></tr>
               </tbody>
             </table>
 
-            <h2>Scheduler and automation</h2>
+            <h3>[output]</h3>
             <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
+              <thead>
+                <tr><th>Field</th><th>toml key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
               <tbody>
-                <tr><td><code>scheduler_auto_start</code></td><td>Start the scheduler at boot.</td><td><code>true</code></td></tr>
-                <tr><td><code>scheduler_interval_s</code></td><td>Scheduler check interval in seconds.</td><td><code>1.0</code></td></tr>
-                <tr><td><code>scheduler_jitter_enabled</code></td><td>Apply deterministic per-job jitter.</td><td><code>true</code></td></tr>
-                <tr><td><code>scheduler_max_jitter_ms</code></td><td>Jitter cap in milliseconds.</td><td><code>900000.0</code></td></tr>
-                <tr><td><code>outcome_tracking_enabled</code></td><td>Enable outcome tracking (experimental).</td><td><code>true</code></td></tr>
-                <tr><td><code>drift_scan_cron</code></td><td>Cron expression for the drift scan (experimental).</td><td><code>0 */6 * * *</code></td></tr>
+                <tr><td><code>verbose</code></td><td><code>output.verbose</code></td><td>bool = false</td><td>Verbose output. Toggle in-session with <code>/verbose</code>.</td></tr>
               </tbody>
             </table>
 
-            <h2>Memory and session</h2>
-            <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
-              <tbody>
-                <tr><td><code>session_ttl_hours</code></td><td>Session idle TTL in hours.</td><td><code>4.0</code></td></tr>
-                <tr><td><code>session_storage_dir</code></td><td>File-backed directory. Empty means in-memory only.</td><td>empty string</td></tr>
-                <tr><td><code>compact_keep_recent</code></td><td>Recent messages preserved during compaction.</td><td><code>10</code></td></tr>
-                <tr><td><code>checkpoint_db</code></td><td>Checkpoint database file.</td><td><code>geode_checkpoints.db</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>Sandbox (file tool guards)</h2>
-            <p><code>config.toml</code> path: <code>[sandbox]</code> table.</p>
-            <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
-              <tbody>
-                <tr><td><code>sandbox_max_file_size_bytes</code> (<code>sandbox.max_file_size_bytes</code>)</td><td>Pre-read file-size guard in bytes.</td><td><code>262144</code></td></tr>
-                <tr><td><code>sandbox_max_read_tokens</code> (<code>sandbox.max_read_tokens</code>)</td><td>Post-read token-estimate guard.</td><td><code>25000</code></td></tr>
-                <tr><td><code>sandbox_max_glob_results</code> (<code>sandbox.max_glob_results</code>)</td><td>Glob tool maximum results.</td><td><code>100</code></td></tr>
-                <tr><td><code>sandbox_max_grep_results</code> (<code>sandbox.max_grep_results</code>)</td><td>Grep tool maximum files.</td><td><code>50</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>Approval and notification</h2>
-            <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
-              <tbody>
-                <tr><td><code>hitl_level</code></td><td>Human-in-the-loop level. <code>0</code> autonomous, <code>1</code> writes only, <code>2</code> ask everything.</td><td><code>2</code></td></tr>
-                <tr><td><code>plan_auto_execute</code></td><td>Auto-execute a plan. <code>GEODE_PLAN_AUTO_EXECUTE=true</code>.</td><td><code>false</code></td></tr>
-                <tr><td><code>computer_use_enabled</code></td><td>Enable desktop automation.</td><td><code>true</code></td></tr>
-                <tr><td><code>notification_channel</code></td><td>Default notification channel.</td><td><code>slack</code></td></tr>
-                <tr><td><code>notification_on_pipeline_error</code></td><td>Notify on pipeline error.</td><td><code>true</code></td></tr>
-                <tr><td><code>webhook_enabled</code></td><td>Enable the webhook endpoint. <code>GEODE_WEBHOOK_ENABLED=true</code>.</td><td><code>false</code></td></tr>
-              </tbody>
-            </table>
-
-            <h2>Credential sources</h2>
-            <table>
-              <thead><tr><th>Key</th><th>What it does</th><th>Default</th></tr></thead>
-              <tbody>
-                <tr><td><code>anthropic_credential_source</code></td><td>Anthropic credential source. <code>auto</code> / <code>api_key</code> / <code>claude-cli</code> / <code>oauth</code> / <code>none</code>.</td><td><code>auto</code></td></tr>
-                <tr><td><code>openai_credential_source</code></td><td>OpenAI credential source. Same set.</td><td><code>auto</code></td></tr>
-                <tr><td><code>anthropic_api_key</code></td><td>Anthropic key. <code>ANTHROPIC_API_KEY</code> alias accepted.</td><td>empty string</td></tr>
-                <tr><td><code>openai_api_key</code></td><td>OpenAI key. <code>OPENAI_API_KEY</code> alias accepted.</td><td>empty string</td></tr>
-                <tr><td><code>zai_api_key</code></td><td>ZhipuAI (GLM) key. <code>ZAI_API_KEY</code> alias accepted.</td><td>empty string</td></tr>
-              </tbody>
-            </table>
-
-            <h2>Note</h2>
+            <h2>Settings: env-only fields</h2>
             <p>
-              This list reflects only keys verified directly against the code's
-              settings model. Model defaults and fallback chains come from a
-              separate manifest, <code>routing.toml</code>, so they are not in
-              these tables. To change per-model routing, see{" "}
-              <a href="/geode/docs/runtime/llm/providers">LLM routing</a>. The
-              credential flow is covered in{" "}
-              <a href="/geode/docs/runtime/auth">Auth and OAuth</a>.
+              The groups below carry no toml mapping. Configure them through
+              <code>GEODE_*</code> env vars or <code>.env</code>.
             </p>
+
+            <h3>Secrets and providers</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>anthropic_api_key</code> / <code>openai_api_key</code> / <code>zai_api_key</code></td><td>str = <code>&quot;&quot;</code></td><td>Aliased to <code>ANTHROPIC_API_KEY</code> / <code>OPENAI_API_KEY</code> / <code>ZAI_API_KEY</code>. Secrets, so they live on the <code>.env</code> layer.</td></tr>
+                <tr><td><code>ensemble_mode</code></td><td>str = <code>&quot;single&quot;</code></td><td><code>single</code> or <code>cross</code> multi-LLM mode.</td></tr>
+                <tr><td><code>forced_login_method</code></td><td>dict = {`{}`}</td><td>Per-provider auth-mode escape hatch (<code>{`{"openai": "apikey"}`}</code>). Subscription preferred by default.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Temperature (0.0-2.0)</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>temperature_agent_loop</code></td><td>1.0</td><td>Agent-loop calls.</td></tr>
+                <tr><td><code>temperature_reflection</code></td><td>1.0</td><td>Reflection calls.</td></tr>
+                <tr><td><code>temperature_verification</code></td><td>0.0</td><td>Verify calls. Determinism for cross-LLM agreement.</td></tr>
+                <tr><td><code>temperature_commentary</code></td><td>1.0</td><td>Commentary calls.</td></tr>
+                <tr><td><code>temperature_self_improving_mutation</code></td><td>1.0</td><td>Mutation-proposal calls.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Sub-agents</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>max_subagent_depth</code></td><td>1</td><td>Nested delegation depth cap.</td></tr>
+                <tr><td><code>max_total_subagents</code></td><td>15</td><td>Total sub-agent cap.</td></tr>
+                <tr><td><code>subagent_max_rounds</code></td><td>0</td><td>Sub-agent round cap. 0 means unlimited.</td></tr>
+                <tr><td><code>subagent_max_tokens</code></td><td>32768</td><td>Sub-agent output token cap.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Token guards and offloading</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>max_tool_result_tokens</code></td><td>25000</td><td>Tool-result token cap. 0 means no limit.</td></tr>
+                <tr><td><code>tool_offload_threshold</code></td><td>15000</td><td>Results above this many tokens are offloaded to disk. 0 disables.</td></tr>
+                <tr><td><code>tool_offload_ttl_hours</code></td><td>4.0</td><td>Offload retention.</td></tr>
+                <tr><td><code>observation_mask_keep_rounds</code></td><td>3</td><td>Rounds kept before observation masking.</td></tr>
+                <tr><td><code>compact_keep_recent</code></td><td>10</td><td>Recent messages preserved on compaction.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Scheduler and triggers</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>trigger_scheduler_interval_s</code></td><td>60.0</td><td>Trigger-scheduler poll interval.</td></tr>
+                <tr><td><code>scheduler_interval_s</code></td><td>1.0</td><td>Scheduler tick interval.</td></tr>
+                <tr><td><code>scheduler_auto_start</code></td><td>true</td><td>Start the scheduler with serve.</td></tr>
+                <tr><td><code>scheduler_jitter_enabled</code></td><td>true</td><td>Apply jitter to scheduled runs.</td></tr>
+                <tr><td><code>scheduler_max_jitter_ms</code></td><td>900000.0</td><td>Jitter cap (15 minutes).</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Memory and sessions</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>session_ttl_hours</code></td><td>4.0</td><td>Session retention.</td></tr>
+                <tr><td><code>session_storage_dir</code></td><td><code>&quot;&quot;</code></td><td>Session storage dir. Empty means in-memory.</td></tr>
+                <tr><td><code>redis_url</code> / <code>postgres_url</code></td><td><code>&quot;&quot;</code></td><td>External store connection strings.</td></tr>
+                <tr><td><code>organization_fixture_dir</code></td><td><code>&quot;&quot;</code></td><td>Organization-memory fixture path.</td></tr>
+                <tr><td><code>user_profile_dir</code></td><td><code>&quot;&quot;</code></td><td>Empty means <code>~/.geode/user_profile</code>.</td></tr>
+                <tr><td><code>checkpoint_db</code></td><td><code>&quot;geode_checkpoints.db&quot;</code></td><td>Checkpoint DB filename.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>Gateway, notification, webhook</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>gateway_enabled</code></td><td>false</td><td>Messaging gateway. Precondition for <code>geode serve</code>.</td></tr>
+                <tr><td><code>gateway_poll_interval_s</code></td><td>3.0</td><td>Gateway poll interval.</td></tr>
+                <tr><td><code>gateway_max_concurrent</code></td><td>4</td><td>Concurrency cap.</td></tr>
+                <tr><td><code>notification_channel</code></td><td><code>&quot;slack&quot;</code></td><td>Notification channel kind.</td></tr>
+                <tr><td><code>notification_recipient</code></td><td><code>&quot;#geode-alerts&quot;</code></td><td>Notification recipient.</td></tr>
+                <tr><td><code>webhook_enabled</code></td><td>false</td><td>Webhook HTTP endpoint.</td></tr>
+                <tr><td><code>webhook_port</code></td><td>8765</td><td>Webhook port.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>HITL, plan, cost, desktop</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>hitl_level</code></td><td>2</td><td>2 = ask everything, 1 = write-only, 0 = autonomous.</td></tr>
+                <tr><td><code>plan_auto_execute</code></td><td>false</td><td>Auto-execute plans.</td></tr>
+                <tr><td><code>cost_limit_usd</code></td><td>0.0</td><td>Cost cap. 0 means no limit; warns at 80%.</td></tr>
+                <tr><td><code>computer_use_enabled</code></td><td>true</td><td>Desktop automation tool.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>LLM connection pool</h3>
+            <table>
+              <thead>
+                <tr><th>Field</th><th>Default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>llm_max_connections</code></td><td>20</td><td>Connection cap.</td></tr>
+                <tr><td><code>llm_max_keepalive_connections</code></td><td>5</td><td>Keepalive connection cap.</td></tr>
+                <tr><td><code>llm_keepalive_expiry</code></td><td>30.0</td><td>Keepalive expiry seconds.</td></tr>
+                <tr><td><code>llm_connect_timeout</code></td><td>5.0</td><td>Connect timeout.</td></tr>
+                <tr><td><code>llm_read_timeout</code></td><td>300.0</td><td>Read timeout.</td></tr>
+                <tr><td><code>llm_write_timeout</code></td><td>30.0</td><td>Write timeout.</td></tr>
+                <tr><td><code>llm_pool_timeout</code></td><td>10.0</td><td>Pool wait timeout.</td></tr>
+                <tr><td><code>llm_retry_base_delay</code></td><td>2.0</td><td>Retry base delay.</td></tr>
+                <tr><td><code>llm_retry_max_delay</code></td><td>30.0</td><td>Retry max delay.</td></tr>
+                <tr><td><code>llm_max_retries</code></td><td>3</td><td>Retry count.</td></tr>
+                <tr><td><code>llm_max_fallback_cost_ratio</code></td><td>0.0</td><td>Fallback cost-ratio cap. 0 means unlimited.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>routing.toml</h2>
+            <p>
+              The shipped manifest is <code>core/config/routing.toml</code>;
+              the user override <code>~/.geode/routing.toml</code> merges over
+              it section by section
+              (<code>core/config/routing_manifest.py</code>).
+            </p>
+            <table>
+              <thead>
+                <tr><th>Section</th><th>Keys</th><th>Content</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>[model.defaults]</code></td><td><code>anthropic</code>, <code>anthropic_secondary</code>, <code>anthropic_budget</code>, <code>openai</code>, <code>codex</code>, <code>glm</code></td><td><code>claude-opus-4-8</code> / <code>claude-sonnet-4-6</code> / <code>claude-haiku-4-5-20251001</code> / <code>gpt-5.5</code> / <code>gpt-5.5</code> / <code>glm-5.1</code>. Exported as <code>core.config.ANTHROPIC_PRIMARY</code> and friends.</td></tr>
+                <tr><td><code>[model.fallbacks]</code></td><td>4 per-provider lists</td><td>All empty by default: no silent same-provider fallback chain ships. A primary failure raises and the user picks via <code>/model</code>. Opt in by editing <code>~/.geode/routing.toml</code>.</td></tr>
+                <tr><td><code>[routing.prefixes]</code></td><td><code>claude-</code>, <code>glm-</code>, <code>gpt-</code>, <code>o3-</code>, <code>o3</code>, <code>o4-</code>, <code>o4-mini</code>, <code>gemini-</code>, <code>deepseek-</code>, <code>llama-</code>, <code>qwen-</code>, <code>qwen3</code></td><td>Model-id prefix to provider. First match wins.</td></tr>
+                <tr><td><code>[routing]</code></td><td><code>codex_only_models</code>, <code>codex_suffixes</code>, <code>fallback_provider</code></td><td><code>gpt-5.5</code>/<code>gpt-5.5-pro</code> are checked before prefixes and route to openai-codex; the <code>-codex</code>/<code>-codex-max</code>/<code>-codex-mini</code> suffixes too. Unresolved ids fall to <code>openai</code>.</td></tr>
+                <tr><td><code>[nodes]</code></td><td><code>analyst</code>, <code>evaluator</code>, <code>scoring</code>, <code>synthesizer</code></td><td>Pipeline-node models, all pinned to <code>claude-opus-4-8</code>, so nodes never inherit the REPL model. Lookup: project <code>.geode/routing.toml</code>, then the manifest, else <code>settings.model</code>.</td></tr>
+                <tr><td><code>[credentials.patterns]</code></td><td><code>sk-ant-</code>, <code>sk-proj-</code>, <code>sk-</code></td><td>Key shape to provider. GLM keys ({`{id}.{secret}`} shape) are sniffed by <code>core.config.env_io.is_glm_key</code>.</td></tr>
+                <tr><td><code>[credentials.env_vars]</code></td><td>3</td><td>anthropic to <code>ANTHROPIC_API_KEY</code>, openai to <code>OPENAI_API_KEY</code>, glm to <code>ZAI_API_KEY</code>.</td></tr>
+                <tr><td><code>[credentials.keychain]</code></td><td>1</td><td>anthropic to <code>&quot;Claude Code-credentials&quot;</code> (macOS). Per-process override: <code>GEODE_&lt;PROVIDER&gt;_KEYCHAIN_SERVICE</code>.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>[self_improving_loop.*]</h2>
+            <p>
+              Read from <code>~/.geode/config.toml</code> (or
+              <code>GEODE_CONFIG_TOML</code>) by
+              <code>load_self_improving_loop_config</code>. A separate loader
+              from Settings by design: the feature is opt-in and lazy, which
+              keeps cold start light. A missing file or section yields a
+              fully-defaulted config; a present but invalid section raises a
+              loud ValueError (<code>extra=&quot;forbid&quot;</code>).
+            </p>
+
+            <h3>[self_improving_loop]</h3>
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>fallback_to_payg</code></td><td>bool = false</td><td>Whether source resolvers may fall through to <code>api_key</code> on subscription exhaustion.</td></tr>
+                <tr><td><code>openai_source</code></td><td>None</td><td>Only <code>&quot;openai-codex&quot;</code> or <code>&quot;api_key&quot;</code>. A single knob fanning out to the autoresearch source, target.source, and mutator.source; authoritative with a UserWarning on conflict.</td></tr>
+                <tr><td><code>warn_threshold</code></td><td>float = 0.5</td><td>Budget warning threshold.</td></tr>
+                <tr><td><code>abort_threshold</code></td><td>float = 0.9</td><td>Abort threshold. Must exceed warn.</td></tr>
+              </tbody>
+            </table>
+
+            <h3>[self_improving_loop.autoresearch]</h3>
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>budget_minutes</code></td><td>int = 5 (1-600)</td><td>Per-cycle time budget.</td></tr>
+                <tr><td><code>mutator_feedback_window</code></td><td>int = 20 (0-200)</td><td>Recent-history window fed to mutation proposals.</td></tr>
+                <tr><td><code>mutator_dedup_window</code></td><td>int = 20</td><td>Duplicate-mutation check window.</td></tr>
+                <tr><td><code>mutator_dedup_threshold</code></td><td>float = 0.85</td><td>Duplicate similarity threshold.</td></tr>
+                <tr><td><code>anchor_confidence_mode</code></td><td>bool = false</td><td>Anchor confidence mode.</td></tr>
+                <tr><td><code>source</code></td><td><code>claude-cli</code></td><td>Default credential source shared by the roles.</td></tr>
+                <tr><td><code>seed_limit</code></td><td>int = 10 (5-1000)</td><td>Seeds per audit.</td></tr>
+                <tr><td><code>seed_select</code></td><td><code>&quot;plugins/petri_audit/seeds&quot;</code></td><td>Co-evolving seed pool path.</td></tr>
+                <tr><td><code>held_out_bench</code></td><td>None</td><td>Frozen fixed-ruler seed dir.</td></tr>
+                <tr><td><code>promote_policy</code></td><td><code>&quot;gate&quot;</code></td><td><code>gate</code> / <code>random</code> / <code>never</code>.</td></tr>
+                <tr><td><code>promote_policy_seed</code></td><td>int = 0</td><td>Seed for the random policy.</td></tr>
+                <tr><td><code>replicate</code></td><td>int = 1 (1-20)</td><td>Audit replications.</td></tr>
+                <tr><td><code>target_effect_size</code></td><td>float = 0.02</td><td>Effect size required to promote.</td></tr>
+                <tr><td><code>dim_set</code></td><td><code>&quot;subset&quot;</code></td><td>Measured dim set.</td></tr>
+                <tr><td><code>max_turns</code></td><td>int = 10 (1-200)</td><td>Turn cap per audit.</td></tr>
+                <tr><td><code>target_model</code> / <code>judge_model</code></td><td>deprecated</td><td>No-op slots. Use the role sub-sections.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              The role sub-sections
+              <code>[self_improving_loop.autoresearch.target|judge|auditor]</code>
+              take <code>model</code> (default <code>&quot;&quot;</code>) and
+              <code>source</code> (default <code>claude-cli</code>); the
+              mutator sub-section takes <code>default_model</code> (None
+              inherits <code>Settings.model</code>), <code>source</code>
+              (<code>auto</code>), and <code>max_tokens</code> (1024). Legacy
+              <code>[self_improving_loop.petri.*]</code> and
+              <code>[self_improving_loop.mutator]</code> auto-migrate with a
+              DeprecationWarning. Role resolution in <code>geode audit</code>:
+              argv, then the role sub-section, then the manifest default.
+            </p>
+            <p>
+              A few keys carry env side-channels:
+              <code>GEODE_HELD_OUT_BENCH</code>,
+              <code>GEODE_PROMOTE_POLICY</code>,
+              <code>GEODE_AUDIT_REPLICATE</code>, and
+              <code>GEODE_TARGET_EFFECT_SIZE</code>, each with an
+              <code>AUTORESEARCH_*</code> alias. Resolution order: env, then
+              CLI flag, then config field, then default.
+            </p>
+
+            <h3>[self_improving_loop.seed_generation]</h3>
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>candidates_default</code></td><td>int = 15 (1-100)</td><td>Default candidates per generation.</td></tr>
+                <tr><td><code>default_gen_tag</code></td><td><code>&quot;gen1&quot;</code></td><td>Default generation tag.</td></tr>
+                <tr><td><code>roles</code></td><td>dict</td><td>Each role sub-section takes <code>model</code>, <code>source</code>, <code>num_turns</code> (0 or 2-6), <code>max_papers</code> (0-20), <code>queries_per_run</code> (1-10).</td></tr>
+              </tbody>
+            </table>
+
+            <h3>[self_improving_loop.scheduler]</h3>
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Type / default</th><th>Purpose</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>enabled</code></td><td>bool = false</td><td>Auto-trigger opt-in.</td></tr>
+                <tr><td><code>cron</code></td><td><code>&quot;0 */6 * * *&quot;</code></td><td>Firing cron.</td></tr>
+                <tr><td><code>min_interval_minutes</code></td><td>int = 60 (1-1440)</td><td>Minimum firing interval.</td></tr>
+                <tr><td><code>max_generation</code></td><td>int = 0</td><td>Generation cap. 0 means unbounded.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
+            <ul>
+              <li><a href="/geode/docs/config/basics">Configuration basics</a>. The layers and resolution order.</li>
+              <li><a href="/geode/docs/capabilities/outer-loop">Outer-loop configuration</a>. The behavioral context of the self-improving sections.</li>
+              <li><a href="/geode/docs/runtime/llm/providers">LLM routing</a>. Where routing.toml is consumed.</li>
+            </ul>
           </>
         }
       />

--- a/site/src/app/docs/ops/oauth/page.tsx
+++ b/site/src/app/docs/ops/oauth/page.tsx
@@ -1,71 +1,206 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "OAuth Token Rotation — GEODE Docs" };
+export const metadata = { title: "OAuth token rotation — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="ops/oauth"
-      title="OAuth Token Rotation"
+      title="OAuth token rotation"
       titleKo="OAuth 토큰 회전"
-      summary="Anthropic ToS, Codex flow, refresh policy."
-      summaryKo="Anthropic ToS, Codex 플로우, 갱신 정책."
+      summary="What core/auth actually does at runtime: profile selection, proactive refresh, 401 auto-refresh, and cooldown escalation."
+      summaryKo="core/auth가 런타임에 실제로 하는 일입니다. 프로파일 선택, 선제 갱신, 401 자동 갱신, 쿨다운 에스컬레이션을 다룹니다."
     >
       <Bi
         ko={
           <>
-            <p>이 가이드는 OAuth 기반 인증을 사용하는 경우의 토큰 갱신 정책을 정리합니다.</p>
-
-            <h2>중요한 정책</h2>
             <p>
-              <strong>Anthropic Claude Pro/Max OAuth 토큰은 third-party harness에서 사용 불가</strong>입니다 (2026-01-09 ToS).
-              GEODE는 해당 토큰을 읽지 않습니다. 대신 Anthropic API 키 (Console)를 사용하세요.
+              토큰 회전의 코드 홈은 <code>core/auth/</code>입니다.
+              프로파일과 플랜의 SoT는 <code>~/.geode/auth.toml</code>
+              (<code>core/auth/auth_toml.py</code>,
+              <code>core/auth/profiles.py</code>)이고, 호출마다 어느
+              프로파일을 쓸지와 언제 갱신할지는
+              <code>core/auth/rotation.py</code>의
+              <code>ProfileRotator</code>가 정합니다.
             </p>
 
-            <h2>Codex OAuth (gpt-5.5 구독)</h2>
-            <pre>{`# 토큰 등록 (CLI 대화형)
-codex login
+            <h2>선택과 갱신 규칙</h2>
+            <table>
+              <thead>
+                <tr><th>규칙</th><th>동작</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>타입 우선 선택</td>
+                  <td>oauth &gt; token &gt; api_key 순으로 고르고, 같은 타입 안에서는 LRU로 돌립니다.</td>
+                </tr>
+                <tr>
+                  <td>선제 갱신</td>
+                  <td>관리형(managed) 토큰은 만료 120초 이내면 외부 저장소에서 다시 읽습니다. Hermes의 skew 상수를 그대로 빌렸습니다.</td>
+                </tr>
+                <tr>
+                  <td>401 자동 갱신</td>
+                  <td>인증 실패(401/403) 시 쿨다운을 적용하기 전에 한 번 더 다시 읽고, 토큰이 바뀌었으면 오류 카운트를 리셋합니다.</td>
+                </tr>
+                <tr>
+                  <td>쿨다운</td>
+                  <td><code>calculate_cooldown_ms</code>가 오류 횟수에 따라 쿨다운을 키웁니다. 키별 상태는 <code>core/auth/cooldown.py</code>의 <code>CooldownTracker</code>가 보관합니다.</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              관리형 토큰의 대표가 Codex입니다. 수명 관리는 Codex CLI가 하고
+              GEODE는 <code>~/.codex/auth.json</code>을 읽기만 합니다. 그래서
+              &quot;갱신&quot;은 새 토큰 발급이 아니라 외부 저장소 재독입니다.
+              발급이 필요하면 <code>codex login</code>을 다시 돌립니다.
+            </p>
 
-# 토큰 위치
-~/.codex/auth.json`}</pre>
+            <h2>운영 시 알아둘 것</h2>
+            <ul>
+              <li>
+                thin CLI에서 <code>/login</code>을 마치면 데몬이 auth 상태를
+                다시 읽습니다. 이 리로드는 추가 전용입니다. 제거된 항목은
+                캐시된 싱글톤에서 즉시 빠지지 않으므로, 프로파일을 지운 뒤
+                확실히 하려면 데몬을 재시작합니다.
+              </li>
+              <li>
+                Codex의 선제 5시간 스로틀을 우회하려면
+                <code>GEODE_CODEX_OAUTH_POLL_DISABLED=1</code>을 켭니다.
+                구독 버킷으로 바로 떨어집니다.
+              </li>
+              <li>
+                <code>core/llm/credentials.py</code>의
+                <code>resolve_provider_key</code>(OAuth 우선, API 키 폴백)는
+                deprecated입니다. 어댑터 레지스트리의 소스별 명시 자격이
+                대체이고, v1.0.0 제거 대상입니다.
+              </li>
+            </ul>
 
-            <h2>자동 갱신</h2>
-            <p>GEODE는 만료 임박을 감지하면 refresh token으로 자동 갱신. 실패 시 <code>OAUTH_REFRESH_FAILED</code> hook 발생.</p>
+            <h2>실패 모드</h2>
+            <table>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>한 프로파일만 계속 401</td>
+                  <td>외부 저장소의 토큰 자체가 만료</td>
+                  <td>Codex는 <code>codex login</code>, Anthropic 구독은 Claude Code 재로그인으로 원본 토큰을 갱신합니다.</td>
+                </tr>
+                <tr>
+                  <td>호출이 점점 뜸해짐</td>
+                  <td>반복 실패로 쿨다운 에스컬레이션</td>
+                  <td>원인 자격을 고치면 성공 콜백이 쿨다운을 리셋합니다.</td>
+                </tr>
+                <tr>
+                  <td>프로파일을 지웠는데 계속 쓰임</td>
+                  <td>데몬 리로드가 추가 전용</td>
+                  <td>데몬을 재시작합니다.</td>
+                </tr>
+              </tbody>
+            </table>
 
-            <h2>수동 재인증</h2>
-            <pre>{`codex login  # 새 토큰 발급
-geode /clean # 캐시 비우기
-geode serve & # 재기동`}</pre>
-
-            <p className="text-[var(--ink-3)] text-sm"><em>참조:</em> wiki/concepts/geode-oauth-policy.md, <a href="/geode/docs/runtime/auth">Auth and OAuth reference</a></p>
+            <h2>다음</h2>
+            <ul>
+              <li><a href="/geode/docs/runtime/auth">인증과 OAuth</a>. 자격 소스와 /login 표면.</li>
+              <li><a href="/geode/docs/run/providers">프로바이더 설정</a>. 처음 자격을 붙이는 절차.</li>
+            </ul>
           </>
         }
         en={
           <>
-            <p>This guide documents the token refresh policy for OAuth-based providers.</p>
-
-            <h2>Policy reminder</h2>
             <p>
-              <strong>Anthropic Claude Pro/Max OAuth tokens cannot be used by third-party harnesses</strong> (per the 2026-01-09 ToS).
-              GEODE does not read them. Use an Anthropic API key (Console) instead.
+              Token rotation lives in <code>core/auth/</code>. The SoT for
+              profiles and plans is <code>~/.geode/auth.toml</code>
+              (<code>core/auth/auth_toml.py</code>,
+              <code>core/auth/profiles.py</code>); which profile a call uses,
+              and when it refreshes, is decided by <code>ProfileRotator</code>
+              in <code>core/auth/rotation.py</code>.
             </p>
 
-            <h2>Codex OAuth (gpt-5.5 subscription)</h2>
-            <pre>{`# Register the token (interactive CLI)
-codex login
+            <h2>Selection and refresh rules</h2>
+            <table>
+              <thead>
+                <tr><th>Rule</th><th>Behavior</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Type-priority selection</td>
+                  <td>oauth &gt; token &gt; api_key, LRU rotation within a type.</td>
+                </tr>
+                <tr>
+                  <td>Proactive refresh</td>
+                  <td>Managed tokens are re-read from external storage when expiry is within 120 seconds. The skew constant is borrowed from Hermes.</td>
+                </tr>
+                <tr>
+                  <td>401 auto-refresh</td>
+                  <td>On an auth failure (401/403) the rotator re-reads once before applying cooldown, and resets the error count if the token changed.</td>
+                </tr>
+                <tr>
+                  <td>Cooldown</td>
+                  <td><code>calculate_cooldown_ms</code> escalates with the error count. Per-key state is held by <code>CooldownTracker</code> in <code>core/auth/cooldown.py</code>.</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              Codex is the canonical managed token: Codex CLI owns the
+              lifecycle and GEODE only reads <code>~/.codex/auth.json</code>.
+              &quot;Refresh&quot; therefore means re-reading external storage,
+              not minting a new token. When minting is needed, rerun
+              <code>codex login</code>.
+            </p>
 
-# Token location
-~/.codex/auth.json`}</pre>
+            <h2>Operational notes</h2>
+            <ul>
+              <li>
+                After <code>/login</code> finishes in the thin CLI, the daemon
+                reloads auth state. The reload is additive: removed entries
+                are not evicted from the cached singleton, so restart the
+                daemon to be sure after deleting a profile.
+              </li>
+              <li>
+                To bypass the pre-emptive 5-hour Codex throttle, set
+                <code>GEODE_CODEX_OAUTH_POLL_DISABLED=1</code>. Calls fall
+                straight through to the subscription bucket.
+              </li>
+              <li>
+                <code>resolve_provider_key</code> in
+                <code>core/llm/credentials.py</code> (OAuth-preferred with an
+                API-key fallback) is deprecated in favor of the adapter
+                registry&apos;s explicit per-source credentials; removal
+                target v1.0.0.
+              </li>
+            </ul>
 
-            <h2>Auto-refresh</h2>
-            <p>GEODE auto-refreshes using the refresh token when expiry is near. On failure, the <code>OAUTH_REFRESH_FAILED</code> hook fires.</p>
+            <h2>Failure modes</h2>
+            <table>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>One profile keeps returning 401</td>
+                  <td>The token in external storage itself expired</td>
+                  <td>Renew the origin token: <code>codex login</code> for Codex, re-login Claude Code for the Anthropic subscription.</td>
+                </tr>
+                <tr>
+                  <td>Calls slow to a trickle</td>
+                  <td>Cooldown escalation from repeated failures</td>
+                  <td>Fix the failing credential; the success callback resets the cooldown.</td>
+                </tr>
+                <tr>
+                  <td>A removed profile is still used</td>
+                  <td>The daemon reload is additive</td>
+                  <td>Restart the daemon.</td>
+                </tr>
+              </tbody>
+            </table>
 
-            <h2>Manual re-auth</h2>
-            <pre>{`codex login  # issue a new token
-geode /clean # clear caches
-geode serve & # restart`}</pre>
-
-            <p className="text-[var(--ink-3)] text-sm"><em>See:</em> wiki/concepts/geode-oauth-policy.md, <a href="/geode/docs/runtime/auth">Auth and OAuth reference</a>.</p>
+            <h2>Next</h2>
+            <ul>
+              <li><a href="/geode/docs/runtime/auth">Auth and OAuth</a>. Credential sources and the /login surface.</li>
+              <li><a href="/geode/docs/run/providers">Configure providers</a>. First-time credential setup.</li>
+            </ul>
           </>
         }
       />

--- a/site/src/app/docs/runtime/auth/page.tsx
+++ b/site/src/app/docs/runtime/auth/page.tsx
@@ -1,113 +1,272 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "Auth & OAuth — GEODE Docs" };
+export const metadata = { title: "Auth and OAuth — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="runtime/auth"
-      title="Auth & OAuth"
+      title="Auth and OAuth"
       titleKo="인증과 OAuth"
-      summary="core/auth/. profile rotator, OAuth flows, credential resolution. Anthropic OAuth disabled per ToS; OpenAI Codex Plus active."
-      summaryKo="core/auth/. 프로파일 로테이터, OAuth 플로우, 자격 증명 해석. Anthropic OAuth는 ToS에 따라 비활성. OpenAI Codex Plus는 활성."
+      summary="Credential sources, OAuth profiles behind /login, the Codex token detection, and where API keys live."
+      summaryKo="자격 소스, /login 뒤의 OAuth 프로파일, Codex 토큰 감지, API 키가 사는 곳을 다룹니다."
     >
       <Bi
         ko={
           <>
-            <h2>두 가지 경로</h2>
-            <ol>
-              <li><strong>API 키</strong>. 환경 변수 또는 <code>~/.geode/config.toml</code>. 항상 사용 가능.</li>
-              <li><strong>OAuth (구독)</strong>. OpenAI Codex Plus용. 대화형 로그인 흐름으로 트리거.</li>
-            </ol>
-
-            <h2>Anthropic OAuth. 비활성</h2>
             <p>
-              Anthropic의 ToS는 비-애플리케이션 계정에 대한 OAuth 기반 프로그래밍
-              접근을 금지합니다. GEODE는 이 경로를 명시적으로 비활성화합니다.
-              Anthropic 사용자는 API 키를 사용해야 합니다.
+              GEODE는 프로바이더마다 두 종류의 자격을 받습니다. 구독
+              OAuth와 PAYG API 키입니다. 어느 쪽을 쓸지는
+              <code>CredentialSource</code> 하나로 표현되고, 프로파일과 플랜은
+              <code>~/.geode/auth.toml</code>에, API 키는
+              <code>~/.geode/.env</code>에 저장됩니다.
             </p>
 
-            <h2>프로파일 로테이터</h2>
+            <h2>자격 소스</h2>
             <p>
-              여러 OpenAI/GLM 자격 증명 프로파일이 공존할 수 있습니다. 프로파일
-              로테이터는 호출마다 프로파일을 선택하며, rate-limit이나 인증 실패
-              시 회전시킵니다. 이것이 폴백 체인이 프로바이더 경계를 안전하게
-              넘나들 수 있게 해주는 토대입니다.
+              단일 SoT는 <code>core/config/credential_source.py</code>의
+              <code>CredentialSource</code> StrEnum입니다.
+            </p>
+            <table>
+              <thead>
+                <tr><th>값</th><th>의미</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>auto</code></td><td>매니페스트 순서 해석. OAuth 우선, PAYG는 <code>fallback_to_payg</code>가 켜진 경우에만.</td></tr>
+                <tr><td><code>api_key</code></td><td>PAYG API 키.</td></tr>
+                <tr><td><code>claude-cli</code></td><td>claude CLI 구독을 통한 Anthropic OAuth.</td></tr>
+                <tr><td><code>openai-codex</code></td><td>Codex CLI를 통한 ChatGPT 구독 OAuth.</td></tr>
+                <tr><td><code>oauth</code></td><td>레거시 별칭. Settings 검증이 받아줍니다.</td></tr>
+                <tr><td><code>none</code></td><td>해당 프로바이더 비활성 센티널.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              선택은 <code>[llm] anthropic_credential_source</code> /
+              <code>openai_credential_source</code>(기본 <code>auto</code>)에
+              저장됩니다. <code>/login source &lt;provider&gt; &lt;type&gt;</code>은
+              toml에만 쓰므로 <code>.env</code>를 지워도 선택이 살아남습니다.
+              (provider, source) 쌍마다 구체 어댑터가 하나씩 레지스트리에
+              등록됩니다(<code>core/llm/adapters/</code>의
+              <code>anthropic_payg</code>, <code>anthropic_oauth</code>,
+              <code>claude_cli</code>, <code>openai_payg</code>,
+              <code>codex_oauth</code>, <code>codex_cli</code>,
+              <code>glm_coding_plan</code>, <code>glm_payg</code>).
             </p>
 
-            <h2>자격 증명 해석</h2>
-            <pre>{`# core/llm/credentials.py
-def resolve_provider_key(provider: str, fallback: str | None = None) -> str:
-    """OAuth-preferred resolution.
+            <h2>/login 대시보드</h2>
+            <p>
+              세션 안의 <code>/login</code>은 플랜과 자격을 한 화면에서
+              관리합니다(<code>core/cli/commands/login.py</code>). thin
+              CLI에서 로컬로 실행되고, 끝나면 데몬에 인증 상태 리로드를
+              알립니다.
+            </p>
+            <table>
+              <thead>
+                <tr><th>서브커맨드</th><th>동작</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>/login openai</code></td><td>Codex OAuth 로그인. device-code 플로우는 <code>core/auth/oauth_login.py</code>이고, 결과는 <code>auth.toml</code>에 OAUTH_BORROWED 플랜 + 프로파일 쌍으로 저장됩니다.</td></tr>
+                <tr><td><code>/login anthropic</code></td><td>Claude 구독 OAuth. macOS 키체인의 <code>&quot;Claude Code-credentials&quot;</code> 항목을 읽습니다(routing.toml <code>[credentials.keychain]</code>, override는 <code>GEODE_ANTHROPIC_KEYCHAIN_SERVICE</code>).</td></tr>
+                <tr><td><code>/login add</code></td><td>자격 추가. 키 모양(<code>sk-ant-</code>, <code>sk-proj-</code>, GLM {`{id}.{secret}`})으로 프로바이더를 추정합니다.</td></tr>
+                <tr><td><code>/login use</code> / <code>remove</code></td><td>프로파일 선택과 제거.</td></tr>
+                <tr><td><code>/login route</code></td><td>프로바이더와 플랜 라우팅 확인.</td></tr>
+                <tr><td><code>/login quota</code></td><td>구독 쿼터 상태.</td></tr>
+                <tr><td><code>/login source &lt;provider&gt; &lt;type&gt;</code></td><td>자격 소스 영속화. config.toml <code>[llm]</code>에 기록.</td></tr>
+              </tbody>
+            </table>
 
-    Order: ProfileRotator (active OAuth profile) →
-           settings.<provider>_api_key →
-           fallback param →
-           empty string."""`}</pre>
+            <h2>Codex 토큰 감지</h2>
+            <p>
+              ChatGPT Plus 구독 OAuth는 Codex CLI의 토큰 저장소
+              <code>~/.codex/auth.json</code>을 읽습니다
+              (<code>core/auth/codex_cli_oauth.py</code>). 토큰 수명은 Codex
+              CLI가 책임집니다. GEODE는 복사본을 영속화하지 않고 읽기만
+              하며, JWT exp로 만료를 판별합니다.
+              <code>geode setup</code>도 API 키를 묻기 전에 이 파일을 먼저
+              감지합니다.
+            </p>
 
-            <h2>파일</h2>
+            <h2>PAYG 키</h2>
+            <p>
+              API 키는 시크릿이므로 <code>~/.geode/.env</code> 층에 삽니다.
+              온보딩과 <code>/login</code>의 키 기록이 이 계약을 따릅니다
+              (<code>core/config/env_io.py</code>의 <code>upsert_env</code>).
+            </p>
+            <pre>{`# ~/.geode/.env
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-proj-...
+ZAI_API_KEY={id}.{secret}`}</pre>
+            <p>
+              GLM은 엔드포인트가 둘입니다. Coding Plan(구독 과금)과
+              PAYG(종량 과금)이고, Coding Plan 키를 PAYG 경로에 쓰면 구독
+              쿼터를 조용히 우회해 종량 과금됩니다.
+            </p>
+
+            <h2>실패 모드</h2>
+            <table>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>응답이 비거나 401</td>
+                  <td>토큰 만료 또는 키 무효</td>
+                  <td><code>geode doctor</code>로 자격 상태를 보고 <code>/login</code>으로 갱신합니다. Codex 쪽은 <code>codex login</code>을 다시 실행합니다.</td>
+                </tr>
+                <tr>
+                  <td>소스를 바꿨는데 그대로</td>
+                  <td>구버전의 <code>GEODE_*_CREDENTIAL_SOURCE</code> env 줄이 마스크</td>
+                  <td><code>geode config explain anthropic_credential_source</code>로 WINNER 층을 확인하고 그 줄을 지웁니다.</td>
+                </tr>
+                <tr>
+                  <td>서브프로세스에서 <code>AdapterNotFoundError</code></td>
+                  <td>어댑터 레지스트리는 프로세스 단위인데 부트스트랩 누락</td>
+                  <td>워커가 <code>core.llm.adapters.registry.bootstrap_builtins()</code>를 호출하는지 확인합니다.</td>
+                </tr>
+                <tr>
+                  <td>구독이 있는데 PAYG로 과금</td>
+                  <td><code>auto</code>가 OAuth를 못 찾고 키로 해석</td>
+                  <td><code>/login route</code>와 <code>/login quota</code>로 플랜 상태를 확인하고, 필요하면 소스를 <code>claude-cli</code>/<code>openai-codex</code>로 고정합니다.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
             <ul>
-              <li><code>core/auth/</code>. 프로파일 로테이터 + OAuth 플로우.</li>
-              <li><code>core/llm/credentials.py</code>. 프로바이더 키 해석.</li>
-              <li><code>core/cli/auth_commands.py</code>. login/logout/status 슬래시 명령.</li>
+              <li><a href="/geode/docs/ops/oauth">OAuth 토큰 회전</a>. 갱신과 쿨다운의 런타임 동작.</li>
+              <li><a href="/geode/docs/run/providers">프로바이더 설정</a>. 처음 자격을 붙이는 절차.</li>
+              <li><a href="/geode/docs/config/basics">설정 기초</a>. 시크릿 층과 해석 사다리.</li>
             </ul>
-
-            <h2>저장</h2>
-            <p>
-              OAuth 토큰은 파일 모드 600으로{" "}
-              <code>~/.geode/auth/profiles/&lt;name&gt;.json</code>에 저장됩니다.
-              리프레시 토큰은 만료 시 회전되며, 401을 포착해 재시도 전에 강제
-              갱신하는 책임은 로테이터에 있습니다.
-            </p>
           </>
         }
         en={
           <>
-            <h2>The two paths</h2>
-            <ol>
-              <li><strong>API key</strong> — env vars or <code>~/.geode/config.toml</code>. Always available.</li>
-              <li><strong>OAuth (subscription)</strong> — for OpenAI Codex Plus. Triggered by interactive login flow.</li>
-            </ol>
-
-            <h2>Anthropic OAuth — disabled</h2>
             <p>
-              Anthropic&apos;s ToS prohibits OAuth-based programmatic access for
-              non-application accounts. GEODE explicitly disables this path. Users
-              on Anthropic must use API keys.
+              GEODE accepts two kinds of credentials per provider:
+              subscription OAuth and PAYG API keys. The choice is expressed by
+              a single <code>CredentialSource</code>; plans and profiles
+              persist in <code>~/.geode/auth.toml</code>, API keys in
+              <code>~/.geode/.env</code>.
             </p>
 
-            <h2>Profile rotator</h2>
+            <h2>Credential sources</h2>
             <p>
-              Multiple OpenAI/GLM credential profiles can coexist. The profile
-              rotator picks a profile per call, rotating on rate-limit or auth
-              failures. This is the foundation that lets fallback chains span
-              provider boundaries safely.
+              The single SoT is the <code>CredentialSource</code> StrEnum in
+              <code>core/config/credential_source.py</code>.
+            </p>
+            <table>
+              <thead>
+                <tr><th>Value</th><th>Meaning</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>auto</code></td><td>Manifest-order resolution. OAuth first; PAYG only when <code>fallback_to_payg</code> allows.</td></tr>
+                <tr><td><code>api_key</code></td><td>PAYG API key.</td></tr>
+                <tr><td><code>claude-cli</code></td><td>Anthropic OAuth via the claude CLI subscription.</td></tr>
+                <tr><td><code>openai-codex</code></td><td>ChatGPT subscription OAuth via the Codex CLI.</td></tr>
+                <tr><td><code>oauth</code></td><td>Legacy alias, accepted by Settings validation.</td></tr>
+                <tr><td><code>none</code></td><td>Disable sentinel for the provider.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              The choice persists as <code>[llm]
+              anthropic_credential_source</code> /
+              <code>openai_credential_source</code> (default
+              <code>auto</code>). <code>/login source &lt;provider&gt;
+              &lt;type&gt;</code> writes toml only, so the choice survives a
+              <code>.env</code> wipe. Each (provider, source) pair maps to one
+              concrete adapter in the registry
+              (<code>core/llm/adapters/</code>: <code>anthropic_payg</code>,
+              <code>anthropic_oauth</code>, <code>claude_cli</code>,
+              <code>openai_payg</code>, <code>codex_oauth</code>,
+              <code>codex_cli</code>, <code>glm_coding_plan</code>,
+              <code>glm_payg</code>).
             </p>
 
-            <h2>Credential resolution</h2>
-            <pre>{`# core/llm/credentials.py
-def resolve_provider_key(provider: str, fallback: str | None = None) -> str:
-    """OAuth-preferred resolution.
+            <h2>The /login dashboard</h2>
+            <p>
+              In-session <code>/login</code> manages plans and credentials on
+              one screen (<code>core/cli/commands/login.py</code>). It runs
+              locally in the thin CLI and notifies the daemon to reload auth
+              state when it finishes.
+            </p>
+            <table>
+              <thead>
+                <tr><th>Subcommand</th><th>Behavior</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>/login openai</code></td><td>Codex OAuth login. The device-code flow lives in <code>core/auth/oauth_login.py</code>; the result lands in <code>auth.toml</code> as an OAUTH_BORROWED plan plus profile pair.</td></tr>
+                <tr><td><code>/login anthropic</code></td><td>Claude subscription OAuth. Reads the macOS keychain entry <code>&quot;Claude Code-credentials&quot;</code> (routing.toml <code>[credentials.keychain]</code>; override with <code>GEODE_ANTHROPIC_KEYCHAIN_SERVICE</code>).</td></tr>
+                <tr><td><code>/login add</code></td><td>Add a credential. The provider is sniffed from the key shape (<code>sk-ant-</code>, <code>sk-proj-</code>, GLM {`{id}.{secret}`}).</td></tr>
+                <tr><td><code>/login use</code> / <code>remove</code></td><td>Select and remove profiles.</td></tr>
+                <tr><td><code>/login route</code></td><td>Inspect provider and plan routing.</td></tr>
+                <tr><td><code>/login quota</code></td><td>Subscription quota state.</td></tr>
+                <tr><td><code>/login source &lt;provider&gt; &lt;type&gt;</code></td><td>Persist the credential source into config.toml <code>[llm]</code>.</td></tr>
+              </tbody>
+            </table>
 
-    Order: ProfileRotator (active OAuth profile) →
-           settings.<provider>_api_key →
-           fallback param →
-           empty string."""`}</pre>
+            <h2>Codex token detection</h2>
+            <p>
+              ChatGPT Plus subscription OAuth reads the Codex CLI&apos;s token
+              store at <code>~/.codex/auth.json</code>
+              (<code>core/auth/codex_cli_oauth.py</code>). This is managed
+              credential reuse: Codex CLI owns the token lifecycle; GEODE
+              reads without persisting copies and decodes the JWT exp for
+              expiry. <code>geode setup</code> also detects this file before
+              asking for any API key.
+            </p>
 
-            <h2>Files</h2>
+            <h2>PAYG keys</h2>
+            <p>
+              API keys are secrets, so they live on the
+              <code>~/.geode/.env</code> layer. Onboarding and
+              <code>/login</code> key writes follow this contract
+              (<code>upsert_env</code> in <code>core/config/env_io.py</code>).
+            </p>
+            <pre>{`# ~/.geode/.env
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-proj-...
+ZAI_API_KEY={id}.{secret}`}</pre>
+            <p>
+              GLM has two endpoints: Coding Plan (subscription-billed) and
+              PAYG (metered). A Coding Plan key pointed at the PAYG path
+              silently bypasses the subscription quota and bills metered.
+            </p>
+
+            <h2>Failure modes</h2>
+            <table>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Empty replies or 401</td>
+                  <td>Expired token or invalid key</td>
+                  <td>Check credentials with <code>geode doctor</code>, refresh with <code>/login</code>. For Codex, rerun <code>codex login</code>.</td>
+                </tr>
+                <tr>
+                  <td>Source switch does not stick</td>
+                  <td>An old <code>GEODE_*_CREDENTIAL_SOURCE</code> env line masks the toml</td>
+                  <td>Run <code>geode config explain anthropic_credential_source</code>, find the WINNER layer, remove the line.</td>
+                </tr>
+                <tr>
+                  <td><code>AdapterNotFoundError</code> in a subprocess</td>
+                  <td>The adapter registry is per-process and bootstrap was skipped</td>
+                  <td>Make sure the worker calls <code>core.llm.adapters.registry.bootstrap_builtins()</code>.</td>
+                </tr>
+                <tr>
+                  <td>Billed PAYG despite a subscription</td>
+                  <td><code>auto</code> resolved to a key because OAuth was not found</td>
+                  <td>Inspect <code>/login route</code> and <code>/login quota</code>; pin the source to <code>claude-cli</code> or <code>openai-codex</code> if needed.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
             <ul>
-              <li><code>core/auth/</code>. profile rotator + OAuth flows</li>
-              <li><code>core/llm/credentials.py</code> — provider key resolution</li>
-              <li><code>core/cli/auth_commands.py</code> — login/logout/status slash commands</li>
+              <li><a href="/geode/docs/ops/oauth">OAuth token rotation</a>. The runtime behavior of refresh and cooldown.</li>
+              <li><a href="/geode/docs/run/providers">Configure providers</a>. First-time credential setup.</li>
+              <li><a href="/geode/docs/config/basics">Configuration basics</a>. The secrets layer and the resolution ladder.</li>
             </ul>
-
-            <h2>Storage</h2>
-            <p>
-              OAuth tokens land in <code>~/.geode/auth/profiles/&lt;name&gt;.json</code>{" "}
-              with file-mode 600. Refresh tokens are rotated on expiry; the
-              rotator is responsible for catching 401s and forcing refresh
-              before retry.
-            </p>
           </>
         }
       />

--- a/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
@@ -1,282 +1,230 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "Prompt Caching — GEODE Docs" };
+export const metadata = { title: "Prompt caching — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="runtime/llm/prompt-caching"
-      title="Prompt Caching"
+      title="Prompt caching"
       titleKo="프롬프트 캐싱"
-      summary="Anthropic ephemeral caching with a STATIC/DYNAMIC boundary, applied at two call sites: the agentic adapter and the router's non-agentic helpers."
-      summaryKo="STATIC/DYNAMIC 경계로 구분되는 Anthropic ephemeral 캐싱. agentic 어댑터와 router의 non-agentic 헬퍼, 두 호출 지점에 적용됩니다."
+      summary="The static/dynamic boundary, rolling message breakpoints, and the append-only system reminder that keeps the prefix cacheable."
+      summaryKo="static/dynamic 경계, 롤링 메시지 breakpoint, 그리고 prefix를 캐시 가능하게 유지하는 append 전용 system reminder를 다룹니다."
     >
       <Bi
         ko={
           <>
-            <h2>경계 마커</h2>
             <p>
-              <code>core/agent/system_prompt.py:35</code>에 정의되어 있습니다. v0.93부터 9개 prompt 파일의 16개 marker가 XML 래퍼로 전환됩니다.
-              경계 자체는 동일 sentinel 문자열이지만, marker가 노출되는 영역은 <code>&lt;dynamic_context&gt;</code> XML 안으로 캡슐화됩니다.
+              프롬프트 캐싱은 prefix 매치입니다. 요청 앞부분이 직전 호출과
+              바이트 단위로 같아야 적중합니다. GEODE의 캐싱 설계는 이 한
+              문장에서 다 나옵니다. 변하지 않는 것을 앞에, 변하는 것을 뒤에
+              두고, 턴마다 바뀌는 조각이 prefix를 다시 키잉하지 못하게
+              막습니다.
             </p>
-            <pre>{`PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"
 
-# v0.93+ XML 래퍼 (system prompt 안에서)
-... STATIC 영역 ...
-__GEODE_PROMPT_CACHE_BOUNDARY__
-<dynamic_context>
-... DYNAMIC 영역 ...
-</dynamic_context>`}</pre>
+            <h2>static/dynamic 경계</h2>
             <p>
-              <code>build_system_prompt()</code>이 이 marker를 두 섹션 사이에 삽입합니다.
-              audit-mode는 dynamic 블록을 strip합니다 (<a href="/geode/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a> 참조).
+              시스템 프롬프트는 <code>core/agent/system_prompt.py</code>의
+              <code>PROMPT_CACHE_BOUNDARY</code>
+              마커(<code>&lt;dynamic_context&gt;</code> 여는 태그)로 두 쪽이
+              납니다. 마커 앞은 턴 사이 불변(베이스 스캐폴드, 스타일 가이드,
+              옵트인 identity), 마커 뒤는 턴마다 변합니다(model card, 날짜,
+              메모리 레이어, 사용자 컨텍스트).
+            </p>
+            <p>
+              Anthropic 어댑터(<code>core/llm/providers/anthropic.py</code>)가
+              이 마커에서 시스템 문자열을 갈라 static 블록에
+              <code>{`cache_control: {"type": "ephemeral"}`}</code>을 붙입니다.
+              dynamic 쪽은 캐시 없이 나갑니다. static이 비어 있으면(audit
+              모드에서 레이어를 벗긴 경우) 빈 텍스트 블록에 cache_control을
+              붙이는 400 오류를 피해 dynamic 쪽을 단일 캐시 블록으로
+              승격합니다.
+            </p>
+
+            <h2>롤링 메시지 breakpoint</h2>
+            <p>
+              Anthropic은 요청당 cache_control breakpoint를 4개까지
+              허용합니다. 시스템 블록이 1-2개를 쓰고, 나머지는
+              <code>apply_messages_cache_control</code>이 대화 이력의 마지막
+              메시지들에 붙입니다. 몇 개를 붙일지(0-3)는 cache-policy
+              SoT(<code>core/llm/cache_policy.py</code>)가 정하고 기본값은
+              3입니다. breakpoint가 많을수록 긴 멀티턴 루프의 적중률이
+              오르지만, 캐시된 블록마다 적중 여부와 무관하게 쓰기 오버헤드가
+              붙습니다. 짧은 작업이라면 낮추는 쪽이 맞습니다.
+            </p>
+            <p>
+              비용 산식은 단가표 기준으로 cache write가 input의 1.25배, cache
+              read가 input의 0.1배입니다
+              (<code>core/llm/pricing_loader.py</code>).
+            </p>
+
+            <h2>system reminder는 append 전용</h2>
+            <p>
+              멀티턴 강화용 <code>&lt;system-reminder&gt;</code> 블록
+              (<code>core/agent/system_injection.py</code>)에는 캐시 계약이
+              걸려 있습니다. 이전 설계는 reminder를 <code>messages[0]</code>에
+              넣고 라운드마다 다시 썼습니다. 메시지는 시스템 블록 뒤에
+              렌더되므로 이력 prefix 전체가 매 라운드 다시 키잉되고, 롤링
+              breakpoint는 한 번도 적중하지 못했습니다. 현재 계약은
+              두 가지입니다.
             </p>
             <ul>
               <li>
-                <strong>STATIC</strong> (마커 이전). router 템플릿,{" "}
-                <code>GEODE.md</code> 의 아이덴티티. 턴 간 안정적.
+                <code>append_system_reminder</code>는 새 리스트를 반환합니다.
+                호출자의 이력 리스트는 그대로이므로 reminder가 저장된
+                대화 컨텍스트에 stale한 중간 prefix 바이트로 남지 않습니다.
               </li>
               <li>
-                <strong>DYNAMIC</strong> (마커 이후). 현재 날짜, 모델 카드,
-                프로젝트 메모리 (G2-G4), 사용자 컨텍스트. 매 턴 변경됨.
+                라운드 인덱스와 날짜 같은 턴별 변량은 마지막 안정 이력 블록
+                뒤에 붙습니다. 매 라운드 캐시에서 빠지는 것은 reminder
+                자신뿐입니다.
               </li>
             </ul>
-
-            <h2>어댑터의 분할 방식</h2>
             <p>
-              <code>core/llm/providers/anthropic.py:476-495</code>의 agentic
-              어댑터.
-            </p>
-            <pre>{`from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
-
-if PROMPT_CACHE_BOUNDARY in system:
-    static_part, dynamic_part = system.split(PROMPT_CACHE_BOUNDARY, 1)
-    sys_blocks = [
-        {"type": "text", "text": static_part.rstrip(),
-         "cache_control": {"type": "ephemeral"}},
-        {"type": "text", "text": dynamic_part.lstrip()},
-    ]
-else:
-    sys_blocks = [
-        {"type": "text", "text": system,
-         "cache_control": {"type": "ephemeral"}},
-    ]`}</pre>
-            <p>
-              STATIC 블록은 캐시 마커를 받지만 DYNAMIC 블록은 받지 않습니다.
-              Anthropic은 STATIC 프리픽스를 서버 측에서 캐싱하며, 5분 TTL 안의
-              후속 턴은 DYNAMIC 접미부와 새 user 메시지에 대해서만 과금됩니다.
+              가드 테스트는
+              <code>tests/core/agent/test_system_injection.py</code>의
+              TestCacheContract입니다.
             </p>
 
-            <h2>Non-agentic 호출 지점</h2>
-            <p>
-              <code>core/llm/router.py</code>의 네 호출 지점 (라인 481, 582, 749,
-              901)은 더 단순한 헬퍼 <code>system_with_cache(system)</code>를 써서
-              system prompt 전체를 단일 ephemeral 블록으로 감쌉니다. 이들은
-              STATIC/DYNAMIC 구조화 system prompt를 조립하지 않는 non-agentic LLM
-              호출 (단발 prompt, 평가 호출) 입니다.
-            </p>
-
-            <h2>캐시되는 것, 캐시되지 않는 것</h2>
+            <h2>실패 모드</h2>
             <table>
               <thead>
-                <tr><th>대상</th><th>캐시 여부</th></tr>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>Anthropic system prompt . STATIC 섹션</td>
-                  <td>Yes (ephemeral)</td>
+                  <td>cache_read가 늘 0</td>
+                  <td>prefix가 매 호출 변함. static 영역에 턴별 값이 새어 들어간 경우</td>
+                  <td>턴마다 변하는 값은 경계 마커 뒤로 옮깁니다.</td>
                 </tr>
                 <tr>
-                  <td>Anthropic system prompt . DYNAMIC 섹션</td>
-                  <td>No (매 턴 변경)</td>
+                  <td>짧은 작업의 비용 증가</td>
+                  <td>breakpoint 쓰기 오버헤드가 적중 이득을 초과</td>
+                  <td>cache-policy SoT에서 <code>messages_breakpoints</code>를 낮춥니다.</td>
                 </tr>
                 <tr>
-                  <td>Anthropic non-agentic system prompt (전체)</td>
-                  <td>Yes (단일 ephemeral 블록)</td>
-                </tr>
-                <tr>
-                  <td>Anthropic <code>messages</code> 배열</td>
-                  <td>Yes. 최근 3개 non-system 메시지 (PR #864, 헬퍼 <code>anthropic.py:175</code>, 호출 <code>:501</code>)</td>
-                </tr>
-                <tr>
-                  <td>OpenAI / Codex system prompt</td>
-                  <td>GEODE 측 명시 wiring 없음 (OpenAI가 서버 측에서 자동 캐싱)</td>
-                </tr>
-                <tr>
-                  <td>GLM system prompt</td>
-                  <td>프로바이더 관리</td>
+                  <td>400: empty text block에 cache_control</td>
+                  <td>빈 static에 breakpoint를 붙이려는 시도</td>
+                  <td>어댑터가 dynamic 승격으로 처리합니다. 직접 어댑터를 다룰 때만 해당합니다.</td>
                 </tr>
               </tbody>
             </table>
 
-            <h2>messages history 캐싱 (PR #864)</h2>
-            <p>
-              Anthropic은 요청당 최대 4개의 캐시 breakpoint를 허용합니다. 어댑터는{" "}
-              <code>messages.create</code> 직전에{" "}
-              <code>apply_messages_cache_control(messages)</code>를 적용해 최근 3개
-              non-system 메시지의 마지막 content 블록에{" "}
-              <code>cache_control: ephemeral</code>을 붙입니다. 위의 system 블록과
-              합치면 4개 슬롯을 모두 채워 롤링 히스토리가 캐시됩니다.
-            </p>
-            <pre>{`# core/llm/providers/anthropic.py:175 (helper) and :501 (call site)
-cached_messages = apply_messages_cache_control(messages)
-create_kwargs = {
-    "system": sys_blocks,
-    "messages": cached_messages,
-    ...
-}`}</pre>
-            <p>
-              헬퍼는 비-변형 (얕은 복사된 새 리스트 반환) 이며,{" "}
-              <code>str</code>과 <code>list[block]</code> content를 모두 처리하고
-              빈 리스트 content는 조용히 건너뜁니다. 19개 케이스가{" "}
-              <code>tests/test_anthropic_messages_cache.py</code>에서 검증됩니다.
-            </p>
-
-            <h2>캐시 무효화</h2>
-            <p>
-              캐시 키는 캐시된 블록의 바이트 단위 콘텐츠와 모델 ID입니다. STATIC
-              섹션의 어떤 변경 (예. 업데이트된 <code>GEODE.md</code> 아이덴티티,
-              새 도메인 예제 목록, router 템플릿 수정) 도 캐시를 무효화하며, 후속 턴이
-              다시 캐시에 적중하기 전에 한 번의 전체 요청 비용을 지불해야 합니다.
-            </p>
-            <p>
-              이것이 prompt drift 감지 (
-              <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>) 와
-              prompt 캐싱이 설계상 긴밀하게 결합된 이유입니다. 조용한 prompt 변경은
-              조용한 캐시 무효화로 이어지며, 해시 잠금장치는 그런 변경을 의식적인
-              단계로 강제합니다.
-            </p>
+            <h2>다음</h2>
+            <ul>
+              <li><a href="/geode/docs/runtime/llm/system-prompt-modes">시스템 프롬프트 모드</a>. static 영역에 무엇이 실리는지.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-hashing">프롬프트 해싱</a>. static 템플릿의 drift 가드.</li>
+              <li><a href="/geode/docs/ops/cost">비용 모니터링</a>. 캐시 적중이 보이는 곳.</li>
+            </ul>
           </>
         }
         en={
           <>
-            <h2>The boundary marker</h2>
             <p>
-              <code>core/agent/system_prompt.py:35</code> defines:
+              Prompt caching is a prefix match: the head of the request must
+              be byte-identical to the previous call to hit. All of
+              GEODE&apos;s caching design follows from that one sentence. Put
+              what does not change first, what changes last, and stop
+              per-turn fragments from re-keying the prefix.
             </p>
-            <pre>{`PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"`}</pre>
+
+            <h2>The static/dynamic boundary</h2>
             <p>
-              <code>build_system_prompt()</code> inserts this marker between two
-              sections:
+              The system prompt splits at the
+              <code>PROMPT_CACHE_BOUNDARY</code> marker (the opening
+              <code>&lt;dynamic_context&gt;</code> tag) defined in
+              <code>core/agent/system_prompt.py</code>. Everything before the
+              marker is stable across turns (base scaffold, style guide,
+              opt-in identity); everything after changes per turn (model
+              card, date, memory layers, user context).
+            </p>
+            <p>
+              The Anthropic adapter
+              (<code>core/llm/providers/anthropic.py</code>) splits the
+              system string at the marker and attaches
+              <code>{`cache_control: {"type": "ephemeral"}`}</code> to the
+              static block; the dynamic side ships uncached. When the static
+              side is empty (audit mode with layers stripped), the dynamic
+              side is promoted to the single cacheable block to avoid the
+              400 for cache_control on an empty text block.
+            </p>
+
+            <h2>Rolling message breakpoints</h2>
+            <p>
+              Anthropic allows up to 4 cache_control breakpoints per request.
+              The system blocks spend 1-2; the rest go on the trailing
+              conversation messages via
+              <code>apply_messages_cache_control</code>. How many (0-3) comes
+              from the cache-policy SoT
+              (<code>core/llm/cache_policy.py</code>), default 3. More
+              breakpoints raise the hit rate on long multi-turn loops, but
+              each cached block carries a write overhead whether the call
+              hits or misses; for short tasks, fewer is the right call.
+            </p>
+            <p>
+              On the pricing table, a cache write costs 1.25 times input and
+              a cache read 0.1 times input
+              (<code>core/llm/pricing_loader.py</code>).
+            </p>
+
+            <h2>The system reminder is append-only</h2>
+            <p>
+              The multi-turn <code>&lt;system-reminder&gt;</code> block
+              (<code>core/agent/system_injection.py</code>) carries an
+              explicit cache contract. The previous design inserted the
+              reminder at <code>messages[0]</code> and rewrote it per round;
+              since messages render after the system blocks, that re-keyed
+              the entire history prefix every round and the rolling
+              breakpoints could never hit. The current contract:
             </p>
             <ul>
               <li>
-                <strong>STATIC</strong> (before the marker): router template,
-                identity from <code>GEODE.md</code>. Stable across turns.
+                <code>append_system_reminder</code> returns a new list. The
+                caller&apos;s history list is never modified, so the reminder
+                cannot persist into the stored conversation context as stale
+                mid-prefix bytes.
               </li>
               <li>
-                <strong>DYNAMIC</strong> (after the marker): current date, model
-                card, project memory (G2-G4), user context. Changes per turn.
+                Per-round variance (round index, date) lands after the last
+                stable history block. Only the reminder itself is uncached
+                each round.
               </li>
             </ul>
-
-            <h2>How the adapter splits</h2>
             <p>
-              <code>core/llm/providers/anthropic.py:476-495</code> in the agentic
-              adapter:
-            </p>
-            <pre>{`from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
-
-if PROMPT_CACHE_BOUNDARY in system:
-    static_part, dynamic_part = system.split(PROMPT_CACHE_BOUNDARY, 1)
-    sys_blocks = [
-        {"type": "text", "text": static_part.rstrip(),
-         "cache_control": {"type": "ephemeral"}},
-        {"type": "text", "text": dynamic_part.lstrip()},
-    ]
-else:
-    sys_blocks = [
-        {"type": "text", "text": system,
-         "cache_control": {"type": "ephemeral"}},
-    ]`}</pre>
-            <p>
-              The static block gets the cache marker; the dynamic block does not.
-              Anthropic then caches the static prefix server-side, and subsequent
-              turns within the 5-minute TTL pay only for the dynamic suffix and
-              the new user message.
+              The guard is TestCacheContract in
+              <code>tests/core/agent/test_system_injection.py</code>.
             </p>
 
-            <h2>Non-agentic call sites</h2>
-            <p>
-              Four call sites in <code>core/llm/router.py</code> (lines 481, 582,
-              749, 901) use the simpler helper{" "}
-              <code>system_with_cache(system)</code> that wraps the entire system
-              prompt as a single ephemeral block. These are the {" "}
-              non-agentic LLM calls (single-shot prompts, evaluation calls) that
-              do not assemble a STATIC/DYNAMIC structured system prompt.
-            </p>
-
-            <h2>What is cached, what is not</h2>
+            <h2>Failure modes</h2>
             <table>
               <thead>
-                <tr><th>Surface</th><th>Cached</th></tr>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>Anthropic system prompt — STATIC section</td>
-                  <td>Yes (ephemeral)</td>
+                  <td>cache_read stays at zero</td>
+                  <td>The prefix changes per call: a per-turn value leaked into the static region</td>
+                  <td>Move anything that varies per turn behind the boundary marker.</td>
                 </tr>
                 <tr>
-                  <td>Anthropic system prompt — DYNAMIC section</td>
-                  <td>No (changes per turn)</td>
+                  <td>Costs go up on short tasks</td>
+                  <td>Breakpoint write overhead exceeds the hit savings</td>
+                  <td>Lower <code>messages_breakpoints</code> in the cache-policy SoT.</td>
                 </tr>
                 <tr>
-                  <td>Anthropic non-agentic system prompt (full)</td>
-                  <td>Yes (single ephemeral block)</td>
-                </tr>
-                <tr>
-                  <td>Anthropic <code>messages</code> array</td>
-                  <td>Yes — last 3 non-system messages (PR #864, helper at <code>anthropic.py:175</code>, call at <code>:501</code>)</td>
-                </tr>
-                <tr>
-                  <td>OpenAI / Codex system prompt</td>
-                  <td>No explicit GEODE wiring (OpenAI auto-caches server-side)</td>
-                </tr>
-                <tr>
-                  <td>GLM system prompt</td>
-                  <td>Provider-managed</td>
+                  <td>400: cache_control on an empty text block</td>
+                  <td>Attaching a breakpoint to an empty static block</td>
+                  <td>The adapter handles this via dynamic promotion; relevant only when driving the adapter directly.</td>
                 </tr>
               </tbody>
             </table>
 
-            <h2>Messages history caching (PR #864)</h2>
-            <p>
-              Anthropic allows up to four cache breakpoints per request. The
-              adapter applies <code>apply_messages_cache_control(messages)</code>{" "}
-              right before <code>messages.create</code>, attaching{" "}
-              <code>cache_control: ephemeral</code> to the last three non-system
-              messages&apos; final content block. Combined with the system block
-              above, that fills all four slots and caches the rolling history.
-            </p>
-            <pre>{`# core/llm/providers/anthropic.py:175 (helper) and :501 (call site)
-cached_messages = apply_messages_cache_control(messages)
-create_kwargs = {
-    "system": sys_blocks,
-    "messages": cached_messages,
-    ...
-}`}</pre>
-            <p>
-              Helper is non-mutating (returns a new list with shallow copies),
-              handles <code>str</code> and <code>list[block]</code> content, and
-              skips empty-list content silently. Tested in{" "}
-              <code>tests/test_anthropic_messages_cache.py</code> (19 cases).
-            </p>
-
-            <h2>Cache invalidation</h2>
-            <p>
-              The cache key is the byte-for-byte content of the cached block plus
-              the model ID. Any change to the static section — e.g. an updated{" "}
-              <code>GEODE.md</code> identity, a router
-              template revision — invalidates the cache and pays one full request
-              before subsequent turns hit again.
-            </p>
-            <p>
-              This is why prompt drift detection (
-              <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>)
-              and prompt caching are tightly coupled in the design: a silent prompt
-              change would silently invalidate the cache, and the hash ratchet
-              forces such changes to be conscious.
-            </p>
+            <h2>Next</h2>
+            <ul>
+              <li><a href="/geode/docs/runtime/llm/system-prompt-modes">System prompt modes</a>. What rides in the static region.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-hashing">Prompt hashing</a>. The drift guard on the static templates.</li>
+              <li><a href="/geode/docs/ops/cost">Cost monitoring</a>. Where cache hits become visible.</li>
+            </ul>
           </>
         }
       />

--- a/site/src/app/docs/runtime/llm/prompt-hashing/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-hashing/page.tsx
@@ -1,246 +1,205 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "Prompt Hashing — GEODE Docs" };
+export const metadata = { title: "Prompt hashing — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="runtime/llm/prompt-hashing"
-      title="Prompt Hashing"
+      title="Prompt hashing"
       titleKo="프롬프트 해싱"
-      summary="A SHA-256 hash ratchet (Karpathy P4) that breaks CI on unintended prompt drift. Core templates pinned, re-pin workflow documented."
-      summaryKo="의도치 않은 prompt drift 발생 시 CI를 중단시키는 SHA-256 해시 잠금장치 (Karpathy P4). 핵심 템플릿이 핀으로 고정되고, 재핀(re-pin) 절차가 문서화되어 있습니다."
+      summary="Four pinned prompt hashes that break the build on unintended drift, and the deliberate re-pin workflow."
+      summaryKo="의도하지 않은 drift에 빌드를 깨뜨리는 4개의 프롬프트 해시 핀과, 의도된 변경의 re-pin 절차를 다룹니다."
     >
       <Bi
         ko={
           <>
-            <h2>두 개의 함수</h2>
-            <pre>{`# core/llm/prompts/__init__.py
-def _hash_prompt(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()[:12]
-
-# core/llm/prompts/axes.py
-def _hash_axes(data) -> str:
-    return hashlib.sha256(
-        json.dumps(data, sort_keys=True).encode()
-    ).hexdigest()[:12]`}</pre>
             <p>
-              12자리 hex = 48비트. 닫힌 prompt 집합에서 충돌 확률은
-              무시할 수 있습니다. 목표는 탐지이지 암호학적 보안이 아닙니다.
-            </p>
-            <p>
-              axes 해시는 YAML 파서 버전과 Python dict 순서에 걸쳐 JSON 직렬화가
-              결정적이도록 <code>sort_keys=True</code>를 사용합니다.
+              핵심 프롬프트 템플릿은 해시로 핀됩니다. 템플릿이 한 글자라도
+              바뀌면 계산된 해시가 핀과 어긋나고 CI가 깨집니다. 프롬프트
+              변경을 막으려는 것이 아니라, 변경이 항상 의도된 diff로
+              드러나게 하려는 래칫입니다.
             </p>
 
-            <h2>고정 엔트리</h2>
-            <pre>{`PROMPT_VERSIONS / _PINNED_HASHES (sorted)
-
-  AGENTIC_SUFFIX             5630f3a61683
-  ANALYST_SPECIFIC           44136fa355b3
-  ANALYST_SYSTEM             b800a57a4599
-  ANALYST_TOOLS_SUFFIX       36055d5618f4
-  ANALYST_USER               63711de6c099
-  COMMENTARY_SYSTEM          488d8916d958
-  COMMENTARY_USER            2024ac4eba69
-  CROSS_LLM_DUAL_VERIFY      602669128ae2
-  CROSS_LLM_RESCORE          163b08e97d66
-  CROSS_LLM_SYSTEM           bf303f600fce
-  EVALUATOR_AXES             44136fa355b3
-  EVALUATOR_SYSTEM           93ecabb14a72
-  EVALUATOR_USER             ad832adfadf0
-  PROSPECT_EVALUATOR_AXES    44136fa355b3
-  ROUTER_SYSTEM              c4220baeb6c0
-  SYNTHESIZER_SYSTEM         1cbe199613a1
-  SYNTHESIZER_TOOLS_SUFFIX   1fd89d3ece5a
-  SYNTHESIZER_USER           e0bb4afab940`}</pre>
+            <h2>네 개의 핀</h2>
             <p>
-              두 dict 모두 동일한 key set을 가집니다.
+              <code>core/llm/prompts/__init__.py</code>가 .md 템플릿
+              (<code>router.md</code>, <code>commentary.md</code>)을 로드해
+              SHA-256 앞 12자를 <code>PROMPT_VERSIONS</code>로 계산하고,
+              하드코딩된 <code>_PINNED_HASHES</code>와 비교합니다.
+            </p>
+            <table>
+              <thead>
+                <tr><th>핀</th><th>출처</th><th>역할</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>ROUTER_SYSTEM</code></td><td><code>core/llm/prompts/router.md</code></td><td>AgenticLoop 시스템 프롬프트의 베이스 템플릿.</td></tr>
+                <tr><td><code>AGENTIC_SUFFIX</code></td><td><code>core/llm/prompts/router.md</code></td><td>agentic 모드에서 덧붙는 suffix 절.</td></tr>
+                <tr><td><code>COMMENTARY_SYSTEM</code></td><td><code>core/llm/prompts/commentary.md</code></td><td>커멘터리 시스템 프롬프트.</td></tr>
+                <tr><td><code>COMMENTARY_USER</code></td><td><code>core/llm/prompts/commentary.md</code></td><td>커멘터리 사용자 템플릿.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              비교 함수는 <code>verify_prompt_integrity</code>입니다. 어긋난
+              핀의 목록을 반환하고, <code>raise_on_drift=True</code>면 첫
+              불일치에서 RuntimeError를 던집니다. CI 테스트가 이 검증을
+              게이트로 겁니다.
             </p>
 
-            <h2>verify_prompt_integrity</h2>
-            <pre>{`def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
-    drifted = []
-    for name, pinned in _PINNED_HASHES.items():
-        if computed[name] != pinned:
-            drifted.append(f"Prompt drift: {name} pin={pinned} now={computed[name]}")
-    if drifted and raise_on_drift:
-        raise RuntimeError(...)
-    return drifted`}</pre>
+            <h2>왜 빌드를 깨는가</h2>
             <p>
-              이 함수는{" "}
-              <code>tests/test_karpathy_prompt_hardening.py::TestPromptDriftDetection</code>에서{" "}
-              <code>raise_on_drift=False</code> (리스트 반환, 비어 있어야 함) 와{" "}
-              <code>raise_on_drift=True</code> (예외가 발생하지 않아야 함) 양쪽
-              모드로 호출됩니다.
+              시스템 프롬프트는 동작을 정의하는 코드입니다. 그런데 일반
+              코드와 달리 타입 체커도 테스트도 문구 변화를 잡지 못합니다.
+              머지 충돌 해소, 포매터, 선의의 한 줄 수정이 프롬프트를 조용히
+              바꾸면 에이전트 동작이 원인 불명으로 흔들립니다. 해시 핀은 그
+              모든 경로를 컴파일 오류와 같은 등급으로 끌어올립니다. 자기개선
+              루프가 wrapper 스캐폴드를 변이시키는 시스템에서는 더
+              중요합니다. 의도된 변이는 SoT 파일로, 의도되지 않은 drift는
+              빌드 실패로, 두 경로가 섞이지 않습니다.
             </p>
 
-            <h2>재핀(re-pin) 절차</h2>
-            <p>의도적으로 prompt를 변경했을 때.</p>
-            <ol>
-              <li><code>.md</code> 파일을 편집합니다 (예. <code>analyst.md</code>).</li>
-              <li>
-                새 해시를 계산합니다.
-                <pre>{`uv run python -c "
-from core.llm.prompts import PROMPT_VERSIONS as V
-import json
-print(json.dumps(dict(sorted(V.items())), indent=2))
-"`}</pre>
-              </li>
-              <li><code>_PINNED_HASHES</code>의 해당 엔트리를 업데이트합니다.</li>
-              <li><code>uv run pytest tests/test_karpathy_prompt_hardening.py</code>를 실행합니다.</li>
-              <li>prompt 변경과 핀 업데이트를 <strong>한 커밋</strong>으로 함께 묶어 커밋합니다.</li>
-            </ol>
+            <h2>의도된 변경: re-pin 절차</h2>
             <p>
-              prompt 변경과 핀 업데이트를 두 커밋으로 나누면{" "}
-              <code>git history</code>에 CI 실패 상태의 커밋이 남게 됩니다.
-              bisect 친화적인 커밋이라면 핀과 prompt가 같은 보폭으로 움직입니다.
+              템플릿을 일부러 고쳤다면 새 해시를 계산해 핀을 갱신하고, 같은
+              커밋에 템플릿 diff와 핀 diff가 나란히 실리게 합니다.
+            </p>
+            <pre>{`python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \\
+  print(dict(sorted(V.items())))"
+# 출력을 _PINNED_HASHES에 반영`}</pre>
+            <p>
+              리뷰어는 핀 diff를 보고 &quot;프롬프트가 의도적으로
+              바뀌었다&quot;는 사실을 한 줄로 확인합니다.
             </p>
 
-            <h2>왜 잠금장치인가</h2>
+            <h2>경계</h2>
             <p>
-              해시 잠금장치는 Karpathy의 P4 원칙을 GEODE 식으로 표현한 것입니다.
-              한 번 통과한 품질 게이트는 조용히 후퇴해서는 안 된다는 원칙. prompt
-              변경은 우연히도 쉽게 일어납니다. 병합 충돌 해결, 자동 포매터, IDE
-              rename 등. 그리고 그 변경이 모델 동작에 미치는 영향을 미리 예측하기는
-              어렵습니다. 잠금장치는 모든 prompt 변경을 의식적인 단계를 거치도록
-              강제합니다.
+              핀 대상은 정적 템플릿이지 렌더된 프롬프트가 아닙니다. 메모리
+              레이어, 날짜, wrapper override처럼 런타임에 합성되는 부분은
+              해시 범위 밖입니다. 렌더 결과의 재현성 감사가 필요하면
+              <code>hash_rendered_prompt</code>가 같은 12자 해시를 렌더된
+              문자열에 적용합니다.
             </p>
 
-            <h2>잠금장치가 다루지 않는 것</h2>
+            <h2>실패 모드</h2>
+            <table>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>CI에서 &quot;Prompt drift&quot; 실패</td>
+                  <td>템플릿 변경이 핀 갱신 없이 들어옴</td>
+                  <td>변경이 의도라면 re-pin 절차를 따릅니다. 아니라면 diff를 되돌립니다.</td>
+                </tr>
+                <tr>
+                  <td>핀만 바뀌고 템플릿은 그대로인 PR</td>
+                  <td>이전 drift를 핀 갱신으로 덮으려는 시도</td>
+                  <td>템플릿 diff 없는 핀 diff는 리뷰에서 거부합니다.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
             <ul>
-              <li>
-                <code>.geode/skills/</code> 의 <strong>skill 본문</strong>은{" "}
-                <code>PROMPT_ASSEMBLED</code> 훅 페이로드로 관찰되지만 핀으로
-                고정되지는 않습니다. prompt 주입된 skill 변경은 CI 실패가
-                아닙니다.
-              </li>
-              <li>
-                <strong>렌더링된 prompt</strong> (<code>.format()</code> 변수 치환
-                이후) 는 해싱되지 않습니다. <code>hash_rendered_prompt()</code>는
-                존재하지만 호출자가 없습니다.{" "}
-                <em>geode-prompt-evolution P2 #3</em> 참조.
-              </li>
-              <li>
-                <strong>디스크 무결성</strong>은 런타임에 재검증되지 않습니다.
-                해싱은 패키지 import 시점에만 일어납니다.
-              </li>
+              <li><a href="/geode/docs/explanation/ratchet">왜 ratchet 규율인가</a>. 이 가드의 설계 철학.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">프롬프트 조립</a>. 핀된 템플릿이 소비되는 곳.</li>
             </ul>
           </>
         }
         en={
           <>
-            <h2>The two functions</h2>
-            <pre>{`# core/llm/prompts/__init__.py
-def _hash_prompt(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()[:12]
-
-# core/llm/prompts/axes.py
-def _hash_axes(data) -> str:
-    return hashlib.sha256(
-        json.dumps(data, sort_keys=True).encode()
-    ).hexdigest()[:12]`}</pre>
             <p>
-              Twelve hex characters = 48 bits. Collision probability is negligible
-              for the closed set of prompts; the goal is detection, not
-              cryptographic security.
-            </p>
-            <p>
-              The axes hash uses <code>sort_keys=True</code> to make the JSON
-              serialization deterministic across YAML parser versions and Python
-              dict orderings.
+              The core prompt templates are pinned by hash. Change a single
+              character and the computed hash diverges from the pin; CI
+              breaks. The point is not to forbid prompt changes but to make
+              every change show up as a deliberate diff. A ratchet.
             </p>
 
-            <h2>The pinned entries</h2>
-            <pre>{`PROMPT_VERSIONS / _PINNED_HASHES (sorted)
-
-  AGENTIC_SUFFIX             5630f3a61683
-  ANALYST_SPECIFIC           44136fa355b3
-  ANALYST_SYSTEM             b800a57a4599
-  ANALYST_TOOLS_SUFFIX       36055d5618f4
-  ANALYST_USER               63711de6c099
-  COMMENTARY_SYSTEM          488d8916d958
-  COMMENTARY_USER            2024ac4eba69
-  CROSS_LLM_DUAL_VERIFY      602669128ae2
-  CROSS_LLM_RESCORE          163b08e97d66
-  CROSS_LLM_SYSTEM           bf303f600fce
-  EVALUATOR_AXES             44136fa355b3
-  EVALUATOR_SYSTEM           93ecabb14a72
-  EVALUATOR_USER             ad832adfadf0
-  PROSPECT_EVALUATOR_AXES    44136fa355b3
-  ROUTER_SYSTEM              c4220baeb6c0
-  SYNTHESIZER_SYSTEM         1cbe199613a1
-  SYNTHESIZER_TOOLS_SUFFIX   1fd89d3ece5a
-  SYNTHESIZER_USER           e0bb4afab940`}</pre>
+            <h2>The four pins</h2>
             <p>
-              Both dictionaries share an identical key set.
+              <code>core/llm/prompts/__init__.py</code> loads the .md
+              templates (<code>router.md</code>, <code>commentary.md</code>),
+              computes the first 12 hex chars of SHA-256 into
+              <code>PROMPT_VERSIONS</code>, and compares them against the
+              hardcoded <code>_PINNED_HASHES</code>.
+            </p>
+            <table>
+              <thead>
+                <tr><th>Pin</th><th>Source</th><th>Role</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>ROUTER_SYSTEM</code></td><td><code>core/llm/prompts/router.md</code></td><td>Base template of the AgenticLoop system prompt.</td></tr>
+                <tr><td><code>AGENTIC_SUFFIX</code></td><td><code>core/llm/prompts/router.md</code></td><td>Suffix section appended in agentic mode.</td></tr>
+                <tr><td><code>COMMENTARY_SYSTEM</code></td><td><code>core/llm/prompts/commentary.md</code></td><td>Commentary system prompt.</td></tr>
+                <tr><td><code>COMMENTARY_USER</code></td><td><code>core/llm/prompts/commentary.md</code></td><td>Commentary user template.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              The comparator is <code>verify_prompt_integrity</code>: it
+              returns the list of drifted pins, and with
+              <code>raise_on_drift=True</code> raises RuntimeError on the
+              first mismatch. A CI test gates on this verification.
             </p>
 
-            <h2>verify_prompt_integrity</h2>
-            <pre>{`def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
-    drifted = []
-    for name, pinned in _PINNED_HASHES.items():
-        if computed[name] != pinned:
-            drifted.append(f"Prompt drift: {name} pin={pinned} now={computed[name]}")
-    if drifted and raise_on_drift:
-        raise RuntimeError(...)
-    return drifted`}</pre>
+            <h2>Why break the build</h2>
             <p>
-              The function is invoked by{" "}
-              <code>tests/test_karpathy_prompt_hardening.py::TestPromptDriftDetection</code>{" "}
-              with both <code>raise_on_drift=False</code> (returns a list, asserted
-              empty) and <code>raise_on_drift=True</code> (asserts no exception).
+              A system prompt is behavior-defining code, yet neither the type
+              checker nor the test suite catches a wording change. A merge
+              conflict resolution, a formatter, or a well-meant one-line edit
+              can silently alter the prompt and shift agent behavior with no
+              traceable cause. The hash pin promotes all of those paths to
+              the severity of a compile error. In a system whose
+              self-improving loop mutates the wrapper scaffold this matters
+              even more: intended mutation flows through the SoT file,
+              unintended drift fails the build, and the two paths never mix.
             </p>
 
-            <h2>Re-pin workflow</h2>
-            <p>When a prompt is intentionally changed:</p>
-            <ol>
-              <li>Edit the <code>.md</code> file (e.g. <code>analyst.md</code>).</li>
-              <li>
-                Compute new hashes:
-                <pre>{`uv run python -c "
-from core.llm.prompts import PROMPT_VERSIONS as V
-import json
-print(json.dumps(dict(sorted(V.items())), indent=2))
-"`}</pre>
-              </li>
-              <li>Update the corresponding entry in <code>_PINNED_HASHES</code>.</li>
-              <li>Run <code>uv run pytest tests/test_karpathy_prompt_hardening.py</code>.</li>
-              <li>Commit prompt change and pin update <strong>together</strong> in one commit.</li>
-            </ol>
+            <h2>Deliberate change: the re-pin workflow</h2>
             <p>
-              Splitting the prompt change and the pin update across two commits
-              leaves a CI-broken commit in <code>git history</code>. Bisect-friendly
-              commits keep the pin and the prompt in lockstep.
+              After an intentional template edit, recompute the hashes,
+              update the pins, and land the template diff and the pin diff in
+              the same commit.
+            </p>
+            <pre>{`python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \\
+  print(dict(sorted(V.items())))"
+# copy the output into _PINNED_HASHES`}</pre>
+            <p>
+              The reviewer reads the pin diff as a one-line attestation that
+              the prompt changed on purpose.
             </p>
 
-            <h2>Why ratchet</h2>
+            <h2>Scope</h2>
             <p>
-              The hash ratchet is the GEODE expression of Karpathy&apos;s P4
-              principle: once a quality gate is passed, it should never silently
-              regress. Prompt changes are easy to make accidentally — a
-              merge-conflict resolution, an autoformatter, an IDE rename — and
-              their downstream effects on model behaviour are hard to foresee. The
-              ratchet forces every prompt change through a conscious step.
+              The pins cover the static templates, not the rendered prompt.
+              Memory layers, the date, and the wrapper override are composed
+              at runtime and sit outside the hash. For reproducibility audits
+              of rendered output, <code>hash_rendered_prompt</code> applies
+              the same 12-char hash to a rendered string.
             </p>
 
-            <h2>What the ratchet does not cover</h2>
+            <h2>Failure modes</h2>
+            <table>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>CI fails with &quot;Prompt drift&quot;</td>
+                  <td>A template change landed without a pin update</td>
+                  <td>If the change is intended, follow the re-pin workflow. Otherwise revert the diff.</td>
+                </tr>
+                <tr>
+                  <td>A PR changes pins but not templates</td>
+                  <td>An attempt to paper over earlier drift via the pins</td>
+                  <td>Reject pin diffs that come without a template diff.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
             <ul>
-              <li>
-                <strong>Skill bodies</strong> in <code>.geode/skills/</code> are
-                observed via the <code>PROMPT_ASSEMBLED</code> hook payload but not
-                pinned. A prompt-injected skill change is not a CI failure.
-              </li>
-              <li>
-                <strong>Rendered prompts</strong> (after <code>.format()</code>{" "}
-                variable substitution) are not hashed. <code>hash_rendered_prompt()</code>{" "}
-                exists but has no callers — see{" "}
-                <em>geode-prompt-evolution P2 #3</em>.
-              </li>
-              <li>
-                <strong>Disk integrity</strong> is not re-verified at runtime; the
-                hash only fires at import time of the package.
-              </li>
+              <li><a href="/geode/docs/explanation/ratchet">Why ratchet discipline</a>. The design philosophy behind this guard.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">Prompt assembly</a>. Where the pinned templates are consumed.</li>
             </ul>
           </>
         }

--- a/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
+++ b/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
@@ -1,110 +1,245 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "System Prompt Modes — GEODE Docs" };
+export const metadata = { title: "System prompt modes — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="runtime/llm/system-prompt-modes"
-      title="System Prompt Modes"
+      title="System prompt modes"
       titleKo="시스템 프롬프트 모드"
-      summary="GEODE_PERSONA opt-in plus audit-mode strip. The two ways the system prompt can be reshaped."
-      summaryKo="GEODE_PERSONA opt-in과 audit-mode strip. 시스템 프롬프트가 변형되는 두 가지 방식."
+      summary="The persona opt-in, the audit-mode strip with the wrapper override, and the program.md contract for the mutator."
+      summaryKo="persona opt-in, wrapper override가 붙는 audit-mode strip, 그리고 mutator의 program.md 계약을 다룹니다."
     >
       <Bi
         ko={
           <>
             <p>
-              <strong>Reference:</strong> GEODE는 같은 사용자 메시지를 두 가지 모드의 시스템 프롬프트로 흘릴 수 있습니다.
-              일반 운영용 (default), Petri audit용 (`audit-mode`). 이 페이지는 두 모드의 차이와 활성화 방법을 정리합니다.
+              같은 요청이라도 시스템 프롬프트는 모드에 따라 다르게
+              조립됩니다. 빌더는 <code>core/agent/system_prompt.py</code>의
+              <code>build_system_prompt</code> 하나이고, env 플래그 두 개가
+              무엇을 싣고 무엇을 벗길지 정합니다.
             </p>
 
-            <h2>두 모드</h2>
+            <h2>기본 모드: persona는 옵트인</h2>
+            <p>
+              기본값에서 GEODE는 베이스 모델의 얇은 래퍼로 동작합니다.
+              GEODE.md의 &quot;You are GEODE&quot; 정체성 프리앰블은 주입되지
+              않습니다. <code>GEODE_PERSONA=on</code>을 켜면 GEODE.md에서 Core
+              Principles, RUNTIME CANNOT, Defaults 섹션만 추려
+              <code>&lt;agent_identity&gt;</code> 레이어로 들어갑니다.
+              audit-mode가 켜져 있으면 이 플래그와 무관하게 강제 OFF입니다.
+            </p>
+            <pre>{`<static_context>        턴 사이 불변, 캐시 적중
+  <agent_baseline>      항상 포함. 기본 능력
+  <agent_identity>      GEODE_PERSONA=on일 때만
+</static_context>
+<dynamic_context>       턴마다 변함, 캐시 제외
+  <model_card> <current_date>
+  <project_memory> <agent_learning> <runtime_rules> <user_context>
+</dynamic_context>`}</pre>
+
+            <h2>audit-mode: GEODE 맥락 strip</h2>
+            <p>
+              <code>GEODE_AUDIT_UNRESTRICTED=1</code>이면 GEODE 고유 레이어를
+              전부 벗깁니다. 정체성, 메모리, 사용자 컨텍스트가 빠지고
+              model_card, current_date, 호출자의 system_suffix만 남습니다.
+              근거는 측정 결과입니다. Petri의 auditor는 시나리오의 정체성을
+              끝까지 통제해야 하는데, GEODE 프리앰블이 트랜스크립트를
+              오염시켰습니다. 플래그는 <code>geode audit</code>의
+              <code>--unrestricted</code>가 inspect 서브프로세스 앞에서
+              설정합니다.
+            </p>
+
+            <h2>wrapper override: 변이된 스캐폴드 주입</h2>
+            <p>
+              자기개선 루프가 진화시키는 것이 바로 이 static 영역의 wrapper
+              스캐폴드입니다. 해석은 두 단계입니다.
+            </p>
+            <ul>
+              <li>
+                <code>GEODE_WRAPPER_OVERRIDE</code> env가 가리키는 JSON 파일.
+                감사 서브프로세스 훅입니다. 설정되어 있으면 파일이 반드시
+                존재하고 파싱돼야 하며, 실패는 fatal입니다. 잘못된 wrapper로
+                쿼터를 조용히 태우는 것보다 감사가 중단되는 편이 낫기
+                때문입니다.
+              </li>
+              <li>
+                env가 없으면
+                <code>~/.geode/autoresearch/handoff/wrapper-sections.json</code>
+                SoT 파일. 일상 <code>geode</code> 실행이 승격된 wrapper를
+                자동으로 집어 듭니다. 여기서는 스키마 실패가 WARNING 후 기본
+                prefix로 우아하게 내려갑니다. 손상된 루프 산출물이 GEODE를
+                벽돌로 만들면 안 되기 때문입니다.
+              </li>
+            </ul>
+            <p>
+              audit-mode에서도 override가 시스템 프롬프트의 베이스가 됩니다.
+              override가 없으면 동일한 도메인 중립 베이스로 폴백해, 감사
+              타깃이 항상 GEODE 스캐폴드를 입도록 보장합니다. 스캐폴드가
+              실제로 프롬프트에 도달했는지는 빌드 때마다
+              <code>system_prompt.scaffold</code> 진단으로 기록됩니다.
+            </p>
+
+            <h2>program.md 계약: mutator의 프롬프트</h2>
+            <p>
+              변이를 제안하는 mutator 에이전트의 시스템 프롬프트는 코드
+              리터럴이 아니라 패키지와 함께 출하되는
+              <code>core/self_improving/program.md</code>입니다. 러너
+              (<code>core/self_improving/loop/mutate/runner.py</code>)가 매
+              호출 디스크에서 읽고, 단일 변이로 범위를 좁히는 계약을 뒤에
+              붙입니다. 파일을 못 읽으면 조용한 폴백 대신 크게 실패합니다.
+              교체가 필요하면 훅 핸들러가 <code>program_md</code> 본문을
+              공급하는 단일 제어 지점을 씁니다.
+            </p>
+
+            <h2>실패 모드</h2>
             <table>
-              <thead><tr><th>모드</th><th>활성화 시점</th><th>시스템 프롬프트에 포함</th></tr></thead>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
               <tbody>
-                <tr><td><strong>Default (운영)</strong></td><td>일반 호출</td><td>5계층 prompt assembly + <code>GEODE_PERSONA</code> opt-in 시 추가</td></tr>
-                <tr><td><strong>audit-mode</strong></td><td>Petri audit 실행 (`geode audit ...`)</td><td>5계층 어셈블리에서 GEODE 정체성/페르소나 strip. base agent behavior만 노출.</td></tr>
+                <tr>
+                  <td>감사가 시작 전에 중단</td>
+                  <td><code>GEODE_WRAPPER_OVERRIDE</code> 경로가 없거나 스키마 불일치</td>
+                  <td>의도된 fail-loud입니다. 파일 경로와 dict[str, str] 스키마를 고칩니다.</td>
+                </tr>
+                <tr>
+                  <td>승격했는데 일상 실행이 기본 프롬프트</td>
+                  <td>SoT 파일 손상으로 graceful 폴백</td>
+                  <td>로그의 WARNING을 확인하고 <code>wrapper-sections.json</code>을 복구합니다.</td>
+                </tr>
+                <tr>
+                  <td>GEODE가 자기 정체성을 말하지 않음</td>
+                  <td>persona 기본 OFF</td>
+                  <td>의도된 동작입니다. 원하면 <code>GEODE_PERSONA=on</code>.</td>
+                </tr>
               </tbody>
             </table>
 
-            <h2>GEODE_PERSONA (opt-in)</h2>
-            <p>
-              `GEODE_PERSONA` 환경 변수 또는 config 플래그가 활성화되면 시스템 프롬프트 최상단에 GEODE 정체성 블록이 추가됩니다.
-              기본은 off. Petri audit 시에는 강제 off로 떨어집니다.
-            </p>
-            <pre>{`# 활성화
-export GEODE_PERSONA=on
-# 또는 ~/.geode/config.toml 의 [prompt] persona = "on"`}</pre>
-
-            <h2>audit-mode</h2>
-            <p>
-              <code>geode audit</code> CLI가 활성화하면 Petri 평가가 측정하려는 "base agent behavior"가 GEODE 정체성에 묻히지 않습니다.
-              평가자(Auditor·Judge)는 vanilla LLM과 비교 가능한 transcript를 받습니다.
-            </p>
+            <h2>다음</h2>
             <ul>
-              <li><a href="/geode/docs/petri/run">Petri audit 실행</a> 가이드 참조.</li>
-              <li>strip 대상: GEODE_PERSONA 블록 + <code>&lt;dynamic_context&gt;</code> 일부.</li>
-              <li>유지 대상: 도구 정의, MCP 설명, 기본 안전 가드.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">프롬프트 조립</a>. 레이어 전체 구조.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-caching">프롬프트 캐싱</a>. static/dynamic 경계의 비용 면.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">폐루프</a>. wrapper를 진화시키는 바깥 루프.</li>
             </ul>
-
-            <h2>변경 출처</h2>
-            <ul>
-              <li>v0.93.0 — <code>GEODE_PERSONA</code> opt-in 도입, audit-mode strip 정합화.</li>
-              <li>v0.92.0 — Petri audit 도입과 함께 audit-mode 분기 신설.</li>
-            </ul>
-
-            <p className="text-[var(--ink-3)] text-sm">
-              <em>참조:</em> <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/geode/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92~0.93.
-            </p>
           </>
         }
         en={
           <>
             <p>
-              <strong>Reference:</strong> GEODE can route the same user message through two system-prompt modes:
-              default operation and Petri audit (<code>audit-mode</code>). This page lists what each mode includes
-              and how to activate it.
+              The same request can ride differently assembled system prompts
+              depending on the mode. There is one builder,
+              <code>build_system_prompt</code> in
+              <code>core/agent/system_prompt.py</code>, and two env flags
+              decide what gets loaded and what gets stripped.
             </p>
 
-            <h2>The two modes</h2>
+            <h2>Default mode: persona is opt-in</h2>
+            <p>
+              By default GEODE behaves as a thin wrapper around the base
+              model: the GEODE.md &quot;You are GEODE&quot; identity preamble
+              is not injected. Setting <code>GEODE_PERSONA=on</code> injects
+              an <code>&lt;agent_identity&gt;</code> layer extracted from
+              GEODE.md (Core Principles, RUNTIME CANNOT, Defaults only).
+              Audit-mode forces this off regardless of the flag.
+            </p>
+            <pre>{`<static_context>        stable across turns, cache hit
+  <agent_baseline>      always present. base capabilities
+  <agent_identity>      only with GEODE_PERSONA=on
+</static_context>
+<dynamic_context>       changes per turn, uncached
+  <model_card> <current_date>
+  <project_memory> <agent_learning> <runtime_rules> <user_context>
+</dynamic_context>`}</pre>
+
+            <h2>Audit mode: stripping GEODE context</h2>
+            <p>
+              With <code>GEODE_AUDIT_UNRESTRICTED=1</code> every
+              GEODE-specific layer is stripped: identity, memory, and user
+              context go away, leaving model_card, current_date, and the
+              caller&apos;s system_suffix. The rationale comes from
+              measurement: Petri&apos;s auditor must control the
+              scenario&apos;s identity end to end, and a GEODE preamble
+              contaminated audit transcripts. The flag is set by
+              <code>geode audit</code>&apos;s
+              <code>--unrestricted</code> before the inspect subprocess.
+            </p>
+
+            <h2>The wrapper override: injecting the mutated scaffold</h2>
+            <p>
+              The wrapper scaffold in the static region is exactly what the
+              self-improving loop evolves. Resolution has two steps.
+            </p>
+            <ul>
+              <li>
+                The JSON file pointed to by
+                <code>GEODE_WRAPPER_OVERRIDE</code>: the audit-subprocess
+                hook. When set, the file must exist and parse; failures are
+                fatal, because aborting the audit beats silently spending
+                quota on the wrong wrapper.
+              </li>
+              <li>
+                With the env unset, the SoT file
+                <code>~/.geode/autoresearch/handoff/wrapper-sections.json</code>:
+                daily <code>geode</code> invocations automatically pick up the
+                promoted wrapper. Schema failures here log a WARNING and
+                degrade gracefully to the default prefix, because a corrupted
+                loop artifact must never brick GEODE.
+              </li>
+            </ul>
+            <p>
+              In audit mode the override is still the base of the system
+              prompt; when no override resolves, the builder falls back to
+              the same domain-neutral base, so the audit target always wears
+              a GEODE scaffold. Whether the scaffold actually reached the
+              prompt is recorded on every build by the
+              <code>system_prompt.scaffold</code> diagnostic.
+            </p>
+
+            <h2>The program.md contract: the mutator&apos;s prompt</h2>
+            <p>
+              The mutation-proposing agent&apos;s system prompt is not a code
+              literal but <code>core/self_improving/program.md</code>, shipped
+              with the package. The runner
+              (<code>core/self_improving/loop/mutate/runner.py</code>) reads
+              it from disk on every invocation and appends a contract that
+              scopes it to a single mutation. If the file is unreadable the
+              runner fails loud rather than silently falling back; the single
+              programmatic control point is a hook handler supplying a
+              replacement <code>program_md</code> body.
+            </p>
+
+            <h2>Failure modes</h2>
             <table>
-              <thead><tr><th>Mode</th><th>Activated by</th><th>Included in system prompt</th></tr></thead>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
               <tbody>
-                <tr><td><strong>Default (operation)</strong></td><td>Normal invocation.</td><td>5-layer prompt assembly plus <code>GEODE_PERSONA</code> block when opted in.</td></tr>
-                <tr><td><strong>audit-mode</strong></td><td>Petri audit (<code>geode audit ...</code>).</td><td>5-layer assembly with GEODE identity stripped. Only base agent behavior is exposed.</td></tr>
+                <tr>
+                  <td>An audit aborts before starting</td>
+                  <td><code>GEODE_WRAPPER_OVERRIDE</code> path missing or schema mismatch</td>
+                  <td>Intended fail-loud. Fix the path and the dict[str, str] schema.</td>
+                </tr>
+                <tr>
+                  <td>Daily runs use the default prompt despite a promotion</td>
+                  <td>Graceful fallback from a corrupted SoT file</td>
+                  <td>Check the WARNING in the logs and repair <code>wrapper-sections.json</code>.</td>
+                </tr>
+                <tr>
+                  <td>GEODE never asserts its own identity</td>
+                  <td>Persona defaults to off</td>
+                  <td>Working as intended. Opt in with <code>GEODE_PERSONA=on</code>.</td>
+                </tr>
               </tbody>
             </table>
 
-            <h2>GEODE_PERSONA (opt-in)</h2>
-            <p>
-              When the <code>GEODE_PERSONA</code> environment variable or config flag is on, a GEODE identity block is
-              prepended to the system prompt. Default is off. During Petri audits this is forced off.
-            </p>
-            <pre>{`# Enable
-export GEODE_PERSONA=on
-# Or in ~/.geode/config.toml: [prompt] persona = "on"`}</pre>
-
-            <h2>audit-mode</h2>
-            <p>
-              The <code>geode audit</code> CLI activates this mode so that the base agent behavior Petri measures is
-              not buried under GEODE identity. The auditor and judge receive a transcript comparable to a vanilla LLM.
-            </p>
+            <h2>Next</h2>
             <ul>
-              <li>See <a href="/geode/docs/petri/run">Run an Audit</a>.</li>
-              <li>Stripped: the GEODE_PERSONA block plus part of <code>&lt;dynamic_context&gt;</code>.</li>
-              <li>Kept: tool definitions, MCP descriptions, baseline safety guards.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">Prompt assembly</a>. The full layer structure.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-caching">Prompt caching</a>. The cost side of the static/dynamic boundary.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">The closed loop</a>. The outer loop that evolves the wrapper.</li>
             </ul>
-
-            <h2>Source</h2>
-            <ul>
-              <li>v0.93.0: <code>GEODE_PERSONA</code> opt-in introduced; audit-mode strip aligned.</li>
-              <li>v0.92.0: audit-mode branch added together with Petri audit integration.</li>
-            </ul>
-
-            <p className="text-[var(--ink-3)] text-sm">
-              <em>See:</em> <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/geode/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92-0.93.
-            </p>
           </>
         }
       />

--- a/site/src/app/docs/runtime/tools/mcp/page.tsx
+++ b/site/src/app/docs/runtime/tools/mcp/page.tsx
@@ -1,164 +1,307 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "MCP Servers — GEODE Docs" };
+export const metadata = { title: "MCP servers — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="runtime/tools/mcp"
-      title="MCP Servers"
+      title="MCP servers"
       titleKo="MCP 서버"
-      summary="MCP servers managed by core/mcp. Token guards, lifecycle, and adapters for Apple Calendar, Discord, Slack, Signal."
-      summaryKo="core/mcp가 관리하는 MCP 서버. 토큰 가드, 라이프사이클, Apple Calendar, Discord, Slack, Signal 어댑터."
+      summary="Both sides of MCP: the client that attaches external servers (config priority, env expansion, result guard) and geode-mcp, the server GEODE ships."
+      summaryKo="MCP의 양면입니다. 외부 서버를 붙이는 클라이언트(설정 우선순위, env 확장, 결과 가드)와 GEODE가 출하하는 서버 geode-mcp를 다룹니다."
     >
       <Bi
         ko={
           <>
-            <h2>MCP란 무엇인가</h2>
             <p>
-              Model Context Protocol. 외부 프로세스 서비스로서 LLM에 도구를
-              노출하는 표준입니다. GEODE는 MCP 서버를 <strong>소비</strong>하기도
-              하고, 자기 자신을 MCP 서버로 <strong>노출</strong>하기도
-              합니다 (<code>core/mcp_server.py</code>).
+              GEODE는 MCP의 양쪽에 다 섭니다. 클라이언트로서 외부 MCP 서버의
+              도구를 에이전트 도구 목록에 합치고(<code>core/mcp/</code>),
+              서버로서 자신의 능력을 다른 MCP 호스트에 노출합니다
+              (<code>geode-mcp</code>, <code>core/mcp_server.py</code>).
             </p>
 
-            <h2>매니저</h2>
+            <h2>클라이언트: 서버 설정과 우선순위</h2>
             <p>
-              <code>core/mcp/manager.py</code>가 <code>MCPManager</code>를 보유합니다.
-              서버 프로세스를 소유하고 도구 호출을 라우팅하며 가드를 강제합니다.
-              공개 API.
+              <code>core/mcp/manager.py</code>의
+              <code>MCPServerManager</code>가 세 곳에서 서버 설정을 읽습니다.
+              같은 이름이 겹치면 더 가까운 쪽이 이깁니다.
             </p>
-            <pre>{`class MCPManager:
-    async def start_server(self, name: str) -> None: ...
-    async def stop_server(self, name: str) -> None: ...
-    async def call_tool(self, server: str, tool: str, args: dict) -> Any: ...
-    async def list_tools(self, server: str) -> list[ToolSpec]: ...`}</pre>
-
-            <h2>25K 토큰 가드</h2>
+            <table>
+              <thead>
+                <tr><th>우선</th><th>위치</th><th>역할</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>1</td><td><code>.geode/config.toml</code>의 <code>[mcp.servers]</code></td><td>프로젝트 override.</td></tr>
+                <tr><td>2</td><td><code>~/.geode/config.toml</code>의 <code>[mcp.servers]</code></td><td>전역 사용자 설정.</td></tr>
+                <tr><td>3</td><td><code>.claude/mcp_servers.json</code></td><td>레거시 폴백 겸 설치 타깃. 앞 두 층에 없는 이름만 추가됩니다.</td></tr>
+              </tbody>
+            </table>
             <p>
-              MCP 도구는 임의로 큰 페이로드를 반환할 수 있습니다 (웹 fetch,
-              디렉토리 트리, DB 쿼리). 상한이 없으면 도구 호출 한 번이 컨텍스트
-              윈도를 날려버릴 수 있습니다. GEODE는 모든 MCP 도구 결과에 대해{" "}
-              <strong>25,000 토큰</strong>의 하드 상한을 강제합니다. 상한 초과 →
-              서버 측 절단 + 절단 지점을 알려주는 sentinel 마커. 모델이 무엇을
-              잃었는지 알 수 있도록 합니다.
+              서버 env의 <code>${`{VAR}`}</code> 참조는 os.environ을 먼저
+              보고, 없으면 <code>.env</code> 값(전역 먼저, 프로젝트가 덮음)
+              으로 확장됩니다. 필수 env가 빈 값으로 해석된 서버는 연결을
+              시도하지 않고 건너뜁니다. 연결과 실패는
+              <code>MCP_SERVER_CONNECTED</code> /
+              <code>MCP_SERVER_FAILED</code> 훅으로 관측됩니다. 전송은
+              stdio입니다(<code>core/mcp/stdio_client.py</code>).
             </p>
-            <p>
-              구현. <code>core/mcp/</code>의 결과 경로 위에 있는 가드 미들웨어.
-              해당하는 경우 HTML→Markdown 변환이 상한 적용보다 먼저 일어나
-              절단이 콘텐츠가 아니라 포매팅 노이즈를 제거하게 합니다.
-            </p>
 
-            <h2>관리되는 서버</h2>
-            <p>대표 목록 (환경별 가용성에 따라 달라질 수 있음).</p>
-            <ul>
-              <li>filesystem, git, github</li>
-              <li>web (fetch + search)</li>
-              <li>apple_calendar, composite_calendar (멀티 계정 병합)</li>
-              <li>signal (composite messaging)</li>
-              <li>slack, discord</li>
-              <li>linkedin-reader (브라우저 제어)</li>
-              <li>claude-in-chrome (브라우저 브릿지)</li>
-              <li>playwright</li>
-              <li>context7 (라이브러리 문서)</li>
-              <li>google-drive</li>
-              <li>+ 몇 개의 특화 어댑터</li>
-            </ul>
-
-            <h2>예외 계층</h2>
+            <h2>클라이언트: 실행 경로와 가드</h2>
             <p>
-              <code>core/mcp/base.py:12</code>에 agentic 루프까지 전파되는 실패
-              타입이 정의되어 있습니다.
+              발견된 MCP 도구는 네이티브 도구와 합쳐져 에이전트에
+              노출됩니다(<code>core/agent/loop/_tool_factory.py</code>).
+              도구 수가 임계값을 넘으면 deferred loading이 켜져
+              <code>tool_search</code>로 찾아 로드합니다. 검색 스코어링은
+              <code>core/mcp/registry.py</code>에 있습니다.
             </p>
             <ul>
-              <li><code>MCPTimeoutError</code>. 서버가 시간 안에 응답하지 않음</li>
-              <li><code>MCPConnectionError</code>. 서버가 크래시했거나 시작되지 않음</li>
-              <li><code>MCPProtocolError</code>. 응답이 잘못된 형식</li>
-              <li><code>MCPGuardError</code>. 가드가 호출을 거부함 (크기 상한, 인증 등)</li>
+              <li>
+                <strong>서버 단위 승인.</strong> 처음 쓰는 서버는 사용자
+                확인을 거치고, 승인은 서버 단위로 기억됩니다
+                (<code>core/agent/tool_executor/executor.py</code>).
+              </li>
+              <li>
+                <strong>시크릿 마스킹.</strong> 결과의 텍스트 필드는 반환 전에
+                <code>redact_secrets</code>를 통과합니다.
+              </li>
+              <li>
+                <strong>결과 크기 가드.</strong> 모든 도구 결과는
+                <code>settings.max_tool_result_tokens</code>(기본 25000)를
+                넘으면 요약을 보존한 채 잘립니다
+                (<code>core/agent/tool_executor/result_token_guard.py</code>).
+                MCP 결과도 예외가 아닙니다. 200K 미만 컨텍스트 모델은 창의
+                5%로 한 번 더 조여집니다.
+              </li>
             </ul>
-
-            <h2>GEODE-as-MCP</h2>
             <p>
-              <code>core/mcp_server.py</code>는 GEODE 자체 도구 (그리고 제한된
-              형태로 agentic 루프 자체) 를 MCP 서버로 노출합니다. Claude Code,
-              Codex CLI 같은 다른 에이전트가 GEODE를 자신이 호출하는 다른
-              에이전트와 같은 방식으로 호출할 수 있게 해줍니다.
+              세션 안에서는 <code>/mcp</code>로 서버 상태, 도구 목록, 추가를
+              관리합니다.
             </p>
+
+            <h2>서버: geode-mcp</h2>
+            <p>
+              <code>geode-mcp</code>는 GEODE의 1급 엔트리 포인트입니다.
+              에이전트 원샷(<code>run_agent</code>), 메모리 검색
+              (<code>query_memory</code>), 자기개선 루프의 2단계
+              propose/apply, 헬스 체크를 MCP 도구로 노출합니다. 저장소
+              루트의 <code>.mcp.json</code>이 이 서버를 stdio로 등록해
+              출하되므로, 이 프로젝트를 연 Claude Code 세션은 바로 쓸 수
+              있습니다. 수동 등록은 한 줄입니다.
+            </p>
+            <pre>{`claude mcp add geode -- geode-mcp`}</pre>
+            <p>
+              기본 전송은 stdio입니다. 클라이언트가 프로세스를 직접 띄우는
+              로컬 전용 경로입니다. 원격 접근은 <code>--http</code>로
+              streamable HTTP 전송을 켭니다.
+            </p>
+            <pre>{`geode-mcp --http --host 127.0.0.1 --port 8765`}</pre>
+            <table>
+              <thead>
+                <tr><th>바인드</th><th>토큰</th><th>동작</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>loopback</td>
+                  <td>없음</td>
+                  <td>허용하되 경고 로그. stdio와 같은 신뢰 경계입니다.</td>
+                </tr>
+                <tr>
+                  <td>loopback 아님</td>
+                  <td>없음</td>
+                  <td>거부, exit code 2. <code>run_agent</code>가 bash와 파일
+                  도구까지 닿는 원격 실행 표면이므로 토큰 없는 네트워크
+                  바인드는 fail-loud입니다.</td>
+                </tr>
+                <tr>
+                  <td>아무 곳</td>
+                  <td><code>GEODE_MCP_TOKEN</code></td>
+                  <td>bearer 토큰 인증. 시크릿이므로 C-2 계약대로
+                  <code>~/.geode/.env</code>에 둡니다. 기동 시 공유
+                  <code>load_env_files</code> 승격이 먼저 돌아 거기 적힌
+                  토큰을 찾습니다.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>실패 모드</h2>
+            <table>
+              <thead>
+                <tr><th>증상</th><th>원인</th><th>해법</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>서버가 목록에 있는데 도구가 없음</td>
+                  <td>필수 env 미해석으로 연결 건너뜀</td>
+                  <td><code>/mcp</code>로 상태를 보고, 참조된 <code>${`{VAR}`}</code>를 <code>.env</code>에 채웁니다.</td>
+                </tr>
+                <tr>
+                  <td>MCP 결과가 잘려서 옴</td>
+                  <td>결과 크기 가드 작동</td>
+                  <td>정상 동작입니다. 더 좁은 쿼리로 다시 호출하거나 <code>max_tool_result_tokens</code>를 조정합니다.</td>
+                </tr>
+                <tr>
+                  <td><code>geode-mcp --http</code>가 exit 2</td>
+                  <td>비 loopback 바인드에 토큰 없음</td>
+                  <td><code>GEODE_MCP_TOKEN</code>을 <code>~/.geode/.env</code>나 환경에 설정합니다.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
+            <ul>
+              <li><a href="/geode/docs/harness/cli">CLI와 슬래시 명령</a>. geode-mcp 도구 표면의 전체 레퍼런스.</li>
+              <li><a href="/geode/docs/runtime/research">리서치·탐색과 llms.txt</a>. 외부 호스트에서 query_memory를 쓰는 맥락.</li>
+              <li><a href="/geode/docs/runtime/tools/protocol">도구와 툴셋</a>. deferred loading의 자세한 동작.</li>
+            </ul>
           </>
         }
         en={
           <>
-            <h2>What MCP is</h2>
             <p>
-              Model Context Protocol — a standard for exposing tools to LLMs as
-              out-of-process services. GEODE both <strong>consumes</strong> MCP
-              servers and <strong>exposes itself</strong> as one (
+              GEODE stands on both sides of MCP. As a client it merges
+              external MCP servers&apos; tools into the agent&apos;s tool list
+              (<code>core/mcp/</code>); as a server it exposes its own
+              capabilities to other MCP hosts (<code>geode-mcp</code>,
               <code>core/mcp_server.py</code>).
             </p>
 
-            <h2>The manager</h2>
+            <h2>Client: server config and priority</h2>
             <p>
-              <code>core/mcp/manager.py</code> holds <code>MCPManager</code>, which
-              owns server processes, routes tool calls, and enforces guards. The
-              public API:
+              <code>MCPServerManager</code> in <code>core/mcp/manager.py</code>
+              reads server definitions from three places. On a name clash the
+              closer layer wins.
             </p>
-            <pre>{`class MCPManager:
-    async def start_server(self, name: str) -> None: ...
-    async def stop_server(self, name: str) -> None: ...
-    async def call_tool(self, server: str, tool: str, args: dict) -> Any: ...
-    async def list_tools(self, server: str) -> list[ToolSpec]: ...`}</pre>
-
-            <h2>The 25K token guard</h2>
+            <table>
+              <thead>
+                <tr><th>Priority</th><th>Location</th><th>Role</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>1</td><td><code>[mcp.servers]</code> in <code>.geode/config.toml</code></td><td>Project override.</td></tr>
+                <tr><td>2</td><td><code>[mcp.servers]</code> in <code>~/.geode/config.toml</code></td><td>Global user config.</td></tr>
+                <tr><td>3</td><td><code>.claude/mcp_servers.json</code></td><td>Legacy fallback and install target. Only names absent from the two layers above are added.</td></tr>
+              </tbody>
+            </table>
             <p>
-              MCP tools can return arbitrarily large payloads (a web fetch, a
-              directory tree, a database query). Without a cap, a single tool
-              call can blow the context window. GEODE enforces a hard{" "}
-              <strong>25,000 token</strong> cap on every MCP tool result. Over the
-              cap → server-side truncation + a sentinel marker indicating where
-              the truncation happened, so the model knows what it lost.
+              <code>${`{VAR}`}</code> references in a server&apos;s env are
+              expanded against os.environ first, then <code>.env</code> values
+              (global first, project overriding). A server whose required env
+              resolves empty is skipped without a connection attempt.
+              Connections and failures are observable through the
+              <code>MCP_SERVER_CONNECTED</code> /
+              <code>MCP_SERVER_FAILED</code> hooks. Transport is stdio
+              (<code>core/mcp/stdio_client.py</code>).
             </p>
-            <p>
-              Implementation: <code>core/mcp/</code> guard middleware on the
-              result path. HTML→Markdown conversion (when applicable) happens
-              before the cap so the truncation removes formatting noise rather
-              than content.
-            </p>
 
-            <h2>Managed servers</h2>
-            <p>A representative list (subject to environment-specific availability):</p>
-            <ul>
-              <li>filesystem, git, github</li>
-              <li>web (fetch + search)</li>
-              <li>apple_calendar, composite_calendar (multi-account merge)</li>
-              <li>signal (composite messaging)</li>
-              <li>slack, discord</li>
-              <li>linkedin-reader (browser-controlled)</li>
-              <li>claude-in-chrome (browser bridge)</li>
-              <li>playwright</li>
-              <li>context7 (library docs)</li>
-              <li>google-drive</li>
-              <li>+ a few specialized adapters</li>
-            </ul>
-
-            <h2>Exception hierarchy</h2>
+            <h2>Client: execution path and guards</h2>
             <p>
-              <code>core/mcp/base.py:12</code> defines the failure types that
-              propagate up to the agentic loop:
+              Discovered MCP tools merge with native tools before reaching
+              the agent (<code>core/agent/loop/_tool_factory.py</code>); past
+              a tool-count threshold, deferred loading kicks in and tools are
+              found via <code>tool_search</code>, with scoring in
+              <code>core/mcp/registry.py</code>.
             </p>
             <ul>
-              <li><code>MCPTimeoutError</code> — server did not respond in time</li>
-              <li><code>MCPConnectionError</code> — server crashed or never started</li>
-              <li><code>MCPProtocolError</code> — malformed response</li>
-              <li><code>MCPGuardError</code> — guard rejected the call (size cap, auth, etc.)</li>
+              <li>
+                <strong>Per-server approval.</strong> A first-use server goes
+                through user confirmation, remembered per server
+                (<code>core/agent/tool_executor/executor.py</code>).
+              </li>
+              <li>
+                <strong>Secret redaction.</strong> Text fields of every result
+                pass through <code>redact_secrets</code> before returning.
+              </li>
+              <li>
+                <strong>Result-size guard.</strong> Any tool result above
+                <code>settings.max_tool_result_tokens</code> (default 25000)
+                is truncated with its summary preserved
+                (<code>core/agent/tool_executor/result_token_guard.py</code>).
+                MCP results are no exception. Models with a context window
+                under 200K get a tighter per-result cap of 5% of the window.
+              </li>
             </ul>
-
-            <h2>GEODE-as-MCP</h2>
             <p>
-              <code>core/mcp_server.py</code> exposes GEODE&apos;s own tools (and
-              the agentic loop itself, in restricted form) as an MCP server. This
-              lets other agents — Claude Code, Codex CLI, etc. — call GEODE the
-              same way GEODE calls them.
+              In-session, <code>/mcp</code> manages server status, tool
+              listings, and additions.
             </p>
+
+            <h2>Server: geode-mcp</h2>
+            <p>
+              <code>geode-mcp</code> is a first-class GEODE entry point. It
+              exposes an agentic one-shot (<code>run_agent</code>), memory
+              search (<code>query_memory</code>), the deliberate two-step
+              propose/apply of the self-improving loop, and a health check as
+              MCP tools. The repo ships <code>.mcp.json</code> at its root
+              registering this server over stdio, so Claude Code sessions
+              opened in this project get it for free. Manual registration is
+              one line:
+            </p>
+            <pre>{`claude mcp add geode -- geode-mcp`}</pre>
+            <p>
+              The default transport is stdio: the client spawns the process,
+              local only. For remote access, <code>--http</code> switches to
+              the streamable HTTP transport.
+            </p>
+            <pre>{`geode-mcp --http --host 127.0.0.1 --port 8765`}</pre>
+            <table>
+              <thead>
+                <tr><th>Bind</th><th>Token</th><th>Behavior</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Loopback</td>
+                  <td>None</td>
+                  <td>Allowed, with a logged warning. Same trust boundary as stdio.</td>
+                </tr>
+                <tr>
+                  <td>Non-loopback</td>
+                  <td>None</td>
+                  <td>Refused, exit code 2. <code>run_agent</code> reaches
+                  GEODE&apos;s full tool surface including bash and file ops,
+                  so a tokenless network bind is a remote-execution surface
+                  and fails loud.</td>
+                </tr>
+                <tr>
+                  <td>Any</td>
+                  <td><code>GEODE_MCP_TOKEN</code></td>
+                  <td>Bearer-token auth. It is a secret, so per the C-2
+                  contract it lives in <code>~/.geode/.env</code>; the shared
+                  <code>load_env_files</code> promotion runs at startup, so a
+                  token written there is found.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Failure modes</h2>
+            <table>
+              <thead>
+                <tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>A configured server exposes no tools</td>
+                  <td>Connection skipped over an unresolved required env</td>
+                  <td>Check <code>/mcp</code>, then fill the referenced <code>${`{VAR}`}</code> in <code>.env</code>.</td>
+                </tr>
+                <tr>
+                  <td>MCP results arrive truncated</td>
+                  <td>The result-size guard fired</td>
+                  <td>Working as intended. Re-query narrower, or tune <code>max_tool_result_tokens</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>geode-mcp --http</code> exits with code 2</td>
+                  <td>Non-loopback bind without a token</td>
+                  <td>Set <code>GEODE_MCP_TOKEN</code> in <code>~/.geode/.env</code> or the environment.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
+            <ul>
+              <li><a href="/geode/docs/harness/cli">CLI and slash commands</a>. The full reference for the geode-mcp tool surface.</li>
+              <li><a href="/geode/docs/runtime/research">Research, search, and llms.txt</a>. The context for query_memory from external hosts.</li>
+              <li><a href="/geode/docs/runtime/tools/protocol">Tools and toolsets</a>. Deferred loading in detail.</li>
+            </ul>
           </>
         }
       />

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -143,13 +143,13 @@ export const DOCS_SITEMAP: DocSection[] = [
     titleKo: "설정",
     pages: [
       { slug: "config/basics", title: "Configuration basics", titleKo: "설정 기초", summary: "Where configuration lives, how it loads, and how overrides resolve.", summaryKo: "설정이 어디에 있고, 어떻게 로드되고, override가 어떻게 결정되는지 설명합니다.", quadrant: "how-to" },
-      { slug: "config/reference", title: "config.toml reference", titleKo: "config.toml 레퍼런스", summary: "Every configuration key, grouped by area, marked stable or experimental.", summaryKo: "영역별로 묶은 모든 설정 키입니다. stable과 experimental을 표시합니다.", quadrant: "reference" },
-      { slug: "runtime/auth", title: "Auth and OAuth", titleKo: "인증과 OAuth", summary: "Profile rotation, the Anthropic ToS path, and the Codex flow.", summaryKo: "프로파일 로테이션, Anthropic ToS 경로, Codex 플로우를 다룹니다.", quadrant: "reference" },
+      { slug: "config/reference", title: "config.toml reference", titleKo: "config.toml 레퍼런스", summary: "Every configuration key, grouped by area: Settings fields, routing.toml, and the self-improving loop sections.", summaryKo: "영역별로 묶은 모든 설정 키입니다. Settings 필드, routing.toml, self-improving 루프 섹션을 다룹니다.", quadrant: "reference" },
+      { slug: "runtime/auth", title: "Auth and OAuth", titleKo: "인증과 OAuth", summary: "Credential sources, the /login OAuth profiles, Codex token detection, and where API keys live.", summaryKo: "자격 소스, /login OAuth 프로파일, Codex 토큰 감지, API 키가 사는 곳을 다룹니다.", quadrant: "reference" },
       { slug: "ops/oauth", title: "OAuth token rotation", titleKo: "OAuth 토큰 회전", summary: "Refresh policy and cooldown across providers.", summaryKo: "프로바이더 전반의 갱신 정책과 쿨다운을 다룹니다.", quadrant: "how-to" },
       { slug: "runtime/llm/system-prompt-modes", title: "System prompt modes", titleKo: "시스템 프롬프트 모드", summary: "The persona opt-in and the audit-mode strip. The two ways the system prompt is reshaped.", summaryKo: "persona opt-in과 audit-mode strip입니다. 시스템 프롬프트가 변형되는 두 가지 방식입니다.", quadrant: "reference" },
       { slug: "runtime/llm/prompt-caching", title: "Prompt caching", titleKo: "프롬프트 캐싱", summary: "The static and dynamic boundary, and ephemeral cache control.", summaryKo: "static과 dynamic 경계, ephemeral 캐시 제어를 다룹니다.", quadrant: "reference" },
       { slug: "runtime/llm/prompt-hashing", title: "Prompt hashing", titleKo: "프롬프트 해싱", summary: "Pinned prompt hashes that break the build on unintended drift.", summaryKo: "의도하지 않은 drift가 생기면 빌드를 깨뜨리는 프롬프트 해시 핀입니다.", quadrant: "reference" },
-      { slug: "runtime/tools/mcp", title: "MCP servers", titleKo: "MCP 서버", summary: "Connecting MCP servers, the result-size guard, and the HTML to Markdown fallback.", summaryKo: "MCP 서버 연결, 결과 크기 가드, HTML to Markdown 폴백을 다룹니다.", quadrant: "reference" },
+      { slug: "runtime/tools/mcp", title: "MCP servers", titleKo: "MCP 서버", summary: "Both sides of MCP: the client that attaches external servers, and geode-mcp, the server GEODE ships.", summaryKo: "MCP의 양면입니다. 외부 서버를 붙이는 클라이언트와 GEODE가 출하하는 서버 geode-mcp를 다룹니다.", quadrant: "reference" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- docs-sprint Phase 3d(마지막 콘텐츠 배치): 07 Configuration 8페이지를 C-1~C-4 통일 이후 기준으로 전면 재생성 + 캐논 §5 문체 검수(9건). 운영자 지시 반영: README EN/KO 헤더 내비에서 Site 링크 제거(Docs·허브·한국어만 유지).

## Why
07 섹션은 config 통일 스프린트(C-1 explain v0.99.164, C-2 secrets-only .165, C-3 dotenv 순서 .167, C-4 로더 통일 .170)를 전혀 반영하지 못한 마지막 구간. 추가로 "Anthropic OAuth는 ToS로 비활성"이라는 거짓 주장(claude-cli keychain 레인 가동 중), 라인 번호 인용, axes.py 잔재가 남아 있었음.

## Changes
| File | Change |
|------|--------|
| `config/basics` | C-2/C-3/C-4 계약 중심 재구축: 파일 역할, 6-layer explain 사다리, 데몬 BEHAVIOR_ENV_KEYS 드롭+탈출구 |
| `config/reference` | 전수 키 인벤토리(76 Settings/23 toml-mapped + routing.toml 전 섹션 + self_improving_loop.*) |
| `runtime/auth` · `ops/oauth` | 거짓 ToS 주장 제거, CredentialSource·/login 서브커맨드·rotation.py 실거동(120s 선제 갱신, 401 자동, cooldown) |
| `system-prompt-modes` | persona/audit-strip 2모드 + GEODE_WRAPPER_OVERRIDE strict-graceful 이중 해석 + program.md fail-loud |
| `prompt-caching` | v0.99.148 append-only 캐시 계약 + rolling breakpoints |
| `prompt-hashing` | 4 PROMPT_VERSIONS 핀, axes 잔재 0 |
| `runtime/tools/mcp` | config 우선순위 정정, result_token_guard 실명, --http bearer 전송(v0.99.171) 추가 |
| `README.md` · `README.ko.md` | 헤더 내비 Site 링크 제거 |

## Verification
- [x] check_docs_canon 0건 / check_docs_links pass (78 routes)
- [x] site npm run build 성공 / tsc clean(에이전트 검증)
- [x] 문체 검수 9건 교정, 잔여 위반 0
- [x] uv.lock 노이즈 커밋 전 제거 확인(0건)
- [x] 문서 전용, 버전 무변

## Reference
팩트시트 facts-config-providers.md + facts-cli-mcp.md, site/CONTENT-CANON.md §5·§7.