### PR TITLE
Release Codex-style plan surface convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Codex-style plan surface convergence.** `goal_decomposition`,
+  `plan_step`, `replan`, and `update_plan` now share the same thin-client plan
+  surface policy, so plan revisions and step advances update the visible plan
+  instead of emitting separate full plan banners into the transcript.
+
 - **Dynamic update_plan terminal surface.** `update_plan` now travels over IPC as
   a structured `progress_plan` event instead of raw console text, so the thin
   client can update the current plan in place when possible and avoids printing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Dynamic update_plan terminal surface.** `update_plan` now travels over IPC as
+  a structured `progress_plan` event instead of raw console text, so the thin
+  client can update the current plan in place when possible and avoids printing
+  a second full checklist after tool/sub-agent output has already scrolled below
+  the first plan.
+
 - **AgenticLoop terminal resize and tool-log stability.** Thin-client UI now
   renders plan progress events, collapses large concurrent tool batches into a
   bounded head/tail view, clears active tool regions by visual rows instead of

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -294,6 +294,7 @@ class IPCClient:
                 "convergence_detected",
                 "repeated_success_no_progress",
                 "goal_decomposition",
+                "progress_plan",
                 # PR-CL-A1 (2026-05-23) — Dynamic Replan UI events.
                 "plan_step",
                 "replan",

