### PR TITLE
fix(agent): delegate_task inherits loop's live /model (v0.99.201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ functional change.
 
 ---
 
+## [0.99.201] - 2026-06-14
+
+### Fixed
+- **Sub-agent (`delegate_task`) now inherits the loop's LIVE `/model`** (PR-SUBAGENT-MODEL-ALIGN; operator review of web-search/tool model consistency). web_search + the main loop route tools through the per-call `ToolContext` (`ctx.model` = the loop's live model, PR-TOOL-EXEC-CONTEXT), so they always track a mid-session `/model` switch. But the `delegate_task` dispatch branch in `ToolExecutor.aexecute` **dropped the `context`** when calling `_aexecute_delegate`, so `SubAgentManager._build_worker_request` fell back to the global `settings.model` — which can lag a live switch (the `loop.model`↔`settings.model` drift-sync was cut, `_model_switching.sync_model_from_settings_async` is a no-op). A sub-agent could therefore run on the pre-switch model. The dispatch now forwards `context` → `default_model` is threaded through `adelegate` → `_build_worker_request`, where it is the base model. Precedence preserved: per-task model (voter) > AgentDefinition model > live `default_model` > `settings.model` (the last only for non-loop callers — services bootstrap / tests). Verified: web_search already used `ctx.model` (live-checked: the current gpt-5.5/codex session searches on gpt-5.5 via `codex-oauth`). Guards: 4 tests incl. a dispatch-wiring test pinning `context.model → adelegate(default_model=)`.
+- **Stale docstring corrected** — `_capability_impls.openai_web_search` claimed "PAYG only — the Codex backend does not advertise web_search support", contradicting `codex_oauth.CodexOAuthAdapter.aweb_search` (the codex-subscription web_search, verified 200 OK, `supports_web_search=True`). Reworded: both OpenAI sources support web_search via different request shapes (PAYG vs the Codex `instructions`+typed-`input` form).
+
 ## [0.99.200] - 2026-06-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.200
+- **Version**: 0.99.201
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 385 core + 72 plugins = 457
-- **Tests**: 8694 (+1 live)
+- **Tests**: 8698 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.200 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.201 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.200 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.201 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -481,6 +481,7 @@ class SubAgentManager:
         *,
         on_progress: Callable[[SubResult], None] | None = None,
         announce: bool = True,
+        default_model: str = "",
     ) -> list[SubResult]:
         """Async sibling of :meth:`delegate` — ``asyncio.gather`` based fan-out.
 
@@ -580,7 +581,7 @@ class SubAgentManager:
             )
             fn_or_request: Any
             if self._action_handlers is not None:
-                fn_or_request = self._build_worker_request(task)
+                fn_or_request = self._build_worker_request(task, default_model=default_model)
             else:
                 # _execute_subtask is bound method; arun expects callable
                 # passed via args/kwargs. The thread-mode path is sync.
@@ -719,7 +720,7 @@ class SubAgentManager:
             child_result.status,
         )
 
-    def _build_worker_request(self, task: SubTask) -> WorkerRequest:
+    def _build_worker_request(self, task: SubTask, *, default_model: str = "") -> WorkerRequest:
         """Build a WorkerRequest for subprocess execution (Phase 2).
 
         The subprocess inherits API keys via env vars. Model config and
@@ -760,7 +761,13 @@ class SubAgentManager:
         # didn't declare one — the worker falls back to
         # ``agent_allowed_tools`` (legacy) or the ``_default`` toolkit.
         agent_toolkit = ""
-        worker_model = settings.model
+        # PR-SUBAGENT-MODEL-ALIGN (2026-06-14) — base model is the loop's LIVE
+        # model (forwarded from the delegate_task ToolContext) so delegation
+        # tracks a mid-session ``/model`` switch, symmetric with web_search.
+        # ``settings.model`` is the fallback for callers without a live context
+        # (services bootstrap / tests). AgentDefinition + per-task overrides
+        # below still win, preserving the voter/agent-model semantics.
+        worker_model = default_model or settings.model
         if agent_ctx is not None:
             agent_name = str(agent_ctx.get("agent_name", ""))
             agent_system_prompt = str(agent_ctx.get("system_prompt", ""))

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -180,7 +180,11 @@ class ToolExecutor:
             # PR-Async-Phase-C step 3 (2026-05-22) — switched to native
             # async delegate dispatch. The old asyncio.to_thread bridge
             # over sync ``_execute_delegate`` is gone.
