### PR TITLE
ci(lychee): linkedin.com 제외 — 999 상시 오탐

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -227,6 +227,7 @@ jobs:
             --accept 200,206,403,429
             --exclude 'petri-bundle'
             --exclude 'self-improving'
+            --exclude 'linkedin\.com'
             site/out/index.html
             site/out/docs.html
             site/out/about.html


### PR DESCRIPTION
## Summary
- blocking lychee가 LinkedIn profile 링크에서 999(봇 차단 전용 상태 코드)로 릴리스 #2165를 막음. linkedin.com을 체커에서 제외.

## Why
LinkedIn은 모든 자동화 요청에 999를 반환(업계 공지 오탐원). --accept에 999를 넣는 전역 완화 대신 도메인 스코프 제외 선택.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/pages.yml` | lychee args에 `--exclude 'linkedin\.com'` 추가 |

## Verification
- [x] 실패 런 27347765582 실측: Errors 2 = 전부 linkedin.com 999