### PR TITLE
docs: sandbox frontier research + Phase E/F design correction

### DIFF
--- a/docs/plans/2026-06-14-computer-use-enhancement.md
+++ b/docs/plans/2026-06-14-computer-use-enhancement.md
@@ -15,7 +15,7 @@
 | 사람-레벨 조작 | **있음** (위 액션 = 마우스 포인터+스크롤+입력) | 동상 |
 | Anthropic 배선 | **있음** — `_COMPUTER_USE_TOOL`(`computer_20251124`) API 주입, `is_computer_use_enabled()` 게이트, handler | `core/llm/providers/anthropic.py:717-720,725,819-820`, `core/config/_settings.py` `computer_use_enabled` |
 | `zoom` 액션 | **없음** — `computer_20251124`의 신규 액션 미구현 | harness 액션셋에 `screenshot/click/double_click/type/key/scroll/move/drag/wait`만(`grep "def "` 검증) |
-| OpenAI computer-use | **없음** — `openai.py`에 `computer`/`ComputerUse` 참조 0개(grep 검증). GA `{type:computer}` 미배선 | `openai.py` grep 0 hits |
+| OpenAI computer-use | **없음** — `openai.py`에 `computer`/`ComputerUse` 참조 0개(grep 검증). GA `{type:"computer"}` 미배선 | `openai.py` grep 0 hits |
 | Zhipu computer-use | **없음** — `glm.py`에 `computer` 참조 0개(grep 검증) | `glm.py` grep 0 hits |
 | `ComputerUseCapable` 프로토콜 | **없음** — Anthropic 전용. (cf. `WebSearchCapable` 패턴) | `core/llm/adapters/base.py` |
 | 실행 격리(샌드박스) | **없음** — pyautogui 로컬 호스트 직접 | — |
@@ -34,7 +34,7 @@
 | 툴 | `computer_20251124` (beta) | **GA: `{type:"computer"}`** / preview: `computer_use_preview` | ComputerRL/AutoGLM(오픈) + GLM-5V grounding |
 | 모델 | Opus 4.8/4.7/4.6, Sonnet 4.6 | **GA `gpt-5.5`** (preview=`computer-use-preview`) | AutoGLM-OS-9B·Phone·GLM-5V-Turbo |
 | 액션 전달 | tool_use.input.action (단일) | **GA=batched `actions[]` 배열** / preview=단일 `action` | bbox grounding |
-| 툴 파라미터 | `display_width_px`·`display_height_px`·`display_number`(X11) | `display_width`·`display_height`·environment(mac/linux/windows/ubuntu/browser) | — |
+| 툴 파라미터 | `display_width_px`·`display_height_px`·`display_number`(X11) | **GA `{type:"computer"}`=무파라미터(bare)**; preview `computer_use_preview`=`display_width`·`display_height`·environment(mac/linux/windows/ubuntu/browser) | — |
 | 안전 | beta header(아래 ⚠) | safety check 적용(computer tool) | self-host |
 
 > **ctx7 출처**: Anthropic=`/anthropics/anthropic-sdk-python` `beta_tool_computer_use_20251124_param.py`(3필드: display_width_px/height_px/display_number) + `anthropic_beta_param.py`(beta enum). OpenAI=`/websites/developers_openai_api` `guides/tools-computer-use`(GA `{type:"computer"}` on gpt-5.5, batched actions[]).
@@ -77,7 +77,7 @@
 - 가드: computer 주입 시 beta 헤더에 computer-use 문자열 존재.
 
 ### Phase C — OpenAI GA 배선 (P1, ctx7 확정) ✅ DONE (v0.99.223)
