### PR TITLE
refactor: fold five duplicated-helper clusters into shared homes (PR-DEDUP-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.232] - 2026-06-19
+
+### Changed
+- **Five more duplicated-helper clusters folded into shared homes** (PR-DEDUP-2; the codebase-audit follow-up to PR-DEDUP-CONFIG-TOML). A cross-tree sweep surfaced five real duplications, each migrated to one home with all callers updated: (1) **JWT payload decode** — four byte-identical "split → pad base64url → `json.loads` → swallow errors" blocks (`oauth_login`, `codex_cli_oauth`, `llm/providers/codex`, `petri_audit/codex_provider`) → new `core/auth/jwt_claims.py:decode_jwt_claims`; (2) **`mask_key`** — three copies (`profiles.masked_key`, `cli/doctor`, the canonical `config/env_io`) → the one `core/config/env_io.py:mask_key`; (3) **duration formatters** — four copies in two idioms (`_format_age` ×2, `_fmt_elapsed`/`_format_seconds`) → new `core/time_format.py` (`format_age` / `format_elapsed`); (4) **inline atomic-write** — four hand-rolled `tmp.write_text + os.replace` sites (`hybrid_session` ×2, `session._persist`, `scheduler/service`) → the existing `core/memory/atomic_write.py` helpers (which add `fsync` + crash-safe temp cleanup), keeping each site's lock / error-swallowing contract and exact serialization; (5) **read-json-or-none** — two copies (`cli/commands/self_improving._load_json`, `seed_generation/eval_export._read_json`) → new `core/memory/atomic_write.py:read_json_or_none`. Behavior-preserving (Codex MCP reviewed: one MEDIUM fixed by writing `hybrid_session` via `atomic_write_text` + bare `json.dumps` so serialization stays byte-identical; two benign edge-differences on unreachable inputs noted — a valid-but-empty codex JWT payload now yields `None` instead of a dict-of-`None`s, and `eval_export` warns on a present-but-non-dict artefact). Also removed two stale `__pycache__`-only ghost directories (`core/utils/`, `core/scheduler/scheduler/`) left by past moves. New `tests/core/test_time_format.py` adds the `format_elapsed` coverage the old copies never had. The four-copy `core/config/__init__.py`/`explain.py` inline config-TOML resolvers remain intentionally un-migrated (module-global monkeypatch seam, as in PR-DEDUP-CONFIG-TOML).
+
 ## [0.99.231] - 2026-06-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.231
+- **Version**: 0.99.232
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 389 core + 72 plugins = 461
-- **Tests**: 8700 (+1 live)
+- **Modules**: 391 core + 72 plugins = 463
+- **Tests**: 8927 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.231 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.232 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.231 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.232 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/auth/codex_cli_oauth.py
+++ b/core/auth/codex_cli_oauth.py
@@ -12,7 +12,6 @@ Token source: ~/.codex/auth.json
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from typing import Any, TypedDict
@@ -22,6 +21,7 @@ from core.auth.credential_cache import (
     read_json_credentials_file,
     refresh_managed_token,
 )
+from core.auth.jwt_claims import decode_jwt_claims
 
 log = logging.getLogger(__name__)
 
@@ -46,21 +46,8 @@ def invalidate_cache() -> None:
 
 def _decode_jwt_expiry(token: str) -> float | None:
     """Decode exp claim from JWT access token (seconds)."""
-    import base64
-
-    parts = token.split(".")
-    if len(parts) < 2:
-        return None
-    try:
-        # Add padding for base64url
-        padded = parts[1] + "=" * (4 - len(parts[1]) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(padded))
-        exp = payload.get("exp")
-        if isinstance(exp, (int, float)) and exp > 0:
-            return float(exp)
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
-        pass
-    return None
+    exp = decode_jwt_claims(token).get("exp")
+    return float(exp) if isinstance(exp, (int, float)) and exp > 0 else None
 
 
 def _read_from_file() -> dict[str, Any] | None:

