### PR TITLE
fix: compact Geodi welcome mascot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.257] - 2026-07-02
+
+### Changed
+- **Compact Geodi welcome mascot.** The startup pixel mascot now follows the
+  Claude Code-style treatment of keeping terminal welcome UI text-first and
+  small: the native half-block Geodi sprite is reduced from 22×20 pixels
+  (22×10 terminal cells) to 16×14 pixels (16×7 terminal cells). The rose
+  axolotl canon remains pinned by tests, including six separated gill stalks,
+  eye catchlights, cheek blush, belly patch, and a compact footprint guard so
+  the mascot cannot grow back into a splash panel.
+
 ## [0.99.256] - 2026-07-02
 
 ### Infrastructure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.256
+- **Version**: 0.99.257
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.256 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.257 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.256 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.257 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/geodi_art.py
+++ b/core/ui/geodi_art.py
@@ -5,13 +5,13 @@ side, deeper rose, visibly separated), simple symmetric 2x2 dark eyes with a
 1px white catchlight in the top-right corner of each, a tiny 2px mouth, a
 lighter belly patch, and a subtle deep-rose cheek blush beside the eyes.
 
-The sprite is authored as a 22x20 pixel grid (``GEODI_PIXELS``) and rendered
+The sprite is authored as a 16x14 pixel grid (``GEODI_PIXELS``) and rendered
 as truecolor half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two
-pixels per terminal cell — so it draws in ANY truecolor terminal: 22 cols x
-10 rows, one code path, no Kitty/iTerm2 detection. Transparent pixels reset
+pixels per terminal cell — so it draws in ANY truecolor terminal: 16 cols x
+7 rows, one code path, no Kitty/iTerm2 detection. Transparent pixels reset
 to the terminal's default background.
 
-Hand-edit ``GEODI_PIXELS`` directly; every row must stay exactly 22 chars.
+Hand-edit ``GEODI_PIXELS`` directly; every row must stay exactly 16 chars.
 Live preview: ``python -m core.ui.geodi_art``.
 """
 
@@ -29,34 +29,28 @@ GEODI_PALETTE: dict[str, str | None] = {
     "w": "#FFFFFF",  # white — eye catchlight
 }
 
-# 22 wide x 20 tall. Rows pair top/bottom into half-block cells (10 rows out).
+# 16 wide x 14 tall. Rows pair top/bottom into half-block cells (7 rows out).
 # Gills: THREE stalks per side — upper diagonal (r2-r3), middle (r5), lower
 # (r7) — with fully transparent side rows (r4, r6) between them so each
 # counts visually. Face (kawaii): symmetric 2x2 dark eyes (r8-r9) with the
 # 1px catchlight in the TOP-RIGHT corner of each, nothing above them but
 # body; cheek blush one row below the eyes (r10); ONE tiny 2px mouth row
-# (r11, cols 10-11). No other dark pixels on the face.
+# (r11, cols 8-9). No other dark pixels on the face.
 GEODI_PIXELS: list[str] = [
-    "........pppppp........",
-    "......pppppppppp......",
-    ".rr..pppppppppppp..rr.",
-    "..rrpppppppppppppprr..",
-    "....pppppppppppppp....",
-    ".rrrpppppppppppppprrr.",
-    "....pppppppppppppp....",
-    "..rrpppppppppppppprr..",
-    "....pppewppppewppp....",
-    "....pppeeppppeeppp....",
-    "....prrpppppppprrp....",
-    "....ppppppeepppppp....",
-    "....ppppllllllpppp....",
-    "....pppllllllllppp....",
-    "....pppllllllllppp....",
-    ".....pppllllllppp.....",
-    "......pppppppppp......",
-    ".......pppppppp.......",
-    "......ppp....ppp......",
-    "......ppp....ppp......",
+    ".....pppppp.....",
+    "...pppppppppp...",
+    ".r.pppppppppp.r.",
+    "..rppppppppppr..",
+    "...pppppppppp...",
+    ".rrpppppppppprr.",
+    "...pppppppppp...",
+    "..rppppppppppr..",
+    "...ppewppppew...",
+    "...ppeeppppee...",
+    "...prpppppprp...",
+    "...pppppeeppp...",
+    "....ppllllpp....",
+    ".....pp..pp.....",
 ]
 
 

--- a/core/ui/mascot.py
+++ b/core/ui/mascot.py
@@ -1,9 +1,11 @@
 """GEODE mascot — Geodi, the rose axolotl, in the startup brand block.
 
 The sprite is the hand-authored pixel grid in ``core/ui/geodi_art.py``,
-rendered as truecolor half-blocks: ONE code path for every terminal — no
-Kitty/iTerm2 image protocol, no baked PNG, no animation env knob. The brand
-text sits to the sprite's right, vertically centred:
+rendered as a compact truecolor half-block accent: ONE code path for every
+terminal — no Kitty/iTerm2 image protocol, no baked PNG, no animation env knob.
+This follows the Claude Code treatment: keep the welcome surface text-first and
+small, with any character art bounded so it cannot dominate the first screen.
+The brand text sits to the sprite's right, vertically centred:
 
     line 1  ``◆ GEODE v{version}``   (rose mark, bold name)
     line 2  dim ``{model} · {cwd}``  ($HOME collapsed to ~)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.256"
