### PR TITLE
Render update_plan as dynamic progress surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Dynamic update_plan terminal surface.** `update_plan` now travels over IPC as
+  a structured `progress_plan` event instead of raw console text, so the thin
+  client can update the current plan in place when possible and avoids printing
+  a second full checklist after tool/sub-agent output has already scrolled below
+  the first plan.
+
 - **AgenticLoop terminal resize and tool-log stability.** Thin-client UI now
   renders plan progress events, collapses large concurrent tool batches into a
   bounded head/tail view, clears active tool regions by visual rows instead of

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -294,6 +294,7 @@ class IPCClient:
                 "convergence_detected",
                 "repeated_success_no_progress",
                 "goal_decomposition",
+                "progress_plan",
                 # PR-CL-A1 (2026-05-23) — Dynamic Replan UI events.
                 "plan_step",
                 "replan",

--- a/core/ui/agentic_ui/render.py
+++ b/core/ui/agentic_ui/render.py
@@ -128,6 +128,11 @@ def render_progress_plan(plan: list[dict[str, str]], *, explanation: str = "") -
     """Render a non-blocking progress checklist."""
     from core.ui import agentic_ui as _pkg
 
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event("progress_plan", plan=plan, explanation=explanation)
+        return
+
     status_style = {
         "pending": ("○", "dim"),
         "in_progress": ("●", "warning"),

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -49,6 +49,14 @@ class _ThinkingRegion:
     ended: bool = False
 
 
+@dataclass
+class _ProgressPlanSurface:
+    visible_lines: list[str] = field(default_factory=list)
+    rendered_once: bool = False
+    at_bottom: bool = False
+    compact: bool = False
+
+
 class EventRenderer:
     """Dispatches IPC events to appropriate rendering handlers.
 
@@ -103,6 +111,7 @@ class EventRenderer:
         # accidentally streams plain assistant Markdown, keep enough state to
         # erase that transient region before final Markdown rendering happens.
         self._clearable_stream_parts: list[str] = []
+        self._progress_plan = _ProgressPlanSurface()
 
     # -- Public API -----------------------------------------------------------
 
@@ -140,10 +149,13 @@ class EventRenderer:
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
             self._reset_clearable_stream_region()
+            if etype != "progress_plan":
+                self._mark_progress_plan_obscured()
             handler(event)
 
     def on_stream(self, data: str) -> None:
         """Handle raw console stream (Rich panels, pipeline output)."""
+        self._mark_progress_plan_obscured()
         self._suppress_all_spinners()
         if self._is_clearable_plain_stream(data):
             self._clearable_stream_parts.append(data)
@@ -459,6 +471,44 @@ class EventRenderer:
         rev = f" · rev {revision}" if revision else ""
         self._out.write(f"  \033[2mPlan revised{suffix} · {step_count} steps{rev}\033[0m\n")
         self._out.flush()
+
+    def _handle_progress_plan(self, event: dict[str, Any]) -> None:
+        """Render update_plan as a managed single plan surface.
+
+        If the previous plan block is still the bottom-most thing in the terminal,
+        redraw it in place. Once tool logs or stream output have appeared below it,
+        do not print a second full checklist; show a compact transition instead.
+        A scrollback terminal cannot safely rewrite an arbitrary older block.
+        """
+        plan = event.get("plan", [])
+        if not isinstance(plan, list):
+            return
+        items = [item for item in plan if isinstance(item, dict)]
+        if not items:
+            return
+
+        explanation = str(event.get("explanation", "") or "").strip()
+        with self._render_lock:
+            self._suppress_all_spinners()
+            surface = self._progress_plan
+            if surface.at_bottom and surface.visible_lines:
+                self._erase_lines_locked(surface.visible_lines)
+
+            should_compact = surface.rendered_once and not (
+                surface.at_bottom and not surface.compact
+            )
+            lines = (
+                self._render_compact_progress_plan(items, explanation)
+                if should_compact
+                else self._render_full_progress_plan(items, explanation)
+            )
+            for line in lines:
+                self._out.write(line)
+            surface.visible_lines = list(lines)
+            surface.rendered_once = True
+            surface.at_bottom = True
+            surface.compact = should_compact
+            self._out.flush()
 
     def _handle_tool_backpressure(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
@@ -930,7 +980,13 @@ class EventRenderer:
         region.is_collapsed = False
 
     def _erase_thinking_visible_locked(self, region: _ThinkingRegion) -> None:
-        rows = self._thinking_visual_rows(region.visible_lines)
+        rows = self._visual_rows(region.visible_lines)
+        self._erase_visual_rows_locked(rows)
+
+    def _erase_lines_locked(self, lines: list[str]) -> None:
+        self._erase_visual_rows_locked(self._visual_rows(lines))
+
+    def _erase_visual_rows_locked(self, rows: int) -> None:
         self._out.write("\r\033[2K")
         if rows <= 0:
             return
@@ -951,12 +1007,70 @@ class EventRenderer:
         )
 
     def _thinking_visual_rows(self, lines: list[str]) -> int:
+        return self._visual_rows(lines)
+
+    def _visual_rows(self, lines: list[str]) -> int:
         width = max(20, shutil.get_terminal_size(fallback=(80, 24)).columns)
         rows = 0
         for line in lines:
             plain = _ANSI_ESCAPE.sub("", line).rstrip("\n")
             rows += max(1, (len(plain) + width - 1) // width)
         return rows
+
+    def _mark_progress_plan_obscured(self) -> None:
+        if self._progress_plan.visible_lines:
+            self._progress_plan.at_bottom = False
+
+    def _render_full_progress_plan(
+        self, items: list[dict[Any, Any]], explanation: str
+    ) -> list[str]:
+        header = "Plan"
+        if explanation:
+            header = f"Plan · {explanation}"
+        lines = ["\n", f"  \033[1;36m{header}\033[0m\n"]
+        for item in items:
+            status = str(item.get("status", "pending"))
+            step = str(item.get("step", ""))
+            symbol, style = self._progress_plan_symbol(status)
+            lines.append(f"    {style}{symbol}\033[0m {step}\n")
+        lines.append("\n")
+        return lines
+
+    def _render_compact_progress_plan(
+        self, items: list[dict[Any, Any]], explanation: str
+    ) -> list[str]:
+        total = len(items)
+        completed = sum(1 for item in items if item.get("status") == "completed")
+        active = next(
+            (
+                str(item.get("step", ""))
+                for item in items
+                if item.get("status") == "in_progress" and item.get("step")
+            ),
+            "",
+        )
+        if not active:
+            active = next(
+                (
+                    str(item.get("step", ""))
+                    for item in items
+                    if item.get("status") == "pending" and item.get("step")
+                ),
+                "",
+            )
+        suffix = f" · {explanation}" if explanation else ""
+        lines = [f"\n  \033[2mPlan updated{suffix} · {completed}/{total} complete\033[0m\n"]
+        if active:
+            lines.append(f"    \033[1;33m●\033[0m {active}\n")
+        return lines
+
+    @staticmethod
+    def _progress_plan_symbol(status: str) -> tuple[str, str]:
+        if status == "completed":
+            return "✓", "\033[32m"
+        if status == "in_progress":
+            return "●", "\033[1;33m"
+        return "○", "\033[2m"
 
     def _suppress_all_spinners(self) -> None:
         """Stop thinking + tool spinners, clear line for new content."""

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -87,6 +87,20 @@ class TestAgenticLoopEmitters:
             count=2,
         )
 
+    def test_render_progress_plan_sends_structured_event(self) -> None:
+        from core.ui.agentic_ui import render_progress_plan
+
+        plan = [
+            {"step": "Inspect UX", "status": "completed"},
+            {"step": "Patch renderer", "status": "in_progress"},
+        ]
+        render_progress_plan(plan, explanation="implementation")
+        self.mock_writer.send_event.assert_called_once_with(
+            "progress_plan",
+            plan=plan,
+            explanation="implementation",
+        )
+
     def test_emit_tool_backpressure(self) -> None:
         from core.ui.agentic_ui import emit_tool_backpressure
 
@@ -254,6 +268,70 @@ class TestEventRendererV2:
         assert "Plan" in out
         assert "2 steps" in out
         assert "● a" in out
+
+    def test_progress_plan_first_render_is_full_checklist(self, renderer) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "implementation",
+                "plan": [
+                    {"step": "Inspect UX", "status": "completed"},
+                    {"step": "Patch renderer", "status": "in_progress"},
+                    {"step": "Run tests", "status": "pending"},
+                ],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "Plan · implementation" in out
+        assert "✓" in out
+        assert "Inspect UX" in out
+        assert "Patch renderer" in out
+        assert "Run tests" in out
+
+    def test_progress_plan_updates_in_place_when_still_at_bottom(self, renderer) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "First plan", "status": "in_progress"}],
+            }
+        )
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "Second plan", "status": "in_progress"}],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "\033[" in out and "A" in out
+        assert "Second plan" in out
+
+    def test_progress_plan_after_tool_output_is_compact_not_second_full_block(
+        self, renderer
+    ) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "first",
+                "plan": [{"step": "Initial investigation", "status": "in_progress"}],
+            }
+        )
+        renderer.on_event({"type": "subagent_complete", "count": 4, "elapsed_s": 12.0})
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "fallback",
+                "plan": [
+                    {"step": "Already done", "status": "completed"},
+                    {"step": "Direct verification", "status": "in_progress"},
+                    {"step": "This full-list tail should not print", "status": "pending"},
+                ],
+            }
+        )
+        out = renderer._out.getvalue()
+        compact = out[out.rindex("Plan updated") :]
+        assert "Plan updated · fallback · 1/3 complete" in compact
+        assert "Direct verification" in compact
+        assert "This full-list tail should not print" not in compact
 
     def test_plan_step(self, renderer) -> None:
         renderer.on_event(
@@ -487,6 +565,7 @@ class TestIPCClientEventWhitelist:
             "time_budget_expired",
             "convergence_detected",
             "goal_decomposition",
+            "progress_plan",
             "tool_backpressure",
             "tool_diversity_forced",
             "model_switched",


### PR DESCRIPTION
Summary
- Route update_plan output through a structured progress_plan IPC event instead of raw console text.
- Let the thin-client EventRenderer manage a single progress-plan surface: redraw in place while it is still at the terminal bottom, and use a compact update once tool/sub-agent logs have appeared below it.
- Add regression coverage for structured progress_plan events and non-duplicating follow-up plan updates.

Why
- update_plan previously printed a full checklist every time through daemon-side console output, so later replans/progress updates duplicated the plan block in scrollback.
- A normal scrollback terminal cannot safely rewrite an arbitrary older block after other output has appeared below it, so the fallback is intentionally compact rather than another full checklist.

Verification
- uv run pytest tests/core/ui/test_event_schema_v2.py tests/core/ui/test_agentic_ui.py tests/core/cli/test_plan_tool_handlers.py -q
- uv run pytest tests/core/ui/test_event_schema_v2.py tests/core/ui/test_agentic_ui.py tests/core/ui/test_tool_tracker_indent.py tests/core/ui/test_thinking_collapse.py tests/core/ui/test_ipc_output_parity.py tests/core/cli/test_plan_tool_handlers.py tests/core/cli/test_ipc_client_resize.py -q
- uv run ruff check core/ tests/ plugins/ scripts/
- uv run ruff format --check core/ tests/ plugins/ scripts/
- uv run mypy core/ plugins/ scripts/