-- `core/llm/providers/openai.py`: Responses API **`{type:"computer"}`** 주입(GA `gpt-5.5` 게이트, preview `computer_use_preview` 회피), `ComputerUseCapable` 구현. `display_width/height` + environment.
+- Responses API **`{type:"computer"}`** 주입(GA `gpt-5.5` 게이트, preview `computer_use_preview` 회피), `ComputerUseCapable` 구현. **GA 툴은 bare `{type:"computer"}`** — `display_width/height`·environment는 preview 전용이라 미포함(구현 시 확정, `core/llm/adapters/_openai_common.py:523-539`).
 - **GA batched `actions[]`**: computer_call이 액션 배열을 담음 → 핸들러가 배열 순회 실행(마지막 screenshot 반환). 액션 매핑(click/double_click/drag/scroll/move/type/keypress/wait/screenshot → harness).
 - safety check 흐름(computer tool 대상) 반영.
 - ctx7 출처(developers_openai_api guides/tools-computer-use) docstring 인용. backend 실제 수용은 live-test 게이트.
@@ -88,17 +88,21 @@
 - ctx7/z.ai docs 확인; self-host라 live 검증은 운영자 환경 의존 → `unverified` 게이트.
 - 가드: bbox→픽셀 변환 단위 테스트.
 
-### Phase E — 실행환경 추상화: 호스트 기본 + Docker+Xvfb 옵인 (P1)
-- `GEODE_COMPUTER_USE_ENV` (`host`(기본) | `sandbox`) config. `host`=현 pyautogui 직접. `sandbox`=Docker+Xvfb(:99)+window manager 컨테이너에서 pyautogui, optional x11vnc/Xpra 관측.
-- harness가 env에 따라 디스플레이 타깃 분기(host display vs `:99`). 컨테이너 spec(Dockerfile)+기동 헬퍼.
-- 패키지: 호스트=pyautogui(현행). 샌드박스=Docker + Xvfb + (fluxbox/x11vnc). 무거우니 옵인 + lazy.
-- 가드: env 분기 단위 테스트(컨테이너 미기동 시 host fallback). 실제 컨테이너 E2E는 운영자 환경(live).
+### Phase E — 실행환경 추상화: 호스트 기본 + Docker+Xvfb 샌드박스 옵인 (P1) — 모델 정정
+> **설계 정정**: 리서치 [`docs/research/computer-use-sandbox-frontier.md`](../research/computer-use-sandbox-frontier.md)(2026-06-17)로 모델 변경. frontier 합의는 **in-container shim**(모델 c)이고, 기존 "host가 `DISPLAY=:99` 설정"(모델 d)은 **격리 0 + macOS 불가**(pyautogui가 Quartz API 사용 — `core/tools/computer_use.py:17` — Quartz는 X11 `DISPLAY` 미사용이라 `:99` 무력, 추론)라 **폐기**. 아무 frontier도 (d)를 안 씀.
+- `GEODE_COMPUTER_USE_ENV` (`host`(기본) | `sandbox`) config. `host`=현 pyautogui 직접(현행, `DANGEROUS_TOOLS` HITL 게이트 유지).
+- `sandbox`=Docker(Linux) 이미지(Xvfb + 경량 WM + harness를 래핑한 작은 HTTP/WS shim)를 띄우고, **host harness는 thin client**가 되어 각 `aexecute(action)`을 컨테이너 `/cmd`에 POST → base64 screenshot 수신(E2B/trycua 모델). host는 디스플레이를 안 만지므로(HTTP 호출만) macOS host도 동작.
+- 스크린샷 모양 불변 → Phase A image-block 직렬화(`_serialize_computer_result`) 그대로 동작. 관측용 noVNC는 별도 채널(선택).
+- 구현 시 `core/llm/adapters/_anthropic_common.py:140-141` 주석(틀린 host-display 모델)도 in-container shim으로 정정.
+- **fail-open 금지**: `env=sandbox`인데 컨테이너 미기동/도달불가면 **fail-loud 에러** — host 데스크탑으로 silent fallback 절대 금지(운영자가 격리를 opt-in했는데 실제 데스크탑을 조작하면 fail-open 보안 구멍). host 제어는 명시적 `env=host`일 때만.
+- 가드: shim 클라이언트 단위(액션→POST 매핑; 컨테이너 미기동 시 host fallback이 아니라 raise 검증). 실제 컨테이너 격리 E2E는 운영자 환경 — `unverified — live test required`.
 
