### PR TITLE
release: develop→main pass-through (v0.99.200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.200] - 2026-06-13
+
+### Changed
+- **Low-risk slop tidy from the codebase-wide scan** (PR-LOWRISK-SLOP; the scan otherwise found the codebase clean — 0 dead public fns, 0 dual registries, 0 emoji-anchor violations, frontier-aligned module sizes). **A — policy-loader dedup**: `core/llm/cache_policy.py` + `core/llm/strategies/provider_routing_policy.py` were the two policy loaders the v0.99.196 7-to-1 `load_policy_sot` dedup missed — they still hand-rolled the strict/graceful `resolve_sot` + read-json + validate + coerce. Migrated both to the shared `load_policy_sot` (behaviour preserved: identical `RuntimeError` shapes + log wording via `label`; `core/llm → core/agent.policy_sot` import verified clean against the import contracts), removing ~60 duplicated lines. **C — tool-definition two-layer doc**: documented why `definitions.json` (declarative LLM-facing metadata SoT) and the `Tool` protocol / `ToolRegistry` (behaviour) coexist by design (`core/tools/base.py`) — not redundancy. **D — naive variable names**: `data` → `result_payload` in `sub_agent.py`'s sub-result parse, `data` → `info_fields` in `eval_export.py`. The flagged "god-modules" (agent_loop 2577, _openai_common 1229, sub_agent 1108) were measured against frontier agent CLIs (hermes core files 13k-16k lines, codex 2.2k-3.8k, openclaw 3k-4k) and found to be at or BELOW the frontier norm for cohesive agent cores — splitting them would make GEODE an over-decomposed outlier, so they are accepted as large-but-cohesive (not slop).
+
 ## [0.99.199] - 2026-06-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.199
+- **Version**: 0.99.200
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.199 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.200 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.199 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.200 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -1058,12 +1058,12 @@ class SubAgentManager:
                 retryable=category in {ErrorCategory.TIMEOUT, ErrorCategory.API_ERROR},
                 duration_ms=isolation.duration_ms,
             )
-        data: dict[str, Any]
+        result_payload: dict[str, Any]
         raw_text = isolation.output or ""
         candidate_text = _strip_json_codeblock(raw_text) if raw_text else raw_text
         try:
             parsed = json.loads(candidate_text) if candidate_text else {}
-            data = parsed if isinstance(parsed, dict) else {"raw": parsed}
+            result_payload = parsed if isinstance(parsed, dict) else {"raw": parsed}
         except (json.JSONDecodeError, RecursionError):
             # PR-HANDOFF-SCHEMAS — embedded {...} fallback (see
             # _last_balanced_json_object docstring).
@@ -1071,20 +1071,22 @@ class SubAgentManager:
             if embedded is not None:
                 try:
                     parsed_emb = json.loads(embedded)
-                    data = parsed_emb if isinstance(parsed_emb, dict) else {"raw": raw_text}
+                    result_payload = (
+                        parsed_emb if isinstance(parsed_emb, dict) else {"raw": raw_text}
+                    )
                 except (json.JSONDecodeError, RecursionError):
-                    data = {"raw": raw_text}
+                    result_payload = {"raw": raw_text}
             else:
-                data = {"raw": raw_text}
-        summary = data.get("summary", "")
+                result_payload = {"raw": raw_text}
+        summary = result_payload.get("summary", "")
         if not summary:
-            summary = str(data.get("tier", data.get("status", "")))[:200]
+            summary = str(result_payload.get("tier", result_payload.get("status", "")))[:200]
         return SubAgentResult(
             task_id=task.task_id,
             task_type=task.task_type,
             status="ok",
             summary=summary,
-            data=data,
+            data=result_payload,
             duration_ms=isolation.duration_ms,
         )
 

--- a/core/llm/cache_policy.py
+++ b/core/llm/cache_policy.py
@@ -47,13 +47,12 @@ turns deserve the breakpoint budget.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
 
+from core.agent.policy_sot import load_policy_sot
 from core.paths import AUTORESEARCH_CACHE_POLICY_PATH, OPERATOR_LOCAL_CACHE_POLICY_PATH
-from core.self_improving.loop.mutate.sot_resolution import resolve_sot
 
 log = logging.getLogger(__name__)
 
@@ -74,44 +73,21 @@ _MIN_BREAKPOINTS = 0
 
 
 def _load_cache_policy_override() -> dict[str, int] | None:
