### PR TITLE
fix(llm): Anthropic prompt-cache hardening — 1h TTL + 20-block breakpoints + hit-rate telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ functional change.
 
 ---
 
+## [0.99.241] - 2026-06-23
+
+### Fixed
+- **Anthropic prompt-cache hardening (PR-ANTHROPIC-CACHE-HARDENING)** — Anthropic flagged degraded prompt-cache performance. A 3-provider policy audit (refreshed to 2026-06) found GEODE's static/dynamic system split correct but the surrounding layers predating two changed Anthropic policies. Three fixes:
+  - **1-hour cache TTL on the stable static system prefix.** Every `cache_control` was 5-minute `ephemeral`; an agentic turn whose tool execution exceeds 5 min lets the static prefix expire and re-pays the cache-write premium on resume. The static prefix (everything before `<dynamic_context>`) is byte-identical across turns, so it now uses `ttl: "1h"` (GA 2026-06, no beta header; SDK 0.100.0 `CacheControlEphemeralParam.ttl`). One-shot calls (`system_with_cache`) and the dynamic / no-boundary blocks keep 5-min. Kill switch: `settings.prompt_cache_extended_ttl` (TOML `llm.prompt_cache_extended_ttl`, default on). reader: `core/llm/providers/anthropic.py:_static_system_cache_control`.
+  - **20-block lookback-aware message breakpoints.** Anthropic's cache walks back ≤20 content blocks from a breakpoint to find a prior entry; GEODE clustered all 3 message breakpoints on the last adjacent messages, so a single tool-heavy turn (>20 blocks) pushed every breakpoint out of the window → silent full miss on the next turn. Long histories now spread the breakpoints ~18 blocks apart (always anchoring the newest message); short histories keep the original last-n behaviour. `core/llm/providers/anthropic.py:_select_breakpoint_targets`.
+  - **Cache hit-rate telemetry + degraded-cache warning.** `LLMUsageAccumulator` recorded cache_creation/cache_read token counts but never a derived hit *rate*, so a busted prefix cache was invisible until the bill. Added `cache_hit_rate` (read / (read + creation)), surfaced in the usage summary, plus a one-shot WARNING when cumulative cacheable tokens exceed 50k at a <30% hit rate.
+
 ## [0.99.240] - 2026-06-21
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.240
+- **Version**: 0.99.241
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.240 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.241 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.240 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.241 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -63,6 +63,8 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     # PR-TOOL-SEARCH-WIRE (2026-06-13) — hosted tool-search defer kill switch.
     "llm.tool_search_defer": "tool_search_defer",
     "llm.tool_search_defer_codex": "tool_search_defer_codex",
+    # PR-ANTHROPIC-CACHE-HARDENING (2026-06-23) — 1h prompt-cache TTL kill switch.
+    "llm.prompt_cache_extended_ttl": "prompt_cache_extended_ttl",
     "llm.openai_credential_source": "openai_credential_source",
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
     "replan.enabled": "replan_enabled",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -316,6 +316,15 @@ class Settings(BaseSettings):
     # live call was the gate (PR-NO-FALLBACK rule); reader: _openai_common.py.
     tool_search_defer_codex: bool = True
 
+    # Prompt cache — 1-hour TTL on the stable static system prefix (Anthropic).
+    # GA as of 2026-06 (no beta header) via ``cache_control: {ttl: "1h"}``; the
+    # static prefix (everything before ``<dynamic_context>``) is byte-identical
+    # across every agentic turn, so the 2x write premium amortizes after ~3
+    # cache reads — which any multi-turn loop clears immediately. Kill switch:
+    # set False to fall back to the 5-minute ephemeral default. reader:
+    # core/llm/providers/anthropic.py:_static_system_cache_control
+    prompt_cache_extended_ttl: bool = True
+
     # Ensemble — Multi-LLM mode
     ensemble_mode: str = "single"  # single | cross
 

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -432,10 +432,127 @@ def system_with_cache(system: str) -> list[TextBlockParam]:
     ]
 
 
