### PR TITLE
Planner progress UX and model inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **Non-blocking progress plans.** GEODE now exposes an `update_plan` tool
+  modelled on Codex's per-turn checklist: it renders a concise
+  pending/in-progress/completed plan for the current task, does not write to
+  `.geode/plans.json`, and does not wait for approval. `create_plan` /
+  `approve_plan` remain available for explicit review checkpoints.
+
 - **CognitiveState checkpoint resume unit.** `SessionCheckpoint` now persists the
   cognitive-loop snapshot alongside messages/tool logs, `AgenticLoop` writes its
   live `CognitiveState` into every checkpoint, and IPC resume restores the loop's
@@ -57,6 +63,20 @@ functional change.
   append-only `COGNITIVE_*` event stream; checkpoint load now reads that store
   before falling back to the legacy `state.json` cache. `/resume` now renders a
   compact cognitive summary from the loaded central snapshot.
+
+### Changed
+- **Plan-first no longer means approval-first.** The router prompt and tool
+  descriptions now direct routine multi-step work to `update_plan` and
+  continued execution. `create_plan` is scoped to user-requested review or
+  unusual risk/resource checkpoints, so normal planning does not become a
+  natural-language permission loop.
+
+- **Planner model split removed.** Initial decomposition and dynamic replan now
+  call the active `AgenticLoop` model directly. The live `plan_model`
+  setting, `GEODE_PLAN_MODEL` env key, and `llm.plan_model` TOML mapping were
+  removed so planning cannot silently diverge into a separate planner-model
+  lane. `act_model` and `judge_model` remain available for their distinct
+  runtime roles.
 
 ### Fixed
 - **Reflection hint naming unified.** Verify failure feedback now uses the

--- a/GEODE.md
+++ b/GEODE.md
@@ -6,7 +6,7 @@
 
 ## Identity
 
-You are GEODE, a general-purpose autonomous execution agent built on a `while(tool_use)` loop. You read a request in natural language, pick and invoke the right tool from the 59 available, observe the result, and decide the next action — repeating until the task is actually done.
+You are GEODE, a general-purpose autonomous execution agent built on a `while(tool_use)` loop. You read a request in natural language, pick and invoke the right tool from the 60 available, observe the result, and decide the next action — repeating until the task is actually done.
 
 You specialize in multi-step, exploratory work: research, web investigation, document analysis, automation, scheduling, and long tool chains that a single answer cannot cover. You act on one operator's behalf, on their machine — closer to a capable personal operator than a chat assistant.
 
@@ -63,7 +63,7 @@ SELF-IMPROVING: train.py (mutation surface + loop) ← measure / fitness / gate 
                 ← loop/{mutate, observe, inject}
 AGENT:    AgenticLoop (while tool_use), SubAgentManager, CLIPoller, Gateway
 HARNESS:  SessionLane, LaneQueue(global:50), PolicyChain, TaskGraph, HookSystem(63 events)
-RUNTIME:  ToolRegistry(59), MCP Registry, Skills, Memory(5-Tier), Reports
+RUNTIME:  ToolRegistry(60), MCP Registry, Skills, Memory(5-Tier), Reports
 MODEL:    ClaudeAdapter, OpenAIAdapter, GLMAdapter (3-provider routing)
 ```
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ geode update                  # source checkout
 | **Agentic tools + MCP catalog** | Web search, file ops, scheduling, memory, calendar, Slack/Discord, Korean job-board search, plus the Anthropic-published MCP registry (cached at `~/.geode/mcp/registry-cache.json`). Auto-installed on first use |
 | **3-provider failover** | Anthropic + OpenAI + ZhipuAI. ChatGPT / Claude subscription OAuth auto-detected; pay-as-you-go API keys also work; failover is in-provider only (no surprise cross-vendor charges, v0.53.0 governance) |
 | **5-tier memory** | SOUL (0) → User Profile (0.5) → Organization (1) → Project (2) → Session (3). Persistent, survives daemon restarts |
-| **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` for multi-step work. Disk-persistent (`.geode/plans.json`), survives restarts |
+| **Progress plans + review checkpoints** | `update_plan` shows a Codex-style per-turn checklist without blocking execution. `create_plan` + `approve_plan` remain for explicit review checkpoints, persisted in `.geode/plans.json` |
 | **MCP server (`geode-mcp`)** | Exposes GEODE itself as an MCP server (stdio): `run_agent`, `self_improving_status`, `self_improving_propose`/`apply` (2-step confirm gate), `query_memory`, `get_health`. Registered for Claude Code via the repo-shipped `.mcp.json` |
 | **Long-running daemon** | `geode serve` runs as background daemon. Slack / Discord / Telegram pollers + scheduler tick + IPC for the thin CLI |
 | **Sub-agents** | Full inheritance of parent capability, depth/cost guards, isolation by Lane |
