### PR TITLE
fix(seedgen): bootstrap .env + auth in generate/resume entry (v0.99.182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.182] - 2026-06-12
+
+### Fixed
+- **Seed-generation entry now bootstraps .env + the auth profile store** — the thin CLI `audit-seeds generate` / `resume` never run `GeodeRuntime.create`, so the wiring `ProfileStore` started empty and the ranker's voter sub-agents resolved credentials through it, failing with `openai.api_key — unknown` and losing tournament quorum (observed on the frontier-2612 live run — pilot completed but ranker halted). The pilot's `inspect eval` subprocess reads `os.environ` directly so a hand-exported key masked the gap there, but the voter path needs the profile store hydrated. `run_audit_seeds` + `run_audit_seeds_resume` now call `_bootstrap_seed_generation_env` (`load_env_files` + idempotent `ensure_profile_store`, the same pattern as the /model picker hydration in v0.99.176). Guards: `tests/plugins/seed_generation/test_env_auth_bootstrap.py` (4).
+
 ## [0.99.181] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.181
+- **Version**: 0.99.182
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.181 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.182 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.181 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.182 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -422,6 +422,8 @@ def run_audit_seeds_resume(
     out = stdout if stdout is not None else sys.stdout
     err = stderr if stderr is not None else sys.stderr
 
+    _bootstrap_seed_generation_env()
+
     from core.observability.run_dir import run_dir_scope
     from core.paths import STATE_SEED_GENERATION_DIR
     from core.self_improving.loop.observe.run_transcript import RunTranscript, run_transcript_scope
@@ -613,6 +615,39 @@ def _load_priors_snapshot(*, err: IO[str]) -> Any:
     return snapshot
 
 
+def _bootstrap_seed_generation_env() -> None:
+    """Load .env + hydrate the auth profile store before the pipeline runs.
+
+    The thin CLI seed-generation entry never goes through ``GeodeRuntime.create``
+    / the serve wiring bootstrap, so two credential surfaces start empty:
+
+    1. ``.env`` API keys are not in ``os.environ`` — the pilot's ``inspect eval``
+       subprocess reads ``os.environ`` directly, so a key the operator exported
+       by hand works there, but the run is not self-sufficient.
+    2. The wiring ``ProfileStore`` is unhydrated — the ranker's voter sub-agents
+       resolve credentials through it, NOT through ``os.environ``, so an
+       ``api_key`` voter fails with ``openai.api_key — unknown`` and the
+       tournament loses quorum (the frontier-2612 ranker halt, 2026-06-12). An
+       exported key does NOT fix this path because the voter never reads
+       ``os.environ``.
+
+    ``load_env_files`` promotes ``.env`` keys to ``os.environ`` (the shared
+    C-3 loader) and ``ensure_profile_store`` hydrates the auth profiles from
+    ``~/.geode/auth.toml`` + env (idempotent — the same pattern as
+    ``core.cli.commands.model._ensure_profiles_hydrated`` for the /model
+    picker). Both surfaces are then populated for the whole pipeline.
+    """
+    import contextlib
+
+    from core.config.env_io import load_env_files
+
+    load_env_files()
+    with contextlib.suppress(Exception):
+        from core.wiring.container import ensure_profile_store
+
+        ensure_profile_store()
+
+
 def run_audit_seeds(
     *,
     target_dim: str | None = None,
@@ -643,6 +678,8 @@ def run_audit_seeds(
     """
     out = stdout if stdout is not None else sys.stdout
     err = stderr if stderr is not None else sys.stderr
+
+    _bootstrap_seed_generation_env()
 
     resolved_dim, baseline_snapshot = _resolve_target_dim(target_dim, err=err)
     if resolved_dim is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.181"
+version = "0.99.182"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/plugins/seed_generation/test_env_auth_bootstrap.py
+++ b/tests/plugins/seed_generation/test_env_auth_bootstrap.py
@@ -1,0 +1,39 @@
+"""Guard: seed-generation entry bootstraps .env + auth (v0.99.182).
+
+The thin CLI seed-generation entry never runs GeodeRuntime.create, so
+without an explicit bootstrap the ranker's voter sub-agents resolve
+credentials through an empty wiring ProfileStore and fail with
+``openai.api_key — unknown`` (tournament quorum loss). The pilot's
+inspect subprocess reads os.environ directly so an exported key masks the
+gap there — but the voter path needs the profile store hydrated.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from plugins.seed_generation import cli as seedgen_cli
+
+
+def test_bootstrap_helper_loads_env_and_hydrates_auth() -> None:
+    source = inspect.getsource(seedgen_cli._bootstrap_seed_generation_env)
+    assert "load_env_files(" in source
+    assert "ensure_profile_store(" in source
+
+
+def test_run_audit_seeds_calls_bootstrap() -> None:
+    source = inspect.getsource(seedgen_cli.run_audit_seeds)
+    assert "_bootstrap_seed_generation_env()" in source
+
+
+def test_run_audit_seeds_resume_calls_bootstrap() -> None:
+    source = inspect.getsource(seedgen_cli.run_audit_seeds_resume)
+    assert "_bootstrap_seed_generation_env()" in source
+
+
+def test_bootstrap_invokes_loaders(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr("core.config.env_io.load_env_files", lambda **_k: calls.append("env"))
+    monkeypatch.setattr("core.wiring.container.ensure_profile_store", lambda: calls.append("auth"))
+    seedgen_cli._bootstrap_seed_generation_env()
+    assert calls == ["env", "auth"]

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.177"
+version = "0.99.182"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.181"
+version = "0.99.177"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- The thin CLI `audit-seeds generate` / `resume` never run `GeodeRuntime.create`, so the wiring `ProfileStore` started empty and the ranker's voter sub-agents failed with `openai.api_key — unknown` (tournament quorum loss). Observed live on the frontier-2612 run: pilot completed (its `inspect eval` subprocess reads os.environ directly, masked by a hand-exported key) but the ranker halted.
- `run_audit_seeds` + `run_audit_seeds_resume` now call `_bootstrap_seed_generation_env` (`load_env_files` + idempotent `ensure_profile_store`) — same pattern as the /model picker hydration (v0.99.176).

## Why
A live frontier seed-gen run exposed that the seed-generation entry is the third thin-CLI surface (after the picker and the model-switch path) that needs explicit env/auth bootstrap because it bypasses the serve wiring. The pilot path is os.environ-direct so an exported key works; the voter path goes through the profile store and silently fails without hydration.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/cli.py` | `_bootstrap_seed_generation_env` helper; called at the top of `run_audit_seeds` and `run_audit_seeds_resume` |
| `tests/plugins/seed_generation/test_env_auth_bootstrap.py` | 4 guards (helper loads env + hydrates auth; both entries call it; invocation order) |

## Verification
- [x] ruff check + format clean (scripts/ included)
- [x] mypy clean
- [x] lint-imports 4 contracts kept
- [x] pytest test_env_auth_bootstrap (4): pass
- [ ] live resume re-run after merge (completes the frontier-2612 ranker)

## Reference
Live frontier-2612-bt run: pilot difficulty floor→midband measured, ranker halted on `vote-...openai.api_key — unknown`. Picker-hydration precedent: v0.99.176.