-            return await self._aexecute_delegate(tool_input)
+            # PR-SUBAGENT-MODEL-ALIGN (2026-06-14) — forward the ToolContext
+            # so the sub-agent inherits the loop's LIVE model (the same
+            # ``ctx.model`` web_search uses), not the global ``settings.model``
+            # which can lag a mid-session ``/model`` switch.
+            return await self._aexecute_delegate(tool_input, context)
 
         handler = self._handlers.get(tool_name)
         if handler is None:
@@ -335,18 +339,27 @@ class ToolExecutor:
 
         return classify_tool_exception(exc, tool_name=tool_name)
 
-    async def _aexecute_delegate(self, tool_input: dict[str, Any]) -> dict[str, Any]:
+    async def _aexecute_delegate(
+        self, tool_input: dict[str, Any], context: ToolContext | None = None
+    ) -> dict[str, Any]:
         """Delegate task(s) to sub-agent (async). Supports single and batch.
 
         PR-Async-Phase-C step 3 (2026-05-22) — async-native sibling of
         :meth:`_execute_delegate`. Uses ``await
         SubAgentManager.adelegate(...)`` so the parent ToolExecutor's
         event loop is not pinned during sub-agent fan-out.
+
+        ``context`` carries the loop's live LLM identity; its ``model`` is
+        forwarded as the sub-agent's default model so delegation inherits
+        the current ``/model`` (PR-SUBAGENT-MODEL-ALIGN). Per-task and
+        AgentDefinition model overrides still win over this default.
         """
         from core.agent.sub_agent import SubTask
 
         if not self._sub_agent_manager:
             return {"error": "SubAgentManager not configured"}
+
+        default_model = getattr(context, "model", "") or ""
 
         tasks_raw: list[dict[str, Any]] = tool_input.get("tasks", [])
         if not tasks_raw:
@@ -391,7 +404,7 @@ class ToolExecutor:
         # announce=False: delegate_task returns full results via tool_result,
         # so skip announce queue to avoid double context injection.
         results = await self._sub_agent_manager.adelegate(
-            sub_tasks, on_progress=_on_progress, announce=False
+            sub_tasks, on_progress=_on_progress, announce=False, default_model=default_model
         )
 
         # Final summary line

