### PR TITLE
release: preserve compact Geodi shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.258] - 2026-07-02
+
+### Fixed
+- **Geodi compact mascot preserves the original character shape.** v0.99.257
+  made the welcome mascot smaller by redrawing it at 16×14 pixels, but that
+  changed the face/body proportions and made Geodi look like a different
+  character. The full 22×20 source sprite is now retained as
+  `GEODI_SOURCE_PIXELS`, while the 16×14 welcome sprite is a compact derivative
+  that preserves the original round head, six gill stalks, eye catchlights,
+  cheek blush, belly patch, and feet. Tests now pin both the source grid and the
+  compact silhouette cues.
+
 ## [0.99.257] - 2026-07-02
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.257
+- **Version**: 0.99.258
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.257 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.258 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.257 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.258 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/geodi_art.py
+++ b/core/ui/geodi_art.py
@@ -5,13 +5,17 @@ side, deeper rose, visibly separated), simple symmetric 2x2 dark eyes with a
 1px white catchlight in the top-right corner of each, a tiny 2px mouth, a
 lighter belly patch, and a subtle deep-rose cheek blush beside the eyes.
 
-The sprite is authored as a 16x14 pixel grid (``GEODI_PIXELS``) and rendered
-as truecolor half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two
-pixels per terminal cell — so it draws in ANY truecolor terminal: 16 cols x
-7 rows, one code path, no Kitty/iTerm2 detection. Transparent pixels reset
-to the terminal's default background.
+The canonical sprite is authored as a 22x20 pixel grid
+(``GEODI_SOURCE_PIXELS``). The welcome screen renders a compact 16x14 pixel
+derivative (``GEODI_PIXELS``) that preserves the original silhouette while
+matching the adjacent three-line brand block. Pixels render as truecolor
+half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two pixels per
+terminal cell — so the compact mascot draws as 16 cols x 7 rows in ANY
+truecolor terminal. Transparent pixels reset to the terminal's default
+background.
 
-Hand-edit ``GEODI_PIXELS`` directly; every row must stay exactly 16 chars.
+Hand-edit ``GEODI_SOURCE_PIXELS`` first; keep ``GEODI_PIXELS`` as a compact
+derivative of that shape. Every compact row must stay exactly 16 chars.
 Live preview: ``python -m core.ui.geodi_art``.
 """
 
@@ -29,6 +33,31 @@ GEODI_PALETTE: dict[str, str | None] = {
     "w": "#FFFFFF",  # white — eye catchlight
 }
 
+# 22 wide x 20 tall. Full-detail source retained to prevent the compact welcome
+# mascot from drifting into a different character.
+GEODI_SOURCE_PIXELS: list[str] = [
+    "........pppppp........",
+    "......pppppppppp......",
+    ".rr..pppppppppppp..rr.",
+    "..rrpppppppppppppprr..",
+    "....pppppppppppppp....",
+    ".rrrpppppppppppppprrr.",
+    "....pppppppppppppp....",
+    "..rrpppppppppppppprr..",
+    "....pppewppppewppp....",
+    "....pppeeppppeeppp....",
+    "....prrpppppppprrp....",
+    "....ppppppeepppppp....",
+    "....ppppllllllpppp....",
+    "....pppllllllllppp....",
+    "....pppllllllllppp....",
+    ".....pppllllllppp.....",
+    "......pppppppppp......",
+    ".......pppppppp.......",
+    "......ppp....ppp......",
+    "......ppp....ppp......",
+]
+
 # 16 wide x 14 tall. Rows pair top/bottom into half-block cells (7 rows out).
 # Gills: THREE stalks per side — upper diagonal (r2-r3), middle (r5), lower
 # (r7) — with fully transparent side rows (r4, r6) between them so each
@@ -39,18 +68,18 @@ GEODI_PALETTE: dict[str, str | None] = {
 GEODI_PIXELS: list[str] = [
     ".....pppppp.....",
     "...pppppppppp...",
-    ".r.pppppppppp.r.",
+    ".rr.pppppppp.rr.",
     "..rppppppppppr..",
     "...pppppppppp...",
-    ".rrpppppppppprr.",
+    ".rrrpppppppprrr.",
     "...pppppppppp...",
     "..rppppppppppr..",
     "...ppewppppew...",
     "...ppeeppppee...",
-    "...prpppppprp...",
+    "...prrpppprrp...",
     "...pppppeeppp...",
-    "....ppllllpp....",
-    ".....pp..pp.....",
+    "..pppllllllppp..",
+    "...ppp....ppp...",
 ]
 
 
@@ -64,7 +93,7 @@ def geodi_pixel_lines() -> list[str]:
 
     Each cell: both pixels colored -> ``▀`` with fg=upper/bg=lower; upper only
     -> reset + fg ``▀`` (default bg below); lower only -> reset + fg ``▄``;
-    both transparent -> reset + space, so rows keep a constant 22-cell width
+    both transparent -> reset + space, so rows keep a constant compact width
     and text can align beside the sprite.
     """
     lines: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.257"
