### PR TITLE
chore(slop): purge dead Game-IP-era verification residue — code knobs + operator doc claims (v0.99.187)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,28 +130,12 @@ Per-call diagnostics for Petri audits (v0.92+).
 - `diagnostics.py` — `CallDiagnostic` dataclass. cache_read/write, cost
   breakdown, latency, audit_mode flag.
 
-### `core/automation/`
-
-Sidecar between agent and runtime. Drift detection, model promotion, expert
-panel voting.
-
-- `model_registry.py:36` — `PromotionStage` (development, staging, production).
-- `feedback_loop.py` — phase FSM.
-- `drift.py` — correlation + severity analysis.
-- `expert_panel.py` — junior / senior / principal voting tiers.
-- `outcome_tracking.py` — long-tail outcome recording.
-
 ### `core/skills/`
 
 Runtime SkillRegistry. Distinct from scaffold `.claude/skills/`.
 
 - `skill_registry.py` — 5-tier discovery (bundled → user → org → project → session).
 - `reports/` — report templates are not bundled in GEODE core.
-
-### `core/verification/`
-
-Schema, Range, Grounding, Coherence guardrails (G1-G4). Specialized bias and
-calibration checks belong in external packages.
 
 ### `core/scheduler/`, `core/orchestration/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.187] - 2026-06-12
+
+### Removed
+- **Dead Game-IP-era verification residue purged from code + operator docs** (PR-SLOP-DEAD-VERIFICATION-REFS, follow-up to the v0.99.149/v0.99.157 pipeline removal). Two zero-caller code artifacts deleted: `Settings.temperature_verification` (its consumer, the cross-LLM agreement rescoring path, left with the pipeline — the PR-TEMP ratchet site list already excluded it) and `MonoLakeOrganizationMemory.get_common_rubric` (14-axis / S-D tier IP rubric; the OrganizationMemoryPort that required it was folded earlier). Operator-facing docs no longer claim the deleted machinery as current capability: GEODE.md drops the Expert Panel / "Confidence < 0.7 loopback" / G3 runtime rules and the confidence-gate defaults (the failure-mode table now documents the real `convergence_detected` stuck-loop guard), README/README.ko replace "Core verification (G1-G4 + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk)" with the implemented turn-verify layer (`core/agent/verify.py`, rule-based + opt-in LLM-judge → replan on FAIL) and an honest ⚠️ WIP label on the cross-provider ranking panel, AGENTS.md drops the nonexistent `core/verification/` + `core/automation/` sections, and setup docs relabel `OPENAI_API_KEY` (was "Cross-LLM").
+
 ## [0.99.186] - 2026-06-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.186
+- **Version**: 0.99.187
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/GEODE.md
+++ b/GEODE.md
@@ -17,7 +17,7 @@ analysis, automation, scheduling, and multi-step tool work.
 
 1. **Evidence-Based**: All judgments are grounded in data evidence. Conclusions are backed by numbers, not intuition.
 2. **Bias-Aware**: Structurally detects and corrects confirmation bias, recency bias, and anchoring bias.
-3. **Multi-Perspective**: For analysis and scoring, cross-checks via the Expert Panel rather than finalizing on a single model's judgment.
+3. **Multi-Perspective**: For high-stakes verdicts, seeks a second opinion (sub-agent delegation or cross-provider review) rather than finalizing on a single model's judgment.
 4. **Graceful Degradation**: Guarantees fallback paths even during API failures or model errors.
 5. **Reproducibility**: Maintains reproducibility through prompt hashes, seeds, and snapshots.
 
@@ -26,9 +26,7 @@ analysis, automation, scheduling, and multi-step tool work.
 > Runtime guardrails — what GEODE the *agent* refuses to do at execution time.
 > For development-time guardrails (what the *engineer* must not do when building GEODE), see `CLAUDE.md` → `### CANNOT`.
 