@@ -455,7 +455,7 @@ A qualitative read on where GEODE sits next to the frontier harnesses (Claude Co
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
 | Memory tiers | ✅ CLAUDE.md merge + auto memory (`~/.claude/projects/*/memory`) | ✅ hierarchical AGENTS.md (global `~/.codex/` + repo + nested dirs) | ⚠️ session-scoped | ✅✅ **multi-tier** (SOUL · User · Org · Project · Session) |
-| Disk-persistent plans | ✅ TodoWrite persistence | ⚠️ via resumable threads | ✅ task registry | ✅ `.geode/plans.json` |
+| Progress / review plans | ✅ TodoWrite persistence | ✅ turn plan updates | ✅ task registry | ✅ `update_plan` for progress + `.geode/plans.json` for checkpoints |
 | Permission / sandbox layers | ✅ default / auto / bypass modes + Confirmation UI | ✅ `sandbox_mode` (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain across many audit surfaces | ✅ Policy Chain + tool gates |
 | Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅ **turn verify** (rule-based + opt-in LLM-judge, `core/agent/verify.py`) → replan on FAIL, plus safety-axis fitness gate in the self-improving loop |
 | Hook events | ✅ PreToolUse / PostToolUse / UserPromptSubmit / Stop / SubagentStop / PreCompact / SessionStart / SessionEnd / Notification | ⚠️ SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop | ✅ several event types · many bundled handlers | ✅✅ broad event surface (`docs/architecture/hook-system.md`) |
@@ -530,7 +530,7 @@ Tier 3    Session         In-memory — conversation, tool results, plans
 ├── rules/              # Auto-generated project rules
 ├── vault/              # Permanent artifacts (reports, research)
 ├── skills/             # project runtime skills (5-tier discovery)
-├── plans.json          # Disk-persistent PlanStore (v0.53.3)
+├── plans.json          # Disk-persistent review checkpoints
 └── result_cache/       # Pipeline LRU (SHA-256, 24h TTL)
 ```
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -817,7 +817,7 @@ class AgenticLoop:
         """Per-round Dynamic Replan trigger.
 
         Asks :func:`core.agent.plan.should_replan`; on a trigger calls
-        :func:`replan_async` (planner LLM via ``settings.plan_model`) and
+        :func:`replan_async` (planner LLM via the active loop model) and
         installs the new :class:`Plan` via ``set_active_plan``.
 
         Triggers: ``verify_fail`` (fires at the first round of the *next*

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -9,9 +9,8 @@ structured :class:`Plan` object on :class:`SessionMetrics` so:
 - PR-CL-A3 verify gains a new ``step_expected_mismatch`` rubric_miss
   that compares the just-finished turn against
   :class:`PlanStep.expected_outcome`.
-- ``_maybe_replan_async`` fires the planner LLM (using
-  :data:`settings.plan_model` from PR-CL-A6) when either of the two
-  triggers fires:
+- ``_maybe_replan_async`` fires the planner LLM on the active
+  :class:`AgenticLoop` model when either of the two triggers fires:
 
   - **Verify FAIL trigger**: ``metrics.last_verify_should_retry``.
   - **Cadence trigger**: every ``settings.replan_interval`` rounds
@@ -20,9 +19,8 @@ structured :class:`Plan` object on :class:`SessionMetrics` so:
 Frontier alignment (Socratic Q5):
 
 - **ReWOO** (arxiv 2305.18323) — plan / observation decouple → 5x token
-  efficiency. ReWOO's *Planner* / *Worker* / *Solver* split is the
-  closest 1:1 to GEODE's plan_model / act_model / judge_model now that
-  A6 has shipped.
+  efficiency. GEODE keeps planner and worker calls on the same active loop
+  model unless the operator explicitly changes the loop model itself.
 - **Self-Discover** (arxiv 2402.03620) — task-level plan composition →
   10-40x fewer inferences vs ToT / Self-Consistency.
 - **Reflexion** (NeurIPS 2023) — verbal RL hint we already prepend
@@ -503,27 +501,21 @@ async def replan_async(
 ) -> Plan | None:
     """Call the planner LLM to revise the plan.
 
-    Uses :data:`settings.plan_model` (PR-CL-A6 knob) so an operator
-    running Opus-plan + Sonnet-act sees cost-aware replans. Failures
-    return ``None`` so the caller keeps the prior plan rather than
-    proceeding plan-less. Bounded by ``asyncio.wait_for`` so a stuck
+    Uses the active :class:`AgenticLoop` model so replans match the main
+    loop's reasoning tier. Failures return ``None`` so the caller keeps
+    the prior plan rather than proceeding plan-less. Bounded by
+    ``asyncio.wait_for`` so a stuck
     planner cannot hang the session.
     """
     try:
         import asyncio
 
-        from core.config import settings
-
-        plan_model_raw = getattr(settings, "plan_model", "")
-        plan_model = (
-            plan_model_raw.strip() if isinstance(plan_model_raw, str) else ""
-        ) or loop.model
         user_prompt = _build_replan_user_prompt(plan, turn_result, trigger)
         response = await asyncio.wait_for(
             loop._call_llm(
                 _REPLAN_SYSTEM_PROMPT,
                 [{"role": "user", "content": user_prompt}],
-                model=plan_model,
+                model=loop.model,
             ),
             timeout=timeout_s,
         )
@@ -637,8 +629,7 @@ def _build_tool_summary(tools: list[dict[str, Any]]) -> str:
     Migrated from ``goal_decomposer._build_tool_summary`` with full
     legacy parity (Codex MCP LOW #3, PR-CL-A1-followup 2026-05-23):
     bold tool name, ``[cost_tier]`` label when present (e.g.
-    ``[expensive]`` / ``[free]`` — preserves cost-aware prompt context
-    the planner uses to choose between paid and free tools), and
+    ``[expensive]`` / ``[free]`` for operator-visible tradeoffs), and
     first-sentence truncation of the description.
     """
     if not tools:
@@ -681,8 +672,8 @@ async def decompose_async(
     2. **System prompt**: ``load_prompt("decomposer", "system")`` +
        ``apply_decomposition_policy`` (ADR-012 SoT — preserves the
        operator-tunable policy surface; only the call site moves).
-    3. **LLM call**: ``loop._call_llm`` with ``settings.plan_model``
-       (PR-CL-A6 knob) bounded by ``_DECOMPOSE_CALL_TIMEOUT_S``
+    3. **LLM call**: ``loop._call_llm`` with the active loop model,
+       bounded by ``_DECOMPOSE_CALL_TIMEOUT_S``
        (180s post-PR-CHECKPOINT-RESUME-TIMEBUDGET, 2026-05-25).
     4. **Parse**: pydantic ``DecompositionResult.model_validate_json``
        — schema-validated, error-on-malformed.
@@ -708,13 +699,7 @@ async def decompose_async(
             _load_decomposition_policy_override,
             apply_decomposition_policy,
         )
-        from core.config import settings
         from core.llm.prompts import load_prompt
-
-        plan_model_raw = getattr(settings, "plan_model", "")
-        plan_model = (
-            plan_model_raw.strip() if isinstance(plan_model_raw, str) else ""
-        ) or loop.model
 
         system_prompt = load_prompt("decomposer", "system")
         # ADR-012 S0c — the decomposition SoT's *single application
@@ -730,7 +715,7 @@ async def decompose_async(
             loop._call_llm(
                 system_prompt,
                 [{"role": "user", "content": user_prompt}],
-                model=plan_model,
+                model=loop.model,
             ),
             timeout=_DECOMPOSE_CALL_TIMEOUT_S,
         )

--- a/core/cli/tool_handlers/plan.py
+++ b/core/cli/tool_handlers/plan.py
@@ -1,4 +1,8 @@
-"""Plan-mode tool handlers (create/approve/reject/modify/list).
+"""Planning tool handlers.
+
+``update_plan`` is the Codex-style progress surface: it replaces the
+current visible checklist for this turn and never waits for approval.
+``create_plan`` / ``approve_plan`` remain for explicit review checkpoints.
 
 The disk-persistent ``PlanStore`` singleton (`_PLAN_STORE`) lives at the
 package level (``core.cli.tool_handlers.__init__``) so test fixtures can
@@ -23,6 +27,53 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
     from core.cli.tool_handlers import _get_plan_store
 
     store = _get_plan_store()
+
+    def handle_update_plan(**kwargs: Any) -> dict[str, Any]:
+        plan_items = kwargs.get("plan")
+        if not isinstance(plan_items, list):
+            return _clarify("update_plan", ["plan"], "진행 항목 목록을 알려주세요.")
+
+        explanation = str(kwargs.get("explanation") or "").strip()
+        cleaned: list[dict[str, str]] = []
+        counts = {"pending": 0, "in_progress": 0, "completed": 0}
+        for item in plan_items:
+            if not isinstance(item, dict):
+                continue
+            step = str(item.get("step") or "").strip()
+            status = str(item.get("status") or "pending").strip()
+            if not step:
+                continue
+            if status not in counts:
+                return {
+                    "error": (
+                        "Invalid plan status: "
+                        f"{status}. Expected pending, in_progress, or completed."
+                    )
+                }
+            cleaned.append({"step": step, "status": status})
+            counts[status] += 1
+
+        if not cleaned:
+            return _clarify("update_plan", ["plan"], "비어 있지 않은 진행 항목이 필요합니다.")
+
+        from core.ui.agentic_ui import render_progress_plan
+
+        render_progress_plan(cleaned, explanation=explanation)
+
+        log.info(
+            "Progress plan updated: total=%d pending=%d in_progress=%d completed=%d",
+            len(cleaned),
+            counts["pending"],
+            counts["in_progress"],
+            counts["completed"],
+        )
+        return {
+            "status": "ok",
+            "action": "update_plan",
+            "plan": cleaned,
+            "counts": counts,
+            "hint": "Progress plan updated. Continue with the task; no approval is required.",
+        }
 
     def _resolve_plan(plan_id: str) -> Any | None:
         """Resolve plan by ID, falling back to most recent."""
@@ -88,7 +139,8 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
         else:
             return _clarify("create_plan", ["goal"], "어떤 작업의 계획을 세울까요?")
 
-        # Display plan steps with HITL approval prompt
+        # Display review checkpoint steps. Routine progress should use
+        # update_plan; this path is for explicit approval checkpoints.
         console.print()
         console.print(f"  [header]● Plan: {plan_title}[/header]")
         console.print()
@@ -101,7 +153,7 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
         )
         if not auto_execute:
             console.print(
-                "  [dim]→ 승인(approve_plan) · 수정(modify_plan) · 거부(reject_plan)[/dim]"
+                "  [dim]→ 승인 checkpoint: approve_plan · modify_plan · reject_plan[/dim]"
             )
         console.print()
         log.info(
@@ -168,7 +220,10 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
             "steps": [s.description for s in plan.steps],
             "summary": plan_summary,
             "execution_mode": PlanExecutionMode.MANUAL.value,
-            "hint": ("Use approve_plan, reject_plan, or modify_plan to proceed."),
+            "hint": (
+                "Review checkpoint created. Use approve_plan, reject_plan, "
+                "or modify_plan only if the user explicitly wants this gate."
+            ),
         }
 
     def handle_approve_plan(**kwargs: Any) -> dict[str, Any]:
@@ -283,6 +338,7 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
         }
 
     return {
+        "update_plan": handle_update_plan,
         "create_plan": handle_create_plan,
         "approve_plan": handle_approve_plan,
         "reject_plan": handle_reject_plan,

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -52,9 +52,8 @@ PROJECT_CONFIG_PATH = PROJECT_CONFIG_TOML
 _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.primary_model": "model",
     "llm.learning_extract_model": "learning_extract_model",
-    # PR-CL-A6 (2026-05-23) — Plan / Action / Judge model knobs. Empty
-    # string falls back to ``llm.primary_model``.
-    "llm.plan_model": "plan_model",
+    # PR-CL-A6 (2026-05-23) — Action / Judge model knobs. Empty string
+    # falls back to ``llm.primary_model``. Planning inherits loop.model.
     "llm.act_model": "act_model",
     "llm.judge_model": "judge_model",
     # C-2 (2026-06-11) — H7 fix: /login source was writing these toml rows

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -72,19 +72,17 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("learning_extract_model", "GEODE_LEARNING_EXTRACT_MODEL"),
         description=(
             "GLM model for the learning-extraction hook "
-            "(``core.hooks.llm_extract_learning``) — a cheap budget call run "
-            "outside the main loop. The default ``glm-4.7-flash`` is on a "
-            "limited-time free tier (see model_pricing.toml); when that promo "
-            "ends the call bills at the standard GLM rate, so cost-sensitive "
-            "operators should pin a known-priced model here."
+            "(``core.hooks.llm_extract_learning``), run outside the main "
+            "loop. Operators can pin a model here when they want the "
+            "learning extraction hook to differ from provider defaults."
         ),
     )
     # PR-3 C-2 (2026-05-21) — Reflection node knobs. The reflection
     # step runs one extra LLM call per tool-use round to populate
-    # ``CognitiveState.hypotheses`` / ``confidence``, so operators
-    # who want the loop to stay zero-extra-cost can flip the toggle.
+    # ``CognitiveState.hypotheses`` / ``confidence``; operators can flip
+    # the toggle when they do not want that extra reflection pass.
     # Empty model inherits the live AgenticLoop model/provider/source;
-    # operators can still pin a separate cheap or strong model.
+    # operators can still pin a separate reflection model.
     cognitive_reflection_enabled: bool = Field(
         default=True,
         validation_alias=AliasChoices(
@@ -113,31 +111,17 @@ class Settings(BaseSettings):
             "PR-3 C-2."
         ),
     )
-    # PR-CL-A6 (2026-05-23) — Plan / Action / Judge model separation
-    # (agentic-loop-evolution.md A6). Empty string ("") means "fall back
-    # to ``settings.model``" so existing operators see no behaviour change
-    # until they set a concrete value. ReWOO (arxiv 2305.18323) showed
-    # plan / observation decoupling yields 5x token efficiency; Anthropic
-    # Plan / Edit mode pattern (claude-code) splits Opus-class planning
-    # from Sonnet-class action.
-    plan_model: str = Field(
-        default="",
-        validation_alias=AliasChoices("plan_model", "GEODE_PLAN_MODEL"),
-        description=(
-            "Model used by the planning step (goal decomposition before "
-            "the main loop). Empty string falls back to ``settings.model``. "
-            "Set to ``claude-opus-4-8`` for higher-quality plans, "
-            "``claude-haiku-4-5-20251001`` for cheaper. PR-CL-A6."
-        ),
-    )
+    # PR-CL-A6 (2026-05-23) originally split Plan / Action / Judge models.
+    # PR-PLAN-MODEL-INHERITANCE keeps planning on the active AgenticLoop
+    # model instead; only action and judge remain operator-tunable.
     act_model: str = Field(
         default="",
         validation_alias=AliasChoices("act_model", "GEODE_ACT_MODEL"),
         description=(
             "Model used by the action loop (per-round tool calls). Empty "
             "string falls back to ``settings.model``. Set to ``claude-"
-            "sonnet-4-6`` to keep planning on Opus while action runs on "
-            "Sonnet for cost. PR-CL-A6."
+            "sonnet-4-6`` only when the operator wants the action loop "
+            "model to differ from the primary model. PR-CL-A6."
         ),
     )
     judge_model: str = Field(
@@ -146,8 +130,7 @@ class Settings(BaseSettings):
         description=(
             "Model used by the per-turn verify LLM-judge mode "
             "(``GEODE_VERIFY_MODE=llm_judge``). Empty string falls back "
-            "to ``settings.model``. Cheap models like Haiku 4.5 are "
-            "appropriate for binary pass/fail judgement. PR-CL-A6."
+            "to ``settings.model``. PR-CL-A6."
         ),
     )
     # PR-CL-A1 (2026-05-23) — Dynamic Replan knobs.
@@ -169,7 +152,7 @@ class Settings(BaseSettings):
             "Number of rounds between cadence-based replans. ``0`` "
             "disables cadence (verify FAIL still triggers). Default 5 "
             "balances ReWOO 5x-token-efficiency target with the cost of "
-            "an extra plan_model call per N rounds. PR-CL-A1."
+            "an extra planner call per N rounds. PR-CL-A1."
         ),
     )
     replan_max_attempts: int = Field(

--- a/core/config/env_io.py
+++ b/core/config/env_io.py
@@ -20,7 +20,6 @@ from pathlib import Path
 # always win — hazard H2), and the bootstrap .env promotion skips them.
 BEHAVIOR_ENV_KEYS: tuple[str, ...] = (
     "GEODE_MODEL",
-    "GEODE_PLAN_MODEL",
     "GEODE_ACT_MODEL",
     "GEODE_JUDGE_MODEL",
     "GEODE_COGNITIVE_REFLECTION_MODEL",

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -119,7 +119,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "b9edd05682d9",
+    "AGENTIC_SUFFIX": "e692d51fa0cc",
     "COMMENTARY_SYSTEM": "9a0936efe790",
     "COMMENTARY_USER": "2024ac4eba69",
     "ROUTER_SYSTEM": "a944cdc73e4f",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -47,14 +47,12 @@ Efficiency target (soft guidance, not a hard limit):
 
 Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, summarize and stop.
 
-## Plan-first for complex tasks
+## Progress planning for complex tasks
 
-For requests that need **3+ tool calls or involve high-cost operations**, present a plan first:
-1. Call `create_plan` to outline the steps, estimated time, and cost.
-2. The runtime displays the plan to the user with approval options.
-3. **Wait for user response** — do NOT proceed until the user approves (approve_plan), modifies (modify_plan), or rejects (reject_plan).
+For requests that need several dependent steps, call `update_plan` to show a concise progress checklist, then continue working. Keep it current as steps complete or the next best action changes.
 
-Plan-worthy requests: multi-step research, multi-subject analysis, report generation, expensive workflows.
+Use `create_plan` only when the user explicitly asks to review/approve a plan before execution, or when unusual risk or resource impact requires a deliberate stop. Routine multi-step work should not become a permission prompt.
+
 Simple requests (single lookup, quick answer): execute directly, no plan needed.
 
 ## Agentic execution
@@ -80,8 +78,8 @@ Select the first applicable tool. Fall back to the second only if the first is u
 | Recall past analysis | `memory_search` | `note_read` | `web_fetch` |
 | Web information | `general_web_search` | `web_fetch` (specific URL) | — |
 | Report generation | `generate_report` | — | — |
-| Planning | `create_plan` | — | `delegate_task` (simple plan) |
-| Parallel subtasks | `delegate_task` | `create_plan` → `approve_plan` | — |
+| Planning/progress | `update_plan` | `create_plan` (explicit approval checkpoint only) | `delegate_task` (simple plan) |
+| Parallel subtasks | `delegate_task` | `update_plan` | `create_plan` → `approve_plan` unless the user requested a checkpoint |
 | Browser automation | `playwright__*` (Playwright MCP) | `playwriter__*` (Chrome extension, login-required sites) | — |
 | System status / MCP list | `check_status` | — | specialized analysis tools |
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -456,8 +456,54 @@
     }
   },
   {
+    "name": "update_plan",
+    "description": "Show or update the current turn's progress checklist. Use for complex, multi-step work to keep the user informed while continuing execution. This is NOT an approval gate and does not persist an execution plan; after calling it, keep working unless the user explicitly asked to stop for review. Keep 3-7 concise steps, exactly one in_progress step while work remains, and update statuses as steps complete. Sibling: create_plan is only for an explicit review checkpoint that should wait for approve_plan.",
+    "category": "planning",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "explanation": {
+          "type": "string",
+          "description": "Optional short reason for a plan change."
+        },
+        "plan": {
+          "type": "array",
+          "description": "Complete replacement checklist for this turn.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "step": {
+                "type": "string",
+                "description": "One concise task step."
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "in_progress",
+                  "completed"
+                ],
+                "description": "Current status for this step."
+              }
+            },
+            "required": [
+              "step",
+              "status"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "plan"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "create_plan",
-    "description": "Create an execution plan the user reviews before a complex task runs (3+ tool calls or expensive operations). Put the user-facing objective in goal; steps auto-generate if omitted. Use for multi-step research/report jobs. Skip it for simple one-shot requests — execute directly. After the user accepts, the runtime runs it (or call approve_plan); change it with modify_plan, discard with reject_plan.",
+    "description": "Create a disk-persistent review checkpoint that waits for approve_plan before execution. Use only when the user explicitly asks to review/approve a plan first, or when you need an intentional stop before an unusually risky/expensive workflow. For ordinary multi-step work, use update_plan and continue executing; do not turn routine planning into a permission prompt.",
     "category": "planning",
     "cost_tier": "cheap",
     "input_schema": {
@@ -493,7 +539,7 @@
   },
   {
     "name": "approve_plan",
-    "description": "Approve and run a plan created by create_plan. Use after the user accepts a proposed plan; pass the plan_id from the create_plan result. Siblings: modify_plan to adjust it first, reject_plan to discard it.",
+    "description": "Approve and run a review checkpoint created by create_plan. Use only after the user explicitly accepts that checkpoint; pass the plan_id from the create_plan result. Siblings: modify_plan to adjust it first, reject_plan to discard it. Do not use for update_plan checklists.",
     "category": "planning",
     "cost_tier": "cheap",
     "input_schema": {
@@ -761,7 +807,7 @@
   },
   {
     "name": "reject_plan",
-    "description": "Discard an execution plan created by create_plan when the user doesn't want it. Pass plan_id (reason optional). Siblings: approve_plan to run it, modify_plan to adjust it.",
+    "description": "Discard a review checkpoint created by create_plan when the user doesn't want it. Pass plan_id (reason optional). Siblings: approve_plan to run it, modify_plan to adjust it. Do not use for update_plan checklists.",
     "category": "planning",
     "cost_tier": "free",
     "input_schema": {
@@ -781,7 +827,7 @@
   },
   {
     "name": "modify_plan",
-    "description": "Adjust an execution plan created by create_plan — change its template or remove steps — when the user wants to tweak a proposal rather than approve or reject it outright. Pass plan_id. Siblings: approve_plan, reject_plan.",
+    "description": "Adjust a review checkpoint created by create_plan — change its template or remove steps — when the user wants to tweak it rather than approve or reject it outright. Pass plan_id. Siblings: approve_plan, reject_plan. Use update_plan for ordinary progress checklist changes.",
     "category": "planning",
     "cost_tier": "free",
     "input_schema": {
@@ -812,7 +858,7 @@
   },
   {
     "name": "list_plans",
-    "description": "List the execution plans created this session via create_plan.",
+    "description": "List disk-persistent review checkpoints created this session via create_plan. This does not list update_plan progress checklists.",
     "category": "planning",
     "cost_tier": "free",
     "input_schema": {
@@ -1160,7 +1206,7 @@
   },
   {
     "name": "task_create",
-    "description": "Create a tracked item in the task list. Use to break a complex request into trackable steps or to record follow-ups, then advance them with task_update. subject (imperative, e.g. 'Analyze repository state') is required. Sibling: create_plan builds ONE reviewable plan for up-front approval; the task_* tools manage an ongoing checklist.",
+    "description": "Create a durable tracked item in the task list for follow-ups or work that should survive the current turn. subject (imperative, e.g. 'Analyze repository state') is required. Siblings: update_plan shows the current turn's non-persistent progress checklist; create_plan creates an explicit review checkpoint.",
     "category": "task",
     "cost_tier": "free",
     "input_schema": {

--- a/core/ui/agentic_ui/__init__.py
+++ b/core/ui/agentic_ui/__init__.py
@@ -90,6 +90,7 @@ from core.ui.agentic_ui.events import (
 from core.ui.agentic_ui.render import (
     render_context_event,
     render_plan_steps,
+    render_progress_plan,
     render_session_cost_summary,
     render_status_line,
     render_subagent_complete,
@@ -163,6 +164,7 @@ __all__ = [
     "render_action_summary",
     "render_context_event",
     "render_plan_steps",
+    "render_progress_plan",
     "render_session_cost_summary",
     "render_status_line",
     "render_subagent_complete",

--- a/core/ui/agentic_ui/render.py
+++ b/core/ui/agentic_ui/render.py
@@ -124,6 +124,28 @@ def render_plan_steps(subject_id: str, steps: list[str]) -> None:
     _pkg.console.print()
 
 
+def render_progress_plan(plan: list[dict[str, str]], *, explanation: str = "") -> None:
+    """Render a non-blocking progress checklist."""
+    from core.ui import agentic_ui as _pkg
+
+    status_style = {
+        "pending": ("○", "dim"),
+        "in_progress": ("●", "warning"),
+        "completed": ("✓", "success"),
+    }
+    _pkg.console.print()
+    header = "Plan"
+    if explanation:
+        header = f"Plan · {explanation}"
+    _pkg.console.print(f"  [header]{header}[/header]")
+    for item in plan:
+        status = item.get("status", "pending")
+        symbol, style = status_style.get(status, ("○", "dim"))
+        step = item.get("step", "")
+        _pkg.console.print(f"    [{style}]{symbol}[/{style}] {step}")
+    _pkg.console.print()
+
+
 def render_subagent_dispatch(task_id: str, task_type: str, description: str) -> None:
     """Render a sub-agent delegation line."""
     from core.ui import agentic_ui as _pkg

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3089,7 +3089,7 @@ geode about                    # 실효 모델 + 마스크 경고 한 줄
 serve 데몬은 시작할 때 상속받은 환경에서 동작(모델 선택) 계열 env 키를 떨어뜨리고, `.env` 승격에서도 건너뜁니다 (`core/cli/bootstrap.py`의`load_daemon_env`). 데몬 환경에 승격된 모델 키가 모든 `/model` 전환보다 오래 살아남던 문제의 수정입니다. 대상 키 목록은 `core/config/env_io.py`의`BEHAVIOR_ENV_KEYS`입니다.
 
 ```
-GEODE_MODEL  GEODE_PLAN_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
+GEODE_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
 GEODE_COGNITIVE_REFLECTION_MODEL  GEODE_LEARNING_EXTRACT_MODEL
 GEODE_AGENTIC_EFFORT
 GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE
@@ -3131,7 +3131,6 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/config/reference.md
 | 필드 | toml 키 | 타입 / 기본값 | 용도 |
 | --- | --- | --- | --- |
 | `model` | `llm.primary_model` | str = `"claude-opus-4-8"` | 기본 모델. 기본값은 routing.toml의 anthropic 기본값을 따라갑니다. |
-| `plan_model` | `llm.plan_model` | str = `""` | 플래닝 단계 모델. 비우면 `model`로 폴백합니다. |
 | `act_model` | `llm.act_model` | str = `""` | 액션 루프 모델. 비우면 `model`로 폴백합니다. |
 | `judge_model` | `llm.judge_model` | str = `""` | 턴 단위 verify judge 모델. 비우면 `model`로 폴백합니다. |
 | `learning_extract_model` | `llm.learning_extract_model` | str = `"glm-4.7-flash"` | learning 추출 훅용 무료 티어 GLM 모델. |

--- a/site/src/app/docs/config/basics/page.tsx
+++ b/site/src/app/docs/config/basics/page.tsx
@@ -138,7 +138,7 @@ geode about                    # 실효 모델 + 마스크 경고 한 줄`}</pre
               수정입니다. 대상 키 목록은 <code>core/config/env_io.py</code>의
               <code>BEHAVIOR_ENV_KEYS</code>입니다.
             </p>
-            <pre>{`GEODE_MODEL  GEODE_PLAN_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
+            <pre>{`GEODE_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
 GEODE_COGNITIVE_REFLECTION_MODEL  GEODE_LEARNING_EXTRACT_MODEL
 GEODE_AGENTIC_EFFORT
 GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>
@@ -330,7 +330,7 @@ geode about                    # effective model + one-line mask warning`}</pre>
               <code>BEHAVIOR_ENV_KEYS</code> in
               <code>core/config/env_io.py</code>.
             </p>
-            <pre>{`GEODE_MODEL  GEODE_PLAN_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
+            <pre>{`GEODE_MODEL  GEODE_ACT_MODEL  GEODE_JUDGE_MODEL
 GEODE_COGNITIVE_REFLECTION_MODEL  GEODE_LEARNING_EXTRACT_MODEL
 GEODE_AGENTIC_EFFORT
 GEODE_ANTHROPIC_CREDENTIAL_SOURCE  GEODE_OPENAI_CREDENTIAL_SOURCE`}</pre>

--- a/site/src/app/docs/config/reference/page.tsx
+++ b/site/src/app/docs/config/reference/page.tsx
@@ -42,7 +42,6 @@ export default function Page() {
               </thead>
               <tbody>
                 <tr><td><code>model</code></td><td><code>llm.primary_model</code></td><td>str = <code>&quot;claude-opus-4-8&quot;</code></td><td>기본 모델. 기본값은 routing.toml의 anthropic 기본값을 따라갑니다.</td></tr>
-                <tr><td><code>plan_model</code></td><td><code>llm.plan_model</code></td><td>str = <code>&quot;&quot;</code></td><td>플래닝 단계 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
                 <tr><td><code>act_model</code></td><td><code>llm.act_model</code></td><td>str = <code>&quot;&quot;</code></td><td>액션 루프 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
                 <tr><td><code>judge_model</code></td><td><code>llm.judge_model</code></td><td>str = <code>&quot;&quot;</code></td><td>턴 단위 verify judge 모델. 비우면 <code>model</code>로 폴백합니다.</td></tr>
                 <tr><td><code>learning_extract_model</code></td><td><code>llm.learning_extract_model</code></td><td>str = <code>&quot;glm-4.7-flash&quot;</code></td><td>learning 추출 훅용 무료 티어 GLM 모델.</td></tr>
@@ -406,7 +405,6 @@ export default function Page() {
               </thead>
               <tbody>
                 <tr><td><code>model</code></td><td><code>llm.primary_model</code></td><td>str = <code>&quot;claude-opus-4-8&quot;</code></td><td>Primary model. The default mirrors the anthropic default in routing.toml.</td></tr>
-                <tr><td><code>plan_model</code></td><td><code>llm.plan_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Planning-step model. Empty falls back to <code>model</code>.</td></tr>
                 <tr><td><code>act_model</code></td><td><code>llm.act_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Action-loop model. Empty falls back to <code>model</code>.</td></tr>
                 <tr><td><code>judge_model</code></td><td><code>llm.judge_model</code></td><td>str = <code>&quot;&quot;</code></td><td>Per-turn verify judge model. Empty falls back to <code>model</code>.</td></tr>
                 <tr><td><code>learning_extract_model</code></td><td><code>llm.learning_extract_model</code></td><td>str = <code>&quot;glm-4.7-flash&quot;</code></td><td>Free-tier GLM model for the learning-extract hook.</td></tr>

--- a/site/src/data/geode/categories.ts
+++ b/site/src/data/geode/categories.ts
@@ -46,16 +46,16 @@ export const geodeCategories: CategoryData[] = [
     icon: "▶️",
     title: "Runtime & Router",
     postsCount: 2,
-    statusKo: "Planner (GLM-5) 비용 기반 라우팅",
-    statusEn: "Planner (GLM-5) cost-aware routing",
-    techBadges: ["GLM-5", "Planner", "Plan Mode", "Pydantic Settings"],
+    statusKo: "Planner 진행 상태 + 체크포인트",
+    statusEn: "Planner progress + checkpoints",
+    techBadges: ["Planner", "Progress Plan", "Review Checkpoint", "Pydantic Settings"],
     descriptionKo:
-      "GLM-5 기반 Planner가 작업의 비용과 깊이에 맞춰 라우트를 고릅니다. full_pipeline부터 script_route, direct_answer까지 비용 폭이 넓고, Plan Mode에서 사용자 승인 후 실행합니다.",
+      "Planner는 메인 루프 모델을 그대로 사용해 요청을 분해하고 진행 상태를 드러냅니다. 일반 작업은 진행 체크리스트로 계속 실행하고, 명시적 검토가 필요할 때만 승인 checkpoint를 둡니다.",
     descriptionEn:
-      "A GLM-5 Planner picks the route by the task's cost and depth, from full_pipeline down to script_route and direct_answer. Plan Mode requires user approval before execution.",
+      "The Planner uses the main loop model to decompose work and surface progress. Routine work uses a live checklist and keeps going; explicit review checkpoints remain available when needed.",
     achievements: [
-      { icon: "⚙️", titleKo: "Planner full_pipeline~script_route 비용 최적화 분기", titleEn: "Planner full_pipeline~script_route cost-optimized routing", modalId: "modal-geode-settings" },
-      { icon: "🏭", titleKo: "Plan Mode 분석 전략 수립 → 사용자 승인 → 실행", titleEn: "Plan Mode analysis strategy → user approval → execution", modalId: "modal-geode-factory" },
+      { icon: "⚙️", titleKo: "Planner가 메인 루프 모델을 상속해 작업 분해", titleEn: "Planner inherits the main loop model for task decomposition", modalId: "modal-geode-settings" },
+      { icon: "🏭", titleKo: "Progress Plan 진행 상태 표시 + 명시적 checkpoint 분리", titleEn: "Progress Plan updates with explicit checkpoints separated", modalId: "modal-geode-factory" },
       { icon: "💉", titleKo: "LLMClientPort 추상화로 Claude·GPT·GLM 계열 역할별 DI", titleEn: "LLMClientPort abstraction wires Claude/GPT/GLM families by role", modalId: "modal-geode-di" },
     ],
     blogLink: "",
@@ -97,7 +97,7 @@ export const geodeCategories: CategoryData[] = [
     achievements: [
       { icon: "🪝", titleKo: "Hook System 이벤트 × CONTINUE/ABORT/MODIFY 제어", titleEn: "Hook System events × CONTINUE/ABORT/MODIFY control", modalId: "modal-geode-hooks" },
       { icon: "📝", titleKo: "TaskSystem 의존성 그래프 기반 병렬/순차 작업 스케줄링", titleEn: "TaskSystem dependency graph-based parallel/sequential scheduling", modalId: "modal-geode-task-system" },
-      { icon: "🧭", titleKo: "Planner GLM-5 비용 기반 분기 + Plan Mode 승인", titleEn: "Planner GLM-5 cost-aware branching + Plan Mode approval", modalId: "modal-geode-planner" },
+      { icon: "🧭", titleKo: "Planner 진행 체크리스트 + 승인 checkpoint", titleEn: "Planner progress checklist + approval checkpoints", modalId: "modal-geode-planner" },
       { icon: "🔌", titleKo: "Bootstrap 서비스 와이어링 + Hook Registry 초기화", titleEn: "Bootstrap service wiring + Hook Registry initialization", modalId: "modal-geode-bootstrap" },
     ],
     blogLink: "",

--- a/tests/core/agent/test_model_split.py
+++ b/tests/core/agent/test_model_split.py
@@ -1,12 +1,12 @@
-"""Unit tests for PR-CL-A6 — Plan/Action/Judge model separation.
+"""Unit tests for model role wiring.
 
 Coverage:
-- Settings knobs (``plan_model`` / ``act_model`` / ``judge_model``) default
-  to empty string (= fall back to ``settings.model``).
-- TOML mapping covers all three knobs.
+- Settings knobs (``act_model`` / ``judge_model``) default to empty string
+  (= fall back to ``settings.model``).
+- TOML mapping covers both live knobs.
 - ``AgenticLoop.__init__`` honours ``settings.act_model`` when no explicit
   ``model`` is passed; explicit ``model`` wins.
-- ``_helpers.try_decompose`` uses ``settings.plan_model`` when set.
+- ``decompose_async`` inherits the active loop model.
 - ``_call_llm(model=...)`` override threads through to the adapter call.
 - ``_verify_llm_judge`` actually calls the LLM via ``loop._call_llm`` with
   ``settings.judge_model`` + parses the judge JSON response.
@@ -37,7 +37,6 @@ from core.agent.verify import (
 @pytest.fixture(autouse=True)
 def reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GEODE_VERIFY_MODE", raising=False)
-    monkeypatch.delenv("GEODE_PLAN_MODEL", raising=False)
     monkeypatch.delenv("GEODE_ACT_MODEL", raising=False)
     monkeypatch.delenv("GEODE_JUDGE_MODEL", raising=False)
 
@@ -60,36 +59,32 @@ def _make_result(
 
 
 def test_settings_default_to_empty_string() -> None:
-    """All three knobs default to ``""`` so existing callers fall back
+    """Live model-role knobs default to ``""`` so existing callers fall back
     to ``settings.model`` until they set a concrete value."""
     from core.config._settings import Settings
 
     s = Settings()
-    assert s.plan_model == ""
     assert s.act_model == ""
     assert s.judge_model == ""
 
 
 def test_settings_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``GEODE_PLAN_MODEL`` / ``ACT_MODEL`` / ``JUDGE_MODEL`` env vars
-    populate the knobs via pydantic AliasChoices."""
+    """``GEODE_ACT_MODEL`` / ``GEODE_JUDGE_MODEL`` env vars populate the
+    knobs via pydantic AliasChoices."""
     from core.config._settings import Settings
 
-    monkeypatch.setenv("GEODE_PLAN_MODEL", "claude-opus-4-7")
     monkeypatch.setenv("GEODE_ACT_MODEL", "claude-sonnet-4-6")
     monkeypatch.setenv("GEODE_JUDGE_MODEL", "claude-haiku-4-5-20251001")
     s = Settings()
-    assert s.plan_model == "claude-opus-4-7"
     assert s.act_model == "claude-sonnet-4-6"
     assert s.judge_model == "claude-haiku-4-5-20251001"
 
 
-def test_toml_mapping_covers_three_knobs() -> None:
-    """Config cascade maps ``[llm].plan_model`` / ``act_model`` /
-    ``judge_model`` to the matching Settings fields."""
+def test_toml_mapping_covers_live_model_knobs() -> None:
+    """Config cascade maps the live model role knobs."""
     from core.config import _TOML_TO_SETTINGS
 
-    assert _TOML_TO_SETTINGS["llm.plan_model"] == "plan_model"
+    assert "llm.plan_model" not in _TOML_TO_SETTINGS
     assert _TOML_TO_SETTINGS["llm.act_model"] == "act_model"
     assert _TOML_TO_SETTINGS["llm.judge_model"] == "judge_model"
 
@@ -158,16 +153,15 @@ def test_call_llm_signature_accepts_model_override() -> None:
     assert param.kind == inspect.Parameter.KEYWORD_ONLY
 
 
-# -- Goal decomposition uses plan_model -------------------------------
+# -- Goal decomposition inherits loop model ---------------------------
 
 
-def test_decompose_async_uses_plan_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """PR-CL-A1-followup (2026-05-23) — ``decompose_async`` reads
-    ``settings.plan_model`` and threads it through ``loop._call_llm``.
-    Replaces the pre-followup test that mocked ``GoalDecomposer``."""
+def test_decompose_async_inherits_loop_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``decompose_async`` threads the active loop model through
+    ``loop._call_llm``."""
     import asyncio
 
-    fake_settings = SimpleNamespace(plan_model="claude-opus-4-7", model="claude-haiku-4-5")
+    fake_settings = SimpleNamespace(model="claude-haiku-4-5")
     monkeypatch.setattr("core.config.settings", fake_settings)
 
     captured: dict[str, str] = {}
@@ -185,16 +179,17 @@ def test_decompose_async_uses_plan_model(monkeypatch: pytest.MonkeyPatch) -> Non
     from core.agent.plan import decompose_async
 
     asyncio.run(decompose_async(loop, "comprehensive analysis and report"))
-    assert captured["model"] == "claude-opus-4-7"
+    assert captured["model"] == "claude-haiku-4-5"
 
 
-def test_decompose_async_falls_back_to_loop_model(
+def test_decompose_async_ignores_removed_plan_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Empty ``plan_model`` → ``decompose_async`` uses ``loop.model``."""
+    """A stale ``settings.plan_model`` attribute cannot split planner model
+    selection away from the active loop."""
     import asyncio
 
-    fake_settings = SimpleNamespace(plan_model="", model="claude-haiku-4-5")
+    fake_settings = SimpleNamespace(plan_model="claude-opus-4-7", model="claude-haiku-4-5")
     monkeypatch.setattr("core.config.settings", fake_settings)
     captured: dict[str, str] = {}
 

--- a/tests/core/agent/test_replan.py
+++ b/tests/core/agent/test_replan.py
@@ -9,7 +9,7 @@ Coverage:
 - :func:`should_replan` env-knob policy: verify FAIL wins; cadence
   fires every N rounds; ``GEODE_REPLAN_ENABLED=false`` disables.
 - :func:`parse_replan_response` handles code fences + bad JSON.
-- :func:`replan_async` calls ``loop._call_llm`` with ``settings.plan_model``,
+- :func:`replan_async` calls ``loop._call_llm`` with the active loop model,
   parses the response, records token usage via ``_track_usage_async``,
   returns None on timeout / bad JSON.
 - SessionMetrics integration: ``set_active_plan`` / ``record_replan`` /
@@ -334,9 +334,9 @@ def test_parse_replan_missing_steps_returns_none() -> None:
 # -- replan_async (LLM call orchestration) ----------------------------
 
 
-def test_replan_async_uses_plan_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``replan_async`` calls ``loop._call_llm`` with ``settings.plan_model``."""
-    fake_settings = SimpleNamespace(plan_model="claude-opus-4-7")
+def test_replan_async_inherits_loop_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``replan_async`` calls ``loop._call_llm`` with the active loop model."""
+    fake_settings = SimpleNamespace(model="claude-haiku-4-5")
     monkeypatch.setattr("core.config.settings", fake_settings)
     captured: dict[str, str] = {}
 
@@ -358,13 +358,13 @@ def test_replan_async_uses_plan_model(monkeypatch: pytest.MonkeyPatch) -> None:
     assert new_plan.revision == 1  # prior revision was 0
     assert len(new_plan.steps) == 1
     assert new_plan.steps[0].id == "s1"
-    assert captured["model"] == "claude-opus-4-7"
+    assert captured["model"] == "claude-sonnet-4-6"
 
 
 def test_replan_async_records_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     """The response is fed to ``loop._track_usage_async`` so planner cost
     surfaces in the TokenTracker."""
-    fake_settings = SimpleNamespace(plan_model="m")
+    fake_settings = SimpleNamespace(model="m")
     monkeypatch.setattr("core.config.settings", fake_settings)
     recorded: list[Any] = []
 
@@ -387,7 +387,7 @@ def test_replan_async_returns_none_on_bad_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Unparseable JSON → None so caller keeps prior plan."""
-    fake_settings = SimpleNamespace(plan_model="")
+    fake_settings = SimpleNamespace(model="m")
     monkeypatch.setattr("core.config.settings", fake_settings)
 
     async def _bad(_system: str, _msgs: list, *, model: str | None = None) -> SimpleNamespace:
@@ -595,7 +595,7 @@ def test_build_tool_summary_empty() -> None:
 
 
 def test_build_tool_summary_cost_tier_label() -> None:
-    """``[cost_tier]`` label preserves planner cost-awareness (Codex LOW #3
+    """``[cost_tier]`` label preserves operator-visible tool tradeoffs (Codex LOW #3
     parity with legacy goal_decomposer._build_tool_summary)."""
     from core.agent.plan import _build_tool_summary
 
@@ -691,7 +691,6 @@ def test_maybe_replan_async_verify_fail_triggers(
     from core.agent.loop.agent_loop import AgenticLoop
 
     fake_settings = SimpleNamespace(
-        plan_model="claude-opus-4-7",
         replan_enabled=True,
         replan_interval=5,
         replan_max_attempts=3,
@@ -735,7 +734,6 @@ def test_maybe_replan_async_cadence_triggers(monkeypatch: pytest.MonkeyPatch) ->
     from core.agent.loop.agent_loop import AgenticLoop
 
     fake_settings = SimpleNamespace(
-        plan_model="m",
         replan_enabled=True,
         replan_interval=2,
         replan_max_attempts=3,
@@ -776,7 +774,6 @@ def test_maybe_replan_async_abandons_after_max_attempts(
     from core.agent.loop.agent_loop import AgenticLoop
 
     fake_settings = SimpleNamespace(
-        plan_model="m",
         replan_enabled=True,
         replan_interval=0,  # cadence off
         replan_max_attempts=2,

--- a/tests/core/cli/test_plan_tool_handlers.py
+++ b/tests/core/cli/test_plan_tool_handlers.py
@@ -45,6 +45,37 @@ def test_create_plan_requires_goal_or_subject(plan_handlers: dict[str, Any]) -> 
     assert result["missing"] == ["goal"]
 
 
+def test_update_plan_is_non_persistent_progress_surface(
+    plan_handlers: dict[str, Any],
+) -> None:
+    result = plan_handlers["update_plan"](
+        explanation="repo change",
+        plan=[
+            {"step": "Inspect plan UX", "status": "completed"},
+            {"step": "Patch router prompt", "status": "in_progress"},
+            {"step": "Run focused tests", "status": "pending"},
+        ],
+    )
+
+    assert result["status"] == "ok"
+    assert result["action"] == "update_plan"
+    assert result["counts"] == {"pending": 1, "in_progress": 1, "completed": 1}
+    assert (
+        result["hint"] == "Progress plan updated. Continue with the task; no approval is required."
+    )
+
+    listed = plan_handlers["list_plans"]()
+    assert listed["count"] == 0
+
+
+def test_update_plan_rejects_unknown_status(plan_handlers: dict[str, Any]) -> None:
+    result = plan_handlers["update_plan"](
+        plan=[{"step": "Patch", "status": "blocked"}],
+    )
+
+    assert "Invalid plan status" in result["error"]
+
+
 def test_create_list_approve_and_latest_fallback(plan_handlers: dict[str, Any]) -> None:
     created = plan_handlers["create_plan"](goal="ship release", steps=["build", "test"])
 
@@ -114,7 +145,7 @@ def test_dangerously_skip_permissions_auto_executes_plan(
 
 
 def test_no_skip_keeps_plan_manual(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without the flag (and auto-execute off) the plan stops for approval."""
+    """Explicit review checkpoints still stop when auto-execute is disabled."""
     store = InMemoryPlanStore()
     monkeypatch.setattr(tool_handlers, "_PLAN_STORE", store)
     monkeypatch.setattr("core.config.settings.plan_auto_execute", False)

--- a/tests/core/config/test_c3_env_loading.py
+++ b/tests/core/config/test_c3_env_loading.py
@@ -51,7 +51,6 @@ def test_settings_global_env_wins_over_empty_project(tmp_path, monkeypatch) -> N
 def test_behavior_keys_cover_all_model_pick_surfaces() -> None:
     expected = {
         "GEODE_MODEL",
-        "GEODE_PLAN_MODEL",
         "GEODE_ACT_MODEL",
         "GEODE_JUDGE_MODEL",
         "GEODE_COGNITIVE_REFLECTION_MODEL",

--- a/tests/core/tools/test_tool_category_tagging.py
+++ b/tests/core/tools/test_tool_category_tagging.py
@@ -156,7 +156,7 @@ class TestCategoryMembershsubject:
 
     def test_planning_tools(self) -> None:
         m = self._category_map()
-        for name in ("create_plan", "approve_plan", "delegate_task"):
+        for name in ("update_plan", "create_plan", "approve_plan", "delegate_task"):
             assert m.get(name) == "planning", f"{name} should be planning"
 
     def test_external_tools(self) -> None:
@@ -194,6 +194,7 @@ class TestCostTierMembershsubject:
             "note_read",
             "manage_rule",
             "switch_model",
+            "update_plan",
             "generate_report",
             "export_json",
         ):

--- a/tests/core/tools/test_tool_descriptions_fable5.py
+++ b/tests/core/tools/test_tool_descriptions_fable5.py
@@ -35,8 +35,11 @@ def test_sibling_collisions_disambiguated() -> None:
     # recall siblings cross-reference.
     assert "note_read" in d["memory_search"] or "session_search" in d["memory_search"]
     assert "memory_search" in d["note_read"]
-    # plan vs task list.
+    # progress checklist vs durable tasks vs review checkpoint.
+    assert "create_plan" in d["update_plan"]
+    assert "update_plan" in d["create_plan"]
     assert "create_plan" in d["task_create"]
+    assert "update_plan" in d["task_create"]
 
 
 def test_no_stale_pipeline_vocabulary() -> None:

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -153,6 +153,25 @@ class TestRenderPlanSteps:
         assert "Analyze" in combined
         assert "3." in combined
 
+    @patch("core.ui.agentic_ui.console")
+    def test_renders_progress_plan(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        from core.ui.agentic_ui import render_progress_plan
+
+        render_progress_plan(
+            [
+                {"step": "Inspect UX", "status": "completed"},
+                {"step": "Patch tools", "status": "in_progress"},
+                {"step": "Run tests", "status": "pending"},
+            ],
+            explanation="implementation",
+        )
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+        assert "Plan · implementation" in combined
+        assert "Inspect UX" in combined
+        assert "Patch tools" in combined
+        assert "Run tests" in combined
+
 
 class TestRenderSubagent:
     """Sub-agent dispatch/complete rendering."""


### PR DESCRIPTION
## Summary
- Add non-blocking `update_plan` progress rendering so routine multi-step work no longer waits on plan approval.
- Remove the live planner model split (`plan_model` / `GEODE_PLAN_MODEL` / `llm.plan_model`) so decomposition and replan inherit the active AgenticLoop model.
- Update public docs/site copy and regression tests around progress plans and planner model inheritance.

## Why
The planner path still exposed a separate model lane. Even though the default fell back to the main loop model, the scaffold kept reintroducing “cheap planner” context. Routine planning also used the approval-oriented plan surface too often, which made normal execution feel like a permission loop.

## Changes
| File | Change |
|------|--------|
| `core/agent/plan.py` | `decompose_async` and `replan_async` now pass `loop.model` directly. |
| `core/config/_settings.py` / `core/config/__init__.py` / `core/config/env_io.py` | Remove `plan_model`, `GEODE_PLAN_MODEL`, and `llm.plan_model`; neutralize cheap-model guidance in live setting descriptions. |
| `core/cli/tool_handlers/plan.py` / `core/tools/definitions.json` / `core/ui/agentic_ui/*` | Add `update_plan` as a non-persistent progress surface and keep `create_plan` scoped to explicit review checkpoints. |
| `core/llm/prompts/router.md` / `core/llm/prompts/__init__.py` | Route ordinary progress planning through `update_plan`; update prompt hash ratchet. |
| `README.md`, `GEODE.md`, `site/**` | Update tool count and remove current GLM/cost-aware planner copy from public config/site docs. |
| `tests/**` | Add regression coverage for `update_plan` and planner model inheritance; remove plan-model override expectations. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ scripts/`
- [x] `uv run ruff format --check core/ tests/ plugins/ scripts/`
- [x] `uv run mypy core/ plugins/ scripts/`
- [x] `uv run lint-imports`
- [x] `uv run python -c "from core.llm.prompts import verify_prompt_integrity; verify_prompt_integrity(raise_on_drift=True); print('prompt integrity ok')"`
- [x] `uv run deptry .`
- [x] `uv run python scripts/check_legacy_imports.py --base-ref origin/develop`
- [x] `uv run python scripts/check_repo_hygiene.py`
- [x] `uv run python scripts/check_llms_version.py`
- [x] `uv run python scripts/validate_petri_bundle.py`
- [x] `uv run python scripts/visualizations/verify_hero_layout.py --static-check`
- [x] `uv run geode version`
- [x] `npm run build`
- [x] Focused pytest: `uv run pytest tests/core/agent/test_model_split.py tests/core/agent/test_replan.py tests/core/config/test_c3_env_loading.py tests/core/cli/test_plan_tool_handlers.py tests/core/ui/test_agentic_ui.py tests/core/tools/test_tool_descriptions_fable5.py tests/core/tools/test_tool_category_tagging.py tests/core/llm/test_prompt_integrity.py -q`

Note: full local `uv run pytest tests/ -m "not live"` in the developer host produced environment-dependent failures from real user `~/.geode`/API key state plus missing `[audit]` extra under default sync. Re-running the failing subset with a clean HOME and CI-style `[audit]` extra cleared all but the known `/login set-key` env/profile isolation issue. GitHub CI runs in a clean environment and installs `[audit]` for the test job.