### PR TITLE
docs: v1.0.0 release readiness checklist

### DIFF
--- a/docs/plans/2026-06-17-v1.0.0-release-readiness.md
+++ b/docs/plans/2026-06-17-v1.0.0-release-readiness.md
@@ -1,0 +1,137 @@
+# GEODE v1.0.0 출시 준비 체크리스트 (2026-06-17)
+
+> **운영자 결정 (2026-06-17)**: ① v1.0.0 게이트 = 남은 두 백로그(computer-use 보강·시스템 프롬프트 어셈블/리팩토링) **둘 다 완료** 후 태그 ② 태그 전 본 체크리스트를 먼저 문서화하고, 이걸로 갈지 결정.
+> **상태 근거**: pre-1.0 punch-list #1~#4(H11-tail·placeholder hygiene·deprecation horizon·result-feedback persist)는 v0.99.219~222로 전부 닫힘. H11-tail까지 완료되어 boot-frozen routing-constant 사이트 0개. 남은 게이트는 기능 2건 + 출시 위생 선언.
+> **이 문서의 역할**: 태그를 막는 항목을 한 곳에 모으고, 권위 있는 plan/SoT로 연결한다. 세부 구현 상태는 각 plan 문서가 SoT이며, 여기서는 게이트 통과 여부만 추적한다.
+
+## 0. 출시 판정 요약
+
+| 영역 | 판정 | 비고 |
+|------|------|------|
+| 안정성/정확성 (punch-list) | GO | #1~#4 전부 닫힘 (v0.99.219~222), 회귀 가드 동반 |
+| 코어 런타임 표면 | GO | AgenticLoop·provider 라우팅·CLI·self-improving 인프라 안정, 최근 churn 냉각 |
+| 품질 게이트 | GO (PR별 그린) | coverage ratchet 75%, 태그 직전 재확인 (§3) |
+| **기능 게이트 #1 — computer-use 보강** | **GAP** | Phase A만 완료(v0.99.208); C/E/F/D 미착수, B' deferred (§1.1) |
+| **기능 게이트 #2 — 프롬프트 어셈블/리팩토링** | **GAP** | P0·P2-a·P2-c 완료; P2-b/P3 잔여 (§1.2) |
+| 출시 위생 선언 (API/지원범위/known-limitations) | TODO | 본 문서 §2에서 초안, 운영자 확정 필요 |
+
+판정: 코어와 품질은 출시 가능 상태. v1.0.0 태그는 **기능 게이트 2건 완료 + §2 출시 위생 선언 확정**에 걸려 있다.
+
+## 1. 기능 게이트 (운영자: 둘 다 1.0 범위)
+
+### 1.1 computer-use 보강
+
+SoT: [`docs/plans/2026-06-14-computer-use-enhancement.md`](2026-06-14-computer-use-enhancement.md). Phase A(production 경로 부활 + `ComputerUseCapable` 프로토콜 + 스크린샷 image-block)는 v0.99.208에 완료. 1.0 범위 = 나머지 provider/실행환경 보강이며, `zoom`은 ctx7 미확인이라 live-test 게이트로 분리(post-1.0).
+
+| Phase | 내용 | 1.0 | 상태 |
+|------|------|------|------|
+| A | production 주입 부활 + `ComputerUseCapable` + image-block | — | ✅ DONE (v0.99.208) |
+| C | OpenAI GA `{type:"computer"}` 배선 + harness batched `actions[]` 일반화 | 필수 | PENDING |
+| E | 실행환경 추상화 — 호스트 기본 + Docker+Xvfb 샌드박스 옵인 | 필수 | PENDING |
+| F | run_bash 커맨드 샌드박스 (codex seatbelt/bwrap 수렴) | 필수 | PENDING |
+| D | Zhipu GLM-5V grounding 배선 (self-host) | 필수 | PENDING |
+| B' | Anthropic `zoom` 액션 + 1:1 좌표 (live-test 게이트) | 제외 | DEFERRED (post-1.0) |
+
+- [ ] Phase C 머지 (OpenAI GA, ctx7 확정 → backend 수용은 live-test 게이트)
+- [ ] Phase E 머지 (env 분기 단위 테스트, 컨테이너 E2E는 운영자 환경 live)
+- [ ] Phase F 머지 (샌드박스 래퍼가 cwd 밖 쓰기/네트워크 차단, 호스트 fallback)
+- [ ] Phase D 머지 (bbox→픽셀 변환 단위 테스트, self-host live는 `unverified` 게이트)
+- [ ] 각 Phase: 품질 게이트 + Codex(gpt-5.5) 리뷰 + provider 주입 배선 가드
+
+> 1.0 출시 시 known-limitation(§2.4)에 "host 모드 = 격리 0, DANGEROUS + HITL 유지", "zoom 미지원(post-1.0)" 명기.
+
+### 1.2 시스템 프롬프트 어셈블 + 리팩토링
+
+SoT: [`docs/plans/2026-06-13-prompt-assembly-refactor.md`](2026-06-13-prompt-assembly-refactor.md). 기준 산출물 = CL4R1T4S `CLAUDE-FABLE-5.md`(운영자 지정 1급 예시), 루브릭 8항. P0(`geode prompt dump` + 구조 가드)·P2-a(어셈블 코히어런스 구조결함) 완료, P2-c(도구 설명 60종 fable5 감사·35 재작성)는 PR-TOOL-DESC-FABLE5 v0.99.214로 완료, persona 하드닝(PR-PERSONA-ON-PROMPT-HARDEN v0.99.212)이 P2-b 일부(router/commentary 네이티브 중복 언어지시 제거·agentic_suffix 인젝션 방어·해시 재핀)를 선반영. 잔여 = P2-b·P3.
+
+| 단계 | 내용 | 상태 |
+|------|------|------|
+| P0 | `geode prompt dump` (모델×표면 매트릭스, --measure 실측) + 구조 가드 5종 | ✅ 완료 |
+| P2-a | 어셈블 코히어런스 (구조결함) | ✅ 완료 |
+| P2-b | router.md + AGENTIC_SUFFIX 루브릭 산문 재작성 (persona 하드닝이 일부 선반영) | 잔여 |
+| P2-c | 도구 설명 60종 트리거 패스 (fable5 감사·35 재작성, tool_search 인덱스 직결) | ✅ 완료 (v0.99.214) |
+| P3 | 해시 re-pin + 어셈블 구조 가드 확장 + 전후 토큰 실측 비교 + wrapper sections는 self-improving baseline 재측정으로 행동 검증 | 잔여 |
+
+- [ ] P2-b — router.md/AGENTIC_SUFFIX 루브릭 8항 채점 → 재작성 (P2-b 잔여분 + scaffold CANNOT 2-tier)
+- [ ] P3 — 해시 핀 + 구조 가드 확장 + 토큰 전후 실측(동일 매트릭스 --measure) + wrapper 변경분 petri dim baseline 재측정
+- [ ] 측정(Q3): 토큰 = 덤프 전후 비교, 행동 = petri dim baseline, 구조 = 해시 핀 + 중복 태그 0 유지
+
+## 2. 출시 위생 (release hygiene) — 1.0이 약속하는 것
+
+1.0은 단순 버전 숫자가 아니라 안정성 계약이다. GEODE는 라이브러리가 아니라 자율 실행 에이전트(앱)이므로, "안정"의 대상은 내부 `core/` API가 아니라 **운영자가 의존하는 외부 표면**이다.
+
+### 2.1 안정성 선언 — SemVer 적용 대상
+
+| 표면 | SoT | 1.0 계약 |
+|------|-----|----------|
+| CLI 명령 (`geode <command>`) | `core.cli:app` (Typer) | breaking 변경은 MINOR 이상에서만 |
+| config.toml / `.env` 스키마 | `Settings` + config.toml 매핑 (PR-OBS-LOGGING-CONFIG) | 키 제거/의미변경은 deprecation 후 MINOR |
+| routing.toml (모델 해석) | `reload_routing_constants()` + `core.config.*` (H11 live-read 완료) | precedence 규약 안정 |
+| MCP 도구 (`geode-mcp`, `mcp__geode__*`) | `core.mcp_server` | 도구 시그니처 안정 |
+| 플러그인 인터페이스 | `plugins/` 로더 | 1차 plugin 계약 안정 |
+
+- [ ] 위 표면 목록 운영자 확정 (무엇을 1.0에서 SemVer로 고정할지)
+- [ ] 내부 `core/` 비안정 명시 — 앱 내부 API는 SemVer 비대상
+
+### 2.2 지원 범위
+
+| 축 | 범위 | 근거 |
+|----|------|------|
+| Python | >= 3.12 | `pyproject.toml:7` |
+| 플랫폼 | macOS / Linux (install matrix CI) | ci 매트릭스 ubuntu+macos |
+| provider lane | anthropic(OAuth/PAYG) · openai-codex · openai · glm | `/model` 피커 = `get_model_profiles()` SoT |
+| 패키지 매니저 | uv | scaffold 표준 |
+
+- [ ] 지원 범위 운영자 확정 (Windows 지원 여부 = 현재 install matrix 밖)
+
+### 2.3 deprecation horizon — v1.1.0
+
+| 대상 | 대체 | 제거 시점 | 근거 |
+|------|------|----------|------|
+| `[self_improving_loop.petri.*]` | `[self_improving_loop.autoresearch.<role>]` | v1.1.0 | `core/config/self_improving.py:667` |
+| `[self_improving_loop.mutator]` | `[self_improving_loop.autoresearch.<role>]` | v1.1.0 | `core/config/self_improving.py:680` |
+
+- [ ] 1.0 출시 노트에 deprecation horizon(v1.1.0) 명기 — 운영자에게 이전 기한 고지
+
+### 2.4 known limitations (정직 고지)
+
+- [ ] computer-use host 모드 = 운영자 실 데스크탑 직접 제어, 격리 0 → DANGEROUS 권한 + HITL 게이트 유지. 샌드박스(Phase E)는 옵인. `zoom` 미지원(post-1.0).
+- [ ] self-improving loop = 인프라(7-kind mutation·closed-loop·baseline registry)는 검증됨, 그러나 metric near-saturation으로 robust self-improvement는 미입증(0-approve 구조 분석 완료). 1.0은 "loop 인프라 제공"이지 "자동 자기개선 보장"이 아님.
+- [ ] live 테스트(`-m live`)는 비용 게이트 — 외부 backend 수용(computer 타입·grounding) 일부는 운영자 환경에서만 최종 확인.
+
+### 2.5 버전/문서 정합
+
+- [ ] 5위치 동기화 (pyproject·README·README.ko·CLAUDE.md·CHANGELOG) — `1.0.0`
+- [ ] site SoT (`node site/scripts/sync-stats.mjs` + `check_llms_version.py --fix`) — llms.txt/llms-full/sot.ts/changelog.ts
+- [ ] `[Unreleased]` 잔존 0 (CHANGELOG)
+
+## 3. 품질 게이트 (상시 — 1.0 재확인)
+
+| 게이트 | 기준 | 1.0 |
+|--------|------|-----|
+| Test | `pytest -m "not live"` 그린 | [ ] |
+| Coverage | `fail_under = 75` (pyproject.toml:493, `--cov=core`) | [ ] |
+| Type | `mypy core/ plugins/ scripts/` 0 errors | [ ] |
+| Lint+Format | `ruff check` + `ruff format --check` (core/tests/plugins/scripts) | [ ] |
+| Imports | `lint-imports` 4 contracts kept | [ ] |
+| CI | changes·lint·typecheck·test·security·gate + install matrix + render-lint + build 전부 그린 | [ ] |
+
+## 4. 태그 절차 (체크리스트 통과 후 결정)
+
+§1·§2가 닫히면 cut 방식을 확정한다. 현재 미결 — 본 문서 통과 시점에 둘 중 택1:
+
+- (a) **main 직접 태그**: develop→main 통과 후 main에서 `v1.0.0` annotated 태그 + GitHub Release(노트=CHANGELOG). 현 gitflow와 동일, 최소 절차.
+- (b) **release/1.0.0 RC**: RC 안정화 기간(라이브 스모크·문서 최종 점검) 후 태그. 1.0 무게에 맞는 신중한 컷, 절차 추가.
+
+> 운영자 선택(2026-06-17): **체크리스트 문서화 먼저** → 본 문서가 그 산출물. cut 방식(a/b)은 §1·§2 완료 시점에 본 문서 기준으로 재결정.
+
+## 5. Status
+
+| 게이트 | 상태 |
+|--------|------|
+| punch-list #1~#4 | ✅ 완료 (v0.99.219~222) |
+| 기능 #1 computer-use (Phase C/E/F/D) | PENDING |
+| 기능 #2 프롬프트 (P2-b/P3) | PENDING |
+| 출시 위생 §2 선언 | TODO (운영자 확정) |
+| 품질 게이트 §3 | PR별 그린 (태그 직전 재확인) |
+| 태그 cut 방식 §4 | 미결 (§1·§2 후 결정) |