-- Never makes judgments without evidence (G3 Grounding violation)
-- For analysis or scoring verdicts, never finalizes on a single LLM output — cross-validate via the Expert Panel
-- Never delivers results with Confidence < 0.7 to the user (loopback)
+- Never makes judgments without evidence
 - Never calls `general_web_search` or `read_web_page` 3+ times directly in a single turn — delegate to sub-agents via `delegate_task` instead (context explosion prevention)
 
 ## Architecture
@@ -98,8 +96,8 @@ Primary / secondary / node defaults come from `core/config/routing.toml` `[model
 | **Anthropic** | `claude-opus-4-8` | 1M | Primary (Pipeline + Agentic + Router) |
 | Anthropic | `claude-sonnet-4-6` | 1M | Secondary (opt-in fallback target) |
 | Anthropic | `claude-haiku-4-5-20251001` | 200K | Budget / reflection node |
-| **OpenAI** | `gpt-5.5` | 1.05M | Cross-LLM primary + Codex (OAuth-only) |
-| OpenAI | `gpt-5.4` | 1.05M | Cross-LLM secondary |
+| **OpenAI** | `gpt-5.5` | 1.05M | OpenAI primary + Codex (OAuth-only) |
+| OpenAI | `gpt-5.4` | 1.05M | OpenAI secondary |
 | **ZhipuAI** | `glm-5.1` | 203K | GLM primary |
 | ZhipuAI | `glm-4.7-flash` | 203K | GLM budget (learning extract) |
 
@@ -123,13 +121,11 @@ Primary / secondary / node defaults come from `core/config/routing.toml` `[model
 |----------|--------|
 | All LLM providers down | Degraded Response (is_degraded=True + defaults) |
 | MCP server spawn failure | Continue without that MCP (Graceful Degradation) |
-| Confidence below threshold | Loopback (max 5 iter), then escalate to user |
 | Context window exhausted | 3-phase compression, then terminate with `context_exhausted` |
+| Stuck loop (3+ identical tool errors) | Terminate with `convergence_detected` |
 
 ## Defaults
 
-- Confidence threshold: 0.7
-- Max pipeline iterations: 5
 - Circuit breaker: 5 failures → 60s open
 - Session TTL: 4 hours
 - SubAgent max concurrent: 8 (Lane global)

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.186 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.187 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 
@@ -352,7 +352,7 @@ geode update                  # 소스 체크아웃
 | **MCP 서버 (`geode-mcp`)** | GEODE 자체를 MCP 서버(stdio)로 노출: `run_agent`, `self_improving_status`, `self_improving_propose`/`apply`(2-step 확인 게이트), `query_memory`, `get_health`. repo의 `.mcp.json`으로 Claude Code에 자동 등록 |
 | **장시간 데몬** | `geode serve` 가 백그라운드로 상주. Slack / Discord / Telegram 폴러 + 스케줄러 tick + thin CLI 용 IPC |
 | **서브에이전트** | 부모 권한 완전 상속, depth/cost 가드, Lane 격리 |
-| **코어 검증** | Guardrails G1-G4 (structural) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal). 전문 편향 / 캘리브레이션 계층은 외부 패키지가 추가 |
+| **턴 검증** | Rule-based 턴 단위 체크 (empty turn, tool error, plan-step 불일치) + opt-in LLM-judge 채점 (`core/agent/verify.py`); verify FAIL 시 리플래닝 트리거 |
 
 
 ### GEODE를 MCP 서버로 쓰기
