### PR TITLE
Converge plan events on Codex-style surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Codex-style plan surface convergence.** `goal_decomposition`,
+  `plan_step`, `replan`, and `update_plan` now share the same thin-client plan
+  surface policy, so plan revisions and step advances update the visible plan
+  instead of emitting separate full plan banners into the transcript.
+
 - **Dynamic update_plan terminal surface.** `update_plan` now travels over IPC as
   a structured `progress_plan` event instead of raw console text, so the thin
   client can update the current plan in place when possible and avoids printing

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -52,6 +52,7 @@ class _ThinkingRegion:
 @dataclass
 class _ProgressPlanSurface:
     visible_lines: list[str] = field(default_factory=list)
+    items: list[dict[str, str]] = field(default_factory=list)
     rendered_once: bool = False
     at_bottom: bool = False
     compact: bool = False
@@ -76,6 +77,7 @@ class EventRenderer:
     _REPEAT_SUPPRESSIBLE = frozenset(
         {"tool_start", "tool_end", "tokens", "thinking_start", "thinking_end", "round_start"}
     )
+    _PLAN_SURFACE_EVENTS = frozenset({"goal_decomposition", "plan_step", "progress_plan", "replan"})
 
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
@@ -149,7 +151,7 @@ class EventRenderer:
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
             self._reset_clearable_stream_region()
-            if etype != "progress_plan":
+            if etype not in self._PLAN_SURFACE_EVENTS:
                 self._mark_progress_plan_obscured()
             handler(event)
 
