### PR TITLE
docs(site): prompt-caching identity layer is default-on, not opt-in

### DIFF
--- a/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
@@ -28,7 +28,7 @@ export default function Page() {
               <code>PROMPT_CACHE_BOUNDARY</code>
               마커(<code>&lt;dynamic_context&gt;</code> 여는 태그)로 두 쪽이
               납니다. 마커 앞은 턴 사이 불변(베이스 스캐폴드, 스타일 가이드,
-              옵트인 identity), 마커 뒤는 턴마다 변합니다(model card, 날짜,
+              기본 ON identity), 마커 뒤는 턴마다 변합니다(model card, 날짜,
               메모리 레이어, 사용자 컨텍스트).
             </p>
             <p>
@@ -135,7 +135,7 @@ export default function Page() {
               <code>&lt;dynamic_context&gt;</code> tag) defined in
               <code>core/agent/system_prompt.py</code>. Everything before the
               marker is stable across turns (base scaffold, style guide,
-              opt-in identity); everything after changes per turn (model
+              default-on identity); everything after changes per turn (model
               card, date, memory layers, user context).
             </p>
             <p>


### PR DESCRIPTION
## Summary
- Tail fix of the prompt-docs sweep: `prompt-caching/page.tsx` still described the `<agent_identity>` static layer as "opt-in identity" (KO + EN). Now "default-on" / "기본 ON", consistent with persona-default-ON (v0.99.212).

## Why
PR-DOCS-PROMPT-SYNC swept system-prompt-modes + prompt-system + sitemap, but prompt-caching also names the static-region layers and was missed. This was the last live doc page carrying the stale opt-in framing (audit-history docs under docs/audits/ + domain-free-core-audit.md keep it as dated records).

## Changes
| File | Change |
|------|--------|
| `site/src/app/docs/runtime/llm/prompt-caching/page.tsx` | "opt-in identity"→"default-on identity" (EN), "옵트인 identity"→"기본 ON identity" (KO) |

## Verification
- [x] grep clean: no "opt-in identity" left in any site doc page
- [x] check_docs_links EXIT 0
- [x] docs-only (no version bump); Next.js build gated by CI

## Reference
Completes the prompt-docs sweep documenting PR-PERSONA-ON-PROMPT-HARDEN (v0.99.212).