### PR TITLE
feat(llm): OpenAI prompt_cache_key cache-routing hint (both backends, Codex live-verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.242] - 2026-06-23
+
+### Added
+- **OpenAI `prompt_cache_key` cache-routing hint (PR-OPENAI-CACHE-KEY)** — follow-up to the Anthropic cache hardening, on the OpenAI Responses path that GEODE's effective default model (gpt-5.5 / openai-codex) actually uses. OpenAI prompt caching is automatic + already active on both backends (`cached_tokens` flows), so this is the one tuning that wasn't free: `prompt_cache_key` groups same-prefix traffic onto the same cache machine. `build_responses_kwargs` now sets it on **both** the platform Responses API and the Codex subscription backend, keyed on a hash of the **static** system prefix (before `<dynamic_context>`) so the key stays byte-stable across a session's turns (the dynamic suffix — date / recalled memory — must not perturb routing). The Codex backend's acceptance is undocumented (it 400s on `max_output_tokens`), so a **live call was the gate** (PR-NO-FALLBACK rule): a streamed `responses.stream` carrying `prompt_cache_key` returned 200 + usage on 2026-06-23. Kill switch `settings.prompt_cache_key_enabled` (TOML `llm.prompt_cache_key_enabled`, default on). `prompt_cache_retention:"24h"` deliberately not sent — it is already default-on for gpt-5.5 and an extra unknown param on the Codex backend. reader: `core/llm/adapters/_openai_common.py:_prompt_cache_key`.
+
 ## [0.99.241] - 2026-06-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.241
+- **Version**: 0.99.242
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.241 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.242 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.241 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.242 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -65,6 +65,8 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.tool_search_defer_codex": "tool_search_defer_codex",
     # PR-ANTHROPIC-CACHE-HARDENING (2026-06-23) — 1h prompt-cache TTL kill switch.
     "llm.prompt_cache_extended_ttl": "prompt_cache_extended_ttl",
+    # PR-OPENAI-CACHE-KEY (2026-06-23) — OpenAI prompt_cache_key routing hint.
+    "llm.prompt_cache_key_enabled": "prompt_cache_key_enabled",
     "llm.openai_credential_source": "openai_credential_source",
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
     "replan.enabled": "replan_enabled",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -325,6 +325,16 @@ class Settings(BaseSettings):
     # core/llm/providers/anthropic.py:_static_system_cache_control
     prompt_cache_extended_ttl: bool = True
 
