### PR TITLE
design(portfolio): footer 하드코딩 색 토큰화 (사례 4 점검 종결)

### DIFF
--- a/site/src/components/geode/sections/footer.tsx
+++ b/site/src/components/geode/sections/footer.tsx
@@ -13,7 +13,7 @@ export function GeodeFooter() {
           <Image src="/geode/images/geode-idle.png" alt="Geodi" width={32} height={32} className="opacity-40" />
           <div>
             <div className="text-sm font-semibold text-white/50">GEODE</div>
-            <div className="text-xs text-[#9BB0CC]">An agentic OS, built by its own scaffold.</div>
+            <div className="text-xs text-[var(--ink-2)]">An agentic OS, built by its own scaffold.</div>
           </div>
         </div>
 
@@ -21,26 +21,26 @@ export function GeodeFooter() {
           <Link
             href="https://github.com/mangowhoiscloud/geode"
             target="_blank"
-            className="text-xs font-mono text-[#9BB0CC] hover:text-[#A0B4D4] transition-colors"
+            className="text-xs font-mono text-[var(--ink-2)] hover:text-[var(--ink)] transition-colors"
           >
             GitHub
           </Link>
           <Link
             href="https://rooftopsnow.tistory.com/category/Harness"
             target="_blank"
-            className="text-xs font-mono text-[#9BB0CC] hover:text-[#A0B4D4] transition-colors"
+            className="text-xs font-mono text-[var(--ink-2)] hover:text-[var(--ink)] transition-colors"
           >
             Dev Blog
           </Link>
           <Link
             href="/"
-            className="text-xs font-mono text-[#9BB0CC] hover:text-[#A0B4D4] transition-colors"
+            className="text-xs font-mono text-[var(--ink-2)] hover:text-[var(--ink)] transition-colors"
           >
             {locale === "en" ? "Portfolio" : "포트폴리오"}
           </Link>
         </div>
 
-        <div className="text-[10px] text-[#9BB0CC]/50 font-mono">
+        <div className="text-[10px] text-[var(--ink-3)] font-mono">
           © 2025-2026 Jihwan Ryu
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 순차 지시 항목 4(portfolio 점검) 종결: 읽기 전용 캐논 감사 결과 라이브 섹션은 클린(정체성 위반·stale 주장·vanity metric 0건, PR-PORTFOLIO-INTRO에서 기정리). 유일한 실발견인 footer 하드코딩 색 2종(#9BB0CC/#A0B4D4)을 Axolotl Rose 잉크 토큰으로 교체.
- 감사 에이전트의 "/geode prefix 죽은 링크 10건" 판정은 오탐으로 기각(basePath 컨벤션 정답, check_docs_links·lychee blocking 모두 통과 상태).

## Why
docs 전수 재생성 후 portfolio 표면의 캐논 정합 여부가 미점검 잔존 항목이었음.

## Changes
| File | Change |
|------|--------|
| `site/src/components/geode/sections/footer.tsx` | `#9BB0CC`/`#A0B4D4` 5곳 → `--ink-2`/`--ink`/`--ink-3` |

## Verification
- [x] site build 성공 / 잔존 하드코딩 0 (grep)
- [x] 감사 비-발견 확인: ML 어휘·4-layer·G1-G4·CircuitBreaker·vanity 0건