+def _static_system_cache_control() -> dict[str, str]:
+    """``cache_control`` for the stable static system prefix (agentic adapter).
+
+    The static prefix — everything before ``<dynamic_context>`` — is
+    byte-identical across every turn of an agentic loop, so it benefits most
+    from the **1-hour TTL**: GA as of 2026-06, enabled by ``ttl: "1h"`` on the
+    ephemeral ``cache_control`` (no beta header). The 2x write premium amortizes
+    after ~3 cache reads, which any multi-turn loop clears immediately. The
+    5-minute default would expire between turns whenever tool execution exceeds
+    5 min, forcing a fresh write every resume.
+
+    Kill switch: ``settings.prompt_cache_extended_ttl`` (set False → 5-minute
+    ephemeral default). One-shot call shapes (``system_with_cache``) and the
+    dynamic / no-boundary blocks keep the 5-minute default — only the reused
+    static prefix earns the extended TTL.
+
+    SDK: ``anthropic.types.CacheControlEphemeralParam`` exposes optional ``ttl``
+    (verified 0.100.0).
+    ref: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+    """
+    from core.config import settings
+
+    if getattr(settings, "prompt_cache_extended_ttl", True):
+        return {"type": "ephemeral", "ttl": "1h"}
+    return {"type": "ephemeral"}
+
+
 # Anthropic allows up to 4 cache_control breakpoints per request.  The agentic
 # adapter already uses 1-2 on the system block (STATIC/DYNAMIC split).  Keep 3
 # slots for the messages array — Hermes "system_and_3" strategy.
 MAX_MESSAGE_CACHE_BREAKPOINTS = 3
