### PR TITLE
release: v0.99.177 — tool-call line indentation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.177] - 2026-06-11
+
+### Fixed
+- **Tool-call lines rendered with ragged indentation** (operator-reported: some `✓ tool` lines indented ~16 columns, others 2). `ToolCallTracker._redraw` moved the cursor up with `\033[{n}A` (preserves the column) and cleared each line with `\033[2K` (does not move the cursor), so when a prior writer — the activity spinner, the thinking region, or an interleaved stream — left the cursor mid-line, the `  ✓ name` text printed at that stale column. Every rendered tool line now starts with `\r` to paint from column 0 (matching what `suspend()` already did). Guards: `tests/core/ui/test_tool_tracker_indent.py` (2).
+
 ## [0.99.176] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.176
+- **Version**: 0.99.177
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.176 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.177 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.176 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.177 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/tool_tracker.py
+++ b/core/ui/tool_tracker.py
@@ -165,14 +165,14 @@ class ToolCallTracker:
                 dur = f" ({float(t['duration']):.1f}s)"
                 if t["error"]:
                     err = _truncate_display(str(t["error"]), 60)
-                    lines.append(f"\033[2K  \033[31m\u2717 {name}\033[0m — {err}{dur}")
+                    lines.append(f"\r\033[2K  \033[31m\u2717 {name}\033[0m — {err}{dur}")
                 else:
                     summary = _truncate_display(str(t["summary"]), 60)
-                    lines.append(f"\033[2K  \033[32m\u2713 {name}\033[0m → {summary}{dur}")
+                    lines.append(f"\r\033[2K  \033[32m\u2713 {name}\033[0m → {summary}{dur}")
             else:
                 args = str(t["args"]).replace("\n", " ")
                 args = _truncate_display(args, 50)
-                lines.append(f"\033[2K  {frame} \033[35m{name}\033[0m({args})")
+                lines.append(f"\r\033[2K  {frame} \033[35m{name}\033[0m({args})")
 
         # Always update line count (tests inspect this)
         self._line_count = len(lines)
@@ -183,6 +183,13 @@ class ToolCallTracker:
         out = sys.stdout
         if self._line_count > 0:
             out.write(f"\033[{self._line_count}A")
+        # Each line starts with ``\r`` so it paints from column 0 even when a
+        # prior writer (activity spinner, thinking region, interleaved stream)
+        # left the cursor mid-line. ``\033[{n}A`` moves UP but preserves the
+        # column, and ``\033[2K`` clears the line without moving the cursor —
+        # so without the ``\r`` the ``  ✓ name`` text printed at the stale
+        # column and the tool lines rendered with ragged indentation
+        # (operator-reported, 2026-06-11). ``suspend()`` already does this.
         output = "\n".join(lines)
         if lines:
             output += "\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.176"
+version = "0.99.177"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/ui/test_tool_tracker_indent.py
+++ b/tests/core/ui/test_tool_tracker_indent.py
@@ -1,0 +1,60 @@
+"""Guard: tool-tracker lines paint from column 0 (v0.99.177).
+
+``_redraw`` moves the cursor UP with ``\\033[{n}A`` (preserves column) and
+clears each line with ``\\033[2K`` (does not move the cursor). Without a
+leading ``\\r`` the ``  ✓ name`` text printed at whatever column a prior
+writer (activity spinner, thinking region, interleaved stream) left the
+cursor at — producing ragged indentation (operator-reported, 2026-06-11:
+some tool lines indented ~16 cols, others 2). Every rendered line must
+start with ``\\r``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import io
+import sys
+
+from core.ui.tool_tracker import ToolCallTracker
+
+
+def test_redraw_lines_are_carriage_return_prefixed() -> None:
+    src = inspect.getsource(ToolCallTracker._redraw)
+    appends = [ln for ln in src.splitlines() if "lines.append" in ln]
+    assert len(appends) == 3, f"expected 3 line builders, found {len(appends)}"
+    for ln in appends:
+        assert r'"\r\033[2K' in ln, f"line not column-0-safe: {ln.strip()}"
+
+
+def test_redraw_output_resets_column_per_line(monkeypatch) -> None:
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    tracker = ToolCallTracker()
+    tracker._tty = True  # force ANSI path (StringIO has no isatty)
+    tracker._tools = [
+        {
+            "name": "memory_search",
+            "args": "",
+            "done": True,
+            "error": "",
+            "summary": "ok",
+            "start_time": 0.0,
+            "duration": 0.1,
+        },
+        {
+            "name": "glob_files",
+            "args": "",
+            "done": True,
+            "error": "",
+            "summary": "ok",
+            "start_time": 0.0,
+            "duration": 0.0,
+        },
+    ]
+    tracker._redraw()
+    out = buf.getvalue()
+    # both tool lines must carry the CR-prefixed clear sequence
+    assert out.count("\r\033[2K") == 2
+    # and no tool line content appears without a preceding CR
+    assert "  \033[32m✓ memory_search" in out
+    assert "  \033[32m✓ glob_files" in out


### PR DESCRIPTION
## Summary
- v0.99.177: tool-call status lines paint from column 0 — fixes ragged indentation (PR #2155).

## Verification
- [x] CI green on #2155
- [x] develop → main pass-through