### PR TITLE
fix(runtime): web_search timing coherence + frontier bridge convergence (v0.99.185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ functional change.
 
 ---
 
+## [0.99.185] - 2026-06-12
+
+### Fixed
+- **Web_search timing coherence** (operator-observed: one search ok at 58.1s, its sibling killed at 119.9s by the 120s wall-clock deadline). With the session-model hint live, claude-fable-5 server-side search+synthesis runs 58-60s — colliding with the per-attempt client timeout of exactly 60s (`anthropic_web_search`), so healthy calls were cut at the wire (`APITimeoutError <- ReadTimeout`), re-run by the dispatch retry, and the 2×60s stack then hit the 120s tool deadline at the boundary. Three knobs now ordered and pinned: per-attempt client timeout 60→100s (`ANTHROPIC_WEB_SEARCH_TIMEOUT_S`), `general_web_search` deadline override 240s (covers timeout × (1+retry) + slack), coherence guard `test_web_search_deadline_covers_client_timeout_with_retry`.
+- **Gateway webhook bridge — last disposable-loop residue removed** (PR-GATEWAY-BRIDGE-FRONTIER, frontier convergence: hermes `gateway/run.py` cron ticker `run_coroutine_threadsafe` into the one long-lived loop; openclaw single-loop lane dispatch). The stdlib webhook server's thread-side bridge built a throwaway `asyncio.Runner` loop per request via `run_process_coroutine`; it now marshals the coroutine into the daemon's main serve loop (`_serve_loop` exposes its loop handle) and blocks on the future with the gateway time budget + 30s, rejecting honestly when the loop is not up yet.
+- **verify.py sync judge — thread-bridge removed**: the "sync caller inside a running loop" branch bridged via `ThreadPoolExecutor` + `asyncio.run` (a disposable loop per call; its comment claimed the fresh loop *protected* shared clients — exactly backwards pre-loop-affinity). Production only uses the async path; the sync wrapper now downgrades honestly to the rule-based fallback with a WARNING when called from inside a running loop, and keeps `asyncio.run` only for the true no-loop process edge. Guardrails: webhook bridge source pin, behavioral downgrade pin, `ThreadPoolExecutor(` source ban in verify.py, and the deadline-coherence pin (loop-pollution suite 21→25 tests).
+
 ## [0.99.184] - 2026-06-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.184
+- **Version**: 0.99.185
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 370 core + 72 plugins = 442
-- **Tests**: 8654 (+1 live)
+- **Tests**: 8660 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.184 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.185 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.184 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.185 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -50,6 +50,13 @@ _TOOL_DEADLINE_OVERRIDES_S: dict[str, float] = {
     "petri_audit": 900.0,  # inspect_ai audit subprocess (own 600s wall clock)
     "eval_dspy_optimize": 900.0,  # optimizer loop
     "computer": 600.0,  # multi-step UI automation (_build_computer_use_handler)
+    # web_search: must cover per-attempt client timeout (100s,
+    # _capability_impls.ANTHROPIC_WEB_SEARCH_TIMEOUT_S) × the dispatch
+    # retry (1 original + 1 same-adapter retry) + backoff. The 120s
+    # default collided with exactly that stack — the operator watched a
+    # healthy retry get killed at 119.9s (2026-06-12 02:0x). Coherence
+    # pinned by test_web_search_deadline_covers_client_timeout_with_retry.
+    "general_web_search": 240.0,
 }
 
 

--- a/core/agent/verify.py
+++ b/core/agent/verify.py
@@ -461,13 +461,22 @@ def _verify_llm_judge(result: AgenticResult, *, loop: Any | None = None) -> Veri
 
     PR-CL-A6 (2026-05-23) — sync wrapper for callers that aren't inside an
     asyncio event loop (CLI smoke tests, pure-sync verify dispatch). The
-    async caller path (``_run_turn_verify_async`` from
-    ``finalize_and_return_async``) uses :func:`_verify_llm_judge_async`
-    directly to avoid the cross-loop thread-pool hop (Codex MCP HIGH #2
-    fix). When invoked from a sync context with no running event loop,
-    we use ``asyncio.run`` with the same :data:`_JUDGE_CALL_TIMEOUT_S`
-    timeout. When invoked from inside a running loop, the only safe sync
-    option is a thread pool — we keep it but with the explicit timeout.
+    production path (``_run_turn_verify_async`` from
+    ``finalize_and_return_async``) awaits :func:`_verify_llm_judge_async`
+    directly.
+
+    PR-GATEWAY-BRIDGE-FRONTIER (2026-06-12) — the previous "sync caller
+    inside a running loop" branch bridged via ThreadPoolExecutor +
+    ``asyncio.run`` (a throwaway loop per call — the loop-pollution
+    residue class; its comment even claimed the new loop *protected*
+    clients, which was exactly backwards pre-loop-affinity). Frontier
+    convergence (hermes ``model_tools._run_async``: never a disposable
+    loop at runtime) and GEODE's own production reality (every running-
+    loop caller has the async path available) make that branch dead
+    weight: a sync call from inside a running loop is a misuse and now
+    downgrades honestly to the rule-based fallback with a WARNING,
+    instead of hiding the misuse behind a thread bridge. The no-loop
+    case keeps ``asyncio.run`` — that IS the process-edge contract.
 
     Failures NEVER raise — observability mustn't break the run it observes.
     """
@@ -479,23 +488,14 @@ def _verify_llm_judge(result: AgenticResult, *, loop: Any | None = None) -> Veri
 
         try:
             asyncio.get_running_loop()
-            running = True
         except RuntimeError:
-            running = False
-        if running:
-            # Sync caller inside an active loop is a misuse — schedule the
-            # async path on a worker thread. ``asyncio.run`` inside that
-            # thread builds its own loop so adapter clients are not shared
-            # across loops. ``asyncio.wait_for`` inside ``_verify_llm_judge_async``
-            # bounds the actual LLM call; the thread join here trusts that.
-            import concurrent.futures
-
-            def _run_in_thread() -> VerifyResult:
-                return asyncio.run(_verify_llm_judge_async(result, loop=loop))
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                return pool.submit(_run_in_thread).result(timeout=_JUDGE_CALL_TIMEOUT_S + 5.0)
-        return asyncio.run(_verify_llm_judge_async(result, loop=loop))
+            return asyncio.run(_verify_llm_judge_async(result, loop=loop))
+        log.warning(
+            "LLM judge: sync verify_turn called from inside a running event "
+            "loop — use verify_turn_async; downgrading to rule_based "
+            "(PR-GATEWAY-BRIDGE-FRONTIER)"
+        )
+        return _llm_judge_fallback(result)
     except Exception:
         log.warning("LLM judge call failed; falling back to rule_based", exc_info=True)
         return _llm_judge_fallback(result)

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -14,7 +14,6 @@ from typing import Any
 
 import typer
 
-from core.async_runtime import run_process_coroutine
 from core.cli.session_state import _scheduler_service_ctx, _set_readiness
 from core.ui.console import console
 from core.wiring.startup import check_readiness
@@ -193,9 +192,35 @@ def serve(
 
     gateway.set_async_processor(_gateway_processor)
 
+    # PR-GATEWAY-BRIDGE-FRONTIER (2026-06-12) — set by ``_serve_loop`` on
+    # startup so thread-side bridges can marshal coroutines into the
+    # long-lived main loop instead of spawning a throwaway loop per call.
+    _main_loop: asyncio.AbstractEventLoop | None = None
+
     def _gateway_processor_sync(content: str, metadata: dict[str, Any]) -> str:
-        """Process-edge bridge for the stdlib HTTP webhook server."""
-        return run_process_coroutine(_gateway_processor(content, metadata))
+        """Thread → main-loop bridge for the stdlib HTTP webhook server.
+
+        PR-GATEWAY-BRIDGE-FRONTIER (2026-06-12) — frontier convergence
+        (hermes ``gateway/run.py`` cron ticker, openclaw single-loop lane
+        dispatch): a worker thread submits the coroutine to the daemon's
+        ONE long-lived serve loop via ``run_coroutine_threadsafe`` and
+        blocks on the future. The previous ``run_process_coroutine`` shape
+        built a throwaway ``asyncio.Runner`` loop per webhook request —
+        the same loop-per-call residue PR-LOOP-POLLUTION-FIX removed from
+        the tool path (clients are loop-affine now, so it was safe but
+        still one disposable loop per request).
+        """
+        loop = _main_loop
+        if loop is None or loop.is_closed():
+            log.warning("Webhook received before the serve loop is up — rejecting")
+            return "Error: serve loop not running yet; retry shortly"
+        future = asyncio.run_coroutine_threadsafe(_gateway_processor(content, metadata), loop)
+        try:
+            return future.result(timeout=float(_gw_time_budget) + 30.0)
+        except TimeoutError:
+            future.cancel()
+            log.error("Webhook gateway turn exceeded %.0fs — cancelled", _gw_time_budget + 30.0)
+            return "Error: gateway turn timed out"
 
     # L4 Gateway Hooks: optional webhook endpoint
     _webhook_server = None
@@ -251,6 +276,10 @@ def serve(
         survive past the drain call.
         """
         from core.cli.interactive_loop import _drain_scheduler_queue