+
+# Anthropic's cache lookup walks back at most this many content blocks from a
+# breakpoint to find a prior cached entry (verified against the prompt-caching
+# guide, 2026-06). When a single agentic turn appends more than this many
+# tool_use/tool_result blocks, breakpoints clustered on the last few messages
+# all fall outside the window on the next turn → silent full miss. Spread the
+# message breakpoints ~``_CACHE_BREAKPOINT_BLOCK_STRIDE`` blocks apart so the
+# newest breakpoint can always reach a prior entry. ref:
+# https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+_CACHE_LOOKBACK_BLOCKS = 20
+_CACHE_BREAKPOINT_BLOCK_STRIDE = 18  # under the 20-block window, with margin
+
+
+def _content_block_count(content: Any) -> int:
+    """Number of content blocks a message contributes to the lookback window."""
+    if isinstance(content, list):
+        return len(content)
+    return 1 if content else 0
+
+
+def _is_markable(content: Any) -> bool:
+    """Whether :func:`apply_messages_cache_control` would actually attach a
+    breakpoint to this message (mirrors its empty-text guards).
+
+    An empty message is skipped at mark time, so selecting it as a breakpoint
+    target would waste a slot (and, for the anchor, leave the newest turn
+    uncached). Only markable messages should be selected.
+    """
+    if isinstance(content, str):
+        return bool(content)
+    if isinstance(content, list) and content:
+        last = content[-1]
+        return not (isinstance(last, dict) and last.get("type") == "text" and not last.get("text"))
+    return False
+
+
+def _select_breakpoint_targets(
+    messages: list[dict[str, Any]],
+    n_breakpoints: int,
+) -> list[int]:
+    """Indices of non-system messages to mark with ``cache_control``.
+
+    Short histories (total content blocks ≤ ``_CACHE_LOOKBACK_BLOCKS``) keep the
+    original "last ``n`` adjacent messages" behaviour — the whole history fits in
+    one lookback window, so spreading buys nothing. Long histories spread the
+    breakpoints ~``_CACHE_BREAKPOINT_BLOCK_STRIDE`` blocks apart (anchoring the
+    newest markable message) so each breakpoint stays within the 20-block window
+    of its predecessor across turns.
+
+    Distance is measured in **content blocks from each message's final block**
+    (where the breakpoint physically sits), counting every block in between —
+    including the newer breakpoint's own blocks, which consume the lookback
+    window. Only *markable* messages are eligible (an empty one is skipped at
+    mark time, so anchoring/spreading on it would waste the breakpoint slot).
+    """
+    non_system = [i for i, m in enumerate(messages) if m.get("role") != "system"]
+    # Guard n<=0 here too: ``markable[-0:]`` is ``markable[0:]`` (the whole
+    # list), so the short-history branch below would mark every message. The
+    # public caller already returns early on n<=0, but keep the helper safe for
+    # any future caller.
+    if not non_system or n_breakpoints <= 0:
+        return []
+
+    markable = [i for i in non_system if _is_markable(messages[i].get("content"))]
+    if not markable:
+        return []
+
+    total_blocks = sum(_content_block_count(messages[i].get("content")) for i in non_system)
+    if total_blocks <= _CACHE_LOOKBACK_BLOCKS:
+        return markable[-n_breakpoints:]
+
+    # ``end_offset[idx]`` = content blocks AFTER ``idx``'s final block (0 for the
+    # very last message). Walk from the end accumulating each message's own block
+    # count *after* recording, so the distance between two breakpoints is the
+    # difference of their end_offsets.
+    end_offset: dict[int, int] = {}
+    acc = 0
+    for idx in reversed(non_system):
+        end_offset[idx] = acc
+        acc += _content_block_count(messages[idx].get("content"))
+
+    selected = [markable[-1]]
+    last_offset = end_offset[markable[-1]]
+    for idx in reversed(markable[:-1]):
+        if len(selected) >= n_breakpoints:
+            break
+        if end_offset[idx] - last_offset >= _CACHE_BREAKPOINT_BLOCK_STRIDE:
+            selected.append(idx)
+            last_offset = end_offset[idx]
+    return sorted(selected)
 
 
 def apply_messages_cache_control(
@@ -443,8 +560,15 @@ def apply_messages_cache_control(
     *,
     n_breakpoints: int = MAX_MESSAGE_CACHE_BREAKPOINTS,
 ) -> list[dict[str, Any]]:
-    """Return a copy of *messages* with ephemeral cache_control on the last
+    """Return a copy of *messages* with ephemeral cache_control on up to
     *n_breakpoints* non-system messages' final content block.
+
+    Placement (see :func:`_select_breakpoint_targets`): short histories keep
+    the original "last ``n`` adjacent messages" strategy; long histories
+    (> 20 content blocks) spread the breakpoints ~18 blocks apart so the newest
+    one stays within Anthropic's 20-block lookback window of its predecessor
+    across turns — otherwise a single tool-heavy turn pushes every clustered
+    breakpoint out of the window and the whole rolling cache silently misses.
 
     Mirrors Hermes ``apply_anthropic_cache_control`` (system_and_3) and
     OpenClaw ``applyAnthropicCacheControlToMessages``.  Used by the agentic
@@ -467,7 +591,7 @@ def apply_messages_cache_control(
         return list(messages)
 
     out: list[dict[str, Any]] = list(messages)
-    targets = [i for i, m in enumerate(out) if m.get("role") != "system"][-n_breakpoints:]
+    targets = _select_breakpoint_targets(out, n_breakpoints)
 
     for i in targets:
         msg = dict(out[i])
@@ -945,7 +1069,7 @@ class ClaudeAgenticAdapter:
                         {
                             "type": "text",
                             "text": static_text,
-                            "cache_control": {"type": "ephemeral"},
+                            "cache_control": _static_system_cache_control(),
                         },
                         {"type": "text", "text": dynamic_text},
                     ]
@@ -962,7 +1086,7 @@ class ClaudeAgenticAdapter:
                         {
                             "type": "text",
                             "text": static_text,
-                            "cache_control": {"type": "ephemeral"},
+                            "cache_control": _static_system_cache_control(),
                         }
                     ]
                 else:

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -73,6 +73,10 @@ class LLMUsageAccumulator:
     """Accumulates multiple LLMUsage records for session-level summary."""
 
     calls: list[LLMUsage] = field(default_factory=list)
