### PR TITLE
release: SoT 격리 정직화 + lychee blocking 승격 + 링크 부패 13건

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -210,10 +210,12 @@ jobs:
           ln -sfn "${{ github.workspace }}/site/out" _lc/geode
 
       # External broken-link checker (lychee) over the ACTUAL built HTML that
-      # ships to Pages: internal nav, anchors, copied hub surfaces, and outbound
-      # links. Reporting mode (jobSummary) so a transient external rate-limit
-      # does not block a deploy; the internal gate above is the hard blocker.
-      # Flip `fail: true` to make external rot block once the summary reads clean.
+      # ships to Pages: internal nav, anchors, and outbound links.
+      # BLOCKING since 2026-06-11 (operator promotion): the 2026-06-11 summary
+      # read 501 errors, all of them link targets inside the vendored/generated
+      # hub surfaces (petri-bundle viewer, self-improving hub) plus 7 site-side
+      # rots fixed in the same PR. Hub targets are excluded below; the hub has
+      # its own validator (petri-publish.yml). Everything else now blocks.
       - name: Broken-link check on built HTML (lychee)
         uses: lycheeverse/lychee-action@v2
         with:
@@ -223,12 +225,14 @@ jobs:
             --cache --max-cache-age 1d
             --max-retries 2 --retry-wait-time 2 --timeout 20
             --accept 200,206,403,429
+            --exclude 'petri-bundle'
+            --exclude 'self-improving'
             site/out/index.html
             site/out/docs.html
             site/out/about.html
             'site/out/docs/**/*.html'
             'site/out/portfolio/**/*.html'
-          fail: false
+          fail: true
           jobSummary: true
           output: lychee-report.md
 

--- a/GEODE.md
+++ b/GEODE.md
@@ -49,14 +49,14 @@ to the 4-layer diagram); S-5 (2026-06-11) made it explicit.
 
 ### Sub-Agent System
 
-Sub-agents inherit parent tools/MCP/skills/memory and execute in parallel within independent contexts.
-`SubAgentManager` → `TaskGraph`(DAG) → `IsolatedRunner`(gated by Lane("global", max=8)).
-Controls: max_depth=1 (explicit depth guard + denied_tools), max_total=15, timeout=120s, auto_approve=True(STANDARD only), max_rounds=0 (unlimited), max_tokens=32768, time_budget_s=0 (same as parent, time-based control).
+Sub-agents execute as isolated worker processes in parallel.
+`SubAgentManager` → `TaskGraph`(DAG) → `IsolatedRunner`(gated by Lane("global", max=50 — `core/wiring/container.py` DEFAULT_GLOBAL_CONCURRENCY)).
+Controls: max_depth=1 (explicit depth guard + denied_tools), max_total=15, timeout=600s (`GEODE_SUBAGENT_TIMEOUT_S`, clamped 10..3600), auto_approve=True(STANDARD only), max_rounds=0 (unlimited), max_tokens=32768, time_budget_s=0 (same as parent, time-based control).
 
-**Memory Isolation Rules:**
-- Sub-agents inherit parent memory snapshots as read-only
-- Sub-agent writes go to a task_id-scoped buffer (direct modification of shared memory is prohibited)
-- Parent merges only the summary after task completion — two agents never write to shared memory simultaneously
+**Isolation boundary (honest contract, 2026-06-11 Codex audit):**
+- Isolation is at the process + artifact level: outputs land under `<run_dir>/sub_agents/<task_id>/`; the parent receives only the returned summary (`core/orchestration/isolated_execution.py`).
+- What a subprocess worker receives is the native tool handlers resolved from its declared toolkit (`core/agent/worker.py`). The parent's MCP connections and skill registry are NOT serialized to the worker; `SubAgentManager` holds `mcp_manager`/`skill_registry` references for in-process use only.
+- Memory-write isolation is governed by toolkit composition, not a task_id buffer: the read-only `_default` toolkit cannot write; a toolkit that includes `memory_save` (e.g. `general_purpose`) writes shared `ProjectMemory` directly. To prevent concurrent shared-memory writes, grant write-free toolkits.
 
 ### Gateway Runtime (Thin-Only Architecture)
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -407,8 +407,12 @@ class SubAgentManager:
     - **HookSystem**: Emits SUBAGENT_STARTED/COMPLETED/FAILED events.
     - **Dedup**: Filters duplicate task_id submissions via seen-set.
     - **AgentRegistry**: Resolves agent definitions for context injection.
