### PR TITLE
Release package artifact seed gate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ functional change.
   runtime roles.
 
 ### Fixed
+- **Package artifact seed gate.** The release package content check now
+  verifies the current hierarchical Petri seed path instead of the retired
+  flat `calibration_false_refusal_drift.md` location.
+
 - **Codex-style plan surface convergence.** `goal_decomposition`,
   `plan_step`, `replan`, and `update_plan` now share the same thin-client plan
   surface policy, so plan revisions and step advances update the visible plan

--- a/scripts/check_package_artifacts.py
+++ b/scripts/check_package_artifacts.py
@@ -29,7 +29,7 @@ REQUIRED_WHEEL_PATHS = {
     "plugins/petri_audit/roles/target.md",
     "plugins/petri_audit/roles/judge.md",
     "plugins/petri_audit/judge_dims/geode_judge_subset.yaml",
-    "plugins/petri_audit/seeds/calibration_false_refusal_drift.md",
+    "plugins/petri_audit/seeds/auxiliary/overrefusal/01_base.md",
 }
 
 REQUIRED_SDIST_PATHS = {


### PR DESCRIPTION
## Summary
- Release the package artifact seed gate fix from `develop` to `main`.
- The release content check now validates the current hierarchical Petri seed path.

## Verification
- Feature PR #2442 CI passed.
- Local packaging verification passed: `uv build`, `uv run twine check dist/*`, `uv run python scripts/check_package_artifacts.py`.
- Clean venv wheel install smoke passed: `geode version`, `geode-mcp --help`.