+    # One-shot guard for the degraded-cache warning (reset per accumulator,
+    # i.e. per session). Underscore-prefixed so it is not mistaken for a
+    # public field; excluded from ``to_dict``.
+    _warned_low_cache: bool = field(default=False, repr=False)
 
     @property
     def total_input_tokens(self) -> int:
@@ -95,11 +99,62 @@ class LLMUsageAccumulator:
         return sum(c.cache_read_tokens for c in self.calls)
 
     @property
+    def cache_hit_rate(self) -> float:
+        """Fraction of cacheable input tokens served from cache.
+
+        ``read / (read + creation)`` — 1.0 means every cacheable token was a
+        cache hit, 0.0 means every one was a fresh write (the symptom of a
+        silently-invalidated prefix). Returns 0.0 when there is no cache
+        activity yet (avoids div-by-zero).
+        """
+        read = self.total_cache_read_tokens
+        denom = read + self.total_cache_creation_tokens
+        return read / denom if denom else 0.0
+
+    @property
     def total_cost_usd(self) -> float:
         return sum(c.cost_usd for c in self.calls)
 
+    def maybe_warn_low_cache_hit_rate(
+        self, *, min_tokens: int = 50_000, threshold: float = 0.3
+    ) -> None:
+        """Emit a one-shot WARNING when the prompt-cache hit rate is degraded.
+
+        Fires at most once per accumulator (per session) once cumulative
+        cacheable tokens exceed *min_tokens* and the hit rate is below
+        *threshold*. A persistently low ratio is the visible signature of a
+        silent prefix-invalidator — volatile content in the cached prefix, a
+        prefix below the model's minimum, or the 20-block lookback exceeded.
+        Without this, a cache that has dropped to ~0% is invisible until an
+        operator (or the provider) notices the bill.
+        """
+        if self._warned_low_cache:
+            return
+        read = self.total_cache_read_tokens
+        denom = read + self.total_cache_creation_tokens
+        # Advisory telemetry must never break a real LLM-call path. Token totals
+        # are ints in production, but tests (and any future adapter that passes a
+        # mocked usage object) may carry non-numeric values — skip silently
+        # rather than raise from this record() hook.
+        if not isinstance(denom, int) or denom < min_tokens:
+            return
+        rate = read / denom if denom else 0.0
+        if rate < threshold:
+            self._warned_low_cache = True
+            log.warning(
+                "prompt cache hit rate degraded: %.1f%% (read=%d, creation=%d) "
+                "over %d cacheable tokens — check for volatile content in the "
+                "cached prefix, a prefix below the model minimum, or a long "
+                "tool-heavy turn exceeding the 20-block lookback window",
+                rate * 100.0,
+                read,
+                self.total_cache_creation_tokens,
+                denom,
+            )
+
     def record(self, usage: LLMUsage) -> None:
         self.calls.append(usage)
+        self.maybe_warn_low_cache_hit_rate()
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -117,6 +172,8 @@ class LLMUsageAccumulator:
         cache_r = self.total_cache_read_tokens
         if cache_r:
             d["total_cache_read_tokens"] = cache_r