+
+        # Expose this loop to thread-side bridges (webhook handler).
+        nonlocal _main_loop
+        _main_loop = asyncio.get_running_loop()
 
         while not stop:
             await _drain_scheduler_queue(

--- a/core/llm/adapters/_capability_impls.py
+++ b/core/llm/adapters/_capability_impls.py
@@ -29,6 +29,19 @@ log = logging.getLogger(__name__)
 # Anthropic — used by AnthropicPaygAdapter + AnthropicOAuthAdapter
 # ---------------------------------------------------------------------------
 
+# Per-attempt client timeout for the server-side web_search call.
+# PR-GATEWAY-BRIDGE-FRONTIER (2026-06-12) — was 60.0, which collided with
+# observed server-side durations once the session-model hint landed:
+# claude-fable-5 search+synthesis runs 58-60s (serve.log 2026-06-12 02:05 —
+# successes at 58.1s/59.8s, ReadTimeout cuts at exactly 60.0s), so healthy
+# calls were killed at the wire and re-run by the dispatch retry, doubling
+# wall time and then colliding with the tool deadline (119.9s ≈ 2×60s).
+# 100s gives fable-5 headroom; the tool deadline override
+# (executor._TOOL_DEADLINE_OVERRIDES_S) covers attempt + retry + backoff —
+# the coherence is pinned by
+# test_web_search_deadline_covers_client_timeout_with_retry.
+ANTHROPIC_WEB_SEARCH_TIMEOUT_S = 100.0
+
 
 async def anthropic_web_search(
     client: Any, *, query: str, max_results: int, model: str, adapter_name: str
@@ -48,7 +61,7 @@ async def anthropic_web_search(
                 ),
             }
         ],