--- a/core/auth/jwt_claims.py
+++ b/core/auth/jwt_claims.py
@@ -1,0 +1,35 @@
+"""Unverified JWT payload decode — shared OAuth-claim reader.
+
+Four sites (``oauth_login``, ``codex_cli_oauth``, ``llm.providers.codex``,
+``petri_audit.codex_provider``) carried byte-identical "split on ``.`` → pad
+base64url → ``json.loads`` → swallow decode errors" blocks, each then pulling a
+different claim out of the payload (PR-DEDUP-2). One decoder now; callers keep
+their thin field extraction on top.
+
+No signature verification — the OAuth provider owns the signature; GEODE only
+needs the public claims (``chatgpt_plan_type`` / ``chatgpt_account_id`` /
+``exp`` / ``email``) for routing + display.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+
+def decode_jwt_claims(token: str) -> dict[str, Any]:
+    """Return the decoded payload dict of a JWT, or ``{}`` on any malformed input.
+
+    Tolerates a non-JWT / empty / truncated token (returns ``{}``) so callers can
+    treat "no claims" uniformly. Never raises.
+    """
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from core.auth.jwt_claims import decode_jwt_claims
+
 log = logging.getLogger(__name__)
 
 # OpenAI Codex OAuth constants (from Hermes Agent)
@@ -58,30 +60,9 @@ AUTH_STORE_PATH = auth_store_path()
 _GEODE_OPENAI_PLAN_ID = "openai-codex-geode"
 
 
-def _decode_jwt_claims(token: str) -> dict[str, Any]:
-    """Decode the payload section of a (signed) JWT, no verification.
-
-    Used to read OpenAI-issued claims like ``chatgpt_plan_type`` /
-    ``chatgpt_account_id`` / ``email`` from the access_token. The token's
-    signature is the OAuth provider's concern; GEODE only needs the
-    public claims for routing + display.
-    """
-    import base64
-
-    parts = token.split(".")
-    if len(parts) < 2:
-        return {}
-    try:
-        padded = parts[1] + "=" * (-len(parts[1]) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(padded))
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
 def _plan_type_from_token(token: str) -> str:
     """Extract ``chatgpt_plan_type`` from an OpenAI OAuth access token."""
-    claims = _decode_jwt_claims(token)
+    claims = decode_jwt_claims(token)
     auth_claim = claims.get("https://api.openai.com/auth", {})
     if isinstance(auth_claim, dict):
         plan_type = auth_claim.get("chatgpt_plan_type", "")
@@ -500,9 +481,9 @@ def login_openai() -> dict[str, Any]:
     if not access_token:
         raise RuntimeError("Token exchange did not return an access_token")
 
-    # Extract account info from JWT (uses _decode_jwt_claims helper —
+    # Extract account info from JWT (uses decode_jwt_claims helper —
     # any decode failure returns {} so the unpacks below resolve to "").
-    payload = _decode_jwt_claims(access_token)
+    payload = decode_jwt_claims(access_token)
     auth_claim = payload.get("https://api.openai.com/auth", {}) or {}
     profile_claim = payload.get("https://api.openai.com/profile", {}) or {}
     account_id = str(auth_claim.get("chatgpt_account_id", "") or "")

--- a/core/auth/profiles.py
+++ b/core/auth/profiles.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from core.config.env_io import mask_key
+
 
 class CredentialType(Enum):
     """Credential type with implicit priority (lower ordinal = higher priority)."""
@@ -119,9 +121,7 @@ class AuthProfile:
 
     @property
     def masked_key(self) -> str:
-        if len(self.key) <= 14:
-            return "***"
-        return self.key[:10] + "..." + self.key[-4:]
+        return mask_key(self.key)
 
     def sort_key(self) -> tuple[int, float]:
         """Sort key for rotation: type priority first, then last_used (LRU)."""

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from core.config.toml_edit import persist_toml_section
+from core.memory.atomic_write import read_json_or_none
 from core.ui.console import console
 
 __all__ = ["cmd_self_improving"]
@@ -146,7 +147,7 @@ def _cmd_status() -> None:
     console.print("  [header]Self-improving loop — status[/header]")
 
     baseline_path = _baseline_path()
-    baseline = _load_json(baseline_path)
+    baseline = read_json_or_none(baseline_path)
     console.print()
     console.print("  [bold]Baseline[/bold]")
     if baseline is None:
@@ -190,19 +191,6 @@ def _baseline_path() -> Path:
     import core.paths
 
     return Path(core.paths.BASELINE_JSON_PATH)
-
-
-def _load_json(path: Path) -> dict[str, Any] | None:
-    """Return the parsed JSON dict, or ``None`` on missing/malformed
-    file. Slash output must never raise on bad input — operator may
-    inspect mid-run when the file is being rewritten."""
-    if not path.is_file():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return data if isinstance(data, dict) else None
 
 
 def _tail_jsonl(path: Path, n: int) -> Iterable[dict[str, Any]]:
@@ -1221,7 +1209,7 @@ def _cmd_rollback_check(opts: list[str]) -> None:
     # on that constant is seen here (the original Codex must-fix #1 isolation
     # property, now keyed on the baseline constant rather than the audit log).
     baseline_path = Path(core.paths.BASELINE_JSON_PATH)
-    baseline = _load_json(baseline_path) or {}
+    baseline = read_json_or_none(baseline_path) or {}
     baseline_dim_raw = baseline.get("dim_means") if isinstance(baseline, dict) else None
     if not isinstance(baseline_dim_raw, dict):
         baseline_dim_raw = None

--- a/core/cli/doctor.py
+++ b/core/cli/doctor.py
@@ -12,6 +12,8 @@ import os
 import subprocess
 from typing import Any
 
+from core.config.env_io import mask_key
+
 log = logging.getLogger(__name__)
 
 # Required Slack Bot Token scopes for full functionality
@@ -51,8 +53,7 @@ def _check_env() -> list[dict[str, Any]]:
 
     token = os.environ.get("SLACK_BOT_TOKEN", "")
     if token:
-        masked = token[:10] + "..." + token[-4:] if len(token) > 14 else "***"
-        results.append({"name": "SLACK_BOT_TOKEN", "ok": True, "detail": masked})
+        results.append({"name": "SLACK_BOT_TOKEN", "ok": True, "detail": mask_key(token)})
     else:
         results.append(
             {

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -16,11 +16,11 @@ and OpenClaw (openai-codex-provider.ts).
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 from typing import Any
 
+from core.auth.jwt_claims import decode_jwt_claims
 from core.config import CODEX_BASE_URL
 
 log = logging.getLogger(__name__)
@@ -38,19 +38,8 @@ _async_codex_lock = threading.Lock()
 
 def _extract_account_id(token: str) -> str:
     """Extract chatgpt_account_id from Codex OAuth JWT."""
-    import base64
-
-    parts = token.split(".")
-    if len(parts) < 2:
-        return ""
-    try:
-        padded = parts[1] + "=" * (4 - len(parts[1]) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(padded))
-        auth_claim = payload.get("https://api.openai.com/auth", {})
-        result: str = auth_claim.get("chatgpt_account_id", "")
-        return result
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
-        return ""
+    auth_claim = decode_jwt_claims(token).get("https://api.openai.com/auth", {})
+    return str(auth_claim.get("chatgpt_account_id", "")) if isinstance(auth_claim, dict) else ""
 
 
 def build_codex_oauth_headers(token: str) -> dict[str, str]:

--- a/core/memory/atomic_write.py
+++ b/core/memory/atomic_write.py
@@ -82,3 +82,21 @@ def atomic_write_json(
         default=default or str,
     )
     atomic_write_text(path, content, encoding=encoding)
+
+
+def read_json_or_none(path: Path) -> dict[str, Any] | None:
+    """Return the parsed JSON dict at *path*, or ``None``.
+
+    Read companion to :func:`atomic_write_json`. Returns ``None`` for a
+    missing / unreadable / malformed / non-dict file and NEVER raises — the
+    read counterpart to the crash-safe write, for callers (slash status,
+    eval export) that must tolerate a file being concurrently rewritten.
+    """
+    path = Path(path)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None

--- a/core/memory/context.py
+++ b/core/memory/context.py
@@ -18,6 +18,7 @@ from core.memory.organization import MonoLakeOrganizationMemory
 from core.memory.port import SessionStorePort
 from core.memory.project import ProjectMemory
 from core.memory.user_profile import FileBasedUserProfile
+from core.time_format import format_age
 
 log = logging.getLogger(__name__)
 
@@ -26,22 +27,6 @@ DEFAULT_FRESHNESS_THRESHOLD_S = 3600.0  # 1 hour
 
 # Maximum run history entries to inject
 DEFAULT_RUN_HISTORY_MAX_ENTRIES = 3
-
-
-def _format_age(seconds: float) -> str:
-    """Format elapsed seconds as human-readable age string."""
-    if seconds < 0:
-        return "now"
-    minutes = seconds / 60
-    if minutes < 1:
-        return "now"
-    if minutes < 60:
-        return f"{int(minutes)}m ago"
-    hours = minutes / 60
-    if hours < 24:
-        return f"{int(hours)}h ago"
-    days = hours / 24
-    return f"{int(days)}d ago"
 
 
 class ContextAssembler:
@@ -249,7 +234,7 @@ class ContextAssembler:
             summaries = []
             for entry in recent:
                 score = entry.metadata.get("score", "?")
-                age = _format_age(now - entry.timestamp)
+                age = format_age(now - entry.timestamp)
                 name = entry.metadata.get("subject_id", subject_id)
                 summaries.append(f"{name} score={score} ({age})")
 

--- a/core/memory/hybrid_session.py
+++ b/core/memory/hybrid_session.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from core.memory.atomic_write import atomic_write_text
 from core.memory.port import SessionStorePort
 
 log = logging.getLogger(__name__)
@@ -140,10 +140,10 @@ class PostgreSQLSessionStore:
 
     def set(self, session_id: str, data: dict[str, Any]) -> None:
         record = {"session_id": session_id, "data": data, "updated_at": time.time()}
-        f = self._session_file(session_id)
-        tmp = f.with_suffix(".tmp")
-        tmp.write_text(json.dumps(record), encoding="utf-8")
-        os.replace(str(tmp), str(f))
+        # atomic_write_text + bare json.dumps (not atomic_write_json) keeps the
+        # original serialization exactly: ensure_ascii=True + no ``default`` so a
+        # non-JSON-native value still raises rather than coercing to str.
+        atomic_write_text(self._session_file(session_id), json.dumps(record))
 
     def delete(self, session_id: str) -> bool:
         f = self._session_file(session_id)
@@ -157,10 +157,7 @@ class PostgreSQLSessionStore:
 
     def save_checkpoint(self, session_id: str, checkpoint_data: dict[str, Any]) -> None:
         record = {"session_id": session_id, "data": checkpoint_data, "saved_at": time.time()}
-        f = self._checkpoint_file(session_id)
-        tmp = f.with_suffix(".tmp")
-        tmp.write_text(json.dumps(record), encoding="utf-8")
-        os.replace(str(tmp), str(f))
+        atomic_write_text(self._checkpoint_file(session_id), json.dumps(record))
 
     def load_checkpoint(self, session_id: str) -> dict[str, Any] | None:
         f = self._checkpoint_file(session_id)

--- a/core/memory/project_journal.py
+++ b/core/memory/project_journal.py
@@ -26,6 +26,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from core.time_format import format_age
+
 log = logging.getLogger(__name__)
 
 # Default resolves to ~/.geode/projects/{id}/journal/ with fallback to .geode/journal/
@@ -278,7 +280,7 @@ class ProjectJournal:
         now = time.time()
         parts = []
         for r in runs:
-            age = _format_age(now - r.ts)
+            age = format_age(now - r.ts)
             parts.append(f"{r.summary} ({age})")
         return "Project history: " + " | ".join(parts)
 
@@ -318,20 +320,6 @@ class ProjectJournal:
             return [ln for ln in fpath.read_text(encoding="utf-8").splitlines() if ln.strip()]
         except OSError:
             return []
-
-
-def _format_age(seconds: float) -> str:
-    """Format elapsed seconds as human-readable age."""
-    if seconds < 60:
-        return "now"
-    minutes = seconds / 60
-    if minutes < 60:
-        return f"{int(minutes)}m ago"
-    hours = minutes / 60
-    if hours < 24:
-        return f"{int(hours)}h ago"
-    days = hours / 24
-    return f"{int(days)}d ago"
 
 
 # ---------------------------------------------------------------------------

--- a/core/memory/session.py
+++ b/core/memory/session.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from core.memory.atomic_write import atomic_write_json
 
 log = logging.getLogger(__name__)
 
@@ -145,22 +146,15 @@ class InMemorySessionStore:
         if entry is None:
             return
         fpath = self._storage_dir / self._safe_filename(session_id)
-        tmp = fpath.with_suffix(".tmp")
         try:
             payload = {
                 "session_id": session_id,
                 "data": entry.data,
                 "created_at": entry.created_at,
             }
-            tmp.write_text(
-                json.dumps(payload, ensure_ascii=False, default=str),
-                encoding="utf-8",
-            )
-            os.replace(str(tmp), str(fpath))
+            atomic_write_json(fpath, payload, ensure_ascii=False, default=str)
         except (TypeError, ValueError, OSError) as exc:
             log.debug("Failed to persist session %s: %s", session_id, exc)
-            if tmp.exists():
-                tmp.unlink(missing_ok=True)
 
     def _remove_from_disk(self, session_id: str) -> None:
         """Remove a session file from disk."""

--- a/core/scheduler/service.py
+++ b/core/scheduler/service.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from core.memory.atomic_write import atomic_write_text
 from core.observability.run_log import JobRunLog
 from core.scheduler.jitter import _jittered_next_run
 from core.scheduler.lock import SchedulerLock
@@ -476,10 +477,7 @@ class SchedulerService:
         payload = json.dumps(data, ensure_ascii=False, indent=2)
         lock = SchedulerLock(path.parent / "scheduled_tasks.lock", session_id=self._session_id)
         with lock:
-            tmp_path = path.with_suffix(".json.tmp")
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                f.write(payload)
-            os.replace(str(tmp_path), str(path))
+            atomic_write_text(path, payload)
         # Update mtime tracking
         with contextlib.suppress(OSError):
             self._last_store_mtime = os.path.getmtime(path)

--- a/core/time_format.py
+++ b/core/time_format.py
@@ -1,0 +1,39 @@
+"""Human-readable duration formatting — one home for two scattered idioms.
+
+Four sites carried two near-identical formatters (PR-DEDUP-2):
+
+- ``format_age`` — relative age (``"5m ago"`` / ``"2h ago"`` / ``"2d ago"``),
+  was ``_format_age`` in ``core/memory/context.py`` + ``project_journal.py``.
+- ``format_elapsed`` — short ``"Ns"`` / ``"Nm Ns"`` duration, was ``_fmt_elapsed``
+  in ``core/ui/event_renderer.py`` + ``_format_seconds`` in ``agentic_ui/_state.py``.
+
+Pure stdlib leaf so any layer (memory, ui) can import it without a cycle.
+"""
+
+from __future__ import annotations
+
+
+def format_age(seconds: float) -> str:
+    """Format elapsed seconds as a relative age (``"now"`` under one minute).
+
+    Negative inputs (clock skew / future timestamps) collapse to ``"now"``.
+    """
+    if seconds < 60:
+        return "now"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{int(minutes)}m ago"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{int(hours)}h ago"
+    days = hours / 24
+    return f"{int(days)}d ago"
+
+
+def format_elapsed(seconds: float) -> str:
+    """Format a duration as ``"Ns"`` (under a minute) or ``"Nm Ns"``."""
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    m, sec = divmod(s, 60)
+    return f"{m}m {sec}s"

--- a/core/ui/agentic_ui/_state.py
+++ b/core/ui/agentic_ui/_state.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 
+from core.time_format import format_elapsed
 from core.ui.context_local import ContextLocal
 
 # Task/thread-local IPC writer for structured tool events.
@@ -67,7 +68,7 @@ class SessionMeter:
 
     @property
     def elapsed_display(self) -> str:
-        return self._format_seconds(self.elapsed_s)
+        return format_elapsed(self.elapsed_s)
 
     # -- Turn-level (per-turn delta) ---------------------------------------
 
@@ -77,17 +78,7 @@ class SessionMeter:
 
     @property
     def turn_elapsed_display(self) -> str:
-        return self._format_seconds(self.turn_elapsed_s)
-
-    # -- Helpers -----------------------------------------------------------
-
-    @staticmethod
-    def _format_seconds(seconds: float) -> str:
-        s = int(seconds)
-        if s < 60:
-            return f"{s}s"
-        m, sec = divmod(s, 60)
-        return f"{m}m {sec}s"
+        return format_elapsed(self.turn_elapsed_s)
 
 
 _meter_local = ContextLocal("geode_session_meter_local")

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from core.time_format import format_elapsed
 from core.ui.tool_tracker import ToolCallTracker
 
 log = logging.getLogger(__name__)
@@ -37,14 +38,6 @@ def _fmt_tokens(n: int) -> str:
     if n >= 1000:
         return f"{n / 1000:.1f}k"
     return str(n)
-
-
-def _fmt_elapsed(seconds: float) -> str:
-    s = int(seconds)
-    if s < 60:
-        return f"{s}s"
-    m, sec = divmod(s, 60)
-    return f"{m}m {sec}s"
 
 
 @dataclass
@@ -715,7 +708,7 @@ class EventRenderer:
         elapsed = time.monotonic() - self._turn_start
         in_str = _fmt_tokens(self._turn_in_tokens)
         out_str = _fmt_tokens(self._turn_out_tokens)
-        parts = [f"\u2722 Worked for {_fmt_elapsed(elapsed)}"]
+        parts = [f"\u2722 Worked for {format_elapsed(elapsed)}"]
         if self._turn_model:
             parts.append(self._turn_model)
         parts.append(f"\u2193{in_str} \u2191{out_str}")
@@ -917,7 +910,7 @@ class EventRenderer:
         elapsed = time.monotonic() - region.start_ts
         suffix = " \u2026 (still running)" if still_running else ""
         return (
-            f"  \033[90m\u2726 Thought for {_fmt_elapsed(elapsed)} \u00b7 "
+            f"  \033[90m\u2726 Thought for {format_elapsed(elapsed)} \u00b7 "
             f"{len(region.items)} items{suffix}\033[0m\n"
         )
 

--- a/plugins/petri_audit/codex_provider.py
+++ b/plugins/petri_audit/codex_provider.py
@@ -82,8 +82,7 @@ def get_codex_oauth_metadata() -> dict[str, Any] | None:
     - the token is not a valid JWT (parts != 3)
     - the JWT payload cannot be decoded
     """
