### PR TITLE
ci(lychee): blocking 승격 + seeds/about 링크 부패 13건 수정

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -210,10 +210,12 @@ jobs:
           ln -sfn "${{ github.workspace }}/site/out" _lc/geode
 
       # External broken-link checker (lychee) over the ACTUAL built HTML that
-      # ships to Pages: internal nav, anchors, copied hub surfaces, and outbound
-      # links. Reporting mode (jobSummary) so a transient external rate-limit
-      # does not block a deploy; the internal gate above is the hard blocker.
-      # Flip `fail: true` to make external rot block once the summary reads clean.
+      # ships to Pages: internal nav, anchors, and outbound links.
+      # BLOCKING since 2026-06-11 (operator promotion): the 2026-06-11 summary
+      # read 501 errors, all of them link targets inside the vendored/generated
+      # hub surfaces (petri-bundle viewer, self-improving hub) plus 7 site-side
+      # rots fixed in the same PR. Hub targets are excluded below; the hub has
+      # its own validator (petri-publish.yml). Everything else now blocks.
       - name: Broken-link check on built HTML (lychee)
         uses: lycheeverse/lychee-action@v2
         with:
@@ -223,12 +225,14 @@ jobs:
             --cache --max-cache-age 1d
             --max-retries 2 --retry-wait-time 2 --timeout 20
             --accept 200,206,403,429
+            --exclude 'petri-bundle'
+            --exclude 'self-improving'
             site/out/index.html
             site/out/docs.html
             site/out/about.html
             'site/out/docs/**/*.html'
             'site/out/portfolio/**/*.html'
-          fail: false
+          fail: true
           jobSummary: true
           output: lychee-report.md
 

--- a/site/src/app/about/page.tsx
+++ b/site/src/app/about/page.tsx
@@ -30,7 +30,7 @@ const personal: Entry[] = [
   },
   {
     id: "eco2",
-    href: "/eco2",
+    href: "",  // no dedicated page on this site; renders as non-link
     range: "2025.10 → 2026.02",
     status: "SeSACTHON 2025 Excellence",
     titleKo: "Eco²",

--- a/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
+++ b/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
@@ -7,7 +7,15 @@ import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 const REPO_ROOT = path.join(process.cwd(), "..");
 const SEEDS_DIR = path.join(REPO_ROOT, "docs", "self-improving", "petri-bundle", "seeds");
-const RAW_BUNDLE_URL = "/self-improving/petri-bundle/seeds/";
+const RAW_BUNDLE_URL = "/geode/self-improving/petri-bundle/seeds/";
+
+function candidatePageExists(runId: string, candidateId: string): boolean {
+  for (const dir of ["candidates", "candidates_evolved"]) {
+    if (fs.existsSync(path.join(SEEDS_DIR, runId, dir, `${candidateId}.md`))) return true;
+  }
+  return false;
+}
+
 
 type Candidate = { run_id: string; candidate_id: string; kind: "candidate" | "evolved" };
 
@@ -314,7 +322,11 @@ function SeedDetail(props: DetailProps) {
             <tr>
               <th>parent_id</th>
               <td>
-                <a href={`./${seed.parent_id}`}><code>{seed.parent_id}</code></a>
+                {candidatePageExists(seed.run_id, seed.parent_id) ? (
+                  <a href={`./${seed.parent_id}`}><code>{seed.parent_id}</code></a>
+                ) : (
+                  <code>{seed.parent_id}</code>
+                )}
               </td>
             </tr>
           )}
@@ -322,9 +334,13 @@ function SeedDetail(props: DetailProps) {
             <tr>
               <th>{t("진화 자식", "evolved children")}</th>
               <td>
-                {seed.evolved_children.map((c) => (
-                  <a key={c} href={`./${c}`} className="mr-2"><code>{c}</code></a>
-                ))}
+                {seed.evolved_children.map((c) =>
+                  candidatePageExists(seed.run_id, c) ? (
+                    <a key={c} href={`./${c}`} className="mr-2"><code>{c}</code></a>
+                  ) : (
+                    <code key={c} className="mr-2">{c}</code>
+                  )
+                )}
               </td>
             </tr>
           )}
