### PR TITLE
Geodi 256 캐릭터 복구 + welcome 블록 스케일 축소 (v0.99.259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ functional change.
 
 ---
 
+## [0.99.259] - 2026-07-03
+
+### Fixed
+- **Compact Geodi restored to the reviewed character, sized to the welcome block** — the 0.99.257/258 compact derivative had broken the face (squished eyes, lost smile). `GEODI_PIXELS` is now a hand-authored 14x8 chibi of the canonical 0.99.256 sprite — 3 separated gill stalks per side, symmetric 2px eyes with same-corner catchlights, minimal mouth, under-eye blush, belly patch, feet — rendering as 4 half-block rows to sit beside the 3-line welcome text (operator size spec). `GEODI_SOURCE_PIXELS` (22x20 original) unchanged; silhouette-cue tests rewritten against grid semantics instead of hard row indices.
+
 ## [0.99.258] - 2026-07-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.258
+- **Version**: 0.99.259
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.258 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.259 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.258 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.259 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/geodi_art.py
+++ b/core/ui/geodi_art.py
@@ -6,16 +6,17 @@ side, deeper rose, visibly separated), simple symmetric 2x2 dark eyes with a
 lighter belly patch, and a subtle deep-rose cheek blush beside the eyes.
 
 The canonical sprite is authored as a 22x20 pixel grid
-(``GEODI_SOURCE_PIXELS``). The welcome screen renders a compact 16x14 pixel
+(``GEODI_SOURCE_PIXELS``). The welcome screen renders a compact 14x8 pixel
 derivative (``GEODI_PIXELS``) that preserves the original silhouette while
 matching the adjacent three-line brand block. Pixels render as truecolor
 half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two pixels per
-terminal cell — so the compact mascot draws as 16 cols x 7 rows in ANY
+terminal cell — so the compact mascot draws as 14 cols x 4 rows — sized to sit beside the
+3-line welcome text block — in ANY
 truecolor terminal. Transparent pixels reset to the terminal's default
 background.
 
 Hand-edit ``GEODI_SOURCE_PIXELS`` first; keep ``GEODI_PIXELS`` as a compact