-    import base64
-    import json
+    from core.auth.jwt_claims import decode_jwt_claims
 
     try:
         from core.llm.providers.codex import _resolve_codex_token
@@ -95,13 +94,8 @@ def get_codex_oauth_metadata() -> dict[str, Any] | None:
         return None
     if not token:
         return None
-    parts = token.split(".")
-    if len(parts) < 2:
-        return None
-    try:
-        padded = parts[1] + "=" * (4 - len(parts[1]) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(padded))
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+    payload = decode_jwt_claims(token)
+    if not payload:
         return None
     auth_claim = payload.get("https://api.openai.com/auth", {})
     if not isinstance(auth_claim, dict):

--- a/plugins/seed_generation/eval_export.py
+++ b/plugins/seed_generation/eval_export.py
@@ -54,6 +54,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from core.memory.atomic_write import read_json_or_none
+
 log = logging.getLogger(__name__)
 
 __all__ = ["PHASE_TASKS", "export_run_to_evals"]
@@ -91,15 +93,12 @@ def _coerce_list(v: Any) -> list[Any]:
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
-        return None
-    try:
-        with path.open(encoding="utf-8") as f:
-            data: Any = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        log.warning("eval_export: failed to read %s", path, exc_info=True)
-        return None
-    return data if isinstance(data, dict) else None
+    # Shared silent reader (core.memory.atomic_write) + this module's warning:
+    # a present-but-unparseable artefact is worth surfacing here.
+    data = read_json_or_none(path)
+    if data is None and path.exists():
+        log.warning("eval_export: failed to read %s", path)
+    return data
 
 
 def _drop_empty(d: dict[str, Any]) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.231"
