### PR TITLE
docs(sot): GEODE.md Sub-Agent 격리 서술 정직화 (Codex 감사, option a)

### DIFF
--- a/GEODE.md
+++ b/GEODE.md
@@ -49,14 +49,14 @@ to the 4-layer diagram); S-5 (2026-06-11) made it explicit.
 
 ### Sub-Agent System
 
-Sub-agents inherit parent tools/MCP/skills/memory and execute in parallel within independent contexts.
-`SubAgentManager` → `TaskGraph`(DAG) → `IsolatedRunner`(gated by Lane("global", max=8)).
-Controls: max_depth=1 (explicit depth guard + denied_tools), max_total=15, timeout=120s, auto_approve=True(STANDARD only), max_rounds=0 (unlimited), max_tokens=32768, time_budget_s=0 (same as parent, time-based control).
+Sub-agents execute as isolated worker processes in parallel.
+`SubAgentManager` → `TaskGraph`(DAG) → `IsolatedRunner`(gated by Lane("global", max=50 — `core/wiring/container.py` DEFAULT_GLOBAL_CONCURRENCY)).
+Controls: max_depth=1 (explicit depth guard + denied_tools), max_total=15, timeout=600s (`GEODE_SUBAGENT_TIMEOUT_S`, clamped 10..3600), auto_approve=True(STANDARD only), max_rounds=0 (unlimited), max_tokens=32768, time_budget_s=0 (same as parent, time-based control).
 
-**Memory Isolation Rules:**
-- Sub-agents inherit parent memory snapshots as read-only
-- Sub-agent writes go to a task_id-scoped buffer (direct modification of shared memory is prohibited)
-- Parent merges only the summary after task completion — two agents never write to shared memory simultaneously
+**Isolation boundary (honest contract, 2026-06-11 Codex audit):**
+- Isolation is at the process + artifact level: outputs land under `<run_dir>/sub_agents/<task_id>/`; the parent receives only the returned summary (`core/orchestration/isolated_execution.py`).
+- What a subprocess worker receives is the native tool handlers resolved from its declared toolkit (`core/agent/worker.py`). The parent's MCP connections and skill registry are NOT serialized to the worker; `SubAgentManager` holds `mcp_manager`/`skill_registry` references for in-process use only.
+- Memory-write isolation is governed by toolkit composition, not a task_id buffer: the read-only `_default` toolkit cannot write; a toolkit that includes `memory_save` (e.g. `general_purpose`) writes shared `ProjectMemory` directly. To prevent concurrent shared-memory writes, grant write-free toolkits.
 
 ### Gateway Runtime (Thin-Only Architecture)
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -407,8 +407,12 @@ class SubAgentManager:
     - **HookSystem**: Emits SUBAGENT_STARTED/COMPLETED/FAILED events.
     - **Dedup**: Filters duplicate task_id submissions via seen-set.
     - **AgentRegistry**: Resolves agent definitions for context injection.
-    - **Full AgenticLoop inheritance** (P2-B): sub-agents get the same tools,
-      MCP, skills, memory as the parent.  Controlled by ``depth`` / ``max_depth``.
+    - **Toolkit-scoped capability** (P2-B revised, 2026-06-11 Codex audit):
+      subprocess workers receive native tool handlers resolved from the
+      declared toolkit (``core/agent/worker.py``). The ``mcp_manager`` /
+      ``skill_registry`` references held here are for in-process use only
+      and are NOT serialized to workers. Controlled by ``depth`` /
+      ``max_depth``.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- 운영자 결정(a안) 실행: GEODE.md "Memory Isolation Rules"와 `sub_agent.py` 독스트링의 미구현 서술을 검증된 실제 경계로 교체. 실측 수치 정정 2건 동반(global lane 8→50, sub-agent timeout 120s→600s).

## Why
Codex 적대 감사가 REFUTED한 2개 주장(task_id 버퍼 메모리 격리, 서브에이전트의 MCP/스킬/메모리 상속)의 출처가 정체성 SoT인 GEODE.md였음. docs 페이지는 p4(#2151)에서 정정 완료, SoT와 독스트링이 남아 있었음.

## Changes
| File | Change |
|------|--------|
| `GEODE.md` | Sub-Agent System 블록: 격리=프로세스+산출물 수준, 워커는 툴킷 해석 네이티브 핸들러만 수신(MCP/스킬 미직렬화), 쓰기 통제=툴킷 구성. lane 50·timeout 600s 실측 반영 |
| `core/agent/sub_agent.py` | "Full AgenticLoop inheritance" 독스트링 → "Toolkit-scoped capability"(in-process 전용 참조 명시) |

## Verification
- [x] ruff check / format / mypy(sub_agent.py) clean
- [x] pytest tests/core/agent -k "sub_agent or subagent": 117 pass
- [x] 행동 변경 없음(독스트링+MD만)

## Reference
Codex MCP 감사(2026-06-11, 26주장) + `core/wiring/container.py` DEFAULT_GLOBAL_CONCURRENCY=50 + `core/agent/sub_agent.py` timeout_s=600.0 실측.