### PR TITLE
release: v0.99.192+193 — openai Responses 이행 + OpenAI tool_search defer (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.193] - 2026-06-13
+
+### Added
+- **OpenAI tool_search deferred loading — both backends, live-gated** (PR-CODEX-TOOL-SEARCH). The shared Responses builder now applies the official OpenAI mechanism (`defer_loading: true` on function defs + hosted `{"type": "tool_search"}`, Responses-only, gpt-5.4+ per developers.openai.com tool-search guide) — mirroring the Anthropic wiring of v0.99.191, with the policy constants (threshold 16 + 11-name always-loaded core set) moved to the provider-neutral `core/llm/tool_defer.py` so both vendors share ONE policy SoT. Per-model gate via `OpenAIModelSpec.supports_tool_search` (gpt-5.4/5.4-mini/5.5 True; o-series/legacy False — unknown models never gamble a 400). **Codex backend acceptance was the open question** (docs cover the platform API only — the PR-NO-FALLBACK ambiguity class): gated on a live call and **verified 2026-06-13** — 20 deferred defs + tool_search through `chatgpt.com/backend-api/codex/responses` on gpt-5.5 returned a normal completion ("DEFER-OK"), so `Settings.tool_search_defer_codex` ships default-True with the attestation in its docstring (kill switches: `llm.tool_search_defer` platform/Anthropic, `llm.tool_search_defer_codex` Codex). `OPENAI_DEFER_NAME_BLOCKLIST` pins the upstream 500 (deferred function named "web" + tool_search + web_search). Platform-side live call blocked by a stale `OPENAI_API_KEY` (401) — platform support is documented, so doc-attestation suffices there. Guards: `tests/core/llm/adapters/test_openai_tool_search_defer.py` (6 — platform shaping, unsupported-model gate, codex default-on + kill switch, "web" blocklist, idempotency).
+
 ## [0.99.192] - 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.192] - 2026-06-13
+
+### Changed
+- **openai-payg moved off Chat Completions onto the Responses API** (PR-OPENAI-RESPONSES) — `acomplete`/`astream` now go through a shared `build_responses_kwargs` builder in `_openai_common.py` (extracted from codex_oauth's `_build_codex_call_kwargs`), completing the migration `acomplete_text`/`aweb_search` started. One builder, one `backend` param carrying the only wire delta: `backend="platform"` sends `max_output_tokens` (supported on the platform API), `backend="codex"` omits it (Subscription manages it server-side; sending returns 400). Everything else — `instructions` system prompt, `store=False`, flat tool shape, reasoning passthrough (`include: reasoning.encrypted_content`), `text.format` response-schema enforcement with strict auto-detection — is now literally the same code on both OpenAI backends. The payg response path reuses the codex SSE stream-aggregation (`translate_codex_response` + `output_item.done` accumulation), so reasoning items survive on payg too. Chat Completions now lives only on the GLM adapters (z.ai's compatibility surface lacks Responses); the payg-side chat tool_choice translator was deleted and its test retargeted at the GLM `normalize("glm", ...)` path. Why: Responses is OpenAI's forward-going surface — new features (tool_search deferred loading 등) are Responses-only, and this PR is the prerequisite for joining them. Naming debt recorded in the builder docstring: `build_codex_input`/`translate_tool_for_codex` keep codex- names while now platform-shared (12-file rename kept out of a migration diff). Guards: `tests/core/llm/adapters/test_openai_payg_responses.py` (4 — backend delta, shared shape, chat-completions source pin, reasoning branch) + 3 test modules migrated to the shared builder import.
+
 ## [0.99.191] - 2026-06-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.192
+- **Version**: 0.99.193
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 381 core + 72 plugins = 453
-- **Tests**: 8675 (+1 live)
+- **Modules**: 382 core + 72 plugins = 454
+- **Tests**: 8683 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.191
+- **Version**: 0.99.192
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 381 core + 72 plugins = 453
-- **Tests**: 8667 (+1 live)
+- **Tests**: 8675 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.191 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.193 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.191 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.192 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.193 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -62,6 +62,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.anthropic_credential_source": "anthropic_credential_source",
     # PR-TOOL-SEARCH-WIRE (2026-06-13) — hosted tool-search defer kill switch.
     "llm.tool_search_defer": "tool_search_defer",
+    "llm.tool_search_defer_codex": "tool_search_defer_codex",
     "llm.openai_credential_source": "openai_credential_source",
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
     "replan.enabled": "replan_enabled",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -293,6 +293,12 @@ class Settings(BaseSettings):
     # Tool search — hosted defer_loading on the Anthropic adapter
     # (PR-TOOL-SEARCH-WIRE; reader: core/llm/providers/anthropic.py)
     tool_search_defer: bool = True  # kill switch for deferred tool loading