--- a/core/ui/agentic_ui/render.py
+++ b/core/ui/agentic_ui/render.py
@@ -128,6 +128,11 @@ def render_progress_plan(plan: list[dict[str, str]], *, explanation: str = "") -
     """Render a non-blocking progress checklist."""
     from core.ui import agentic_ui as _pkg
 
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event("progress_plan", plan=plan, explanation=explanation)
+        return
+
     status_style = {
         "pending": ("○", "dim"),
         "in_progress": ("●", "warning"),

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -52,6 +52,7 @@ class _ThinkingRegion:
 @dataclass
 class _ProgressPlanSurface:
     visible_lines: list[str] = field(default_factory=list)
+    items: list[dict[str, str]] = field(default_factory=list)
     rendered_once: bool = False
     at_bottom: bool = False
     compact: bool = False
@@ -76,6 +77,7 @@ class EventRenderer:
     _REPEAT_SUPPRESSIBLE = frozenset(
         {"tool_start", "tool_end", "tokens", "thinking_start", "thinking_end", "round_start"}
     )
+    _PLAN_SURFACE_EVENTS = frozenset({"goal_decomposition", "plan_step", "progress_plan", "replan"})
 
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
@@ -149,7 +151,7 @@ class EventRenderer:
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
             self._reset_clearable_stream_region()
-            if etype != "progress_plan":
+            if etype not in self._PLAN_SURFACE_EVENTS:
                 self._mark_progress_plan_obscured()
             handler(event)
 
@@ -440,37 +442,61 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_goal_decomposition(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         steps = event.get("steps", [])
-        self._out.write(f"  \033[2mPlan \u00b7 {len(steps)} steps\033[0m\n")
-        for i, s in enumerate(steps[:5], 1):
-            marker = "\u25cf" if i == 1 else "\u25cb"
-            self._out.write(f"    \033[2m{marker} {s}\033[0m\n")
-        if len(steps) > 5:
-            self._out.write(f"    \033[2m\u2026 +{len(steps) - 5} more steps\033[0m\n")
-        self._out.flush()
+        if not isinstance(steps, list):
+            return
+        items = [
+            {"step": str(step), "status": "in_progress" if i == 0 else "pending"}
+            for i, step in enumerate(steps)
+            if str(step).strip()
+        ]
+        if not items:
+            return
+        self._render_progress_plan_surface(items, f"{len(items)} steps")
 
     def _handle_plan_step(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         current = int(event.get("current", 0))
         total = int(event.get("total", 0))
         revision = int(event.get("revision", 0))
         description = str(event.get("description", ""))
+        if current <= 0 or total <= 0:
+            return
+        surface_items = list(self._progress_plan.items)
+        if len(surface_items) != total:
+            surface_items = [
+                {"step": description if i == current else f"Step {i}", "status": "pending"}
+                for i in range(1, total + 1)
+            ]
+        for idx, item in enumerate(surface_items, 1):
+            if idx < current:
+                item["status"] = "completed"
+            elif idx == current:
+                item["status"] = "in_progress"
+                if description:
+                    item["step"] = description
+            else:
+                item["status"] = "pending"
         rev = f" · rev {revision}" if revision else ""
-        self._out.write(f"  \033[2mPlan \u00b7 step {current}/{total}{rev}\033[0m\n")
-        if description:
-            self._out.write(f"    \033[2m\u25cf {description}\033[0m\n")
-        self._out.flush()
+        self._render_progress_plan_surface(surface_items, f"step {current}/{total}{rev}")
 
     def _handle_replan(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
         trigger = str(event.get("trigger", ""))
         step_count = int(event.get("step_count", 0))
         revision = int(event.get("revision", 0))
         suffix = f" · {trigger}" if trigger else ""
         rev = f" · rev {revision}" if revision else ""
-        self._out.write(f"  \033[2mPlan revised{suffix} · {step_count} steps{rev}\033[0m\n")
-        self._out.flush()
+        items = list(self._progress_plan.items)
+        if step_count > 0 and len(items) != step_count:
+            items = [{"step": f"Step {i}", "status": "pending"} for i in range(1, step_count + 1)]
+        compact_explanation = (
+            f"{trigger} · {step_count} steps{rev}" if trigger else f"{step_count} steps{rev}"
+        )
+        self._render_progress_plan_surface(
+            items,
+            f"revised{suffix} · {step_count} steps{rev}",
+            compact_message="Plan revised",
+            compact_explanation=compact_explanation,
+        )
 
     def _handle_progress_plan(self, event: dict[str, Any]) -> None:
         """Render update_plan as a managed single plan surface.
@@ -488,6 +514,27 @@ class EventRenderer:
             return
 
         explanation = str(event.get("explanation", "") or "").strip()
+        self._render_progress_plan_surface(items, explanation)
+
+    def _render_progress_plan_surface(
+        self,
+        items: list[dict[Any, Any]],
+        explanation: str,
+        *,
+        compact_message: str = "Plan updated",
+        compact_explanation: str | None = None,
+    ) -> None:
+        normalized = [
+            {
+                "step": str(item.get("step", "")).strip(),
+                "status": str(item.get("status", "pending")).strip() or "pending",
+            }
+            for item in items
+            if str(item.get("step", "")).strip()
+        ]
+        if not normalized:
+            return
+
         with self._render_lock:
             self._suppress_all_spinners()
             surface = self._progress_plan
@@ -498,13 +545,18 @@ class EventRenderer:
                 surface.at_bottom and not surface.compact
             )
             lines = (
-                self._render_compact_progress_plan(items, explanation)
+                self._render_compact_progress_plan(
+                    normalized,
+                    compact_explanation if compact_explanation is not None else explanation,
+                    message=compact_message,
+                )
                 if should_compact
-                else self._render_full_progress_plan(items, explanation)
+                else self._render_full_progress_plan(normalized, explanation)
             )
             for line in lines:
                 self._out.write(line)
             surface.visible_lines = list(lines)
+            surface.items = list(normalized)
             surface.rendered_once = True
             surface.at_bottom = True
             surface.compact = should_compact
@@ -1037,7 +1089,7 @@ class EventRenderer:
         return lines
 
     def _render_compact_progress_plan(
-        self, items: list[dict[Any, Any]], explanation: str
+        self, items: list[dict[Any, Any]], explanation: str, *, message: str = "Plan updated"
     ) -> list[str]:
         total = len(items)
         completed = sum(1 for item in items if item.get("status") == "completed")
@@ -1059,7 +1111,7 @@ class EventRenderer:
                 "",
             )
         suffix = f" · {explanation}" if explanation else ""
-        lines = [f"\n  \033[2mPlan updated{suffix} · {completed}/{total} complete\033[0m\n"]
+        lines = [f"\n  \033[2m{message}{suffix} · {completed}/{total} complete\033[0m\n"]
         if active:
             lines.append(f"    \033[1;33m●\033[0m {active}\n")
         return lines

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -49,6 +49,14 @@ class _ThinkingRegion:
     ended: bool = False
 
 
+@dataclass
+class _ProgressPlanSurface:
+    visible_lines: list[str] = field(default_factory=list)
+    rendered_once: bool = False
+    at_bottom: bool = False
+    compact: bool = False
+
+
 class EventRenderer:
     """Dispatches IPC events to appropriate rendering handlers.
 
@@ -103,6 +111,7 @@ class EventRenderer:
         # accidentally streams plain assistant Markdown, keep enough state to
         # erase that transient region before final Markdown rendering happens.
         self._clearable_stream_parts: list[str] = []
+        self._progress_plan = _ProgressPlanSurface()
 
     # -- Public API -----------------------------------------------------------
 
@@ -140,10 +149,13 @@ class EventRenderer:
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
             self._reset_clearable_stream_region()
+            if etype != "progress_plan":
+                self._mark_progress_plan_obscured()
             handler(event)
 
     def on_stream(self, data: str) -> None:
         """Handle raw console stream (Rich panels, pipeline output)."""
+        self._mark_progress_plan_obscured()
         self._suppress_all_spinners()
         if self._is_clearable_plain_stream(data):
             self._clearable_stream_parts.append(data)
@@ -459,6 +471,44 @@ class EventRenderer:
         rev = f" · rev {revision}" if revision else ""
         self._out.write(f"  \033[2mPlan revised{suffix} · {step_count} steps{rev}\033[0m\n")
         self._out.flush()
+
+    def _handle_progress_plan(self, event: dict[str, Any]) -> None:
+        """Render update_plan as a managed single plan surface.
+
+        If the previous plan block is still the bottom-most thing in the terminal,
+        redraw it in place. Once tool logs or stream output have appeared below it,
+        do not print a second full checklist; show a compact transition instead.
+        A scrollback terminal cannot safely rewrite an arbitrary older block.
+        """
+        plan = event.get("plan", [])
+        if not isinstance(plan, list):
+            return
+        items = [item for item in plan if isinstance(item, dict)]
+        if not items:
+            return
+
+        explanation = str(event.get("explanation", "") or "").strip()
+        with self._render_lock:
+            self._suppress_all_spinners()
+            surface = self._progress_plan
+            if surface.at_bottom and surface.visible_lines:
+                self._erase_lines_locked(surface.visible_lines)
+
+            should_compact = surface.rendered_once and not (
+                surface.at_bottom and not surface.compact
+            )
+            lines = (
+                self._render_compact_progress_plan(items, explanation)
+                if should_compact
+                else self._render_full_progress_plan(items, explanation)
+            )
+            for line in lines:
+                self._out.write(line)
+            surface.visible_lines = list(lines)
+            surface.rendered_once = True
+            surface.at_bottom = True
+            surface.compact = should_compact
+            self._out.flush()
 
     def _handle_tool_backpressure(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
@@ -930,7 +980,13 @@ class EventRenderer:
         region.is_collapsed = False
 
     def _erase_thinking_visible_locked(self, region: _ThinkingRegion) -> None:
-        rows = self._thinking_visual_rows(region.visible_lines)
+        rows = self._visual_rows(region.visible_lines)
+        self._erase_visual_rows_locked(rows)
+
+    def _erase_lines_locked(self, lines: list[str]) -> None:
+        self._erase_visual_rows_locked(self._visual_rows(lines))
+
+    def _erase_visual_rows_locked(self, rows: int) -> None:
         self._out.write("\r\033[2K")
         if rows <= 0:
             return
@@ -951,12 +1007,70 @@ class EventRenderer:
         )
 
     def _thinking_visual_rows(self, lines: list[str]) -> int:
+        return self._visual_rows(lines)
+
+    def _visual_rows(self, lines: list[str]) -> int:
         width = max(20, shutil.get_terminal_size(fallback=(80, 24)).columns)
         rows = 0
         for line in lines:
             plain = _ANSI_ESCAPE.sub("", line).rstrip("\n")
             rows += max(1, (len(plain) + width - 1) // width)
         return rows
+
+    def _mark_progress_plan_obscured(self) -> None:
+        if self._progress_plan.visible_lines:
+            self._progress_plan.at_bottom = False
+
+    def _render_full_progress_plan(
+        self, items: list[dict[Any, Any]], explanation: str
+    ) -> list[str]:
+        header = "Plan"
+        if explanation:
+            header = f"Plan · {explanation}"
+        lines = ["\n", f"  \033[1;36m{header}\033[0m\n"]
+        for item in items:
+            status = str(item.get("status", "pending"))
+            step = str(item.get("step", ""))
+            symbol, style = self._progress_plan_symbol(status)
+            lines.append(f"    {style}{symbol}\033[0m {step}\n")
+        lines.append("\n")
+        return lines
+
+    def _render_compact_progress_plan(
+        self, items: list[dict[Any, Any]], explanation: str
+    ) -> list[str]:
+        total = len(items)
+        completed = sum(1 for item in items if item.get("status") == "completed")
+        active = next(
+            (
+                str(item.get("step", ""))
+                for item in items
+                if item.get("status") == "in_progress" and item.get("step")
+            ),
+            "",
+        )
+        if not active:
+            active = next(
+                (
+                    str(item.get("step", ""))
+                    for item in items
+                    if item.get("status") == "pending" and item.get("step")
+                ),
+                "",
+            )
+        suffix = f" · {explanation}" if explanation else ""
+        lines = [f"\n  \033[2mPlan updated{suffix} · {completed}/{total} complete\033[0m\n"]
+        if active:
+            lines.append(f"    \033[1;33m●\033[0m {active}\n")
+        return lines
+
+    @staticmethod
+    def _progress_plan_symbol(status: str) -> tuple[str, str]:
+        if status == "completed":
+            return "✓", "\033[32m"
+        if status == "in_progress":
+            return "●", "\033[1;33m"
+        return "○", "\033[2m"
 
     def _suppress_all_spinners(self) -> None:
         """Stop thinking + tool spinners, clear line for new content."""

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -267,7 +267,8 @@ class TestEventRendererV2:
         out = renderer._out.getvalue()
         assert "Plan" in out
         assert "2 steps" in out
-        assert "● a" in out
+        assert "●" in out
+        assert "a" in out
 
     def test_progress_plan_first_render_is_full_checklist(self, renderer) -> None:
         renderer.on_event(
@@ -334,28 +335,42 @@ class TestEventRendererV2:
         assert "This full-list tail should not print" not in compact
 
     def test_plan_step(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
         renderer.on_event(
             {
                 "type": "plan_step",
                 "current": 2,
-                "total": 4,
+                "total": 2,
                 "description": "verify the renderer",
                 "revision": 1,
             }
         )
         out = renderer._out.getvalue()
+        assert "\033[" in out and "A" in out
         assert "Plan" in out
-        assert "step 2/4" in out
+        assert "step 2/2" in out
         assert "verify the renderer" in out
+        assert "✓" in out
 
     def test_replan(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
         renderer.on_event(
             {"type": "replan", "trigger": "verify_fail", "step_count": 3, "revision": 2}
         )
         out = renderer._out.getvalue()
-        assert "Plan revised" in out
+        assert "\033[" in out and "A" in out
+        assert "Plan · revised" in out
         assert "verify_fail" in out
         assert "3 steps" in out
+
+    def test_replan_after_tool_output_is_compact(self, renderer) -> None:
+        renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
+        renderer.on_event({"type": "subagent_complete", "count": 2, "elapsed_s": 5.0})
+        renderer.on_event({"type": "replan", "trigger": "cadence", "step_count": 2, "revision": 1})
+        out = renderer._out.getvalue()
+        compact = out[out.rindex("Plan revised") :]
+        assert "Plan revised · cadence · 2 steps · rev 1" in compact
+        assert "Step 2" not in compact
 
     def test_tool_backpressure(self, renderer) -> None:
         renderer.on_event({"type": "tool_backpressure", "consecutive_errors": 3})

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -87,6 +87,20 @@ class TestAgenticLoopEmitters:
             count=2,
         )
 
+    def test_render_progress_plan_sends_structured_event(self) -> None:
+        from core.ui.agentic_ui import render_progress_plan
+
+        plan = [
+            {"step": "Inspect UX", "status": "completed"},
+            {"step": "Patch renderer", "status": "in_progress"},
+        ]
+        render_progress_plan(plan, explanation="implementation")
+        self.mock_writer.send_event.assert_called_once_with(
+            "progress_plan",
+            plan=plan,
+            explanation="implementation",
+        )
+
     def test_emit_tool_backpressure(self) -> None:
         from core.ui.agentic_ui import emit_tool_backpressure
 
@@ -254,6 +268,70 @@ class TestEventRendererV2:
         assert "Plan" in out
         assert "2 steps" in out
         assert "● a" in out
+
+    def test_progress_plan_first_render_is_full_checklist(self, renderer) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "implementation",
+                "plan": [
+                    {"step": "Inspect UX", "status": "completed"},
+                    {"step": "Patch renderer", "status": "in_progress"},
+                    {"step": "Run tests", "status": "pending"},
+                ],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "Plan · implementation" in out
+        assert "✓" in out
+        assert "Inspect UX" in out
+        assert "Patch renderer" in out
+        assert "Run tests" in out
+
+    def test_progress_plan_updates_in_place_when_still_at_bottom(self, renderer) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "First plan", "status": "in_progress"}],
+            }
+        )
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "Second plan", "status": "in_progress"}],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "\033[" in out and "A" in out
+        assert "Second plan" in out
+
+    def test_progress_plan_after_tool_output_is_compact_not_second_full_block(
+        self, renderer
+    ) -> None:
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "first",
+                "plan": [{"step": "Initial investigation", "status": "in_progress"}],
+            }
+        )
+        renderer.on_event({"type": "subagent_complete", "count": 4, "elapsed_s": 12.0})
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "fallback",
+                "plan": [
+                    {"step": "Already done", "status": "completed"},
+                    {"step": "Direct verification", "status": "in_progress"},
+                    {"step": "This full-list tail should not print", "status": "pending"},
+                ],
+            }
+        )
+        out = renderer._out.getvalue()
+        compact = out[out.rindex("Plan updated") :]
+        assert "Plan updated · fallback · 1/3 complete" in compact
+        assert "Direct verification" in compact
+        assert "This full-list tail should not print" not in compact
 
     def test_plan_step(self, renderer) -> None:
         renderer.on_event(
@@ -487,6 +565,7 @@ class TestIPCClientEventWhitelist:
             "time_budget_expired",
             "convergence_detected",
             "goal_decomposition",
+            "progress_plan",
             "tool_backpressure",
             "tool_diversity_forced",
             "model_switched",


### PR DESCRIPTION
Summary
- Release the structured progress_plan IPC path for update_plan.
- Release Codex-style convergence for goal_decomposition, plan_step, replan, and update_plan through one managed thin-client plan surface.
- Preserve terminal stability by redrawing at the bottom when possible and using compact plan transitions once tool/sub-agent output appears below the plan.

Why
- Codex treats plan/progress as a managed UI surface rather than repeated transcript banners.
- These changes reduce duplicated Plan blocks and converge GEODE's AgenticLoop plan UI toward that behavior.

Verification
- Feature PR #2439 CI passed.
- Feature PR #2440 CI passed.
- develop->main diff checked by content, not commit count.