### PR TITLE
docs: v1.0.0 stability contract (§2 release hygiene, code-verified)

### DIFF
--- a/docs/plans/2026-06-14-computer-use-enhancement.md
+++ b/docs/plans/2026-06-14-computer-use-enhancement.md
@@ -76,7 +76,7 @@
 - **zoom 액션 + 1:1 좌표는 분리**(ctx7 미확인) → Phase B' live-test 게이트 후속(§6 보류로 이동).
 - 가드: computer 주입 시 beta 헤더에 computer-use 문자열 존재.
 
-### Phase C — OpenAI GA 배선 (P1, ctx7 확정)
+### Phase C — OpenAI GA 배선 (P1, ctx7 확정) ✅ DONE (v0.99.223)
 - `core/llm/providers/openai.py`: Responses API **`{type:"computer"}`** 주입(GA `gpt-5.5` 게이트, preview `computer_use_preview` 회피), `ComputerUseCapable` 구현. `display_width/height` + environment.
 - **GA batched `actions[]`**: computer_call이 액션 배열을 담음 → 핸들러가 배열 순회 실행(마지막 screenshot 반환). 액션 매핑(click/double_click/drag/scroll/move/type/keypress/wait/screenshot → harness).
 - safety check 흐름(computer tool 대상) 반영.
@@ -128,7 +128,7 @@
 | Phase | 상태 |
 |---|---|
 | A — production 경로 부활 + ComputerUseCapable 프로토콜 | ✅ DONE (v0.99.208) |
-| C — OpenAI GA {type:computer} 배선 (+harness batched actions[]) | PENDING |
+| C — OpenAI GA {type:computer} 배선 (+harness batched actions[]) | ✅ DONE (v0.99.223) |
 | E — 호스트 기본 + Docker+Xvfb 샌드박스 옵인 | PENDING |
 | F — run_bash 커맨드 샌드박스(codex 수렴) | PENDING |
 | D — Zhipu GLM-5V grounding 배선 (self-host) | PENDING |

--- a/docs/plans/2026-06-17-v1.0.0-release-readiness.md
+++ b/docs/plans/2026-06-17-v1.0.0-release-readiness.md
@@ -11,9 +11,9 @@
 | 안정성/정확성 (punch-list) | GO | #1~#4 전부 닫힘 (v0.99.219~222), 회귀 가드 동반 |
 | 코어 런타임 표면 | GO | AgenticLoop·provider 라우팅·CLI·self-improving 인프라 안정, 최근 churn 냉각 |
 | 품질 게이트 | GO (PR별 그린) | coverage ratchet 75%, 태그 직전 재확인 (§3) |
-| **기능 게이트 #1 — computer-use 보강** | **GAP** | Phase A만 완료(v0.99.208); C/E/F/D 미착수, B' deferred (§1.1) |
+| **기능 게이트 #1 — computer-use 보강** | **GAP** | Phase A+C 완료(v0.99.208/223); E/F/D 미착수, B' deferred (§1.1) |
 | **기능 게이트 #2 — 프롬프트 어셈블/리팩토링** | **GAP** | P0·P2-a·P2-c 완료; P2-b/P3 잔여 (§1.2) |
-| 출시 위생 선언 (API/지원범위/known-limitations) | TODO | 본 문서 §2에서 초안, 운영자 확정 필요 |
+| 출시 위생 선언 (API/지원범위/known-limitations) | GO | 계약 doc 확정 — [`docs/v1.0.0-stability-contract.md`](../v1.0.0-stability-contract.md) (§2) |
 
 판정: 코어와 품질은 출시 가능 상태. v1.0.0 태그는 **기능 게이트 2건 완료 + §2 출시 위생 선언 확정**에 걸려 있다.
 