+version = "0.99.257"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.256. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.257. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.256. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.257. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.257",
+    "date": "2026-07-02",
+    "body": "### Changed\n- **Compact Geodi welcome mascot.** The startup pixel mascot now follows the\n  Claude Code-style treatment of keeping terminal welcome UI text-first and\n  small: the native half-block Geodi sprite is reduced from 22×20 pixels\n  (22×10 terminal cells) to 16×14 pixels (16×7 terminal cells). The rose\n  axolotl canon remains pinned by tests, including six separated gill stalks,\n  eye catchlights, cheek blush, belly patch, and a compact footprint guard so\n  the mascot cannot grow back into a splash panel."
+  },
+  {
     "version": "0.99.256",
     "date": "2026-07-02",
     "body": "### Infrastructure\n- **Slop growth ratchet.** CI now runs `scripts/check_slop_ratchet.py`, a\n  committed-baseline gate over four low-signal-growth metrics: bypass markers,\n  stale TODO markers, dead placeholder branches, and duplicated function\n  signatures. Existing debt is tolerated through\n  `scripts/slop_ratchet_baseline.json`; PRs fail only when a metric grows\n  above the accepted floor unless the baseline is deliberately updated and\n  reviewed in the diff."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.256",
+  version: "0.99.257",
   syncedAt: "2026-07-02",
 } as const;

--- a/tests/core/ui/test_mascot.py
+++ b/tests/core/ui/test_mascot.py
@@ -16,8 +16,8 @@ class TestGeodiPixels:
     """The hand-authored sprite grid stays well-formed."""
 
     def test_grid_dimensions(self) -> None:
-        assert len(GEODI_PIXELS) == 20  # even row count — pairs into half-blocks
-        assert all(len(row) == 22 for row in GEODI_PIXELS)
+        assert len(GEODI_PIXELS) == 14  # even row count — pairs into half-blocks
+        assert all(len(row) == 16 for row in GEODI_PIXELS)
 
     def test_only_palette_chars(self) -> None:
         assert set("".join(GEODI_PIXELS)) <= set(GEODI_PALETTE)
@@ -43,12 +43,18 @@ class TestGeodiPixels:
 
     def test_pixel_lines_render_constant_width(self) -> None:
         lines = geodi_pixel_lines()
-        assert len(lines) == 10  # 20 px tall -> 10 half-block rows
+        assert len(lines) == 7  # 14 px tall -> 7 half-block rows
         for line in lines:
-            assert len(_ANSI.sub("", line)) == 22  # text can align beside it
+            assert len(_ANSI.sub("", line)) == 16  # text can align beside it
             assert "▀" in line or "▄" in line or " " in line
         # Truecolor body rose must appear (244;155;196 = #F49BC4).
         assert any("38;2;244;155;196" in line for line in lines)
+
+    def test_sprite_stays_compact(self) -> None:
+        """Keep the welcome mascot as a Claude Code-scale accent, not a splash panel."""
+        lines = geodi_pixel_lines()
+        assert len(lines) <= 7
+        assert max(len(_ANSI.sub("", line)) for line in lines) <= 16
 
 
 class TestMascotBrandBlock:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.256"
+version = "0.99.257"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Shrinks the startup Geodi pixel mascot from 22x20 pixels / 22x10 terminal cells to 16x14 pixels / 16x7 terminal cells.
- Keeps the rose axolotl canon pinned while making the welcome surface closer to Claude Code's text-first, compact terminal treatment.
- Stamps v0.99.257 and syncs generated site/version files.

## Why
The current pixel character is cute but too large for the first terminal screen. Claude Code's current installed surface does not expose a comparable large pixel mascot; its welcome treatment is compact and text-led, so GEODE should keep Geodi as an accent instead of a splash panel.

## Changes
| File | Change |
|------|--------|
| `core/ui/geodi_art.py` | Reauthored Geodi as a 16x14 native half-block sprite. |
| `core/ui/mascot.py` | Documented compact/text-first mascot treatment. |
| `tests/core/ui/test_mascot.py` | Updated dimension guards and added a compact footprint ratchet. |
| `CHANGELOG.md`, version files, site data | Stamped v0.99.257 and resynced generated metadata. |

## Verification
- `uv run pytest -q tests/core/ui/test_mascot.py`
- `uv run ruff check core/ tests/ plugins/ scripts/`
- `uv run ruff format --check core/ tests/ plugins/ scripts/`
- `uv run mypy core/ plugins/ scripts/`
- `uv run lint-imports`
- `uv run python scripts/check_llms_version.py`
- `git diff --check`
- `uv run python scripts/check_slop_ratchet.py`
- `uv run geode version`