@@ -418,10 +434,10 @@ function SeedDetail(props: DetailProps) {
           <a href={seed.raw_path}>{t("raw `.md` 다운로드", "raw `.md` download")}</a>
         </li>
         <li>
-          <a href={`/petri-bundle/landing.html`}>{t("Petri bundle 허브", "Petri bundle hub")}</a>
+          <a href="/geode/self-improving/">{t("Self-improving 허브", "Self-improving hub")}</a>
         </li>
         <li>
-          <a href={`/petri-bundle/`}>{t("Eval 로그 viewer", "Eval log viewer")}</a>
+          <a href="/geode/self-improving/petri-bundle/">{t("Eval 로그 viewer", "Eval log viewer")}</a>
         </li>
       </ul>
     </>

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -8,7 +8,15 @@ export const metadata = { title: "Seed Generation Runs · GEODE Docs" };
 // Seeds live one level up under docs/self-improving/petri-bundle/seeds/ in the repo root.
 const REPO_ROOT = path.join(process.cwd(), "..");
 const SEEDS_DIR = path.join(REPO_ROOT, "docs", "self-improving", "petri-bundle", "seeds");
-const RAW_BUNDLE_URL = "/self-improving/petri-bundle/seeds/";
+const RAW_BUNDLE_URL = "/geode/self-improving/petri-bundle/seeds/";
+
+function candidateFileExists(runId: string, candidateId: string): boolean {
+  for (const dir of ["candidates", "candidates_evolved"]) {
+    if (fs.existsSync(path.join(SEEDS_DIR, runId, dir, `${candidateId}.md`))) return true;
+  }
+  return false;
+}
+
 
 type ListingRun = {
   run_id: string;
@@ -213,11 +221,21 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                     : undefined;
                   const evolved = evolvedByParent.get(sid) ?? [];
                   // next.config.ts has `trailingSlash: false` so links must NOT end in `/`.
-                  const detailHref = `/docs/petri/seeds/${run.run_id}/${sid}`;
+                  // Link only when the candidate .md exists in the bundle, in
+                  // parity with [candidate_id]/generateStaticParams. gen1 runs
+                  // list survivors whose files never shipped (bundle sync gap);
+                  // a forced link 404s on the deployed site.
+                  const detailHref = candidateFileExists(run.run_id, sid)
+                    ? `/geode/docs/petri/seeds/${run.run_id}/${sid}`
+                    : undefined;
                   return (
                     <tr key={sid}>
                       <td>
-                        <a href={detailHref}><code>{sid}</code></a>
+                        {detailHref ? (
+                          <a href={detailHref}><code>{sid}</code></a>
+                        ) : (
+                          <code>{sid}</code>
+                        )}
                       </td>
                       <td>{Math.round(elo)}</td>
                       <td>{pilotStatus}</td>
@@ -230,7 +248,10 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                         {evolved.length > 0 && (
                           <span className="ml-2 text-[var(--ink-3)] text-xs">
                             → {evolved.map((e) => {
-                              const eHref = `/docs/petri/seeds/${run.run_id}/${e}`;
+                              if (!candidateFileExists(run.run_id, e)) {
+                                return <code key={e} className="mr-1">{e}</code>;
+                              }
+                              const eHref = `/geode/docs/petri/seeds/${run.run_id}/${e}`;
                               return (
                                 <a key={e} href={eHref} className="mr-1"><code>{e}</code></a>
                               );


### PR DESCRIPTION
## Summary
- 운영자 지시 항목 2(lychee fail:true 승격) 실행. 직전 main 배포 요약 실측: 16,106 링크 중 501 오류, 전수 file:// 미존재(외부 rot 0). 허브 vendored 표면은 exclude(자체 validator 보유), 사이트측 부패 13건은 본 PR에서 수정 후 blocking 전환.

## Why
fail:false 운영의 전제였던 "summary clean 확인"을 수행한 결과 사이트측 실부패 발견: seeds 목록/상세의 raw `<a>`가 `/geode` basePath 누락으로 배포에서 전부 404(체커는 template literal이라 UNRESOLVED 처리해 못 잡던 사각), gen1 번들 동기 갭으로 존재하지 않는 후보 상세를 링크, 상세 footer가 삭제된 `landing.html` 참조, about이 미존재 `/eco2` 내부 링크.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/pages.yml` | lychee fail:true + exclude(petri-bundle, self-improving) + 승격 근거 주석 |
| `site/.../petri/seeds/page.tsx` | `/geode` prefix + 후보 .md 존재 시에만 상세/evolved 링크(파리티 가드) |
| `site/.../seeds/[run_id]/[candidate_id]/page.tsx` | RAW_BUNDLE_URL prefix, parent/children 존재 가드, footer를 live 허브 경로로 |
| `site/src/app/about/page.tsx` | `/eco2` 비링크화 |

## Verification
- [x] 로컬 lychee --offline 동일 인자: 16,945 중 0 Errors (수정 전 52)
- [x] check_docs_links pass / check_docs_canon 0건 / site build 성공
- [x] uv.lock 노이즈 제거 확인

## Reference
운영자 순차 지시(항목 2) + pages run 27322513492 lychee summary 실측.