### PR TITLE
chore(v1-prep): 감사 확정 더미/slop/dead 표면 정리 (v0.99.190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.190] - 2026-06-13
+
+### Removed
+- **v1.0.0 pre-release cleanup — audit-confirmed dummy/slop/dead surface** (PR-V1-PRE-CLEANUP; 3-dimension audit: slop/dummy + leak/hygiene + wiring/contract, leak dimension fully clean). `CortexAnalystTool` / `CortexSearchTool` deleted from `core/tools/data_tools.py` + container registration — Game-IP-era Snowflake placeholders that always returned `{"status": "stub"}` while registered as live tools (the v0.99.187 purge missed them); the dead `("query_monolake", "cortex_analyst", "cortex_search")` category branch in `ToolRegistry.to_anthropic_tools_with_defer` went with them. `Settings.subagent_max_rounds` removed (zero readers). `ToolExecutor.register` removed (zero callers — handlers arrive via the `_build_tool_handlers` map, dangerous tools via the executor's built-in paths).
+
+### Fixed
+- **MCP client handshake reported a hardcoded "0.9.0"** — `core/mcp/stdio_client.py` clientInfo now resolves the real package version (same handshake-misreport class geode-mcp fixed server-side in v0.99.169). Would have read as a wrong major after the v1.0.0 bump.
+
+### Changed
+- **`core/agent/tool_search.py` renamed to `core/agent/tool_ranking.py`** — the module ranks tools by episodic Wilson-LB success, it does not search them; the old name collided with the `tool_search` meta-tool (`ToolSearchTool`, `core.tools.registry`) that the upcoming defer wiring makes prominent. Importer (`in_context_wiring.py`) + test module migrated in the same PR (no shim, per the 1-release-grace rule).
+- `scripts/check_docs_links.py` CLI output de-emojified (`[OK]`/`[FAIL]`/`[INFO]` — emoji are report-only per the slop rule); `core/ui/mascot.py` docstring drops a stale `v0.10.0` example.
+
+### Audit notes (no change shipped)
+- Audit false-positives refuted with evidence: `run_bash`/`delegate_task` are NOT half-wired (they execute via the executor's built-in dangerous/delegation paths, `core/agent/tool_executor/executor.py:177,183`, not the handler map); `ADAPTER_DISPATCH_ATTEMPT` does emit (`core/llm/adapters/dispatch.py:294`). `recall_tool_result`/`doctor_slack` handler-without-definition is intentional (offload-recovery hint path / internal diagnostics). 20 reserved-unemitted HookEvents remain documented-RESERVED tracked debt, not a 1.0 blocker.
+
 ## [0.99.189] - 2026-06-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.189
+- **Version**: 0.99.190
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 381 core + 72 plugins = 453
-- **Tests**: 8695 (+1 live)
+- **Tests**: 8694 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.189 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.190 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.189 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.190 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -131,10 +131,6 @@ class ToolExecutor:
         """Delegates to ApprovalWorkflow."""
         self._approval.track_decision(tool_name, decision)
 
-    def register(self, tool_name: str, handler: ToolHandler) -> None:
-        """Register a tool handler."""
-        self._handlers[tool_name] = handler
-
     # Delegation methods — route to ApprovalWorkflow, patchable by tests
     def _confirm_write(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
         return self._approval.confirm_write(tool_name, tool_input)

--- a/core/agent/tool_ranking.py
+++ b/core/agent/tool_ranking.py
@@ -1,5 +1,10 @@
 """Tool selection ranking — CL-A2 (Tool Selection as Search).
 
+Renamed from ``tool_search.py`` (PR-V1-PRE-CLEANUP, 2026-06-13): the old
+name collided with the ``ToolSearchTool`` meta-tool in
+``core.tools.registry`` — this module RANKS tools by episodic success,
+it does not search them.
+
 GEODE's tool selection is currently the LLM's free choice each step —
 no policy. The cognitive-loop-uplift roadmap calls for an A*-style
 policy biased by historical success and current plan step
@@ -138,13 +143,13 @@ def load_recent_episodes(limit: int = RECENT_WINDOW) -> list[object]:
     try:
         from core.memory.episodic import EpisodicStore
     except Exception as exc:  # pragma: no cover — defensive
-        log.debug("tool_search: episodic store import failed: %s", exc)
+        log.debug("tool_ranking: episodic store import failed: %s", exc)
         return []
     try:
         store = EpisodicStore()
         return list(store.recent(limit=limit))
     except Exception as exc:
-        log.debug("tool_search: episodic store read failed: %s", exc)
+        log.debug("tool_ranking: episodic store read failed: %s", exc)
         return []
 
 

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -296,7 +296,6 @@ class Settings(BaseSettings):
     # Sub-Agent Orchestration (P2)
     max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
     max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
-    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
     subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
 
     # Token Guard — tool result truncation threshold (0 = unlimited)

--- a/core/mcp/stdio_client.py
+++ b/core/mcp/stdio_client.py
@@ -19,6 +19,19 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+
+def _geode_version() -> str:
+    """Real package version for the MCP handshake clientInfo.
+
+    PR-V1-PRE-CLEANUP (2026-06-13): was a hardcoded "0.9.0" — the same
+    handshake-misreport class geode-mcp fixed in v0.99.169, on the
+    client side this time.
+    """
+    from core import __version__
+
+    return __version__
+
+
 # Graceful shutdown timeout before force kill (seconds)
 _CLOSE_TIMEOUT_S = 5
 
@@ -95,7 +108,7 @@ class StdioMCPClient:
                 {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "geode", "version": "0.9.0"},
+                    "clientInfo": {"name": "geode", "version": _geode_version()},
                 },
             )
 

--- a/core/self_improving/loop/inject/in_context_wiring.py
+++ b/core/self_improving/loop/inject/in_context_wiring.py
@@ -206,7 +206,7 @@ def apply_in_context_slots(
         # confidence threshold. Complements tool_hints.
         if tool_ranking_cfg is not None:
             try:
-                from core.agent.tool_search import (
+                from core.agent.tool_ranking import (
                     find_recommended_tools,
                     format_tool_ranking_block,
                 )

--- a/core/tools/data_tools.py
+++ b/core/tools/data_tools.py
@@ -1,9 +1,11 @@
-"""Data Retrieval Tools — generic Snowflake stubs.
+"""Data Retrieval Tools.
 
 Layer 5 tools for data access:
-- CortexAnalystTool: Placeholder for Snowflake Cortex Analyst SQL
-- CortexSearchTool: Placeholder for Cortex Search semantic retrieval
 - GenerateDataTool: Deterministic synthetic records for tests/demo workflows
+
+PR-V1-PRE-CLEANUP (2026-06-13): the CortexAnalyst/CortexSearch placeholder
+stubs (Game-IP-era Snowflake surface, always returned status="stub") were
+deleted — registered tools must do real work.
 
 Specialized fixture/query tools live in external packages.
 """
@@ -21,110 +23,6 @@ class _AsyncExecuteMixin:
     async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
         """Run sync data client work off the event loop."""
         return await asyncio.to_thread(self._execute_sync, **kwargs)
-
-
-class CortexAnalystTool(_AsyncExecuteMixin):
-    """Placeholder tool for Snowflake Cortex Analyst SQL queries.
-
-    In production, translates natural-language questions into
-    SQL via Cortex Analyst and executes against Snowflake.
-    Demo returns a stub acknowledgment.
-    """
-
-    @property
-    def name(self) -> str:
-        return "cortex_analyst"
-
-    @property
-    def description(self) -> str:
-        return (
-            "Run a natural-language query against Snowflake via Cortex Analyst. "
-            "Translates question to SQL, executes, and returns tabular results."
-        )
-
-    @property
-    def parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "question": {
-                    "type": "string",
-                    "description": "Natural-language question to answer via SQL.",
-                },
-                "database": {
-                    "type": "string",
-                    "description": "Target database name.",
-                    "default": "GEODE_DB",
-                },
-            },
-            "required": ["question"],
-        }
-
-    def _execute_sync(self, **kwargs: Any) -> dict[str, Any]:
-        question: str = kwargs["question"]
-        database: str = kwargs.get("database", "GEODE_DB")
-        return {
-            "result": {
-                "status": "stub",
-                "message": (f"Cortex Analyst query against {database} would execute: '{question}'"),
-                "rows": [],
-                "columns": [],
-            }
-        }
-
-
-class CortexSearchTool(_AsyncExecuteMixin):
-    """Placeholder tool for Cortex Search semantic retrieval.
-
-    In production, performs vector-based semantic search over documents,
-    reviews, and community content.
-    Demo returns a stub result.
-    """
-
-    @property
-    def name(self) -> str:
-        return "cortex_search"
-
-    @property
-    def description(self) -> str:
-        return (
-            "Semantic search across documents, reviews, and community content "
-            "using Cortex Search vector retrieval."
-        )
-
-    @property
-    def parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Semantic search query.",
-                },
-                "top_k": {
-                    "type": "integer",
-                    "description": "Number of results to return.",
-                    "default": 5,
-                },
-                "filters": {
-                    "type": "object",
-                    "description": "Optional metadata filters (e.g., genre, year).",
-                },
-            },
-            "required": ["query"],
-        }
-
-    def _execute_sync(self, **kwargs: Any) -> dict[str, Any]:
-        query: str = kwargs["query"]
-        top_k: int = kwargs.get("top_k", 5)
-        return {
-            "result": {
-                "status": "stub",
-                "message": (f"Cortex Search would return top-{top_k} results for: '{query}'"),
-                "documents": [],
-                "scores": [],
-            }
-        }
 
 
 class GenerateDataTool(_AsyncExecuteMixin):

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -269,9 +269,7 @@ class ToolRegistry:
         categories: set[str] = set()
         for tool in all_tools:
             name = tool.get("name", "")