-### Phase F — run_bash 커맨드 샌드박스 (codex 수렴, P2)
-- `run_bash` 실행을 OS 샌드박스로 감싸기: macOS=`sandbox-exec`+`.sb`(deny default, cwd+/tmp writable, network off), Linux=`bwrap`(있으면)+seccomp. 패키지: macOS=OS 바이너리(crate 불필요), Linux=`pyseccomp`/`bwrap` 바이너리.
-- `GEODE_BASH_SANDBOX` (`off`(기본, 호환) | `on`) — 옵인, codex `AskForApproval` 정렬.
-- ctx7 불필요(OS 기제), 단 macOS seatbelt 프로필은 codex `.sbpl`(`seatbelt_base_policy.sbpl`) 참조.
-- 가드: 샌드박스 래퍼가 cwd 밖 쓰기/네트워크 차단(단위), 호스트 fallback.
+### Phase F — run_bash 커맨드 샌드박스 (codex 수렴, P2) — 구체화
+> **구체화**: 리서치 [`docs/research/computer-use-sandbox-frontier.md`](../research/computer-use-sandbox-frontier.md). GEODE는 Python(Rust 0) → codex Rust crate(landlock/seccompiler) 불가 → **OS 바이너리 shell-out**(codex가 `/usr/bin/sandbox-exec`/`bwrap` 부르는 형태). 삽입점 = `core/tools/bash_tool.py` `aexecute`(현 `create_subprocess_shell(command, cwd=...)` + regex `validate` deny-list) — `command`를 래핑.
+- macOS=`sandbox-exec -p <sbpl> -D WRITABLE_ROOT_0=<cwd> -- /bin/sh -c <cmd>`: codex `seatbelt_base_policy.sbpl` 본뜬 `(deny default)` + cwd(+TMPDIR) writable + network 규칙 없음(=차단). `/usr/bin/sandbox-exec` 하드코딩(PATH 주입 방어).
+- Linux=`bwrap --unshare-user --unshare-pid --unshare-net --die-with-parent --ro-bind / / --bind <cwd> <cwd> --proc /proc --dev /dev -- /bin/sh -c <cmd>`. seccomp syscall-deny(ptrace/io_uring/socket)는 Phase F+1(Python `libseccomp` ctypes 필요 — `--unshare-net`이 이미 network 차단).
+- `GEODE_BASH_SANDBOX` (`off`(기본, 호환) | `on` | `strict`) — 옵인. 바이너리 런타임 확인(`shutil.which("bwrap")`/`os.path.exists("/usr/bin/sandbox-exec")`), 부재 시 non-strict=fail-loud 경고+unsandboxed, strict=raise. `supports=True` 하드코딩 금지(codex도 bwrap 부재 시 warn+fallback).
+- 가드: argv/프로필 **builder** 단위(생성 argv에 `(deny default)`·cwd writable·`--unshare-net`·network-allow 부재 assert) + knob 게이팅 + 바이너리부재 분기(monkeypatch `which`). 실제 격리(cwd밖 쓰기/network 차단)는 live(macOS/Linux+userns) — `unverified — live test required`.
 
 ---
 
@@ -128,7 +132,7 @@
 | Phase | 상태 |
 |---|---|
 | A — production 경로 부활 + ComputerUseCapable 프로토콜 | ✅ DONE (v0.99.208) |
-| C — OpenAI GA {type:computer} 배선 (+harness batched actions[]) | ✅ DONE (v0.99.223) |
+| C — OpenAI GA {type:"computer"} 배선 (+harness batched actions[]) | ✅ DONE (v0.99.223) |
 | E — 호스트 기본 + Docker+Xvfb 샌드박스 옵인 | PENDING |
 | F — run_bash 커맨드 샌드박스(codex 수렴) | PENDING |
 | D — Zhipu GLM-5V grounding 배선 (self-host) | PENDING |