@@ -424,7 +424,7 @@ frontier 하네스 (Claude Code, Codex CLI, OpenClaw) 옆에서 GEODE 가 어디
 | 메모리 tier | ✅ CLAUDE.md 머지 + auto memory (`~/.claude/projects/*/memory`) | ✅ 계층적 AGENTS.md (전역 `~/.codex/` + repo + nested dirs) | ⚠️ 세션 범위 | ✅✅ **multi-tier** (SOUL · User · Org · Project · Session) |
 | 디스크 영구 plan | ✅ TodoWrite 영속화 | ⚠️ resumable 스레드 경유 | ✅ task registry | ✅ `.geode/plans.json` |
 | 권한 / 샌드박스 계층 | ✅ default / auto / bypass 모드 + Confirmation UI | ✅ `sandbox_mode` (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain, 다수 감사 표면 | ✅ Policy Chain + 도구 게이트 |
-| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **코어 검증** (G1-G4 + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk, 편향/캘리브레이션용 플러그인 확장점) |
+| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅ **턴 검증** (rule-based + opt-in LLM-judge, `core/agent/verify.py`) → FAIL 시 리플랜, self-improving 루프의 safety-axis fitness 게이트 별도 |
 | Hook 이벤트 | ✅ PreToolUse / PostToolUse / UserPromptSubmit / Stop / SubagentStop / PreCompact / SessionStart / SessionEnd / Notification | ⚠️ SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop | ✅ 여러 이벤트 타입 · 다수 번들 핸들러 | ✅✅ 넓은 이벤트 표면 (`docs/architecture/hook-system.md`) |
 
 </details>
@@ -439,7 +439,7 @@ frontier 하네스 (Claude Code, Codex CLI, OpenClaw) 옆에서 GEODE 가 어디
 | **교체 가능한 파이프라인 DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — DAG 추상화 아님) | ⚠️ 외부 패키지 책임. GEODE core 는 더 이상 파이프라인 포트를 제공하지 않음 |
 | 트레이스 / 리플레이 / Run Log | ✅ `tengu_*` 텔레메트리 + `/insights` HTML | ⚠️ `/status` + `/debug-config` 만 | ✅ ACP 세션 lineage + Task Registry | ✅ 자체 RunLog + Petri eval 통합 |
 | Self-improving 안전성 loop | ❌ | ❌ | ❌ | ✅✅ outer loop: scaffold 변이 + 적대적 안전성 audit + (1+1) promote/revert |
-| Cross-LLM 검증 | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 평가자 간 일치도 게이트 |
+| 크로스 프로바이더 리뷰 | ❌ | ❌ | ❌ | ⚠️ self-improving 루프의 멀티-voter 크로스 프로바이더 랭킹 패널 (≥2 providers, `plugins/seed_generation/agents/ranker.py`); 일치도 캘리브레이션은 WIP |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.186 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.187 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 
@@ -353,7 +353,7 @@ geode update                  # source checkout
 | **MCP server (`geode-mcp`)** | Exposes GEODE itself as an MCP server (stdio): `run_agent`, `self_improving_status`, `self_improving_propose`/`apply` (2-step confirm gate), `query_memory`, `get_health`. Registered for Claude Code via the repo-shipped `.mcp.json` |
 | **Long-running daemon** | `geode serve` runs as background daemon. Slack / Discord / Telegram pollers + scheduler tick + IPC for the thin CLI |
 | **Sub-agents** | Full inheritance of parent capability, depth/cost guards, isolation by Lane |
-| **Core verification** | Guardrails G1-G4 (structural) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal). External packages can add specialized bias / calibration layers |
+| **Turn verification** | Rule-based per-turn checks (empty turn, tool errors, plan-step mismatch) + opt-in LLM-judge scoring (`core/agent/verify.py`); a verify FAIL triggers replanning |
 
 
 ### Using GEODE as an MCP server
