### PR TITLE
hotfix: context window 리졸버 int-타입 가드 (0.99.252 CI Test 실패 수정)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ functional change.
 
 ## [0.99.252] - 2026-07-02
 
+### Fixed
+- **Context-window resolver trusts only real ints** — `_resolve_context_window` returns the default window unless the catalog value is an actual positive `int`. A mocked `core.llm.token_tracker` module (tests patch `sys.modules`) or a garbage catalog entry previously coerced through `int(MagicMock)` to a 1-token window, tripping context-exhausted on every loop turn (CI `test_autonomous_safety` failures on the 0.99.252 merge).
+
 ### Changed
 - **Context budget policy resolver.** Context overflow handling now derives
   warning/critical thresholds, prompt budget, output reserve, safety margin,

--- a/core/orchestration/context_budget.py
+++ b/core/orchestration/context_budget.py
@@ -200,9 +200,16 @@ def _resolve_context_window(model: str, context_window: int | None = None) -> in
     try:
         from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
-        return max(1, int(MODEL_CONTEXT_WINDOW.get(model, DEFAULT_CONTEXT_WINDOW_TOKENS)))
+        window = MODEL_CONTEXT_WINDOW.get(model, DEFAULT_CONTEXT_WINDOW_TOKENS)
     except (TypeError, ValueError, AttributeError):
         return DEFAULT_CONTEXT_WINDOW_TOKENS
+    # Trust only real positive ints — a mocked module (tests patch
+    # sys.modules['core.llm.token_tracker']) or a garbage catalog entry
+    # otherwise coerces to a 1-token window and every loop turn trips
+    # context-exhausted before its actual assertion.
+    if not isinstance(window, int) or isinstance(window, bool) or window < 1:
+        return DEFAULT_CONTEXT_WINDOW_TOKENS
+    return window
 
 
 def _resolve_tier(context_window: int) -> ContextBudgetTier:


### PR DESCRIPTION
## Summary
- `_resolve_context_window`가 카탈로그 값이 실제 양의 `int`일 때만 신뢰하고 아니면 기본 윈도로 폴백.

## Why
- #2463 머지의 CI Test 잡 실패 2건(`test_autonomous_safety`): 테스트가 `sys.modules`로 token_tracker를 목킹 → `MODEL_CONTEXT_WINDOW.get()`이 MagicMock 반환 → `int(MagicMock)`=1 → 1토큰 윈도로 매 턴 context_exhausted. graceful 계약을 스키마 타입 캐스트 지점에 적용(하우스 규칙).
- 절차 사고 공지: #2463은 Test fail 상태에서 머지됨(게이트 체인을 `&&`가 아닌 `;`로 이은 제 실수). main은 미오염 — 이 hotfix가 develop을 green으로 복원.

## Changes
| File | Change |
|------|--------|
| `core/orchestration/context_budget.py` | isinstance(int)+양수 가드(bool 제외), 실패 시 DEFAULT 폴백 |
| CHANGELOG | 0.99.252 Fixed 항목 추가 |

## Verification
- [x] `test_autonomous_safety` 13/13 + tests/core/agent + orchestration 전체 0 fail (로컬)
- [x] ruff/format/mypy clean