### PR TITLE
Promote develop to main after reflection hint unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,12 @@ functional change.
   compact cognitive summary from the loaded central snapshot.
 
 ### Fixed
-- **Task-completion Reflexion ordering.** Final turn verify/reflexion now
+- **Reflection hint naming unified.** Verify failure feedback now uses the
+  canonical `reflection_hint` / `<reflection>` surface owned by
+  `core.agent.loop._reflection`, with `reflexion_hint` retained only as a
+  legacy payload/API alias for existing consumers.
+
+- **Task-completion reflection ordering.** Final turn verify/reflection now
   runs before `SESSION_ENDED` / `TURN_COMPLETED` hooks are emitted, and
   those terminal payloads include `turn_verify` when verification is
   enabled. Text-only terminal rounds also pass through the optional

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -261,7 +261,7 @@ def _finalize_verify_outcome(
         mode=vr.mode.value,
         effective_mode=vr.effective_mode.value,
         rubric_misses=vr.rubric_misses,
-        reflexion_hint=vr.reflexion_hint,
+        reflection_hint=vr.reflection_hint,
         should_retry=vr.should_retry,
     )
     _persist_verify_state(loop, metrics, vr.should_retry)
@@ -351,7 +351,7 @@ def finalize_and_return(
 ) -> AgenticResult:
     """Log result, record transcript end, save checkpoint, and return (DRY)."""
     _prepare_final_result(loop, result, user_input, round_idx)
-    # Verify/reflexion belongs to the task-completion boundary. Run it
+    # Verify/reflection belongs to the task-completion boundary. Run it
     # before SESSION_ENDED/TURN_COMPLETED hooks so lifecycle consumers can
     # read the final self-evaluation from the same terminal payload.
     verify_payload = _run_turn_verify(loop, result)
@@ -389,7 +389,7 @@ async def finalize_and_return_async(
 ) -> AgenticResult:
     """Async finalizer for ``AgenticLoop.arun`` hook emission."""
     _prepare_final_result(loop, result, user_input, round_idx)
-    # Verify/reflexion belongs to the task-completion boundary. Run it
+    # Verify/reflection belongs to the task-completion boundary. Run it
     # before SESSION_ENDED/TURN_COMPLETED hooks so lifecycle consumers can
     # read the final self-evaluation from the same terminal payload.
     verify_payload = await _run_turn_verify_async(loop, result)

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -237,6 +237,50 @@ def _apply_reflection(state: CognitiveState, parsed: dict[str, Any]) -> None:
                 del state.subgoals[0 : len(state.subgoals) - 5]
 
 
