### PR TITLE
Add provider-specific PDF ingest tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ functional change.
 ## [Unreleased]
 
 ### Added
+- **Provider-specific PDF ingest tool.** Added `document_ingest`, a gated PDF
+  workflow tool that turns local PDFs into `.geode/documents/<doc_id>/`
+  Markdown bundles. It keeps a thin shared manifest/page writer while exposing
+  separate backends for `local_text`, OpenAI Responses PDF input, Claude PDF
+  document blocks, and Zhipu GLM-OCR layout parsing.
+
 - **Non-blocking progress plans.** GEODE now exposes an `update_plan` tool
   modelled on Codex's per-turn checklist: it renders a concise
   pending/in-progress/completed plan for the current task, does not write to

--- a/core/agent/safety.py
+++ b/core/agent/safety.py
@@ -85,6 +85,7 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "calendar_sync_scheduler",
         "manage_context",
         "switch_model",
+        "document_ingest",
         "edit_file",
         "write_file",
     }

--- a/core/cli/tool_handlers/delegated.py
+++ b/core/cli/tool_handlers/delegated.py
@@ -18,6 +18,7 @@ _DELEGATED_TOOLS: dict[str, tuple[str, str]] = {
     "llms_txt_index": ("core.tools.llms_txt", "LlmsTxtIndexTool"),
     "general_web_search": ("core.tools.web_tools", "GeneralWebSearchTool"),
     "read_document": ("core.tools.document_tools", "ReadDocumentTool"),
+    "document_ingest": ("core.tools.document_ingest", "DocumentIngestTool"),
     "glob_files": ("core.tools.file_tools", "GlobTool"),
     "grep_files": ("core.tools.file_tools", "GrepTool"),
     "edit_file": ("core.tools.file_tools", "EditFileTool"),

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -656,6 +656,63 @@
     }
   },
   {
+    "name": "document_ingest",
+    "description": "Ingest a local PDF into a GEODE-readable bundle under .geode/documents/<doc_id>. Use this when the user asks GEODE to read, analyze, parse, summarize, OCR, or use a PDF as context. Backends are provider-specific: local_text extracts embedded text with pdftotext, openai_pdf uses OpenAI Responses input_file, claude_pdf uses Claude PDF document blocks, and zhipu_ocr uses Z.ai GLM-OCR layout_parsing. Prefer local_text for text-layer PDFs; use provider backends for visual layout, scans, charts, tables, or OCR.",
+    "category": "discovery",
+    "cost_tier": "expensive",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "description": "Path to a local PDF inside the GEODE file sandbox."
+        },
+        "backend": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "claude_pdf",
+            "local_text",
+            "openai_pdf",
+            "zhipu_ocr"
+          ],
+          "description": "Backend to use. auto tries local text first, then the current provider family if local extraction is empty."
+        },
+        "task_prompt": {
+          "type": "string",
+          "description": "Provider prompt for PDF parsing or extraction."
+        },
+        "model": {
+          "type": "string",
+          "description": "Provider model override for OpenAI or Claude backends."
+        },
+        "doc_id": {
+          "type": "string",
+          "description": "Optional stable output bundle id."
+        },
+        "output_dir": {
+          "type": "string",
+          "description": "Optional output directory. Defaults to .geode/documents/<doc_id> under the project root."
+        },
+        "start_page": {
+          "type": "integer",
+          "description": "First PDF page for Zhipu GLM-OCR, 1-indexed."
+        },
+        "end_page": {
+          "type": "integer",
+          "description": "Last PDF page for Zhipu GLM-OCR, 1-indexed."
+        },
+        "timeout_s": {
+          "type": "integer",
+          "description": "Backend timeout in seconds. Default: 300."
+        }
+      },
+      "required": [
+        "file_path"
+      ]
+    }
+  },
+  {
     "name": "glob_files",
     "description": "Find files by glob pattern (e.g. '**/*.py', 'core/**/*.json'). Results sorted by modification time. ALWAYS prefer this over run_bash for file discovery (ls, find). To search file contents, use grep_files instead.",
     "category": "discovery",

--- a/core/tools/document_ingest.py
+++ b/core/tools/document_ingest.py
@@ -1,0 +1,594 @@
+"""PDF document ingest tool.
+
+Builds a GEODE-readable bundle from a local PDF by either extracting an
+embedded text layer locally or asking one provider-specific PDF API to parse it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from core.paths import get_project_root
+from core.tools.base import tool_error
+from core.tools.sandbox import validate_path
+
+_BACKENDS = frozenset({"auto", "local_text", "openai_pdf", "claude_pdf", "zhipu_ocr"})
+_PROVIDER_BACKENDS = frozenset({"openai_pdf", "claude_pdf", "zhipu_ocr"})
+_DEFAULT_PROMPT = (
+    "Extract the document into clean Markdown. Preserve headings, lists, tables, "
+    "figures, equations, and page-relevant structure where possible."
+)
+_DOC_ID_SAFE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+@dataclass(slots=True)
+class _IngestedDocument:
+    backend: str
+    markdown: str
+    pages: list[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    raw_response: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+class DocumentIngestTool:
+    """Ingest a PDF into a manifest + Markdown page bundle."""
+
+    category = "discovery"
+    cost_tier = "expensive"
+
+    @property
+    def name(self) -> str:
+        return "document_ingest"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Ingest a local PDF into a GEODE-readable bundle. Supports local "
+            "text-layer extraction plus provider-native OpenAI PDF, Claude PDF, "
+            "and Zhipu GLM-OCR backends."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to a local PDF inside the GEODE file sandbox.",
+                },
+                "backend": {
+                    "type": "string",
+                    "enum": sorted(_BACKENDS),
+                    "description": (
+                        "Backend to use. auto tries local text first, then the "
+                        "current provider family if local extraction is empty."
+                    ),
+                },
+                "task_prompt": {
+                    "type": "string",
+                    "description": "Provider prompt for PDF parsing/extraction.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Provider model override for OpenAI or Claude backends.",
+                },
+                "doc_id": {
+                    "type": "string",
+                    "description": "Optional stable output bundle id.",
+                },
+                "output_dir": {
+                    "type": "string",
+                    "description": (
+                        "Optional output directory. Defaults to "
+                        ".geode/documents/<doc_id> under the project root."
+                    ),
+                },
+                "start_page": {
+                    "type": "integer",
+                    "description": "First PDF page for Zhipu GLM-OCR, 1-indexed.",
+                },
+                "end_page": {
+                    "type": "integer",
+                    "description": "Last PDF page for Zhipu GLM-OCR, 1-indexed.",
+                },
+                "timeout_s": {
+                    "type": "integer",
+                    "description": "Backend timeout in seconds. Default: 300.",
+                },
+            },
+            "required": ["file_path"],
+        }
+
+    async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
+        return await asyncio.to_thread(self._execute_sync, **kwargs)
+
+    def _execute_sync(self, **kwargs: Any) -> dict[str, Any]:
+        backend = str(kwargs.get("backend") or "auto")
+        if backend not in _BACKENDS:
+            return tool_error(
+                f"Unsupported document_ingest backend: {backend}",
+                error_type="validation",
+                hint=f"Use one of: {', '.join(sorted(_BACKENDS))}.",
+            )
+
+        path_result = validate_path(str(kwargs["file_path"]), write=False)
+        if isinstance(path_result, dict):
+            return path_result
+        pdf_path = path_result
+        err = _validate_pdf_path(pdf_path)
+        if err:
+            return err
+
+        prompt = str(kwargs.get("task_prompt") or _DEFAULT_PROMPT)
+        timeout_s = int(kwargs.get("timeout_s") or 300)
+        doc_id = _doc_id(kwargs.get("doc_id"), pdf_path)
+        output_dir_result = _resolve_output_dir(kwargs.get("output_dir"), doc_id)
+        if isinstance(output_dir_result, dict):
+            return output_dir_result
+        output_dir = output_dir_result
+
+        selected = _select_backend(backend, kwargs.get("_tool_context"))
+        extracted = _run_backend(
+            selected,
+            pdf_path=pdf_path,
+            prompt=prompt,
+            model=str(kwargs.get("model") or ""),
+            timeout_s=timeout_s,
+            start_page=kwargs.get("start_page"),
+            end_page=kwargs.get("end_page"),
+        )
+        if isinstance(extracted, dict):
+            if backend == "auto" and selected == "local_text":
+                fallback = _select_provider_backend(kwargs.get("_tool_context"))
+                if fallback:
+                    extracted = _run_backend(
+                        fallback,
+                        pdf_path=pdf_path,
+                        prompt=prompt,
+                        model=str(kwargs.get("model") or ""),
+                        timeout_s=timeout_s,
+                        start_page=kwargs.get("start_page"),
+                        end_page=kwargs.get("end_page"),
+                    )
+            if isinstance(extracted, dict):
+                return extracted
+        if backend == "auto" and selected == "local_text" and not extracted.markdown.strip():
+            fallback = _select_provider_backend(kwargs.get("_tool_context"))
+            if fallback:
+                provider_result = _run_backend(
+                    fallback,
+                    pdf_path=pdf_path,
+                    prompt=prompt,
+                    model=str(kwargs.get("model") or ""),
+                    timeout_s=timeout_s,
+                    start_page=kwargs.get("start_page"),
+                    end_page=kwargs.get("end_page"),
+                )
+                if not isinstance(provider_result, dict):
+                    extracted = provider_result
+
+        bundle = _write_bundle(
+            output_dir=output_dir,
+            doc_id=doc_id,
+            pdf_path=pdf_path,
+            prompt=prompt,
+            document=extracted,
+        )
+        return {"result": bundle}
+
+
+def _validate_pdf_path(pdf_path: Path) -> dict[str, Any] | None:
+    if not pdf_path.exists():
+        return tool_error(
+            f"PDF not found: {pdf_path}",
+            error_type="not_found",
+            context={"file_path": str(pdf_path)},
+        )
+    if not pdf_path.is_file():
+        return tool_error(
+            f"Not a file: {pdf_path}",
+            error_type="validation",
+            context={"file_path": str(pdf_path)},
+        )
+    if pdf_path.suffix.lower() != ".pdf":
+        return tool_error(
+            f"document_ingest only accepts PDF files: {pdf_path.name}",
+            error_type="validation",
+            hint="Provide a .pdf file.",
+        )
+    return None
+
+
+def _doc_id(raw: Any, pdf_path: Path) -> str:
+    base = str(raw or pdf_path.stem).strip() or "document"
+    clean = _DOC_ID_SAFE.sub("-", base).strip(".-")
+    return clean[:80] or "document"
+
+
+def _resolve_output_dir(raw: Any, doc_id: str) -> Path | dict[str, Any]:
+    if raw:
+        result = validate_path(str(raw), write=True)
+        if isinstance(result, dict):
+            return result
+        return result
+    return get_project_root() / ".geode" / "documents" / doc_id
+
+
+def _select_backend(backend: str, tool_context: Any) -> str:
+    if backend != "auto":
+        return backend
+    if _has_command("pdftotext"):
+        return "local_text"
+    return _select_provider_backend(tool_context) or "local_text"
+
+
+def _select_provider_backend(tool_context: Any) -> str:
+    provider = str(getattr(tool_context, "provider", "") or "").lower()
+    model = str(getattr(tool_context, "model", "") or "").lower()
+    if provider in {"openai", "openai-codex"} or model.startswith(("gpt-", "o3", "o4")):
+        return "openai_pdf"
+    if provider == "anthropic" or model.startswith("claude-"):
+        return "claude_pdf"
+    if provider in {"glm", "glm-coding"} or model.startswith("glm-"):
+        return "zhipu_ocr"
+    return ""
+
+
+def _run_backend(
+    backend: str,
+    *,
+    pdf_path: Path,
+    prompt: str,
+    model: str,
+    timeout_s: int,
+    start_page: Any,
+    end_page: Any,
+) -> _IngestedDocument | dict[str, Any]:
+    if backend == "local_text":
+        return _local_text_backend(pdf_path, timeout_s=timeout_s)
+    if backend == "openai_pdf":
+        return _openai_pdf_backend(pdf_path, prompt=prompt, model=model, timeout_s=timeout_s)
+    if backend == "claude_pdf":
+        return _claude_pdf_backend(pdf_path, prompt=prompt, model=model, timeout_s=timeout_s)
+    if backend == "zhipu_ocr":
+        return _zhipu_ocr_backend(
+            pdf_path,
+            model=model or "glm-ocr",
+            timeout_s=timeout_s,
+            start_page=_optional_int(start_page),
+            end_page=_optional_int(end_page),
+        )
+    return tool_error(f"Unsupported backend: {backend}", error_type="validation")
+
+
+def _has_command(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def _require_command(name: str) -> str | dict[str, Any]:
+    command = shutil.which(name)
+    if not command:
+        return tool_error(
+            f"Required command not found: {name}",
+            error_type="dependency",
+            hint=f"Install {name} or choose a provider PDF backend.",
+        )
+    return command
+
+
+def _local_text_backend(pdf_path: Path, *, timeout_s: int) -> _IngestedDocument | dict[str, Any]:
+    command = _require_command("pdftotext")
+    if isinstance(command, dict):
+        return command
+    with tempfile.TemporaryDirectory(prefix="geode-pdf-") as tmp:
+        out_path = Path(tmp) / "document.txt"
+        try:
+            proc = subprocess.run(  # noqa: S603
+                [command, "-enc", "UTF-8", str(pdf_path), str(out_path)],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired:
+            return tool_error(
+                f"pdftotext timed out after {timeout_s}s",
+                error_type="timeout",
+                hint="Try a provider PDF backend or split the PDF.",
+            )
+        if proc.returncode != 0:
+            return tool_error(
+                f"pdftotext failed: {proc.stderr.strip() or proc.stdout.strip()}",
+                error_type="dependency",
+                hint="Try a provider PDF backend for scanned or malformed PDFs.",
+            )
+        text = out_path.read_text(encoding="utf-8", errors="replace")
+    pages = _split_pages(text)
+    warnings = []
+    if not text.strip():
+        warnings.append("local_text produced no text; this PDF may be scanned.")
+    return _IngestedDocument(
+        backend="local_text",
+        markdown=_pages_to_markdown(pages),
+        pages=pages,
+        metadata={"extractor": "pdftotext", "page_count": len(pages)},
+        warnings=warnings,
+    )
+
+
+def _openai_pdf_backend(
+    pdf_path: Path, *, prompt: str, model: str, timeout_s: int
+) -> _IngestedDocument | dict[str, Any]:
+    try:
+        import openai
+    except ImportError:
+        return tool_error("openai SDK not installed", error_type="dependency")
+    from core.config import OPENAI_PRIMARY, settings
+
+    api_key = settings.openai_api_key or os.environ.get("OPENAI_API_KEY", "")
+    if not api_key:
+        return tool_error(
+            "OPENAI_API_KEY is not configured",
+            error_type="dependency",
+            hint="Set OPENAI_API_KEY or choose another backend.",
+        )
+    client = openai.OpenAI(api_key=api_key, timeout=timeout_s, max_retries=0)
+    file_data = _pdf_data_uri(pdf_path)
+    try:
+        response = client.responses.create(
+            model=model or OPENAI_PRIMARY,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_file",
+                            "filename": pdf_path.name,
+                            "file_data": file_data,
+                        },
+                        {"type": "input_text", "text": prompt},
+                    ],
+                }
+            ],
+        )
+    except Exception as exc:
+        return tool_error(
+            f"OpenAI PDF ingest failed: {exc}",
+            error_type="connection",
+            hint="Try local_text, split the PDF, or verify the model supports PDF input.",
+        )
+    text = str(getattr(response, "output_text", "") or "")
+    raw = _model_dump(response)
+    return _IngestedDocument(
+        backend="openai_pdf",
+        markdown=text,
+        pages=[text] if text else [],
+        metadata={"model": model or OPENAI_PRIMARY},
+        raw_response=raw,
+    )
+
+
+def _claude_pdf_backend(
+    pdf_path: Path, *, prompt: str, model: str, timeout_s: int
+) -> _IngestedDocument | dict[str, Any]:
+    try:
+        import anthropic
+    except ImportError:
+        return tool_error("anthropic SDK not installed", error_type="dependency")
+    from core.config import ANTHROPIC_PRIMARY, settings
+
+    api_key = settings.anthropic_api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return tool_error(
+            "ANTHROPIC_API_KEY is not configured",
+            error_type="dependency",
+            hint="Set ANTHROPIC_API_KEY or choose another backend.",
+        )
+    client = anthropic.Anthropic(api_key=api_key, timeout=timeout_s, max_retries=0)
+    try:
+        response = client.messages.create(
+            model=model or ANTHROPIC_PRIMARY,
+            max_tokens=8192,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": _pdf_base64(pdf_path),
+                            },
+                        },
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ],
+        )
+    except Exception as exc:
+        return tool_error(
+            f"Claude PDF ingest failed: {exc}",
+            error_type="connection",
+            hint="Try local_text, split the PDF, or verify the model supports PDF input.",
+        )
+    text = _anthropic_text(response)
+    raw = _model_dump(response)
+    return _IngestedDocument(
+        backend="claude_pdf",
+        markdown=text,
+        pages=[text] if text else [],
+        metadata={"model": model or ANTHROPIC_PRIMARY},
+        raw_response=raw,
+    )
+
+
+def _zhipu_ocr_backend(
+    pdf_path: Path,
+    *,
+    model: str,
+    timeout_s: int,
+    start_page: int | None,
+    end_page: int | None,
+) -> _IngestedDocument | dict[str, Any]:
+    try:
+        import httpx
+    except ImportError:
+        return tool_error("httpx not installed", error_type="dependency")
+    from core.config import settings
+
+    api_key = settings.zai_api_key or os.environ.get("ZAI_API_KEY", "")
+    if not api_key:
+        return tool_error(
+            "ZAI_API_KEY is not configured",
+            error_type="dependency",
+            hint="Set ZAI_API_KEY or choose another backend.",
+        )
+    payload: dict[str, Any] = {"model": model or "glm-ocr", "file": _pdf_data_uri(pdf_path)}
+    if start_page is not None:
+        payload["start_page_id"] = start_page
+    if end_page is not None:
+        payload["end_page_id"] = end_page
+    try:
+        response = httpx.post(
+            "https://api.z.ai/api/paas/v4/layout_parsing",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json=payload,
+            timeout=timeout_s,
+        )
+        response.raise_for_status()
+    except Exception as exc:
+        return tool_error(
+            f"Zhipu GLM-OCR ingest failed: {exc}",
+            error_type="connection",
+            hint="Try local_text, split the PDF, or check ZAI_API_KEY and GLM-OCR limits.",
+        )
+    data = response.json()
+    markdown = str(data.get("md_results") or "")
+    return _IngestedDocument(
+        backend="zhipu_ocr",
+        markdown=markdown,
+        pages=[markdown] if markdown else [],
+        metadata={
+            "model": data.get("model") or model,
+            "request_id": data.get("request_id", ""),
+            "data_info": data.get("data_info", {}),
+            "usage": data.get("usage", {}),
+        },
+        raw_response=data if isinstance(data, dict) else {},
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def _pdf_base64(pdf_path: Path) -> str:
+    return base64.b64encode(pdf_path.read_bytes()).decode("ascii")
+
+
+def _pdf_data_uri(pdf_path: Path) -> str:
+    return f"data:application/pdf;base64,{_pdf_base64(pdf_path)}"
+
+
+def _split_pages(text: str) -> list[str]:
+    pages = text.split("\f")
+    if pages and pages[-1].strip() == "":
+        pages = pages[:-1]
+    return [page.strip() for page in pages]
+
+
+def _pages_to_markdown(pages: list[str]) -> str:
+    if not pages:
+        return ""
+    return "\n\n".join(f"## Page {index}\n\n{page}" for index, page in enumerate(pages, 1))
+
+
+def _anthropic_text(response: Any) -> str:
+    parts: list[str] = []
+    for block in getattr(response, "content", []) or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _model_dump(obj: Any) -> dict[str, Any]:
+    if hasattr(obj, "model_dump"):
+        dumped = obj.model_dump()
+        return dumped if isinstance(dumped, dict) else {}
+    if isinstance(obj, dict):
+        return obj
+    return {}
+
+
+def _write_bundle(
+    *,
+    output_dir: Path,
+    doc_id: str,
+    pdf_path: Path,
+    prompt: str,
+    document: _IngestedDocument,
+) -> dict[str, Any]:
+    pages_dir = output_dir / "pages"
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    full_path = output_dir / "full.md"
+    manifest_path = output_dir / "manifest.json"
+    raw_path = output_dir / "raw_response.json"
+
+    full_path.write_text(document.markdown, encoding="utf-8")
+    page_paths = []
+    for index, page in enumerate(document.pages, 1):
+        page_path = pages_dir / f"page-{index:04d}.md"
+        page_path.write_text(page, encoding="utf-8")
+        page_paths.append(page_path)
+    if document.raw_response:
+        raw_path.write_text(
+            json.dumps(document.raw_response, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    manifest = {
+        "doc_id": doc_id,
+        "source_path": str(pdf_path),
+        "backend": document.backend,
+        "created_at": datetime.now(UTC).isoformat(),
+        "task_prompt": prompt,
+        "page_count": len(document.pages),
+        "chars": len(document.markdown),
+        "words": len(document.markdown.split()),
+        "full_text_path": str(full_path),
+        "pages_dir": str(pages_dir),
+        "page_paths": [str(path) for path in page_paths],
+        "raw_response_path": str(raw_path) if document.raw_response else "",
+        "metadata": document.metadata,
+        "warnings": document.warnings,
+    }
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    return {
+        "doc_id": doc_id,
+        "backend": document.backend,
+        "page_count": manifest["page_count"],
+        "chars": manifest["chars"],
+        "words": manifest["words"],
+        "output_dir": str(output_dir),
+        "manifest_path": str(manifest_path),
+        "full_text_path": str(full_path),
+        "pages_dir": str(pages_dir),
+        "warnings": document.warnings,
+    }

--- a/tests/core/tools/test_document_ingest.py
+++ b/tests/core/tools/test_document_ingest.py
@@ -1,0 +1,164 @@
+"""document_ingest tool wiring and bundle tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from core.tools import document_ingest as mod
+from core.tools.document_ingest import DocumentIngestTool
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFINITIONS = REPO_ROOT / "core" / "tools" / "definitions.json"
+
+
+def _fake_pdf(tmp_path: Path) -> Path:
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n% fake fixture\n")
+    return pdf
+
+
+def _patch_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "validate_path", lambda path, write=False: Path(path))
+
+
+def test_local_text_backend_writes_manifest_and_pages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_paths(monkeypatch)
+    pdf = _fake_pdf(tmp_path)
+
+    monkeypatch.setattr(mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(argv: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        out_path = Path(argv[-1])
+        out_path.write_text("First page\n\fSecond page\n\f", encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    result = asyncio.run(
+        DocumentIngestTool().aexecute(
+            file_path=str(pdf),
+            backend="local_text",
+            output_dir=str(tmp_path / "bundle"),
+            doc_id="sample-doc",
+        )
+    )
+
+    bundle = result["result"]
+    manifest = json.loads(Path(bundle["manifest_path"]).read_text(encoding="utf-8"))
+    assert bundle["backend"] == "local_text"
+    assert bundle["page_count"] == 2
+    assert manifest["doc_id"] == "sample-doc"
+    assert "First page" in Path(bundle["full_text_path"]).read_text(encoding="utf-8")
+    assert (Path(bundle["pages_dir"]) / "page-0002.md").read_text(encoding="utf-8") == "Second page"
+
+
+def test_auto_backend_uses_provider_when_local_text_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_paths(monkeypatch)
+    pdf = _fake_pdf(tmp_path)
+    monkeypatch.setattr(mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(argv: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        Path(argv[-1]).write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        mod,
+        "_openai_pdf_backend",
+        lambda *args, **kwargs: mod._IngestedDocument(
+            backend="openai_pdf",
+            markdown="# Provider parse",
+            pages=["# Provider parse"],
+        ),
+    )
+
+    result = asyncio.run(
+        DocumentIngestTool().aexecute(
+            file_path=str(pdf),
+            backend="auto",
+            output_dir=str(tmp_path / "bundle"),
+            _tool_context=SimpleNamespace(provider="openai", model="gpt-5.5"),
+        )
+    )
+
+    assert result["result"]["backend"] == "openai_pdf"
+    assert "# Provider parse" in Path(result["result"]["full_text_path"]).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_zhipu_payload_uses_layout_parsing_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf = _fake_pdf(tmp_path)
+    monkeypatch.setenv("ZAI_API_KEY", "test-key")
+
+    class _Settings:
+        zai_api_key = ""
+
+    monkeypatch.setattr("core.config.settings", _Settings())
+
+    captured: dict[str, Any] = {}
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "model": "GLM-OCR",
+                "md_results": "# OCR",
+                "request_id": "req_123456",
+                "data_info": {"num_pages": 1},
+                "usage": {"total_tokens": 12},
+            }
+
+    def fake_post(url: str, **kwargs: Any) -> _Response:
+        captured["url"] = url
+        captured.update(kwargs)
+        return _Response()
+
+    monkeypatch.setattr(mod.httpx if hasattr(mod, "httpx") else "httpx.post", fake_post)
+
+    result = mod._zhipu_ocr_backend(
+        pdf,
+        model="glm-ocr",
+        timeout_s=30,
+        start_page=2,
+        end_page=3,
+    )
+
+    assert not isinstance(result, dict)
+    assert captured["url"].endswith("/layout_parsing")
+    assert captured["json"]["file"].startswith("data:application/pdf;base64,")
+    assert captured["json"]["start_page_id"] == 2
+    assert captured["json"]["end_page_id"] == 3
+    assert result.markdown == "# OCR"
+
+
+def test_document_ingest_is_wired() -> None:
+    tools = json.loads(DEFINITIONS.read_text(encoding="utf-8"))
+    definition = next(t for t in tools if t.get("name") == "document_ingest")
+    assert definition["cost_tier"] == "expensive"
+    assert "openai_pdf" in definition["input_schema"]["properties"]["backend"]["enum"]
+    assert "claude_pdf" in definition["description"]
+    assert "zhipu_ocr" in definition["description"]
+
+    from core.agent.safety import WRITE_TOOLS
+    from core.cli.tool_handlers.delegated import _DELEGATED_TOOLS
+
+    assert _DELEGATED_TOOLS["document_ingest"] == (
+        "core.tools.document_ingest",
+        "DocumentIngestTool",
+    )
+    assert "document_ingest" in WRITE_TOOLS


### PR DESCRIPTION
## Summary
- Add document_ingest, a gated PDF workflow tool that writes .geode/documents/<doc_id>/ bundles
- Support separate backends for local_text, OpenAI Responses PDF input, Claude PDF document blocks, and Zhipu GLM-OCR layout_parsing
- Wire the tool through definitions/delegated handlers and classify it as approval-gated because it writes files and may call paid provider APIs

## Ponytail gate
- Kept the abstraction thin: shared code only handles backend selection and bundle writing
- Provider-specific request shapes remain separate instead of being hidden behind a false universal OCR contract
- No LLM adapter rewrite or slash-command surface in this PR

## Verification
- uv run ruff check core/tools/document_ingest.py tests/core/tools/test_document_ingest.py core/cli/tool_handlers/delegated.py core/agent/safety.py
- uv run ruff format --check core/tools/document_ingest.py tests/core/tools/test_document_ingest.py core/cli/tool_handlers/delegated.py core/agent/safety.py
- uv run pytest tests/core/tools/test_document_ingest.py tests/core/tools/test_tool_category_tagging.py -q
- uv run mypy core/tools/document_ingest.py
- local smoke: Agentic_Design_Patterns.pdf extracted via local_text backend: 482 pages, 841486 chars