### PR TITLE
Stabilize AgenticLoop terminal UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **AgenticLoop terminal resize and tool-log stability.** Thin-client UI now
+  renders plan progress events, collapses large concurrent tool batches into a
+  bounded head/tail view, clears active tool regions by visual rows instead of
+  logical lines, refreshes Rich console width before final Markdown/code-block
+  rendering, and re-sends terminal width before each IPC prompt so resizing the
+  window does not leave stair-step ANSI/code-block artifacts.
+
 - **Reflection hint naming unified.** Verify failure feedback now uses the
   canonical `reflection_hint` / `<reflection>` surface owned by
   `core.agent.loop._reflection`, with `reflexion_hint` retained only as a

--- a/core/cli/interactive_loop.py
+++ b/core/cli/interactive_loop.py
@@ -66,7 +66,10 @@ def _render_text_with_latex(text: str) -> None:
     from rich.markdown import Markdown
 
     from core.ui.cjk_markdown import cjk_safe_emphasis
+    from core.ui.console import refresh_console_width
     from core.ui.latex import extract_and_render_inline
+
+    refresh_console_width()
 
     # CommonMark rejects `**…**` when the closer touches a Korean particle
     # (`**[추정]**이지만`) — pad spans so emphasis renders instead of

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -248,6 +248,11 @@ class IPCClient:
         """
         if not self._sock:
             return {"type": "error", "message": "Not connected"}
+        # Refresh width immediately before each prompt. The initial handshake
+        # happens at connect-time, but users often resize the terminal between
+        # prompts; stale Rich widths make streamed panels/code blocks paint a
+        # stair-step background at the old column count.
+        self._send_client_capability()
         self._send({"type": "prompt", "text": text})
 
         while True:

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -81,6 +81,20 @@ def _get_terminal_width() -> int | None:
     return max(80, min(cols, 160))
 
 
+def refresh_console_width() -> None:
+    """Refresh the active Rich console width from the current terminal.
+
+    The default Console is created once at import time. If the user resizes
+    the terminal before the final Markdown render, Rich code-block backgrounds
+    otherwise keep painting to the stale width and leave stair-step artifacts.
+    Test/capture consoles and non-TTY output keep their fixed width.
+    """
+    if not sys.stdout.isatty():
+        return
+    current = console._current() if isinstance(console, _ConsoleProxy) else console
+    current.width = _get_terminal_width() or current.width
+
+
 # ───────────────────────────────────────────────────────────────────────────
 # Thread-safe Console proxy
 # ───────────────────────────────────────────────────────────────────────────

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -430,9 +430,34 @@ class EventRenderer:
     def _handle_goal_decomposition(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
         steps = event.get("steps", [])
-        self._out.write(f"  \033[2m\u25cf Goal decomposed into {len(steps)} steps\033[0m\n")
+        self._out.write(f"  \033[2mPlan \u00b7 {len(steps)} steps\033[0m\n")
         for i, s in enumerate(steps[:5], 1):
-            self._out.write(f"    \033[2m{i}. {s}\033[0m\n")
+            marker = "\u25cf" if i == 1 else "\u25cb"
+            self._out.write(f"    \033[2m{marker} {s}\033[0m\n")
+        if len(steps) > 5:
+            self._out.write(f"    \033[2m\u2026 +{len(steps) - 5} more steps\033[0m\n")
+        self._out.flush()
+
+    def _handle_plan_step(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
+        current = int(event.get("current", 0))
+        total = int(event.get("total", 0))
+        revision = int(event.get("revision", 0))
+        description = str(event.get("description", ""))
+        rev = f" · rev {revision}" if revision else ""
+        self._out.write(f"  \033[2mPlan \u00b7 step {current}/{total}{rev}\033[0m\n")
+        if description:
+            self._out.write(f"    \033[2m\u25cf {description}\033[0m\n")
+        self._out.flush()
+
+    def _handle_replan(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
+        trigger = str(event.get("trigger", ""))
+        step_count = int(event.get("step_count", 0))
+        revision = int(event.get("revision", 0))
+        suffix = f" · {trigger}" if trigger else ""
+        rev = f" · rev {revision}" if revision else ""
+        self._out.write(f"  \033[2mPlan revised{suffix} · {step_count} steps{rev}\033[0m\n")
         self._out.flush()
 
     def _handle_tool_backpressure(self, event: dict[str, Any]) -> None:

--- a/core/ui/tool_tracker.py
+++ b/core/ui/tool_tracker.py
@@ -16,10 +16,14 @@ Usage (by thin client IPC handler)::
 
 from __future__ import annotations
 
+import re
+import shutil
 import sys
 import threading
 import time
 import unicodedata
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _truncate_display(text: str, max_width: int) -> str:
@@ -47,6 +51,10 @@ _FRAMES = [
     "\u280f",
 ]
 
+_MAX_VISIBLE_TOOL_LINES = 8
+_VISIBLE_TOOL_HEAD = 3
+_VISIBLE_TOOL_TAIL = 4
+
 
 class ToolCallTracker:
     """Renders tool call lines with spinners, updating in-place on completion.
