### PR TITLE
fix(docs): anonymize hardcoded home paths in aligned-logging SoT

### DIFF
--- a/docs/plans/2026-06-19-aligned-logging-transcript-policy.md
+++ b/docs/plans/2026-06-19-aligned-logging-transcript-policy.md
@@ -121,5 +121,5 @@ Each PR is independent and behavior-preserving except where it closes a parity g
 ## 8. Reference
 
 - Current-state evidence: four parallel subsystem audits (2026-06-19), file:line cited inline above.
-- Frontier alignment: `/Users/mango/workspace/codex` (`recorder.rs:826-836`), `/Users/mango/workspace/openclaw` (`transcript-stream.ts:4-12`), on-disk `~/.claude/projects/*.jsonl` (4399 files confirmed one-object-per-line).
+- Frontier alignment: `~/workspace/codex` (`recorder.rs:826-836`), `~/workspace/openclaw` (`transcript-stream.ts:4-12`), on-disk `~/.claude/projects/*.jsonl` (4399 files confirmed one-object-per-line).
 - Prior dedup precedent: PR-DEDUP-CONFIG-TOML, PR-DEDUP-2, PR-DEDUP-JSONL (#2383).


### PR DESCRIPTION
## Summary
- Anonymize `/Users/mango/...` → `~/workspace/...` in the §8 frontier references of the aligned-logging SoT doc.

## Why
The repo-hygiene ratchet (`scripts/check_repo_hygiene.py`) flagged a hardcoded home path. It was SKIPPED on the docs-only PR #2384 (`code=false`) and only surfaced on the v0.99.235 release bundle (which carries #2383 code → `code=true` → ratchet runs). Real portability fix ([[feedback_no_hardcoded_user_paths]]).

## Changes
| File | Change |
|------|--------|
| `docs/plans/2026-06-19-aligned-logging-transcript-policy.md` | `/Users/mango/workspace/` → `~/workspace/` (frontier refs) |

## Verification
- [x] `check_repo_hygiene.py` exit 0 (was 1)
- [x] docs-only