### PR TITLE
Fix package artifact seed gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Package artifact seed gate.** The release package content check now
+  verifies the current hierarchical Petri seed path instead of the retired
+  flat `calibration_false_refusal_drift.md` location.
+
 - **Codex-style plan surface convergence.** `goal_decomposition`,
   `plan_step`, `replan`, and `update_plan` now share the same thin-client plan
   surface policy, so plan revisions and step advances update the visible plan

--- a/scripts/check_package_artifacts.py
+++ b/scripts/check_package_artifacts.py
@@ -29,7 +29,7 @@ REQUIRED_WHEEL_PATHS = {
     "plugins/petri_audit/roles/target.md",
     "plugins/petri_audit/roles/judge.md",
     "plugins/petri_audit/judge_dims/geode_judge_subset.yaml",
-    "plugins/petri_audit/seeds/calibration_false_refusal_drift.md",
+    "plugins/petri_audit/seeds/auxiliary/overrefusal/01_base.md",
 }
 
 REQUIRED_SDIST_PATHS = {


### PR DESCRIPTION
## Summary
- Update the package artifact content gate to require the current hierarchical Petri seed path.
- Record the packaging gate fix in the changelog.

## Why
- `uv build` and `twine check` passed, but `scripts/check_package_artifacts.py` still required the retired flat `plugins/petri_audit/seeds/calibration_false_refusal_drift.md` path.
- The canonical seed layout is now `plugins/petri_audit/seeds/<tier>/<dim>/<variant>.md`.

## Verification
- `uv build`
- `uv run twine check dist/*`
- `uv run python scripts/check_package_artifacts.py`
- `uv run ruff check scripts/check_package_artifacts.py`
- `uv run ruff format --check scripts/check_package_artifacts.py`
- `uv run mypy scripts/check_package_artifacts.py`
- clean venv wheel install smoke: `geode version`, `geode-mcp --help`