--- a/docs/research/computer-use-sandbox-frontier.md
+++ b/docs/research/computer-use-sandbox-frontier.md
@@ -1,0 +1,101 @@
+# Computer-use + command 샌드박싱 — frontier 사례 리서치 (2026-06-17)
+
+> **목적**: GEODE computer-use 샌드박스(Phase E) + run_bash 샌드박스(Phase F)의 구현 전 설계 확정. 운영자 지시("sandbox 조치는 외부 사례 리서치 더 진행부터").
+> **방법**: frontier 시스템 전수(WebSearch/WebFetch + ctx7) + 로컬 1차 소스(`~/workspace/codex/codex-rs/sandboxing`, `~/workspace/claude-code-ref`) 직접 판독. 모든 주장에 출처(URL 또는 repo file:line) 병기.
+> **결론(BLUF)**: ① **GUI 샌드박스의 frontier 합의 = in-container shim** — 손(pyautogui/xdotool)을 컨테이너 안에 두고 host는 구조화된 액션을 HTTP/WS로 dispatch. **"host가 `DISPLAY=:99` 설정" 모델(현 plan Phase E)은 아무도 안 쓰고, 격리 0이며, macOS에서 물리적으로 작동 안 함**(pyautogui가 macOS에서 Quartz API 사용 — `core/tools/computer_use.py:17` — Quartz는 X11 `DISPLAY`를 읽지 않으므로 `DISPLAY=:99` 무력, 추론). ② **command 샌드박스 = codex 수렴형** — macOS `sandbox-exec`+`.sbpl`(deny-default) / Linux `bwrap --unshare-net`. GEODE는 Rust 없음(Python) → OS 바이너리로 shell-out. ③ **격리 보장은 CI 검증 불가** — live Docker/OS 환경 필요, `unverified — live test required`.
+
+---
+
+## 1. GUI computer-use 샌드박스 (Phase E)
+
+### 1.1 frontier 사례 (전수, 출처 병기)
+
+| 시스템 | 격리 primitive | dispatch 모델 | agent 위치 | 출처 |
+|--------|---------------|---------------|-----------|------|
+| Anthropic computer-use-demo | Docker(Linux) — Xvfb+mutter+tint2+x11vnc+noVNC | host dispatch **없음**(루프 전체 컨테이너 내부) | **컨테이너 내부** | [README](https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/README.md) |
+| OpenAI computer-use(CUA/GA) | **개발자 제공**(OpenAI는 환경 미호스팅) | 모델이 `actions[]` 반환 → 개발자 코드가 자기 sandbox에서 실행 후 screenshot POST. `environment`는 OS 힌트일 뿐 | 개발자 host 코드 | [OpenAI guide](https://developers.openai.com/api/docs/guides/tools-computer-use) |
+| trycua/cua | Lume(Apple Virtualization) VM / Docker / cloud | **in-sandbox `cua-computer-server` shim** — host SDK가 `/cmd`(HTTP)+`/ws`로 click/type/screenshot dispatch | host agent + 컨테이너 내부 손 | [repo](https://github.com/trycua/cua), [WS API](https://cua.ai/docs/libraries/computer-server/WebSocket-API) |
+| E2B Desktop | Firecracker microVM(E2B 인프라) | **in-sandbox shim**(SDK click/screenshot 등이 컨테이너 내부 실행, `pyautogui()` 메서드 노출); 관측은 별도 VNC stream | host agent + 컨테이너 내부 손 | [repo](https://github.com/e2b-dev/desktop), [docs](https://e2b.dev/docs/use-cases/computer-use) |
+| HUD | per-eval Docker Ubuntu | **MCP over stdio**; VNC=관측 | agent가 MCP 도구 호출, 실행은 컨테이너 | [docs](https://docs.hud.ai/) |
+| Scrapybara | cloud Ubuntu/Browser VM | host `act()` → 원격 인스턴스 | agent host, 실행 원격 | [Act SDK](https://docs.scrapybara.com/act-sdk) |
+| browser-use / Skyvern | 로컬/원격 Chrome(브라우저 한정) | CDP/Playwright | host | [browser-use](https://docs.browser-use.com/examples/templates/playwright-integration) |
+
+**교차 사실**: 풀-데스크탑 격리의 수렴 패턴 = **in-sandbox 자동화 도구(xdotool/pyautogui) + in-sandbox 액션 shim(HTTP/WS 또는 MCP) + 관측용 별도 VNC 채널**. VNC는 *보기*용이지 *액션 dispatch*용이 아니다. Anthropic 데모만 예외(루프 전체를 컨테이너에 넣어 host dispatch 자체를 회피).
+
+### 1.2 dispatch 모델 분류 + 판정
+
+| 모델 | 설명 | 격리 | 복잡도 | macOS host | 채택처 |
+|------|------|------|--------|-----------|--------|
+| (a) agent가 sandbox 내부 | 루프+GUI 한 컨테이너 | 강 | GEODE엔 높음(런타임 전체를 컨테이너에) | host-resident 설계 포기 | Anthropic demo |
+| (b) host가 remote-display(VNC/RDP)로 dispatch | host가 합성 입력+framebuffer | 강 | 중(VNC client 필요, 입력 fidelity 낮음) | 가능하나 비효율 | (대개 관측용) |
+| **(c) host가 in-sandbox HTTP/WS shim으로 dispatch** | 컨테이너 내 shim이 로컬 pyautogui 호출, host는 구조화 액션 POST | **강** | 중(shim+이미지 제작; 액션 vocab 1:1) | **최적**(host OS 무관, HTTP만) | **E2B·cua·HUD** |
+| (d) host-display virtual(`Xvfb DISPLAY=:99`) | host에 Xvfb 띄우고 pyautogui를 `:99`로 | **없음/약**(같은 커널·fs·user) | 낮음 | **macOS 작동 불가**(Quartz가 DISPLAY 무시) | **아무도 안 씀 = 현 plan** |
+
+### 1.3 GEODE Phase E 권고 — 모델 (c) 채택, (d) 폐기
+
+GEODE는 host-resident 에이전트(데몬이 운영자 macOS/Linux에서 실행)이고 macOS+Linux 양쪽을 지원해야 한다. frontier 합의는 명확하다 — **모델 (c): opt-in Docker(Linux) 샌드박스 + in-container HTTP/WS shim이 기존 `ComputerUseHarness`(pyautogui)를 컨테이너 안에서 구동**.
+
+- **현 plan의 (d)("host가 `DISPLAY=:99`")는 폐기.** 격리 0(`docs/v1.0.0-stability-contract.md:143`이 이미 host=격리 0 명시)이고 macOS에서 물리적 불가(`core/tools/computer_use.py:17` Quartz API → X11 `DISPLAY` 미사용, 추론). `core/llm/adapters/_anthropic_common.py:140-141`의 "Xvfb sandbox가 display_number 설정" 주석은 틀린 멘탈모델 — sandbox 모드의 `display_number`는 *컨테이너 내부* Xvfb 디스플레이지 host가 타깃하는 게 아니다.
+- **harness 변경 최소**: 액션 vocab은 이미 provider-agnostic + pyautogui 매핑(`core/tools/computer_use.py:249-307`). Phase E는 새 harness가 아니라 **transport 분기**다:
+  1. `GEODE_COMPUTER_USE_ENV = host(기본) | sandbox` config (코드에 없음 — grep 0, 미구현 확인).
+  2. `host`: 현행(운영자 실제 데스크탑 직접, `DANGEROUS_TOOLS` `core/agent/safety.py:68` HITL 게이트 유지).
+  3. `sandbox`: GEODE가 로컬 pyautogui를 부르지 않고 — Docker 이미지(Xvfb+경량 WM+harness 래핑한 작은 HTTP/WS 서버)를 띄우고, **host harness가 thin client**가 되어 각 `aexecute(action)`을 컨테이너 `/cmd`에 POST하고 base64 screenshot을 받는다(= cua `/cmd`+`/ws`, E2B `pyautogui()` 모델). 스크린샷 모양 불변 → Phase A의 image-block 직렬화(`_serialize_computer_result`) 그대로 동작. 관측용 noVNC는 별도 채널(선택).
+- **macOS 특정**: macOS host는 `DISPLAY`로 Linux Xvfb 못 몬다(확정). (c)에서는 **host가 디스플레이를 안 만지므로**(HTTP 호출만) 무관 — pyautogui는 *Linux 컨테이너 내부*에서 자기 Xvfb를 구동. (진짜 *macOS-GUI* 격리가 필요하면 Apple Virtualization/Lume macOS VM뿐 — Docker는 macOS GUI 불가 — 이건 Phase E "Docker+Xvfb" 범위 밖.)
+
+---
+
+## 2. command(run_bash) 샌드박스 (Phase F)
+
+### 2.1 codex 1차 소스 판독 (`~/workspace/codex/codex-rs`)
+
+- **플랫폼 분기**: `get_platform_sandbox()` — macOS→Seatbelt, Linux→Seccomp, 그 외→none (`sandboxing/src/manager.rs:48-62`).
+- **macOS**: `/usr/bin/sandbox-exec`(하드코딩 경로 — PATH 주입 방어) `-p <sbpl> -D<K>=<v> -- <cmd>` (`seatbelt.rs:25-29,731-740`). base 프로필 `(deny default)`(`seatbelt_base_policy.sbpl:8`), write는 `/dev/null`만 기본 + writable root 동적 주입, **network 규칙 없음=기본 차단**.
+- **Linux**: 기본 **bubblewrap**(`bwrap` argv에 `--unshare-net`(`linux-sandbox/src/bwrap.rs:280,326`) + full-fs read-only 정책 `--ro-bind / /` + cwd writable `--bind` + 보호 subpath 재적용 `--ro-bind <subpath>`(동일 파일 `:355-363,447-505`)) + **seccomp-bpf**(`seccompiler`로 ptrace/io_uring/socket 류 deny, `linux-sandbox/src/landlock.rs:169-267`). Landlock(0.4.4)은 legacy fallback.
+- **승인/네트워크**: `AskForApproval`(`protocol/src/protocol.rs:787-818`) + 모든 `SandboxPolicy` network 기본 off(`protocol.rs:881-929`). 실패 시 escalate-retry(`core/src/tools/orchestrator.rs`).
+- **crate**: `landlock=0.4.4`, `seccompiler=0.5.0` (`codex-rs/Cargo.toml:310,355`).
+
+### 2.2 claude-code-ref — permission 모델만, OS primitive 없음
+
+`~/workspace/claude-code-ref`에 `seatbelt|sandbox-exec|landlock|seccomp|bwrap` grep = 0. permission 모델(`PermissionMode` + `Bash(pattern)` allow/deny, `src/config/permissions.ts:56,80-98`)뿐이고 "sandbox mode"는 에이전트 프로세스 내 패턴 분석이지 커널 경계 아님. (프로덕션 Claude Code는 별도 `srt` 바이너리가 Seatbelt/bwrap 사용 — 본 ref엔 없음. 출처: [wincent gist](https://gist.github.com/wincent/2752d8d97727577050c043e4ff9e386e).)
+
+### 2.3 primitive 비교
+
+| primitive | 경계 | macOS | Linux | 무게 | 출처 |
+|-----------|------|-------|-------|------|------|
+| Seatbelt/`sandbox-exec` | TrustedBSD MAC, `.sbpl` deny-default | O(native, 단 deprecated) | X | 경량 | codex `seatbelt.rs:29`; [deprecation HN](https://news.ycombinator.com/item?id=44283454) |
+| Landlock(LSM) | unprivileged fs(+최신 net) | X | O(≥5.13) | 경량 | [kernel.org](https://docs.kernel.org/userspace-api/landlock.html) |
+| seccomp-bpf | syscall 필터 | X | O | 초경량 | codex `linux-sandbox/.../landlock.rs:169-267` |
+| bubblewrap | user/pid/net ns + bind-mount | X | O(userns 필요, WSL1 불가) | 경량-중 | codex `bwrap.rs:280,326,355-363` |
+| gVisor | user-space 커널 | X | O | 중 | [Northflank](https://northflank.com/blog/what-is-gvisor) |
+| Firecracker microVM | HW 가상화(KVM) | X(KVM=Linux host) | O | 무거움(~150ms) | [Northflank](https://northflank.com/blog/firecracker-vs-gvisor) |
+| Docker/OCI | ns+cgroups(공유 커널) | O(VM 경유) | O | 중-무거움 | [Unit42](https://unit42.paloaltonetworks.com/making-containers-more-isolated-an-overview-of-sandboxed-container-technologies/) |
+
+수렴(출처 [wincent gist](https://gist.github.com/wincent/2752d8d97727577050c043e4ff9e386e)): Codex=Seatbelt(mac)/Landlock+seccomp(linux); Claude Code srt=Seatbelt(mac)/bwrap+proxy(linux); 로컬/대화형은 VM 안 씀.
+
+### 2.4 GEODE Phase F 권고 — codex 수렴형 shell-out
+
+GEODE는 Python(Rust 0 — `*.rs`/`Cargo.toml` 코어에 없음) → codex의 Rust crate 사용 불가 → **OS 바이너리로 shell-out**(codex가 `/usr/bin/sandbox-exec`/`bwrap` 부르는 것과 동일 형태). 삽입점 = `core/tools/bash_tool.py`의 `aexecute`(현 `asyncio.create_subprocess_shell(command, cwd=...)` + regex deny-list `validate`) — `command`를 래핑.
+
+- **macOS**: `sandbox-exec -p <sbpl> -D WRITABLE_ROOT_0=<cwd> -- /bin/sh -c <cmd>`. codex `seatbelt_base_policy.sbpl` 본뜬 `(deny default)` + cwd(+TMPDIR) writable + network 규칙 없음.
+- **Linux**: `bwrap --unshare-user --unshare-pid --unshare-net --die-with-parent --ro-bind / / --bind <cwd> <cwd> --proc /proc --dev /dev -- /bin/sh -c <cmd>`. seccomp syscall-deny는 Phase F+1(Python에서 `libseccomp` ctypes 필요 — `--unshare-net`이 이미 네트워크 차단하니 위협모델이 요구할 때만).
+- **knob**: `GEODE_BASH_SANDBOX` 기본 **off**(호환) — `bwrap`은 userns 필요(WSL1/CI/하드닝 호스트 부재 가능, codex도 warn+fallback), `sandbox-exec`은 호출마다 deprecation 경고+미래 macOS에서 깨질 수 있음. 런타임에 바이너리 존재 확인(`shutil.which`/`os.path.exists`) — 부재 시 non-strict=fail-loud 경고 후 unsandboxed, strict=raise. `supports=True` 하드코딩 금지.
+
+---
+
+## 3. 검증 경계 (live env 필요 — `unverified — live test required`)
+
+샌드박스의 본질은 격리이고, 격리는 정적/CI로 입증 불가다(CI에 Docker/userns 없음, 크로스플랫폼 불가). 따라서:
+
+- **단위 테스트 가능(라이브 불요)**: argv/프로필 **builder**는 순수 함수 — codex도 이렇게 테스트(`seatbelt_tests.rs` 등). 생성된 `sandbox-exec -p ...`/`bwrap` argv에 `(deny default)`·cwd writable·`--unshare-net`·network-allow 부재가 들었는지 assert. knob 게이팅(off→원본 명령, on→래핑), 바이너리 부재 분기(monkeypatch `which`)도 단위 가능.
+- **live 전용(입증 전까지 `unverified`)**: cwd 밖 쓰기 실제 차단·network 실제 차단·정상 명령 성공 — 실제 macOS(Seatbelt)/Linux+userns(bwrap) 필요. GUI Phase E도: in-container harness가 Xvfb 실제 구동·shim 왕복·noVNC 렌더는 live Docker 전용. **격리 "보장"을 입증 전 SemVer 안정/완료로 표기 금지.**
+
+---
+
+## 4. plan 반영
+
+본 리서치로 `docs/plans/2026-06-14-computer-use-enhancement.md` Phase E를 모델 (d)→(c)로 정정, Phase F를 codex-수렴 shell-out으로 구체화(아래 plan 문서에 반영). 구현 시 `_anthropic_common.py:140-141` 주석도 in-container shim 모델로 수정 필요(코드 변경은 구현 PR에서).
+
+## 출처
+
+frontier(이번 세션 fetch/search): [Anthropic computer-use-demo](https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/README.md) · [OpenAI computer-use guide](https://developers.openai.com/api/docs/guides/tools-computer-use) · [trycua/cua](https://github.com/trycua/cua) ([WS API](https://cua.ai/docs/libraries/computer-server/WebSocket-API), [macOS Operator](https://cua.ai/blog/build-your-own-operator-on-macos-1)) · [e2b-dev/desktop](https://github.com/e2b-dev/desktop) ([computer-use docs](https://e2b.dev/docs/use-cases/computer-use)) · [Scrapybara Act SDK](https://docs.scrapybara.com/act-sdk) · [HUD](https://docs.hud.ai/) · [browser-use](https://docs.browser-use.com/examples/templates/playwright-integration) · [coding-agent-sandboxes(wincent gist)](https://gist.github.com/wincent/2752d8d97727577050c043e4ff9e386e) · [Landlock](https://docs.kernel.org/userspace-api/landlock.html) · [gVisor](https://northflank.com/blog/what-is-gvisor) · [Firecracker vs gVisor](https://northflank.com/blog/firecracker-vs-gvisor) · [sandbox-exec deprecation(HN)](https://news.ycombinator.com/item?id=44283454).
+로컬 1차 소스: `~/workspace/codex/codex-rs/sandboxing/`, `~/workspace/codex/codex-rs/linux-sandbox/`, `~/workspace/claude-code-ref/src/config/permissions.ts` (file:line 본문 인용).


### PR DESCRIPTION
## Summary
- New `docs/research/computer-use-sandbox-frontier.md` — cited external-case research on GUI computer-use + command sandboxing, resolving the Phase E design fork.
- Corrects the computer-use plan's Phase E (wrong model) + Phase F (Python shell-out).

## Why
Operator: "sandbox 조치는 외부 사례 리서치 더 진행부터." The Phase E plan specified the one model **nobody uses** (host sets `DISPLAY=:99`) — zero isolation + broken on macOS (pyautogui uses Quartz, ignores DISPLAY). Needed frontier grounding before implementing.

## Findings
- **GUI sandbox** frontier consensus = **in-container shim** (model c): hands inside the container, host POSTs structured actions over HTTP/WS, base64 screenshot back; host never touches a display → macOS works. (E2B, trycua/cua, HUD. Anthropic demo = whole loop in-container.)
- **Command sandbox** = codex convergence: macOS `sandbox-exec`+`.sbpl` / Linux `bwrap --unshare-net`; GEODE is Python → shell out to OS binaries (no Rust crates).
- **Isolation is not statically verifiable** (no Docker/userns in CI) → live-gated.

## Changes
| File | Change |
|------|--------|
| `docs/research/computer-use-sandbox-frontier.md` (new) | frontier comparison + dispatch taxonomy (a-d) + command-primitive table + GEODE Phase E/F recommendation + live-verification boundary |
| `docs/plans/2026-06-14-computer-use-enhancement.md` | Phase E model d→c (in-container shim, **fail-loud not host-fallback** = no fail-open), Phase F Python shell-out spec; GA `{type:"computer"}` bare-tool corrections |

## Verification
- [x] **Codex-MCP-audited, multi-round** — all GEODE-internal claims verified against code (computer_use.py Quartz `:17` + DISPLAY inference, `_anthropic_common:140-141` wrong-model comment, safety.py:68 DANGEROUS, bash_tool.py insertion point, `GEODE_COMPUTER_USE_ENV` absent, Python-only/no-Rust). Fixed: citation overclaim, **fail-open hole** (host-fallback on isolation opt-in), GA bare-tool, bwrap line refs (personally re-read in `~/workspace/codex` source).
- [x] external citations carry verifiable sources (URLs + local `~/workspace/codex` file:line); no Hanja; links resolve
- [x] docs-only: no version bump, no CHANGELOG

## Reference
frontier: anthropic-quickstarts computer-use-demo, OpenAI computer-use guide, trycua/cua, e2b-dev/desktop, HUD; local `~/workspace/codex/codex-rs/sandboxing`.