@@ -425,7 +425,7 @@ A qualitative read on where GEODE sits next to the frontier harnesses (Claude Co
 | Memory tiers | ✅ CLAUDE.md merge + auto memory (`~/.claude/projects/*/memory`) | ✅ hierarchical AGENTS.md (global `~/.codex/` + repo + nested dirs) | ⚠️ session-scoped | ✅✅ **multi-tier** (SOUL · User · Org · Project · Session) |
 | Disk-persistent plans | ✅ TodoWrite persistence | ⚠️ via resumable threads | ✅ task registry | ✅ `.geode/plans.json` |
 | Permission / sandbox layers | ✅ default / auto / bypass modes + Confirmation UI | ✅ `sandbox_mode` (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain across many audit surfaces | ✅ Policy Chain + tool gates |
-| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **core verification** (G1-G4 + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk, plugin extension points for bias/calibration) |
+| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅ **turn verify** (rule-based + opt-in LLM-judge, `core/agent/verify.py`) → replan on FAIL, plus safety-axis fitness gate in the self-improving loop |
 | Hook events | ✅ PreToolUse / PostToolUse / UserPromptSubmit / Stop / SubagentStop / PreCompact / SessionStart / SessionEnd / Notification | ⚠️ SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop | ✅ several event types · many bundled handlers | ✅✅ broad event surface (`docs/architecture/hook-system.md`) |
 
 </details>
@@ -440,7 +440,7 @@ A qualitative read on where GEODE sits next to the frontier harnesses (Claude Co
 | **Swappable pipeline DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — not a DAG abstraction) | ⚠️ external package responsibility; GEODE core no longer ships a pipeline port |
 | Trace / replay / Run Log | ✅ `tengu_*` telemetry + `/insights` HTML | ⚠️ `/status` + `/debug-config` only | ✅ ACP session lineage + Task Registry | ✅ Native RunLog + Petri eval integration |
 | Self-improving safety loop | ❌ | ❌ | ❌ | ✅✅ outer loop: scaffold mutation + adversarial safety audit + (1+1) promote/revert |
-| Cross-LLM verification | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 inter-rater agreement gate |
+| Cross-provider review | ❌ | ❌ | ❌ | ⚠️ multi-voter cross-provider ranking panel (≥2 providers, `plugins/seed_generation/agents/ranker.py`) in the self-improving loop; agreement calibration is WIP |
 
 </details>
 

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -238,22 +238,6 @@ class Settings(BaseSettings):
             "confidence call. Previously hardcoded to 0.2."
         ),
     )