+        if cache_w or cache_r:
+            d["cache_hit_rate"] = round(self.cache_hit_rate, 3)
         return d
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.240"
+version = "0.99.241"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.240. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.241. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.240. Last sync 2026-06-20. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.241. Last sync 2026-06-22. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-20
+ * Last sync: 2026-06-22
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.241",
+    "date": "2026-06-23",
+    "body": "### Fixed\n- **Anthropic prompt-cache hardening (PR-ANTHROPIC-CACHE-HARDENING)** — Anthropic flagged degraded prompt-cache performance. A 3-provider policy audit (refreshed to 2026-06) found GEODE's static/dynamic system split correct but the surrounding layers predating two changed Anthropic policies. Three fixes:\n  - **1-hour cache TTL on the stable static system prefix.** Every `cache_control` was 5-minute `ephemeral`; an agentic turn whose tool execution exceeds 5 min lets the static prefix expire and re-pays the cache-write premium on resume. The static prefix (everything before `<dynamic_context>`) is byte-identical across turns, so it now uses `ttl: \"1h\"` (GA 2026-06, no beta header; SDK 0.100.0 `CacheControlEphemeralParam.ttl`). One-shot calls (`system_with_cache`) and the dynamic / no-boundary blocks keep 5-min. Kill switch: `settings.prompt_cache_extended_ttl` (TOML `llm.prompt_cache_extended_ttl`, default on). reader: `core/llm/providers/anthropic.py:_static_system_cache_control`.\n  - **20-block lookback-aware message breakpoints.** Anthropic's cache walks back ≤20 content blocks from a breakpoint to find a prior entry; GEODE clustered all 3 message breakpoints on the last adjacent messages, so a single tool-heavy turn (>20 blocks) pushed every breakpoint out of the window → silent full miss on the next turn. Long histories now spread the breakpoints ~18 blocks apart (always anchoring the newest message); short histories keep the original last-n behaviour. `core/llm/providers/anthropic.py:_select_breakpoint_targets`.\n  - **Cache hit-rate telemetry + degraded-cache warning.** `LLMUsageAccumulator` recorded cache_creation/cache_read token counts but never a derived hit *rate*, so a busted prefix cache was invisible until the bill. Added `cache_hit_rate` (read / (read + creation)), surfaced in the usage summary, plus a one-shot WARNING when cumulative cacheable tokens exceed 50k at a <30% hit rate."
+  },
   {
     "version": "0.99.240",
     "date": "2026-06-21",
@@ -1923,4 +1928,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-06-20";
+export const CHANGELOG_SYNCED_AT = "2026-06-22";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-20
+ * Last sync: 2026-06-22
  */
 
 export const GEODE_SOT = {
-  version: "0.99.240",
-  syncedAt: "2026-06-20",
+  version: "0.99.241",
+  syncedAt: "2026-06-22",
 } as const;

--- a/tests/core/llm/test_anthropic_messages_cache.py
+++ b/tests/core/llm/test_anthropic_messages_cache.py
@@ -7,11 +7,14 @@ edge cases (empty/short message lists), and content-shape handling
 
 from __future__ import annotations
 
+import itertools
 from typing import Any
 
 import pytest
 from core.llm.providers.anthropic import (
     MAX_MESSAGE_CACHE_BREAKPOINTS,
+    _select_breakpoint_targets,
+    _static_system_cache_control,
     apply_messages_cache_control,
 )
 
@@ -158,6 +161,8 @@ class TestNonMutation:
     [0, 1, 2, 3, 5, 10],
 )
 def test_n_breakpoints_bound(n: int):
+    # 20 single-block messages = 20 blocks, == lookback window → short-history
+    # path keeps the original "last n" behaviour, so exactly min(n, 20) marks.
     msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
     out = apply_messages_cache_control(msgs, n_breakpoints=n)
     marked = sum(
@@ -166,6 +171,113 @@ def test_n_breakpoints_bound(n: int):
         if isinstance(m["content"], list) and m["content"] and m["content"][-1].get("cache_control")
     )
     assert marked == min(n, 20)