-    - **Full AgenticLoop inheritance** (P2-B): sub-agents get the same tools,
-      MCP, skills, memory as the parent.  Controlled by ``depth`` / ``max_depth``.
+    - **Toolkit-scoped capability** (P2-B revised, 2026-06-11 Codex audit):
+      subprocess workers receive native tool handlers resolved from the
+      declared toolkit (``core/agent/worker.py``). The ``mcp_manager`` /
+      ``skill_registry`` references held here are for in-process use only
+      and are NOT serialized to workers. Controlled by ``depth`` /
+      ``max_depth``.
     """
 
     def __init__(

--- a/site/src/app/about/page.tsx
+++ b/site/src/app/about/page.tsx
@@ -30,7 +30,7 @@ const personal: Entry[] = [
   },
   {
     id: "eco2",
-    href: "/eco2",
+    href: "",  // no dedicated page on this site; renders as non-link
     range: "2025.10 → 2026.02",
     status: "SeSACTHON 2025 Excellence",
     titleKo: "Eco²",

--- a/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
+++ b/site/src/app/docs/petri/seeds/[run_id]/[candidate_id]/page.tsx
@@ -7,7 +7,15 @@ import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 const REPO_ROOT = path.join(process.cwd(), "..");
 const SEEDS_DIR = path.join(REPO_ROOT, "docs", "self-improving", "petri-bundle", "seeds");
-const RAW_BUNDLE_URL = "/self-improving/petri-bundle/seeds/";
+const RAW_BUNDLE_URL = "/geode/self-improving/petri-bundle/seeds/";
+
+function candidatePageExists(runId: string, candidateId: string): boolean {
+  for (const dir of ["candidates", "candidates_evolved"]) {
+    if (fs.existsSync(path.join(SEEDS_DIR, runId, dir, `${candidateId}.md`))) return true;
+  }
+  return false;
+}
+
 
 type Candidate = { run_id: string; candidate_id: string; kind: "candidate" | "evolved" };
 
@@ -314,7 +322,11 @@ function SeedDetail(props: DetailProps) {
             <tr>
               <th>parent_id</th>
               <td>
-                <a href={`./${seed.parent_id}`}><code>{seed.parent_id}</code></a>
+                {candidatePageExists(seed.run_id, seed.parent_id) ? (
+                  <a href={`./${seed.parent_id}`}><code>{seed.parent_id}</code></a>
+                ) : (
+                  <code>{seed.parent_id}</code>
+                )}
               </td>
             </tr>
           )}
@@ -322,9 +334,13 @@ function SeedDetail(props: DetailProps) {
             <tr>
               <th>{t("진화 자식", "evolved children")}</th>
               <td>
-                {seed.evolved_children.map((c) => (
-                  <a key={c} href={`./${c}`} className="mr-2"><code>{c}</code></a>
-                ))}
+                {seed.evolved_children.map((c) =>
+                  candidatePageExists(seed.run_id, c) ? (
+                    <a key={c} href={`./${c}`} className="mr-2"><code>{c}</code></a>
+                  ) : (
+                    <code key={c} className="mr-2">{c}</code>
+                  )
+                )}
               </td>
             </tr>
           )}
@@ -418,10 +434,10 @@ function SeedDetail(props: DetailProps) {
           <a href={seed.raw_path}>{t("raw `.md` 다운로드", "raw `.md` download")}</a>
         </li>
         <li>
-          <a href={`/petri-bundle/landing.html`}>{t("Petri bundle 허브", "Petri bundle hub")}</a>
+          <a href="/geode/self-improving/">{t("Self-improving 허브", "Self-improving hub")}</a>
         </li>
         <li>
-          <a href={`/petri-bundle/`}>{t("Eval 로그 viewer", "Eval log viewer")}</a>
+          <a href="/geode/self-improving/petri-bundle/">{t("Eval 로그 viewer", "Eval log viewer")}</a>
         </li>
       </ul>
     </>

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -8,7 +8,15 @@ export const metadata = { title: "Seed Generation Runs · GEODE Docs" };
 // Seeds live one level up under docs/self-improving/petri-bundle/seeds/ in the repo root.
 const REPO_ROOT = path.join(process.cwd(), "..");
 const SEEDS_DIR = path.join(REPO_ROOT, "docs", "self-improving", "petri-bundle", "seeds");
-const RAW_BUNDLE_URL = "/self-improving/petri-bundle/seeds/";
+const RAW_BUNDLE_URL = "/geode/self-improving/petri-bundle/seeds/";
+
+function candidateFileExists(runId: string, candidateId: string): boolean {
+  for (const dir of ["candidates", "candidates_evolved"]) {
+    if (fs.existsSync(path.join(SEEDS_DIR, runId, dir, `${candidateId}.md`))) return true;
+  }
+  return false;
+}
+
 
 type ListingRun = {
   run_id: string;
@@ -213,11 +221,21 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                     : undefined;
                   const evolved = evolvedByParent.get(sid) ?? [];
                   // next.config.ts has `trailingSlash: false` so links must NOT end in `/`.
-                  const detailHref = `/docs/petri/seeds/${run.run_id}/${sid}`;
+                  // Link only when the candidate .md exists in the bundle, in
+                  // parity with [candidate_id]/generateStaticParams. gen1 runs
+                  // list survivors whose files never shipped (bundle sync gap);
+                  // a forced link 404s on the deployed site.
+                  const detailHref = candidateFileExists(run.run_id, sid)
+                    ? `/geode/docs/petri/seeds/${run.run_id}/${sid}`
+                    : undefined;
                   return (
                     <tr key={sid}>
                       <td>
-                        <a href={detailHref}><code>{sid}</code></a>
+                        {detailHref ? (
+                          <a href={detailHref}><code>{sid}</code></a>
+                        ) : (
+                          <code>{sid}</code>
+                        )}
                       </td>
                       <td>{Math.round(elo)}</td>
                       <td>{pilotStatus}</td>
@@ -230,7 +248,10 @@ function RunDetailBlock({ detail, locale }: { detail: RunDetail; locale: "ko" | 
                         {evolved.length > 0 && (
                           <span className="ml-2 text-[var(--ink-3)] text-xs">
                             → {evolved.map((e) => {
-                              const eHref = `/docs/petri/seeds/${run.run_id}/${e}`;
+                              if (!candidateFileExists(run.run_id, e)) {
+                                return <code key={e} className="mr-1">{e}</code>;
+                              }
+                              const eHref = `/geode/docs/petri/seeds/${run.run_id}/${e}`;
                               return (
                                 <a key={e} href={eHref} className="mr-1"><code>{e}</code></a>
                               );


### PR DESCRIPTION
## Summary
- 순차 지시 항목 1+2 패스스루: GEODE.md Sub-Agent 격리 서술 정직화(#2157, lane 50·timeout 600s 실측 동반) + lychee fail:true 승격 및 사이트측 링크 부패 13건 수정(#2160, 로컬 lychee 0 Errors). 버전 무변.

## Verification
- [x] feature PR CI 그린 x2 / check_docs_canon·links pass / lychee --offline 0 Errors