+# Reason-code -> human-readable failure summary mapping used by final-turn
+# verify. It lives in the reflection module so all next-turn self-feedback
+# prompt material has one canonical owner.
+_FAILURE_REASON_DESCRIPTIONS: dict[str, str] = {
+    "empty_turn": "Last turn produced no text and called no tools.",
+    "short_output": "Last turn returned an unusually short response without tool action.",
+    "tool_error": "A tool call in the last turn failed with an error.",
+    "model_action_required": "The model surfaced a recoverable error (cost, billing, etc.).",
+    "step_expected_mismatch": (
+        "Last turn's output did not contain any keyword from the current "
+        "PlanStep's expected_outcome. Replan may revise the plan."
+    ),
+    "judge_fail": "The turn-level judge rejected the previous turn.",
+}
+
+
+def synthesize_failure_reflection_hint(rubric_misses: tuple[str, ...]) -> str:
+    """Build the final-turn failure reflection block for the next prompt.
+
+    This is the non-LLM sibling of :func:`reflect_async`: verify supplies
+    rubric miss codes, and this renderer turns them into a compact
+    ``<reflection>`` block that the next ``AgenticLoop.arun`` can prepend.
+    The separate ``synthesize_reflexion_hint`` name remains as a legacy
+    alias for older callers and stored telemetry.
+    """
+    if not rubric_misses:
+        return ""
+    lines = ["<reflection>", "Self-evaluation flagged the previous turn:"]
+    for code in rubric_misses:
+        description = _FAILURE_REASON_DESCRIPTIONS.get(code, code)
+        lines.append(f"- {code}: {description}")
+    lines.append(
+        "Next turn: address the flagged item(s) directly. "
+        "If you cannot, say so and ask the user to clarify."
+    )
+    lines.append("</reflection>")
+    return "\n".join(lines)
+
+
+def synthesize_reflexion_hint(rubric_misses: tuple[str, ...]) -> str:
+    """Legacy alias for :func:`synthesize_failure_reflection_hint`."""
+    return synthesize_failure_reflection_hint(rubric_misses)
+
+
 async def reflect_async(
     state: CognitiveState,
     tool_results: list[dict[str, Any]],
@@ -268,7 +312,7 @@ async def reflect_async(
     # escape and break the agentic loop, violating the "errors
     # swallowed at WARN" guarantee).
     try:
-        resolved_provider = provider or _resolve_provider(model)
+        provider = provider or _resolve_provider(model)
         # PR-SOURCE-ROUTING (2026-05-28) — reflection used to hard-code
         # ``"payg"`` so a subscription-only operator (Pattern B) routed
         # the reflection turn through the depleted PAYG endpoint while
@@ -278,15 +322,15 @@ async def reflect_async(
         # default resolution.
         from core.llm.adapters._source_inference import infer_source
 
-        resolved_source = source or infer_source(resolved_provider)
-        adapter = resolve_for(normalize_registry_provider(resolved_provider), resolved_source)
+        resolved_source = source or infer_source(provider)
+        adapter = resolve_for(normalize_registry_provider(provider), resolved_source)
         tool_summary = _summarise_tool_results(tool_results)
         user_prompt = _build_user_prompt(state, tool_summary)
 
         log.info(
             "reflection dispatch: model=%s provider=%s source=%s round=%d max_tokens=%d",
             model,
-            resolved_provider,
+            provider,
             resolved_source,
             state.round_count,
             max_tokens,
@@ -369,4 +413,9 @@ async def reflect_async(
     _apply_reflection(state, parsed)
 
 
-__all__ = ["REFLECTION_TOOL_NAME", "reflect_async"]
+__all__ = [
+    "REFLECTION_TOOL_NAME",
+    "reflect_async",
+    "synthesize_failure_reflection_hint",
+    "synthesize_reflexion_hint",
+]

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -718,13 +718,13 @@ class AgenticLoop:
         self,
         system_prompt: str,
         decomposition_hint: str | None,
-        reflexion_hint: str | None = None,
+        reflection_hint: str | None = None,
     ) -> str:
         """Sync model drift + rebuild the system prompt.
 
         Rebuilds when the model drifted (``settings.model`` changed) or
         ``_prompt_dirty`` is set (direct ``update_model_async``). On
-        rebuild, re-applies the decomposition / reflexion / plan hints so
+        rebuild, re-applies the decomposition / reflection / plan hints so
         a mid-arun drift doesn't drop them. Returns the (possibly-rebuilt)
         prompt; clears ``_prompt_dirty``.
         """
@@ -734,8 +734,8 @@ class AgenticLoop:
             system_prompt = self._build_system_prompt()
             if decomposition_hint:
                 system_prompt += "\n\n" + decomposition_hint
-            if reflexion_hint:
-                system_prompt += "\n\n" + reflexion_hint
+            if reflection_hint:
+                system_prompt += "\n\n" + reflection_hint
             # re-apply the active plan on rebuild (getattr tolerates stub loops)
             _plan_consume = getattr(self, "_consume_plan_hint", None)
             plan_hint = _plan_consume() if callable(_plan_consume) else ""
@@ -924,10 +924,10 @@ class AgenticLoop:
             log.warning("Plan hint consume failed", exc_info=True)
             return ""
 
-    def _consume_reflexion_hint(self) -> str:
-        """Read+clear the verbal-RL hint left by the prior turn.
+    def _consume_reflection_hint(self) -> str:
+        """Read+clear the failure-reflection hint left by the prior turn.
 
-        Returns the ``<reflexion>...</reflexion>`` block from the prior
+        Returns the ``<reflection>...</reflection>`` block from the prior
         turn's verify FAIL, else empty (verify passed / didn't run).
         Read+clear is asyncio-task safe (no ``await`` between); a threaded
         race only risks a duplicate prepend, not data loss. Failures NEVER
@@ -940,13 +940,17 @@ class AgenticLoop:
             from core.observability.session_metrics import current_session_metrics
 
             metrics = current_session_metrics()
-            hint = metrics.last_verify_reflexion_hint
+            hint = metrics.last_verify_reflection_hint
             if hint:
-                metrics.last_verify_reflexion_hint = ""
+                metrics.last_verify_reflection_hint = ""
             return hint
         except Exception:
-            log.warning("Reflexion hint consume failed", exc_info=True)
+            log.warning("Reflection hint consume failed", exc_info=True)
             return ""
+
+    def _consume_reflexion_hint(self) -> str:
+        """Legacy alias for :meth:`_consume_reflection_hint`."""
+        return AgenticLoop._consume_reflection_hint(self)
 
     def _maybe_start_session_budget(self) -> None:
         """Begin the session-wide wall-clock budget if not already started.
@@ -1219,11 +1223,11 @@ class AgenticLoop:
         if decomposition_hint:
             system_prompt += "\n\n" + decomposition_hint
 
-        # Reflexion hint injection — prepend the prior turn's verify-FAIL
+        # Failure reflection injection — prepend the prior turn's verify-FAIL
         # analysis (consume semantics; cleared after read).
-        reflexion_hint = self._consume_reflexion_hint()
-        if reflexion_hint:
-            system_prompt += "\n\n" + reflexion_hint
+        reflection_hint = self._consume_reflection_hint()
+        if reflection_hint:
+            system_prompt += "\n\n" + reflection_hint
 
         # Plan injection — render the current-step ``<plan>`` block
         # (read-only consume; plan persists until advance / replan).
@@ -1258,7 +1262,7 @@ class AgenticLoop:
             await self._maybe_replan_async(round_idx)
 
             system_prompt = await self._sync_model_and_rebuild_prompt(
-                system_prompt, decomposition_hint, reflexion_hint=reflexion_hint
+                system_prompt, decomposition_hint, reflection_hint=reflection_hint
             )
 
             # Poll for sub-agent announced results (OpenClaw Spawn+Announce)

--- a/core/agent/verify.py
+++ b/core/agent/verify.py
@@ -1,4 +1,4 @@
-"""In-loop verify (Reflexion-style) for AgenticLoop turns.
+"""In-loop verify for AgenticLoop turns.
 
 Per-turn verification of agent action quality. Fires once per turn at the
 TURN_COMPLETED boundary so it does not interrupt mid-turn execution. The
@@ -19,8 +19,8 @@ When a verify check FAILs, the result includes:
 
 - ``rubric_misses``: tuple of short reason codes (e.g. ``"empty_turn"``,
   ``"tool_error"``).
-- ``reflexion_hint``: a ready-to-inject ``<reflexion>...</reflexion>``
-  block (verbal RL pattern, Reflexion paper NeurIPS 2023). Callers
+- ``reflection_hint``: a ready-to-inject ``<reflection>...</reflection>``
+  block (verbal-RL pattern, Reflexion paper NeurIPS 2023). Callers
   prepend this to the next round's ``loop._system_suffix`` so the model
   sees its own failure analysis next turn.
 
@@ -42,6 +42,11 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from core.agent.loop._reflection import (
+    synthesize_failure_reflection_hint,
+    synthesize_reflexion_hint,
+)
+
 if TYPE_CHECKING:
     from core.agent.loop.models import AgenticResult
 
@@ -52,9 +57,13 @@ __all__ = [
     "VerifyMode",
     "VerifyResult",
     "get_verify_mode",
+    "synthesize_failure_reflection_hint",
+    "synthesize_reflection_hint",
     "synthesize_reflexion_hint",
     "verify_turn",
 ]
+
+synthesize_reflection_hint = synthesize_failure_reflection_hint
 
 
 class VerifyMode(StrEnum):
@@ -84,7 +93,7 @@ _RETRYABLE_MISSES: frozenset[str] = frozenset(
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class VerifyResult:
     """Outcome of a single per-turn verify pass.
 
@@ -100,7 +109,7 @@ class VerifyResult:
     - ``score``: 0.0–1.0 numeric score. ``rule_based`` returns 1.0 on pass,
       0.0 on fail (no gradation). ``llm_judge`` returns the judge's score.
     - ``rubric_misses``: short reason codes for failed checks. Empty on pass.
-    - ``reflexion_hint``: ready-to-inject system-suffix block for the next
+    - ``reflection_hint``: ready-to-inject system-suffix block for the next
       round. Empty when passed.
     - ``ts``: monotonic timestamp when the verify ran (for ordering).
     """
@@ -109,7 +118,7 @@ class VerifyResult:
     mode: VerifyMode
     score: float = 1.0
     rubric_misses: tuple[str, ...] = ()
-    reflexion_hint: str = ""
+    reflection_hint: str = ""
     ts: float = 0.0
     # ``effective_mode`` differs from ``mode`` when the requested mode
     # falls back to a different implementation. Today the only fallback
@@ -119,11 +128,38 @@ class VerifyResult:
     # ``should_retry`` is the machine-readable replan signal for PR-CL-A1
     # (Dynamic Replan) — agentic-loop-evolution.md A3 spec calls for a
     # "pass / fail / retry" signal, distinct from the human-readable
-    # ``reflexion_hint`` (Codex MCP MEDIUM #4, 2026-05-23). Set True when
+    # ``reflection_hint`` (Codex MCP MEDIUM #4, 2026-05-23). Set True when
     # a verify failure is recoverable (any rubric_miss is in the
     # ``_RETRYABLE_MISSES`` allowlist); set False on a hard fail (e.g.
     # ``model_action_required`` indicates operator intervention needed).
     should_retry: bool = False
+
+    def __init__(
+        self,
+        passed: bool,
+        mode: VerifyMode,
+        score: float = 1.0,
+        rubric_misses: tuple[str, ...] = (),
+        reflection_hint: str = "",
+        ts: float = 0.0,
+        effective_mode: VerifyMode = VerifyMode.RULE_BASED,
+        should_retry: bool = False,
+        reflexion_hint: str | None = None,
+    ) -> None:
+        hint = reflection_hint if reflexion_hint is None else reflexion_hint
+        object.__setattr__(self, "passed", passed)
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "score", score)
+        object.__setattr__(self, "rubric_misses", rubric_misses)
+        object.__setattr__(self, "reflection_hint", hint)
+        object.__setattr__(self, "ts", ts)
+        object.__setattr__(self, "effective_mode", effective_mode)
+        object.__setattr__(self, "should_retry", should_retry)
+
+    @property
+    def reflexion_hint(self) -> str:
+        """Legacy alias for callers that still use the paper spelling."""
+        return self.reflection_hint
 
     def to_payload(self) -> dict[str, Any]:
         """Render as a hook-payload-friendly dict."""
@@ -133,7 +169,8 @@ class VerifyResult:
             "effective_mode": self.effective_mode.value,
             "score": round(self.score, 4),
             "rubric_misses": list(self.rubric_misses),
-            "reflexion_hint": self.reflexion_hint,
+            "reflection_hint": self.reflection_hint,
+            "reflexion_hint": self.reflection_hint,
             "should_retry": self.should_retry,
             "ts": self.ts,
         }
@@ -255,7 +292,7 @@ def _verify_rule_based(result: AgenticResult) -> VerifyResult:
         misses.append("step_expected_mismatch")
 
     passed = not misses
-    hint = "" if passed else synthesize_reflexion_hint(tuple(misses))
+    hint = "" if passed else synthesize_failure_reflection_hint(tuple(misses))
     # Retry signal: hard-fail (e.g. ``model_action_required``) ALWAYS
     # wins — even if a retryable miss (e.g. ``step_expected_mismatch``)
     # co-occurs, the operator-action signal should not be ignored
@@ -270,50 +307,10 @@ def _verify_rule_based(result: AgenticResult) -> VerifyResult:
         effective_mode=VerifyMode.RULE_BASED,
         score=1.0 if passed else 0.0,
         rubric_misses=tuple(misses),
-        reflexion_hint=hint,
+        reflection_hint=hint,
         should_retry=retry,
         ts=time.monotonic(),
     )
-
-
-# Reason-code → human-readable failure summary mapping used by
-# ``synthesize_reflexion_hint``. Kept module-local so reason codes stay
-# in lock-step with hint text and downstream test harnesses can lift the
-# table to assert on phrasing.
-_REASON_DESCRIPTIONS: dict[str, str] = {
-    "empty_turn": "Last turn produced no text and called no tools.",
-    "short_output": "Last turn returned an unusually short response without tool action.",
-    "tool_error": "A tool call in the last turn failed with an error.",
-    "model_action_required": "The model surfaced a recoverable error (cost, billing, etc.).",
-    "step_expected_mismatch": (
-        "Last turn's output did not contain any keyword from the current "
-        "PlanStep's expected_outcome. PR-CL-A1 replan may revise the plan."
-    ),
-}
-
-
-def synthesize_reflexion_hint(rubric_misses: tuple[str, ...]) -> str:
-    """Build the ``<reflexion>...</reflexion>`` system-suffix block.
-
-    Verbal RL — the agent reads its own failure analysis at the start of
-    the next round. The block is concise (3 lines per miss max) to avoid
-    crowding the system prompt; longer rubrics live in the LLM-judge mode.
-
-    Returns the empty string when no misses are supplied so callers can
-    cheaply skip the suffix mutation on pass.
-    """
-    if not rubric_misses:
-        return ""
-    lines = ["<reflexion>", "Self-evaluation flagged the previous turn:"]
-    for code in rubric_misses:
-        description = _REASON_DESCRIPTIONS.get(code, code)
-        lines.append(f"- {code}: {description}")
-    lines.append(
-        "Next turn: address the flagged item(s) directly. "
-        "If you cannot, say so and ask the user to clarify."
-    )
-    lines.append("</reflexion>")
-    return "\n".join(lines)
 
 
 _LLM_JUDGE_SYSTEM_PROMPT = """\
@@ -388,7 +385,7 @@ def _build_judge_result_from_response(response: Any, result: AgenticResult) -> V
     hint = ""
     if not passed:
         misses = ("judge_fail",) if not reason else ("judge_fail", reason[:40])
-        hint = synthesize_reflexion_hint(("judge_fail",)) + (
+        hint = synthesize_failure_reflection_hint(("judge_fail",)) + (
             f"\nJudge reason: {reason}" if reason else ""
         )
     return VerifyResult(
@@ -397,7 +394,7 @@ def _build_judge_result_from_response(response: Any, result: AgenticResult) -> V
         effective_mode=VerifyMode.LLM_JUDGE,
         score=score,
         rubric_misses=misses,
-        reflexion_hint=hint,
+        reflection_hint=hint,
         should_retry=(not passed),
         ts=time.monotonic(),
     )
@@ -513,7 +510,7 @@ def _llm_judge_fallback(result: AgenticResult) -> VerifyResult:
         effective_mode=VerifyMode.RULE_BASED,
         score=rb.score,
         rubric_misses=rb.rubric_misses,
-        reflexion_hint=rb.reflexion_hint,
+        reflection_hint=rb.reflection_hint,
         should_retry=rb.should_retry,
         ts=rb.ts,
     )

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -157,9 +157,7 @@ AGENT_ROLES: list[AgentRole] = [
         env_var="GEODE_COGNITIVE_REFLECTION_MODEL",
         toml_section="cognitive",
         toml_key="reflection_model",
-        description=(
-            "Reflection override - empty inherits the main agentic loop model/source"
-        ),
+        description=("Reflection override - empty inherits the main agentic loop model/source"),
         has_effort=False,
     ),
     # PR-G2 (2026-05-21) — self-improving loop mutator role. Unlike

--- a/core/cli/commands/session.py
+++ b/core/cli/commands/session.py
@@ -121,9 +121,7 @@ def cmd_resume(args: str) -> SessionState | None:
         label = s.user_input[:50] if s.user_input else "(no input)"
         cognitive_summary = _format_cognitive_state_summary(s.cognitive_state)
         suffix = f" | {cognitive_summary}" if cognitive_summary else ""
-        _pkg.console.print(
-            f"  {i}. [bold]{s.session_id}[/bold] [{s.status}] {age_str}{suffix}"
-        )
+        _pkg.console.print(f"  {i}. [bold]{s.session_id}[/bold] [{s.status}] {age_str}{suffix}")
         _pkg.console.print(f"     [muted]{label}[/muted]")
     _pkg.console.print()
     _pkg.console.print("  [muted]Usage: /resume <session_id>[/muted]")

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -269,7 +269,8 @@ class HookEvent(Enum):
     # (Dynamic Replan) can read them to decide whether to replan the
     # next round. Payload schema:
     #   {"passed": bool, "mode": str, "score": float,
-    #    "rubric_misses": list[str], "reflexion_hint": str, "ts": float}
+    #    "rubric_misses": list[str], "reflection_hint": str,
+    #    "reflexion_hint": str, "ts": float}
     TURN_VERIFY_PASSED = "turn_verify_passed"
     TURN_VERIFY_FAILED = "turn_verify_failed"
 

--- a/core/observability/session_metrics.py
+++ b/core/observability/session_metrics.py
@@ -175,9 +175,9 @@ class SessionMetrics:
         default_factory=threading.Lock, repr=False, compare=False
     )
 
-    # J. Per-turn verify telemetry (PR-CL-A3, 2026-05-23) — feeds the
-    #    Dynamic Replan path (PR-CL-A1) and supplies the verbal-RL hint
-    #    callers prepend to the next round's ``loop._system_suffix``.
+    # J. Per-turn verify telemetry — feeds the Dynamic Replan path and
+    #    supplies the failure-reflection hint callers prepend to the next
+    #    round's system prompt.
     #    ``last_verify_passed`` defaults to True so a session with no
     #    verify runs reads as "clean" (no false replan signal).
     verify_pass_count: int = 0
@@ -188,7 +188,7 @@ class SessionMetrics:
     # may fall back to RULE_BASED until PR-CL-A6 lands; preserves the
     # distinction in sessions.jsonl telemetry — Codex MCP follow-up #1)
     last_verify_rubric_misses: tuple[str, ...] = ()
-    last_verify_reflexion_hint: str = ""
+    last_verify_reflection_hint: str = ""
     last_verify_should_retry: bool = False  # PR-CL-A3 — machine-readable replan signal
 
     # K. Active execution plan (PR-CL-A1, 2026-05-23) — the explicit
@@ -320,15 +320,16 @@ class SessionMetrics:
         mode: str,
         effective_mode: str = "",
         rubric_misses: tuple[str, ...] = (),
-        reflexion_hint: str = "",
+        reflection_hint: str = "",
+        reflexion_hint: str | None = None,
         should_retry: bool = False,
     ) -> None:
         """Record one per-turn verify outcome.
 
         Increments pass/fail counters + stores the *latest* miss list and
-        reflexion hint. The next-turn caller reads
-        ``last_verify_reflexion_hint`` to decide whether to prepend a
-        reflexion block to ``loop._system_suffix`` (verbal RL pattern).
+        reflection hint. The next-turn caller reads
+        ``last_verify_reflection_hint`` to decide whether to prepend a
+        failure-reflection block to the system prompt.
 
         ``mode`` is the operator-requested mode (e.g. ``llm_judge``);
         ``effective_mode`` is the path that actually ran (e.g. ``rule_based``
@@ -343,8 +344,18 @@ class SessionMetrics:
         self.last_verify_mode = str(mode)
         self.last_verify_effective_mode = str(effective_mode or mode)
         self.last_verify_rubric_misses = tuple(rubric_misses)
-        self.last_verify_reflexion_hint = str(reflexion_hint)
+        hint = reflection_hint if reflexion_hint is None else reflexion_hint
+        self.last_verify_reflection_hint = str(hint)
         self.last_verify_should_retry = bool(should_retry)
+
+    @property
+    def last_verify_reflexion_hint(self) -> str:
+        """Legacy alias for ``last_verify_reflection_hint``."""
+        return self.last_verify_reflection_hint
+
+    @last_verify_reflexion_hint.setter
+    def last_verify_reflexion_hint(self, value: str) -> None:
+        self.last_verify_reflection_hint = str(value)
 
     def set_active_plan(self, plan: Any, *, reset_attempts: bool = False) -> None:
         """PR-CL-A1 — install or replace the active execution plan.

--- a/site/src/app/portfolio/versions/v1/components-snapshot/sections/verification.tsx
+++ b/site/src/app/portfolio/versions/v1/components-snapshot/sections/verification.tsx
@@ -15,9 +15,9 @@ const pipelineLayers = [
   {
     tier: 2,
     title: "Turn Verify",
-    items: ["rule_based", "llm_judge opt-in", "reflexion"],
+    items: ["rule_based", "llm_judge opt-in", "reflection hint"],
     accent: "#818CF8",
-    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflexion/replan 신호로 넘깁니다.",
+    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflection/replan 신호로 넘깁니다.",
   },
   {
     tier: 3,

--- a/site/src/app/portfolio/versions/v2/components-snapshot/sections/verification.tsx
+++ b/site/src/app/portfolio/versions/v2/components-snapshot/sections/verification.tsx
@@ -15,9 +15,9 @@ const pipelineLayers = [
   {
     tier: 2,
     title: "Turn Verify",
-    items: ["rule_based", "llm_judge opt-in", "reflexion"],
+    items: ["rule_based", "llm_judge opt-in", "reflection hint"],
     accent: "#818CF8",
-    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflexion/replan 신호로 넘깁니다.",
+    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflection/replan 신호로 넘깁니다.",
   },
   {
     tier: 3,

--- a/site/src/app/portfolio/versions/v3/components-snapshot/sections/verification.tsx
+++ b/site/src/app/portfolio/versions/v3/components-snapshot/sections/verification.tsx
@@ -15,9 +15,9 @@ const pipelineLayers = [
   {
     tier: 2,
     title: "Turn Verify",
-    items: ["rule_based", "llm_judge opt-in", "reflexion"],
+    items: ["rule_based", "llm_judge opt-in", "reflection hint"],
     accent: "#818CF8",
-    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflexion/replan 신호로 넘깁니다.",
+    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflection/replan 신호로 넘깁니다.",
   },
   {
     tier: 3,

--- a/site/src/app/portfolio/versions/v4/components-snapshot/sections/verification.tsx
+++ b/site/src/app/portfolio/versions/v4/components-snapshot/sections/verification.tsx
@@ -15,9 +15,9 @@ const pipelineLayers = [
   {
     tier: 2,
     title: "Turn Verify",
-    items: ["rule_based", "llm_judge opt-in", "reflexion"],
+    items: ["rule_based", "llm_judge opt-in", "reflection hint"],
     accent: "#818CF8",
-    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflexion/replan 신호로 넘깁니다.",
+    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflection/replan 신호로 넘깁니다.",
   },
   {
     tier: 3,

--- a/site/src/app/portfolio/versions/v5/components-snapshot/sections/verification.tsx
+++ b/site/src/app/portfolio/versions/v5/components-snapshot/sections/verification.tsx
@@ -15,9 +15,9 @@ const pipelineLayers = [
   {
     tier: 2,
     title: "Turn Verify",
-    items: ["rule_based", "llm_judge opt-in", "reflexion"],
+    items: ["rule_based", "llm_judge opt-in", "reflection hint"],
     accent: "#818CF8",
-    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflexion/replan 신호로 넘깁니다.",
+    description: "턴 경계에서 구조 검증을 실행하고, 재시도 가능한 실패는 다음 턴의 reflection/replan 신호로 넘깁니다.",
   },
   {
     tier: 3,

--- a/tests/core/agent/test_model_split.py
+++ b/tests/core/agent/test_model_split.py
@@ -246,7 +246,7 @@ def test_verify_llm_judge_judge_fail_records_misses(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Judge FAIL response → ``passed=False`` + ``judge_fail`` rubric_miss
-    + reflexion_hint includes judge's reason."""
+    + reflection_hint includes judge's reason."""
     fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
     monkeypatch.setattr("core.config.settings", fake_settings)
 
@@ -263,7 +263,7 @@ def test_verify_llm_judge_judge_fail_records_misses(
     assert vr.effective_mode is VerifyMode.LLM_JUDGE
     assert "judge_fail" in vr.rubric_misses
     assert vr.should_retry is True
-    assert "tool error masked the goal" in vr.reflexion_hint
+    assert "tool error masked the goal" in vr.reflection_hint
 
 
 def test_verify_llm_judge_falls_back_when_no_loop() -> None:

--- a/tests/core/agent/test_verify.py
+++ b/tests/core/agent/test_verify.py
@@ -1,4 +1,4 @@
-"""Unit tests for :mod:`core.agent.verify` — per-turn verify (Reflexion).
+"""Unit tests for :mod:`core.agent.verify` — per-turn verify.
 
 Coverage:
 - ``VerifyMode`` StrEnum values
@@ -6,10 +6,10 @@ Coverage:
 - ``get_verify_mode`` env knob parsing (default + override + invalid fallback)
 - ``_verify_rule_based`` catches: empty_turn, short_output, tool_error,
   model_action_required
-- ``synthesize_reflexion_hint`` renders the verbal-RL block + empty on no misses
+- ``synthesize_reflection_hint`` renders the failure-reflection block
 - ``verify_turn`` dispatcher: OFF / RULE_BASED / LLM_JUDGE (stub-falls-back)
-- SessionMetrics integration: ``record_verify`` + ``last_verify_reflexion_hint``
-- AgenticLoop hint consumption: ``_consume_reflexion_hint`` reads+clears
+- SessionMetrics integration: ``record_verify`` + ``last_verify_reflection_hint``
+- AgenticLoop hint consumption: ``_consume_reflection_hint`` reads+clears
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ from core.agent.verify import (
     VerifyMode,
     VerifyResult,
     get_verify_mode,
+    synthesize_reflection_hint,
     synthesize_reflexion_hint,
     verify_turn,
 )
@@ -78,15 +79,27 @@ def test_verify_result_to_payload() -> None:
         mode=VerifyMode.RULE_BASED,
         score=0.0,
         rubric_misses=("empty_turn",),
-        reflexion_hint="<reflexion>...</reflexion>",
+        reflection_hint="<reflection>...</reflection>",
         ts=123.4,
     )
     payload = vr.to_payload()
     assert payload["passed"] is False
     assert payload["mode"] == "rule_based"
     assert payload["rubric_misses"] == ["empty_turn"]
-    assert payload["reflexion_hint"].startswith("<reflexion>")
+    assert payload["reflection_hint"].startswith("<reflection>")
+    assert payload["reflexion_hint"] == payload["reflection_hint"]
     assert payload["score"] == 0.0
+
+
+def test_verify_result_accepts_reflexion_hint_legacy_kwarg() -> None:
+    """The constructor accepts the old spelling while storing canonical state."""
+    vr = VerifyResult(
+        passed=False,
+        mode=VerifyMode.RULE_BASED,
+        reflexion_hint="<reflection>legacy</reflection>",
+    )
+    assert vr.reflection_hint == "<reflection>legacy</reflection>"
+    assert vr.reflexion_hint == vr.reflection_hint
 
 
 # -- Mode resolution ----------------------------------------------------
@@ -134,7 +147,8 @@ def test_rule_based_flags_empty_turn() -> None:
     vr = verify_turn(result)
     assert vr.passed is False
     assert "empty_turn" in vr.rubric_misses
-    assert vr.reflexion_hint.startswith("<reflexion>")
+    assert vr.reflection_hint.startswith("<reflection>")
+    assert vr.reflexion_hint == vr.reflection_hint
 
 
 def test_rule_based_flags_short_output() -> None:
@@ -186,20 +200,25 @@ def test_rule_based_min_chars_env_override(monkeypatch: pytest.MonkeyPatch) -> N
     assert "short_output" in vr.rubric_misses
 
 
-# -- Reflexion hint -----------------------------------------------------
+# -- Reflection hint ----------------------------------------------------
 
 
 def test_synthesize_hint_empty_on_no_misses() -> None:
-    assert synthesize_reflexion_hint(()) == ""
+    assert synthesize_reflection_hint(()) == ""
 
 
 def test_synthesize_hint_includes_reason_codes() -> None:
     """Each rubric_miss code surfaces in the hint body."""
-    hint = synthesize_reflexion_hint(("empty_turn", "tool_error"))
-    assert hint.startswith("<reflexion>")
-    assert hint.endswith("</reflexion>")
+    hint = synthesize_reflection_hint(("empty_turn", "tool_error"))
+    assert hint.startswith("<reflection>")
+    assert hint.endswith("</reflection>")
     assert "empty_turn" in hint
     assert "tool_error" in hint
+
+
+def test_synthesize_reflexion_hint_legacy_alias() -> None:
+    """Older callers using the paper spelling get the canonical block."""
+    assert synthesize_reflexion_hint(("empty_turn",)).startswith("<reflection>")
 
 
 # -- Mode dispatch ------------------------------------------------------
@@ -238,7 +257,7 @@ def test_record_verify_pass() -> None:
         assert m.verify_pass_count == 1
         assert m.verify_fail_count == 0
         assert m.last_verify_passed is True
-        assert m.last_verify_reflexion_hint == ""
+        assert m.last_verify_reflection_hint == ""
 
 
 def test_record_verify_fail() -> None:
@@ -248,12 +267,13 @@ def test_record_verify_fail() -> None:
             passed=False,
             mode="rule_based",
             rubric_misses=("empty_turn",),
-            reflexion_hint="<reflexion>x</reflexion>",
+            reflection_hint="<reflection>x</reflection>",
         )
         assert m.verify_fail_count == 1
         assert m.last_verify_passed is False
         assert m.last_verify_rubric_misses == ("empty_turn",)
-        assert m.last_verify_reflexion_hint == "<reflexion>x</reflexion>"
+        assert m.last_verify_reflection_hint == "<reflection>x</reflection>"
+        assert m.last_verify_reflexion_hint == m.last_verify_reflection_hint
 
 
 def test_session_row_exposes_verify_telemetry() -> None:
@@ -268,24 +288,34 @@ def test_session_row_exposes_verify_telemetry() -> None:
         assert row["last_verify_rubric_misses"] == ["empty_turn"]
 
 
-# -- AgenticLoop reflexion-hint consume --------------------------------
+# -- AgenticLoop reflection-hint consume -------------------------------
 
 
-def test_consume_reflexion_hint_clears_after_read() -> None:
-    """``_consume_reflexion_hint`` returns the hint then leaves an empty slot
+def test_consume_reflection_hint_clears_after_read() -> None:
+    """``_consume_reflection_hint`` returns the hint then leaves an empty slot
     so the same hint can't be injected into two consecutive arun's."""
     from core.agent.loop.agent_loop import AgenticLoop
 
     with session_metrics_scope(session_id="t-consume"):
-        current_session_metrics().last_verify_reflexion_hint = "<reflexion>z</reflexion>"
-        consume = AgenticLoop._consume_reflexion_hint.__get__(
+        current_session_metrics().last_verify_reflection_hint = "<reflection>z</reflection>"
+        consume = AgenticLoop._consume_reflection_hint.__get__(
             object(), object
         )  # bind to a bare stub
-        assert consume() == "<reflexion>z</reflexion>"
+        assert consume() == "<reflection>z</reflection>"
         # Second call yields empty.
         assert consume() == ""
         # Stored value also cleared.
-        assert current_session_metrics().last_verify_reflexion_hint == ""
+        assert current_session_metrics().last_verify_reflection_hint == ""
+
+
+def test_consume_reflexion_hint_legacy_alias() -> None:
+    """The old AgenticLoop method name remains as an alias."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    with session_metrics_scope(session_id="t-consume-legacy"):
+        current_session_metrics().last_verify_reflection_hint = "<reflection>z</reflection>"
+        consume = AgenticLoop._consume_reflexion_hint.__get__(object(), object)
+        assert consume() == "<reflection>z</reflection>"
 
 
 def test_verify_turn_crash_treats_as_pass() -> None:
@@ -335,9 +365,9 @@ def test_rule_based_multi_miss_combination() -> None:
     assert "tool_error" in multi_vr.rubric_misses
     assert "model_action_required" in multi_vr.rubric_misses
     assert len(multi_vr.rubric_misses) >= 2
-    # Reflexion hint surfaces both codes.
-    assert "tool_error" in multi_vr.reflexion_hint
-    assert "model_action_required" in multi_vr.reflexion_hint
+    # Reflection hint surfaces both codes.
+    assert "tool_error" in multi_vr.reflection_hint
+    assert "model_action_required" in multi_vr.reflection_hint
 
 
 def test_effective_mode_distinguishes_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -378,7 +408,7 @@ def test_lifecycle_finalize_sync_records_verify(monkeypatch: pytest.MonkeyPatch)
         assert "empty_turn" in payload["rubric_misses"]
         m = current_session_metrics()
         assert m.verify_fail_count == 1
-        assert m.last_verify_reflexion_hint.startswith("<reflexion>")
+        assert m.last_verify_reflection_hint.startswith("<reflection>")
 
 
 def test_lifecycle_run_turn_verify_off_mode_skips(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -398,7 +428,7 @@ def test_lifecycle_run_turn_verify_off_mode_skips(monkeypatch: pytest.MonkeyPatc
 
 
 def test_finalizers_run_verify_before_lifecycle_hooks() -> None:
-    """Reflexion runs at the task-completion boundary before terminal
+    """Reflection verification runs at the task-completion boundary before terminal
     lifecycle hooks are emitted."""
     from core.agent.loop import _lifecycle
 
@@ -417,7 +447,7 @@ def test_final_hook_payloads_include_verify_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SESSION_ENDED and TURN_COMPLETED payloads carry the final verify
-    result when verify/reflexion is enabled."""
+    result when verify/reflection is enabled."""
     from types import SimpleNamespace
 
     from core.agent.loop import _lifecycle

--- a/tests/integration/test_session_resume.py
+++ b/tests/integration/test_session_resume.py
@@ -81,7 +81,10 @@ class TestCmdResume:
             }
         )
 
-        assert summary == "round=4 | confidence=0.81 | last=tools: read_file, search_files | hypotheses=2"
+        assert (
+            summary
+            == "round=4 | confidence=0.81 | last=tools: read_file, search_files | hypotheses=2"
+        )
 
     def test_parse_last_flag(self) -> None:
         remaining, limit = _parse_last_flag(["abc", "--last", "3"])


### PR DESCRIPTION
## Summary
- Promote develop after PR #2428: verify failure hints now use canonical Reflection naming and `<reflection>` prompt tags.
- Includes CI-ratchet formatting cleanup required by the repository-wide format check.

## Ratchet
- Feature PR #2428 passed CI, Install Smoke Test, and Pages before merge into develop.
- This PR exists to run the same main-target checks before promotion.