-    temperature_verification: float = Field(
-        default=0.0,
-        ge=0.0,
-        le=2.0,
-        validation_alias=AliasChoices(
-            "temperature_verification",
-            "GEODE_TEMPERATURE_VERIFICATION",
-        ),
-        description=(
-            "Sampling temperature for cross-LLM agreement rescoring. "
-            "Defaults to 0.0 because consensus needs determinism — "
-            "stochastic rescoring would make the G3 agreement coefficient "
-            "noisy. Operators may raise it if the secondary model rejects "
-            "0.0 sampling. Previously hardcoded to 0.1."
-        ),
-    )
     temperature_commentary: float = Field(
         default=1.0,
         ge=0.0,

--- a/core/memory/organization.py
+++ b/core/memory/organization.py
@@ -27,7 +27,6 @@ class MonoLakeOrganizationMemory:
     Usage:
         org = MonoLakeOrganizationMemory()
         ctx = org.get_subject_context("example")
-        rubric = org.get_common_rubric()
     """
 
     def __init__(
@@ -64,21 +63,6 @@ class MonoLakeOrganizationMemory:
         Empty dict if the subject is not found.
         """
         return self._cache.get(subject.lower(), {})
-
-    def get_common_rubric(self) -> dict[str, Any]:
-        """Get organization-wide default rubric configuration."""
-        return {
-            "axes_count": 14,
-            "scale": "1-5",
-            "confidence_threshold": 0.7,
-            "tier_mapping": {
-                "S": {"min_score": 80},
-                "A": {"min_score": 65},
-                "B": {"min_score": 50},
-                "C": {"min_score": 35},
-                "D": {"min_score": 0},
-            },
-        }
 
     def get_soul(self) -> str:
         """Load GEODE.md — agent identity and mission statement.

--- a/docs/setup.ko.md
+++ b/docs/setup.ko.md
@@ -270,7 +270,7 @@ geode serve [-p 3.0]                   # Headless daemon
 |------|--------|------|
 | **LLM** | | |
 | `ANTHROPIC_API_KEY` | | Claude API key |
-| `OPENAI_API_KEY` | | GPT API key (Cross-LLM) |
+| `OPENAI_API_KEY` | | GPT API key (OpenAI adapter) |
 | `ZAI_API_KEY` | | ZhipuAI GLM key |
 | `GEODE_MODEL` | `claude-opus-4-6` | 기본 LLM 모델 |
 | `GEODE_ENSEMBLE_MODE` | `single` | 앙상블 모드 (`single` / `cross`) |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -279,7 +279,7 @@ geode serve [-p 3.0]                   # Headless daemon
 |----------|---------|-------------|
 | **LLM** | | |
 | `ANTHROPIC_API_KEY` | | Claude API key |
-| `OPENAI_API_KEY` | | GPT API key (Cross-LLM) |
+| `OPENAI_API_KEY` | | GPT API key (OpenAI adapter) |
 | `ZAI_API_KEY` | | ZhipuAI GLM key |
 | `GEODE_MODEL` | `claude-opus-4-8` | Model override (env layer — outranks config files; see Model resolution) |
 | `GEODE_ENSEMBLE_MODE` | `single` | Ensemble mode (`single` / `cross`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.186"
+version = "0.99.187"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/config/test_temperature_config_invariants.py
+++ b/tests/core/config/test_temperature_config_invariants.py
@@ -5,6 +5,10 @@ commentary 0.4 / self-improving mutation 0.3 / progressive compression 0.0)
 were lifted into ``Settings.temperature_*`` knobs so operators can tune each
 call path via ``~/.geode/config.toml`` or env vars.
 
+``temperature_verification`` was retired in v0.99.187: its consumer (the
+cross-LLM agreement rescoring path) left with the Game-IP pipeline in
+v0.99.149, leaving the knob with zero call sites.
+
 These tests ratchet the migration so future edits cannot silently
 re-introduce a literal at the same site (Karpathy P4 ratchet).
 """
@@ -30,7 +34,6 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
     [
         ("temperature_agent_loop", 1.0),
         ("temperature_reflection", 1.0),
-        ("temperature_verification", 0.0),
         ("temperature_commentary", 1.0),
         ("temperature_self_improving_mutation", 1.0),
     ],
@@ -38,11 +41,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 def test_temperature_setting_default(attr: str, expected_default: float) -> None:
     """Each temperature knob must exist on ``Settings`` with the expected
     frontier-aligned default. The defaults encode the design decision:
-    most paths default to 1.0 (provider default — Anthropic/OpenAI/Gemini
-    all converge on 1.0); verification and compression default to 0.0
-    because their downstream consumers (cross-LLM agreement coefficient +
-    reproducible summaries) are functional invariants where stochastic
-    output is meaningless.
+    these paths default to 1.0 (provider default — Anthropic/OpenAI/Gemini
+    all converge on 1.0).
     """
     assert hasattr(settings, attr), f"Settings.{attr} missing"
     value = getattr(settings, attr)
@@ -64,7 +64,6 @@ def test_temperature_setting_range_validation() -> None:
     for attr in (
         "temperature_agent_loop",
         "temperature_reflection",
-        "temperature_verification",
         "temperature_commentary",
         "temperature_self_improving_mutation",
     ):

--- a/tests/core/memory/test_organization_memory.py
+++ b/tests/core/memory/test_organization_memory.py
@@ -26,11 +26,6 @@ class TestMonoLakeOrganizationMemory:
         ctx = org.get_subject_context("Unknown Subject")
         assert ctx == {}
 
-    def test_get_common_rubric(self):
-        org = MonoLakeOrganizationMemory()
-        rubric = org.get_common_rubric()
-        assert rubric["axes_count"] == 14
-
     def test_save_analysis_result(self):
         org = MonoLakeOrganizationMemory()
         result = {"tier": "S", "score": 82.2}

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.186"
+version = "0.99.187"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Operator-initiated honesty pass before the public-benchmark report: every doc surface that still claims the v0.99.149-removed Game-IP verification stack (G1-G4, Cross-LLM Krippendorff α ≥ 0.67 gate, Expert Panel, "Confidence < 0.7 loopback") as *current* capability is corrected or dropped.
- Two zero-caller code artifacts deleted: `Settings.temperature_verification` and `MonoLakeOrganizationMemory.get_common_rubric`.
- Replacement claims are grep-provable against live code: turn verify (`core/agent/verify.py`, rule-based + opt-in LLM-judge → replan on FAIL), `convergence_detected` stuck-loop guard, multi-voter cross-provider ranking panel (`plugins/seed_generation/agents/ranker.py`) labeled ⚠️ WIP for calibration.

## Why
A code audit ahead of an external benchmark report found docs-code drift: GEODE.md (the SOUL injected into every session) and README told the agent/readers that deleted machinery still gates output. Operator decision: "이건 IP 가치추론 파이프라인이었어. 제거해도 좋아." External reporting of these claims would not survive verification; internal SOUL claims actively mislead the running agent.

## Changes
| File | Change |
|------|--------|
| `GEODE.md` | Drop Expert Panel / G3 / confidence-loopback runtime rules + confidence defaults; reword Multi-Perspective principle; model-table role labels "Cross-LLM" → "OpenAI"; failure-mode table documents the real `convergence_detected` guard |
| `README.md` / `README.ko.md` | "Core verification (G1-G4 + Cross-LLM α ≥ 0.67 + Rights Risk)" → implemented turn-verify layer; comparison-table cells downgraded ✅✅ → ✅/⚠️ with code paths |
| `AGENTS.md` | Remove sections for nonexistent `core/verification/` and `core/automation/` (expert_panel.py et al.) |
| `core/config/_settings.py` | Delete `temperature_verification` knob (zero call sites; PR-TEMP ratchet list already excluded it) |
| `core/memory/organization.py` | Delete `get_common_rubric` (14-axis / S-D tier IP rubric; port folded earlier) |
| `tests/core/config/test_temperature_config_invariants.py` | Drop verification rows; module docstring records the retirement |
| `tests/core/memory/test_organization_memory.py` | Drop `test_get_common_rubric` |
| `docs/setup.md` / `docs/setup.ko.md` | `OPENAI_API_KEY` label "(Cross-LLM)" → "(OpenAI adapter)" |
| `CHANGELOG.md`, `pyproject.toml`, `CLAUDE.md`, `README*.md`, `uv.lock` | v0.99.187 stamp + Removed entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Dated records (docs/audits, docs/plans, ADRs, blog, progress, CONTENT-CANON) | Dropped (intentional) | Historical records stay as written; CONTENT-CANON already states the deletion |
| `ensemble_mode` knob (`single \| cross`) | Deferred | Display-only consumer (status surfaces); no behavior switches on "cross" — candidate for a follow-up knob retirement |
| AGENTS.md `core/gateway/` section | Deferred | Also stale (dir is now `core/messaging`) but unrelated to the verification residue scope |

## Verification
- [x] ruff check + format clean (4 touched py files)
- [x] mypy clean (`core/config/_settings.py`, `core/memory/organization.py`)
- [x] pytest: affected suites 24 + doc-pinning/config 224 + tests/core/memory full suite — all pass, no live tests
- [x] Repo-wide grep: zero remaining `temperature_verification` / `get_common_rubric` / `GEODE_TEMPERATURE_VERIFICATION` references in code

## Reference
Operator audit session 2026-06-12 (benchmark-prep honesty pass); v0.99.149 pipeline removal, v0.99.154 G1-G4 deletion, v0.99.157 PR-SLOP-CLEANUP precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)