--- a/core/llm/adapters/_capability_impls.py
+++ b/core/llm/adapters/_capability_impls.py
@@ -122,9 +122,15 @@ async def anthropic_complete_text(
 async def openai_web_search(
     client: Any, *, query: str, max_results: int, model: str, adapter_name: str
 ) -> WebSearchResult:
-    """OpenAI Responses API ``web_search`` hosted tool. PAYG only — the Codex
-    backend subscription endpoint does not advertise web_search support
-    (frontier audit 2026-05-28)."""
+    """OpenAI PAYG Responses API ``web_search`` hosted tool.
+
+    This is the **PAYG** path. The Codex **subscription** backend has its OWN
+    ``web_search`` implementation in ``codex_oauth.CodexOAuthAdapter.aweb_search``
+    — it requires the ``instructions`` field + a typed ``input`` list that PAYG
+    treats as optional (PR-NO-FALLBACK; the two 400s + a 200 OK proved the Codex
+    backend exposes the tool). Both OpenAI sources support web_search; they just
+    use different request shapes (PR-SUBAGENT-MODEL-ALIGN — corrected the stale
+    "Codex does not support web_search" claim)."""
     response = await client.responses.create(
         model=model,
         tools=[{"type": "web_search"}],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.200"
+version = "0.99.201"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/agent/test_subagent_agent_dispatch.py
+++ b/tests/core/agent/test_subagent_agent_dispatch.py
@@ -219,3 +219,72 @@ def test_shared_services_passes_agent_registry_to_manager() -> None:
         assert defn is not None
         assert defn.role  # non-empty role
         assert defn.system_prompt  # non-empty prompt
+
+
+# PR-SUBAGENT-MODEL-ALIGN (2026-06-14) — delegate_task forwards the loop's
+# live ToolContext model as the sub-agent default, symmetric with web_search.
+
+
+def test_build_worker_request_honors_default_model() -> None:
+    """The live ``default_model`` (from the delegate ToolContext) is the base
+    when neither an AgentDefinition nor a per-task model override applies —
+    previously this silently used the global ``settings.model``."""
+    manager = _make_manager(AgentRegistry())
+    task = SubTask(task_id="d-1", description="x", task_type="unknown", args={}, agent=None)
+    request: WorkerRequest = manager._build_worker_request(task, default_model="claude-opus-4-8")
+    assert request.model == "claude-opus-4-8"
+
+
+def test_task_and_agent_model_override_win_over_default_model(
+    seed_generator_registry: AgentRegistry,
+) -> None:
+    """Precedence preserved: per-task model > AgentDefinition model >
+    live default_model. The alignment must NOT clobber the voter/agent path."""
+    manager = _make_manager(seed_generator_registry)
+    # AgentDefinition model (claude-sonnet-4-6) wins over default_model.
+    agent_task = SubTask(
+        task_id="d-2", description="x", task_type="seed-generation", args={}, agent="seed_generator"
+    )
+    assert (
+        manager._build_worker_request(agent_task, default_model="claude-opus-4-8").model
+        == "claude-sonnet-4-6"
+    )
+    # Per-task model (voter) wins over both.
+    voter_task = SubTask(
+        task_id="d-3", description="x", task_type="unknown", args={}, agent=None, model="glm-5"
+    )
+    assert (
+        manager._build_worker_request(voter_task, default_model="claude-opus-4-8").model == "glm-5"
+    )
+
+
+def test_default_model_empty_falls_back_to_settings() -> None:
+    """No live context (services bootstrap / legacy callers) → settings.model."""
+    from core.config import _get_settings
+
+    manager = _make_manager(AgentRegistry())
+    task = SubTask(task_id="d-4", description="x", task_type="unknown", args={}, agent=None)
+    request: WorkerRequest = manager._build_worker_request(task, default_model="")
+    assert request.model == _get_settings().model
+
+
+def test_delegate_dispatch_forwards_tool_context_model() -> None:
+    """Wiring guard for the exact bug: the delegate_task dispatch branch must
+    forward the ToolContext's live ``model`` to ``adelegate(default_model=)``.
+    Pre-fix the ``context`` was dropped at the ``_aexecute_delegate`` call so
+    sub-agents silently used ``settings.model`` instead of the live ``/model``."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from core.agent.tool_executor import ToolExecutor
+    from core.tools.base import ToolContext
+
+    mgr = _make_manager(AgentRegistry())
+    mgr.adelegate = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    executor = ToolExecutor(sub_agent_manager=mgr, auto_approve=True, hitl_level=0)
+    ctx = ToolContext(
+        provider="anthropic", source="subscription", model="claude-opus-4-8", adapter_name="x"
+    )
+    asyncio.run(executor.aexecute("delegate_task", {"task_description": "do a thing"}, context=ctx))
+    assert mgr.adelegate.await_count == 1
+    assert mgr.adelegate.await_args.kwargs.get("default_model") == "claude-opus-4-8"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.200"
+version = "0.99.201"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `delegate_task` sub-agents now inherit the loop's **live `/model`** (the same `ctx.model` web_search uses), not the global `settings.model` which lags a mid-session `/model` switch.
- Corrected a stale docstring claiming the Codex backend doesn't support web_search (it does — `codex_oauth.aweb_search`, 200 OK verified).

## Why
Operator review: "does web_search / tools run on the same model as `/model`?" Verified web_search = YES (live: gpt-5.5/codex session searches on gpt-5.5 via codex-oauth). But found an **asymmetry**: `ToolExecutor.aexecute` builds a `ToolContext` with the live `model` and passes it to tools, yet the `delegate_task` branch **dropped `context`** when calling `_aexecute_delegate` → sub-agents fell back to `settings.model`. Since the `loop.model`↔`settings.model` drift-sync is a no-op, a sub-agent could run on the pre-switch model.

## Changes
| File | Change |
|------|--------|
| `core/agent/tool_executor/executor.py` | delegate dispatch forwards `context`; `_aexecute_delegate(context)` extracts `default_model=ctx.model` → `adelegate(default_model=)` |
| `core/agent/sub_agent.py` | `adelegate(default_model=)` threads to `_build_worker_request(default_model=)`; base becomes `default_model or settings.model` (precedence: task > agent > live default > settings) |
| `core/llm/adapters/_capability_impls.py` | corrected stale "Codex doesn't support web_search" docstring |
| `tests/core/agent/test_subagent_agent_dispatch.py` | +4 guards (default honored, task/agent override wins, settings fallback, dispatch-wiring) |

## Verification
- [x] ruff + mypy (486) + lint-imports clean
- [x] pytest — sub_agent/executor/delegate suites green; 4 new model-precedence + wiring guards
- [x] live: web_search on current gpt-5.5/codex session → codex-oauth + model=gpt-5.5 (same as /model)
- [ ] CI 5/5 (pending)

## Reference
PR-TOOL-EXEC-CONTEXT (ctx.model), PR-WEB-SEARCH-MODEL-HINT, PR-VOTER-PROVIDER-WIRE (per-task model), `_model_switching` drift-sync no-op.