-            if name in ("query_monolake", "cortex_analyst", "cortex_search"):
-                categories.add("data")
-            elif name in ("memory_search", "memory_get", "memory_save"):
+            if name in ("memory_search", "memory_get", "memory_save"):
                 categories.add("memory")
             elif name in ("generate_report", "export_json", "send_notification"):
                 categories.add("output")

--- a/core/ui/mascot.py
+++ b/core/ui/mascot.py
@@ -2,7 +2,7 @@
 
 3-line layout mirroring Claude Code::
 
-    ╲╲( ◕ ᵕ ◕ )╱╱  GEODE v0.10.0
+    ╲╲( ◕ ᵕ ◕ )╱╱  GEODE v<version>
                      claude-opus-4-6 · autonomous execution agent
                      ~/geode
 

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -110,10 +110,8 @@ def build_default_registry() -> ToolRegistry:
     """
     registry = ToolRegistry()
     # Data (3)
-    from core.tools.data_tools import CortexAnalystTool, CortexSearchTool, GenerateDataTool
+    from core.tools.data_tools import GenerateDataTool
 
-    registry.register(CortexAnalystTool())
-    registry.register(CortexSearchTool())
     registry.register(GenerateDataTool())
 
     # Search (2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.189"
+version = "0.99.190"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -343,11 +343,11 @@ def main() -> int:
     broken, unresolved, external = classify_and_check(links, routes, assets, page_ids)
 
     if broken:
-        print(f"❌ {len(broken)} broken internal link(s):")
+        print(f"[FAIL] {len(broken)} broken internal link(s):")
         for line in broken:
             print(line)
     else:
-        print("✅ no broken internal links")
+        print("[OK] no broken internal links")
     print()
 
     # Raw `<a href="/docs/...">` in TSX bypasses Next.js basePath rewriting
@@ -365,7 +365,7 @@ def main() -> int:
             )
     if base_path_violations:
         print(
-            f"❌ {len(base_path_violations)} raw href missing /geode basePath:",
+            f"[FAIL] {len(base_path_violations)} raw href missing /geode basePath:",
         )
         for line in base_path_violations:
             print(line)
@@ -377,7 +377,7 @@ def main() -> int:
         print()
 
     if unresolved and not args.quiet:
-        print(f"ℹ️  {len(unresolved)} unresolved (interpolated or relative):")
+        print(f"[INFO]  {len(unresolved)} unresolved (interpolated or relative):")
         for line in unresolved[:20]:
             print(line)
         if len(unresolved) > 20:
@@ -390,11 +390,11 @@ def main() -> int:
         print("Probing external URLs (HEAD with GET fallback)...")
         ext_broken = http_probe(external)
         if ext_broken:
-            print(f"❌ {len(ext_broken)} broken external URL(s):")
+            print(f"[FAIL] {len(ext_broken)} broken external URL(s):")
             for line in ext_broken:
                 print(line)
         else:
-            print("✅ all external URLs reachable")
+            print("[OK] all external URLs reachable")
 
     return 1 if broken or ext_broken or base_path_violations else 0
 

--- a/tests/core/agent/test_tool_ranking.py
+++ b/tests/core/agent/test_tool_ranking.py
@@ -1,4 +1,4 @@
-"""CL-A2 — ``core.agent.tool_search`` invariants.
+"""CL-A2 — ``core.agent.tool_ranking`` invariants.
 
 Pins the Wilson score interval LB math, the
 ``find_recommended_tools`` aggregation contract, and the rendered
@@ -12,8 +12,8 @@ import math
 from dataclasses import dataclass
 
 import pytest
-from core.agent import tool_search
-from core.agent.tool_search import (
+from core.agent import tool_ranking
+from core.agent.tool_ranking import (
     MIN_INVOCATIONS,
     WILSON_THRESHOLD,
     ToolRanking,
@@ -43,7 +43,7 @@ def test_module_exports_stable():
         "load_recent_episodes",
         "wilson_lower_bound",
     }
-    assert set(tool_search.__all__) == expected
+    assert set(tool_ranking.__all__) == expected
 
 
 # ── Wilson lower-bound math ───────────────────────────────────────────
@@ -235,12 +235,12 @@ def test_min_invocations_constant_matches_tool_hints():
 
 
 def test_load_recent_episodes_handles_missing_store(monkeypatch: pytest.MonkeyPatch):
-    """``tool_search.load_recent_episodes`` is the module-internal loader
+    """``tool_ranking.load_recent_episodes`` is the module-internal loader
     used when callers invoke the ranker without going through
     ``in_context_wiring``. The wiring opts to share ``tool_hints``'
     loader as a shared-read optimisation; this test pins the parallel
     public API so it isn't quietly dead code."""