+    # Prompt cache — OpenAI ``prompt_cache_key`` cache-routing hint (Responses
+    # API; openai-payg + Codex backends). Groups same-prefix traffic onto the
+    # same cache machine; keyed on the static system prefix so it is stable
+    # across a session's turns. Live-verified accepted by the Codex
+    # subscription backend (2026-06-23 — streamed call with prompt_cache_key
+    # returned 200 + usage; PR-NO-FALLBACK gate) and documented on the platform
+    # Responses API (openai 2.30.0). Kill switch. reader:
+    # core/llm/adapters/_openai_common.py:_prompt_cache_key / build_responses_kwargs
+    prompt_cache_key_enabled: bool = True
+
     # Ensemble — Multi-LLM mode
     ensemble_mode: str = "single"  # single | cross
 

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -24,6 +24,7 @@ smoke that hit both ``Unsupported parameter: 'max_tokens'`` and
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -1266,6 +1267,33 @@ def _apply_openai_tool_search_defer(
     return [*shaped, {"type": "tool_search"}]
 
 
+def _prompt_cache_key(system_prompt: str) -> str:
+    """Stable OpenAI ``prompt_cache_key`` derived from the static system prefix.
+
+    OpenAI routes same-``prompt_cache_key`` traffic onto the same cache machine
+    (combined with the prefix hash), improving cache-hit rate for requests that
+    share a common prefix. We key on the STATIC system prefix — everything
+    before ``<dynamic_context>`` — so the key is byte-stable across a session's
+    turns (the dynamic suffix: date / recalled memory / user context changes per
+    turn and must not perturb the routing key). Returns ``""`` when there is no
+    system prompt (nothing to group on).
+
+    Accepted on both surfaces: the platform Responses API (openai 2.30.0 exposes
+    ``prompt_cache_key``) and the Codex subscription backend — live-verified
+    2026-06-23: a streamed ``responses.stream`` call carrying the param returned
+    200 + usage. That live call was the gate (PR-NO-FALLBACK rule) because the
+    Codex backend is reverse-engineered and its parameter acceptance is
+    undocumented (the same backend 400s on ``max_output_tokens``).
+    """
+    if not system_prompt:
+        return ""
+    from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
+
+    static = system_prompt.split(PROMPT_CACHE_BOUNDARY, 1)[0]
+    digest = hashlib.sha256(static.encode("utf-8")).hexdigest()[:16]
+    return f"geode-{digest}"
+
+
 def build_responses_kwargs(
     req: AdapterCallRequest, *, backend: str, adapter_name: str
 ) -> dict[str, Any]:
@@ -1326,6 +1354,16 @@ def build_responses_kwargs(
         "input": resp_input or [{"role": "user", "content": "hello"}],
         "store": False,
     }
+    # OpenAI ``prompt_cache_key`` — cache-routing hint on both backends (each
+    # verified: platform documented + openai 2.30.0 SDK, Codex live-2026-06-23).
+    # Keyed on the static system prefix so it stays stable across a session's
+    # turns. Kill switch: settings.prompt_cache_key_enabled.
+    from core.config import settings as _settings
+
+    if getattr(_settings, "prompt_cache_key_enabled", True):
+        cache_key = _prompt_cache_key(req.system_prompt)
+        if cache_key:
+            kwargs["prompt_cache_key"] = cache_key
     if backend == "platform":
         kwargs["max_output_tokens"] = req.max_tokens
     if req.stop_sequences:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.241"
+version = "0.99.242"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.241. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.242. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.241. Last sync 2026-06-22. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.242. Last sync 2026-06-23. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-22
+ * Last sync: 2026-06-23
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.242",
+    "date": "2026-06-23",
+    "body": "### Added\n- **OpenAI `prompt_cache_key` cache-routing hint (PR-OPENAI-CACHE-KEY)** — follow-up to the Anthropic cache hardening, on the OpenAI Responses path that GEODE's effective default model (gpt-5.5 / openai-codex) actually uses. OpenAI prompt caching is automatic + already active on both backends (`cached_tokens` flows), so this is the one tuning that wasn't free: `prompt_cache_key` groups same-prefix traffic onto the same cache machine. `build_responses_kwargs` now sets it on **both** the platform Responses API and the Codex subscription backend, keyed on a hash of the **static** system prefix (before `<dynamic_context>`) so the key stays byte-stable across a session's turns (the dynamic suffix — date / recalled memory — must not perturb routing). The Codex backend's acceptance is undocumented (it 400s on `max_output_tokens`), so a **live call was the gate** (PR-NO-FALLBACK rule): a streamed `responses.stream` carrying `prompt_cache_key` returned 200 + usage on 2026-06-23. Kill switch `settings.prompt_cache_key_enabled` (TOML `llm.prompt_cache_key_enabled`, default on). `prompt_cache_retention:\"24h\"` deliberately not sent — it is already default-on for gpt-5.5 and an extra unknown param on the Codex backend. reader: `core/llm/adapters/_openai_common.py:_prompt_cache_key`."
+  },
   {
     "version": "0.99.241",
     "date": "2026-06-23",
@@ -1928,4 +1933,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-06-22";
+export const CHANGELOG_SYNCED_AT = "2026-06-23";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-06-22
+ * Last sync: 2026-06-23
  */
 
 export const GEODE_SOT = {
-  version: "0.99.241",
-  syncedAt: "2026-06-22",
+  version: "0.99.242",
+  syncedAt: "2026-06-23",
 } as const;

--- a/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
+++ b/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
@@ -12,7 +12,8 @@ References:
 
 from __future__ import annotations
 
-from core.llm.adapters._openai_common import build_responses_kwargs
+from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
+from core.llm.adapters._openai_common import _prompt_cache_key, build_responses_kwargs
 from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
 
 
@@ -311,3 +312,45 @@ def test_codex_kwargs_text_format_strict_recurses_into_array_items() -> None:
         _req(response_schema=array_of_open), backend="codex", adapter_name="codex-oauth"
     )
     assert kwargs["text"]["format"]["strict"] is False