-    """Return the active cache-policy dict, or ``None`` if no SoT applies."""
-    selection = resolve_sot(
+    """Return the active cache-policy dict, or ``None`` if no SoT applies.
+
+    Uses the shared :func:`load_policy_sot` loader (PR-LOWRISK-SLOP — this
+    module + provider_routing were the two policy loaders the v0.99.196
+    7-to-1 dedup missed, still hand-rolling the strict/graceful read).
+    Behaviour preserved: same RuntimeError shapes + log wording (via ``label``)."""
+    return load_policy_sot(
         env_var=_CACHE_POLICY_OVERRIDE_ENV,
         operator_local=_OPERATOR_LOCAL_CACHE_POLICY_PATH,
         in_repo=_CACHE_POLICY_SOT_PATH,
+        label="cache-policy",
+        validate_strict=_validate_schema,
+        validate_graceful=_validate_schema,
+        coerce=_coerce,
     )
-    if selection is None:
-        return None
-    if selection.strict:
-        return _strict_load(selection.path)
-    return _graceful_load(selection.path)
-
-
-def _strict_load(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        raise RuntimeError(f"{_CACHE_POLICY_OVERRIDE_ENV}={path} file not found")
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"{_CACHE_POLICY_OVERRIDE_ENV}={path} load failed: {exc}") from exc
-    _validate_schema(data, path)
-    return _coerce(data)
-
-
-def _graceful_load(path: Path) -> dict[str, int] | None:
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except (OSError, json.JSONDecodeError):
-        log.warning("cache-policy SoT at %s is unreadable; ignoring", path)
-        return None
-    try:
-        _validate_schema(data, path)
-    except RuntimeError as exc:
-        log.warning("cache-policy SoT at %s schema invalid: %s; ignoring", path, exc)
-        return None
-    return _coerce(data)
 
 
 def _validate_schema(data: Any, path: Path) -> None:

--- a/core/llm/strategies/provider_routing_policy.py
+++ b/core/llm/strategies/provider_routing_policy.py
@@ -39,15 +39,11 @@ them is a measurable cost lever.
 
 from __future__ import annotations
 
-import json
-import logging
 from pathlib import Path
 from typing import Any
 
+from core.agent.policy_sot import load_policy_sot
 from core.paths import AUTORESEARCH_PROVIDER_ROUTING_PATH, OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
-from core.self_improving.loop.mutate.sot_resolution import resolve_sot
-
-log = logging.getLogger(__name__)
 
 _PROVIDER_ROUTING_OVERRIDE_ENV = "GEODE_PROVIDER_ROUTING_OVERRIDE"
 
@@ -59,44 +55,21 @@ _OPERATOR_LOCAL_PROVIDER_ROUTING_PATH = OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
 
 
 def _load_provider_routing_override() -> dict[str, list[str]] | None:
-    """Return the active provider-routing dict, or ``None`` if no SoT applies."""
-    selection = resolve_sot(
+    """Return the active provider-routing dict, or ``None`` if no SoT applies.
+
+    Uses the shared :func:`load_policy_sot` loader (PR-LOWRISK-SLOP — this
+    module + cache_policy were the two policy loaders the v0.99.196 7-to-1
+    dedup missed). Behaviour preserved: same RuntimeError shapes + log
+    wording (via ``label``)."""
+    return load_policy_sot(
         env_var=_PROVIDER_ROUTING_OVERRIDE_ENV,
         operator_local=_OPERATOR_LOCAL_PROVIDER_ROUTING_PATH,
         in_repo=_PROVIDER_ROUTING_SOT_PATH,
+        label="provider-routing",
+        validate_strict=_validate_schema,
+        validate_graceful=_validate_schema,
+        coerce=_coerce,
     )
-    if selection is None:
-        return None
-    if selection.strict:
-        return _strict_load(selection.path)
-    return _graceful_load(selection.path)
-
-
-def _strict_load(path: Path) -> dict[str, list[str]]:
-    if not path.is_file():
-        raise RuntimeError(f"{_PROVIDER_ROUTING_OVERRIDE_ENV}={path} file not found")
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"{_PROVIDER_ROUTING_OVERRIDE_ENV}={path} load failed: {exc}") from exc
-    _validate_schema(data, path)
-    return _coerce(data)
-
-
-def _graceful_load(path: Path) -> dict[str, list[str]] | None:
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except (OSError, json.JSONDecodeError):
-        log.warning("provider-routing SoT at %s is unreadable; ignoring", path)
-        return None
-    try:
-        _validate_schema(data, path)
-    except RuntimeError as exc:
-        log.warning("provider-routing SoT at %s schema invalid: %s; ignoring", path, exc)
-        return None
-    return _coerce(data)
 
 
 def _validate_schema(data: Any, path: Path) -> None:

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -240,6 +240,16 @@ def classify_tool_exception(exc: Exception, tool_name: str = "") -> dict[str, An
 
 _TOOLS_JSON_PATH = Path(__file__).resolve().parent / "definitions.json"
 
+# Two-layer tool model (intentional, not redundancy — PR-LOWRISK-SLOP C):
+#   1. ``definitions.json`` — the DECLARATIVE layer: name / description /
+#      input_schema / category / cost_tier. Single SoT for the metadata the LLM
+#      sees (prompt-injectable + git-diffable). No behaviour here.
+#   2. the ``Tool`` protocol + ``ToolRegistry`` — the BEHAVIOUR layer: each tool
+#      class implements ``aexecute()``. The registry filters/dispatches instances.
+# The split is deliberate: metadata that ships to the model must be a static,
+# reviewable artifact, while execution is polymorphic Python. The registry's
+# schema is validated against this JSON so the two layers cannot silently drift.
+
 
 def load_all_tool_definitions() -> list[dict[str, Any]]:
     """Load all tool definitions from definitions.json (single source of truth).

--- a/plugins/seed_generation/eval_export.py
+++ b/plugins/seed_generation/eval_export.py
@@ -162,8 +162,8 @@ def export_run_to_evals(
         """
         if not isinstance(payload, dict):
             return []
-        data = _drop_empty(payload)
-        return [InfoEvent(data=data, source=info_source)] if data else []
+        info_fields = _drop_empty(payload)
+        return [InfoEvent(data=info_fields, source=info_source)] if info_fields else []
 
     state = _read_json(run_dir_path / "state.json")
     if state is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.199"
+version = "0.99.200"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.199"
+version = "0.99.200"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Pass-through to main:
- **v0.99.200** PR-LOWRISK-SLOP — policy-loader dedup (cache_policy + provider_routing → load_policy_sot, the 2 the v0.99.196 7→1 missed), tool-def two-layer doc, naive var renames. Codebase-wide scan otherwise clean; god-modules accepted as cohesive (frontier-measured).

## Verification
- [x] PR #2250 merged to develop, CI green
- [x] Codex MCP (gpt-5.5) — behaviour-preservation confirmed clean
- [x] -34 net lines; 212 + 6 affected tests green