+
+
+class TestBreakpointSpreading:
+    """20-block lookback hardening (2026-06): long histories spread the
+    message breakpoints ~18 blocks apart instead of clustering on the last
+    few adjacent messages, so the newest breakpoint stays within Anthropic's
+    20-block lookback window of its predecessor across turns. Short histories
+    keep the original last-n behaviour (everything fits one window)."""
+
+    def test_short_history_keeps_last_n_adjacent(self):
+        # 10 blocks <= 20 → original behaviour: last 3 adjacent.
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+        assert _select_breakpoint_targets(msgs, 3) == [7, 8, 9]
+
+    def test_zero_breakpoints_selects_nothing(self):
+        # Guard against the ``non_system[-0:]`` footgun (== whole list).
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(5)]
+        assert _select_breakpoint_targets(msgs, 0) == []
+
+    def test_long_history_anchors_newest_and_spreads(self):
+        # 60 single-block messages > 20 → spread to the full budget.
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(60)]
+        targets = _select_breakpoint_targets(msgs, 3)
+        assert targets[-1] == 59  # newest always anchored
+        assert len(targets) == 3
+        gaps = [b - a for a, b in itertools.pairwise(targets)]
+        assert all(1 <= g <= 18 for g in gaps)  # spaced within the window
+
+    def test_moderate_history_spaces_within_lookback_window(self):
+        # 30 blocks > 20 but < n*stride → fewer breakpoints, still spaced
+        # so no two consecutive ones exceed the 20-block window.
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(30)]
+        targets = _select_breakpoint_targets(msgs, 3)
+        assert targets[-1] == 29
+        assert all(b - a <= 20 for a, b in itertools.pairwise(targets))
+
+    def test_counts_list_content_blocks_not_messages(self):
+        # 3 messages × 10 blocks each = 30 blocks > 20 → spread by block count.
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": f"b{j}"} for j in range(10)]}
+            for _ in range(3)
+        ]
+        # newest anchored (msg 2); walking back, msg1 adds 10 (<18), msg0 adds
+        # another 10 → 20 >= 18 → breakpoint on msg0. Result: [0, 2].
+        assert _select_breakpoint_targets(msgs, 3) == [0, 2]
+
+    def test_apply_marks_spread_targets_end_to_end(self):
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(60)]
+        out = apply_messages_cache_control(msgs, n_breakpoints=3)
+        marked = [
+            i
+            for i, m in enumerate(out)
+            if isinstance(m["content"], list) and m["content"][-1].get("cache_control")
+        ]
+        assert marked[-1] == 59
+        assert len(marked) == 3
+
+    def _block_distance(self, msgs, targets):
+        # Content-block distance between consecutive breakpoints' final blocks.
+        from core.llm.providers.anthropic import _content_block_count
+
+        end_offset = {}
+        acc = 0
+        for i in reversed(range(len(msgs))):
+            end_offset[i] = acc
+            acc += _content_block_count(msgs[i]["content"])
+        return [end_offset[a] - end_offset[b] for a, b in itertools.pairwise(targets)]
+
+    def test_newest_large_message_consumes_window(self):
+        # MED1 (Codex): the newest message's own blocks consume the lookback
+        # window, so distance must be measured from each final block — not the
+        # older messages' block sums. 60 one-block msgs + a newest 20-block msg.
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(60)]
+        msgs.append(
+            {"role": "user", "content": [{"type": "text", "text": f"b{j}"} for j in range(20)]}
+        )
+        targets = _select_breakpoint_targets(msgs, 3)
+        assert targets[-1] == 60  # newest anchored
+        # every consecutive breakpoint within the 20-block lookback window
+        assert all(d <= 20 for d in self._block_distance(msgs, targets))
+
+    def test_empty_tail_anchors_newest_markable(self):
+        # MED2 (Codex): an empty trailing message is unmarkable, so the anchor
+        # must fall on the newest *markable* message and no slot is wasted.
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(60)]
+        msgs.append({"role": "user", "content": ""})  # empty, unmarkable
+        targets = _select_breakpoint_targets(msgs, 3)
+        assert 60 not in targets  # empty tail never selected
+        assert targets[-1] == 59  # newest markable anchored
+        assert len(targets) == 3  # full budget, none wasted
+
+
+class TestStaticSystemCacheControl:
+    """1-hour TTL on the stable static system prefix (GA 2026-06). Kill
+    switch: settings.prompt_cache_extended_ttl."""
+
+    def test_extended_ttl_on_by_default(self, monkeypatch):
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "prompt_cache_extended_ttl", True, raising=False)
+        assert _static_system_cache_control() == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_kill_switch_falls_back_to_5min_ephemeral(self, monkeypatch):
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "prompt_cache_extended_ttl", False, raising=False)
+        assert _static_system_cache_control() == {"type": "ephemeral"}
 
 
 class TestEmptyTextBlockGuard:

--- a/tests/core/llm/test_cache_hit_rate.py
+++ b/tests/core/llm/test_cache_hit_rate.py
@@ -1,0 +1,91 @@
+"""Prompt-cache hit-rate telemetry + degraded-cache warning (2026-06).
+
+``LLMUsageAccumulator`` records cache_creation / cache_read token counts but
+never derived a hit RATE or alerted on a degraded one, so a silently-busted
+prefix cache (volatile content, below-minimum prefix, 20-block lookback
+exceeded) was invisible until the provider noticed the bill. These tests pin
+the new ``cache_hit_rate`` property + one-shot ``maybe_warn_low_cache_hit_rate``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.llm.token_tracker import LLMUsage, LLMUsageAccumulator
+
+
+def _usage(*, creation: int = 0, read: int = 0) -> LLMUsage:
+    return LLMUsage(
+        model="claude-opus-4-8",
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_tokens=creation,
+        cache_read_tokens=read,
+    )
+
+
+class TestCacheHitRate:
+    def test_zero_when_no_cache_activity(self):
+        acc = LLMUsageAccumulator()
+        acc.record(_usage())
+        assert acc.cache_hit_rate == 0.0
+
+    def test_ratio_is_read_over_read_plus_creation(self):
+        acc = LLMUsageAccumulator()
+        acc.record(_usage(creation=1000, read=3000))
+        assert acc.cache_hit_rate == 0.75
+
+    def test_to_dict_includes_rate_only_with_cache_activity(self):
+        acc = LLMUsageAccumulator()
+        acc.record(_usage())  # no cache tokens
+        assert "cache_hit_rate" not in acc.to_dict()
+        acc.record(_usage(creation=100, read=900))
+        assert acc.to_dict()["cache_hit_rate"] == 0.9
+
+
+class TestDegradedCacheWarning:
+    def _degraded(self, r: logging.LogRecord) -> bool:
+        return "hit rate degraded" in r.getMessage()
+
+    def test_warns_once_below_threshold(self, caplog):
+        acc = LLMUsageAccumulator()
+        with caplog.at_level(logging.WARNING, logger="core.llm.token_tracker"):
+            # 60k cacheable tokens at 10% hit rate → below 30% / above 50k min.
+            acc.record(_usage(creation=54_000, read=6_000))
+        assert len([r for r in caplog.records if self._degraded(r)]) == 1
+
+    def test_one_shot_guard_prevents_repeat(self, caplog):
+        acc = LLMUsageAccumulator()
+        with caplog.at_level(logging.WARNING, logger="core.llm.token_tracker"):
+            acc.record(_usage(creation=54_000, read=6_000))
+            acc.record(_usage(creation=54_000, read=6_000))
+        assert len([r for r in caplog.records if self._degraded(r)]) == 1
+
+    def test_no_warning_below_min_tokens(self, caplog):
+        acc = LLMUsageAccumulator()
+        with caplog.at_level(logging.WARNING, logger="core.llm.token_tracker"):
+            acc.record(_usage(creation=900, read=100))  # 1k « 50k min
+        assert not [r for r in caplog.records if self._degraded(r)]
+
+    def test_no_warning_above_threshold(self, caplog):
+        acc = LLMUsageAccumulator()
+        with caplog.at_level(logging.WARNING, logger="core.llm.token_tracker"):
+            acc.record(_usage(creation=10_000, read=90_000))  # 90% hit on 100k
+        assert not [r for r in caplog.records if self._degraded(r)]
+
+    def test_record_tolerates_non_int_tokens(self):
+        # A mocked usage object (MagicMock token fields, as test_failover does)
+        # must not raise from the record() -> maybe_warn hook — advisory
+        # telemetry never breaks the call path.
+        from unittest.mock import MagicMock
+
+        acc = LLMUsageAccumulator()
+        acc.record(
+            LLMUsage(
+                model="claude-test",
+                input_tokens=MagicMock(),
+                output_tokens=MagicMock(),
+                cache_creation_tokens=MagicMock(),
+                cache_read_tokens=MagicMock(),
+            )
+        )  # no exception

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.240"
+version = "0.99.241"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Anthropic flagged degraded prompt-cache performance. A 3-provider caching-policy audit (refreshed to 2026-06) found GEODE's static/dynamic system split correct but the surrounding layers predating two changed Anthropic policies.
- Three fixes to `core/llm/providers/anthropic.py` + `core/llm/token_tracker.py` + a settings kill-switch. v0.99.241 (PATCH).

## Why
The static/dynamic split (`<dynamic_context>` boundary) was right — date/memory/model-card sit *after* the boundary, uncached. But: (1) every `cache_control` was 5-min `ephemeral`, so any turn whose tool execution exceeds 5 min lets the static prefix expire and re-pays the write premium; (2) all 3 message breakpoints clustered on the last adjacent messages, so a single tool-heavy turn (>20 content blocks) pushed every breakpoint outside Anthropic's 20-block lookback window → silent full miss next turn; (3) GEODE recorded cache_creation/cache_read tokens but never a hit *rate*, so a busted cache was invisible until Anthropic noticed.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` | `_static_system_cache_control()` — `ttl:"1h"` on the stable static system block (one-shot/dynamic/no-boundary keep 5-min). `_select_breakpoint_targets()` + `_content_block_count()` — spread message breakpoints ~18 blocks apart for long (>20-block) histories; short histories unchanged. n<=0 footgun guard. |
| `core/llm/token_tracker.py` | `LLMUsageAccumulator.cache_hit_rate` property + `maybe_warn_low_cache_hit_rate()` one-shot WARNING (>50k cacheable tokens at <30% hit rate), called from `record()`; `cache_hit_rate` surfaced in `to_dict()`. |
| `core/config/_settings.py`, `core/config/__init__.py` | `prompt_cache_extended_ttl` kill switch (default on; TOML `llm.prompt_cache_extended_ttl`). |
| `tests/core/llm/test_anthropic_messages_cache.py`, `tests/core/llm/test_cache_hit_rate.py` | Spreading, static-TTL, n<=0 guard, hit-rate + degraded-warning tests (+17). |
| version × 5 + site SoT | 0.99.240 → 0.99.241 (pyproject/CLAUDE.md/README×2/CHANGELOG + sot.ts/llms). |

## External-contract attestation (doc-before-behaviour)
- **Anthropic 1-hour cache TTL** confirmed GA as of 2026-06 (no beta header) via live `platform.claude.com/docs/.../prompt-caching` + the prompt-caching news page (two sources); enabled by `cache_control: {ttl:"1h"}`. SDK `anthropic 0.100.0` `CacheControlEphemeralParam` exposes optional `ttl` (introspection-verified). Source cited in `_static_system_cache_control` docstring.
- **Not live-round-trip-tested** (live tests need authorization): the 1h-write acceptance is doc+SDK-confirmed but not yet exercised against the backend. Safety nets: `settings.prompt_cache_extended_ttl` kill switch (instant rollback) + the new `cache_hit_rate` telemetry + a 400 would surface loudly through `retry_with_backoff`. Recommend a one-call confirmation after the post-merge rebuild.
- **Codex MCP review could not run** this round — `mcp__codex__codex` OAuth token refresh failed ("refresh token already used"; needs re-login). Self-reviewed against the verification-team / anti-deception lens (found + fixed the n<=0 footgun). Suggest re-auth + Codex (or `/code-review ultra`) on this PR before merge.

## Verification
- [x] ruff check clean (core/ tests/ plugins/ scripts/)
- [x] ruff format --check clean
- [x] mypy clean (455 source files)
- [x] lint-imports — 4 contracts kept
- [x] pytest — cache/telemetry/config/anthropic suites pass (new +18); CLI smoke `geode version` → v0.99.241
- [ ] Codex MCP / ultrareview — pending re-auth
- [ ] 1h-TTL backend round-trip — pending post-rebuild one-call confirmation

## Reference
Anthropic prompt-caching docs (2026-06) · OpenAI `prompt_cache_key`/`prompt_cache_retention` + Zhipu GLM implicit caching tracked as a follow-up PR (OpenAI Fix 6).