+
+
+# --- PR-OPENAI-CACHE-KEY (2026-06-23) — prompt_cache_key routing hint -------
+
+
+def test_prompt_cache_key_set_on_both_backends() -> None:
+    """Both the Codex subscription backend (live-verified 2026-06-23) and the
+    platform Responses API carry the cache-routing key."""
+    for backend in ("codex", "platform"):
+        kwargs = build_responses_kwargs(
+            _req(system_prompt="stable instructions"), backend=backend, adapter_name="x"
+        )
+        assert kwargs["prompt_cache_key"].startswith("geode-")
+
+
+def test_prompt_cache_key_stable_across_dynamic_suffix() -> None:
+    """Keyed on the STATIC prefix (before <dynamic_context>) so a changing
+    dynamic suffix (date / recalled memory) does not perturb the routing key —
+    the whole point of a stable per-session key."""
+    static = "you are geode"
+    a = _prompt_cache_key(f"{static}{PROMPT_CACHE_BOUNDARY}date: monday\nmemory: x")
+    b = _prompt_cache_key(f"{static}{PROMPT_CACHE_BOUNDARY}date: tuesday\nmemory: y")
+    assert a == b
+    assert a.startswith("geode-")
+
+
+def test_prompt_cache_key_differs_on_static_change() -> None:
+    assert _prompt_cache_key("agent A instructions") != _prompt_cache_key("agent B instructions")
+
+
+def test_prompt_cache_key_empty_system_prompt_yields_no_key() -> None:
+    assert _prompt_cache_key("") == ""
+    kwargs = build_responses_kwargs(_req(system_prompt=""), backend="codex", adapter_name="x")
+    assert "prompt_cache_key" not in kwargs
+
+
+def test_prompt_cache_key_kill_switch_omits_key(monkeypatch) -> None:
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "prompt_cache_key_enabled", False, raising=False)
+    kwargs = build_responses_kwargs(_req(system_prompt="x"), backend="codex", adapter_name="x")
+    assert "prompt_cache_key" not in kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.241"
+version = "0.99.242"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Follow-up to PR-ANTHROPIC-CACHE-HARDENING, on the OpenAI Responses path that GEODE's **effective default model** (gpt-5.5 / openai-codex) actually uses.
- `build_responses_kwargs` now sets `prompt_cache_key` on both the platform Responses API and the Codex subscription backend. v0.99.242.

## Why
OpenAI prompt caching is automatic + already active on both backends (`cached_tokens` flows through `_openai_common.py:1078`) — so unlike Anthropic there is no broken cache to fix. `prompt_cache_key` is the one non-free tuning OpenAI documents: it groups same-prefix traffic onto the same cache machine (combined with the prefix hash), improving hit-rate stability. The effective default routes through OpenAI, so this is where the marginal cache win lands.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/_openai_common.py` | `_prompt_cache_key()` — `geode-<sha256(static system prefix)[:16]>`, keyed on the prefix BEFORE `<dynamic_context>` so it stays stable across a session's turns; applied in `build_responses_kwargs` for both backends behind the kill switch. |
| `core/config/_settings.py`, `core/config/__init__.py` | `prompt_cache_key_enabled` (default on; TOML `llm.prompt_cache_key_enabled`). |
| `tests/core/llm/adapters/test_codex_oauth_backend_invariants.py` | both-backends / static-stability / static-change / empty / kill-switch tests (+5). |
| version × 5 + site SoT | 0.99.241 → 0.99.242. |

## External-contract attestation (doc-before-behaviour)
- **Codex subscription backend** acceptance is undocumented (the same backend 400s on `max_output_tokens`), so a **live call was the gate** (PR-NO-FALLBACK rule): a streamed `responses.stream` carrying `prompt_cache_key` returned **200 + usage** on 2026-06-23 (`gpt-5.5`, via GEODE's `build_async_codex_client` + production `build_responses_kwargs`).
- **Platform Responses API** documents `prompt_cache_key`; openai SDK 2.30.0 `Responses.create` exposes it (introspection-verified).
- `prompt_cache_retention:"24h"` deliberately **not** sent — already default-on for gpt-5.5 and an extra unknown param on the Codex backend.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| OpenAI automatic caching | Already exists | `cached_tokens` read at `_openai_common.py:1078`; not broken |
| prompt_cache_key | Implemented | both backends, static-prefix key, kill-switched |
| prompt_cache_retention | Dropped | default-on for gpt-5.5; risky unknown param on Codex |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ scripts/)
- [x] ruff format --check clean
- [x] mypy clean (455 source files)
- [x] lint-imports — 4 contracts kept
- [x] pytest — adapter/config suites pass (new +5); CLI smoke v0.99.242
- [x] Codex MCP review — CLEAN (no findings)
- [x] Codex backend prompt_cache_key acceptance — live-verified 200 + usage (2026-06-23)

## Reference
OpenAI prompt-caching guide (2026-06) · PR-ANTHROPIC-CACHE-HARDENING (#2401) Fix 6 follow-up.