-        timeout=60.0,
+        timeout=ANTHROPIC_WEB_SEARCH_TIMEOUT_S,
     )
     text_parts: list[str] = []
     source_urls: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.184"
+version = "0.99.185"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/llm/test_loop_pollution_guardrails.py
+++ b/tests/core/llm/test_loop_pollution_guardrails.py
@@ -326,7 +326,7 @@ def test_deadline_overrides_cover_long_running_tools() -> None:
         _tool_deadline_s,
     )
 
-    assert _tool_deadline_s("general_web_search") == _TOOL_DEADLINE_DEFAULT_S
+    assert _tool_deadline_s("glob_files") == _TOOL_DEADLINE_DEFAULT_S
     assert _TOOL_DEADLINE_DEFAULT_S >= 60.0, (
         "Anthropic server-side web_search legitimately takes 25-50s — a "
         "tighter default would kill healthy calls"
@@ -456,3 +456,77 @@ def test_ipc_client_handler_catches_connection_reset() -> None:
     )[0]
     assert "ConnectionResetError" in handler_src
     assert "BrokenPipeError" in handler_src
+
+
+# ---------------------------------------------------------------------------
+# PR-GATEWAY-BRIDGE-FRONTIER — remaining disposable-loop residue removed
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_bridge_marshals_into_main_loop_not_a_throwaway_loop() -> None:
+    """Source pin — frontier convergence (hermes cron-ticker
+    ``run_coroutine_threadsafe`` into the one long-lived gateway loop;
+    openclaw single-loop lane dispatch): the stdlib webhook server's
+    thread-side bridge must submit to the main serve loop, never build a
+    disposable ``asyncio.Runner`` loop per request."""
+    src = (REPO_ROOT / "core" / "cli" / "typer_serve.py").read_text(encoding="utf-8")
+    assert "run_coroutine_threadsafe" in src
+    assert "run_process_coroutine(_gateway_processor" not in src, (
+        "webhook bridge reverted to a throwaway event loop per request"
+    )
+
+
+def test_sync_llm_judge_inside_running_loop_downgrades_to_rule_based(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behavioral pin — the sync judge wrapper called from INSIDE a running
+    loop must downgrade to the rule-based fallback (effective_mode marks
+    the downgrade) instead of bridging through ThreadPoolExecutor +
+    ``asyncio.run`` (a disposable loop per call, removed
+    PR-GATEWAY-BRIDGE-FRONTIER)."""
+    from core.agent.loop.agent_loop import AgenticResult
+    from core.agent.verify import VerifyMode, _verify_llm_judge
+
+    monkeypatch.setenv("GEODE_VERIFY_MODE", "llm_judge")
+    result = AgenticResult(text="OK", tool_calls=[], rounds=1, termination_reason="natural")
+
+    async def _call_from_inside_loop() -> Any:
+        return _verify_llm_judge(result, loop=object())
+
+    verdict = asyncio.run(_call_from_inside_loop())
+    assert verdict.mode is VerifyMode.LLM_JUDGE
+    assert verdict.effective_mode is VerifyMode.RULE_BASED, (
+        "sync judge inside a running loop must downgrade, not thread-bridge"
+    )
+
+
+def test_verify_judge_has_no_thread_pool_loop_bridge() -> None:
+    """Source pin — no ThreadPoolExecutor + asyncio.run bridge in the sync
+    judge wrapper (the comment on the old branch claimed per-call loops
+    protected shared clients — exactly backwards pre-loop-affinity)."""
+    src = (REPO_ROOT / "core" / "agent" / "verify.py").read_text(encoding="utf-8")
+    # Match the executable pattern, not the docstring documenting its removal.
+    assert "ThreadPoolExecutor(" not in src
+    assert "import concurrent.futures" not in src
+
+
+def test_web_search_deadline_covers_client_timeout_with_retry() -> None:
+    """Coherence pin — the operator watched a healthy web_search retry get
+    killed at 119.9s (2026-06-12 02:0x): per-attempt client timeout 60s ×
+    (1 try + 1 dispatch retry) stacked exactly onto the 120s harness
+    deadline. The three knobs must stay ordered:
+
+        client timeout × (retries + 1) + slack <= tool deadline
+    """
+    from core.agent.tool_executor.executor import _tool_deadline_s
+    from core.llm.adapters._capability_impls import ANTHROPIC_WEB_SEARCH_TIMEOUT_S
+    from core.llm.adapters.dispatch import _CONNECTION_TRANSIENT_RETRIES
+
+    attempts = _CONNECTION_TRANSIENT_RETRIES + 1
+    slack_s = 10.0
+    assert _tool_deadline_s("general_web_search") >= (
+        ANTHROPIC_WEB_SEARCH_TIMEOUT_S * attempts + slack_s
+    ), (
+        "general_web_search: deadline no longer covers client-timeout x retry "
+        "— healthy retries will be killed at the boundary again"
+    )


### PR DESCRIPTION
## Summary
- Web_search timing coherence: per-attempt client timeout 60→100s (`ANTHROPIC_WEB_SEARCH_TIMEOUT_S`), `general_web_search` deadline override 240s, and the inequality `client timeout × (1+retry) + slack ≤ deadline` pinned as a guardrail — the operator watched a healthy retry get killed at 119.9s by the exact 2×60s/120s boundary collision.
- Frontier convergence (workspace survey: hermes single gateway loop + `run_coroutine_threadsafe` cron bridge, persistent-loop-only sync bridges; openclaw single Node loop + lane dispatch): webhook thread bridge now marshals into the daemon's long-lived serve loop instead of a throwaway `asyncio.Runner` per request; verify.py's `ThreadPoolExecutor`+`asyncio.run` judge bridge removed (in-loop sync misuse downgrades honestly to rule_based).
- Loop-pollution guardrail suite 21→25 tests (webhook source pin, judge downgrade behavioral pin, ThreadPoolExecutor source ban, deadline coherence pin).

## Why
Live session (v0.99.184, fable-5): 3 parallel web_search — `ok 58.1s` / `exceeded its 120s wall-clock deadline (119.9s)`. The session-model hint (v0.99.183) moved searches from opus (25-50s) to fable-5 (58-60s), landing exactly on the 60s client timeout; the cut + same-adapter retry stacked to 120s and the harness deadline killed the healthy retry at the boundary. Separately, the workspace frontier survey confirmed GEODE's two remaining disposable-loop residues (webhook bridge, verify thread bridge) diverge from the hermes/openclaw pattern (never a throwaway loop at runtime).

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/_capability_impls.py` | `ANTHROPIC_WEB_SEARCH_TIMEOUT_S = 100.0` (was inline 60.0) with incident rationale |
| `core/agent/tool_executor/executor.py` | `general_web_search: 240.0` deadline override (covers timeout × attempts + slack) |
| `core/cli/typer_serve.py` | webhook bridge → `run_coroutine_threadsafe` into `_serve_loop`'s loop handle; honest rejection pre-startup; gateway-budget+30s future timeout; dead `run_process_coroutine` import dropped |
| `core/agent/verify.py` | sync judge in-loop branch → rule_based downgrade + WARNING; no-loop branch keeps `asyncio.run` (true process edge) |
| `tests/core/llm/test_loop_pollution_guardrails.py` | +4 guardrails (25 total): webhook bridge pin, judge downgrade pin, `ThreadPoolExecutor(` ban, deadline-coherence pin |

## Verification
- [x] ruff check + format clean (full scope)
- [x] mypy: only the 3 pre-existing `codex_overrides.py` errors visible solely with the audit extra (CI typecheck env is sync-only)
- [x] lint-imports: 4 contracts kept
- [x] pytest full suite: pass (1 known xdist flake `test_ranker_semaphore::test_default_is_three`, passes standalone); collection 8660 (+1 live)
- [x] CLI smoke: `geode version` → v0.99.185

## Reference
serve.log 2026-06-12 02:05 (58.1s/59.8s successes, 60.0s ReadTimeout cuts, 119.9s deadline kill); workspace frontier survey — hermes `gateway/run.py:16105` (`run_coroutine_threadsafe` cron bridge), `model_tools.py:45-173` (persistent per-thread loops, never disposable), openclaw `command-queue.ts` single-loop lane dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)