+    # Codex backend acceptance of OpenAI tool_search: live-verified
+    # 2026-06-13 — 20 defer_loading defs + {"type": "tool_search"} through
+    # chatgpt.com/backend-api/codex/responses on gpt-5.5 returned a normal
+    # completion ("DEFER-OK"). Docs cover the platform API only, so the
+    # live call was the gate (PR-NO-FALLBACK rule); reader: _openai_common.py.
+    tool_search_defer_codex: bool = True
 
     # Ensemble — Multi-LLM mode
     ensemble_mode: str = "single"  # single | cross

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -863,11 +863,21 @@ def translate_codex_response(
     if not text and fallback_text_parts:
         text = "".join(fallback_text_parts)
     usage = getattr(response, "usage", None)
+    # Codex review of PR-OPENAI-RESPONSES (2026-06-13): Responses reports
+    # prompt-cache hits under ``input_tokens_details.cached_tokens`` —
+    # dropping it under-reported cache reads/cost on BOTH backends (the
+    # codex path had always dropped it). Same path the legacy normalizer
+    # reads in ``core/llm/agentic_response.py``.
+    cached_tokens = 0
+    if usage is not None:
+        input_details = getattr(usage, "input_tokens_details", None)
+        cached_tokens = int(getattr(input_details, "cached_tokens", 0) or 0)
     return AdapterCallResult(
         text=text,
         usage=UsageSummary(
             input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
             output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+            cached_input_tokens=cached_tokens,
         ),
         stop_reason=getattr(response, "status", "completed") or "completed",
         tool_uses=tuple(tool_uses),
@@ -981,6 +991,16 @@ def build_responses_kwargs(
     }
     if backend == "platform":
         kwargs["max_output_tokens"] = req.max_tokens
+    if req.stop_sequences:
+        # Responses API exposes no ``stop`` parameter (Chat Completions
+        # did). Observable drop instead of a silent one — Codex review of
+        # PR-OPENAI-RESPONSES, finding 2.
+        log.warning(
+            "%s: stop_sequences unsupported on the Responses API — ignoring %d entr%s",
+            adapter_name,
+            len(req.stop_sequences),
+            "y" if len(req.stop_sequences) == 1 else "ies",
+        )
     if req.tools:
         translated = [translate_tool_for_codex(t) for t in req.tools]
         kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=adapter_name)

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -83,6 +83,12 @@ class OpenAIModelSpec:
     context_window: int
     """Total context window (input + output) in tokens — for guard logging only."""
 
+    supports_tool_search: bool = False
+    """True → model accepts ``{"type": "tool_search"}`` + ``defer_loading``
+    on the Responses API ("only gpt-5.4 and later models support
+    tool_search" — developers.openai.com/api/docs/guides/tools-tool-search).
+    Default False so unknown/legacy models never gamble a 400."""
+
 
 # Registry — keep alphabetically sorted within each family for stable diffs.
 _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
@@ -100,6 +106,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     "gpt-5.4-mini": OpenAIModelSpec(
         model_id="gpt-5.4-mini",
@@ -107,6 +114,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     "gpt-5.5": OpenAIModelSpec(
         model_id="gpt-5.5",
@@ -114,6 +122,7 @@ _OPENAI_MODELS: dict[str, OpenAIModelSpec] = {
         accepts_temperature=False,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         context_window=1_050_000,
+        supports_tool_search=True,
     ),
     # ── o-series (always-on reasoning, no temperature, no "none" effort) ──
     "o3": OpenAIModelSpec(
@@ -929,6 +938,79 @@ def _normalize_summary_list(summary: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _apply_openai_tool_search_defer(
+    tools: list[dict[str, Any]],
+    *,
+    backend: str,
+    spec: OpenAIModelSpec,
+    adapter_name: str,
+) -> list[dict[str, Any]]:
+    """OpenAI Responses deferred tool loading — official mechanism.
+
+    Marks non-core function tools with the official ``defer_loading: true``
+    field and appends the hosted ``{"type": "tool_search"}`` tool, mirroring
+    the Anthropic wiring (policy SoT: ``core.llm.tool_defer``).
+    ref: https://developers.openai.com/api/docs/guides/tools-tool-search
+    (Responses-only; "only gpt-5.4 and later models support tool_search").
+
+    Backend gating:
+
+    - ``platform`` — documented supported; enabled by
+      ``settings.tool_search_defer`` (same kill switch as Anthropic).
+    - ``codex`` — the docs cover the platform API only (same ambiguity
+      class as PR-NO-FALLBACK #1839), so Codex backend acceptance was
+      gated on a live call: verified 2026-06-13 (20 deferred defs +
+      tool_search on gpt-5.5 → normal completion). Kill switch:
+      ``settings.tool_search_defer_codex`` (default True post-gate).
+
+    Never defers: the model lacks ``supports_tool_search``, hosted entries
+    (anything whose ``type`` is not ``"function"``), the always-loaded core
+    set, and names in ``OPENAI_DEFER_NAME_BLOCKLIST`` (upstream 500 when a
+    deferred function named "web" rides with tool_search + web_search).
+    Idempotent: already-shaped input passes through unchanged.
+    """
+    from core.config import settings as _settings
+    from core.llm.tool_defer import (
+        OPENAI_DEFER_NAME_BLOCKLIST,
+        TOOL_DEFER_THRESHOLD,
+        TOOL_SEARCH_ALWAYS_LOADED,
+    )
+
+    if not spec.supports_tool_search or len(tools) <= TOOL_DEFER_THRESHOLD:
+        return tools
+    if backend == "codex":
+        if not getattr(_settings, "tool_search_defer_codex", False):
+            return tools
+    elif not getattr(_settings, "tool_search_defer", True):
+        return tools
+    if any(t.get("type") == "tool_search" or t.get("defer_loading") for t in tools):
+        return tools  # already shaped — idempotent pass-through
+    shaped: list[dict[str, Any]] = []
+    deferred_count = 0
+    for tool in tools:
+        name = str(tool.get("name", ""))
+        if (
+            tool.get("type") != "function"
+            or name in TOOL_SEARCH_ALWAYS_LOADED
+            or name in OPENAI_DEFER_NAME_BLOCKLIST
+        ):
+            shaped.append(tool)
+            continue
+        deferred_tool = dict(tool)
+        deferred_tool["defer_loading"] = True
+        shaped.append(deferred_tool)
+        deferred_count += 1
+    if not deferred_count:
+        return tools
+    log.info(
+        "%s: openai tool_search defer active — %d/%d tool defs deferred",
+        adapter_name,
+        deferred_count,
+        len(shaped) + 1,
+    )
+    return [*shaped, {"type": "tool_search"}]
+
+
 def build_responses_kwargs(
     req: AdapterCallRequest, *, backend: str, adapter_name: str
 ) -> dict[str, Any]:
@@ -1003,7 +1085,10 @@ def build_responses_kwargs(
         )
     if req.tools:
         translated = [translate_tool_for_codex(t) for t in req.tools]
-        kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=adapter_name)
+        capped = cap_tools(translated, model=req.model, adapter_name=adapter_name)
+        kwargs["tools"] = _apply_openai_tool_search_defer(
+            capped, backend=backend, spec=spec, adapter_name=adapter_name
+        )
         kwargs["tool_choice"] = translate_responses_tool_choice(req.tool_choice)
         kwargs["parallel_tool_calls"] = True
     if spec.reasoning_effort_values is not None:

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -919,6 +919,191 @@ def _normalize_summary_list(summary: Any) -> list[dict[str, Any]]:
     return out
 
 
+def build_responses_kwargs(
+    req: AdapterCallRequest, *, backend: str, adapter_name: str
+) -> dict[str, Any]:
+    """Shared OpenAI Responses API kwargs — platform (openai-payg) + Codex backends.
+
+    PR-OPENAI-RESPONSES (2026-06-13): extracted from codex_oauth's
+    ``_build_codex_call_kwargs`` so openai-payg's ``acomplete``/``astream``
+    leave Chat Completions and join the Responses surface this module's
+    ``acomplete_text``/``aweb_search`` already use (Responses is OpenAI's
+    forward-going API; new features such as tool_search are Responses-only).
+
+    Backend deltas:
+
+    - ``backend="codex"`` — ``max_output_tokens`` FORBIDDEN (Subscription
+      manages it server-side; sending it returns 400).
+    - ``backend="platform"`` — ``max_output_tokens`` supported and sent
+      from ``req.max_tokens``.
+    - ``store=False`` on both (stateless requests; reasoning replays inline).
+
+    Naming debt (deliberate, scheduled for a cleanup PR): the helpers
+    ``build_codex_input`` / ``translate_tool_for_codex`` keep their codex-
+    prefixed names although the platform backend now shares them — the
+    rename touches a 12-file radius that does not belong in a migration
+    diff.
+
+    Critical Codex backend constraints (from
+    ``docs/research/codex-oauth-request-spec.md``):
+
+    - ``instructions`` carries the system prompt (not ``input[].role:system``)
+    - ``input`` is the user/assistant/tool array — built via
+      :func:`build_codex_input` which re-encodes Anthropic content blocks
+      into Codex typed items (``function_call`` / ``function_call_output``)
+    - ``store=False`` is mandatory
+    - ``max_output_tokens`` is FORBIDDEN — Subscription manages it
+      server-side, sending the field returns 400
+    - Tools use the FLAT shape (``translate_tool_for_codex``)
+    - Reasoning models (per
+      :func:`core.llm.adapters._openai_common.get_openai_model_spec`)
+      omit ``temperature`` and add ``reasoning`` + ``include:
+      ["reasoning.encrypted_content"]``
+    - A2 (v0.99.44): previous-turn reasoning items replay inline via
+      :func:`build_codex_input` — each assistant :class:`Message` carries
+      its own ``codex_reasoning_items`` (populated by the bridge from the
+      Anthropic-shape assistant message dict's ``codex_reasoning_items``
+      key) and ``build_codex_input`` prepends those entries at the
+      correct ordinal position. The legacy whole-input prepend approach
+      lost per-turn association for multi-assistant histories — Codex
+      MCP A2 BLOCKER 3.
+    - PR-DRIFT-CUT (2026-05-24): replaced ``req.model.startswith("gpt-5")``
+      heuristic with explicit registry lookup so o3 / o4-mini / new
+      reasoning models go through the same branch automatically.
+    """
+    spec = get_openai_model_spec(req.model)
+    resp_input = build_codex_input(req)
+    kwargs: dict[str, Any] = {
+        "model": req.model,
+        "instructions": req.system_prompt or "You are a helpful assistant.",
+        "input": resp_input or [{"role": "user", "content": "hello"}],
+        "store": False,
+    }
+    if backend == "platform":
+        kwargs["max_output_tokens"] = req.max_tokens
+    if req.tools:
+        translated = [translate_tool_for_codex(t) for t in req.tools]
+        kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=adapter_name)
+        kwargs["tool_choice"] = translate_responses_tool_choice(req.tool_choice)
+        kwargs["parallel_tool_calls"] = True
+    if spec.reasoning_effort_values is not None:
+        # Reasoning-model branch — encrypted reasoning passthrough +
+        # reasoning effort. Temperature is dropped per spec.
+        kwargs["include"] = ["reasoning.encrypted_content"]
+        kwargs["reasoning"] = {"effort": req.effort, "summary": "auto"}
+    elif req.temperature is not None and spec.accepts_temperature:
+        kwargs["temperature"] = req.temperature
+    # PR-CODEX-OAUTH-RESPONSE-SCHEMA (2026-05-25) — Responses API
+    # structured-output enforcement. PR-JSON-WIRE (#79) routed
+    # ``req.response_schema`` through claude-cli (--json-schema) and
+    # codex-cli (--output-schema <FILE>) but silently dropped the
+    # codex-oauth path. Without API-level schema enforcement, gpt-5.x
+    # reasoning models can return ``stop_reason=completed`` with the
+    # entire output budget spent on encrypted reasoning items + empty
+    # ``output_text`` (smoke 17: 20+ codex-oauth-empty-text dumps,
+    # ~10 per match). Adding ``text.format = {type:"json_schema", ...}``
+    # forwards the schema for server-side enforcement. Spec: OpenAI
+    # Responses API ``text.format`` (replaces Chat Completions
+    # ``response_format``).
+    #
+    # Codex MCP review of PR #1687: ``strict: True`` requires the schema
+    # to satisfy OpenAI's Structured Outputs subset (all object schemas
+    # set ``additionalProperties: false`` AND every property listed in
+    # ``required``). GEODE's seed-generation schemas in
+    # ``plugins/seed_generation/json_schemas.py`` intentionally use the
+    # additive helper that omits both, so unconditional strict=True would
+    # cause the server to **reject the request** (400) before generation
+    # — a worse retry storm than the empty-text path. Auto-detect strict
+    # compatibility per schema and fall through to ``strict: False`` for
+    # non-compatible schemas (still forwards the shape as a strong hint,
+    # but server treats it as informational rather than gated).
+    if req.response_schema is not None:
+        schema_name = str(req.response_schema.get("title") or "response")
+        kwargs["text"] = {
+            "format": {
+                "type": "json_schema",
+                "name": schema_name,
+                "strict": _is_openai_strict_compatible(req.response_schema),
+                "schema": req.response_schema,
+            }
+        }
+    return kwargs
+
+
+def _is_openai_strict_compatible(schema: Any) -> bool:
+    """Check whether ``schema`` satisfies OpenAI's strict Structured Outputs subset.
+
+    Provider-specific (OpenAI Responses API only). Do NOT reuse from
+    other adapters without verifying the target API's subset rules —
+    Anthropic Structured Outputs (Claude API) shares the
+    ``additionalProperties: false`` constraint but DIVERGES on:
+
+    - ``required`` completeness: OpenAI requires every property key to
+      appear in ``required``; Anthropic allows up to 24 optional
+      properties.
+    - ``oneOf``: OpenAI supports; Anthropic does not.
+    - Numerical / string constraints (``minimum`` / ``maxLength`` …):
+      OpenAI supports; Anthropic does not.
+
+    Codex OAuth hits the OpenAI Responses API, so this helper enforces
+    OpenAI's stricter rule set. Per OpenAI docs (ctx7 `/websites/
+    developers_openai_api`, responses-vs-chat-completions guide),
+    ``strict: True`` requires every ``type: "object"`` subschema:
+
+    - sets ``additionalProperties: false`` (typed-additional or True is rejected)
+    - lists ALL declared property keys in ``required``
+
+    Plus array ``items`` and nested objects must satisfy the same recursively.
+    ``oneOf`` / ``anyOf`` / ``allOf`` branches must each be strict-compatible.
+
+    Returns ``True`` when the schema is safe to send with ``strict: True``;
+    ``False`` when ``strict: False`` should be used instead. This keeps
+    legacy GEODE schemas (designed for additive-output tolerance) from
+    causing 400 rejections while still forwarding the schema shape as a
+    server hint.
+    """
+    if not isinstance(schema, dict):
+        return True
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        if schema.get("additionalProperties") is not False:
+            return False
+        properties = schema.get("properties") or {}
+        required = set(schema.get("required") or [])
+        if set(properties.keys()) != required:
+            return False
+        for prop_schema in properties.values():
+            if not _is_openai_strict_compatible(prop_schema):
+                return False
+    if "items" in schema and not _is_openai_strict_compatible(schema["items"]):
+        return False
+    for combinator_key in ("oneOf", "anyOf", "allOf"):
+        # Combinators are accepted only when every branch is strict-compatible.
+        branches = schema.get(combinator_key)
+        if isinstance(branches, list):
+            for branch in branches:
+                if not _is_openai_strict_compatible(branch):
+                    return False
+    return True
+
+
+def translate_responses_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any]:
+    """Adapter-neutral ``tool_choice`` → Responses API wire shape (platform + Codex).
+
+    Routes through :func:`core.llm.tool_choice.normalize` with
+    ``provider="openai"`` — Responses API uses the FLAT shape
+    ``{"type": "function", "name": "..."}`` (not the Chat nested
+    ``function`` wrapper). The legacy helper accepts the Anthropic-shape
+    dicts the AgenticLoop emits (``{"type": "auto"}`` / ``{"type":
+    "none"}`` / ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``)
+    and returns the Codex-correct payload (Codex MCP A2 BLOCKER 2).
+    """
+    from core.llm.tool_choice import normalize
+
+    normalised = normalize("openai", tc)
+    return normalised if normalised is not None else "auto"
+
+
 def _attr_or_key(item: Any, name: str) -> Any:
     """Read ``item.name`` whether ``item`` is an SDK object or a dict."""
     if isinstance(item, dict):

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -27,9 +27,8 @@ from typing import Any
 
 from core.llm.adapters._openai_common import (
     build_async_codex_client,
-    build_codex_input,
+    build_responses_kwargs,
     translate_codex_response,
-    translate_tool_for_codex,
 )
 from core.llm.adapters.base import (
     SOURCE_SUBSCRIPTION,
@@ -136,7 +135,7 @@ class CodexOAuthAdapter:
         forwards them to :attr:`AgenticResponse.codex_reasoning_items`.
         """
         client = self._get_client()
-        kwargs = _build_codex_call_kwargs(req)
+        kwargs = build_responses_kwargs(req, backend="codex", adapter_name="codex-oauth")
         # PR-LEGACY-PROVIDER-REMOVAL (2026-05-28) — pre-send input-shape
         # diagnostic backfilled from the now-deleted
         # ``CodexAgenticAdapter.agentic_call``. The Codex backend rejects
@@ -321,7 +320,7 @@ class CodexOAuthAdapter:
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
-        kwargs = _build_codex_call_kwargs(req)
+        kwargs = build_responses_kwargs(req, backend="codex", adapter_name="codex-oauth")
         async with client.responses.stream(**kwargs) as stream:
             async for event in stream:
                 ev_type = getattr(event, "type", "")
@@ -403,169 +402,6 @@ class CodexOAuthAdapter:
             provider=self.provider,
             source_path=source_path,
         )
-
-
-def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
-    """Codex Responses API call kwargs — mirrors CodexAgenticAdapter shape.
-
-    Critical Codex backend constraints (from
-    ``docs/research/codex-oauth-request-spec.md``):
-
-    - ``instructions`` carries the system prompt (not ``input[].role:system``)
-    - ``input`` is the user/assistant/tool array — built via
-      :func:`build_codex_input` which re-encodes Anthropic content blocks
-      into Codex typed items (``function_call`` / ``function_call_output``)
-    - ``store=False`` is mandatory
-    - ``max_output_tokens`` is FORBIDDEN — Subscription manages it
-      server-side, sending the field returns 400
-    - Tools use the FLAT shape (``translate_tool_for_codex``)
-    - Reasoning models (per
-      :func:`core.llm.adapters._openai_common.get_openai_model_spec`)
-      omit ``temperature`` and add ``reasoning`` + ``include:
-      ["reasoning.encrypted_content"]``
-    - A2 (v0.99.44): previous-turn reasoning items replay inline via
-      :func:`build_codex_input` — each assistant :class:`Message` carries
-      its own ``codex_reasoning_items`` (populated by the bridge from the
-      Anthropic-shape assistant message dict's ``codex_reasoning_items``
-      key) and ``build_codex_input`` prepends those entries at the
-      correct ordinal position. The legacy whole-input prepend approach
-      lost per-turn association for multi-assistant histories — Codex
-      MCP A2 BLOCKER 3.
-    - PR-DRIFT-CUT (2026-05-24): replaced ``req.model.startswith("gpt-5")``
-      heuristic with explicit registry lookup so o3 / o4-mini / new
-      reasoning models go through the same branch automatically.
-    """
-    from core.llm.adapters._openai_common import cap_tools, get_openai_model_spec
-
-    spec = get_openai_model_spec(req.model)
-    resp_input = build_codex_input(req)
-    kwargs: dict[str, Any] = {
-        "model": req.model,
-        "instructions": req.system_prompt or "You are a helpful assistant.",
-        "input": resp_input or [{"role": "user", "content": "hello"}],
-        "store": False,
-    }
-    if req.tools:
-        translated = [translate_tool_for_codex(t) for t in req.tools]
-        kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name="codex-oauth")
-        kwargs["tool_choice"] = _translate_codex_tool_choice(req.tool_choice)
-        kwargs["parallel_tool_calls"] = True
-    if spec.reasoning_effort_values is not None:
-        # Reasoning-model branch — encrypted reasoning passthrough +
-        # reasoning effort. Temperature is dropped per spec.
-        kwargs["include"] = ["reasoning.encrypted_content"]
-        kwargs["reasoning"] = {"effort": req.effort, "summary": "auto"}
-    elif req.temperature is not None and spec.accepts_temperature:
-        kwargs["temperature"] = req.temperature
-    # PR-CODEX-OAUTH-RESPONSE-SCHEMA (2026-05-25) — Responses API
-    # structured-output enforcement. PR-JSON-WIRE (#79) routed
-    # ``req.response_schema`` through claude-cli (--json-schema) and
-    # codex-cli (--output-schema <FILE>) but silently dropped the
-    # codex-oauth path. Without API-level schema enforcement, gpt-5.x
-    # reasoning models can return ``stop_reason=completed`` with the
-    # entire output budget spent on encrypted reasoning items + empty
-    # ``output_text`` (smoke 17: 20+ codex-oauth-empty-text dumps,
-    # ~10 per match). Adding ``text.format = {type:"json_schema", ...}``
-    # forwards the schema for server-side enforcement. Spec: OpenAI
-    # Responses API ``text.format`` (replaces Chat Completions
-    # ``response_format``).
-    #
-    # Codex MCP review of PR #1687: ``strict: True`` requires the schema
-    # to satisfy OpenAI's Structured Outputs subset (all object schemas
-    # set ``additionalProperties: false`` AND every property listed in
-    # ``required``). GEODE's seed-generation schemas in
-    # ``plugins/seed_generation/json_schemas.py`` intentionally use the
-    # additive helper that omits both, so unconditional strict=True would
-    # cause the server to **reject the request** (400) before generation
-    # — a worse retry storm than the empty-text path. Auto-detect strict
-    # compatibility per schema and fall through to ``strict: False`` for
-    # non-compatible schemas (still forwards the shape as a strong hint,
-    # but server treats it as informational rather than gated).
-    if req.response_schema is not None:
-        schema_name = str(req.response_schema.get("title") or "response")
-        kwargs["text"] = {
-            "format": {
-                "type": "json_schema",
-                "name": schema_name,
-                "strict": _is_openai_strict_compatible(req.response_schema),
-                "schema": req.response_schema,
-            }
-        }
-    return kwargs
-
-
-def _is_openai_strict_compatible(schema: Any) -> bool:
-    """Check whether ``schema`` satisfies OpenAI's strict Structured Outputs subset.
-
-    Provider-specific (OpenAI Responses API only). Do NOT reuse from
-    other adapters without verifying the target API's subset rules —
-    Anthropic Structured Outputs (Claude API) shares the
-    ``additionalProperties: false`` constraint but DIVERGES on:
-
-    - ``required`` completeness: OpenAI requires every property key to
-      appear in ``required``; Anthropic allows up to 24 optional
-      properties.
-    - ``oneOf``: OpenAI supports; Anthropic does not.
-    - Numerical / string constraints (``minimum`` / ``maxLength`` …):
-      OpenAI supports; Anthropic does not.
-
-    Codex OAuth hits the OpenAI Responses API, so this helper enforces
-    OpenAI's stricter rule set. Per OpenAI docs (ctx7 `/websites/
-    developers_openai_api`, responses-vs-chat-completions guide),
-    ``strict: True`` requires every ``type: "object"`` subschema:
-
-    - sets ``additionalProperties: false`` (typed-additional or True is rejected)
-    - lists ALL declared property keys in ``required``
-
-    Plus array ``items`` and nested objects must satisfy the same recursively.
-    ``oneOf`` / ``anyOf`` / ``allOf`` branches must each be strict-compatible.
-
-    Returns ``True`` when the schema is safe to send with ``strict: True``;
-    ``False`` when ``strict: False`` should be used instead. This keeps
-    legacy GEODE schemas (designed for additive-output tolerance) from
-    causing 400 rejections while still forwarding the schema shape as a
-    server hint.
-    """
-    if not isinstance(schema, dict):
-        return True
-    schema_type = schema.get("type")
-    if schema_type == "object":
-        if schema.get("additionalProperties") is not False:
-            return False
-        properties = schema.get("properties") or {}
-        required = set(schema.get("required") or [])
-        if set(properties.keys()) != required:
-            return False
-        for prop_schema in properties.values():
-            if not _is_openai_strict_compatible(prop_schema):
-                return False
-    if "items" in schema and not _is_openai_strict_compatible(schema["items"]):
-        return False
-    for combinator_key in ("oneOf", "anyOf", "allOf"):
-        # Combinators are accepted only when every branch is strict-compatible.
-        branches = schema.get(combinator_key)
-        if isinstance(branches, list):
-            for branch in branches:
-                if not _is_openai_strict_compatible(branch):
-                    return False
-    return True
-
-
-def _translate_codex_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any]:
-    """Adapter-neutral ``tool_choice`` → Codex Responses API wire shape.
-
-    Routes through :func:`core.llm.tool_choice.normalize` with
-    ``provider="openai"`` — Responses API uses the FLAT shape
-    ``{"type": "function", "name": "..."}`` (not the Chat nested
-    ``function`` wrapper). The legacy helper accepts the Anthropic-shape
-    dicts the AgenticLoop emits (``{"type": "auto"}`` / ``{"type":
-    "none"}`` / ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``)
-    and returns the Codex-correct payload (Codex MCP A2 BLOCKER 2).
-    """
-    from core.llm.tool_choice import normalize
-
-    normalised = normalize("openai", tc)
-    return normalised if normalised is not None else "auto"
 
 
 def _dump_empty_text_postmortem(

--- a/core/llm/adapters/openai_payg.py
+++ b/core/llm/adapters/openai_payg.py
@@ -9,6 +9,15 @@ isolation.
 
 Pair with :class:`CodexOAuthAdapter` (same provider, OAuth path) and
 :class:`CodexCliAdapter` (subprocess path).
+
+PR-OPENAI-RESPONSES (2026-06-13): ``acomplete``/``astream`` moved from
+Chat Completions to the Responses API via the shared
+:func:`core.llm.adapters._openai_common.build_responses_kwargs`
+(``backend="platform"``) — completing the migration that
+``acomplete_text``/``aweb_search`` started. Responses is OpenAI's
+forward-going surface; new features (tool_search deferred loading 등)
+are Responses-only. Chat Completions now lives only on the GLM adapters
+(z.ai compatibility surface lacks Responses).
 """
 
 from __future__ import annotations
@@ -20,11 +29,8 @@ from typing import Any
 
 from core.llm.adapters._openai_common import (
     build_async_openai_client,
-    build_messages,
-    cap_tools,
-    get_openai_model_spec,
-    translate_chat_response,
-    translate_tool,
+    build_responses_kwargs,
+    translate_codex_response,
 )
 from core.llm.adapters.base import (
     SOURCE_PAYG,
@@ -77,47 +83,6 @@ class OpenAIPaygAdapter:
             )
         return self._clients.get(lambda: build_async_openai_client(api_key))
 
-    def _build_kwargs(self, req: AdapterCallRequest, *, stream: bool) -> dict[str, Any]:
-        """Compose Chat Completions kwargs honouring per-model spec quirks.
-
-        PR-DRIFT-CUT (2026-05-24) consults
-        :func:`core.llm.adapters._openai_common.get_openai_model_spec`
-        for the per-model API surface (rather than the previous
-        ``startswith("gpt-5")`` heuristic):
-
-          * ``spec.uses_max_completion_tokens`` chooses between
-            ``max_completion_tokens`` (GPT-5.x + o-series) and the
-            legacy ``max_tokens`` key.
-          * ``spec.accepts_temperature`` is False for reasoning models,
-            so ``temperature`` is omitted entirely.
-          * ``tools`` array hard-caps at 128 entries via shared
-            :func:`cap_tools` with an operator-actionable log.
-
-        Unknown ``req.model`` falls back to legacy gpt-4.x defaults
-        with a one-shot WARNING so silent drift on new models is
-        impossible.
-        """
-        spec = get_openai_model_spec(req.model)
-        token_key = "max_completion_tokens" if spec.uses_max_completion_tokens else "max_tokens"
-        kwargs: dict[str, Any] = {
-            "model": req.model,
-            "messages": build_messages(req),
-            token_key: req.max_tokens,
-        }
-        if stream:
-            kwargs["stream"] = True
-        if req.temperature is not None and spec.accepts_temperature:
-            kwargs["temperature"] = req.temperature
-        if req.tools:
-            translated = [translate_tool(t) for t in req.tools]
-            kwargs["tools"] = cap_tools(translated, model=req.model, adapter_name=self.name)
-            tc = _translate_tool_choice(req.tool_choice)
-            if tc is not None:
-                kwargs["tool_choice"] = tc
-        if req.stop_sequences:
-            kwargs["stop"] = list(req.stop_sequences)
-        return kwargs
-
     async def aweb_search(
         self, query: str, *, max_results: int = 5, model: str = ""
     ) -> WebSearchResult:
@@ -166,38 +131,44 @@ class OpenAIPaygAdapter:
 
     async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
         client = self._get_client()
-        kwargs = self._build_kwargs(req, stream=False)
+        kwargs = build_responses_kwargs(req, backend="platform", adapter_name=self.name)
         # PR-OAUTH-API-LANES (2026-05-26) — pooled with codex-oauth in
         # the same per-account openai-api lane (OpenAI rate-limits
         # per-account, not per-source).
         lane_key = f"openai-payg:{req.model}"
         async with acquire_openai_api_lane_async(lane_key):
             try:
-                response = await client.chat.completions.create(**kwargs)
+                # Stream + aggregate, mirroring codex-oauth: uniform SSE
+                # handling across both Responses backends, and reasoning
+                # items arrive as typed output items either way.
+                async with client.responses.stream(**kwargs) as stream:
+                    accumulated: list[Any] = []
+                    async for event in stream:
+                        if getattr(event, "type", "") == "response.output_item.done":
+                            item = getattr(event, "item", None)
+                            if item is not None:
+                                accumulated.append(item)
+                    final = await stream.get_final_response()
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "openai-payg: chat.completions.create failed model=%s err=%s",
+                    "openai-payg: responses.stream failed model=%s err=%s",
                     req.model,
                     exc,
                 )
                 raise
-        return translate_chat_response(response)
+        return translate_codex_response(final, accumulated_items=accumulated)
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
-        kwargs = self._build_kwargs(req, stream=True)
-        async for chunk in await client.chat.completions.create(**kwargs):
-            choice = chunk.choices[0] if chunk.choices else None
-            if choice is None:
-                continue
-            delta = getattr(choice, "delta", None)
-            text_chunk = getattr(delta, "content", None) if delta else None
-            if text_chunk:
-                yield StreamEvent(kind="text", payload={"text": text_chunk})
-            finish_reason = getattr(choice, "finish_reason", None)
-            if finish_reason is not None:
-                yield StreamEvent(kind="stop", payload={"stop_reason": finish_reason})
+        kwargs = build_responses_kwargs(req, backend="platform", adapter_name=self.name)
+        async with client.responses.stream(**kwargs) as stream:
+            async for event in stream:
+                ev_type = getattr(event, "type", "")
+                if ev_type.endswith("output_text.delta"):
+                    yield StreamEvent(kind="text", payload={"text": getattr(event, "delta", "")})
+                elif ev_type == "response.completed":
+                    yield StreamEvent(kind="stop", payload={"stop_reason": "completed"})
 
     def test_environment(self) -> EnvironmentReport:
         from core.config import settings
@@ -250,22 +221,6 @@ class OpenAIPaygAdapter:
             provider=self.provider,
             source_path="settings.openai_api_key",
         )
-
-
-def _translate_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any] | None:
-    """Adapter-neutral ``tool_choice`` → Chat Completions wire shape.
-
-    Routes through :func:`core.llm.tool_choice.normalize` with
-    ``provider="glm"`` — Chat Completions uses the SAME nested
-    ``{"type": "function", "function": {"name": "..."}}`` shape that
-    GLM does. The legacy helper accepts the Anthropic-shape dicts the
-    AgenticLoop emits (``{"type": "auto"}`` / ``{"type": "none"}`` /
-    ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``) and
-    returns the Chat-correct payload (Codex MCP A2 BLOCKER 2).
-    """
-    from core.llm.tool_choice import normalize
-
-    return normalize("glm", tc)
 
 
 __all__ = ["OpenAIPaygAdapter"]

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -660,30 +660,12 @@ _TOOL_SEARCH_TOOL: dict[str, Any] = {
     "name": "tool_search_tool_regex",
 }
 
-TOOL_DEFER_THRESHOLD = 16
-"""Tool count above which deferred loading activates (docs: 10+ tools is
-the good-use-case bar; GEODE ships ~60). Below it, defer adds a search
-round-trip for no context saving."""
-
-# Immediately-loaded core set — the high-frequency tools the loop should
-# never pay a search round-trip for. Everything else defers behind
-# tool_search. Kept here (provider-level) because defer_loading is an
-# Anthropic Messages API field; OpenAI-family adapters rebuild tool
-# definitions from name/description/schema, so the field never leaks.
-TOOL_SEARCH_ALWAYS_LOADED: frozenset[str] = frozenset(
-    {
-        "memory_search",
-        "memory_save",
-        "note_read",
-        "note_save",
-        "read_document",
-        "glob_files",
-        "grep_files",
-        "general_web_search",
-        "web_fetch",
-        "llms_txt_index",
-        "check_status",
-    }
+# Policy constants (threshold + always-loaded core set) live in the
+# provider-neutral ``core.llm.tool_defer`` since PR-CODEX-TOOL-SEARCH —
+# the OpenAI Responses builder shares the same policy.
+from core.llm.tool_defer import (  # noqa: E402  (policy import next to its use)
+    TOOL_DEFER_THRESHOLD,
+    TOOL_SEARCH_ALWAYS_LOADED,
 )
 
 

--- a/core/llm/tool_defer.py
+++ b/core/llm/tool_defer.py
@@ -1,0 +1,43 @@
+"""Deferred tool loading policy — provider-neutral SoT.
+
+PR-CODEX-TOOL-SEARCH (2026-06-13): the always-loaded core set and the
+activation threshold moved here from ``core/llm/providers/anthropic.py``
+so the OpenAI Responses builder (``_openai_common.build_responses_kwargs``)
+shares ONE policy with the Anthropic adapter instead of growing a second
+copy (dual-SoT rule). Both providers expose the same official mechanism:
+a ``defer_loading`` field on tool definitions plus a hosted search tool
+(Anthropic ``tool_search_tool_regex_20251119`` / OpenAI
+``{"type": "tool_search"}``).
+"""
+
+from __future__ import annotations
+
+TOOL_DEFER_THRESHOLD = 16
+"""Tool count above which deferred loading activates (both vendors cite
+10+ tools as the good-use-case bar; GEODE ships ~60). Below it, defer
+adds a search round-trip for no context saving."""
+
+TOOL_SEARCH_ALWAYS_LOADED: frozenset[str] = frozenset(
+    {
+        "memory_search",
+        "memory_save",
+        "note_read",
+        "note_save",
+        "read_document",
+        "glob_files",
+        "grep_files",
+        "general_web_search",
+        "web_fetch",
+        "llms_txt_index",
+        "check_status",
+    }
+)
+"""Immediately-loaded core set — high-frequency tools the loop should
+never pay a search round-trip for. Everything else defers behind the
+provider's hosted tool-search tool."""
+
+# OpenAI Responses 500 bug (community.openai.com/t/.../1375850):
+# tool_search + hosted web_search + a DEFERRED function named "web"
+# returns a 500. GEODE ships no tool named "web", but the exclusion is
+# pinned so a future tool cannot trip the upstream bug.
+OPENAI_DEFER_NAME_BLOCKLIST: frozenset[str] = frozenset({"web"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.192"
+version = "0.99.193"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.191"
+version = "0.99.192"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
+++ b/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
@@ -12,8 +12,8 @@ References:
 
 from __future__ import annotations
 
+from core.llm.adapters._openai_common import build_responses_kwargs
 from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
-from core.llm.adapters.codex_oauth import _build_codex_call_kwargs
 
 
 def _req(model: str = "gpt-5.5", **kw: object) -> AdapterCallRequest:
@@ -29,20 +29,24 @@ def _req(model: str = "gpt-5.5", **kw: object) -> AdapterCallRequest:
 
 def test_codex_kwargs_does_not_send_max_output_tokens() -> None:
     """Codex backend rejects ``max_output_tokens`` with 400 — must not be sent."""
-    kwargs = _build_codex_call_kwargs(_req(max_tokens=2048))
+    kwargs = build_responses_kwargs(
+        _req(max_tokens=2048), backend="codex", adapter_name="codex-oauth"
+    )
     assert "max_output_tokens" not in kwargs
     assert "max_tokens" not in kwargs
 
 
 def test_codex_kwargs_sets_store_false() -> None:
     """``store = False`` is required on Codex backend (Plus subscription policy)."""
-    kwargs = _build_codex_call_kwargs(_req())
+    kwargs = build_responses_kwargs(_req(), backend="codex", adapter_name="codex-oauth")
     assert kwargs["store"] is False
 
 
 def test_codex_kwargs_lifts_system_prompt_to_instructions() -> None:
     """System prompt belongs in ``instructions``, not in ``input[].role=system``."""
-    kwargs = _build_codex_call_kwargs(_req(system_prompt="audit only"))
+    kwargs = build_responses_kwargs(
+        _req(system_prompt="audit only"), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["instructions"] == "audit only"
     roles_in_input = [m.get("role") for m in kwargs["input"]]
     assert "system" not in roles_in_input
@@ -50,13 +54,17 @@ def test_codex_kwargs_lifts_system_prompt_to_instructions() -> None:
 
 def test_codex_kwargs_instructions_default_when_empty() -> None:
     """Empty system_prompt still produces a non-empty instructions string."""
-    kwargs = _build_codex_call_kwargs(_req(system_prompt=""))
+    kwargs = build_responses_kwargs(
+        _req(system_prompt=""), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["instructions"]  # non-empty fallback
 
 
 def test_codex_kwargs_gpt5_omits_temperature_adds_reasoning() -> None:
     """gpt-5.x family omits ``temperature`` and adds ``reasoning`` block."""
-    kwargs = _build_codex_call_kwargs(_req(model="gpt-5.5", temperature=0.7))
+    kwargs = build_responses_kwargs(
+        _req(model="gpt-5.5", temperature=0.7), backend="codex", adapter_name="codex-oauth"
+    )
     assert "temperature" not in kwargs
     assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
     assert kwargs["include"] == ["reasoning.encrypted_content"]
@@ -72,7 +80,9 @@ def test_codex_kwargs_o_series_also_omits_temperature() -> None:
     omit ``temperature`` and add the ``reasoning`` block. Verified
     2026-05-24 against OpenAI reasoning-models guide.
     """
-    kwargs = _build_codex_call_kwargs(_req(model="o3", temperature=0.3))
+    kwargs = build_responses_kwargs(
+        _req(model="o3", temperature=0.3), backend="codex", adapter_name="codex-oauth"
+    )
     assert "temperature" not in kwargs
     assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
     assert kwargs["include"] == ["reasoning.encrypted_content"]
@@ -86,7 +96,9 @@ def test_codex_kwargs_legacy_model_keeps_temperature() -> None:
     unknown model id (e.g. ``gpt-4o`` until it's registered) keeps
     the temperature path.
     """
-    kwargs = _build_codex_call_kwargs(_req(model="gpt-4o-legacy", temperature=0.3))
+    kwargs = build_responses_kwargs(
+        _req(model="gpt-4o-legacy", temperature=0.3), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["temperature"] == 0.3
     assert "reasoning" not in kwargs
 
@@ -94,7 +106,7 @@ def test_codex_kwargs_legacy_model_keeps_temperature() -> None:
 def test_codex_kwargs_tools_use_flat_responses_shape() -> None:
     """Codex Responses API requires the FLAT tool shape (not nested ``function``)."""
     tool = ToolSpec(name="search", description="web search", input_schema={"type": "object"})
-    kwargs = _build_codex_call_kwargs(_req(tools=[tool]))
+    kwargs = build_responses_kwargs(_req(tools=[tool]), backend="codex", adapter_name="codex-oauth")
     assert kwargs["tools"] == [
         {
             "type": "function",
@@ -108,7 +120,7 @@ def test_codex_kwargs_tools_use_flat_responses_shape() -> None:
 
 
 def test_codex_kwargs_no_tools_when_none_provided() -> None:
-    kwargs = _build_codex_call_kwargs(_req())
+    kwargs = build_responses_kwargs(_req(), backend="codex", adapter_name="codex-oauth")
     assert "tools" not in kwargs
     assert "parallel_tool_calls" not in kwargs
 
@@ -130,7 +142,7 @@ _VOTE_SCHEMA: dict[str, object] = {
 
 def test_codex_kwargs_omits_text_format_when_no_response_schema() -> None:
     """Back-compat: callers that don't pin a schema keep the pre-fix shape."""
-    kwargs = _build_codex_call_kwargs(_req())
+    kwargs = build_responses_kwargs(_req(), backend="codex", adapter_name="codex-oauth")
     assert "text" not in kwargs
 
 
@@ -148,7 +160,9 @@ def test_codex_kwargs_wires_response_schema_to_text_format() -> None:
     ``False``. Strict=True is exercised by
     ``test_codex_kwargs_text_format_strict_true_for_strict_compat_schema``.
     """
-    kwargs = _build_codex_call_kwargs(_req(response_schema=_VOTE_SCHEMA))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=_VOTE_SCHEMA), backend="codex", adapter_name="codex-oauth"
+    )
     assert "text" in kwargs, "text.format missing — codex-oauth silently dropped response_schema"
     text = kwargs["text"]
     assert isinstance(text, dict)
@@ -164,7 +178,9 @@ def test_codex_kwargs_wires_response_schema_to_text_format() -> None:
 def test_codex_kwargs_text_format_name_fallback_when_no_title() -> None:
     """Schemas without ``title`` get a generic ``response`` name."""
     untitled = {k: v for k, v in _VOTE_SCHEMA.items() if k != "title"}
-    kwargs = _build_codex_call_kwargs(_req(response_schema=untitled))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=untitled), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["name"] == "response"
 
 
@@ -173,7 +189,9 @@ def test_codex_kwargs_text_format_coexists_with_reasoning() -> None:
 
     The fix must not regress the reasoning kwargs — both blocks coexist.
     """
-    kwargs = _build_codex_call_kwargs(_req(response_schema=_VOTE_SCHEMA))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=_VOTE_SCHEMA), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
     assert kwargs["include"] == ["reasoning.encrypted_content"]
     assert kwargs["text"]["format"]["type"] == "json_schema"
@@ -205,7 +223,9 @@ def test_codex_kwargs_text_format_strict_true_for_strict_compat_schema() -> None
     docs): every object schema must set ``additionalProperties: false``
     AND list every property in ``required``.
     """
-    kwargs = _build_codex_call_kwargs(_req(response_schema=_STRICT_COMPAT_SCHEMA))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=_STRICT_COMPAT_SCHEMA), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["strict"] is True
 
 
@@ -219,7 +239,9 @@ def test_codex_kwargs_text_format_strict_false_when_additional_properties_open()
         "required": ["x"],
         # NB: no additionalProperties → not strict-compatible
     }
-    kwargs = _build_codex_call_kwargs(_req(response_schema=open_schema))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=open_schema), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["strict"] is False
 
 
@@ -235,7 +257,9 @@ def test_codex_kwargs_text_format_strict_false_when_required_misses_property() -
         "required": ["a"],  # b missing
         "additionalProperties": False,
     }
-    kwargs = _build_codex_call_kwargs(_req(response_schema=partial_required))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=partial_required), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["strict"] is False
 
 
@@ -258,7 +282,9 @@ def test_codex_kwargs_text_format_strict_false_when_typed_additional_properties(
         "required": ["scores"],
         "additionalProperties": False,
     }
-    kwargs = _build_codex_call_kwargs(_req(response_schema=typed_extra))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=typed_extra), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["strict"] is False
 
 
@@ -281,5 +307,7 @@ def test_codex_kwargs_text_format_strict_recurses_into_array_items() -> None:
         "required": ["list"],
         "additionalProperties": False,
     }
-    kwargs = _build_codex_call_kwargs(_req(response_schema=array_of_open))
+    kwargs = build_responses_kwargs(
+        _req(response_schema=array_of_open), backend="codex", adapter_name="codex-oauth"
+    )
     assert kwargs["text"]["format"]["strict"] is False

--- a/tests/core/llm/adapters/test_codex_oauth_empty_text_retry_edge.py
+++ b/tests/core/llm/adapters/test_codex_oauth_empty_text_retry_edge.py
@@ -38,8 +38,9 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from core.llm.adapters._openai_common import build_responses_kwargs
 from core.llm.adapters.base import AdapterCallRequest, Message
-from core.llm.adapters.codex_oauth import CodexOAuthAdapter, _build_codex_call_kwargs
+from core.llm.adapters.codex_oauth import CodexOAuthAdapter
 
 _VOTE_SCHEMA: dict[str, Any] = {
     "title": "vote",
@@ -237,7 +238,9 @@ def test_acomplete_with_schema_preserves_codex_backend_invariants() -> None:
     dropping another (e.g. an over-eager refactor that overwrites kwargs)
     is caught.
     """
-    kwargs = _build_codex_call_kwargs(_voter_req(schema=_VOTE_SCHEMA))
+    kwargs = build_responses_kwargs(
+        _voter_req(schema=_VOTE_SCHEMA), backend="codex", adapter_name="codex-oauth"
+    )
     # Pre-PR invariants (must coexist with the new text block).
     assert kwargs["store"] is False
     assert kwargs["instructions"] == "You are a ranker voter."
@@ -260,8 +263,12 @@ def test_kwargs_text_format_is_the_only_schema_difference() -> None:
     ``_build_codex_call_kwargs`` quietly diverges other fields based on
     schema presence, this test catches it before it lands in production.
     """
-    no_schema = _build_codex_call_kwargs(_voter_req(schema=None))
-    with_schema = _build_codex_call_kwargs(_voter_req(schema=_VOTE_SCHEMA))
+    no_schema = build_responses_kwargs(
+        _voter_req(schema=None), backend="codex", adapter_name="codex-oauth"
+    )
+    with_schema = build_responses_kwargs(
+        _voter_req(schema=_VOTE_SCHEMA), backend="codex", adapter_name="codex-oauth"
+    )
 
     # Drop the differing field and assert the rest is identical.
     with_schema_pruned = {k: v for k, v in with_schema.items() if k != "text"}

--- a/tests/core/llm/adapters/test_codex_reasoning_replay.py
+++ b/tests/core/llm/adapters/test_codex_reasoning_replay.py
@@ -30,9 +30,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from core.llm.adapters._openai_common import translate_codex_response
+from core.llm.adapters._openai_common import build_responses_kwargs, translate_codex_response
 from core.llm.adapters.base import AdapterCallResult, UsageSummary
-from core.llm.adapters.codex_oauth import _build_codex_call_kwargs
 from core.llm.adapters.translation import (
     agentic_response_from_adapter_result,
     build_adapter_request,
@@ -197,7 +196,7 @@ def test_codex_call_kwargs_replays_reasoning_at_assistant_turn() -> None:
             Message(role="user", content="next"),
         ],
     )
-    kwargs = _build_codex_call_kwargs(req)
+    kwargs = build_responses_kwargs(req, backend="codex", adapter_name="codex-oauth")
     # Sequence: user1, reasoning_for_assistant1, assistant1, user2
     assert kwargs["input"][0] == {"role": "user", "content": "first"}
     assert kwargs["input"][1]["type"] == "reasoning"
@@ -216,7 +215,7 @@ def test_codex_call_kwargs_no_reasoning_when_empty() -> None:
         system_prompt="be brief",
         messages=[Message(role="user", content="hello")],
     )
-    kwargs = _build_codex_call_kwargs(req)
+    kwargs = build_responses_kwargs(req, backend="codex", adapter_name="codex-oauth")
     assert kwargs["input"][0] == {"role": "user", "content": "hello"}
 
 
@@ -373,7 +372,7 @@ def test_codex_call_kwargs_tool_choice_translation(
         tools=[ToolSpec(name="t", description="", input_schema={"type": "object"})],
         tool_choice=tool_choice,
     )
-    kwargs = _build_codex_call_kwargs(req)
+    kwargs = build_responses_kwargs(req, backend="codex", adapter_name="codex-oauth")
     assert kwargs["tool_choice"] == expected
 
 
@@ -394,7 +393,13 @@ def test_codex_call_kwargs_tool_choice_translation(
     ],
 )
 def test_chat_tool_choice_translation(tool_choice: str | dict, expected: str | dict) -> None:
-    """OpenAI Chat Completions tool_choice translation (BLOCKER 2 fix)."""
-    from core.llm.adapters.openai_payg import _translate_tool_choice
+    """Chat Completions tool_choice translation (BLOCKER 2 fix).
 
-    assert _translate_tool_choice(tool_choice) == expected
+    PR-OPENAI-RESPONSES (2026-06-13): openai-payg left Chat Completions,
+    so the Chat nested shape now lives only on the GLM adapters — this
+    pins the same ``normalize("glm", ...)`` path glm_payg/glm_coding_plan
+    call (glm_payg.py / glm_coding_plan.py).
+    """
+    from core.llm.tool_choice import normalize
+
+    assert normalize("glm", tool_choice) == expected

--- a/tests/core/llm/adapters/test_openai_payg_responses.py
+++ b/tests/core/llm/adapters/test_openai_payg_responses.py
@@ -1,0 +1,76 @@
+"""openai-payg Responses API migration guards.
+
+PR-OPENAI-RESPONSES (2026-06-13). ``acomplete``/``astream`` left Chat
+Completions and joined the shared Responses builder
+(``build_responses_kwargs``, ``backend="platform"``) that codex-oauth
+already used — completing the migration ``acomplete_text``/
+``aweb_search`` started, and putting openai-payg on the surface where
+OpenAI ships new features (tool_search deferred loading is
+Responses-only).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.llm.adapters._openai_common import build_responses_kwargs
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _request(**overrides: object) -> AdapterCallRequest:
+    request_kwargs: dict = {
+        "model": "gpt-5.5",
+        "messages": (Message(role="user", content="hi"),),
+        "system_prompt": "test system",
+        "max_tokens": 4096,
+    }
+    request_kwargs.update(overrides)
+    return AdapterCallRequest(**request_kwargs)
+
+
+def test_platform_backend_sends_max_output_tokens() -> None:
+    """The Codex backend 400s on max_output_tokens; the platform API
+    supports it — the backend param must carry exactly this delta."""
+    platform = build_responses_kwargs(_request(), backend="platform", adapter_name="openai-payg")
+    codex = build_responses_kwargs(_request(), backend="codex", adapter_name="codex-oauth")
+    assert platform["max_output_tokens"] == 4096
+    assert "max_output_tokens" not in codex
+
+
+def test_platform_backend_shares_responses_shape_with_codex() -> None:
+    """Everything except the max_output_tokens delta is one builder —
+    instructions carry the system prompt, store=False, flat tools."""
+    tool_specs = (ToolSpec(name="demo", description="demo", input_schema={"type": "object"}),)
+    platform = build_responses_kwargs(
+        _request(tools=tool_specs), backend="platform", adapter_name="openai-payg"
+    )
+    assert platform["instructions"] == "test system"
+    assert platform["store"] is False
+    flat_tool = platform["tools"][0]
+    assert flat_tool["type"] == "function"
+    assert flat_tool["name"] == "demo"
+    assert "function" not in flat_tool, "Responses uses the FLAT shape, not Chat nesting"
+
+
+def test_payg_adapter_module_has_left_chat_completions() -> None:
+    """Source pin: the adapter must not fall back to chat.completions —
+    Chat Completions now lives only on the GLM adapters."""
+    adapter_source = (REPO_ROOT / "core" / "llm" / "adapters" / "openai_payg.py").read_text(
+        encoding="utf-8"
+    )
+    assert "chat.completions" not in adapter_source
+    assert "responses.stream" in adapter_source
+    assert 'backend="platform"' in adapter_source
+
+
+def test_reasoning_branch_applies_on_platform_backend() -> None:
+    """gpt-5.x on the platform backend keeps the reasoning passthrough
+    (encrypted content replay) exactly as on codex."""
+    platform = build_responses_kwargs(
+        _request(effort="high"), backend="platform", adapter_name="openai-payg"
+    )
+    assert platform["include"] == ["reasoning.encrypted_content"]
+    assert platform["reasoning"]["effort"] == "high"
+    assert "temperature" not in platform

--- a/tests/core/llm/adapters/test_openai_payg_responses.py
+++ b/tests/core/llm/adapters/test_openai_payg_responses.py
@@ -74,3 +74,37 @@ def test_reasoning_branch_applies_on_platform_backend() -> None:
     assert platform["include"] == ["reasoning.encrypted_content"]
     assert platform["reasoning"]["effort"] == "high"
     assert "temperature" not in platform
+
+
+def test_usage_carries_cached_input_tokens() -> None:
+    """Responses reports cache hits under input_tokens_details.cached_tokens
+    — both backends must surface them (Codex review finding 1; the codex
+    path had always dropped them)."""
+    from types import SimpleNamespace
+
+    from core.llm.adapters._openai_common import translate_codex_response
+
+    fake_response = SimpleNamespace(
+        output_text="ok",
+        output=[],
+        status="completed",
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=10,
+            input_tokens_details=SimpleNamespace(cached_tokens=64),
+        ),
+    )
+    result = translate_codex_response(fake_response)
+    assert result.usage.cached_input_tokens == 64
+
+
+def test_stop_sequences_drop_is_observable(caplog) -> None:
+    """Responses has no ``stop`` param — the builder must warn, never
+    silently drop (Codex review finding 2)."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="core.llm.adapters._openai_common"):
+        build_responses_kwargs(
+            _request(stop_sequences=("END",)), backend="platform", adapter_name="openai-payg"
+        )
+    assert any("stop_sequences unsupported" in r.message for r in caplog.records)

--- a/tests/core/llm/adapters/test_openai_tool_search_defer.py
+++ b/tests/core/llm/adapters/test_openai_tool_search_defer.py
@@ -1,0 +1,111 @@
+"""OpenAI Responses tool_search defer — request shaping guards.
+
+PR-CODEX-TOOL-SEARCH (2026-06-13). Official OpenAI mechanism
+(defer_loading + {"type": "tool_search"}, Responses-only, gpt-5.4+)
+wired into the shared builder, policy SoT shared with Anthropic via
+core.llm.tool_defer. Codex backend acceptance was
+live-verified 2026-06-13 (DEFER-OK, gpt-5.5) so the codex gate defaults
+ON with a kill switch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.llm.adapters._openai_common import build_responses_kwargs
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+from core.llm.tool_defer import TOOL_DEFER_THRESHOLD, TOOL_SEARCH_ALWAYS_LOADED
+
+
+def _request(model: str = "gpt-5.5", tool_count: int = TOOL_DEFER_THRESHOLD + 5):
+    tool_specs = [
+        ToolSpec(name=name, description=f"{name} core", input_schema={"type": "object"})
+        for name in sorted(TOOL_SEARCH_ALWAYS_LOADED)[:3]
+    ]
+    tool_specs += [
+        ToolSpec(name=f"extra_{i}", description=f"extra {i}", input_schema={"type": "object"})
+        for i in range(tool_count - 3)
+    ]
+    return AdapterCallRequest(
+        model=model,
+        messages=(Message(role="user", content="hi"),),
+        tools=tuple(tool_specs),
+    )
+
+
+def _tool_names(kwargs: dict) -> list[str]:
+    return [t.get("name", t.get("type", "?")) for t in kwargs["tools"]]
+
+
+def test_platform_defers_above_threshold_on_supported_model() -> None:
+    request_kwargs = build_responses_kwargs(
+        _request(), backend="platform", adapter_name="openai-payg"
+    )
+    tools = request_kwargs["tools"]
+    assert tools[-1] == {"type": "tool_search"}, "hosted search tool appended"
+    deferred_names = {t["name"] for t in tools if t.get("defer_loading")}
+    assert deferred_names and all(n.startswith("extra_") for n in deferred_names)
+    loaded = {t.get("name") for t in tools if not t.get("defer_loading")}
+    for core_name in sorted(TOOL_SEARCH_ALWAYS_LOADED)[:3]:
+        assert core_name in loaded, "core set never defers"
+
+
+def test_unsupported_model_never_defers() -> None:
+    """o3 lacks tool_search (gpt-5.4+ only) — shaping must not fire."""
+    request_kwargs = build_responses_kwargs(
+        _request(model="o3"), backend="platform", adapter_name="openai-payg"
+    )
+    assert not any(t.get("defer_loading") for t in request_kwargs["tools"])
+    assert {"type": "tool_search"} not in request_kwargs["tools"]
+
+
+def test_codex_backend_on_by_default_post_live_gate() -> None:
+    """Codex backend acceptance was live-verified 2026-06-13 (DEFER-OK on
+    gpt-5.5) — default ON since; _settings.py carries the attestation."""
+    request_kwargs = build_responses_kwargs(_request(), backend="codex", adapter_name="codex-oauth")
+    assert request_kwargs["tools"][-1] == {"type": "tool_search"}
+
+
+def test_codex_backend_kill_switch() -> None:
+    from core.config import settings
+
+    with patch.object(settings, "tool_search_defer_codex", False):
+        request_kwargs = build_responses_kwargs(
+            _request(), backend="codex", adapter_name="codex-oauth"
+        )
+    assert not any(t.get("defer_loading") for t in request_kwargs["tools"])
+    assert {"type": "tool_search"} not in request_kwargs["tools"]
+
+
+def test_web_named_tool_never_defers() -> None:
+    """Upstream 500: deferred function named "web" + tool_search +
+    web_search (community.openai.com/t/.../1375850) — blocklisted."""
+    base_request = _request()
+    tool_specs = (
+        *base_request.tools,
+        ToolSpec(name="web", description="web tool", input_schema={"type": "object"}),
+    )
+    request_kwargs = build_responses_kwargs(
+        AdapterCallRequest(model="gpt-5.5", messages=base_request.messages, tools=tool_specs),
+        backend="platform",
+        adapter_name="openai-payg",
+    )
+    web_tool = next(t for t in request_kwargs["tools"] if t.get("name") == "web")
+    assert "defer_loading" not in web_tool
+
+
+def test_shaping_is_idempotent() -> None:
+    first = build_responses_kwargs(_request(), backend="platform", adapter_name="openai-payg")
+    # feed the shaped tools back through the helper directly
+    from core.llm.adapters._openai_common import (
+        _apply_openai_tool_search_defer,
+        get_openai_model_spec,
+    )
+
+    reshaped = _apply_openai_tool_search_defer(
+        first["tools"],
+        backend="platform",
+        spec=get_openai_model_spec("gpt-5.5"),
+        adapter_name="openai-payg",
+    )
+    assert reshaped is first["tools"]

--- a/tests/plugins/seed_generation/test_json_schemas_wire.py
+++ b/tests/plugins/seed_generation/test_json_schemas_wire.py
@@ -304,7 +304,7 @@ def test_strict_role_schemas_pass_openai_strict_check(name: str, schema: dict) -
     constraint that prevents gpt-5.5's reasoning budget from consuming
     the entire output budget on empty responses.
     """
-    from core.llm.adapters.codex_oauth import _is_openai_strict_compatible
+    from core.llm.adapters._openai_common import _is_openai_strict_compatible
 
     assert _is_openai_strict_compatible(schema), (
         f"{name} declared strict-compatible but failed the codex adapter's "
@@ -327,7 +327,7 @@ def test_non_strict_role_schemas_documented_reason(name: str, schema: dict) -> N
     would start enforcing strict on a schema the role doesn't
     actually conform to.
     """
-    from core.llm.adapters.codex_oauth import _is_openai_strict_compatible
+    from core.llm.adapters._openai_common import _is_openai_strict_compatible
 
     assert not _is_openai_strict_compatible(schema), (
         f"{name} is documented as non-strict-compatible "

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.192"
+version = "0.99.193"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.191"
+version = "0.99.192"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.99.192 (PR #2229): openai-payg를 Chat Completions → Responses API로 이행, 공유 빌더 단일화 + Codex 리뷰 2건(usage 캐시 토큰, stop_sequences 관측 드롭) 반영
- v0.99.193 (PR #2230): OpenAI tool_search defer 양 백엔드 배선 — Codex 백엔드 라이브 게이트 통과(DEFER-OK) 후 기본 ON, 정책 SoT를 provider 중립 tool_defer.py로 단일화

## Verification
- [x] PR #2229 CI green ×2런, PR #2230 CI green
- [x] 라이브: codex 백엔드 tool_search 수락 검증(gpt-5.5, defer 20)
- [x] 로컬 게이트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)