+version = "0.99.232"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.231. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.232. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.231. Last sync 2026-06-18. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.232. Last sync 2026-06-19. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-18
+ * Last sync: 2026-06-19
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.232",
+    "date": "2026-06-19",
+    "body": "### Changed\n- **Five more duplicated-helper clusters folded into shared homes** (PR-DEDUP-2; the codebase-audit follow-up to PR-DEDUP-CONFIG-TOML). A cross-tree sweep surfaced five real duplications, each migrated to one home with all callers updated: (1) **JWT payload decode** — four byte-identical \"split → pad base64url → `json.loads` → swallow errors\" blocks (`oauth_login`, `codex_cli_oauth`, `llm/providers/codex`, `petri_audit/codex_provider`) → new `core/auth/jwt_claims.py:decode_jwt_claims`; (2) **`mask_key`** — three copies (`profiles.masked_key`, `cli/doctor`, the canonical `config/env_io`) → the one `core/config/env_io.py:mask_key`; (3) **duration formatters** — four copies in two idioms (`_format_age` ×2, `_fmt_elapsed`/`_format_seconds`) → new `core/time_format.py` (`format_age` / `format_elapsed`); (4) **inline atomic-write** — four hand-rolled `tmp.write_text + os.replace` sites (`hybrid_session` ×2, `session._persist`, `scheduler/service`) → the existing `core/memory/atomic_write.py` helpers (which add `fsync` + crash-safe temp cleanup), keeping each site's lock / error-swallowing contract and exact serialization; (5) **read-json-or-none** — two copies (`cli/commands/self_improving._load_json`, `seed_generation/eval_export._read_json`) → new `core/memory/atomic_write.py:read_json_or_none`. Behavior-preserving (Codex MCP reviewed: one MEDIUM fixed by writing `hybrid_session` via `atomic_write_text` + bare `json.dumps` so serialization stays byte-identical; two benign edge-differences on unreachable inputs noted — a valid-but-empty codex JWT payload now yields `None` instead of a dict-of-`None`s, and `eval_export` warns on a present-but-non-dict artefact). Also removed two stale `__pycache__`-only ghost directories (`core/utils/`, `core/scheduler/scheduler/`) left by past moves. New `tests/core/test_time_format.py` adds the `format_elapsed` coverage the old copies never had. The four-copy `core/config/__init__.py`/`explain.py` inline config-TOML resolvers remain intentionally un-migrated (module-global monkeypatch seam, as in PR-DEDUP-CONFIG-TOML)."
+  },
   {
     "version": "0.99.231",
     "date": "2026-06-19",
@@ -1878,4 +1883,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-06-18";
+export const CHANGELOG_SYNCED_AT = "2026-06-19";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-18
+ * Last sync: 2026-06-19
  */
 
 export const GEODE_SOT = {
-  version: "0.99.231",
-  syncedAt: "2026-06-18",
+  version: "0.99.232",
+  syncedAt: "2026-06-19",
 } as const;

--- a/tests/core/auth/test_chatgpt_plan_label.py
+++ b/tests/core/auth/test_chatgpt_plan_label.py
@@ -14,8 +14,8 @@ import json
 from pathlib import Path
 
 import pytest
+from core.auth.jwt_claims import decode_jwt_claims
 from core.auth.oauth_login import (
-    _decode_jwt_claims,
     _plan_type_from_token,
     chatgpt_plan_label,
     resolve_local_chatgpt_plan_label,
@@ -66,7 +66,7 @@ class TestChatgptPlanLabel:
 
 class TestPlanTypeFromToken:
     """JWT-extraction edge cases. The decode helper itself is tested via
-    ``_decode_jwt_claims``; this wraps the slug-extract step."""
+    ``decode_jwt_claims`` (core.auth.jwt_claims); this wraps the slug-extract step."""
 
     def test_empty_token(self) -> None:
         assert _plan_type_from_token("") == ""
@@ -120,13 +120,13 @@ class TestDecodeJwtClaims:
         # Force unpadded (rstrip already did, but assert no padding remains)
         assert "=" not in raw
         token = f"hdr.{raw}.sig"
-        assert _decode_jwt_claims(token) == payload
+        assert decode_jwt_claims(token) == payload
 
     def test_empty_token_returns_empty_dict(self) -> None:
-        assert _decode_jwt_claims("") == {}
+        assert decode_jwt_claims("") == {}
 
     def test_single_segment_token(self) -> None:
-        assert _decode_jwt_claims("only-one-segment") == {}
+        assert decode_jwt_claims("only-one-segment") == {}
 
 
 class TestResolveLocalLabel:

--- a/tests/core/auth/test_oauth_login.py
+++ b/tests/core/auth/test_oauth_login.py
@@ -164,7 +164,7 @@ class TestCmdLogin:
 def _build_fake_jwt(claims: dict) -> str:
     """Construct a JWT-shaped string with ``claims`` as the payload.
 
-    Signature is bogus — ``_decode_jwt_claims`` does no verification.
+    Signature is bogus — ``decode_jwt_claims`` does no verification.
     """
     import base64
     import json
@@ -179,11 +179,11 @@ def _build_fake_jwt(claims: dict) -> str:
 
 
 class TestJWTDecode:
-    """`_decode_jwt_claims` + `_plan_type_from_token` — regression for the
+    """`decode_jwt_claims` + `_plan_type_from_token` — regression for the
     v0.95.x plan tier reconciliation path."""
 
     def test_decode_valid_jwt(self):
-        from core.auth.oauth_login import _decode_jwt_claims
+        from core.auth.jwt_claims import decode_jwt_claims
 
         token = _build_fake_jwt(
             {
@@ -192,19 +192,19 @@ class TestJWTDecode:
                 "exp": 9999999999,
             }
         )
-        claims = _decode_jwt_claims(token)
+        claims = decode_jwt_claims(token)
         assert claims["exp"] == 9999999999
         assert claims["https://api.openai.com/auth"]["chatgpt_plan_type"] == "pro"
 
     def test_decode_malformed_returns_empty(self):
-        from core.auth.oauth_login import _decode_jwt_claims
+        from core.auth.jwt_claims import decode_jwt_claims
 
         # Fewer than 2 dot-separated parts → early return.
-        assert _decode_jwt_claims("not-a-jwt") == {}
-        assert _decode_jwt_claims("") == {}
+        assert decode_jwt_claims("not-a-jwt") == {}
+        assert decode_jwt_claims("") == {}
         # 2+ parts but the payload section is not valid base64+JSON.
-        assert _decode_jwt_claims("garbage.payload.sig") == {}
-        assert _decode_jwt_claims("only.one") == {}
+        assert decode_jwt_claims("garbage.payload.sig") == {}
+        assert decode_jwt_claims("only.one") == {}
 
     def test_plan_type_extraction(self):
         from core.auth.oauth_login import _plan_type_from_token

--- a/tests/core/memory/test_project_journal.py
+++ b/tests/core/memory/test_project_journal.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 
-from core.memory.project_journal import ProjectJournal, RunRecord, _format_age
+from core.memory.project_journal import ProjectJournal, RunRecord
+from core.time_format import format_age as _format_age
 
 
 class TestRunRecord:

--- a/tests/core/memory/test_run_history_context.py
+++ b/tests/core/memory/test_run_history_context.py
@@ -2,8 +2,9 @@
 
 import time
 
-from core.memory.context import ContextAssembler, _format_age
+from core.memory.context import ContextAssembler
 from core.observability.run_log import RunLog, RunLogEntry
+from core.time_format import format_age as _format_age
 
 
 class TestFormatAge:

--- a/tests/core/test_time_format.py
+++ b/tests/core/test_time_format.py
@@ -1,0 +1,46 @@
+"""Guards for the consolidated duration formatters (PR-DEDUP-2).
+
+``format_age`` is also exercised via the memory tests it was lifted from; this
+pins both functions at their new home, and adds the ``format_elapsed`` coverage
+the ``_fmt_elapsed`` / ``_format_seconds`` copies never had.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.time_format import format_age, format_elapsed
+
+
+class TestFormatAge:
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [
+            (-10, "now"),
+            (0, "now"),
+            (59, "now"),
+            (60, "1m ago"),
+            (300, "5m ago"),
+            (3600, "1h ago"),
+            (7200, "2h ago"),
+            (86400, "1d ago"),
+            (172800, "2d ago"),
+        ],
+    )
+    def test_age(self, seconds: float, expected: str) -> None:
+        assert format_age(seconds) == expected
+
+
+class TestFormatElapsed:
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [
+            (0, "0s"),
+            (5, "5s"),
+            (59, "59s"),
+            (60, "1m 0s"),
+            (90, "1m 30s"),
+            (3661, "61m 1s"),
+        ],
+    )
+    def test_elapsed(self, seconds: float, expected: str) -> None:
+        assert format_elapsed(seconds) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.231"
+version = "0.99.232"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Codebase-audit follow-up to PR-DEDUP-CONFIG-TOML. A cross-tree sweep found **five** real duplicated-helper clusters; each folded into one home with all callers migrated.
- Behavior-preserving (Codex MCP reviewed); one MEDIUM fixed, two benign edge-differences on unreachable inputs noted.
- Also removed two stale `__pycache__`-only ghost directories.

## Why
The repo's "one home, no copies" norm had drifted: the same JWT-decode block existed in 4 files, `mask_key` in 3, a duration formatter in 4, hand-rolled atomic-write in 4, and read-json-or-none in 2. A fix to one copy silently skips the rest.

## Changes
| Cluster | Copies → Home |
|---------|---------------|
| JWT payload decode | 4 (`oauth_login`, `codex_cli_oauth`, `llm/providers/codex`, `petri_audit/codex_provider`) → **new** `core/auth/jwt_claims.py:decode_jwt_claims` |
| `mask_key` | 3 (`auth/profiles`, `cli/doctor`, canonical `config/env_io`) → `config/env_io.mask_key` |
| duration formatters | 4 (`memory/context`, `memory/project_journal`, `ui/event_renderer`, `ui/agentic_ui/_state`) → **new** `core/time_format.py` |
| inline atomic-write | 4 (`memory/hybrid_session` ×2, `memory/session`, `scheduler/service`) → `core/memory/atomic_write` (adds fsync) |
| read-json-or-none | 2 (`cli/commands/self_improving`, `seed_generation/eval_export`) → **new** `atomic_write.read_json_or_none` |
| ghost dirs | removed `core/utils/`, `core/scheduler/scheduler/` (untracked `__pycache__` shells) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `config/__init__.py` + `explain.py` inline resolvers | Intentionally kept | module-global `GLOBAL_CONFIG_PATH` monkeypatch seam (same call as PR-DEDUP-CONFIG-TOML) |
| `hybrid_session` serialization | Made byte-identical (Codex MEDIUM) | uses `atomic_write_text` + bare `json.dumps` so `ensure_ascii`/raise-on-unserializable are unchanged |
| petri empty-payload, eval_export non-dict warning | Accepted edge-diffs | only differ on unreachable/degenerate inputs |

## Verification
- [x] ruff check + format clean (`core/ tests/ plugins/ scripts/`)
- [x] mypy clean on all touched files (the 3 errors in untouched `petri_audit/mcp_bridge/codex_overrides.py` are pre-existing inspect_ai-only, masked on CI which runs mypy without `[audit]`)
- [x] lint-imports — 4 kept, 0 broken (new cross-layer edges all pass)
- [x] pytest — affected suites pass; the 7 failures are pre-existing env-dependent (stash-verified byte-identical on clean base), 0 regressions
- [x] Codex MCP review — 1 MEDIUM fixed + pinned, 2 benign edges documented

## Reference
Parallel-agent codebase audit + Codex MCP adversarial review. Net per-cluster reduction; +2 leaf modules (`jwt_claims`, `time_format`).