@@ -60,6 +68,8 @@ class ToolCallTracker:
         self._spinner_thread: threading.Thread | None = None
         self._running = False
         self._line_count = 0  # how many lines we've printed
+        self._visual_row_count = 0
+        self._rendered_lines: list[str] = []
         self._tty = sys.stdout.isatty()  # suppress ANSI output in non-TTY contexts
 
     def on_tool_start(self, event: dict[str, object]) -> None:
@@ -70,6 +80,8 @@ class ToolCallTracker:
             if not self._running and self._tools and all(t["done"] for t in self._tools):
                 self._tools.clear()
                 self._line_count = 0
+                self._visual_row_count = 0
+                self._rendered_lines = []
             self._tools.append(
                 {
                     "name": str(event.get("name", "?")),
@@ -137,13 +149,15 @@ class ToolCallTracker:
             self._spinner_thread.join(timeout=0.3)
             self._spinner_thread = None
         with self._lock:
-            if self._line_count > 0 and self._tty:
+            if self._visual_row_count > 0 and self._tty:
                 out = sys.stdout
-                for _ in range(self._line_count):
+                for _ in range(self._visual_row_count):
                     out.write("\033[A\033[2K")
                 out.write("\r")
                 out.flush()
             self._line_count = 0
+            self._visual_row_count = 0
+            self._rendered_lines = []
 
     def _animate(self) -> None:
         while self._running:
@@ -158,40 +172,79 @@ class ToolCallTracker:
         tracker behaviour.  ANSI stdout writes are suppressed in non-TTY.
         """
         frame = _FRAMES[int(time.monotonic() * 12) % len(_FRAMES)]
-        lines: list[str] = []
-        for t in self._tools:
-            name = t["name"]
-            if t["done"]:
-                dur = f" ({float(t['duration']):.1f}s)"
-                if t["error"]:
-                    err = _truncate_display(str(t["error"]), 60)
-                    lines.append(f"\r\033[2K  \033[31m\u2717 {name}\033[0m — {err}{dur}")
-                else:
-                    summary = _truncate_display(str(t["summary"]), 60)
-                    lines.append(f"\r\033[2K  \033[32m\u2713 {name}\033[0m → {summary}{dur}")
-            else:
-                args = str(t["args"]).replace("\n", " ")
-                args = _truncate_display(args, 50)
-                lines.append(f"\r\033[2K  {frame} \033[35m{name}\033[0m({args})")
+        lines = self._render_tool_lines(frame)
 
-        # Always update line count (tests inspect this)
+        previous_lines = list(self._rendered_lines)
+        width = self._terminal_width()
+        previous_rows = max(
+            self._visual_row_count,
+            self._visual_rows(previous_lines, width),
+        )
+        current_rows = self._visual_rows(lines, width)
         self._line_count = len(lines)
+        self._visual_row_count = current_rows
+        self._rendered_lines = list(lines)
 
         # Only write ANSI output to real terminals
         if not self._tty:
             return
         out = sys.stdout
-        if self._line_count > 0:
-            out.write(f"\033[{self._line_count}A")
-        # Each line starts with ``\r`` so it paints from column 0 even when a
-        # prior writer (activity spinner, thinking region, interleaved stream)
-        # left the cursor mid-line. ``\033[{n}A`` moves UP but preserves the
-        # column, and ``\033[2K`` clears the line without moving the cursor —
-        # so without the ``\r`` the ``  ✓ name`` text printed at the stale
-        # column and the tool lines rendered with ragged indentation
-        # (operator-reported, 2026-06-11). ``suspend()`` already does this.
+        if previous_rows > 0:
+            out.write(f"\033[{previous_rows}A")
+
         output = "\n".join(lines)
         if lines:
             output += "\n"
         out.write(output)
+
+        # If this redraw rendered fewer rows than the previous frame
+        # (for example after a large batch collapses), wipe the stale tail.
+        for _ in range(max(0, previous_rows - current_rows)):
+            out.write("\r\033[2K\n")
+
         out.flush()
+
+    def _render_tool_lines(self, frame: str) -> list[str]:
+        """Return the bounded terminal rows for the currently tracked tools."""
+        lines = [self._render_tool_line(t, frame) for t in self._tools]
+        if len(lines) <= _MAX_VISIBLE_TOOL_LINES:
+            return lines
+
+        omitted = len(lines) - _VISIBLE_TOOL_HEAD - _VISIBLE_TOOL_TAIL
+        if omitted <= 0:
+            return lines
+
+        return [
+            *lines[:_VISIBLE_TOOL_HEAD],
+            f"\r\033[2K  \033[2m… +{omitted} tool calls collapsed\033[0m",
+            *lines[-_VISIBLE_TOOL_TAIL:],
+        ]
+
+    def _render_tool_line(self, tool: dict[str, str | bool | float], frame: str) -> str:
+        """Render one tool call row. Every row starts from column 0."""
+        name = tool["name"]
+        if tool["done"]:
+            dur = f" ({float(tool['duration']):.1f}s)"
+            if tool["error"]:
+                err = _truncate_display(str(tool["error"]), 60)
+                return f"\r\033[2K  \033[31m\u2717 {name}\033[0m — {err}{dur}"
+            summary = _truncate_display(str(tool["summary"]), 60)
+            return f"\r\033[2K  \033[32m\u2713 {name}\033[0m → {summary}{dur}"
+
+        args = str(tool["args"]).replace("\n", " ")
+        args = _truncate_display(args, 50)
+        return f"\r\033[2K  {frame} \033[35m{name}\033[0m({args})"
+
+    def _terminal_width(self) -> int:
+        return max(20, shutil.get_terminal_size(fallback=(80, 24)).columns)
+
+    def _visual_rows(self, lines: list[str], width: int | None = None) -> int:
+        width = width or self._terminal_width()
+        rows = 0
+        for line in lines:
+            plain = _ANSI_ESCAPE.sub("", line).lstrip("\r").rstrip("\n")
+            display_width = sum(
+                2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1 for ch in plain
+            )
+            rows += max(1, (display_width + width - 1) // width)
+        return rows

--- a/tests/core/cli/test_ipc_client_resize.py
+++ b/tests/core/cli/test_ipc_client_resize.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from core.cli.ipc_client import IPCClient
+
+
+def test_send_prompt_refreshes_client_capability_before_prompt(monkeypatch) -> None:
+    client = IPCClient()
+    client._sock = object()  # truthy sentinel; no real socket needed
+    sent: list[dict] = []
+    monkeypatch.setattr(client, "_send", lambda payload: sent.append(payload))
+    monkeypatch.setattr(client, "_recv", lambda: {"type": "result", "text": ""})
+
+    result = client.send_prompt("hello")
+
+    assert result["type"] == "result"
+    assert [payload["type"] for payload in sent[:2]] == ["client_capability", "prompt"]
+    assert sent[1]["text"] == "hello"

--- a/tests/core/ui/test_console_width.py
+++ b/tests/core/ui/test_console_width.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import io
+import os
+import sys
+
+from core.ui.console import (
+    make_session_console,
+    refresh_console_width,
+    reset_thread_console,
+    set_thread_console,
+)
+
+
+class _TtyStdout(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_refresh_console_width_updates_active_tty_console(monkeypatch) -> None:
+    console = make_session_console(io.StringIO(), force_terminal=True, width=80)
+    set_thread_console(console)
+    monkeypatch.setattr(sys, "stdout", _TtyStdout())
+    monkeypatch.setattr(
+        "core.ui.console.shutil.get_terminal_size",
+        lambda: os.terminal_size((100, 24)),
+    )
+    try:
+        refresh_console_width()
+        assert console._width == 100
+    finally:
+        reset_thread_console()
+
+
+def test_refresh_console_width_preserves_non_tty_capture(monkeypatch) -> None:
+    console = make_session_console(io.StringIO(), force_terminal=False, width=80)
+    set_thread_console(console)
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    try:
+        refresh_console_width()
+        assert console._width == 80
+    finally:
+        reset_thread_console()

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -250,7 +250,34 @@ class TestEventRendererV2:
 
     def test_goal_decomposition(self, renderer) -> None:
         renderer.on_event({"type": "goal_decomposition", "steps": ["a", "b"], "count": 2})
-        assert "2 steps" in renderer._out.getvalue()
+        out = renderer._out.getvalue()
+        assert "Plan" in out
+        assert "2 steps" in out
+        assert "● a" in out
+
+    def test_plan_step(self, renderer) -> None:
+        renderer.on_event(
+            {
+                "type": "plan_step",
+                "current": 2,
+                "total": 4,
+                "description": "verify the renderer",
+                "revision": 1,
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "Plan" in out
+        assert "step 2/4" in out
+        assert "verify the renderer" in out
+
+    def test_replan(self, renderer) -> None:
+        renderer.on_event(
+            {"type": "replan", "trigger": "verify_fail", "step_count": 3, "revision": 2}
+        )
+        out = renderer._out.getvalue()
+        assert "Plan revised" in out
+        assert "verify_fail" in out
+        assert "3 steps" in out
 
     def test_tool_backpressure(self, renderer) -> None:
         renderer.on_event({"type": "tool_backpressure", "consecutive_errors": 3})

--- a/tests/core/ui/test_tool_tracker_indent.py
+++ b/tests/core/ui/test_tool_tracker_indent.py
@@ -11,19 +11,37 @@ start with ``\\r``.
 
 from __future__ import annotations
 
-import inspect
 import io
 import sys
 
 from core.ui.tool_tracker import ToolCallTracker
 
 
-def test_redraw_lines_are_carriage_return_prefixed() -> None:
-    src = inspect.getsource(ToolCallTracker._redraw)
-    appends = [ln for ln in src.splitlines() if "lines.append" in ln]
-    assert len(appends) == 3, f"expected 3 line builders, found {len(appends)}"
-    for ln in appends:
-        assert r'"\r\033[2K' in ln, f"line not column-0-safe: {ln.strip()}"
+def _tool(name: str, *, done: bool = True) -> dict[str, str | bool | float]:
+    return {
+        "name": name,
+        "args": "",
+        "done": done,
+        "error": "",
+        "summary": "ok",
+        "start_time": 0.0,
+        "duration": 0.1,
+    }
+
+
+def test_rendered_tool_lines_are_carriage_return_prefixed() -> None:
+    tracker = ToolCallTracker()
+    tracker._tools = [
+        _tool("memory_search"),
+        _tool("glob_files", done=False),
+        {**_tool("grep_files"), "error": "failed"},
+    ]
+
+    lines = tracker._render_tool_lines("⠋")
+
+    assert len(lines) == 3
+    for line in lines:
+        assert line.startswith("\r\033[2K"), f"line not column-0-safe: {line!r}"
 
 
 def test_redraw_output_resets_column_per_line(monkeypatch) -> None:
@@ -58,3 +76,55 @@ def test_redraw_output_resets_column_per_line(monkeypatch) -> None:
     # and no tool line content appears without a preceding CR
     assert "  \033[32m✓ memory_search" in out
     assert "  \033[32m✓ glob_files" in out
+
+
+def test_large_tool_batches_collapse_to_bounded_view() -> None:
+    tracker = ToolCallTracker()
+    tracker._tools = [_tool(f"tool_{i}") for i in range(10)]
+
+    lines = tracker._render_tool_lines("⠋")
+
+    assert len(lines) == 8
+    assert "tool_0" in lines[0]
+    assert "tool_1" in lines[1]
+    assert "tool_2" in lines[2]
+    assert "+3 tool calls collapsed" in lines[3]
+    assert "tool_6" in lines[4]
+    assert "tool_9" in lines[-1]
+    assert all(line.startswith("\r\033[2K") for line in lines)
+
+
+def test_redraw_clears_previous_taller_frame(monkeypatch) -> None:
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    tracker = ToolCallTracker()
+    tracker._tty = True
+    tracker._line_count = 8
+    tracker._visual_row_count = 8
+    tracker._tools = [_tool("memory_search"), _tool("glob_files")]
+
+    tracker._redraw()
+
+    out = buf.getvalue()
+    assert out.startswith("\033[8A")
+    assert out.count("\r\033[2K\n") >= 6
+
+
+def test_redraw_overclears_when_terminal_width_shrinks(monkeypatch) -> None:
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    monkeypatch.setattr(
+        "core.ui.tool_tracker.shutil.get_terminal_size",
+        lambda fallback=(80, 24): __import__("os").terminal_size((20, 24)),
+    )
+    tracker = ToolCallTracker()
+    tracker._tty = True
+    tracker._line_count = 1
+    tracker._visual_row_count = 1
+    tracker._rendered_lines = ["\r\033[2K  ✓ very_long_tool_name_that_wrapped_at_narrow_width"]
+    tracker._tools = [_tool("ok")]
+
+    tracker._redraw()
+
+    out = buf.getvalue()
+    assert out.startswith("\033[3A")


### PR DESCRIPTION
## Summary
- Render AgenticLoop plan progress events in the thin client.
- Collapse large concurrent tool batches into a bounded head/tail view.
- Refresh terminal width before prompt/Markdown rendering and clear active tool regions by visual rows to avoid resize artifacts.

## Why
Users reported that AgenticLoop output did not expose the expected plan-style UI and that terminal output flooded downward until earlier context disappeared. A second report showed Rich/ANSI output breaking into stair-step artifacts when the terminal was resized during rendering.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | Adds plan/replan handlers and renders goal decomposition as `Plan · N steps`. |
| `core/ui/tool_tracker.py` | Bounds visible tool rows, preserves head/tail context, and clears by visual row count across terminal width changes. |
| `core/ui/console.py` | Adds `refresh_console_width()` for final Rich renders after terminal resize. |
| `core/cli/interactive_loop.py` | Refreshes console width before Markdown/LaTeX response rendering. |
| `core/cli/ipc_client.py` | Re-sends terminal capability before each prompt so daemon-side width is current. |
| `tests/core/**` | Adds regression coverage for resize width refresh, prompt capability refresh, plan event rendering, and bounded tool views. |
| `CHANGELOG.md` | Documents the terminal resize/tool-log stability fix under Unreleased. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Plan event rendering | Implemented | `plan_step`/`replan` were already allowed by IPC but lacked renderer handlers. |
| Tool flood control | Implemented | `ToolCallTracker` now caps visible rows and preserves first/latest tools. |
| Resize artifacts | Implemented | Active tool erasure uses visual rows; final Rich render refreshes width. |

## Verification
- [x] `uv run pytest tests/core/ui/test_tool_tracker_indent.py tests/core/ui/test_event_schema_v2.py tests/core/ui/test_console_width.py tests/core/ui/test_cli_latex_uiux.py tests/core/cli/test_ipc_client_resize.py tests/core/server/test_dangerously_skip_permissions.py -q`
- [x] `uv run ruff check core/ tests/ plugins/ scripts/`
- [x] `uv run ruff format --check core/ tests/ plugins/ scripts/`
- [x] `uv run mypy core/ plugins/ scripts/`
- [!] `uv run pytest -q` was attempted. It fails on baseline/environment issues unrelated to this change: `inspect_ai` optional extra missing, baseline event state visible in clean `origin/develop`, and local config/auth/concurrency state leaking into tests. A clean `origin/develop` worktree reproduces representative failures for `inspect_ai` and baseline event state.
