### PR TITLE
release: promote GEODE context skill cleanup

### DIFF
--- a/.geode/skills/geode-context/SKILL.md
+++ b/.geode/skills/geode-context/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: geode-context
 visibility: public
-description: GEODE v0.99.11 runtime and release context. Use for architecture, packaging, release, docs, CI, async runtime, and external plugin boundary questions. "geode", "harness", "agent", "runtime", "release", "packaging", "docs", "plugin" 키워드로 트리거.
+description: GEODE v0.99.247 runtime and release context. Use for architecture, packaging, release, docs, CI, AgenticLoop, async runtime, and external plugin boundary questions. Triggers include "geode", "harness", "agent", "runtime", "release", "packaging", "docs", and "plugin".
 ---
 
-# GEODE v0.99.11 Context
+# GEODE v0.99.247 Context
 
 ## Current Shape
 
-- GEODE is a general-purpose autonomous execution harness on LangGraph.
-- Core runtime is domain-agnostic. Domain analysis packages are distributed separately.
-- Current SOT metrics: v0.99.11, 339 modules, 4,897 standard tests, 24 live tests, 154 releases.
+- GEODE is a general-purpose autonomous-agent harness whose runtime is `AgenticLoop(while tool_use)`.
+- The agent loop, sub-agents, plans, and batches are all modeled as instances of the same tool-use loop.
+- Core runtime is domain-agnostic. Domain analysis packages are distributed separately through plugins or external packages.
+- Current SOT metrics: v0.99.247, 455 modules, 8,854 standard tests, 1 live test.
 - Main packages:
   - `core/` — agent loop, tools, MCP, memory, hooks, wiring, CLI, server, gateway.
-  - `plugins/` — first-party auxiliary plugins only. Bundled Game IP analysis is no longer part of GEODE core.
+  - `plugins/` — first-party auxiliary plugins such as `petri_audit`.
   - `site/` — public Next.js docs/site.
 
 ## Runtime Boundaries
@@ -22,30 +23,30 @@ description: GEODE v0.99.11 runtime and release context. Use for architecture, p
   - agent loop: `AgenticLoop.arun()`
   - tools: `aexecute()`
   - providers: async SDK clients and async tool-use paths
-  - process-edge coroutine execution: `core.async_runtime`
 - Public sync facades were removed or reduced to process-edge compatibility only.
-- `core/agent/loop/agent_loop.py` is the implementation. Legacy loop module paths are compatibility shims only where still present.
+- `core/agent/loop/agent_loop.py` is the implementation. `DEFAULT_MAX_ROUNDS = 0` means unlimited rounds by default; time and termination signals control completion.
+- Auto-escalation was removed in v0.90.0. The model emits explicit termination signals such as `model_action_required` or `user_clarification_needed`.
+- Sub-agent concurrency is managed by `core/agent/subagent.py` with `MAX_CONCURRENT = 5` and `SessionLane` slot allocation.
 
 ## Prompt And Context Injection
 
-- Prompt templates use XML-shaped sections.
-- Static and dynamic context are separated by `<dynamic_context>`.
+- `core/llm/prompt_assembler.py` owns six-step prompt assembly and emits `PROMPT_ASSEMBLED`.
+- `core/agent/system_prompt.py` inserts `__GEODE_PROMPT_CACHE_BOUNDARY__` between STATIC and DYNAMIC blocks.
+- Since v0.93, dynamic context is wrapped in `<dynamic_context>`.
 - Sandwich reminders use XML tags such as `<system-reminder>`.
 - Skill metadata injected into the agent prompt must stay metadata-only and XML-delimited; full skill bodies are loaded on demand.
-- Do not inject old Game IP pipeline facts into the general GEODE system prompt.
+- Do not inject old Game IP pipeline facts, fixed DAG claims, analyst/evaluator topology, or confidence-threshold loop claims into the general GEODE system prompt.
 
 ## Release Pipeline
 
 - Functional commits update `CHANGELOG.md`.
 - Release validation includes:
-  - `uv run ruff check .`
-  - `uv run ruff format --check core plugins tests autoresearch scripts`
-  - `uv run mypy core plugins scripts`
-  - `uv run pytest -q`
-  - `uv run python scripts/check_official_docs.py`
+  - `uv run ruff check core/ tests/ plugins/ scripts/`
+  - `uv run ruff format --check core/ tests/ plugins/ scripts/`
+  - `uv run mypy core/ plugins/ scripts/`
+  - `uv run python -m pytest tests/ -q`
   - `uv build`
-  - `uv run twine check dist/*`
-  - CLI smoke: `uv run geode version`, `uv run geode doctor bootstrap`
+  - install smoke and site build through GitHub Actions when PRs are opened
 - Hugging Face release assets are generated into a versioned bundle with wheel, sdist, checksums, release notes, manifest, repo card, and `latest.json`.
 - Publishing should be manual/approval-gated, not automatic on every main push.
 
@@ -74,5 +75,7 @@ description: GEODE v0.99.11 runtime and release context. Use for architecture, p
 
 - Do not reintroduce `plugins.game_ip` imports into `core/`.
 - Do not make Game IP the default domain for GEODE core.
+- Do not describe GEODE as a fixed Plan-and-Execute DAG, fixed StateGraph, or confidence-threshold pipeline.
 - Do not cite LangSmith as current observability; GEODE uses its own hooks, audit diagnostics, run logs, and site/docs gates.
 - Do not hard-code deprecated model names. Use the provider registries and token/cost tables.
+- For current metrics and version, prefer `site/src/data/geode/sot.ts`, `CLAUDE.md`, and `AGENTS.md` over skill memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **GEODE context skill stale-runtime cleanup.** Refreshed `.geode/skills/geode-context`
+  from the old v0.99.11 / LangGraph-pipeline framing to the current
+  v0.99.247 `AgenticLoop(while tool_use)` runtime shape, and added explicit
+  guardrails against reintroducing fixed-DAG or confidence-threshold pipeline
+  claims into GEODE prompt context.
+
 ## [0.99.247] - 2026-06-24
 
 ### Changed


### PR DESCRIPTION
## Summary
- Promote the GEODE context skill stale-runtime cleanup from `develop` to `main`.
- Updates the project skill context to current AgenticLoop/v0.99.247 wording and records the fix in the changelog.

## Verification
- [x] `main -> develop` pre-sync completed in PR #2426
- [x] `git merge-base --is-ancestor origin/main origin/develop`
- [x] Source PR #2425 CI and Install Smoke Test succeeded
- [x] `git diff --stat origin/main..origin/develop` shows only the intended 2-file cleanup