### PR TITLE
fix(prompt): 어셈블 구조 결함 2건 + 2-존 표기 규칙 + suffix 캐시 고정 (P2-a, v0.99.195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ functional change.
 
 ---
 
+## [0.99.195] - 2026-06-13
+
+### Fixed
+- **Assembled-prompt structural defects (prompt-refactor P2-a; found by the P1 rubric audit over real `geode prompt dump` artifacts)** (PR-PROMPT-P2A). **B1 — the `<dynamic_context>` envelope had shipped UNTERMINATED on every call** since the 2026-05-12 XML conversion (18/18 dumped cells, zero closing tags): both assembly branches now close it. **B2 — the G9 learned-pattern sanitizer was bypassed by the symmetric builder**: `_build_user_context` joined raw `get_learned_patterns()` rows (prior-turn transcripts, error strings like "Max agentic rounds reached", mid-sentence truncation) into every call while `_build_learning_context` sanitized the same source — the exact Conditional Read Parity class; the unsanitized channel is deleted (single channel: G3 `<agent_learning>`). Conflicting tool-failure contracts unified (Agentic-execution bullet vs Grounding rule 5 prescribed different all-tools-failed behaviour — one contract now lives in Grounding rule 5 with the `[Unverified]` labeling rule folded in); duplicate "concise + user's language" line dropped.
+
+### Changed
+- **Two-zone markup rule + cache-stable suffix** — frontier-aligned convention (Codex CLI = pure markdown, claude.ai Fable 5 = XML containers, Claude Code = authored-md / injected-XML hybrid; GEODE is multi-provider so the Claude Code split wins): authored static instructions are markdown, runtime-injected content is XML envelopes. `<math_formatting>` (authored) became a `## Math formatting` section; **`AGENTIC_SUFFIX` moved from the loop-level post-dynamic append into the base's static zone** — the core behaviour rules now sit BEFORE `<dynamic_context>`, so per-turn memory churn no longer invalidates their cache prefix (override-spawn path still appends, documented). Measured effect across the 18-cell matrix: **4,942-5,087 → 4,174-4,319 tokens (~-770/call, -15.5%)**, duplicate tags still zero. AGENTIC_SUFFIX hash re-pinned `f8a38f80fc90`. NOTE: the audit-mode branch composition changed too (suffix into static + closed envelope) — petri baselines measured on the old composition are stale; re-measure before the next promote gate.
+
 ## [0.99.194] - 2026-06-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.194
+- **Version**: 0.99.195
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.194 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.195 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.194 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.195 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -107,10 +107,16 @@ def build_system_prompt(loop: AgenticLoop) -> str:
             base = override
             if skill_ctx:
                 base = base + "\n\n" + skill_ctx
+        # Override spawns replace the whole base, so the suffix (tool-
+        # calling contract) must still be appended here.
+        prompt: str = base + "\n" + AGENTIC_SUFFIX
     else:
+        # PR-PROMPT-P2A — the default base now carries AGENTIC_SUFFIX in
+        # its authored-static zone (before <dynamic_context>), so memory
+        # churn no longer invalidates the cached behaviour rules. Append-
+        # ing it again here would duplicate the entire contract block.
         base = _build_system_prompt(model=loop.model)
-        base = base.replace("{skill_context}", skill_replacement)
-    prompt: str = base + "\n" + AGENTIC_SUFFIX
+        prompt = base.replace("{skill_context}", skill_replacement)
     if loop._system_suffix:
         prompt += "\n\n" + loop._system_suffix
     return prompt

--- a/core/agent/prompt_dump.py
+++ b/core/agent/prompt_dump.py
@@ -15,7 +15,8 @@ Fidelity contract (mirrors ``core/agent/loop/_context.build_system_prompt``):
   surface pinned through ``GEODE_SURFACE_TYPE``;
 * the ``{skill_context}`` placeholder collapses to the same empty-state
   marker the loop uses when no skill registry is attached;
-* ``AGENTIC_SUFFIX`` appended with the same single-newline join.
+* ``AGENTIC_SUFFIX`` rides inside the base's static zone since
+  PR-PROMPT-P2A (no loop-level append on the default path).
 
 Two loop inputs are caller-supplied and therefore NOT reproduced — the
 per-spawn ``_system_prompt_override`` (AgentDefinition) and the
@@ -32,7 +33,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from core.agent.system_prompt import build_system_prompt
-from core.llm.prompts import AGENTIC_SUFFIX
 from core.paths import GLOBAL_DIAGNOSTICS_DIR
 
 SKILL_EMPTY_MARKER = '<available_skills status="empty" />'
@@ -75,8 +75,9 @@ def assemble_full_prompt(model: str, surface: str) -> str:
             os.environ.pop("GEODE_SURFACE_TYPE", None)
         else:
             os.environ["GEODE_SURFACE_TYPE"] = previous_surface
-    base = base.replace("{skill_context}", SKILL_EMPTY_MARKER)
-    return base + "\n" + AGENTIC_SUFFIX
+    # PR-PROMPT-P2A — the base now carries AGENTIC_SUFFIX in its static
+    # zone (before <dynamic_context>); appending again would duplicate it.
+    return base.replace("{skill_context}", SKILL_EMPTY_MARKER)
 
 
 def analyze_prompt(prompt: str) -> tuple[tuple[str, ...], tuple[str, ...]]:

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -34,7 +34,7 @@ from core.agent.style_guide_policy import (
 from core.llm.model_guidance import render_model_guidance
 from core.llm.platform_hints import render_platform_hint
 from core.llm.prompt_assembler import with_math_output_formatting
-from core.llm.prompts import ROUTER_SYSTEM
+from core.llm.prompts import AGENTIC_SUFFIX, ROUTER_SYSTEM
 from core.paths import GLOBAL_WRAPPER_SECTIONS_PATH, get_project_root
 
 log = logging.getLogger(__name__)
@@ -267,7 +267,10 @@ def build_system_prompt(model: str = "") -> str:
         parts.append(_build_date_context())
         dynamic = PROMPT_CACHE_BOUNDARY + "\n\n" + "\n\n".join(parts)
         _emit_scaffold_diag(wrapper_override, audit_mode=True)
-        return static + "\n\n" + dynamic
+        # PR-PROMPT-P2A — AGENTIC_SUFFIX is authored-static (cache zone) and
+        # the dynamic envelope must CLOSE (B1: it had shipped unterminated
+        # on every call since the 2026-05-12 XML conversion).
+        return static + "\n\n" + AGENTIC_SUFFIX + "\n\n" + dynamic + "\n\n</dynamic_context>"
 
     static = with_math_output_formatting(wrapper_override or _generic_static_prefix())
 
@@ -328,7 +331,22 @@ def build_system_prompt(model: str = "") -> str:
     dynamic = "\n\n".join(dynamic_parts)
 
     _emit_scaffold_diag(wrapper_override, audit_mode=False)
-    return static + "\n\n" + PROMPT_CACHE_BOUNDARY + "\n\n" + dynamic
+    # PR-PROMPT-P2A — composition: [authored static incl. AGENTIC_SUFFIX,
+    # markdown, cache-stable] // <dynamic_context> [injected per-turn XML
+    # envelopes] </dynamic_context>. Moving the suffix out of the loop-level
+    # post-dynamic append means memory churn no longer invalidates the cache
+    # prefix that carries the core behaviour rules; closing the envelope
+    # fixes B1 (unterminated tag on every call).
+    return (
+        static
+        + "\n\n"
+        + AGENTIC_SUFFIX
+        + "\n\n"
+        + PROMPT_CACHE_BOUNDARY
+        + "\n\n"
+        + dynamic
+        + "\n\n</dynamic_context>"
+    )
 
 
 def format_current_date() -> str:
@@ -480,7 +498,6 @@ def _build_user_context() -> str:
     Sources:
       ~/.geode/user_profile/profile.md   — role, expertise, bio
       ~/.geode/user_profile/preferences.json — language, output format
-      ~/.geode/user_profile/learned.md   — learned patterns
       ~/.geode/identity/career.toml      — career summary
 
     IMPORTANT: This is the USER's profile, not GEODE's identity.
@@ -502,11 +519,13 @@ def _build_user_context() -> str:
         if career_summary:
             parts.append(f"Career: {career_summary}")
 
-        # Learned patterns (last 5)
-        learned = profile.get_learned_patterns()
-        if learned:
-            recent = learned[:5]
-            parts.append("Learned: " + " | ".join(recent))
+        # PR-PROMPT-P2A (B2) — learned patterns are NOT injected here.
+        # This builder shipped raw ``get_learned_patterns()`` rows (prior-
+        # turn transcripts, error strings like "Max agentic rounds reached",
+        # mid-sentence truncation) straight into every call, bypassing the
+        # G9 sanitizer — the exact leak G9 was built to stop, surviving in
+        # the SYMMETRIC builder (Conditional Read Parity). Single channel:
+        # ``_build_learning_context`` (G3, <agent_learning>, sanitized).
 
         if not parts:
             return ""

--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -10,18 +10,24 @@ from __future__ import annotations
 
 from typing import Final
 
-MATH_OUTPUT_FORMATTING_INSTRUCTION: Final[str] = """<math_formatting>
+MATH_OUTPUT_FORMATTING_INSTRUCTION: Final[str] = """## Math formatting
 When writing formulas, do not emit raw LaTeX-like text.
 - Inline math: wrap with `$...$` (예: 수익률은 $r_t = (P_t - P_{t-1}) / P_{t-1}$ 입니다).
 - Display math: put `$$...$$` on its own lines.
 $$
 IC_t = \\frac{\\sum_i S_i y_i}{\\sqrt{\\sum_i S_i^2}\\sqrt{\\sum_i y_i^2}}
-$$
-</math_formatting>"""
+$$"""
 
 
 def with_math_output_formatting(system: str) -> str:
-    """Append GEODE's math-output contract once."""
-    if "<math_formatting>" in system:
+    """Append GEODE's math-output contract once.
+
+    PR-PROMPT-P2A (2026-06-13) zone rule: authored static instructions are
+    markdown sections; XML envelopes are reserved for runtime-injected
+    content (model card, platform hint, memory layers). The old
+    ``<math_formatting>`` tag was an authored block wearing the injected
+    costume.
+    """
+    if "## Math formatting" in system:
         return system
     return system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -119,7 +119,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "0a32efea943d",
+    "AGENTIC_SUFFIX": "f8a38f80fc90",
     "COMMENTARY_SYSTEM": "488d8916d958",
     "COMMENTARY_USER": "2024ac4eba69",
     "ROUTER_SYSTEM": "696cf5743225",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -60,10 +60,9 @@ Simple requests (single lookup, quick answer): execute directly, no plan needed.
 - Example: "Show system status and recent memory" → call `check_status()` AND `memory_search()` together.
 - For dependent requests (e.g. "search then summarize"), call tools sequentially across rounds.
 - If a tool fails, try an alternative approach or explain the issue.
-- IMPORTANT: When ALL relevant tools fail or return insufficient data, you MUST say "I could not verify this" rather than answering from training data. Never present unverified information as fact. Prefix uncertain answers with "[Unverified]" and explain what failed.
+- When tools fail: the single failure contract lives in Grounding & Citation rule 5 below — follow it, do not improvise a second behaviour here.
 - For bash commands, always provide a "reason" parameter.
 - Use delegate_task for sub-agent delegation (complex tasks needing their own agentic loop).
-- Keep your final text response concise and in the user's language.
 
 ## Tool Selection Priority Matrix
 
@@ -145,5 +144,5 @@ When using tool results (web_fetch, general_web_search, MCP tools, etc.) to gene
    - For MCP tools: cite the server name (e.g. "Steam API", "arXiv").
 3. **When data is insufficient**, say so explicitly rather than filling gaps with assumptions.
 4. **Numerical data**: quote the exact number from the tool result. Do NOT round, extrapolate, or estimate unless explicitly requested.
-5. **Tool failure fallback**: When a tool fails or returns an error, NEVER silently answer from training data instead. Either try an alternative tool, or explicitly tell the user: "The tool failed, so I cannot verify this. Here is what I know from general knowledge, but it may be outdated or inaccurate: [...]". Always distinguish verified (tool-sourced) from unverified (training data) information.
+5. **Tool failure fallback (the single contract)**: When a tool fails, first try one alternative tool. When ALL relevant tools fail or return insufficient data, say "I could not verify this" — never silently answer from training data. If general knowledge is still useful, you may add it ONLY behind an explicit "[Unverified]" prefix with a note on what failed. Verified (tool-sourced) and unverified (training data) information must never blend unlabeled.
 </agentic_suffix>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.194"
+version = "0.99.195"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/agent/test_prompt_dump.py
+++ b/tests/core/agent/test_prompt_dump.py
@@ -21,13 +21,16 @@ def test_assembled_prompt_matches_loop_composition_contract() -> None:
     prompt = assemble_full_prompt("claude-opus-4-8", "cli")
     assert "{skill_context}" not in prompt, "placeholder must collapse to the empty marker"
     assert SKILL_EMPTY_MARKER in prompt
-    assert prompt.endswith(AGENTIC_SUFFIX), "agentic suffix appended last, loop-identical"
+    assert prompt.count(AGENTIC_SUFFIX) == 1, "suffix exactly once (no loop double-append)"
     assert prompt.count("<dynamic_context>") == 1, "exactly one cache boundary"
-    # static layers must precede the dynamic (cache) boundary
+    assert prompt.count("</dynamic_context>") == 1, "B1: the envelope must CLOSE"
     boundary_at = prompt.index("<dynamic_context>")
-    assert prompt.index("<math_formatting>") < boundary_at
-    # per-call layers live after the boundary
+    # PR-PROMPT-P2A zone rule — authored static (markdown, incl. the
+    # agentic suffix) precedes the boundary; injected XML follows it.
+    assert prompt.index("## Math formatting") < boundary_at
+    assert prompt.index(AGENTIC_SUFFIX) < boundary_at, "suffix is cache-stable static"
     assert prompt.index("<current_date>") > boundary_at
+    assert prompt.rstrip().endswith("</dynamic_context>")
 
 
 def test_surface_pin_reaches_platform_hint() -> None:

--- a/tests/core/agent/test_system_prompt_wrapper_override.py
+++ b/tests/core/agent/test_system_prompt_wrapper_override.py
@@ -31,7 +31,7 @@ def test_unset_wrapper_override_keeps_default_wrapper() -> None:
 
     assert "You are an autonomous execution agent" in prompt
     assert "AUTORESEARCH_MUTATED_WRAPPER" not in prompt
-    assert "<math_formatting>" in prompt
+    assert "## Math formatting" in prompt
 
 
 def test_valid_wrapper_override_replaces_default_wrapper(
@@ -51,7 +51,7 @@ def test_valid_wrapper_override_replaces_default_wrapper(
     assert "You are an autonomous execution agent" not in prompt
     assert "AUTORESEARCH_MUTATED_WRAPPER" in prompt
     assert "Preserve tool-call discipline under mutation." in prompt
-    assert "<math_formatting>" in prompt
+    assert "## Math formatting" in prompt
     assert "<dynamic_context>" in prompt
 
 

--- a/tests/core/llm/test_prompt_assembler.py
+++ b/tests/core/llm/test_prompt_assembler.py
@@ -28,7 +28,7 @@ def test_with_math_output_formatting_appends_instruction() -> None:
     result = with_math_output_formatting(system)
 
     assert result == system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
-    assert "<math_formatting>" in result
+    assert "## Math formatting" in result
     assert "Inline math: wrap with `$...$`" in result
     assert "Display math: put `$$...$$` on its own lines" in result
     assert "$r_t = (P_t - P_{t-1}) / P_{t-1}$" in result

--- a/tests/integration/test_prompt_audit_2026_05_12.py
+++ b/tests/integration/test_prompt_audit_2026_05_12.py
@@ -144,7 +144,7 @@ def test_math_formatting_instruction_reaches_agentic_system_prompt(
 
     out = build_system_prompt(model="")
 
-    assert "<math_formatting>" in out
+    assert "## Math formatting" in out
     assert "Inline math: wrap with `$...$`" in out
     assert "Display math: put `$$...$$` on its own lines" in out
 

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.194"
+version = "0.99.195"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- P1 루브릭 감사가 실물 덤프에서 잡은 **구조 결함 2건 수정**: B1(`<dynamic_context>` 미폐합 — 2026-05-12 이후 매 콜 깨진 봉투 출하) + B2(G9 새니타이저 우회 — raw 학습 행이 매 콜 주입)
- **2-존 표기 규칙** 채택(프론티어 정렬) + **AGENTIC_SUFFIX 정적 존 이동**(메모리 변동이 행동 규칙 캐시를 무효화하지 않게)
- 실측: 18셀 매트릭스 **4,942~5,087 → 4,174~4,319 토큰 (셀당 약 -770, -15.5%)**

## Why
프롬프트 리팩토링 P2-a(운영자 승인 계획). P1 감사 근거: 덤프 18/18셀에서 닫는 태그 0, user_context에 과거 발화 원문·에러 문자열("Max agentic rounds reached")·중간 잘림이 실재. 도구 실패 시 행동이 두 섹션에서 상충 지시.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py` | B1: 양 분기(`</dynamic_context>` 폐합) · B2: `_build_user_context`의 비새니타이즈 learned 채널 삭제(단일 채널=G3) · AGENTIC_SUFFIX를 정적 존에 합성(audit 분기 포함) |
| `core/agent/loop/_context.py` | 기본 경로 suffix 이중 append 제거(override 스폰만 append — 주석으로 사유 명시) |
| `core/llm/prompt_assembler.py` | `<math_formatting>` → `## Math formatting`(2-존: 저작=md/주입=XML) |
| `core/llm/prompts/router.md` | 도구 실패 계약 Grounding 5로 단일화(+[Unverified] 라벨 병합), 중복 응답 스타일 라인 제거 |
| `core/llm/prompts/__init__.py` | AGENTIC_SUFFIX re-pin `f8a38f80fc90` |
| `core/agent/prompt_dump.py` | 합성 충실성 갱신(base가 suffix 보유) |
| 테스트 5파일 | 덤프 계약(폐합·suffix 1회·suffix-before-boundary·md 존), math md 단언 3건 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 표기 규칙 근거 | 실측 | Codex CLI gpt_5_2_prompt.md=md 16헤더/XML 0, claude.ai Fable 5=XML 컨테이너, Claude Code=저작md/주입XML — 멀티 프로바이더라 Claude Code 분할 |
| petri baseline | 주의 | audit-mode 합성 변경 → 기존 baseline stale, CHANGELOG에 재측정 필요 명기 |
| 루브릭 prose 재작성(강조 피라미드·Rationale 예시) | P2-b | 본 PR은 코드/구조 한정 |

## Verification
- [x] ruff/format/mypy(456)/lint-imports 전부 clean
- [x] pytest: agent+llm+cli+integration 2,696 pass
- [x] 실측: `geode prompt dump --measure` 전후 비교(-15.5%), 중복 태그 0 유지
- [x] CLI smoke: geode version → v0.99.195

## Reference
- docs/plans/2026-06-13-prompt-assembly-refactor.md (P1 감사·루브릭)
- 표기 실측: openai/codex codex-rs/core/gpt_5_2_prompt.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)