-    import core.agent.tool_search as ts_module
+    import core.agent.tool_ranking as ts_module
 
     class _ExplodingStore:
         def recent(self, *, limit: int) -> list[object]:
@@ -254,7 +254,7 @@ def test_load_recent_episodes_handles_missing_store(monkeypatch: pytest.MonkeyPa
 
 def test_load_recent_episodes_returns_store_output(monkeypatch: pytest.MonkeyPatch):
     """Happy path — loader forwards the store's ``recent()`` result."""
-    import core.agent.tool_search as ts_module
+    import core.agent.tool_ranking as ts_module
 
     expected = [_FakeEpisode("read", True), _FakeEpisode("read", False)]
 

--- a/tests/core/test_runtime.py
+++ b/tests/core/test_runtime.py
@@ -129,17 +129,15 @@ class TestRuntimePolicyChain:
         runtime = GeodeRuntime.create("Project Atlas", log_dir=tmp_path)
         tools = runtime.get_available_tools(mode="full_pipeline")
         # 17 total registered (PR-Hermes-1d +session_search) − send_notification = 16
-        assert len(tools) == 16
+        assert len(tools) == 14  # Cortex stubs deleted (PR-V1-PRE-CLEANUP)
         assert "send_notification" not in tools
 
 
 class TestRuntimeToolRegistry:
     def test_registry_has_all_tools(self, tmp_path: Path):
         runtime = GeodeRuntime.create("Project Atlas", log_dir=tmp_path)
-        assert len(runtime.tool_registry) == 17  # +1 session_search (PR-Hermes-1d)
+        assert len(runtime.tool_registry) == 15  # Cortex stubs deleted (PR-V1-PRE-CLEANUP)
         # Data tools
-        assert "cortex_analyst" in runtime.tool_registry
-        assert "cortex_search" in runtime.tool_registry
         assert "generate_data" in runtime.tool_registry
         # Search tools
         assert "web_search" in runtime.tool_registry
@@ -187,7 +185,7 @@ class TestDefaultBuilders:
 
     def test_default_registry(self):
         registry = _build_default_registry()
-        assert len(registry) == 17  # +1 session_search (PR-Hermes-1d)
+        assert len(registry) == 15  # Cortex stubs deleted (PR-V1-PRE-CLEANUP)
 
     def test_make_run_log_handler(self, tmp_path: Path):
         run_log = RunLog("test_session", log_dir=tmp_path)

--- a/tests/core/tools/test_tool_search_defer.py
+++ b/tests/core/tools/test_tool_search_defer.py
@@ -352,16 +352,6 @@ class TestToolSearchToolMCP:
 class TestCategoryDetection:
     """Category strings in tool_search description."""
 
-    def test_data_category(self) -> None:
-        reg = _make_registry(
-            "cortex_analyst",
-            "cortex_search",
-            *[f"extra{i}" for i in range(9)],
-        )
-        result = reg.to_anthropic_tools_with_defer(defer_threshold=DEFAULT_THRESHOLD)
-        desc = result[0]["description"]
-        assert "data" in desc
-
     def test_memory_category(self) -> None:
         reg = _make_registry(
             "memory_search",
@@ -387,13 +377,12 @@ class TestCategoryDetection:
     def test_multiple_categories(self) -> None:
         reg = _make_registry(
             "memory_search",
-            "cortex_search",
             "generate_report",
-            *[f"extra{i}" for i in range(8)],
+            *[f"extra{i}" for i in range(9)],
         )
         result = reg.to_anthropic_tools_with_defer(defer_threshold=DEFAULT_THRESHOLD)
         desc = result[0]["description"]
-        for cat in ("memory", "data", "output", "other"):
+        for cat in ("memory", "output", "other"):
             assert cat in desc
 
 

--- a/tests/core/wiring/test_full_tool_registration.py
+++ b/tests/core/wiring/test_full_tool_registration.py
@@ -13,9 +13,7 @@ from core.wiring.container import (
 )
 
 ALL_TOOL_NAMES = {
-    # Data (3)
-    "cortex_analyst",
-    "cortex_search",
+    # Data (1) — Cortex stubs deleted (PR-V1-PRE-CLEANUP 2026-06-13)
     "generate_data",
     # Search (2)
     "web_search",
@@ -70,7 +68,7 @@ class TestPolicyChainDryRun:
 
     def test_dry_run_allows_data_tools(self) -> None:
         chain = _build_default_policies()
-        for tool in ("cortex_analyst", "cortex_search", "generate_data"):
+        for tool in ("generate_data",):
             assert chain.is_allowed(tool, mode="dry_run") is True
 
     def test_dry_run_allows_memory_tools(self) -> None:
@@ -112,7 +110,7 @@ class TestPolicyFilterIntegration:
         dry_tools = runtime.get_available_tools(mode="dry_run")
         assert "send_notification" not in dry_tools
         assert "memory_search" in dry_tools
-        assert "cortex_search" in dry_tools
+        assert "generate_data" in dry_tools
 
     def test_runtime_full_pipeline_filtering(self, tmp_path: Path) -> None:
         runtime = GeodeRuntime.create("Project Atlas", log_dir=tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.189"
+version = "0.99.190"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v1.0.0 사전 3-차원 감사(slop/더미 · 누수/위생 · 배선/계약) 확정분 정리 — 누수 차원은 전수 clean, 확정 결함만 제거
- Game-IP 잔재 Cortex 스텁 2종(등록된 채 `{"status":"stub"}` 반환) 삭제, dead knob·dead method 제거, MCP 핸드셰이크 버전 하드코드 수정, `tool_search.py`→`tool_ranking.py` 이름 충돌 해소

## Why
v1.0.0 승격 전 더미/slop/누수 전수 점검(운영자 지시). Explore 에이전트 3기 fan-out 후 전 발견을 직접 재검증 — 오탐 2건(run_bash/delegate_task "half-wired", ADAPTER_DISPATCH_ATTEMPT "미발화")은 증거로 반박하고 확정분만 반영.

## Changes
| File | Change |
|------|--------|
| `core/tools/data_tools.py` | CortexAnalystTool/CortexSearchTool 삭제(placeholder 스텁, v0.99.187 퍼지 누락분). GenerateDataTool만 잔존 |
| `core/wiring/container.py` | Cortex 2종 등록 제거 |
| `core/tools/registry.py` | dead category 분기(`query_monolake`/`cortex_*`) 제거 |
| `core/config/_settings.py` | `subagent_max_rounds` 제거(판독자 0) |
| `core/agent/tool_executor/executor.py` | `register()` 제거(호출자 0) |
| `core/mcp/stdio_client.py` | clientInfo 버전 "0.9.0" 하드코드 → `core.__version__` 동적 해석 |
| `core/agent/tool_ranking.py` | `tool_search.py`에서 rename(실체=Wilson-LB 랭킹, ToolSearchTool 메타도구와 충돌). 임포터+테스트 동시 이행, shim 없음 |
| `scripts/check_docs_links.py` | emoji → `[OK]`/`[FAIL]`/`[INFO]` |
| `core/ui/mascot.py` | 스테일 버전 예시 제거 |
| 테스트 5파일 | 카운트 앵커·기대값 갱신 (17→15, 16→14 등) |
| 버전 5위치 + uv.lock | v0.99.190, Tests 8694 실측 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| run_bash/delegate_task half-wired (BLOCKER 주장) | 오탐 반박 | executor 내장 경로 실행 (executor.py:177·183) |
| ADAPTER_DISPATCH_ATTEMPT 미발화 주장 | 오탐 반박 | dispatch.py:294 발화 |
| recall_tool_result/doctor_slack 정의-없는 핸들러 | 의도적 | offload 회복 힌트 경로 / 내부 진단 |
| 예약-미발화 HookEvent 20종 | 추적 디버트 | "RESERVED" 명시(정직) — 1.0 블로커 아님 |
| tool_search defer 미배선 | 후속 PR | 별도 기능 PR로 분리(이 PR은 cleanup 한정) |

## Verification
- [x] ruff check / format --check clean (scripts/ 포함)
- [x] mypy clean (453 files)
- [x] lint-imports 4 kept
- [x] pytest: 영향권 스위트 1,223 pass + mcp/config 12 pass. 전체 스위트 실패 3건은 lane 순서 의존 플레이크(단독 통과, 미변경 코드 동일 재현, 본 diff는 orchestration 미접촉)
- [x] CLI smoke: geode version → v0.99.190

## Reference
- 감사: Explore 3기(slop/누수/배선) + 직접 재검증
- 선례: PR-SLOP-DEAD-VERIFICATION-REFS v0.99.187 (Game-IP 퍼지 본편)

🤖 Generated with [Claude Code](https://claude.com/claude-code)