-derivative of that shape. Every compact row must stay exactly 16 chars.
+derivative of that shape. Every compact row must stay exactly 14 chars.
 Live preview: ``python -m core.ui.geodi_art``.
 """
 
@@ -66,20 +67,14 @@ GEODI_SOURCE_PIXELS: list[str] = [
 # body; cheek blush one row below the eyes (r10); ONE tiny 2px mouth row
 # (r11, cols 8-9). No other dark pixels on the face.
 GEODI_PIXELS: list[str] = [
-    ".....pppppp.....",
-    "...pppppppppp...",
-    ".rr.pppppppp.rr.",
-    "..rppppppppppr..",
-    "...pppppppppp...",
-    ".rrrpppppppprrr.",
-    "...pppppppppp...",
-    "..rppppppppppr..",
-    "...ppewppppew...",
-    "...ppeeppppee...",
-    "...prrpppprrp...",
-    "...pppppeeppp...",
-    "..pppllllllppp..",
-    "...ppp....ppp...",
+    "....pppppp....",
+    "rr.pppppppp.rr",
+    "...pppppppp...",
+    "rr.pewppewp.rr",
+    "...prpeeprp...",
+    "rr.ppllllpp.rr",
+    "...ppllllpp...",
+    "....rr..rr....",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.258"
+version = "0.99.259"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.258. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.259. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.258. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.259. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.259",
+    "date": "2026-07-03",
+    "body": "### Fixed\n- **Compact Geodi restored to the reviewed character, sized to the welcome block** — the 0.99.257/258 compact derivative had broken the face (squished eyes, lost smile). `GEODI_PIXELS` is now a hand-authored 14x8 chibi of the canonical 0.99.256 sprite — 3 separated gill stalks per side, symmetric 2px eyes with same-corner catchlights, minimal mouth, under-eye blush, belly patch, feet — rendering as 4 half-block rows to sit beside the 3-line welcome text (operator size spec). `GEODI_SOURCE_PIXELS` (22x20 original) unchanged; silhouette-cue tests rewritten against grid semantics instead of hard row indices."
+  },
+  {
     "version": "0.99.258",
     "date": "2026-07-02",
     "body": "### Fixed\n- **Geodi compact mascot preserves the original character shape.** v0.99.257\n  made the welcome mascot smaller by redrawing it at 16×14 pixels, but that\n  changed the face/body proportions and made Geodi look like a different\n  character. The full 22×20 source sprite is now retained as\n  `GEODI_SOURCE_PIXELS`, while the 16×14 welcome sprite is a compact derivative\n  that preserves the original round head, six gill stalks, eye catchlights,\n  cheek blush, belly patch, and feet. Tests now pin both the source grid and the\n  compact silhouette cues."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.258",
+  version: "0.99.259",
   syncedAt: "2026-07-02",
 } as const;

--- a/tests/core/ui/test_mascot.py
+++ b/tests/core/ui/test_mascot.py
@@ -20,8 +20,8 @@ class TestGeodiPixels:
         assert all(len(row) == 22 for row in GEODI_SOURCE_PIXELS)
 
     def test_grid_dimensions(self) -> None:
-        assert len(GEODI_PIXELS) == 14  # even row count — pairs into half-blocks
-        assert all(len(row) == 16 for row in GEODI_PIXELS)
+        assert len(GEODI_PIXELS) == 8  # even row count — pairs into half-blocks
+        assert all(len(row) == 14 for row in GEODI_PIXELS)
 
     def test_only_palette_chars(self) -> None:
         assert set("".join(GEODI_SOURCE_PIXELS + GEODI_PIXELS)) <= set(GEODI_PALETTE)
@@ -47,9 +47,9 @@ class TestGeodiPixels:
 
     def test_pixel_lines_render_constant_width(self) -> None:
         lines = geodi_pixel_lines()
-        assert len(lines) == 7  # 14 px tall -> 7 half-block rows
+        assert len(lines) == 4  # 8 px tall -> 4 half-block rows, beside 3 text lines
         for line in lines:
-            assert len(_ANSI.sub("", line)) == 16  # text can align beside it
+            assert len(_ANSI.sub("", line)) == 14  # text can align beside it
             assert "▀" in line or "▄" in line or " " in line
         # Truecolor body rose must appear (244;155;196 = #F49BC4).
         assert any("38;2;244;155;196" in line for line in lines)
@@ -58,17 +58,19 @@ class TestGeodiPixels:
         """Keep the welcome mascot as a Claude Code-scale accent, not a splash panel."""
         lines = geodi_pixel_lines()
         assert len(lines) <= 7
-        assert max(len(_ANSI.sub("", line)) for line in lines) <= 16
+        assert max(len(_ANSI.sub("", line)) for line in lines) <= 14
 
     def test_compact_keeps_source_silhouette_cues(self) -> None:
         """The compact grid should read like the original, not a redesigned mascot."""
         assert GEODI_SOURCE_PIXELS[2].startswith(".rr..")
-        assert GEODI_PIXELS[2].startswith(".rr.")
         assert GEODI_SOURCE_PIXELS[5].startswith(".rrr")
-        assert GEODI_PIXELS[5].startswith(".rrr")
-        assert "ppew" in GEODI_SOURCE_PIXELS[8] and "ppew" in GEODI_PIXELS[8]
+        assert "ppew" in GEODI_SOURCE_PIXELS[8]
         assert "llllll" in "".join(GEODI_SOURCE_PIXELS)
-        assert "llllll" in "".join(GEODI_PIXELS)
+        # Compact derivative (14x8): gill rows hug the edges, eyes keep the
+        # e+w catchlight pair twice, belly patch present.
+        assert sum(1 for row in GEODI_PIXELS if row.startswith("rr.")) == 3
+        assert "".join(GEODI_PIXELS).count("ew") == 2
+        assert "llll" in "".join(GEODI_PIXELS)
 
 
 class TestMascotBrandBlock:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.258"
+version = "0.99.259"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 0.99.257/258 컴팩트 패스가 망가뜨린 얼굴을 폐기하고, 검수 확정본(0.99.256) 캐릭터를 **14×8 치비로 수제 재작성** — 하프블록 4행으로 welcome 텍스트 3줄과 호응(운영자 크기 스펙).
- 캐논 유지: 아가미 좌우 3개씩 분리, 대칭 눈+동일 코너 캐치라이트, 눈밑 블러시, 미니멀 입, 배 패치, 발. 22×20 원본(`GEODI_SOURCE_PIXELS`)은 불변.
- 실루엣 테스트를 하드 행 인덱스 → 그리드 시맨틱스(엣지 gill행 3·ew쌍 2·belly 존재)로 재작성.

## Why
- 운영자 스크린샷 비교: 256(정상) vs 258(얼굴 붕괴) — "256으로 복구 후 크기 축소, 우측 welcome과 호응".

## Changes
| File | Change |
|------|--------|
| `core/ui/geodi_art.py` | `GEODI_PIXELS` 14×8 재작성 + 문서 갱신 |
| `tests/core/ui/test_mascot.py` | 크기/실루엣 핀 갱신 |
| CHANGELOG 외 5위치+site | v0.99.259 |

## Verification
- [x] PNG 프리뷰 시각 검수 3라운드(대칭·라운드·블러시 위치 확정)
- [x] UI 스위트 0 fail, ruff/mypy/hygiene/slop-ratchet 전부 green