@@ -440,37 +442,61 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_goal_decomposition(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         steps = event.get("steps", [])
-        self._out.write(f"  \033[2mPlan \u00b7 {len(steps)} steps\033[0m\n")
-        for i, s in enumerate(steps[:5], 1):
-            marker = "\u25cf" if i == 1 else "\u25cb"
-            self._out.write(f"    \033[2m{marker} {s}\033[0m\n")
-        if len(steps) > 5:
-            self._out.write(f"    \033[2m\u2026 +{len(steps) - 5} more steps\033[0m\n")
-        self._out.flush()
+        if not isinstance(steps, list):
+            return
+        items = [
+            {"step": str(step), "status": "in_progress" if i == 0 else "pending"}
+            for i, step in enumerate(steps)
+            if str(step).strip()
+        ]
+        if not items:
+            return
+        self._render_progress_plan_surface(items, f"{len(items)} steps")
 
     def _handle_plan_step(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         current = int(event.get("current", 0))
         total = int(event.get("total", 0))
         revision = int(event.get("revision", 0))
         description = str(event.get("description", ""))
+        if current <= 0 or total <= 0:
+            return
+        surface_items = list(self._progress_plan.items)
+        if len(surface_items) != total:
+            surface_items = [
+                {"step": description if i == current else f"Step {i}", "status": "pending"}
+                for i in range(1, total + 1)
+            ]
+        for idx, item in enumerate(surface_items, 1):
+            if idx < current:
+                item["status"] = "completed"
+            elif idx == current:
+                item["status"] = "in_progress"
+                if description:
+                    item["step"] = description
+            else:
+                item["status"] = "pending"
         rev = f" · rev {revision}" if revision else ""
-        self._out.write(f"  \033[2mPlan \u00b7 step {current}/{total}{rev}\033[0m\n")
-        if description:
-            self._out.write(f"    \033[2m\u25cf {description}\033[0m\n")
-        self._out.flush()
+        self._render_progress_plan_surface(surface_items, f"step {current}/{total}{rev}")
 
     def _handle_replan(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         trigger = str(event.get("trigger", ""))
         step_count = int(event.get("step_count", 0))
         revision = int(event.get("revision", 0))
         suffix = f" · {trigger}" if trigger else ""
         rev = f" · rev {revision}" if revision else ""
-        self._out.write(f"  \033[2mPlan revised{suffix} · {step_count} steps{rev}\033[0m\n")
-        self._out.flush()
+        items = list(self._progress_plan.items)
+        if step_count > 0 and len(items) != step_count:
+            items = [{"step": f"Step {i}", "status": "pending"} for i in range(1, step_count + 1)]
+        compact_explanation = (
+            f"{trigger} · {step_count} steps{rev}" if trigger else f"{step_count} steps{rev}"
+        )
+        self._render_progress_plan_surface(
+            items,
+            f"revised{suffix} · {step_count} steps{rev}",
+            compact_message="Plan revised",
+            compact_explanation=compact_explanation,
+        )
 
     def _handle_progress_plan(self, event: dict[str, Any]) -> None:
         """Render update_plan as a managed single plan surface.
@@ -488,6 +514,27 @@ class EventRenderer:
             return
 
         explanation = str(event.get("explanation", "") or "").strip()
+        self._render_progress_plan_surface(items, explanation)
+
+    def _render_progress_plan_surface(
+        self,
+        items: list[dict[Any, Any]],
+        explanation: str,
+        *,
+        compact_message: str = "Plan updated",
+        compact_explanation: str | None = None,
+    ) -> None:
+        normalized = [
+            {
+                "step": str(item.get("step", "")).strip(),
+                "status": str(item.get("status", "pending")).strip() or "pending",
+            }
+            for item in items
+            if str(item.get("step", "")).strip()
+        ]
+        if not normalized:
+            return
+
         with self._render_lock:
             self._suppress_all_spinners()
             surface = self._progress_plan
@@ -498,13 +545,18 @@ class EventRenderer:
                 surface.at_bottom and not surface.compact
             )
             lines = (
-                self._render_compact_progress_plan(items, explanation)
+                self._render_compact_progress_plan(
+                    normalized,
+                    compact_explanation if compact_explanation is not None else explanation,
+                    message=compact_message,
+                )
                 if should_compact
-                else self._render_full_progress_plan(items, explanation)
+                else self._render_full_progress_plan(normalized, explanation)
             )
             for line in lines:
                 self._out.write(line)
             surface.visible_lines = list(lines)
+            surface.items = list(normalized)
             surface.rendered_once = True
             surface.at_bottom = True
             surface.compact = should_compact
@@ -1037,7 +1089,7 @@ class EventRenderer:
         return lines
 
     def _render_compact_progress_plan(
-        self, items: list[dict[Any, Any]], explanation: str
+        self, items: list[dict[Any, Any]], explanation: str, *, message: str = "Plan updated"
     ) -> list[str]:
         total = len(items)
         completed = sum(1 for item in items if item.get("status") == "completed")
@@ -1059,7 +1111,7 @@ class EventRenderer:
                 "",
             )
         suffix = f" · {explanation}" if explanation else ""
-        lines = [f"\n  \033[2mPlan updated{suffix} · {completed}/{total} complete\033[0m\n"]
+        lines = [f"\n  \033[2m{message}{suffix} · {completed}/{total} complete\033[0m\n"]
         if active:
             lines.append(f"    \033[1;33m●\033[0m {active}\n")
         return lines

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -267,7 +267,8 @@ class TestEventRendererV2:
         out = renderer._out.getvalue()
         assert "Plan" in out
         assert "2 steps" in out
-        assert "● a" in out
+        assert "●" in out
+        assert "a" in out
 
     def test_progress_plan_first_render_is_full_checklist(self, renderer) -> None:
         renderer.on_event(
@@ -334,28 +335,42 @@ class TestEventRendererV2:
         assert "This full-list tail should not print" not in compact
 
     def test_plan_step(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
         renderer.on_event(
             {
                 "type": "plan_step",
                 "current": 2,
-                "total": 4,
+                "total": 2,
                 "description": "verify the renderer",
                 "revision": 1,
             }
         )
         out = renderer._out.getvalue()
+        assert "\033[" in out and "A" in out
         assert "Plan" in out
-        assert "step 2/4" in out
+        assert "step 2/2" in out
         assert "verify the renderer" in out
+        assert "✓" in out
 
     def test_replan(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
         renderer.on_event(
             {"type": "replan", "trigger": "verify_fail", "step_count": 3, "revision": 2}
         )
         out = renderer._out.getvalue()
-        assert "Plan revised" in out
+        assert "\033[" in out and "A" in out
+        assert "Plan · revised" in out
         assert "verify_fail" in out
         assert "3 steps" in out
+
+    def test_replan_after_tool_output_is_compact(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
+        renderer.on_event({"type": "subagent_complete", "count": 2, "elapsed_s": 5.0})
+        renderer.on_event({"type": "replan", "trigger": "cadence", "step_count": 2, "revision": 1})
+        out = renderer._out.getvalue()
+        compact = out[out.rindex("Plan revised") :]
+        assert "Plan revised · cadence · 2 steps · rev 1" in compact
+        assert "Step 2" not in compact
 
     def test_tool_backpressure(self, renderer) -> None:
         renderer.on_event({"type": "tool_backpressure", "consecutive_errors": 3})


### PR DESCRIPTION
Summary
- Make goal_decomposition, plan_step, replan, and update_plan share the same thin-client plan surface policy.
- Preserve current plan items so step advances update status in place instead of printing separate Plan step banners.
- Render replans through the same surface, with compact transition output once tool/sub-agent logs have appeared below the plan.

Why
- Codex treats plan/progress as a managed UI surface rather than independent transcript banners.
- GEODE still had four separate plan-like event renderers, so plan initialization, step progress, replans, and update_plan could stack duplicated plan text.

Verification
- uv run pytest tests/core/ui/test_event_schema_v2.py tests/core/ui/test_agentic_ui.py tests/core/ui/test_tool_tracker_indent.py tests/core/ui/test_thinking_collapse.py tests/core/ui/test_ipc_output_parity.py tests/core/cli/test_plan_tool_handlers.py tests/core/cli/test_ipc_client_resize.py -q
- uv run ruff check core/ tests/ plugins/ scripts/
- uv run ruff format --check core/ tests/ plugins/ scripts/
- uv run mypy core/ plugins/ scripts/