@@ -26,19 +26,19 @@ SoT: [`docs/plans/2026-06-14-computer-use-enhancement.md`](2026-06-14-computer-u
 | Phase | 내용 | 1.0 | 상태 |
 |------|------|------|------|
 | A | production 주입 부활 + `ComputerUseCapable` + image-block | — | ✅ DONE (v0.99.208) |
-| C | OpenAI GA `{type:"computer"}` 배선 + harness batched `actions[]` 일반화 | 필수 | PENDING |
+| C | OpenAI GA `{type:"computer"}` 배선 + harness batched `actions[]` 일반화 | 필수 | ✅ DONE (v0.99.223) |
 | E | 실행환경 추상화 — 호스트 기본 + Docker+Xvfb 샌드박스 옵인 | 필수 | PENDING |
 | F | run_bash 커맨드 샌드박스 (codex seatbelt/bwrap 수렴) | 필수 | PENDING |
 | D | Zhipu GLM-5V grounding 배선 (self-host) | 필수 | PENDING |
 | B' | Anthropic `zoom` 액션 + 1:1 좌표 (live-test 게이트) | 제외 | DEFERRED (post-1.0) |
 
-- [ ] Phase C 머지 (OpenAI GA, ctx7 확정 → backend 수용은 live-test 게이트)
+- [x] Phase C 머지 (OpenAI GA, v0.99.223 — ctx7 확정, backend 수용은 live-test 게이트로 잔존)
 - [ ] Phase E 머지 (env 분기 단위 테스트, 컨테이너 E2E는 운영자 환경 live)
 - [ ] Phase F 머지 (샌드박스 래퍼가 cwd 밖 쓰기/네트워크 차단, 호스트 fallback)
 - [ ] Phase D 머지 (bbox→픽셀 변환 단위 테스트, self-host live는 `unverified` 게이트)
 - [ ] 각 Phase: 품질 게이트 + Codex(gpt-5.5) 리뷰 + provider 주입 배선 가드
 
-> 1.0 출시 시 known-limitation(§2.4)에 "host 모드 = 격리 0, DANGEROUS + HITL 유지", "zoom 미지원(post-1.0)" 명기.
+> 1.0 출시 시 known-limitation은 [stability-contract §G.1](../v1.0.0-stability-contract.md)에 명기됨 — "host 모드 = 격리 0, DANGEROUS + HITL 유지", "zoom 미지원(post-1.0)", "OpenAI GA backend 수용 unverified".
 
 ### 1.2 시스템 프롬프트 어셈블 + 리팩토링
 
@@ -60,44 +60,17 @@ SoT: [`docs/plans/2026-06-13-prompt-assembly-refactor.md`](2026-06-13-prompt-ass
 
 1.0은 단순 버전 숫자가 아니라 안정성 계약이다. GEODE는 라이브러리가 아니라 자율 실행 에이전트(앱)이므로, "안정"의 대상은 내부 `core/` API가 아니라 **운영자가 의존하는 외부 표면**이다.
 
-### 2.1 안정성 선언 — SemVer 적용 대상
+SoT: [`docs/v1.0.0-stability-contract.md`](../v1.0.0-stability-contract.md). 계약의 전체 열거(SemVer 적용 표면 A-F + known-limitations G)는 모두 코드 grep으로 검증되어 그 문서에 있다. 본 §2는 게이트 추적만 한다 — 열거를 두 문서에 중복하지 않는다.
 
-| 표면 | SoT | 1.0 계약 |
-|------|-----|----------|
-| CLI 명령 (`geode <command>`) | `core.cli:app` (Typer) | breaking 변경은 MINOR 이상에서만 |
-| config.toml / `.env` 스키마 | `Settings` + config.toml 매핑 (PR-OBS-LOGGING-CONFIG) | 키 제거/의미변경은 deprecation 후 MINOR |
-| routing.toml (모델 해석) | `reload_routing_constants()` + `core.config.*` (H11 live-read 완료) | precedence 규약 안정 |
-| MCP 도구 (`geode-mcp`, `mcp__geode__*`) | `core.mcp_server` | 도구 시그니처 안정 |
-| 플러그인 인터페이스 | `plugins/` 로더 | 1차 plugin 계약 안정 |
+| 영역 | 계약 doc 절 | 게이트 | 상태 |
+|------|------------|--------|------|
+| SemVer 적용 표면 (CLI 안정/실험 tier · config 72키+3 시크릿 · MCP 6 도구 · provider 4 lane) | §A-D | 운영자 확정 | ✅ 확정 (계약 doc) |
+| 내부 `core/` 비안정 명시 (앱 내부 API는 SemVer 비대상) | §G.4 | 운영자 확정 | ✅ 확정 (계약 doc) |
+| 지원 범위 (Python ≥3.12 · macOS+Linux · Windows 비지원 · uv) | §E | Windows 여부 확정 | ✅ 확정 — Windows 비지원 (install matrix 밖, `install-smoke.yml:34`) |
+| deprecation horizon v1.1.0 (2개 레거시 섹션) | §F | 출시 노트 명기 | ✅ 확정 (계약 doc); 출시 노트 반영은 §2.5 5위치 동기화에서 |
+| known limitations (computer-use 격리 0/샌드박스·zoom deferred·OpenAI GA unverified · self-improving 자동개선 미보장 · live 게이트) | §G | 정직 고지 | ✅ 확정 (계약 doc) |
 
-- [ ] 위 표면 목록 운영자 확정 (무엇을 1.0에서 SemVer로 고정할지)
-- [ ] 내부 `core/` 비안정 명시 — 앱 내부 API는 SemVer 비대상
-
-### 2.2 지원 범위
-
-| 축 | 범위 | 근거 |
-|----|------|------|
-| Python | >= 3.12 | `pyproject.toml:7` |
-| 플랫폼 | macOS / Linux (install matrix CI) | ci 매트릭스 ubuntu+macos |
-| provider lane | anthropic(OAuth/PAYG) · openai-codex · openai · glm | `/model` 피커 = `get_model_profiles()` SoT |
-| 패키지 매니저 | uv | scaffold 표준 |
-
-- [ ] 지원 범위 운영자 확정 (Windows 지원 여부 = 현재 install matrix 밖)
-
-### 2.3 deprecation horizon — v1.1.0
-
-| 대상 | 대체 | 제거 시점 | 근거 |
-|------|------|----------|------|
-| `[self_improving_loop.petri.*]` | `[self_improving_loop.autoresearch.<role>]` | v1.1.0 | `core/config/self_improving.py:667` |
-| `[self_improving_loop.mutator]` | `[self_improving_loop.autoresearch.<role>]` | v1.1.0 | `core/config/self_improving.py:680` |
-
-- [ ] 1.0 출시 노트에 deprecation horizon(v1.1.0) 명기 — 운영자에게 이전 기한 고지
-
-### 2.4 known limitations (정직 고지)
-
-- [ ] computer-use host 모드 = 운영자 실 데스크탑 직접 제어, 격리 0 → DANGEROUS 권한 + HITL 게이트 유지. 샌드박스(Phase E)는 옵인. `zoom` 미지원(post-1.0).
-- [ ] self-improving loop = 인프라(7-kind mutation·closed-loop·baseline registry)는 검증됨, 그러나 metric near-saturation으로 robust self-improvement는 미입증(0-approve 구조 분석 완료). 1.0은 "loop 인프라 제공"이지 "자동 자기개선 보장"이 아님.
-- [ ] live 테스트(`-m live`)는 비용 게이트 — 외부 backend 수용(computer 타입·grounding) 일부는 운영자 환경에서만 최종 확인.
+> tier 메모(계약 doc §A.2 검증분): self-improving/연구 명령(`seeds`/`hub`/`prompt`/`audit`/`audit-seeds`/`petri-archive`/`outer-bundle`/`campaign`/`reindex`)은 **실험 tier — SemVer 비적용**으로 확정. `core/cli/__init__.py:334-335` 주석이 repo-only thin wrapper임을 명시하고, audit/petri-archive/audit-seeds는 별도 plugin(`plugins/petri_audit`·`plugins/seed_generation`) backed다. routing precedence는 §D에서 `get_model_profiles()` + routing 상수 live-reload로 다룬다.
 
 ### 2.5 버전/문서 정합
 
@@ -130,8 +103,8 @@ SoT: [`docs/plans/2026-06-13-prompt-assembly-refactor.md`](2026-06-13-prompt-ass
 | 게이트 | 상태 |
 |--------|------|
 | punch-list #1~#4 | ✅ 완료 (v0.99.219~222) |
-| 기능 #1 computer-use (Phase C/E/F/D) | PENDING |
+| 기능 #1 computer-use (C done v0.99.223; E/F/D 잔여) | PENDING |
 | 기능 #2 프롬프트 (P2-b/P3) | PENDING |
-| 출시 위생 §2 선언 | TODO (운영자 확정) |
+| 출시 위생 §2 선언 | ✅ 확정 (stability-contract §A-G) |
 | 품질 게이트 §3 | PR별 그린 (태그 직전 재확인) |
 | 태그 cut 방식 §4 | 미결 (§1·§2 후 결정) |

--- a/docs/v1.0.0-stability-contract.md
+++ b/docs/v1.0.0-stability-contract.md
@@ -1,0 +1,173 @@
+# GEODE v1.0.0 안정성 계약 (Stability Contract)
+
+> **작성**: 2026-06-17
+> **역할**: v1.0.0이 운영자에게 약속하는 SemVer 안정성 계약의 단일 SoT. [`docs/plans/2026-06-17-v1.0.0-release-readiness.md`](plans/2026-06-17-v1.0.0-release-readiness.md) §2(출시 위생)의 구체화 산출물.
+> **검증 원칙**: 본 문서의 모든 명령·키·도구·상수는 코드에서 grep으로 확인한 것만 적는다 (file:line 병기). 확인 불가 항목은 추측 대신 `unverified`로 표기.
+
+GEODE는 라이브러리가 아니라 자율 실행 에이전트(앱)다. 따라서 "안정"의 대상은 내부 `core/` Python API가 아니라 **운영자가 직접 의존하는 외부 표면** — CLI 명령, config/env 스키마, MCP 도구, provider lane, 지원 범위다. 이 표면들만 SemVer로 고정한다. 내부 모듈은 자유롭게 재구성될 수 있으며, import 경로 안정성을 약속하지 않는다 (§G.4).
+
+SemVer 규약: breaking 변경(명령 제거, config 키 제거/의미 변경, MCP 도구 시그니처 변경)은 **MINOR 이상**에서만, 그리고 deprecation 경고를 1개 MINOR 먼저 거친 뒤에만 일어난다. 버그 수정·내부 리팩토링·새 옵션 추가는 PATCH로 나간다.
+
+---
+
+## A. CLI 명령 표면 — 안정 vs 실험 tier
+
+SoT: `core.cli:app` (Typer). 등록 블록 = `core/cli/__init__.py:326-449`. GEODE는 명령을 두 tier로 나눠 약속한다.
+
+### A.1 안정 (SemVer 적용 — lifecycle / interaction)
+
+운영자가 매일 쓰는 생애주기·상호작용 명령. breaking 변경은 deprecation → MINOR로만.
+
+| 명령 | 등록 | 출처 모듈 |
+|------|------|-----------|
+| `geode version` | `__init__.py:350` | `core.cli.typer_commands` (`__init__.py:52-60`) |
+| `geode about` | `__init__.py:351` | `core.cli.typer_commands` |
+| `geode setup` | `__init__.py:352` | `core.cli.typer_commands` |
+| `geode doctor` | `__init__.py:353` | `core.cli.typer_commands` |
+| `geode update` | `__init__.py:354` | `core.cli.typer_commands` |
+| `geode uninstall` | `__init__.py:355` | `core.cli.typer_commands` |
+| `geode init` | `__init__.py:356` | `core.cli.typer_init` (`__init__.py:62`) |
+| `geode history` | `__init__.py:357` | `core.cli.typer_commands` |
+| `geode serve` | `__init__.py:358` | `core.cli.typer_serve` (`__init__.py:64`) |
+| `geode "<task>"` (자연어 기본 호출) | `@app.callback()` `__init__.py:458-513` | 서브명령 없을 때 `_thin_interactive_loop` |
+| `geode config <sub>` | `add_typer` `__init__.py:332` | `migrate-petri-toml`·`explain` (`commands/config.py:127,255`) |
+| `geode skill <sub>` | `add_typer` `__init__.py:331` | `list`·`create`·`remove`·`show` (`commands/skill.py:53,74,119,134`) |
+| `geode adapters <sub>` | `add_typer` `__init__.py:330` | `list`·`detect-model`·`stats` (`commands/adapters.py:40,66,115`) |
+
+자연어 기본 호출은 `ctx.invoked_subcommand is None`일 때 발동하며(`__init__.py:491`), serve 데몬 자동 기동 후 IPC interactive loop로 진입한다. 전역 플래그 `--version`/`--continue`/`--resume`/`--dangerously-skip-permissions`(`__init__.py:461-476`)도 이 표면의 일부다.
+
+### A.2 실험 / repo-only (SemVer 비적용 — 변경될 수 있음)
+
+self-improving 루프·연구 도구용 명령. `core/cli/__init__.py:334-335` 주석이 seeds/hub/prompt를 "repo-only; thin wrappers over scripts/ modules"로 명시한다. 이들은 운영자 일상 표면이 아니라 클론 안에서 실험을 돌리는 진입점이며, **시그니처가 릴리스 간 바뀔 수 있다**. audit·audit-seeds·petri-archive는 별도 배포되는 plugin(`plugins/petri_audit`·`plugins/seed_generation`)이 뒤를 받친다.
+
+| 명령 | 등록 | 성격 |
+|------|------|------|
+| `geode seeds <sub>` | `add_typer` `__init__.py:339` | repo-only thin wrapper (`commands/seed_pool.py:20`) |
+| `geode hub <sub>` | `add_typer` `__init__.py:340` | repo-only thin wrapper (`commands/seed_pool.py:41`) |
+| `geode prompt <sub>` | `add_typer` `__init__.py:341` | repo-only thin wrapper (`commands/prompt_inspect.py:15` `dump`) |
+| `geode audit` | `__init__.py:359` | plugin-backed (`plugins.petri_audit.cli_audit`, `__init__.py:20`) |
+| `geode audit-seeds <sub>` | `add_typer` `__init__.py:361` | plugin-backed (`plugins.seed_generation.cli`, `__init__.py:21`) |
+| `geode petri-archive` | `__init__.py:360` | plugin-backed (`plugins.petri_audit.cli_audit`, `__init__.py:20`) |
+| `geode outer-bundle` | `__init__.py:366` | outer-loop bundle viewer (`core.cli.outer_bundle`) |
+| `geode campaign` | `__init__.py:449` | 3-arm self-improving 캠페인 thin forwarder (`__init__.py:382-446`) |
+| `geode reindex` | `__init__.py:371` | cross-project search index rebuild (`core.cli.commands.reindex`) |
+
+> **tier 정정**: 원 plan은 `petri-archive`를 실험 tier로 분류했고 코드도 이를 뒷받침한다 — `petri_archive`는 `audit`과 같은 `plugins.petri_audit.cli_audit`에서 import되며(`__init__.py:20`), self-improving 관측 plugin 표면이라 실험 tier가 맞다. 별도 재분류는 없었다.
+
+---
+
+## B. config.toml / `.env` 스키마
+
+SoT: `Settings` 모델(`core/config/_settings.py`) + `_TOML_TO_SETTINGS` 매핑(`core/config/__init__.py:52-134`). 우선순위는 CLI > env > project `.geode/config.toml` > global `~/.geode/config.toml` > defaults (`core/config/__init__.py:145`).
+
+| 항목 | 값 | 근거 |
+|------|----|------|
+| config.toml 매핑 키 수 | **72** | `python -c "from core.config import _TOML_TO_SETTINGS; print(len(_TOML_TO_SETTINGS))"` → 72; 정의 `__init__.py:52-134` |
+| env/CLI-only 시크릿 수 | **3** | `_TOML_ENV_ONLY_FIELDS` = `anthropic_api_key`·`openai_api_key`·`zai_api_key` (`__init__.py:139-141`) |
+| 매핑 parity 가드 | `test_toml_settings_map` | `__init__.py:85,138` 주석 인용 |
+
+시크릿 3종은 의도적으로 TOML 맵 밖이다 — 커밋/동기화되는 `config.toml`에 키를 넣는 누설을 피하기 위해 env/CLI로만 받는다(`__init__.py:136-138`). 나머지 비시크릿 Settings 필드는 PR-OBS-LOGGING-CONFIG(2026-06-14)로 전부 config.toml에서도 설정 가능해졌다(`__init__.py:83-85`).
+
+**계약**: 위 72개 config 키 + 3개 env 시크릿 이름은 SemVer 대상이다. 키 제거/의미 변경은 deprecation 경고 → MINOR로만(§F가 그 첫 사례). 새 키 추가는 PATCH.
+
+---
+
+## C. MCP 도구 (`geode-mcp` 서버)
+
+SoT: `core/mcp_server.py` (`FastMCP("geode")`, `mcp_server.py:165`). 서버는 정확히 6개 도구를 노출하며, 클라이언트에는 `mcp__geode__<name>`으로 보인다.
+
+| MCP 도구 | 등록 | 시그니처 |
+|----------|------|----------|
+| `run_agent` | `mcp_server.py:182` | `(prompt: str, time_budget_s: float = 120.0) -> dict` |
+| `self_improving_status` | `mcp_server.py:195` | `() -> dict` |
+| `self_improving_propose` | `mcp_server.py:200` | `() -> dict` |
+| `self_improving_apply` | `mcp_server.py:220` | `(mutation_id: str) -> dict` |
+| `query_memory` | `mcp_server.py:236` | `(query: str) -> dict` |
+| `get_health` | `mcp_server.py:247` | `() -> dict` |
+
+서버는 추가로 `geode://soul` **리소스**(도구 아님, `mcp_server.py:269`)를 노출한다. `self_improving_propose` → `self_improving_apply`는 2단계 확인 게이트다 — propose가 `mutation_id`로 park하면 apply가 소비한다(`mcp_server.py:178-180`).
+
+**계약**: 위 6개 도구 이름 + 시그니처는 안정 표면이다. breaking 변경은 MINOR 이상.
+
+---
+
+## D. Provider / 모델 표면
+
+SoT: `core.cli.commands._state.get_model_profiles()` (`core/cli/commands/_state.py:46-79`). `/model` 피커가 매 호출마다 이 리스트를 새로 빌드한다(H11-tail — boot-frozen 아님, `_state.py:47-54`).
+
+| provider lane | 모델 (피커 라벨) | 근거 |
+|---------------|------------------|------|
+| `anthropic` | Fable 5 · Opus 4.8 · Opus 4.7 · Opus 4.6 · Sonnet 4.6 · Haiku 4.5 | `_state.py:61-66` |
+| `openai-codex` | GPT-5.5 · GPT-5.3 Codex | `_state.py:72,75` |
+| `openai` | GPT-5.4 · GPT-5.4 Mini | `_state.py:73-74` |
+| `glm` | GLM-5.1 · GLM-5 Turbo · GLM-4.7 Flash | `_state.py:76-78` |
+
+모델 id는 version-pinned 리터럴(`"claude-opus-4-8"` 등)과 routing 상수(`ANTHROPIC_SECONDARY`·`ANTHROPIC_BUDGET`·`OPENAI_PRIMARY`·`GLM_PRIMARY`, `core/config/__init__.py:371-384`)가 섞여 있다. routing 상수는 `reload_routing_constants()`로 라이브 갱신된다(`__init__.py:417-424`) — 모델 목록 자체는 churn하므로 **본 계약은 구체 모델 리스트를 고정하지 않는다**. 안정 약속의 대상은 (1) 4개 provider lane 식별자(`anthropic`/`openai-codex`/`openai`/`glm`)와 (2) `get_model_profiles()`가 모델 목록의 SoT라는 사실이다. auth-mode(OAuth vs PAYG)는 피커에 없고 LLM 호출 시점에 `resolve_routing()`이 자동 해석한다(`_state.py:38-40`).
+
+---
+
+## E. 지원 범위
+
+| 축 | 범위 | 근거 |
+|----|------|------|
+| Python | `>= 3.12` | `pyproject.toml:7` (`requires-python = ">=3.12"`) |
+| 플랫폼 | macOS + Linux | install 매트릭스 `os: [ubuntu-latest, macos-latest]` (`.github/workflows/install-smoke.yml:34`) |
+| Windows | **비지원** (매트릭스 밖) | install-smoke.yml 매트릭스에 windows 없음; `ci.yml`은 전 job `ubuntu-latest`(`ci.yml:23,45,91,111,147,164`) |
+| 패키지 매니저 | uv | scaffold 표준 (`CLAUDE.md` Quick Start) |
+
+> **CI 표면 주의**: 기능 CI(`.github/workflows/ci.yml` — lint/type/test/security/gate)는 **`ubuntu-latest` 단일**이다. macOS 커버리지는 install/version/update/uninstall 라이프사이클만 도는 `install-smoke.yml`에서만 검증된다. 즉 "macOS 지원"은 설치·생애주기 스모크 수준의 약속이며, 전체 테스트 스위트가 macOS에서 매 PR 돌지는 않는다. Windows는 어느 매트릭스에도 없어 미지원이다.
+
+---
+
+## F. Deprecation horizon — v1.1.0
+
+v1.0.0이 고지하는 단 하나의 예정 제거. 두 레거시 config 섹션이 v1.1.0(v1.0.0 직후 첫 MINOR)에서 제거된다. 현재는 DeprecationWarning + 자동 마이그레이션으로 동작한다.
+
+| 제거 대상 | 대체 | 제거 시점 | 근거 |
+|-----------|------|-----------|------|
+| `[self_improving_loop.petri.*]` | `[self_improving_loop.autoresearch.<role>]` | v1.1.0 | `core/config/self_improving.py:663-668` (경고 텍스트 `:667`) |
+| `[self_improving_loop.mutator]` | `[self_improving_loop.autoresearch.mutator]` | v1.1.0 | `core/config/self_improving.py:676-681` (경고 텍스트 `:680`) |
+
+두 경고 모두 "The legacy section will be removed in v1.1.0 (the first minor after the v1.0.0 stable)"를 명시한다(`self_improving.py:667,680`). 레거시 섹션이 있으면 role 바인딩을 `autoresearch_section`으로 자동 이전한 뒤 경고를 띄운다(`self_improving.py:658-684`).
+
+---
+
+## G. Known limitations (정직 고지)
+
+v1.0.0이 **약속하지 않는** 것 — 인프라는 있으나 보장하지 않거나, 격리가 없거나, 외부 backend 수용이 미검증인 표면.
+
+### G.1 computer-use
+
+SoT: `core/tools/computer_use.py` + [`docs/plans/2026-06-14-computer-use-enhancement.md`](plans/2026-06-14-computer-use-enhancement.md).
+
+- **host 모드 = 격리 0**: 기본 실행은 host pyautogui 직접 제어다(`computer_use.py:55-66`, FAILSAFE만 — 마우스를 모서리로 보내면 중단). 운영자의 실제 데스크탑을 그대로 조작하므로 격리가 없다. `computer` 도구는 `DANGEROUS_TOOLS`에 등록되어(`core/agent/safety.py:65-70`) HITL 승인 게이트를 강제한다. 게이트 우회는 `--dangerously-skip-permissions`로만(`__init__.py:472-476`).
+- **샌드박스(Docker+Xvfb)는 deferred**: plan의 Phase E(`GEODE_COMPUTER_USE_ENV` host/sandbox 분기)는 코드에 없다 — `grep "GEODE_COMPUTER_USE_ENV\|Xvfb\|sandbox" core/tools/computer_use.py` → 0 hit. v1.0.0은 host 모드만 제공한다.
+- **OpenAI GA 수용은 `unverified — live test required`**: Phase C(OpenAI Responses `{type:"computer"}` 주입)는 **코드에 들어가 있다** — `_maybe_inject_openai_computer_use` (`core/llm/adapters/_openai_common.py:542`), GA 모델 `gpt-5.5`만 게이트(`_OPENAI_COMPUTER_USE_GA_MODELS`, `_openai_common.py:520`). 그러나 backend 실제 수용은 미검증으로, 함수 docstring이 "backend acceptance unverified — live test required (CANNOT §4d)"를 명시한다(`_openai_common.py:557`). v1.0.0은 OpenAI computer-use 동작을 보장하지 않는다.
+- **`zoom` 액션 미지원**: plan의 Phase B'(Anthropic `zoom` 액션)는 deferred. 코드에 없다 — `grep "zoom" core/tools/computer_use.py` → 0 hit. harness 액션셋은 screenshot/click/double_click/type/key/scroll/move/drag/wait + provider alias(left_click/right_click/middle_click/triple_click/keypress/cursor_position)뿐(`computer_use.py:254-288`).
+
+### G.2 self-improving loop
+
+인프라(7-kind mutation · closed-loop · baseline registry · 3-arm campaign)는 검증됐고 MCP 도구(`self_improving_*`, §C)·CLI(`campaign`, §A.2)로 노출된다. 그러나 metric near-saturation으로 인해 robust self-improvement는 미입증이다(0-approve 구조 분석 완료). **v1.0.0은 "loop 인프라 제공"이지 "자동 자기개선 보장"이 아니다.**
+
+### G.3 live 테스트 / 외부 backend 수용
+
+라이브 테스트(`-m live`)는 비용 게이트라 CI에서 무단 실행되지 않는다(CLAUDE.md Quality Gates: `pytest -m "not live"`). 현재 코드에 들어간 외부 backend 수용 중 OpenAI computer 타입(§G.1)만 `unverified — live test required`로 docstring에 명기돼 있다(`_openai_common.py:557`). Zhipu grounding은 Phase D로 아직 코드에 없다(미구현, plan text만 존재). 이런 외부 backend 수용은 운영자 환경에서만 최종 확인 가능하다.
+
+### G.4 내부 `core/` API 비안정
+
+GEODE는 앱이지 라이브러리가 아니다. 본 문서 §A-F의 표면만 SemVer 대상이며, 내부 `core/` Python 모듈·클래스·함수 시그니처·import 경로는 **안정 표면이 아니다**. 이들은 릴리스 간 자유롭게 재구성될 수 있다(과거 사례: `core/llm/client.py`·`core/agent/loop/loop.py` 모듈 제거, CLAUDE.md Compat 규칙).
+
+---
+
+## 요약 — v1.0.0이 SemVer로 고정하는 것
+
+| 표면 | SoT | 약속 |
+|------|-----|------|
+| A. CLI 안정 명령 | `core.cli:app` (`__init__.py:326-449`) | 생애주기·상호작용 명령 breaking은 deprecation → MINOR (실험 tier §A.2 제외) |
+| B. config/env 스키마 | `_TOML_TO_SETTINGS` 72키 + 3 env 시크릿 (`config/__init__.py:52-141`) | 키 제거/의미변경은 deprecation → MINOR |
+| C. MCP 도구 | `core/mcp_server.py` 6 도구 (`:182-247`) | 도구 이름·시그니처 안정 |
+| D. provider lane | `get_model_profiles()` (`_state.py:46-79`) | 4 lane 식별자 안정 (모델 리스트는 churn — 비고정) |
+| E. 지원 범위 | `pyproject.toml:7` + `install-smoke.yml:34` | Python ≥3.12, macOS+Linux (Windows 비지원) |
+| F. deprecation horizon | `config/self_improving.py:667,680` | 2개 레거시 섹션 v1.1.0 제거 예고 |
+
+§G(known limitations)는 약속하지 **않는** 것의 정직 고지다 — computer-use host 격리 0 + 샌드박스/zoom deferred + OpenAI GA unverified, self-improving 자동개선 미보장, live-test 비용 게이트, 내부 `core/` API 비안정.


### PR DESCRIPTION
## Summary
- New `docs/v1.0.0-stability-contract.md` — the code-verified v1.0.0 SemVer stability contract, finalizing the §2 (release hygiene) item the readiness doc left as "operator to confirm".
- Every surface enumerated from code (grep-cited, file:line) and Codex-MCP-audited for hallucinations.

## Why
Operator directed §2 to be completed without further approval, with strict verification + Codex MCP. A 1.0 stability declaration must be concrete (actual commands/keys/tools), not vague — so each surface is enumerated and code-backed.

## Changes
| File | Change |
|------|--------|
| `docs/v1.0.0-stability-contract.md` (new) | §A CLI (stable vs experimental tiers) · §B config (72 keys + 3 secrets) · §C MCP (6 tools) · §D providers (4 lanes) · §E support (py≥3.12, macOS+Linux) · §F deprecation (v1.1.0) · §G known-limitations |
| `docs/plans/2026-06-17-v1.0.0-release-readiness.md` | §2 flipped to confirmed → contract; §0/§1.1/§5 Phase C marked done |
| `docs/plans/2026-06-14-computer-use-enhancement.md` | §8 status + Phase C heading → DONE (v0.99.223) |

## Verification
- [x] **Codex-MCP-audited, 3 rounds**: round 1 caught 4 (skill subcommand hallucination `save/delete`→`create/remove`, MCP file label, stale plan SoT, Zhipu docstring overclaim); round 2 caught 2 cross-ref slips (§7→§G.4, §5 TODO); round 3 GO. Every enumerated command/key/tool re-verified against code.
- [x] config count (72) + MCP count (6) verified by running/grepping; CLI tiering verified against `core/cli/__init__.py`
- [x] no Hanja (pure Hangul), relative links resolve, tables well-formed
- [x] Docs-only: no version bump, no CHANGELOG (per scope rules)

## Reference
`docs/plans/2026-06-17-v1.0.0-release-readiness.md` §2. Code SoT: `core/cli/__init__.py`, `core/config/__init__.py`, `core/mcp_server.py`, `core/cli/commands/_state.py`.