+version = "0.99.258"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.257. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.258. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.257. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.258. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.258",
+    "date": "2026-07-02",
+    "body": "### Fixed\n- **Geodi compact mascot preserves the original character shape.** v0.99.257\n  made the welcome mascot smaller by redrawing it at 16×14 pixels, but that\n  changed the face/body proportions and made Geodi look like a different\n  character. The full 22×20 source sprite is now retained as\n  `GEODI_SOURCE_PIXELS`, while the 16×14 welcome sprite is a compact derivative\n  that preserves the original round head, six gill stalks, eye catchlights,\n  cheek blush, belly patch, and feet. Tests now pin both the source grid and the\n  compact silhouette cues."
+  },
+  {
     "version": "0.99.257",
     "date": "2026-07-02",
     "body": "### Changed\n- **Compact Geodi welcome mascot.** The startup pixel mascot now follows the\n  Claude Code-style treatment of keeping terminal welcome UI text-first and\n  small: the native half-block Geodi sprite is reduced from 22×20 pixels\n  (22×10 terminal cells) to 16×14 pixels (16×7 terminal cells). The rose\n  axolotl canon remains pinned by tests, including six separated gill stalks,\n  eye catchlights, cheek blush, belly patch, and a compact footprint guard so\n  the mascot cannot grow back into a splash panel."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.257",
+  version: "0.99.258",
   syncedAt: "2026-07-02",
 } as const;

--- a/tests/core/ui/test_mascot.py
+++ b/tests/core/ui/test_mascot.py
@@ -6,7 +6,7 @@ import re
 from io import StringIO
 from pathlib import Path
 
-from core.ui.geodi_art import GEODI_PALETTE, GEODI_PIXELS, geodi_pixel_lines
+from core.ui.geodi_art import GEODI_PALETTE, GEODI_PIXELS, GEODI_SOURCE_PIXELS, geodi_pixel_lines
 from core.ui.mascot import _collapse_home, _spec_lines, render_mascot
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -15,12 +15,16 @@ _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 class TestGeodiPixels:
     """The hand-authored sprite grid stays well-formed."""
 
+    def test_source_grid_dimensions(self) -> None:
+        assert len(GEODI_SOURCE_PIXELS) == 20
+        assert all(len(row) == 22 for row in GEODI_SOURCE_PIXELS)
+
     def test_grid_dimensions(self) -> None:
         assert len(GEODI_PIXELS) == 14  # even row count — pairs into half-blocks
         assert all(len(row) == 16 for row in GEODI_PIXELS)
 
     def test_only_palette_chars(self) -> None:
-        assert set("".join(GEODI_PIXELS)) <= set(GEODI_PALETTE)
+        assert set("".join(GEODI_SOURCE_PIXELS + GEODI_PIXELS)) <= set(GEODI_PALETTE)
 
     def test_character_canon(self) -> None:
         joined = "".join(GEODI_PIXELS)
@@ -55,6 +59,16 @@ class TestGeodiPixels:
         lines = geodi_pixel_lines()
         assert len(lines) <= 7
         assert max(len(_ANSI.sub("", line)) for line in lines) <= 16
+
+    def test_compact_keeps_source_silhouette_cues(self) -> None:
+        """The compact grid should read like the original, not a redesigned mascot."""
+        assert GEODI_SOURCE_PIXELS[2].startswith(".rr..")
+        assert GEODI_PIXELS[2].startswith(".rr.")
+        assert GEODI_SOURCE_PIXELS[5].startswith(".rrr")
+        assert GEODI_PIXELS[5].startswith(".rrr")
+        assert "ppew" in GEODI_SOURCE_PIXELS[8] and "ppew" in GEODI_PIXELS[8]
+        assert "llllll" in "".join(GEODI_SOURCE_PIXELS)
+        assert "llllll" in "".join(GEODI_PIXELS)
 
 
 class TestMascotBrandBlock:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.257"
+version = "0.99.258"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Promote v0.99.258 to main.
- Preserve the original Geodi mascot shape while keeping the compact welcome footprint.
- Keep the canonical 22x20 source sprite pinned in tests and render a compact 16x14 derivative for the CLI welcome block.

## Verification
- uv run pytest -q tests/core/ui/test_mascot.py
- uv run ruff format core/ui/geodi_art.py tests/core/ui/test_mascot.py
- uv run ruff check core/ui/geodi_art.py tests/core/ui/test_mascot.py
- uv run ruff check core/ tests/ plugins/ scripts/
- uv run ruff format --check core/ tests/ plugins/ scripts/
- uv run mypy core/ plugins/ scripts/
- uv run lint-imports
- uv run python scripts/check_llms_version.py
- uv run python scripts/check_slop_ratchet.py
- git diff --check && uv run geode version