### PR DESCRIPTION
## Summary
- New `docs/plans/2026-06-17-v1.0.0-release-readiness.md` — aggregates the v1.0.0 gate into one checklist with pointers to the authoritative plan/SoT docs.

## Why
Operator decision (2026-06-17): both remaining backlog items (computer-use enhancement + system-prompt assemble/refactor) are in v1.0.0 scope, and the release checklist should be **documented first**, then used to decide the tag cut. The pre-1.0 punch-list (#1–#4) is now fully closed (v0.99.219–222), so the remaining gate is two feature items + release-hygiene declarations.

## Changes
| File | Change |
|------|--------|
| `docs/plans/2026-06-17-v1.0.0-release-readiness.md` | New readiness checklist: §0 verdict, §1 feature gates (link the two plan docs), §2 release-hygiene draft (API stability surfaces, support scope, v1.1.0 deprecation horizon, known limitations), §3 quality gates, §4 tag-cut decision deferred, §5 status |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Existing 1.0 doc | None found | First readiness doc; placed in `docs/plans/` (dated convention, beside the two plans it aggregates) |
| Voice alignment | Matched | Modeled on the Fable-5-era plan docs (dense tables, concrete file refs, pure Hangul + English terms, no emoji/box-card) |

## Verification
- [x] All factual claims verified against repo (deprecation horizon `self_improving.py:667/680`, `fail_under=75` `pyproject.toml:493`, `requires-python>=3.12`, CI `mypy core/ plugins/ scripts/`, named symbols exist)
- [x] Codex MCP factual-accuracy pass — caught 4 issues, all fixed: P2-c was already DONE (v0.99.214, not remaining); TOML mapping count dropped (brittle); mypy scope corrected to include `scripts/`; "CI green" softened to per-PR/at-tag (external state)
- [x] Relative links resolve (both referenced plan docs exist); markdown well-formed; pure Hangul (no Hanja)
- [x] Docs-only: no version bump, no CHANGELOG entry (per scope rules); `docs/plans/` not in render-lint allowlist

## Reference
Operator decisions 2026-06-17 (AskUserQuestion: scope=both in 1.0, mechanics=document checklist first). Aggregates `2026-06-14-computer-use-enhancement.md` + `2026-06-13-prompt-assembly-refactor.md`.