### PR TITLE
feat(llm): OpenAI tool_search defer — 양 백엔드, codex 라이브 게이트 통과 (v0.99.193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.193] - 2026-06-13
+
+### Added
+- **OpenAI tool_search deferred loading — both backends, live-gated** (PR-CODEX-TOOL-SEARCH). The shared Responses builder now applies the official OpenAI mechanism (`defer_loading: true` on function defs + hosted `{"type": "tool_search"}`, Responses-only, gpt-5.4+ per developers.openai.com tool-search guide) — mirroring the Anthropic wiring of v0.99.191, with the policy constants (threshold 16 + 11-name always-loaded core set) moved to the provider-neutral `core/llm/tool_defer.py` so both vendors share ONE policy SoT. Per-model gate via `OpenAIModelSpec.supports_tool_search` (gpt-5.4/5.4-mini/5.5 True; o-series/legacy False — unknown models never gamble a 400). **Codex backend acceptance was the open question** (docs cover the platform API only — the PR-NO-FALLBACK ambiguity class): gated on a live call and **verified 2026-06-13** — 20 deferred defs + tool_search through `chatgpt.com/backend-api/codex/responses` on gpt-5.5 returned a normal completion ("DEFER-OK"), so `Settings.tool_search_defer_codex` ships default-True with the attestation in its docstring (kill switches: `llm.tool_search_defer` platform/Anthropic, `llm.tool_search_defer_codex` Codex). `OPENAI_DEFER_NAME_BLOCKLIST` pins the upstream 500 (deferred function named "web" + tool_search + web_search). Platform-side live call blocked by a stale `OPENAI_API_KEY` (401) — platform support is documented, so doc-attestation suffices there. Guards: `tests/core/llm/adapters/test_openai_tool_search_defer.py` (6 — platform shaping, unsupported-model gate, codex default-on + kill switch, "web" blocklist, idempotency).
+
 ## [0.99.192] - 2026-06-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.192
+- **Version**: 0.99.193
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 381 core + 72 plugins = 453
-- **Tests**: 8675 (+1 live)
+- **Modules**: 382 core + 72 plugins = 454
+- **Tests**: 8683 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.193 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.193 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -62,6 +62,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.anthropic_credential_source": "anthropic_credential_source",
     # PR-TOOL-SEARCH-WIRE (2026-06-13) — hosted tool-search defer kill switch.
     "llm.tool_search_defer": "tool_search_defer",
+    "llm.tool_search_defer_codex": "tool_search_defer_codex",
     "llm.openai_credential_source": "openai_credential_source",
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
     "replan.enabled": "replan_enabled",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -293,6 +293,12 @@ class Settings(BaseSettings):
     # Tool search — hosted defer_loading on the Anthropic adapter
     # (PR-TOOL-SEARCH-WIRE; reader: core/llm/providers/anthropic.py)
     tool_search_defer: bool = True  # kill switch for deferred tool loading
+    # Codex backend acceptance of OpenAI tool_search: live-verified
+    # 2026-06-13 — 20 defer_loading defs + {"type": "tool_search"} through
+    # chatgpt.com/backend-api/codex/responses on gpt-5.5 returned a normal
+    # completion ("DEFER-OK"). Docs cover the platform API only, so the
+    # live call was the gate (PR-NO-FALLBACK rule); reader: _openai_common.py.
+    tool_search_defer_codex: bool = True
 
     # Ensemble — Multi-LLM mode
     ensemble_mode: str = "single"  # single | cross

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -83,6 +83,12 @@ class OpenAIModelSpec:
     context_window: int
     """Total context window (input + output) in tokens — for guard logging only."""
 
+    supports_tool_search: bool = False
+    """True → model accepts ``{"type": "tool_search"}`` + ``defer_loading``
+    on the Responses API ("only gpt-5.4 and later models support
+    tool_search" — developers.openai.com/api/docs/guides/tools-tool-search).
+    Default False so unknown/legacy models never gamble a 400."""
+
 
 # Registry — keep alphabetically sorted within each family for stable diffs.
 _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
