### PR TITLE
docs(config): correct stale secret-precedence + README Configuration section

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -281,6 +281,39 @@ geode config migrate-petri-toml --yes    # [self_improving_loop.petri.*] 를 con
 
 ---
 
+## 설정
+
+시크릿은 `.env`에, 동작은 `config.toml`에 둡니다. `.env`는 시크릿 전용, `config.toml`은 동작 전용이라 두 층은 충돌하지 않고 각각 우선순위 규칙이 하나씩 있습니다.
+
+- 전역 `~/.geode/.env`가 권위를 갖는 시크릿 저장소입니다. 프로젝트 `./.env`는 전역에 없는 키만 채우고 전역 키를 덮지 못합니다. `~/.geode/.env`의 `OPENAI_API_KEY`는 프로젝트 `./.env`가 비어 있어도 이깁니다.
+- 프로젝트 `./.geode/config.toml`이 전역 `~/.geode/config.toml`을 덮습니다. 동작은 프로젝트마다 조정합니다.
+
+모든 필드는 하나의 사다리를 탑니다. 위가 이깁니다:
+
+```
+1. os.environ                      셸 export (세션 한정)
+2. 전역  ~/.geode/.env             시크릿: 권위
+3. 프로젝트 ./.env                 전역에 없는 키만 채움
+4. 프로젝트 ./.geode/config.toml   동작: 프로젝트가 이김
+5. 전역  ~/.geode/config.toml
+6. 내장 기본값
+```
+
+`.env`는 전역이 위, `config.toml`은 프로젝트가 위입니다. 자격 증명은 한 곳에 두고 동작은 프로젝트마다 조정한다는 뜻입니다.
+
+자격 증명 추가/전환:
+
+```bash
+geode setup                          # wizard 재실행 (구독 OAuth 또는 API 키)
+/login openai                        # 세션 중: 구독 OAuth
+/key openai sk-proj-...              # 세션 중: API 키 붙여넣기
+echo 'OPENAI_API_KEY=sk-proj-...' >> ~/.geode/.env    # 권위를 갖는 파일 직접 편집
+```
+
+설정을 바꿨는데 안 먹으면 `geode config explain <KEY>`를 실행하세요. 층별 후보를 출력하고 winner와 가려진 층을 파일 경로까지 표시해 고칠 줄을 정확히 짚어 줍니다. `geode about`은 실효 모델을 보여줍니다. 전체 레퍼런스: [설정 기초](https://mangowhoiscloud.github.io/geode/docs/config/basics).
+
+---
+
 ## 트러블슈팅
 
 먼저 `geode doctor` 부터 실행하세요. Python 버전, `geode` PATH, `~/.geode/.env`, Codex CLI OAuth, ProfileStore, serve 소켓, `~/.local/bin` PATH 까지 확인하고, 실패한 항목마다 fix 명령을 알려줍니다. 아래 expander 들은 같은 내용을 글로 풀어쓴 것입니다.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,39 @@ To run a campaign, start with the quick-start: [docs/self-improving/campaign-qui
 
 ---
 
+## Configuration
+
+Secrets live in `.env`, behavior lives in `config.toml`. The two never collide, because `.env` is secrets-only and `config.toml` is behavior-only, so each has a single precedence rule.
+
+- The global `~/.geode/.env` is the authoritative secret store. A project `./.env` fills only the keys it lacks and never shadows a global key. An `OPENAI_API_KEY` in `~/.geode/.env` wins even when a project `./.env` leaves it blank.
+- The project `./.geode/config.toml` overrides the global `~/.geode/config.toml`. Behavior is tuned per project.
+
+Every field rides one ladder. Higher wins:
+
+```
+1. os.environ                      shell exports (session-scoped)
+2. global  ~/.geode/.env           secrets: authoritative
+3. project ./.env                  fills only the keys global lacks
+4. project ./.geode/config.toml    behavior: project wins
+5. global  ~/.geode/config.toml
+6. built-in defaults
+```
+
+`.env` ranks the global file higher, `config.toml` ranks the project file higher. The asymmetry is deliberate: credentials have one home, behavior is tuned per project.
+
+Add or switch a credential:
+
+```bash
+geode setup                          # re-run the wizard (subscription OAuth or API key)
+/login openai                        # in a session: subscription OAuth
+/key openai sk-proj-...              # in a session: paste an API key
+echo 'OPENAI_API_KEY=sk-proj-...' >> ~/.geode/.env    # edit the authoritative file
+```
+
+When a change does not take effect, run `geode config explain <KEY>`. It prints every layer, marks the winner and any masked layers with file paths, and points at the exact line to edit. `geode about` shows the effective model. Full reference: [Configuration basics](https://mangowhoiscloud.github.io/geode/docs/config/basics).
+
+---
+
 ## Troubleshooting
 
 Run `geode doctor` first. It checks Python version, `geode` PATH, `~/.geode/.env`, Codex CLI OAuth, ProfileStore, the serve socket, and `~/.local/bin` PATH — and prints a concrete fix command for each failure. The expanders below cover the same ground in narrative form.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -66,7 +66,7 @@ EOF
 chmod 600 ~/.geode/.env
 ```
 
-**Key 우선순위**: Environment variable > Project `.env` > `~/.geode/.env`
+**시크릿(`.env`) 우선순위**: 수동 env export > 전역 `~/.geode/.env` > 프로젝트 `.env`. 전역이 권위를 갖는 시크릿 저장소이고, 프로젝트 `.env`는 전역에 없는 키만 채웁니다 (전역 키를 덮지 못함, Hermes 2026-06-15). 동작 설정(`config.toml`)은 방향이 반대로, 프로젝트가 전역을 덮습니다. 실효값은 `geode config explain <KEY>`로 확인하세요.
 
 ### 2. Project Setup
 
@@ -75,7 +75,7 @@ chmod 600 ~/.geode/.env
 uv run geode init
 
 # 또는 수동으로
-cp .env.example .env       # project-local keys (non-empty만 override)
+cp .env.example .env       # 프로젝트 시크릿. 전역에 없는 키만 채움(전역이 권위)
 ```
 
 ### 3. Global CLI Install

--- a/site/src/app/docs/config/basics/page.tsx
+++ b/site/src/app/docs/config/basics/page.tsx
@@ -29,11 +29,11 @@ export default function Page() {
               <tbody>
                 <tr>
                   <td><code>~/.geode/.env</code></td>
-                  <td>전역 시크릿 층. API 키와 자격 증명이 들어갑니다. 온보딩과 <code>/login</code>의 키 기록이 여기로 갑니다.</td>
+                  <td>전역 시크릿 층이자 권위를 갖는 시크릿 저장소. API 키와 자격 증명이 들어가고, 온보딩과 <code>/login</code>의 키 기록이 여기로 갑니다.</td>
                 </tr>
                 <tr>
                   <td>프로젝트 <code>.env</code> (cwd)</td>
-                  <td>프로젝트 시크릿 층. 전역 <code>.env</code>보다 우선합니다.</td>
+                  <td>프로젝트 시크릿 층. 전역에 없는 키만 채우며 전역 키를 덮지 못합니다 (Hermes, 2026-06-15). 시크릿은 전역에 두는 것이 기본입니다.</td>
                 </tr>
                 <tr>
                   <td><code>~/.geode/config.toml</code></td>
@@ -67,11 +67,21 @@ export default function Page() {
               (<code>core/config/explain.py</code>의 <code>LAYERS</code>).
             </p>
             <pre>{`1. os.environ            셸 export. 세션 한정 수동 override
-2. 프로젝트 .env          cwd의 .env
-3. 전역 .env             ~/.geode/.env
+2. 전역 .env             ~/.geode/.env (시크릿 권위)
+3. 프로젝트 .env          cwd의 .env (전역에 없는 키만 채움)
 4. 프로젝트 config.toml   .geode/config.toml
 5. 전역 config.toml      ~/.geode/config.toml
 6. 코드 기본값`}</pre>
+            <p>
+              시크릿(<code>.env</code>)과 동작(<code>config.toml</code>)은 전역과
+              프로젝트의 우선 방향이 반대입니다. <code>.env</code>는 전역이
+              위(권위), <code>config.toml</code>은 프로젝트가 위(프로젝트 튜닝).
+              같은 키가 양쪽에 동시에 들어가지 않으므로(시크릿 전용, 동작 전용
+              분리, C-2) 사다리는 하나로 충분합니다. v0.99.216 이전에는
+              <code>.env</code>도 프로젝트가 위였는데, 빈 프로젝트
+              <code>.env</code>가 전역 실키를 가리는 함정이 있어 전역 권위로
+              뒤집었습니다 (Hermes 정렬).
+            </p>
             <p>
               모델 해석으로 좁히면 같은 사다리가 이렇게 읽힙니다. CLI 인자 &gt;
               env 층(os.environ + .env 파일들) &gt; 프로젝트 toml &gt; 전역
@@ -136,9 +146,10 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
               데몬의 모델을 env로 일부러 고정하고 싶다면
               <code>GEODE_SERVE_KEEP_MODEL_ENV=1</code>을 켭니다. C-4부터 이
               플래그는 프로세스 env뿐 아니라 양쪽 <code>.env</code> 파일에서도
-              읽힙니다. 승격 우선순위는 수동 export &gt; 프로젝트
-              <code>.env</code> &gt; 전역 <code>.env</code>이고, 파일은 이미
-              존재하는 프로세스 env를 덮지 않으며 빈 값도 덮지 않습니다.
+              읽힙니다. 승격 우선순위는 수동 export &gt; 전역 <code>.env</code>
+              &gt; 프로젝트 <code>.env</code>이고 (전역이 권위, 프로젝트는 전역에
+              없는 키만 채움), 파일은 이미 존재하는 프로세스 env를 덮지 않으며
+              빈 값도 덮지 않습니다.
             </p>
 
             <h2>실패 모드</h2>
@@ -163,9 +174,9 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
                   <td>세션 리로드로 매니페스트 독자는 갱신됩니다. 그래도 남으면 프로세스를 재시작합니다.</td>
                 </tr>
                 <tr>
-                  <td>프로젝트 <code>.env</code>가 전역에 짐</td>
-                  <td>C-3 이전 버전의 역전된 dotenv 순서</td>
-                  <td>업그레이드합니다. 현재 계약은 프로젝트 <code>.env</code>가 전역을 이깁니다.</td>
+                  <td>프로젝트 <code>.env</code>에 둔 시크릿이 안 먹고 전역 값이 이김</td>
+                  <td>전역 <code>~/.geode/.env</code>가 같은 키를 가짐. 전역이 권위입니다 (Hermes, 2026-06-15)</td>
+                  <td>의도된 동작입니다. 시크릿은 전역에 두고, 프로젝트는 전역에 없는 키만 채웁니다. <code>geode config explain &lt;KEY&gt;</code>로 WINNER 층을 확인하세요.</td>
                 </tr>
                 <tr>
                   <td><code>GEODE_CONFIG_TOML</code>이 일부 로더에만 적용</td>
@@ -201,11 +212,11 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
               <tbody>
                 <tr>
                   <td><code>~/.geode/.env</code></td>
-                  <td>Global secrets layer. API keys and credentials. Onboarding and <code>/login</code> write keys here.</td>
+                  <td>Global secrets layer, the authoritative secret store. API keys and credentials; onboarding and <code>/login</code> write keys here.</td>
                 </tr>
                 <tr>
                   <td>Project <code>.env</code> (cwd)</td>
-                  <td>Project secrets layer. Beats the global <code>.env</code>.</td>
+                  <td>Project secrets layer. Fills only the keys the global file lacks; it never shadows a global key (Hermes, 2026-06-15). Keep secrets in the global file by default.</td>
                 </tr>
                 <tr>
                   <td><code>~/.geode/config.toml</code></td>
@@ -240,11 +251,23 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
               (<code>LAYERS</code> in <code>core/config/explain.py</code>).
             </p>
             <pre>{`1. os.environ            shell exports. session-scoped manual override
-2. project .env          .env in the cwd
-3. global .env           ~/.geode/.env
+2. global .env           ~/.geode/.env (authoritative secrets)
+3. project .env          .env in the cwd (fills only keys global lacks)
 4. project config.toml   .geode/config.toml
 5. global config.toml    ~/.geode/config.toml
 6. code default`}</pre>
+            <p>
+              Secrets (<code>.env</code>) and behavior
+              (<code>config.toml</code>) order global vs project in opposite
+              directions. For <code>.env</code> the global file is higher
+              (authoritative); for <code>config.toml</code> the project file is
+              higher (project tuning). The same key never appears in both
+              layers (secrets-only, behavior-only, C-2), so one ladder is
+              enough. Before
+              v0.99.216 the <code>.env</code> pair was also project-first, but an
+              empty project <code>.env</code> could shadow a real global key, so
+              it was flipped to global-authoritative (the Hermes alignment).
+            </p>
             <p>
               Narrowed to model resolution, the same ladder reads: CLI args
               &gt; env layer (os.environ plus both .env files) &gt; project
@@ -315,10 +338,11 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
               To pin the daemon&apos;s model via env on purpose, set
               <code>GEODE_SERVE_KEEP_MODEL_ENV=1</code>. Since C-4 the flag is
               honored from the process env or from either <code>.env</code>
-              file. Promotion precedence is manual exports &gt; project
-              <code>.env</code> &gt; global <code>.env</code>; files never
-              clobber pre-existing process env, and empty values never
-              clobber anything.
+              file. Promotion precedence is manual exports &gt; global
+              <code>.env</code> &gt; project <code>.env</code> (global is
+              authoritative; the project file only fills keys global lacks);
+              files never clobber pre-existing process env, and empty values
+              never clobber anything.
             </p>
 
             <h2>Failure modes</h2>
@@ -343,9 +367,9 @@ GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
                   <td>Session reload refreshes manifest readers. If a path still lags, restart the process.</td>
                 </tr>
                 <tr>
-                  <td>Project <code>.env</code> loses to the global one</td>
-                  <td>Pre-C-3 versions had the dotenv order inverted</td>
-                  <td>Upgrade. The current contract is project <code>.env</code> beats global.</td>
+                  <td>A secret set in the project <code>.env</code> is ignored and the global value wins</td>
+                  <td>The global <code>~/.geode/.env</code> holds the same key, and global is authoritative (Hermes, 2026-06-15)</td>
+                  <td>This is intended. Keep secrets in the global file; the project file only fills keys global lacks. Run <code>geode config explain &lt;KEY&gt;</code> to see the WINNER layer.</td>
                 </tr>
                 <tr>
                   <td><code>GEODE_CONFIG_TOML</code> only applies to some loaders</td>


### PR DESCRIPTION
## Summary
- Re-confirming this session's config alignment surfaced that the **public docs still teach the wrong precedence**: the site `config/basics` page describes the pre-Hermes (C-3) "project `.env` beats global" model, which v0.99.216 **reversed** (global `~/.geode/.env` is now the authoritative secret store; project `.env` only fills gaps).
- Fixed the site page (4 spots, KO+EN) + `docs/setup.md`, and added a **Configuration section to README.md / README.ko.md** documenting the corrected model.

## Why
A new user reading `config/basics` today is told project `.env` wins for secrets — the **exact wrong mental model** that produced the "keys not loading / dry-run" confusion this whole config thread started from. The failure-mode table even labels the now-intended behavior ("project `.env` loses to global") as a pre-C-3 *bug to upgrade away from*. Docs must match the code (`explain.py LAYERS`, `env_io.load_env_files`, `_settings.py` env_file order — all global-authoritative since v0.99.216).

## Changes
| File | Change |
|------|--------|
| `site/src/app/docs/config/basics/page.tsx` | Fix `.env` precedence (global authoritative, project fills gaps) in the files table, resolution ladder, daemon-promotion line, and failure-mode row — KO **and** EN. Add an asymmetry note (`.env` global-first vs `config.toml` project-first; never collide, secrets-only vs behavior-only). |
| `docs/setup.md` | Fix the "Key 우선순위" line + the `cp .env.example .env` comment. |
| `README.md`, `README.ko.md` | New "Configuration — where settings live" section: the split, the corrected ladder, add/switch-credential recipes, `geode config explain`, link to the site reference. |

## Verification
- [x] Source-of-truth verified: `explain.py:47-52 LAYERS` (global .env above project .env), `env_io.py:44,62-64`, `_settings.py:50`
- [x] `scripts/check_docs_links.py` exit 0
- [x] page.tsx JSX tags balanced (`<p>` 22/22, `<tr>` 24/24); entities escaped (`&lt;`/`&gt;`)
- [x] Docs-only — no version bump (README version header unchanged at v0.99.218)
- [ ] CI: Next.js build + render lint + check_docs_links (gate)

## Reference
This-session config alignment (PR-HERMES-ENV-ALIGN v0.99.216, PR-READINESS-OAUTH v0.99.217, PR-CONFIG-SLOP-SWEEP v0.99.218). Surfaced by the v1.0.0 docs-readiness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)