@@ -100,6 +106,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     "gpt-5.4-mini": OpenAIModelSpec(
         model_id="gpt-5.4-mini",
@@ -107,6 +114,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     "gpt-5.5": OpenAIModelSpec(
         model_id="gpt-5.5",
@@ -114,6 +122,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     # ── o-series (always-on reasoning, no temperature, no "none" effort) ──
     "o3": OpenAIModelSpec(
@@ -929,6 +938,79 @@ def _normalize_summary_list(summary: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _apply_openai_tool_search_defer(
+    tools: list[dict[str, Any]],
+    *,
+    backend: str,
+    spec: OpenAIModelSpec,
+    adapter_name: str,
+) -> list[dict[str, Any]]:
+    """OpenAI Responses deferred tool loading — official mechanism.
+
+    Marks non-core function tools with the official ``defer_loading: true``
+    field and appends the hosted ``{"type": "tool_search"}`` tool, mirroring
+    the Anthropic wiring (policy SoT: ``core.llm.tool_defer``).
+    ref: https://developers.openai.com/api/docs/guides/tools-tool-search
+    (Responses-only; "only gpt-5.4 and later models support tool_search").
+
+    Backend gating:
+
+    - ``platform`` — documented supported; enabled by
+      ``settings.tool_search_defer`` (same kill switch as Anthropic).
+    - ``codex`` — the docs cover the platform API only (same ambiguity
+      class as PR-NO-FALLBACK #1839), so Codex backend acceptance was
+      gated on a live call: verified 2026-06-13 (20 deferred defs +
+      tool_search on gpt-5.5 → normal completion). Kill switch:
+      ``settings.tool_search_defer_codex`` (default True post-gate).
+
+    Never defers: the model lacks ``supports_tool_search``, hosted entries
+    (anything whose ``type`` is not ``"function"``), the always-loaded core
+    set, and names in ``OPENAI_DEFER_NAME_BLOCKLIST`` (upstream 500 when a
+    deferred function named "web" rides with tool_search + web_search).
+    Idempotent: already-shaped input passes through unchanged.
+    """
+    from core.config import settings as _settings
+    from core.llm.tool_defer import (
+        OPENAI_DEFER_NAME_BLOCKLIST,
+        TOOL_DEFER_THRESHOLD,
+        TOOL_SEARCH_ALWAYS_LOADED,
+    )
+
+    if not spec.supports_tool_search or len(tools) <= TOOL_DEFER_THRESHOLD:
+        return tools
+    if backend == "codex":
+        if not getattr(_settings, "tool_search_defer_codex", False):
+            return tools
+    elif not getattr(_settings, "tool_search_defer", True):
+        return tools
+    if any(t.get("type") == "tool_search" or t.get("defer_loading") for t in tools):
+        return tools  # already shaped — idempotent pass-through
+    shaped: list[dict[str, Any]] = []
+    deferred_count = 0
+    for tool in tools:
+        name = str(tool.get("name", ""))
+        if (
+            tool.get("type") != "function"
+            or name in TOOL_SEARCH_ALWAYS_LOADED
+            or name in OPENAI_DEFER_NAME_BLOCKLIST
+        ):
+            shaped.append(tool)
+            continue
+        deferred_tool = dict(tool)
+        deferred_tool["defer_loading"] = True
+        shaped.append(deferred_tool)
+        deferred_count += 1
+    if not deferred_count:
+        return tools
+    log.info(
+        "%s: openai tool_search defer active — %d/%d tool defs deferred",
+        adapter_name,
+        deferred_count,
+        len(shaped) + 1,
+    )
+    return [*shaped, {"type": "tool_search"}]
+
+
 def build_responses_kwargs(
     req: AdapterCallRequest, *, backend: str, adapter_name: str
 ) -> dict[str, Any]:
@@ -1003,7 +1085,10 @@ def build_responses_kwargs(
         )
     if req.tools:
         translated = [translate_tool_for_codex(t) for t in req.tools]
-        kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=adapter_name)
+        capped = cap_tools(translated, model=req.model, adapter_name=adapter_name)
+        kwargs["tools"] = _apply_openai_tool_search_defer(
+            capped, backend=backend, spec=spec, adapter_name=adapter_name
+        )
         kwargs["tool_choice"] = translate_responses_tool_choice(req.tool_choice)
         kwargs["parallel_tool_calls"] = True
     if spec.reasoning_effort_values is not None:

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -660,30 +660,12 @@ _TOOL_SEARCH_TOOL: dict[str, Any] = {
     "name": "tool_search_tool_regex",
 }
 
-TOOL_DEFER_THRESHOLD = 16
-"""Tool count above which deferred loading activates (docs: 10+ tools is
-the good-use-case bar; GEODE ships ~60). Below it, defer adds a search
-round-trip for no context saving."""
-
-# Immediately-loaded core set — the high-frequency tools the loop should
-# never pay a search round-trip for. Everything else defers behind
-# tool_search. Kept here (provider-level) because defer_loading is an
-# Anthropic Messages API field; OpenAI-family adapters rebuild tool
-# definitions from name/description/schema, so the field never leaks.
-TOOL_SEARCH_ALWAYS_LOADED: frozenset[str] = frozenset(
-    {
-        "memory_search",
-        "memory_save",
-        "note_read",
-        "note_save",
-        "read_document",
-        "glob_files",
-        "grep_files",
-        "general_web_search",
-        "web_fetch",
-        "llms_txt_index",
-        "check_status",
-    }
+# Policy constants (threshold + always-loaded core set) live in the
+# provider-neutral ``core.llm.tool_defer`` since PR-CODEX-TOOL-SEARCH —
+# the OpenAI Responses builder shares the same policy.
+from core.llm.tool_defer import (  # noqa: E402  (policy import next to its use)
+    TOOL_DEFER_THRESHOLD,
+    TOOL_SEARCH_ALWAYS_LOADED,
 )
 
 

--- a/core/llm/tool_defer.py
+++ b/core/llm/tool_defer.py
@@ -1,0 +1,43 @@
+"""Deferred tool loading policy — provider-neutral SoT.
+
+PR-CODEX-TOOL-SEARCH (2026-06-13): the always-loaded core set and the
+activation threshold moved here from ``core/llm/providers/anthropic.py``
+so the OpenAI Responses builder (``_openai_common.build_responses_kwargs``)
+shares ONE policy with the Anthropic adapter instead of growing a second
+copy (dual-SoT rule). Both providers expose the same official mechanism:
+a ``defer_loading`` field on tool definitions plus a hosted search tool
+(Anthropic ``tool_search_tool_regex_20251119`` / OpenAI
+``{"type": "tool_search"}``).
+"""
+
+from __future__ import annotations
+
+TOOL_DEFER_THRESHOLD = 16
+"""Tool count above which deferred loading activates (both vendors cite
+10+ tools as the good-use-case bar; GEODE ships ~60). Below it, defer
+adds a search round-trip for no context saving."""
+
+TOOL_SEARCH_ALWAYS_LOADED: frozenset[str] = frozenset(
+    {
+        "memory_search",
+        "memory_save",
+        "note_read",
+        "note_save",
+        "read_document",
+        "glob_files",
+        "grep_files",
+        "general_web_search",
+        "web_fetch",
+        "llms_txt_index",
+        "check_status",
+    }
+)
+"""Immediately-loaded core set — high-frequency tools the loop should
+never pay a search round-trip for. Everything else defers behind the
+provider's hosted tool-search tool."""
+
+# OpenAI Responses 500 bug (community.openai.com/t/.../1375850):
+# tool_search + hosted web_search + a DEFERRED function named "web"
+# returns a 500. GEODE ships no tool named "web", but the exclusion is
+# pinned so a future tool cannot trip the upstream bug.
+OPENAI_DEFER_NAME_BLOCKLIST: frozenset[str] = frozenset({"web"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.192"
+version = "0.99.193"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/llm/adapters/test_openai_tool_search_defer.py
+++ b/tests/core/llm/adapters/test_openai_tool_search_defer.py
@@ -1,0 +1,111 @@
+"""OpenAI Responses tool_search defer — request shaping guards.
+
+PR-CODEX-TOOL-SEARCH (2026-06-13). Official OpenAI mechanism
+(defer_loading + {"type": "tool_search"}, Responses-only, gpt-5.4+)
+wired into the shared builder, policy SoT shared with Anthropic via
+core.llm.tool_defer. Codex backend acceptance was
+live-verified 2026-06-13 (DEFER-OK, gpt-5.5) so the codex gate defaults
+ON with a kill switch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.llm.adapters._openai_common import build_responses_kwargs
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+from core.llm.tool_defer import TOOL_DEFER_THRESHOLD, TOOL_SEARCH_ALWAYS_LOADED
+
+
+def _request(model: str = "gpt-5.5", tool_count: int = TOOL_DEFER_THRESHOLD + 5):
+    tool_specs = [
+        ToolSpec(name=name, description=f"{name} core", input_schema={"type": "object"})
+        for name in sorted(TOOL_SEARCH_ALWAYS_LOADED)[:3]
+    ]
+    tool_specs += [
+        ToolSpec(name=f"extra_{i}", description=f"extra {i}", input_schema={"type": "object"})
+        for i in range(tool_count - 3)
+    ]
+    return AdapterCallRequest(
+        model=model,
+        messages=(Message(role="user", content="hi"),),
+        tools=tuple(tool_specs),
+    )
+
+
+def _tool_names(kwargs: dict) -> list[str]:
+    return [t.get("name", t.get("type", "?")) for t in kwargs["tools"]]
+
+
+def test_platform_defers_above_threshold_on_supported_model() -> None:
+    request_kwargs = build_responses_kwargs(
+        _request(), backend="platform", adapter_name="openai-payg"
+    )
+    tools = request_kwargs["tools"]
+    assert tools[-1] == {"type": "tool_search"}, "hosted search tool appended"
+    deferred_names = {t["name"] for t in tools if t.get("defer_loading")}
+    assert deferred_names and all(n.startswith("extra_") for n in deferred_names)
+    loaded = {t.get("name") for t in tools if not t.get("defer_loading")}
+    for core_name in sorted(TOOL_SEARCH_ALWAYS_LOADED)[:3]:
+        assert core_name in loaded, "core set never defers"
+
+
+def test_unsupported_model_never_defers() -> None:
+    """o3 lacks tool_search (gpt-5.4+ only) — shaping must not fire."""
+    request_kwargs = build_responses_kwargs(
+        _request(model="o3"), backend="platform", adapter_name="openai-payg"
+    )
+    assert not any(t.get("defer_loading") for t in request_kwargs["tools"])
+    assert {"type": "tool_search"} not in request_kwargs["tools"]
+
+
+def test_codex_backend_on_by_default_post_live_gate() -> None:
+    """Codex backend acceptance was live-verified 2026-06-13 (DEFER-OK on
+    gpt-5.5) — default ON since; _settings.py carries the attestation."""
+    request_kwargs = build_responses_kwargs(_request(), backend="codex", adapter_name="codex-oauth")
+    assert request_kwargs["tools"][-1] == {"type": "tool_search"}
+
+
+def test_codex_backend_kill_switch() -> None:
+    from core.config import settings
+
+    with patch.object(settings, "tool_search_defer_codex", False):
+        request_kwargs = build_responses_kwargs(
+            _request(), backend="codex", adapter_name="codex-oauth"
+        )
+    assert not any(t.get("defer_loading") for t in request_kwargs["tools"])
+    assert {"type": "tool_search"} not in request_kwargs["tools"]
+
+
+def test_web_named_tool_never_defers() -> None:
+    """Upstream 500: deferred function named "web" + tool_search +
+    web_search (community.openai.com/t/.../1375850) — blocklisted."""
+    base_request = _request()
+    tool_specs = (
+        *base_request.tools,
+        ToolSpec(name="web", description="web tool", input_schema={"type": "object"}),
+    )
+    request_kwargs = build_responses_kwargs(
+        AdapterCallRequest(model="gpt-5.5", messages=base_request.messages, tools=tool_specs),
+        backend="platform",
+        adapter_name="openai-payg",
+    )
+    web_tool = next(t for t in request_kwargs["tools"] if t.get("name") == "web")
+    assert "defer_loading" not in web_tool
+
+
+def test_shaping_is_idempotent() -> None:
+    first = build_responses_kwargs(_request(), backend="platform", adapter_name="openai-payg")
+    # feed the shaped tools back through the helper directly
+    from core.llm.adapters._openai_common import (
+        _apply_openai_tool_search_defer,
+        get_openai_model_spec,
+    )
+
+    reshaped = _apply_openai_tool_search_defer(
+        first["tools"],
+        backend="platform",
+        spec=get_openai_model_spec("gpt-5.5"),
+        adapter_name="openai-payg",
+    )
+    assert reshaped is first["tools"]

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.192"
+version = "0.99.193"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- OpenAI 공식 tool_search 메커니즘(`defer_loading` + `{"type":"tool_search"}`, Responses 전용, gpt-5.4+)을 공유 Responses 빌더에 배선 — v0.99.191 Anthropic 배선의 OpenAI 대칭
- defer 정책 상수(임계 16 + 코어 11종)를 provider 중립 `core/llm/tool_defer.py`로 이동 — 양 벤더 단일 SoT
- **Codex 백엔드 수락을 라이브 게이트로 해소**: 2026-06-13 DEFER-OK(gpt-5.5, defer 20) → `tool_search_defer_codex` default True + attestation

## Why
직전 리서치에서 OpenAI도 동일 메커니즘을 공식 지원함을 확인(gpt-5.4+, Responses 전용). 단 문서는 platform API만 커버해 Codex 백엔드 수락이 PR-NO-FALLBACK #1839와 동일 모호성 클래스였음 — CANNOT 규칙대로 라이브 게이트를 먼저 통과시키고 기본값을 플립.

## Changes
| File | Change |
|------|--------|
| `core/llm/tool_defer.py` | 신규 — TOOL_DEFER_THRESHOLD/TOOL_SEARCH_ALWAYS_LOADED(anthropic.py에서 이동) + OPENAI_DEFER_NAME_BLOCKLIST("web" 명명 시 업스트림 500 핀) |
| `core/llm/adapters/_openai_common.py` | `_apply_openai_tool_search_defer`(모델 게이트·백엔드 게이트·코어 제외·블록리스트·멱등) + 빌더 배선 + `OpenAIModelSpec.supports_tool_search`(5.4/5.4-mini/5.5 True, 기본 False) |
| `core/llm/providers/anthropic.py` | 정책 상수를 tool_defer 임포트로 재지정(동작 무변) |
| `core/config/_settings.py` `__init__.py` | `tool_search_defer_codex: bool = True`(라이브 검증 attestation docstring) + TOML 매핑 |
| `tests/core/llm/adapters/test_openai_tool_search_defer.py` | 가드 6종: platform shaping·미지원 모델 게이트·codex 기본 ON+kill switch·"web" 블록리스트·멱등성 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Codex 백엔드 수락 | 라이브 검증 | chatgpt.com/backend-api/codex/responses, gpt-5.5, defer 20 + tool_search → 정상 완료("DEFER-OK") |
| platform 라이브 | 차단(무해) | OPENAI_API_KEY stale 401 — 공식 문서가 platform 지원 명시라 doc-attestation 충분. 키 갱신 후 스모크 권장 |
| namespace 기능 | 후속 | OpenAI 고유 namespace 그룹화는 definitions.json category 매핑과 함께 별도 검토 |

## Verification
- [x] ruff check / format --check clean, mypy 454 files clean, lint-imports 4 kept
- [x] pytest: llm+config 전체 green(신규 6 포함)
- [x] 라이브: codex 백엔드 DEFER-OK
- [x] CLI smoke: geode version → v0.99.193

## Reference
- developers.openai.com/api/docs/guides/tools-tool-search (gpt-5.4+, Responses 전용)
- community.openai.com Responses 500 버그(\"web\" 충돌) / openai/codex#14507
- 선행: PR #2229(Responses 이행), PR #2224(Anthropic tool_search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)