### PR TITLE
Record MCPMark benchmark results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes
+  common schema mismatches before server calls, including mapping `file_path`
+  to `path` when the MCP schema requires `path`, dropping conflicting
+  `read_text_file` `head`/`tail` pairs, annotating exact-read caveats in
+  exposed MCP tool descriptions, and offloading source EOF preservation from
+  model turns into the MCP dispatch layer for same-name text writes.
+
 ## [0.99.261] - 2026-07-03
 
 ### Changed
@@ -101,7 +112,6 @@ functional change.
   that preserves the original round head, six gill stalks, eye catchlights,
   cheek blush, belly patch, and feet. Tests now pin both the source grid and the
   compact silhouette cues.
-
 ## [0.99.257] - 2026-07-02
 
 ### Changed

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -37,6 +37,22 @@ _GLOBAL_DOTENV_PATH = GLOBAL_ENV_FILE
 _EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
 _FAILED_RETRY_COOLDOWN_S = 300.0
 
+_MCP_TOOL_DESCRIPTION_NOTES: dict[str, str] = {
+    "read_multiple_files": (
+        "For exact file-copy or text-conversion work, do not infer source EOF from "
+        "combined display separators. GEODE tracks local source EOF metadata after "
+        "successful reads and preserves it for same-name writes when possible."
+    ),
+    "read_text_file": (
+        "For whole-file reads, omit head and tail. Do not pass head and tail together."
+    ),
+    "write_file": (
+        "Use the server schema's path argument when it is present; GEODE also accepts "
+        "file_path as a compatibility alias for path and preserves cached source EOF "
+        "for same-name text writes when possible."
+    ),
+}
+
 # Hook system injection (same pattern as core/llm/router.py)
 _mcp_hooks: Any = None
 
@@ -103,11 +119,77 @@ def _normalise_mcp_tool(raw: dict[str, Any]) -> dict[str, Any]:
     minimal ``{"type": "object", "properties": {}}``.
     """
     schema = raw.get("input_schema") or raw.get("inputSchema") or _EMPTY_SCHEMA
-    return {
+    tool = {
         "name": raw.get("name", ""),
         "description": raw.get("description", ""),
         "input_schema": schema,
     }
+    _augment_mcp_tool_description(tool)
+    return tool
+
+
+def _augment_mcp_tool_description(tool: dict[str, Any]) -> None:
+    """Add GEODE-side compatibility notes for common MCP tool ambiguities."""
+    name = str(tool.get("name") or "")
+    note = _MCP_TOOL_DESCRIPTION_NOTES.get(name)
+    if not note:
+        return
+    description = str(tool.get("description") or "")
+    if note in description:
+        return
+    separator = " " if description else ""
+    tool["description"] = f"{description}{separator}GEODE note: {note}"
+
+
+def _mcp_tool_schema_properties(raw_tool: dict[str, Any]) -> dict[str, Any]:
+    schema = raw_tool.get("input_schema") or raw_tool.get("inputSchema") or {}
+    if not isinstance(schema, dict):
+        return {}
+    properties = schema.get("properties")
+    return properties if isinstance(properties, dict) else {}
+
+
+def _mcp_result_text(result: dict[str, Any]) -> str | None:
+    content = result.get("content")
+    if not isinstance(content, list):
+        return None
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            return text
+    return None
+
+
+def _normalise_mcp_tool_args(
+    *,
+    tool_name: str,
+    args: dict[str, Any],
+    raw_tool: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Apply narrow MCP argument compatibility fixes before dispatch.
+
+    These are not semantic rewrites of tool calls. They handle common schema
+    aliasing and mutually-exclusive parameter mistakes that otherwise produce
+    deterministic MCP validation failures.
+    """
+    normalised = dict(args)
+    properties = _mcp_tool_schema_properties(raw_tool or {})
+
+    if (
+        "path" in properties
+        and "file_path" not in properties
+        and "path" not in normalised
+        and "file_path" in normalised
+    ):
+        normalised["path"] = normalised.pop("file_path")
+
+    if tool_name == "read_text_file" and "head" in normalised and "tail" in normalised:
+        normalised.pop("head", None)
+        normalised.pop("tail", None)
+
+    return normalised
 
 
 class MCPServerManager:
@@ -124,6 +206,7 @@ class MCPServerManager:
         self._clients: dict[str, StdioMCPClient] = {}
         self._failed_at: dict[str, float] = {}
         self._dotenv_cache: dict[str, str | None] = {}
+        self._text_read_cache: dict[tuple[str, str], str] = {}
         self._signal_installed = False
         self._prev_sigterm: Any = None
         self._prev_sigint: signal.Handlers | None = None
@@ -498,7 +581,25 @@ class MCPServerManager:
             )
 
         try:
-            return await client.acall_tool(tool_name, args)
+            raw_tool = self._raw_tool_for_client(client, tool_name)
+            normalised_args = _normalise_mcp_tool_args(
+                tool_name=tool_name,
+                args=args,
+                raw_tool=raw_tool,
+            )
+            normalised_args = self._normalise_cached_text_write(
+                server_name=server_name,
+                tool_name=tool_name,
+                args=normalised_args,
+            )
+            result = await client.acall_tool(tool_name, normalised_args)
+            self._record_text_read_result(
+                server_name=server_name,
+                tool_name=tool_name,
+                args=normalised_args,
+                result=result,
+            )
+            return result
         except Exception as exc:
             log.error("MCP async tool call failed: %s/%s: %s", server_name, tool_name, exc)
             hint = self._FALLBACK_HINTS.get(server_name, "")
@@ -509,6 +610,82 @@ class MCPServerManager:
                 hint=f"Use {hint} instead" if hint else "Retry or use an alternative tool.",
                 context={"server": server_name, "tool": tool_name},
             )
+
+    def _raw_tool_for_client(self, client: StdioMCPClient, tool_name: str) -> dict[str, Any] | None:
+        try:
+            tools = client.list_tools()
+        except Exception:
+            log.debug("MCP tool schema lookup failed: %s", tool_name, exc_info=True)
+            return None
+        for tool in tools:
+            if tool.get("name") == tool_name:
+                return tool
+        return None
+
+    def _record_text_read_result(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+        result: dict[str, Any],
+    ) -> None:
+        if result.get("isError") or result.get("error"):
+            return
+
+        paths: list[str] = []
+        if tool_name in {"read_file", "read_text_file"} and isinstance(args.get("path"), str):
+            paths.append(args["path"])
+        elif tool_name == "read_multiple_files" and isinstance(args.get("paths"), list):
+            paths.extend(path for path in args["paths"] if isinstance(path, str))
+        else:
+            return
+
+        fallback_text = _mcp_result_text(result)
+        for path in paths:
+            text = self._read_local_text_if_available(path)
+            if text is None and len(paths) == 1 and tool_name in {"read_file", "read_text_file"}:
+                text = fallback_text
+            if text is None:
+                continue
+            self._text_read_cache[(server_name, Path(path).name)] = text
+
+    def _normalise_cached_text_write(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        if tool_name != "write_file":
+            return args
+        content = args.get("content")
+        path = args.get("path") or args.get("file_path")
+        if not isinstance(content, str) or not isinstance(path, str):
+            return args
+        if not content.endswith("\n"):
+            return args
+
+        source = self._text_read_cache.get((server_name, Path(path).name))
+        if source is None or source.endswith("\n"):
+            return args
+
+        candidate = content[:-1]
+        if candidate not in {source, source.upper(), source.lower()}:
+            return args
+
+        normalised = dict(args)
+        normalised["content"] = candidate
+        return normalised
+
+    def _read_local_text_if_available(self, path: str) -> str | None:
+        try:
+            file_path = Path(path)
+            if not file_path.is_file():
+                return None
+            return file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
 
     def find_server_for_tool(self, tool_name: str) -> str | None:
         """Find which server provides a given tool."""

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -19,6 +19,9 @@
 |---|---|---|
 | GUI Trajectory Eval | observation coverage, classified failures, coordinate sanity, final screenshot availability | `computer`/`computer_use` trajectory rows를 모델 prose와 분리해 사후 평가 |
 | Capability/Evidence Preflight | provider/source/tool support, required evidence classes | 작업 시작 전 route mismatch를 드러내고 evidence ledger에 남김 |
+| Frontier agentic tool-use benchmark cases | MCPMark/BFCL V4/tau2 공개 사례와 GEODE 측정 계약 | GPT-5.5 subscription 결과를 공개 baseline과 섞기 전 비교 가능성 분리 |
+
+참고: [frontier-agentic-tool-use-benchmark-cases.md](frontier-agentic-tool-use-benchmark-cases.md)
 
 ## 의존성 그래프
 
@@ -67,4 +70,6 @@ HAL Reliability (τ-bench airline rerun) ← 절반 무료
 
 | 일자 | 변경 |
 |---|---|
+| 2026-07-03 | MCPMark filesystem easy에서 GEODE + GPT-5.5 xhigh 10/10 실측 및 EOF offload 결과 기록 |
+| 2026-07-02 | GPT-5.5 subscription 측정 준비용 MCPMark/BFCL V4/tau2 공개 사례 ledger 추가 |
 | 2026-05-07 | 초기 작성 — 4종 채택, 각 벤치별 사례/인프라/시나리오 |

--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -1,0 +1,555 @@
+# Frontier Agentic Tool-Use Benchmark Cases
+
+Date: 2026-07-02; updated 2026-07-03
+
+Purpose: prepare GEODE's public benchmark ledger for agentic tool-use scores,
+with the planned GEODE run using GPT-5.5 from a subscription/Codex account.
+This note is an evidence ledger, not a full GEODE scorecard. A no-LLM MCPMark
+harness smoke was run to validate setup and verification. Live GEODE runs were
+also completed for one MCPMark filesystem easy smoke task and the 10-task
+MCPMark filesystem easy suite with `gpt-5.5` / `xhigh`.
+
+Target benchmark cluster:
+
+- MCPMark / MCPMark Verified
+- BFCL V4
+- tau2-bench / tau2-Bench
+
+## Finding
+
+There is no single public primary-source case found so far that runs the exact
+planned GEODE configuration, namely GEODE harness + GPT-5.5 via subscription
+account, across MCPMark, BFCL V4, and tau2-bench.
+
+There is also no public case found so far that runs Codex/GPT-5.5 across all
+three target benchmarks. The closest external evidence is split: MCPMark has a
+Codex/GPT-5.5 xhigh result; BFCL V4 and tau2 have GPT-5.5 results from API or
+provider-managed routes, not clearly Codex.
+
+The closest evidence splits into four buckets:
+
+| Status | Case | What it gives GEODE | Limitation |
+|---|---|---|---|
+| Strong baseline | Agent-World Table 1 | Same three benchmark suites in one table, including frontier proprietary model rows | Uses GPT-5.2 High, Claude Sonnet 4.5, Gemini 3 Pro, Seed 2.0; not GPT-5.5 subscription |
+| Same target model, MCPMark | MCPMark Verified README / release PR | `gpt-5.5` (`xhigh`) leads MCPMark Verified at 92.9%; verified task set is pinned and stabilized | MCPMark only; likely model/API-style harness, not Codex subscription product |
+| Same target model, tau2 | OpenAI GPT-5.5 release | GPT-5.5 reaches 98.0% on tau2-bench Telecom without prompt tuning, with GPT-4.1 as user model | Telecom domain only; not the full retail/telecom/airline average from Agent-World |
+| Same target model, BFCL/tau2 comparator | Surge cross-benchmark study | GPT-5.5 evaluated through Azure AI Foundry at medium reasoning effort on BFCL V4, tau2-Bench, and Toolathlon; BFCL V4 pass@4 comparator is 69.4% | Third-party study; medium reasoning, not subscription/Codex; most numeric values are embedded in images |
+| Same target model and Codex route, MCPMark | Moonshot Kimi K2.7 Code model card | GPT-5.5 ran in Codex with xhigh mode; MCPMark Verified 92.9 | MCPMark only; vendor comparison table, not GEODE |
+
+## Benchmark Grounding
+
+### MCPMark / MCPMark Verified
+
+Official source: <https://github.com/eval-sys/mcpmark>
+
+MCPMark evaluates agentic models in real MCP tool environments: Notion, GitHub,
+Filesystem, Postgres, and Playwright. The repo describes one-command tasks,
+isolated sandboxes, auto-resume, unified metrics, and aggregated reports.
+
+Current important versioning note:
+
+- MCPMark Verified is now the default standard task set.
+- Earlier task versions are deprecated and not directly comparable.
+- Standard covers 127 tasks.
+- `easy` hosts 10 lightweight tasks per MCP for smoke tests / CI.
+- The Verified release pins all five MCP server versions and the harness so the
+  model under test is the intended variable.
+
+Relevant frontier case:
+
+| Source | Model / setting | Reported result |
+|---|---|---|
+| MCPMark README / PR #264 | `gpt-5.5`, `xhigh` reasoning effort | 92.9% on MCPMark Verified |
+| Moonshot Kimi K2.7 Code model card | GPT-5.5 in Codex, xhigh mode | 92.9% on MCPMark Verified |
+
+Use for GEODE:
+
+- Treat MCPMark Verified, not older MCP-Mark, as the canonical MCP score.
+- Record server versions, harness commit, task suite, model route, reasoning
+  effort, and whether GEODE used native API, Codex subscription, or an emulated
+  tool path.
+
+## BFCL V4
+
+Official sources:
+
+- Leaderboard: <https://gorilla.cs.berkeley.edu/leaderboard.html>
+- V4 web-search blog: <https://gorilla.cs.berkeley.edu/blogs/15_bfcl_v4_web_search.html>
+- Code/data: <https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard>
+
+BFCL V4 evaluates function/tool calling accuracy. The public leaderboard states
+that models are evaluated using commit `f7cf735`, and reproduction should use
+that checkpoint or `bfcl-eval==2025.12.17`.
+
+V4 score composition from the Berkeley blog:
+
+| Component | Weight / role |
+|---|---|
+| Agentic | 40%, unweighted average across Web Search and Memory |
+| Multi-Turn | 30% |
+| Live | 10% |
+| Non-Live | 10% |
+| Hallucination Measurement | 10% |
+| Format Sensitivity | non-scoring stress surface |
+
+Relevant frontier cases:
+
+| Source | Model / setting | Reported result |
+|---|---|---|
+| Agent-World Table 1 | GPT-5.2 High | BFCL V4 average 62.9 |
+| Agent-World Table 1 | Claude Sonnet 4.5 | BFCL V4 average 73.2 |
+| Agent-World Table 1 | Gemini 3 Pro | BFCL V4 average 72.5 |
+| Agent-World Table 1 | Seed 2.0 | BFCL V4 average 73.4 |
+| Surge cross-benchmark study | GPT-5.5 via Azure AI Foundry, medium reasoning | BFCL V4 pass@1 64.9; pass@4 comparator 69.4 |
+
+Use for GEODE:
+
+- Do not mix BFCL V4 overall accuracy with BFCL subcategory scores unless the
+  report names the exact aggregation.
+- Record whether the model used native function calling (`FC`) or prompt-based
+  function calling, because the leaderboard distinguishes those modes.
+
+## tau2-bench
+
+Official sources:
+
+- Repo: <https://github.com/sierra-research/tau2-bench>
+- Leaderboard: <https://taubench.com/>
+- Paper: <https://arxiv.org/pdf/2506.07982>
+
+The current repo describes tau-bench as a simulation framework for customer
+service agents. It supports text half-duplex evaluation and voice full-duplex
+evaluation. Domains currently listed in the repo are `mock`, `airline`,
+`retail`, `telecom`, and `banking_knowledge`.
+
+Relevant frontier cases:
+
+| Source | Model / setting | Reported result |
+|---|---|---|
+| OpenAI GPT-5.5 release | GPT-5.5, no prompt tuning, GPT-4.1 user model | tau2-bench Telecom 98.0% |
+| Agent-World Table 1 | GPT-5.2 High | Retail 81.6, Telecom 95.8, Airline 62.5, average 80.2 |
+| Agent-World Table 1 | Claude Sonnet 4.5 | Retail 86.2, Telecom 98.0, Airline 70.1, average 84.7 |
+| Agent-World Table 1 | Gemini 3 Pro | Retail 85.3, Telecom 98.0, Airline 72.7, average 85.4 |
+| Agent-World Table 1 | Seed 2.0 | Retail 90.4, Telecom 94.2, Airline 64.4, average 83.0 |
+| Surge cross-benchmark study | GPT-5.5 via Azure AI Foundry, medium reasoning | tau2-Bench pass@1 60.9 |
+
+Use for GEODE:
+
+- If we publish a tau2 score, report the domain split, not only the average.
+- For direct comparison to OpenAI's GPT-5.5 claim, run Telecom with GPT-4.1 as
+  the user model and state that it is a Telecom-only comparison.
+
+## Same-Suite Frontier Table
+
+Source: Agent-World, arXiv `2604.18292v1`, Table 1:
+<https://arxiv.org/html/2604.18292v1>
+
+The paper reports accuracy across MCP-Mark, BFCL V4, and tau2-Bench in one
+table. This is the closest directly comparable public table for the three-suite
+cluster, but it is not the planned GPT-5.5 subscription spec.
+
+Frontier proprietary rows from the paper:
+
+| Method | MCP-Mark Avg. | BFCL V4 Avg. | tau2-Bench Avg. |
+|---|---:|---:|---:|
+| GPT-5.2 High | 53.1 | 62.9 | 80.2 |
+| Claude Sonnet 4.5 | 33.3 | 73.2 | 84.7 |
+| Gemini 3 Pro | 50.8 | 72.5 | 85.4 |
+| Seed 2.0 | 54.7 | 73.4 | 83.0 |
+
+Open-source environment-scaling rows from the same table:
+
+| Method | MCP-Mark Avg. | BFCL V4 Avg. | tau2-Bench Avg. |
+|---|---:|---:|---:|
+| Simulator-8B | 2.4 | 23.9 | 31.8 |
+| TOUCAN-7B | 1.0 | 36.6 | 17.7 |
+| EnvScaler-8B | 5.6 | 47.6 | 37.9 |
+| AWM-8B | 2.4 | 40.0 | 34.4 |
+| AWM-14B | 5.1 | 42.4 | 39.0 |
+| ScaleEnv-8B | - | - | 38.5 |
+| Agent-World-8B | 8.9 | 51.4 | 61.8 |
+| Agent-World-14B | 13.3 | 55.8 | 65.4 |
+
+## GEODE Reporting Contract
+
+When GEODE scores are added later, use this schema:
+
+| Field | Required value |
+|---|---|
+| Harness | GEODE commit SHA and branch |
+| Model route | `openai-subscription/codex` vs `openai-api` vs other |
+| Model label | Exact UI/API label, e.g. `GPT-5.5 Thinking`, `gpt-5.5`, etc. |
+| Reasoning setting | UI/default/medium/high/xhigh/max, if visible |
+| Tool path | Native provider tools, GEODE function tools, MCP servers, or emulation |
+| Benchmark version | Repo commit, package version, task suite, server versions |
+| User simulator | Required for tau2, e.g. `gpt-4.1` |
+| Trials | `k`, pass@k, domain/task count |
+| Cost / time | Wall time, estimated cost, subscription limits hit |
+| Artifacts | Raw JSONL, trajectories, verifier outputs, run config |
+
+Comparison rule:
+
+- Compare GEODE subscription results to other subscription/product-agent
+  results only when the external source states that same product route.
+- Compare GEODE subscription results to API/model-card scores as directional
+  baselines, not apples-to-apples scores.
+- Never combine MCPMark Verified with pre-Verified MCP-Mark results in the same
+  leaderboard column without an explicit version label.
+
+## External Codex/GPT-5.5 Cases
+
+Follow-up search date: 2026-07-02.
+
+No public external case was found that reports Codex/GPT-5.5 on all three
+target benchmarks (`MCPMark`, `BFCL V4`, `tau2-bench`) under one consistent
+run spec.
+
+Found cases:
+
+| Benchmark | External case | Route / setting | Data | Use for GEODE |
+|---|---|---|---|---|
+| MCPMark Verified | Moonshot Kimi K2.7 Code model card | GPT-5.5 ran in Codex with xhigh mode | 92.9, averaged over 3 runs; 100-step tool-call budget; 32k max tokens per step | Strongest Codex/GPT-5.5 comparator for MCPMark |
+| MCPMark Verified | MCPMark README / release PR #264 | `gpt-5.5`, xhigh; public model entry added in MCPMark Verified release | 92.9; verified task set is pinned and stabilized | Strong model/harness comparator; Codex route is clarified by Moonshot, not by MCPMark README alone |
+| BFCL V4 | Surge / Edwin Chen cross-benchmark study | GPT-5.5 through Azure AI Foundry, medium reasoning | pass@1 64.9; pass@4 69.4 | Good GPT-5.5 medium comparator, but not Codex |
+| tau2-bench | Surge / Edwin Chen cross-benchmark study | GPT-5.5 through Azure AI Foundry, medium reasoning | pass@1 60.9 | Good GPT-5.5 medium comparator, but not Codex |
+| tau2-bench Telecom | OpenAI GPT-5.5 release | GPT-5.5 with original prompts, GPT-4.1 user model | 98.0 on Telecom | Official model-card comparator, domain-only and not clearly Codex |
+
+Near-miss:
+
+- MarginLab runs a daily `Codex gpt-5.5-xhigh` tracker directly in Codex CLI,
+  but it targets SWE-Bench-Pro, not MCPMark/BFCL/tau2. It is useful as evidence
+  that third-party Codex CLI benchmarking exists, not as a score source for
+  this benchmark cluster.
+
+Current interpretation:
+
+- For MCPMark, we can cite a Codex/GPT-5.5 xhigh external score.
+- For BFCL V4, the public GPT-5.5 number found is Azure AI Foundry medium, not
+  Codex.
+- For tau2, the public GPT-5.5 numbers found are Azure AI Foundry medium for
+  broad tau2 and OpenAI official Telecom-only for the release note, not Codex.
+- Therefore GEODE's planned Codex/subscription run will likely be the first
+  locally controlled apples-to-apples Codex/GPT-5.5 ledger across these three
+  suites, unless a private or newly published Codex benchmark appears.
+
+## Local Harness Inventory
+
+The benchmark harnesses were fetched under ignored local artifacts so they can
+be used for setup and smoke testing without vendoring third-party repos into
+GEODE:
+
+| Benchmark | Local path | Upstream commit / version | Status |
+|---|---|---:|---|
+| MCPMark | `artifacts/eval/harnesses/mcpmark` | `cd45b7f` | Installed in local Python 3.12 venv; filesystem easy smoke passed |
+| tau2-bench | `artifacts/eval/harnesses/tau2-bench` | `1901a30` | Installed with `uv sync`; `tau2 check-data` passed |
+| BFCL V4 | `artifacts/eval/harnesses/gorilla/berkeley-function-call-leaderboard` | Gorilla `6ea5797` | Fetched via sparse checkout; CLI commands inspected |
+
+MCPMark install command used:
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+/opt/homebrew/bin/python3.12 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/pip install -e .
+```
+
+The first attempt with system `python3` failed because `/usr/bin/python3` is
+Python 3.9.6 and MCPMark requires Python 3.11 or newer.
+
+tau2 setup commands used:
+
+```bash
+cd artifacts/eval/harnesses/tau2-bench
+uv sync
+uv run tau2 check-data
+```
+
+tau2 data check result:
+
+| Field | Value |
+|---|---|
+| Data directory | `artifacts/eval/harnesses/tau2-bench/data` |
+| Registered domains | `mock`, `airline`, `retail`, `telecom`, `telecom-workflow`, `banking_knowledge` |
+| Registered users | `user_simulator`, `dummy_user` |
+| Status | Passed; `You can now run tau2 commands.` |
+
+BFCL V4 inspected commands:
+
+```bash
+cd artifacts/eval/harnesses/gorilla/berkeley-function-call-leaderboard
+pip install -e .
+bfcl generate --model MODEL_NAME --test-category TEST_CATEGORY --num-threads 1
+bfcl evaluate --model MODEL_NAME --test-category TEST_CATEGORY
+```
+
+BFCL V4 notes:
+
+- Web Search requires a SerpAPI key or compatible replacement.
+- Editable install defaults result and score folders under the BFCL project
+  root; PyPI install requires `BFCL_PROJECT_ROOT`.
+- BFCL generation is a model-calling step and was not run here.
+
+### MCPMark Harness Smoke
+
+Smoke command:
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+OPENAI_API_KEY=dummy .venv/bin/python pipeline.py \
+  --mcp filesystem \
+  --task-suite easy \
+  --tasks file_context/uppercase \
+  --models smoke \
+  --agent smoke \
+  --k 1 \
+  --timeout 120 \
+  --exp-name geode-smoke-20260702 \
+  --output-dir ./results-geode-smoke
+```
+
+Result:
+
+| Field | Value |
+|---|---|
+| Task | `filesystem/easy/file_context/uppercase` |
+| Result path | `artifacts/eval/harnesses/mcpmark/results-geode-smoke/geode-smoke-20260702/smoke__filesystem-easy/run-1` |
+| Passed | 1 / 1 |
+| Success rate | 100.0% |
+| Total task execution time | 0.559s |
+| Model calls | 0 |
+
+What this proves:
+
+- MCPMark imports and runs in the local Python 3.12 environment.
+- Filesystem easy fixtures download from `storage.mcpmark.ai`.
+- The harness setup, backup isolation, verifier, `messages.json`, `meta.json`,
+  and `summary.json` paths work end-to-end.
+
+What this does not prove:
+
+- It is not a GEODE score.
+- It does not exercise GEODE's `AgenticLoop`.
+- It does not exercise MCP tool calls through GEODE.
+- It does not use GPT-5.5 or the subscription/Codex route.
+
+### Live GEODE MCPMark Smoke
+
+Run date: 2026-07-03.
+
+Authentication note for the live GEODE commands below: `OPENAI_API_KEY=dummy`
+only satisfies the MCPMark pipeline's environment-variable expectation. The
+actual model calls used GEODE's `openai-codex` provider with `source=subscription`.
+An API-key route would not have authenticated with the dummy value.
+
+Command:
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+GEODE_REPO_ROOT=<geode-worktree> \
+OPENAI_API_KEY=dummy \
+.venv/bin/python pipeline.py \
+  --mcp filesystem \
+  --task-suite easy \
+  --tasks file_context/uppercase \
+  --models geode-gpt-5.5 \
+  --agent geode \
+  --reasoning-effort xhigh \
+  --k 1 \
+  --timeout 900 \
+  --exp-name geode-gpt55-xhigh-20260703-smoke-r10 \
+  --output-dir ./results-geode-live
+```
+
+Result:
+
+| Field | Value |
+|---|---|
+| Task | `filesystem/easy/file_context/uppercase` |
+| Model route | GEODE `gpt-5.5`, provider `openai-codex`, source `subscription` |
+| Reasoning effort | `xhigh` |
+| Result path | `artifacts/eval/harnesses/mcpmark/results-geode-live/geode-gpt55-xhigh-20260703-smoke-r10/geode-gpt-5-5-xhigh__filesystem-easy/run-1` |
+| Passed | 1 / 1 |
+| Success rate | 100.0% |
+| Agent execution time | 398.486s |
+| Task execution time | 398.623s |
+| GEODE rounds | 12 |
+| MCP tool calls | 11 |
+| Token usage | 59,219 input / 7,457 output / 66,676 total |
+
+What this proves:
+
+- MCPMark can drive GEODE's `AgenticLoop` through a local `BaseMCPAgent`
+  adapter.
+- GEODE can discover and execute MCP filesystem tools from the MCPMark
+  task-specific server.
+- The `gpt-5.5` Codex/subscription route completed a verifier-backed MCPMark
+  filesystem task under `xhigh`.
+
+Adapter caveats found during smoke:
+
+- GEODE's MCP tool surface exposed a `write_file` argument name mismatch for
+  this server path (`file_path` from the model vs `path` required by the MCP
+  filesystem server). This is now normalized in GEODE core before MCP dispatch.
+- `read_multiple_files` adds display separators/newlines, which can break exact
+  byte-for-byte verifier checks if the model copies the display text literally.
+  GEODE now caches local source EOF metadata after successful reads and trims a
+  single display-induced trailing newline on same-name text writes when the
+  source did not have one.
+- `read_text_file` rejects simultaneous `head` and `tail`; GEODE now drops both
+  when both are present so full-file reads work.
+
+### Live GEODE MCPMark Smoke After EOF Offload
+
+Run date: 2026-07-03.
+
+Command:
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+GEODE_REPO_ROOT=<geode-worktree> \
+OPENAI_API_KEY=dummy \
+.venv/bin/python pipeline.py \
+  --mcp filesystem \
+  --task-suite easy \
+  --tasks file_context/uppercase \
+  --models geode-gpt-5.5 \
+  --agent geode \
+  --reasoning-effort xhigh \
+  --k 1 \
+  --timeout 900 \
+  --exp-name geode-gpt55-xhigh-20260703-smoke-r11-eof-offload \
+  --output-dir ./results-geode-live
+```
+
+Result:
+
+| Field | Value |
+|---|---|
+| Task | `filesystem/easy/file_context/uppercase` |
+| Result path | `artifacts/eval/harnesses/mcpmark/results-geode-live/geode-gpt55-xhigh-20260703-smoke-r11-eof-offload/geode-gpt-5-5-xhigh__filesystem-easy/run-1` |
+| Passed | 1 / 1 |
+| Success rate | 100.0% |
+| Task execution time | 167.9s |
+| GEODE rounds | 3 |
+| MCP tool calls | 7 |
+
+Interpretation:
+
+- EOF handling no longer needs to be solved by forcing file-by-file
+  `read_text_file` calls in the model loop.
+- For the same uppercase smoke, wall time dropped from 398.6s / 12 rounds to
+  167.9s / 3 rounds while preserving verifier correctness.
+
+### Live GEODE MCPMark Filesystem Easy
+
+Run date: 2026-07-03.
+
+Command:
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+GEODE_REPO_ROOT=<geode-worktree> \
+OPENAI_API_KEY=dummy \
+.venv/bin/python pipeline.py \
+  --mcp filesystem \
+  --task-suite easy \
+  --models geode-gpt-5.5 \
+  --agent geode \
+  --reasoning-effort xhigh \
+  --k 1 \
+  --timeout 900 \
+  --exp-name geode-gpt55-xhigh-20260703-filesystem-easy \
+  --output-dir ./results-geode-live
+```
+
+Result:
+
+| Field | Value |
+|---|---|
+| Suite | `MCPMark filesystem/easy` |
+| Model route | GEODE `gpt-5.5`, provider `openai-codex`, source `subscription` |
+| Reasoning effort | `xhigh` |
+| Result path | `artifacts/eval/harnesses/mcpmark/results-geode-live/geode-gpt55-xhigh-20260703-filesystem-easy/geode-gpt-5-5-xhigh__filesystem-easy/run-1` |
+| Passed | 10 / 10 |
+| Success rate | 100.0% |
+| Total task execution time | 1706.044s |
+| Average task execution time | 170.604s |
+| Total agent execution time | 1696.300s |
+| GEODE rounds | 40 total / 4.0 average |
+| Token usage | 234,483 input / 32,296 output / 266,779 total |
+
+Task-level results:
+
+| Task | Result | Time | Rounds | Tokens |
+|---|---:|---:|---:|---:|
+| `file_context__file_splitting` | PASS | 640.287s | 7 | 52,925 |
+| `file_context__pattern_matching` | PASS | 162.561s | 3 | 24,781 |
+| `file_context__uppercase` | PASS | 145.404s | 3 | 17,541 |
+| `file_property__largest_rename` | PASS | 61.050s | 4 | 17,532 |
+| `file_property__txt_merging` | PASS | 124.666s | 4 | 22,619 |
+| `folder_structure__structure_analysis` | PASS | 85.059s | 3 | 12,977 |
+| `legal_document__file_reorganize` | PASS | 115.090s | 5 | 24,307 |
+| `papers__papers_counting` | PASS | 113.489s | 3 | 32,570 |
+| `student_database__duplicate_name` | PASS | 105.057s | 3 | 20,720 |
+| `student_database__recommender_name` | PASS | 153.381s | 5 | 40,807 |
+
+Interpretation:
+
+- This is a verifier-backed GEODE result for the MCPMark filesystem easy subset,
+  not a MCPMark Verified or full MCPMark score.
+- Accuracy is saturated on this subset: 100.0%.
+- Runtime remains high for `xhigh`; the slowest task was
+  `file_context__file_splitting` at 640.3s. Median task time is roughly two
+  minutes, but long reasoning turns dominate wall time.
+- Token usage averages 26,678 tokens per task. The run is suitable as a
+  smoke/regression baseline, but not as a cost-efficient CI gate.
+
+### Required GEODE Adapter Work
+
+MCPMark's native agents call models directly through LiteLLM. Running the
+default MCPMark agent with `gpt-5.5` would measure `MCPMark + OpenAI API-style
+LiteLLM`, not GEODE.
+
+For a real GEODE result, add an adapter that implements MCPMark's
+`BaseMCPAgent.execute()` and routes each task through:
+
+1. MCPMark task setup and service config.
+2. GEODE `MCPServerManager` configured with the task-specific MCP server.
+3. GEODE `ToolExecutor(mcp_manager=...)`.
+4. GEODE `AgenticLoop(model="gpt-5.5", provider=_resolve_provider("gpt-5.5"))`
+   using the subscription/Codex source.
+5. MCPMark verifier and result reporter.
+
+The relevant GEODE injection points already exist:
+
+| GEODE surface | Role |
+|---|---|
+| `core/mcp/manager.py` | loads MCP server config and exposes MCP tools |
+| `core/agent/tool_executor/executor.py` | dispatches MCP tool calls through `mcp_manager` |
+| `core/agent/loop/agent_loop.py` | accepts `mcp_manager` and merges MCP tool schemas into the visible tool surface |
+| `core/config/routing.toml` | routes `gpt-5.5` / `gpt-5.5-pro` through Codex/subscription |
+
+## Suggested First Measurement Pass
+
+1. MCPMark Verified `easy` suite across all available MCPs using the GEODE
+   adapter, starting with filesystem.
+2. tau2 `mock` smoke, then Telecom small run using GPT-4.1 as user simulator.
+3. BFCL V4 agentic subset first; full BFCL V4 only after the function-calling
+   route is stable.
+4. Archive every run under `artifacts/eval/<bench>/<date>/` and add only
+   verifier-backed scores to the public docs.
+
+## Sources
+
+- Agent-World paper, Table 1: <https://arxiv.org/html/2604.18292v1>
+- MCPMark repo: <https://github.com/eval-sys/mcpmark>
+- MCPMark Verified release PR: <https://github.com/eval-sys/mcpmark/pull/264>
+- Moonshot Kimi K2.7 Code model card: <https://huggingface.co/moonshotai/Kimi-K2.7-Code>
+- BFCL V4 leaderboard: <https://gorilla.cs.berkeley.edu/leaderboard.html>
+- BFCL V4 web-search methodology: <https://gorilla.cs.berkeley.edu/blogs/15_bfcl_v4_web_search.html>
+- tau2-bench repo: <https://github.com/sierra-research/tau2-bench>
+- OpenAI GPT-5.5 release: <https://openai.com/index/introducing-gpt-5-5/>
+- GPT-5.5 system card: <https://deploymentsafety.openai.com/gpt-5-5>
+- Surge cross-benchmark study: <https://surgehq.ai/blog/cross-benchmark-generalization-for-long-horizon-agentic-tasks>
+- Edwin Chen LinkedIn summary of Surge study: <https://www.linkedin.com/posts/edwinzchen_cross-benchmark-generalization-for-long-horizon-activity-7467343602092986368-T4DW>
+- MarginLab Codex gpt-5.5-xhigh tracker: <https://marginlab.ai/trackers/codex/>

--- a/site/public/diagrams/seed-scenario-generation-cycle.svg
+++ b/site/public/diagrams/seed-scenario-generation-cycle.svg
@@ -1,0 +1,80 @@
+<svg width="100%" viewBox="0 0 760 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Seed Scenario Generation cycle</title>
+  <desc id="desc">A flowchart showing target dimension selection, candidate drafting, critique, pilot measurement, tournament ranking, evolution, seed pools, and the Closed-Loop audit consumer.</desc>
+  <defs>
+    <marker id="seed-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0L10 4L0 8Z" fill="#ABA4BC"/>
+    </marker>
+    <marker id="seed-arrow-accent" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0L10 4L0 8Z" fill="#F49BC4"/>
+    </marker>
+    <style>
+      .label { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #F2EEF5; font-size: 14px; font-weight: 600; }
+      .sub { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #ABA4BC; font-size: 10px; }
+      .tag { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #F49BC4; font-size: 8px; letter-spacing: .12em; }
+      .node { fill: #14121B; stroke: rgba(244,155,196,.45); stroke-width: 1; }
+      .node-soft { fill: rgba(244,155,196,.06); stroke: rgba(244,155,196,.35); stroke-width: 1; }
+      .store { fill: rgba(171,164,188,.07); stroke: rgba(171,164,188,.45); stroke-width: 1; }
+      .edge { stroke: #ABA4BC; stroke-width: 1.5; marker-end: url(#seed-arrow); }
+      .edge-accent { stroke: #F49BC4; stroke-width: 1.8; marker-end: url(#seed-arrow-accent); }
+      .dash { stroke-dasharray: 5 5; }
+    </style>
+  </defs>
+
+  <rect width="760" height="520" fill="transparent"/>
+
+  <rect x="286" y="20" width="188" height="58" rx="6" class="node-soft"/>
+  <text x="380" y="43" text-anchor="middle" class="label">target dimension</text>
+  <text x="380" y="62" text-anchor="middle" class="sub">picker + prior gaps</text>
+
+  <rect x="70" y="120" width="170" height="70" rx="6" class="node"/>
+  <text x="155" y="142" text-anchor="middle" class="tag">DRAFT</text>
+  <text x="155" y="164" text-anchor="middle" class="label">candidate seeds</text>
+  <text x="155" y="181" text-anchor="middle" class="sub">generator debate</text>
+
+  <rect x="298" y="120" width="164" height="70" rx="6" class="node"/>
+  <text x="380" y="142" text-anchor="middle" class="tag">FILTER</text>
+  <text x="380" y="164" text-anchor="middle" class="label">cluster + critique</text>
+  <text x="380" y="181" text-anchor="middle" class="sub">proximity, critic</text>
+
+  <rect x="520" y="120" width="170" height="70" rx="6" class="node"/>
+  <text x="605" y="142" text-anchor="middle" class="tag">MEASURE</text>
+  <text x="605" y="164" text-anchor="middle" class="label">pilot audit</text>
+  <text x="605" y="181" text-anchor="middle" class="sub">dim_means + stderr</text>
+
+  <path d="M380 78V101C380 112 380 112 367 118" class="edge"/>
+  <path d="M240 155H286" class="edge"/>
+  <path d="M462 155H508" class="edge"/>
+
+  <polygon points="380,244 456,304 380,364 304,304" class="node-soft"/>
+  <text x="380" y="292" text-anchor="middle" class="tag">SELECT</text>
+  <text x="380" y="313" text-anchor="middle" class="label">3-judge Elo</text>
+  <text x="380" y="331" text-anchor="middle" class="sub">blend with difficulty</text>
+
+  <path d="M605 190V304H468" class="edge-accent"/>
+
+  <rect x="70" y="398" width="170" height="70" rx="6" class="node"/>
+  <text x="155" y="420" text-anchor="middle" class="tag">EVOLVE</text>
+  <text x="155" y="442" text-anchor="middle" class="label">survivor mutation</text>
+  <text x="155" y="459" text-anchor="middle" class="sub">next candidates</text>
+
+  <rect x="295" y="398" width="170" height="70" rx="6" class="store"/>
+  <text x="380" y="420" text-anchor="middle" class="tag">STORE</text>
+  <text x="380" y="442" text-anchor="middle" class="label">seed pools</text>
+  <text x="380" y="459" text-anchor="middle" class="sub">cycle-input, held-out</text>
+
+  <rect x="520" y="398" width="170" height="70" rx="6" class="node-soft"/>
+  <text x="605" y="420" text-anchor="middle" class="tag">CONSUME</text>
+  <text x="605" y="442" text-anchor="middle" class="label">Closed-Loop audit</text>
+  <text x="605" y="459" text-anchor="middle" class="sub">fitness gate input</text>
+
+  <path d="M323 344L218 397" class="edge"/>
+  <path d="M240 433H283" class="edge"/>
+  <path d="M465 433H508" class="edge-accent"/>
+  <path d="M155 398V304H292" class="edge dash"/>
+  <rect x="144" y="296" width="80" height="18" rx="3" fill="#0B0A10"/>
+  <text x="184" y="309" text-anchor="middle" class="sub">repeat</text>
+
+  <line x1="60" y1="498" x2="700" y2="498" stroke="rgba(171,164,188,.2)" stroke-width="1"/>
+  <text x="60" y="512" class="sub">Source pattern: Google AI Co-Scientist-style generate, review, rank, evolve flow adapted for GEODE Petri seeds.</text>
+</svg>

--- a/site/src/app/docs/architecture/overview/page.tsx
+++ b/site/src/app/docs/architecture/overview/page.tsx
@@ -130,7 +130,7 @@ export default function Page() {
               <code>gate.py</code>, <code>ledger.py</code>에 있고, 런타임 쪽
               배선은 <code>core/self_improving/loop/</code>의 mutate, observe,
               inject 경로가 맡습니다. 전체 루프는{" "}
-              <a href="/geode/docs/capabilities/autoresearch">폐루프</a>에서
+              <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>에서
               다룹니다.
             </p>
             <p>
@@ -292,7 +292,7 @@ export default function Page() {
               <code>gate.py</code>, and <code>ledger.py</code>; the runtime
               wiring is mutate, observe, and inject under{" "}
               <code>core/self_improving/loop/</code>. The full loop is covered
-              in <a href="/geode/docs/capabilities/autoresearch">The closed loop</a>.
+              in <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>.
             </p>
             <p>
               Where its responsibility ends: this layer never produces the

--- a/site/src/app/docs/benchmarks/mcpmark/filesystem-easy/page.tsx
+++ b/site/src/app/docs/benchmarks/mcpmark/filesystem-easy/page.tsx
@@ -1,0 +1,365 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "MCPMark filesystem/easy — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="benchmarks/mcpmark/filesystem-easy"
+      title="MCPMark: filesystem/easy"
+      titleKo="MCPMark: filesystem/easy"
+      summary="Verifier-backed GEODE run record for MCPMark's filesystem easy subset with GPT-5.5 xhigh through the Codex subscription route."
+      summaryKo="Codex subscription route의 GPT-5.5 xhigh로 실행한 MCPMark filesystem easy 하위 suite의 verifier-backed GEODE 실측 기록입니다."
+    >
+      <Bi
+        ko={
+          <>
+            <h2>결과 요약</h2>
+            <p>
+              이 페이지는 GEODE가 MCPMark의 <code>filesystem/easy</code> 하위
+              suite를 실행한 첫 공식 benchmark ledger입니다. 측정 대상은
+              GEODE의 <code>AgenticLoop</code>, MCP filesystem server, Codex
+              subscription route의 <code>gpt-5.5</code>, reasoning effort{" "}
+              <code>xhigh</code> 조합입니다.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>항목</th>
+                  <th>값</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Benchmark</td><td>MCPMark</td></tr>
+                <tr><td>하위 suite</td><td><code>filesystem/easy</code></td></tr>
+                <tr><td>Run date</td><td>2026-07-03</td></tr>
+                <tr><td>Agent</td><td>GEODE local MCPMark adapter</td></tr>
+                <tr><td>Model route</td><td>GEODE <code>gpt-5.5</code>, provider <code>openai-codex</code>, source <code>subscription</code></td></tr>
+                <tr><td>Reasoning effort</td><td><code>xhigh</code></td></tr>
+                <tr><td>Tasks</td><td>10</td></tr>
+                <tr><td>Passed</td><td><strong>10 / 10</strong></td></tr>
+                <tr><td>Accuracy</td><td><strong>100.0%</strong></td></tr>
+                <tr><td>Total task execution time</td><td>1706.044s</td></tr>
+                <tr><td>Average task execution time</td><td>170.604s</td></tr>
+                <tr><td>Total agent execution time</td><td>1696.300s</td></tr>
+                <tr><td>GEODE rounds</td><td>40 total / 4.0 average</td></tr>
+                <tr><td>Token usage</td><td>234,483 input / 32,296 output / 266,779 total</td></tr>
+              </tbody>
+            </table>
+
+            <h2>비교 가능성</h2>
+            <p>
+              이 수치는 MCPMark 전체 점수나 MCPMark Verified 점수가 아닙니다.
+              <code>filesystem/easy</code>는 MCPMark의 가벼운 smoke/CI용 하위
+              suite입니다. 따라서 이 결과는 GEODE의 MCPMark 연결, MCP dispatch,
+              파일 시스템 작업 정확도, 장기 추론 비용을 보는 regression
+              baseline으로 읽어야 합니다.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>비교 대상</th>
+                  <th>판정</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>MCPMark <code>filesystem/easy</code></td><td>직접 비교 가능</td></tr>
+                <tr><td>MCPMark Verified</td><td>직접 비교 불가. task set과 aggregation이 다름</td></tr>
+                <tr><td>Agent-World Table 1의 MCP-Mark 평균</td><td>방향성 참고만 가능. benchmark version과 suite가 다름</td></tr>
+                <tr><td>BFCL V4 / tau2-bench</td><td>별도 benchmark. 이 페이지의 수치와 평균내지 않음</td></tr>
+              </tbody>
+            </table>
+
+            <h2>실행 명령</h2>
+            <pre><code>{`cd artifacts/eval/harnesses/mcpmark
+GEODE_REPO_ROOT=<geode-worktree> \\
+OPENAI_API_KEY=dummy \\
+.venv/bin/python pipeline.py \\
+  --mcp filesystem \\
+  --task-suite easy \\
+  --models geode-gpt-5.5 \\
+  --agent geode \\
+  --reasoning-effort xhigh \\
+  --k 1 \\
+  --timeout 900 \\
+  --exp-name geode-gpt55-xhigh-20260703-filesystem-easy \\
+  --output-dir ./results-geode-live`}</code></pre>
+            <p>
+              <code>OPENAI_API_KEY=dummy</code>는 MCPMark pipeline의 환경변수
+              존재 기대를 만족시키기 위한 placeholder입니다. 실제 모델 호출은
+              GEODE의 <code>openai-codex</code> provider와{" "}
+              <code>source=subscription</code> 경로를 사용했습니다. API key
+              경로였다면 이 dummy 값으로는 인증되지 않습니다.
+            </p>
+            <p>
+              Raw result artifact:
+              <br />
+              <code>artifacts/eval/harnesses/mcpmark/results-geode-live/geode-gpt55-xhigh-20260703-filesystem-easy/geode-gpt-5-5-xhigh__filesystem-easy/run-1</code>
+            </p>
+
+            <h2>Task별 결과</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Task</th>
+                  <th>Result</th>
+                  <th>Time</th>
+                  <th>Rounds</th>
+                  <th>Tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td><code>file_context__file_splitting</code></td><td>PASS</td><td>640.287s</td><td>7</td><td>52,925</td></tr>
+                <tr><td><code>file_context__pattern_matching</code></td><td>PASS</td><td>162.561s</td><td>3</td><td>24,781</td></tr>
+                <tr><td><code>file_context__uppercase</code></td><td>PASS</td><td>145.404s</td><td>3</td><td>17,541</td></tr>
+                <tr><td><code>file_property__largest_rename</code></td><td>PASS</td><td>61.050s</td><td>4</td><td>17,532</td></tr>
+                <tr><td><code>file_property__txt_merging</code></td><td>PASS</td><td>124.666s</td><td>4</td><td>22,619</td></tr>
+                <tr><td><code>folder_structure__structure_analysis</code></td><td>PASS</td><td>85.059s</td><td>3</td><td>12,977</td></tr>
+                <tr><td><code>legal_document__file_reorganize</code></td><td>PASS</td><td>115.090s</td><td>5</td><td>24,307</td></tr>
+                <tr><td><code>papers__papers_counting</code></td><td>PASS</td><td>113.489s</td><td>3</td><td>32,570</td></tr>
+                <tr><td><code>student_database__duplicate_name</code></td><td>PASS</td><td>105.057s</td><td>3</td><td>20,720</td></tr>
+                <tr><td><code>student_database__recommender_name</code></td><td>PASS</td><td>153.381s</td><td>5</td><td>40,807</td></tr>
+              </tbody>
+            </table>
+
+            <h2>카테고리별 집계</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Tasks</th>
+                  <th>Accuracy</th>
+                  <th>Average time</th>
+                  <th>Tokens</th>
+                  <th>Average rounds</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td><code>file_context</code></td><td>3</td><td>100.0%</td><td>316.08s</td><td>95,247</td><td>4.33</td></tr>
+                <tr><td><code>file_property</code></td><td>2</td><td>100.0%</td><td>92.86s</td><td>40,151</td><td>4.00</td></tr>
+                <tr><td><code>folder_structure</code></td><td>1</td><td>100.0%</td><td>85.06s</td><td>12,977</td><td>3.00</td></tr>
+                <tr><td><code>legal_document</code></td><td>1</td><td>100.0%</td><td>115.09s</td><td>24,307</td><td>5.00</td></tr>
+                <tr><td><code>papers</code></td><td>1</td><td>100.0%</td><td>113.49s</td><td>32,570</td><td>3.00</td></tr>
+                <tr><td><code>student_database</code></td><td>2</td><td>100.0%</td><td>129.22s</td><td>61,527</td><td>4.00</td></tr>
+              </tbody>
+            </table>
+
+            <h2>EOF offload 보정</h2>
+            <p>
+              이 run 전에 <code>read_multiple_files</code>의 display separator와
+              trailing newline이 byte-for-byte verifier를 깨는 문제가 확인됐습니다.
+              GEODE는 이를 모델 prompt에 맡기지 않고 MCP dispatch 계층에서
+              보정합니다. 성공한 read 이후 local source EOF metadata를 캐시하고,
+              같은 파일명으로 write할 때 source에 없던 display-induced trailing
+              newline 하나만 제거합니다.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Smoke run</th>
+                  <th>Result</th>
+                  <th>Time</th>
+                  <th>Rounds</th>
+                  <th>Tool calls</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>EOF offload 전 <code>file_context/uppercase</code></td><td>1 / 1</td><td>398.6s</td><td>12</td><td>11</td></tr>
+                <tr><td>EOF offload 후 <code>file_context/uppercase</code></td><td>1 / 1</td><td>167.9s</td><td>3</td><td>7</td></tr>
+              </tbody>
+            </table>
+
+            <h2>판독</h2>
+            <ul>
+              <li>정확도는 이 하위 suite에서 포화입니다. 모든 verifier가 통과했습니다.</li>
+              <li><code>xhigh</code> 설정의 wall time은 큽니다. 가장 느린 task는 <code>file_context__file_splitting</code>이며 640.287s가 걸렸습니다.</li>
+              <li>평균 token 사용량은 task당 26,678 tokens입니다.</li>
+              <li>현재 값은 smoke/regression baseline으로 적합하고, 비용 효율적인 PR 단위 CI gate로 쓰기에는 무겁습니다.</li>
+            </ul>
+
+            <h2>다음 측정</h2>
+            <ul>
+              <li>MCPMark Verified의 filesystem slice로 확장합니다.</li>
+              <li>Notion, GitHub, Postgres, Playwright MCP server를 같은 GEODE adapter로 순차 연결합니다.</li>
+              <li>BFCL V4와 tau2-bench는 별도 페이지로 분리해 route, user simulator, aggregation을 독립 기록합니다.</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>Result Summary</h2>
+            <p>
+              This page is GEODE&apos;s first official benchmark ledger for the
+              MCPMark <code>filesystem/easy</code> subset. The measured system is
+              GEODE&apos;s <code>AgenticLoop</code>, the MCP filesystem server,
+              and <code>gpt-5.5</code> through the Codex subscription route with
+              reasoning effort <code>xhigh</code>.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Benchmark</td><td>MCPMark</td></tr>
+                <tr><td>Subset</td><td><code>filesystem/easy</code></td></tr>
+                <tr><td>Run date</td><td>2026-07-03</td></tr>
+                <tr><td>Agent</td><td>GEODE local MCPMark adapter</td></tr>
+                <tr><td>Model route</td><td>GEODE <code>gpt-5.5</code>, provider <code>openai-codex</code>, source <code>subscription</code></td></tr>
+                <tr><td>Reasoning effort</td><td><code>xhigh</code></td></tr>
+                <tr><td>Tasks</td><td>10</td></tr>
+                <tr><td>Passed</td><td><strong>10 / 10</strong></td></tr>
+                <tr><td>Accuracy</td><td><strong>100.0%</strong></td></tr>
+                <tr><td>Total task execution time</td><td>1706.044s</td></tr>
+                <tr><td>Average task execution time</td><td>170.604s</td></tr>
+                <tr><td>Total agent execution time</td><td>1696.300s</td></tr>
+                <tr><td>GEODE rounds</td><td>40 total / 4.0 average</td></tr>
+                <tr><td>Token usage</td><td>234,483 input / 32,296 output / 266,779 total</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Comparability</h2>
+            <p>
+              This is not a full MCPMark score and not a MCPMark Verified score.
+              <code>filesystem/easy</code> is MCPMark&apos;s lightweight smoke/CI
+              subset. Read it as a regression baseline for GEODE&apos;s MCPMark
+              wiring, MCP dispatch, filesystem-task correctness, and long
+              reasoning cost.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Comparator</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>MCPMark <code>filesystem/easy</code></td><td>Directly comparable</td></tr>
+                <tr><td>MCPMark Verified</td><td>Not directly comparable. The task set and aggregation differ</td></tr>
+                <tr><td>Agent-World Table 1 MCP-Mark average</td><td>Directional only. Benchmark version and suite differ</td></tr>
+                <tr><td>BFCL V4 / tau2-bench</td><td>Different benchmarks. Do not average with this page&apos;s score</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Run Command</h2>
+            <pre><code>{`cd artifacts/eval/harnesses/mcpmark
+GEODE_REPO_ROOT=<geode-worktree> \\
+OPENAI_API_KEY=dummy \\
+.venv/bin/python pipeline.py \\
+  --mcp filesystem \\
+  --task-suite easy \\
+  --models geode-gpt-5.5 \\
+  --agent geode \\
+  --reasoning-effort xhigh \\
+  --k 1 \\
+  --timeout 900 \\
+  --exp-name geode-gpt55-xhigh-20260703-filesystem-easy \\
+  --output-dir ./results-geode-live`}</code></pre>
+            <p>
+              <code>OPENAI_API_KEY=dummy</code> is a placeholder for the
+              MCPMark pipeline environment-variable expectation. The actual
+              model calls used the GEODE <code>openai-codex</code> provider with{" "}
+              <code>source=subscription</code>. An API-key route would not have
+              authenticated with the dummy value.
+            </p>
+            <p>
+              Raw result artifact:
+              <br />
+              <code>artifacts/eval/harnesses/mcpmark/results-geode-live/geode-gpt55-xhigh-20260703-filesystem-easy/geode-gpt-5-5-xhigh__filesystem-easy/run-1</code>
+            </p>
+
+            <h2>Task Results</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Task</th>
+                  <th>Result</th>
+                  <th>Time</th>
+                  <th>Rounds</th>
+                  <th>Tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td><code>file_context__file_splitting</code></td><td>PASS</td><td>640.287s</td><td>7</td><td>52,925</td></tr>
+                <tr><td><code>file_context__pattern_matching</code></td><td>PASS</td><td>162.561s</td><td>3</td><td>24,781</td></tr>
+                <tr><td><code>file_context__uppercase</code></td><td>PASS</td><td>145.404s</td><td>3</td><td>17,541</td></tr>
+                <tr><td><code>file_property__largest_rename</code></td><td>PASS</td><td>61.050s</td><td>4</td><td>17,532</td></tr>
+                <tr><td><code>file_property__txt_merging</code></td><td>PASS</td><td>124.666s</td><td>4</td><td>22,619</td></tr>
+                <tr><td><code>folder_structure__structure_analysis</code></td><td>PASS</td><td>85.059s</td><td>3</td><td>12,977</td></tr>
+                <tr><td><code>legal_document__file_reorganize</code></td><td>PASS</td><td>115.090s</td><td>5</td><td>24,307</td></tr>
+                <tr><td><code>papers__papers_counting</code></td><td>PASS</td><td>113.489s</td><td>3</td><td>32,570</td></tr>
+                <tr><td><code>student_database__duplicate_name</code></td><td>PASS</td><td>105.057s</td><td>3</td><td>20,720</td></tr>
+                <tr><td><code>student_database__recommender_name</code></td><td>PASS</td><td>153.381s</td><td>5</td><td>40,807</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Category Rollup</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Tasks</th>
+                  <th>Accuracy</th>
+                  <th>Average time</th>
+                  <th>Tokens</th>
+                  <th>Average rounds</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td><code>file_context</code></td><td>3</td><td>100.0%</td><td>316.08s</td><td>95,247</td><td>4.33</td></tr>
+                <tr><td><code>file_property</code></td><td>2</td><td>100.0%</td><td>92.86s</td><td>40,151</td><td>4.00</td></tr>
+                <tr><td><code>folder_structure</code></td><td>1</td><td>100.0%</td><td>85.06s</td><td>12,977</td><td>3.00</td></tr>
+                <tr><td><code>legal_document</code></td><td>1</td><td>100.0%</td><td>115.09s</td><td>24,307</td><td>5.00</td></tr>
+                <tr><td><code>papers</code></td><td>1</td><td>100.0%</td><td>113.49s</td><td>32,570</td><td>3.00</td></tr>
+                <tr><td><code>student_database</code></td><td>2</td><td>100.0%</td><td>129.22s</td><td>61,527</td><td>4.00</td></tr>
+              </tbody>
+            </table>
+
+            <h2>EOF Offload</h2>
+            <p>
+              Before this run, <code>read_multiple_files</code> display
+              separators and trailing newlines were found to break
+              byte-for-byte verifier checks. GEODE now handles that in the MCP
+              dispatch layer instead of relying on the model prompt. After a
+              successful read, GEODE caches local source EOF metadata and trims
+              one display-induced trailing newline on same-name writes when the
+              source file did not have one.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Smoke run</th>
+                  <th>Result</th>
+                  <th>Time</th>
+                  <th>Rounds</th>
+                  <th>Tool calls</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Before EOF offload, <code>file_context/uppercase</code></td><td>1 / 1</td><td>398.6s</td><td>12</td><td>11</td></tr>
+                <tr><td>After EOF offload, <code>file_context/uppercase</code></td><td>1 / 1</td><td>167.9s</td><td>3</td><td>7</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Reading</h2>
+            <ul>
+              <li>Accuracy is saturated on this subset. Every verifier passed.</li>
+              <li><code>xhigh</code> wall time is high. The slowest task was <code>file_context__file_splitting</code> at 640.287s.</li>
+              <li>Average token usage is 26,678 tokens per task.</li>
+              <li>This is a good smoke/regression baseline, but too heavy for a cost-efficient per-PR CI gate.</li>
+            </ul>
+
+            <h2>Next Measurements</h2>
+            <ul>
+              <li>Extend to the MCPMark Verified filesystem slice.</li>
+              <li>Attach Notion, GitHub, Postgres, and Playwright MCP servers through the same GEODE adapter.</li>
+              <li>Record BFCL V4 and tau2-bench on separate pages, with independent route, user-simulator, and aggregation fields.</li>
+            </ul>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/capabilities/autoresearch/page.tsx
+++ b/site/src/app/docs/capabilities/autoresearch/page.tsx
@@ -1,13 +1,13 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "The closed loop — GEODE Docs" };
+export const metadata = { title: "Closed-Loop — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="capabilities/autoresearch"
-      title="The closed loop"
-      titleKo="폐루프"
+      title="Closed-Loop"
+      titleKo="Closed-Loop"
       summary="The outer loop end to end. Mutate the scaffold, audit with Petri, gate the fitness gain on a margin, then promote or revert. No model weight or parameter ever changes."
       summaryKo="바깥쪽 루프의 전체 흐름입니다. 스캐폴드를 변이하고, Petri로 감사하고, fitness 이득을 margin 게이트로 검증해 승격하거나 되돌립니다. 모델 가중치와 파라미터는 일절 바꾸지 않습니다."
     >
@@ -179,7 +179,7 @@ geode campaign --n 10 --k 5 --dry-run
             <h2>다음</h2>
             <ul>
               <li><a href="/geode/docs/petri/judge-dimensions">Judge 차원</a>. 18-dim fitness universe와 critical floor.</li>
-              <li><a href="/geode/docs/capabilities/co-scientist">Co-scientist seed 생성</a>. 테스트 분포를 함께 키우는 쪽.</li>
+              <li><a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>. 테스트 분포를 함께 키우는 쪽.</li>
               <li><a href="/geode/docs/capabilities/lineage">계보와 좌표</a>. 이 루프가 문헌 어디에 서 있는지.</li>
             </ul>
           </>
@@ -361,7 +361,7 @@ geode campaign --n 10 --k 5 --dry-run
             <h2>Next</h2>
             <ul>
               <li><a href="/geode/docs/petri/judge-dimensions">Judge dimensions</a>. The 18-dim fitness universe and the critical floor.</li>
-              <li><a href="/geode/docs/capabilities/co-scientist">Co-scientist seed generation</a>. The side that grows the test distribution.</li>
+              <li><a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>. The side that grows the test distribution.</li>
               <li><a href="/geode/docs/capabilities/lineage">Lineage and positioning</a>. Where this loop sits in the literature.</li>
             </ul>
           </>

--- a/site/src/app/docs/capabilities/co-scientist/page.tsx
+++ b/site/src/app/docs/capabilities/co-scientist/page.tsx
@@ -1,32 +1,43 @@
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
-export const metadata = { title: "Co-scientist seed generation — GEODE Docs" };
+export const metadata = { title: "Seed Scenario Generation — GEODE Docs" };
 
 export default function Page() {
   return (
     <DocsShell
       slug="capabilities/co-scientist"
-      title="Co-scientist seed generation"
-      titleKo="Co-scientist seed 생성"
-      summary="A nine-role agent loop that grows the evaluation seed corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer."
-      summaryKo="평가용 seed 코퍼스를 키우는 9-역할 에이전트 루프입니다. supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer로 이어집니다."
+      title="Seed Scenario Generation"
+      titleKo="Seed Scenario Generation"
+      summary="A nine-role generation loop that grows the evaluation scenario corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer."
+      summaryKo="평가용 scenario corpus를 키우는 9-역할 생성 루프입니다. supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer로 이어집니다."
     >
       <Bi
         ko={
           <>
-            <h2>왜 seed를 에이전트가 만드나</h2>
+            <h2>왜 scenario를 에이전트가 만드나</h2>
             <p>
-              고정된 벤치마크는 루프가 돌수록 포화됩니다. 폐루프가 스캐폴드를
+              고정된 벤치마크는 루프가 돌수록 포화됩니다. Closed-Loop가 스캐폴드를
               개선하는 동안 테스트 분포도 함께 자라야 측정 여유가
-              남습니다. 그래서 GEODE는 Google AI Co-Scientist의 generate,
-              review, rank, evolve 멀티 에이전트 흐름을 Petri seed 생성에
-              이식했습니다. 한 target dimension(예:{" "}
-              <code>broken_tool_use</code>)에 대해 후보 seed를 생성하고,
+              남습니다. GEODE는 Google AI Co-Scientist에서 참조한 generate,
+              review, rank, evolve 멀티 에이전트 흐름을 Petri scenario 생성에
+              맞게 적용했습니다. 한 target dimension(예:{" "}
+              <code>broken_tool_use</code>)에 대해 후보 scenario를 생성하고,
               토너먼트로 순위를 매기고, 생존자를 진화시켜 다음 세대로
               넘깁니다. <code>plugins/seed_generation/orchestrator.py</code>의{" "}
               <code>Pipeline.arun</code>이 phase 순서대로 sub-agent를
               fan-out합니다.
             </p>
+            <figure>
+              <img
+                src="/geode/diagrams/seed-scenario-generation-cycle.svg"
+                alt="Seed Scenario Generation cycle. target dimension에서 후보 scenario를 만들고, clustering과 critique, pilot audit, Elo tournament, survivor evolution, seed pool, Closed-Loop audit으로 이어진다"
+              />
+              <figcaption>
+                Seed Scenario Generation은 후보를 만들고 평가한 뒤 생존자를
+                seed pool로 넘깁니다. Closed-Loop는 그 pool을 다음 측정 입력으로
+                소비합니다.
+              </figcaption>
+            </figure>
 
             <h2>9개 역할</h2>
             <p>
@@ -97,25 +108,36 @@ geode audit-seeds config`}</pre>
             <ul>
               <li><a href="/geode/docs/capabilities/seed-pipeline">Seed 파이프라인</a>. picker, manifest, 비용 미리보기, blend 선택식.</li>
               <li><a href="/geode/docs/petri/seeds">Seed 생성 런</a>. 세대별 결과 대시보드.</li>
-              <li><a href="/geode/docs/petri/scenarios">시나리오</a>. 만들어진 seed가 들어가는 코퍼스.</li>
+              <li><a href="/geode/docs/petri/scenarios">시나리오</a>. 만들어진 scenario가 들어가는 코퍼스.</li>
             </ul>
           </>
         }
         en={
           <>
-            <h2>Why agents generate the seeds</h2>
+            <h2>Why agents generate scenarios</h2>
             <p>
-              A fixed benchmark saturates as the loop runs. While the closed
-              loop improves the scaffold, the test distribution has to grow
-              alongside it or measurement runs out of headroom. So GEODE ports
-              Google AI Co-Scientist&apos;s generate, review, rank, evolve
-              multi-agent flow onto Petri seed generation. For one target
-              dimension (say <code>broken_tool_use</code>) it drafts candidate
-              seeds, ranks them in a tournament, and evolves the survivors into
-              the next generation. <code>Pipeline.arun</code> in{" "}
+              A fixed benchmark saturates as the loop runs. While the
+              Closed-Loop improves the scaffold, the test distribution has to grow
+              alongside it or measurement runs out of headroom. GEODE adapts
+              the generate, review, rank, evolve multi-agent flow referenced
+              from Google AI Co-Scientist for Petri scenario generation. For one
+              target dimension (say <code>broken_tool_use</code>) it drafts
+              candidate scenarios, ranks them in a tournament, and evolves the
+              survivors into the next generation. <code>Pipeline.arun</code> in{" "}
               <code>plugins/seed_generation/orchestrator.py</code> fans out one
               sub-agent per phase, in order.
             </p>
+            <figure>
+              <img
+                src="/geode/diagrams/seed-scenario-generation-cycle.svg"
+                alt="Seed Scenario Generation cycle: target dimension, candidate scenarios, clustering and critique, pilot audit, Elo tournament, survivor evolution, seed pools, and Closed-Loop audit"
+              />
+              <figcaption>
+                Seed Scenario Generation drafts, measures, ranks, and evolves
+                candidates before handing survivors to the seed pools consumed
+                by the Closed-Loop.
+              </figcaption>
+            </figure>
 
             <h2>The nine roles</h2>
             <p>
@@ -190,7 +212,7 @@ geode audit-seeds config`}</pre>
             <ul>
               <li><a href="/geode/docs/capabilities/seed-pipeline">Seed pipeline</a>. Picker, manifest, cost preview, and the blend formula.</li>
               <li><a href="/geode/docs/petri/seeds">Seed-generation runs</a>. The per-generation results dashboard.</li>
-              <li><a href="/geode/docs/petri/scenarios">Scenarios</a>. The corpus the generated seeds feed.</li>
+              <li><a href="/geode/docs/petri/scenarios">Scenarios</a>. The corpus the generated scenarios feed.</li>
             </ul>
           </>
         }

--- a/site/src/app/docs/capabilities/lineage/page.tsx
+++ b/site/src/app/docs/capabilities/lineage/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
               두 루프의 구조 자체가 처음이라면{" "}
               <a href="/geode/docs/concepts/two-loops">두 개의 루프</a>를 먼저
               읽으세요. 바깥쪽 루프의 전체 흐름은{" "}
-              <a href="/geode/docs/capabilities/autoresearch">폐루프</a>에
+              <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>에
               있습니다.
             </p>
 
@@ -137,7 +137,7 @@ scaffolding   DGM, ADAS, STOP,        <- 거의 비어 있음
               </li>
               <li>
                 <strong>고정 벤치마크 → 공진화하는 적대적 seed</strong>.
-                co-scientist seed 생성 파이프라인이 에이전트와 나란히 테스트
+                Seed Scenario Generation 파이프라인이 에이전트와 나란히 테스트
                 분포를 키웁니다.
               </li>
             </ol>
@@ -149,7 +149,7 @@ scaffolding   DGM, ADAS, STOP,        <- 거의 비어 있음
             </p>
             <p>
               이 치환들이 코드에서 어떻게 도는지는{" "}
-              <a href="/geode/docs/capabilities/autoresearch">폐루프</a>에서,
+              <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>에서,
               감사에 쓰는 평가 프레임워크는{" "}
               <a href="/geode/docs/petri/overview">Petri × GEODE</a>에서 다룹니다.
             </p>
@@ -245,7 +245,7 @@ scaffolding   DGM, ADAS, STOP,        <- 거의 비어 있음
               If the two-loop structure itself is new to you, read{" "}
               <a href="/geode/docs/concepts/two-loops">The two loops</a> first,
               and{" "}
-              <a href="/geode/docs/capabilities/autoresearch">The closed loop</a>{" "}
+              <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>{" "}
               for the outer loop end to end. This page reads better after them.
             </p>
 
@@ -356,7 +356,7 @@ weight update  (RLHF family)             Constitutional AI, MART, Self-MOA`}</pr
               </li>
               <li>
                 <strong>fixed benchmark to co-evolved adversarial seeds</strong>.
-                A co-scientist seed-generation pipeline grows the test
+                A Seed Scenario Generation pipeline grows the test
                 distribution alongside the agent.
               </li>
             </ol>
@@ -368,7 +368,7 @@ weight update  (RLHF family)             Constitutional AI, MART, Self-MOA`}</pr
             </p>
             <p>
               For how these substitutions run in code, see{" "}
-              <a href="/geode/docs/capabilities/autoresearch">The closed loop</a>.
+              <a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>.
               For the evaluation framework that does the auditing, see{" "}
               <a href="/geode/docs/petri/overview">Petri × GEODE</a>.
             </p>

--- a/site/src/app/docs/capabilities/outer-loop/page.tsx
+++ b/site/src/app/docs/capabilities/outer-loop/page.tsx
@@ -91,7 +91,7 @@ min_interval_minutes = 60`}</pre>
 
             <h2>다음</h2>
             <ul>
-              <li><a href="/geode/docs/capabilities/autoresearch">폐루프</a>. 이 설정을 소비하는 루프 본체.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. 이 설정을 소비하는 루프 본체.</li>
               <li><a href="/geode/docs/config/reference">설정 레퍼런스</a>. config.toml 전체 표면.</li>
             </ul>
           </>
@@ -178,7 +178,7 @@ min_interval_minutes = 60`}</pre>
 
             <h2>Next</h2>
             <ul>
-              <li><a href="/geode/docs/capabilities/autoresearch">The closed loop</a>. The loop body these settings drive.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. The loop body these settings drive.</li>
               <li><a href="/geode/docs/config/reference">Config reference</a>. The full config.toml surface.</li>
             </ul>
           </>

--- a/site/src/app/docs/capabilities/seed-pipeline/page.tsx
+++ b/site/src/app/docs/capabilities/seed-pipeline/page.tsx
@@ -28,7 +28,7 @@ export default function Page() {
               </thead>
               <tbody>
                 <tr><td><code>picker.py</code></td><td>다음 런이 겨눌 target dimension 선택</td></tr>
-                <tr><td><code>orchestrator.py</code></td><td>9-역할 phase 그래프 실행 (<a href="/geode/docs/capabilities/co-scientist">Co-scientist seed 생성</a>)</td></tr>
+                <tr><td><code>orchestrator.py</code></td><td>9-역할 phase 그래프 실행 (<a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>)</td></tr>
                 <tr><td><code>manifest.py</code></td><td>seed 파일 × dimension × 예산 manifest</td></tr>
                 <tr><td><code>cost_preview.py</code></td><td>실행 전 비용 추정. confirm 프롬프트의 근거</td></tr>
                 <tr><td><code>pre_flight.py</code></td><td>자격, 쿼터, 의존성 사전 점검</td></tr>
@@ -75,7 +75,7 @@ confidence = pilot stderr 기반 가중치      # 노이즈가 크면 자동 감
 
             <h2>seed pool로의 연결</h2>
             <p>
-              생존자는 런 번들에 남는 것으로 끝나지 않습니다. 폐루프가 실제로
+              생존자는 런 번들에 남는 것으로 끝나지 않습니다. Closed-Loop가 실제로
               읽는 곳은 두 풀입니다.
             </p>
             <ul>
@@ -95,7 +95,7 @@ confidence = pilot stderr 기반 가중치      # 노이즈가 크면 자동 감
             <h2>다음</h2>
             <ul>
               <li><a href="/geode/docs/petri/seeds">Seed 생성 런</a>. 공개된 런별 대시보드.</li>
-              <li><a href="/geode/docs/capabilities/autoresearch">폐루프</a>. 이 seed들이 측정에 쓰이는 곳.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. 이 seed들이 측정에 쓰이는 곳.</li>
             </ul>
           </>
         }
@@ -117,7 +117,7 @@ confidence = pilot stderr 기반 가중치      # 노이즈가 크면 자동 감
               </thead>
               <tbody>
                 <tr><td><code>picker.py</code></td><td>Selects the target dimension the next run aims at</td></tr>
-                <tr><td><code>orchestrator.py</code></td><td>Runs the nine-role phase graph (<a href="/geode/docs/capabilities/co-scientist">Co-scientist seed generation</a>)</td></tr>
+                <tr><td><code>orchestrator.py</code></td><td>Runs the nine-role phase graph (<a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>)</td></tr>
                 <tr><td><code>manifest.py</code></td><td>Seed file by dimension by budget manifest</td></tr>
                 <tr><td><code>cost_preview.py</code></td><td>Pre-run cost estimate behind the confirm prompt</td></tr>
                 <tr><td><code>pre_flight.py</code></td><td>Credential, quota, and dependency checks</td></tr>
@@ -165,7 +165,7 @@ confidence = weight from pilot stderr      # noisy pilots are damped`}</pre>
 
             <h2>Into the seed pools</h2>
             <p>
-              Survivors do not stop at the run bundle. The closed loop reads
+              Survivors do not stop at the run bundle. The Closed-Loop reads
               from two pools.
             </p>
             <ul>
@@ -186,7 +186,7 @@ confidence = weight from pilot stderr      # noisy pilots are damped`}</pre>
             <h2>Next</h2>
             <ul>
               <li><a href="/geode/docs/petri/seeds">Seed-generation runs</a>. The published per-run dashboard.</li>
-              <li><a href="/geode/docs/capabilities/autoresearch">The closed loop</a>. Where these seeds get used for measurement.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. Where these seeds get used for measurement.</li>
             </ul>
           </>
         }

--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -39,7 +39,7 @@ export default function DocsIndex() {
               아니라 <strong>적대적 안전 감사</strong>(Petri 급의 다차원
               감사)로 측정하며, 핵심 안전 차원에는 하한선이 있어 그 선을 넘어
               후퇴하는 변화는 거부합니다. 평가에 쓰는 seed도 고정돼 있지
-              않습니다. co-scientist 파이프라인이 에이전트와 나란히 적대적 seed
+              않습니다. Seed Scenario Generation 파이프라인이 에이전트와 나란히 적대적 seed
               분포를 키웁니다.
             </p>
             <h2>두 개의 루프</h2>
@@ -55,7 +55,7 @@ export default function DocsIndex() {
               </li>
               <li>
                 <strong>Outer loop (Self-Improving Loop)</strong>. 작업을 처리하는
-                시스템 자체를 다듬는 폐루프입니다. 스캐폴드를 변형하고, 감사하고,
+                시스템 자체를 다듬는 Closed-Loop입니다. 스캐폴드를 변형하고, 감사하고,
                 결과를 귀속한 뒤, 실제 이득이 있을 때만 승격하고 아니면 되돌립니다.
                 정직한 (1+1) champion chain입니다.
               </li>
@@ -92,7 +92,7 @@ export default function DocsIndex() {
               multi-dimensional), not a capability benchmark, and critical
               safety dimensions sit behind a hard floor: a change that
               regresses them is rejected. The evaluation seeds are not fixed
-              either. A co-scientist pipeline grows an adversarial seed
+              either. A Seed Scenario Generation pipeline grows an adversarial seed
               distribution alongside the agent.
             </p>
             <h2>Two loops</h2>
@@ -127,7 +127,7 @@ export default function DocsIndex() {
             <h2>레퍼런스: GEODE의 좌표부터</h2>
             <p>
               레퍼런스의 진입점은 검증 절차가 아니라{" "}
-              <strong>자기개선 폐루프의 계보와 좌표</strong>입니다. GEODE가 어떤
+              <strong>자기개선 Closed-Loop의 계보와 좌표</strong>입니다. GEODE가 어떤
               프론티어 시스템에서 무엇을 빌려오고, 어디서 갈라지는지부터 짚습니다.
             </p>
             <ul>
@@ -140,7 +140,7 @@ export default function DocsIndex() {
                 self-evolving agents 문헌에서 어디에 위치하는지.
               </li>
               <li>
-                <a href="/geode/docs/capabilities/co-scientist">Co-scientist 루프</a>.
+                <a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>.
                 적대적 seed 분포를 함께 진화시키는 다중 역할 루프.
               </li>
               <li>
@@ -169,7 +169,7 @@ export default function DocsIndex() {
                 Where this loop sits in the self-evolving agents literature.
               </li>
               <li>
-                <a href="/geode/docs/capabilities/co-scientist">Co-scientist loop</a>.
+                <a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>.
                 The multi-role loop that co-evolves the adversarial seed distribution.
               </li>
               <li>
@@ -222,7 +222,7 @@ export default function DocsIndex() {
                 문서가 기대는 멘탈 모델입니다.
               </li>
               <li>
-                <a href="/geode/docs/capabilities/autoresearch">자기개선 루프(폐루프)</a>.
+                <a href="/geode/docs/capabilities/autoresearch">자기개선 Closed-Loop</a>.
                 스캐폴드를 변형하고, 감사하고, 승격하거나 되돌리는 바깥쪽 루프입니다.
               </li>
               <li>

--- a/site/src/app/docs/petri/judge-dimensions/page.tsx
+++ b/site/src/app/docs/petri/judge-dimensions/page.tsx
@@ -112,7 +112,7 @@ export default function Page() {
 
             <h2>다음</h2>
             <ul>
-              <li><a href="/geode/docs/capabilities/autoresearch">폐루프</a>. 이 점수가 게이트로 들어가는 곳.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. 이 점수가 게이트로 들어가는 곳.</li>
               <li><a href="/geode/docs/petri/scenarios">시나리오</a>. 티어별 seed 코퍼스.</li>
             </ul>
           </>
@@ -221,7 +221,7 @@ export default function Page() {
 
             <h2>Next</h2>
             <ul>
-              <li><a href="/geode/docs/capabilities/autoresearch">The closed loop</a>. Where these scores feed the gate.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. Where these scores feed the gate.</li>
               <li><a href="/geode/docs/petri/scenarios">Scenarios</a>. The seed corpus, organized by tier.</li>
             </ul>
           </>

--- a/site/src/app/docs/petri/scenarios/page.tsx
+++ b/site/src/app/docs/petri/scenarios/page.tsx
@@ -57,8 +57,8 @@ export default function Page() {
             <h2>코퍼스는 어떻게 자라나</h2>
             <p>
               정적 카탈로그가 아닙니다. seed-generation 파이프라인
-              (<a href="/geode/docs/capabilities/co-scientist">Co-scientist seed
-              생성</a>)이 target dimension별로 새 seed를 만들고, 생존자가{" "}
+              (<a href="/geode/docs/capabilities/co-scientist">Seed Scenario
+              Generation</a>)이 target dimension별로 새 seed를 만들고, 생존자가{" "}
               <code>geode seeds assemble</code>을 거쳐 사이클 입력
               풀(<code>state/seed-pools/cycle-input</code>)로 조립됩니다.
               버전 고정 held-out 벤치마크(<code>state/seed-pools/held-out</code>)는
@@ -137,8 +137,8 @@ export default function Page() {
             <h2>How the corpus grows</h2>
             <p>
               This is not a static catalog. The seed-generation pipeline
-              (<a href="/geode/docs/capabilities/co-scientist">Co-scientist
-              seed generation</a>) drafts new seeds per target dimension, and
+              (<a href="/geode/docs/capabilities/co-scientist">Seed Scenario
+              Generation</a>) drafts new seeds per target dimension, and
               survivors are assembled by <code>geode seeds assemble</code> into
               the cycle-input pool
               (<code>state/seed-pools/cycle-input</code>). A version-frozen

--- a/site/src/app/docs/petri/seeds/page.tsx
+++ b/site/src/app/docs/petri/seeds/page.tsx
@@ -402,7 +402,7 @@ export default function Page() {
 
             <h2>SoT와 파이프라인</h2>
             <ul>
-              <li>seed-generation 소스: <code>plugins/seed_generation/orchestrator.py</code> (9-역할: supervisor → literature_review → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer. 상세는 <a href="/geode/docs/capabilities/co-scientist">Co-scientist seed 생성</a>)</li>
+              <li>seed-generation 소스: <code>plugins/seed_generation/orchestrator.py</code> (9-역할: supervisor → literature_review → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer. 상세는 <a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>)</li>
               <li>bundle 동기화: <code>plugins/seed_generation/bundle_sync.py</code>가 run 종료 시 결과를 <code>docs/self-improving/petri-bundle/seeds/&lt;run_id&gt;/</code>로 동기화합니다</li>
               <li>관련 문서: <a href="/geode/docs/capabilities/seed-pipeline">Seed 파이프라인</a> · <a href="/geode/docs/petri/scenarios">Petri 시나리오</a></li>
             </ul>
@@ -435,7 +435,7 @@ export default function Page() {
 
             <h2>Source &amp; pipeline</h2>
             <ul>
-              <li>seed-generation source: <code>plugins/seed_generation/orchestrator.py</code> (nine roles: supervisor → literature_review → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer; details in <a href="/geode/docs/capabilities/co-scientist">Co-scientist seed generation</a>)</li>
+              <li>seed-generation source: <code>plugins/seed_generation/orchestrator.py</code> (nine roles: supervisor → literature_review → generator → proximity → critic → pilot → ranker → evolver → meta_reviewer; details in <a href="/geode/docs/capabilities/co-scientist">Seed Scenario Generation</a>)</li>
               <li>bundle sync: <code>plugins/seed_generation/bundle_sync.py</code> mirrors completed runs into <code>docs/self-improving/petri-bundle/seeds/&lt;run_id&gt;/</code></li>
               <li>related: <a href="/geode/docs/capabilities/seed-pipeline">Seed Pipeline</a> · <a href="/geode/docs/petri/scenarios">Petri Scenarios</a></li>
             </ul>

--- a/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
+++ b/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
@@ -121,7 +121,7 @@ export default function Page() {
             <ul>
               <li><a href="/geode/docs/runtime/llm/prompt-system">프롬프트 조립</a>. 레이어 전체 구조.</li>
               <li><a href="/geode/docs/runtime/llm/prompt-caching">프롬프트 캐싱</a>. static/dynamic 경계의 비용 면.</li>
-              <li><a href="/geode/docs/capabilities/autoresearch">폐루프</a>. wrapper를 진화시키는 바깥 루프.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. wrapper를 진화시키는 바깥 루프.</li>
             </ul>
           </>
         }
@@ -239,7 +239,7 @@ export default function Page() {
             <ul>
               <li><a href="/geode/docs/runtime/llm/prompt-system">Prompt assembly</a>. The full layer structure.</li>
               <li><a href="/geode/docs/runtime/llm/prompt-caching">Prompt caching</a>. The cost side of the static/dynamic boundary.</li>
-              <li><a href="/geode/docs/capabilities/autoresearch">The closed loop</a>. The outer loop that evolves the wrapper.</li>
+              <li><a href="/geode/docs/capabilities/autoresearch">Closed-Loop</a>. The outer loop that evolves the wrapper.</li>
             </ul>
           </>
         }

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -14,7 +14,7 @@
  * Bilingual: every entry carries an English and Korean title + summary.
  *
  * PR-DOCS-REDESIGN (2026-05-29) — restructured from ten layer-named sections
- * into nine reader-facing sections, concepts-first with a task router on top.
+ * into reader-facing sections, concepts-first with a task router on top.
  * The self-improving loop is its own top-level section (GEODE's signature,
  * carries the petri-blue accent). Vanity counts (tool / hook / module / seed
  * numbers) are removed from every title and summary; the system is described
@@ -96,8 +96,8 @@ export const DOCS_SITEMAP: DocSection[] = [
     title: "The Self-Improving Loop",
     titleKo: "자기개선 루프",
     pages: [
-      { slug: "capabilities/autoresearch", title: "The closed loop", titleKo: "폐루프", summary: "The outer loop end to end. Mutate the scaffold, audit with Petri, gate the fitness gain on a margin, then promote or revert. No model weight or parameter ever changes.", summaryKo: "바깥쪽 루프의 전체 흐름입니다. 스캐폴드를 변이하고, Petri로 감사하고, fitness 이득을 margin 게이트로 검증해 승격하거나 되돌립니다. 모델 가중치와 파라미터는 일절 바꾸지 않습니다.", quadrant: "explanation" },
-      { slug: "capabilities/co-scientist", title: "Co-scientist seed generation", titleKo: "Co-scientist seed 생성", summary: "A nine-role agent loop that grows the evaluation seed corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer.", summaryKo: "평가용 seed 코퍼스를 키우는 9-역할 에이전트 루프입니다. supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer로 이어집니다.", quadrant: "explanation" },
+      { slug: "capabilities/autoresearch", title: "Closed-Loop", titleKo: "Closed-Loop", summary: "The outer loop end to end. Mutate the scaffold, audit with Petri, gate the fitness gain on a margin, then promote or revert. No model weight or parameter ever changes.", summaryKo: "바깥쪽 루프의 전체 흐름입니다. 스캐폴드를 변이하고, Petri로 감사하고, fitness 이득을 margin 게이트로 검증해 승격하거나 되돌립니다. 모델 가중치와 파라미터는 일절 바꾸지 않습니다.", quadrant: "explanation" },
+      { slug: "capabilities/co-scientist", title: "Seed Scenario Generation", titleKo: "Seed Scenario Generation", summary: "A nine-role generation loop that grows the evaluation scenario corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer.", summaryKo: "평가용 scenario corpus를 키우는 9-역할 생성 루프입니다. supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer로 이어집니다.", quadrant: "explanation" },
       { slug: "capabilities/seed-pipeline", title: "Seed pipeline", titleKo: "Seed 파이프라인", summary: "The plugin that regenerates the seed corpus each generation. Picker, orchestrator, manifest, cost preview, and the blend survivor selection.", summaryKo: "세대마다 seed 코퍼스를 다시 만드는 플러그인입니다. picker, orchestrator, manifest, cost preview와 blend 생존자 선택을 다룹니다.", quadrant: "reference" },
       { slug: "capabilities/outer-loop", title: "Outer-loop configuration", titleKo: "아우터 루프 설정", summary: "The shared schema and loader for autoresearch, seed generation, Petri roles, and the auto-trigger scheduler. Strict by default.", summaryKo: "autoresearch, seed 생성, Petri 역할, auto-trigger 스케줄러가 공유하는 스키마와 로더입니다. 기본은 strict 검증입니다.", quadrant: "reference" },
       { slug: "petri/overview", title: "Petri × GEODE", titleKo: "Petri × GEODE", summary: "Anthropic Alignment Science's evaluation framework, wrapped over the GEODE agent as the loop's measurement layer.", summaryKo: "Anthropic Alignment Science의 평가 프레임워크를 GEODE 에이전트 위에 얹어 루프의 측정 계층으로 씁니다.", quadrant: "explanation" },
@@ -126,7 +126,15 @@ export const DOCS_SITEMAP: DocSection[] = [
     ],
   },
   {
-    id: "06-guides",
+    id: "06-benchmarks",
+    title: "Benchmarks",
+    titleKo: "벤치마크",
+    pages: [
+      { slug: "benchmarks/mcpmark/filesystem-easy", title: "MCPMark: filesystem/easy", titleKo: "MCPMark: filesystem/easy", summary: "Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.", summaryKo: "MCPMark filesystem easy 하위 suite에 대한 GEODE verifier-backed 실측 기록입니다. run spec, 산출물, task별 점수, EOF offload 기록을 포함합니다.", quadrant: "reference" },
+    ],
+  },
+  {
+    id: "07-guides",
     title: "Guides and How-to",
     titleKo: "가이드",
     pages: [
@@ -138,7 +146,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     ],
   },
   {
-    id: "07-config",
+    id: "08-config",
     title: "Configuration",
     titleKo: "설정",
     pages: [
@@ -153,7 +161,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     ],
   },
   {
-    id: "08-reference",
+    id: "09-reference",
     title: "Reference",
     titleKo: "레퍼런스",
     pages: [
@@ -169,7 +177,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     ],
   },
   {
-    id: "09-develop",
+    id: "10-develop",
     title: "Developer and Architecture",
     titleKo: "개발과 아키텍처",
     pages: [

--- a/tests/core/mcp/test_mcp_lifecycle.py
+++ b/tests/core/mcp/test_mcp_lifecycle.py
@@ -18,7 +18,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from core.hooks import HookEvent
-from core.mcp.manager import MCPServerManager
+from core.mcp.manager import MCPServerManager, _normalise_mcp_tool
 from core.mcp.stdio_client import _CLOSE_TIMEOUT_S, StdioMCPClient
 
 # ---------------------------------------------------------------------------
@@ -436,6 +436,12 @@ class TestMCPAsyncCalls:
     def test_manager_acall_tool_uses_client_async_path(self) -> None:
         mgr = MCPServerManager()
         mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "navigate",
+                "inputSchema": {"type": "object", "properties": {"url": {"type": "string"}}},
+            }
+        ]
         mock_client.acall_tool = AsyncMock(return_value={"result": "ok"})
 
         async def scenario() -> dict[str, Any]:
@@ -446,6 +452,224 @@ class TestMCPAsyncCalls:
 
         mock_client.acall_tool.assert_awaited_once_with("navigate", {"url": "x"})
         assert result == {"result": "ok"}
+
+    def test_manager_acall_tool_maps_file_path_alias_to_schema_path(self) -> None:
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "write_file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            }
+        ]
+        mock_client.acall_tool = AsyncMock(return_value={"result": "ok"})
+
+        async def scenario() -> dict[str, Any]:
+            with patch.object(mgr, "_get_client", return_value=mock_client):
+                return await mgr.acall_tool(
+                    "filesystem",
+                    "write_file",
+                    {"file_path": "/workspace/out.txt", "content": "hello"},
+                )
+
+        result = asyncio.run(scenario())
+
+        mock_client.acall_tool.assert_awaited_once_with(
+            "write_file",
+            {"path": "/workspace/out.txt", "content": "hello"},
+        )
+        assert result == {"result": "ok"}
+
+    def test_manager_acall_tool_preserves_file_path_when_schema_requires_it(self) -> None:
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "write_file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            }
+        ]
+        mock_client.acall_tool = AsyncMock(return_value={"result": "ok"})
+
+        async def scenario() -> dict[str, Any]:
+            with patch.object(mgr, "_get_client", return_value=mock_client):
+                return await mgr.acall_tool(
+                    "filesystem",
+                    "write_file",
+                    {"file_path": "/workspace/out.txt", "content": "hello"},
+                )
+
+        result = asyncio.run(scenario())
+
+        mock_client.acall_tool.assert_awaited_once_with(
+            "write_file",
+            {"file_path": "/workspace/out.txt", "content": "hello"},
+        )
+        assert result == {"result": "ok"}
+
+    def test_manager_acall_tool_drops_conflicting_read_text_window_args(self) -> None:
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "read_text_file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "head": {"type": "integer"},
+                        "tail": {"type": "integer"},
+                    },
+                },
+            }
+        ]
+        mock_client.acall_tool = AsyncMock(return_value={"result": "ok"})
+
+        async def scenario() -> dict[str, Any]:
+            with patch.object(mgr, "_get_client", return_value=mock_client):
+                return await mgr.acall_tool(
+                    "filesystem",
+                    "read_text_file",
+                    {"path": "/workspace/in.txt", "head": 2000, "tail": 2000},
+                )
+
+        result = asyncio.run(scenario())
+
+        mock_client.acall_tool.assert_awaited_once_with(
+            "read_text_file",
+            {"path": "/workspace/in.txt"},
+        )
+        assert result == {"result": "ok"}
+
+    def test_manager_acall_tool_offloads_eof_trim_from_cached_multi_read(self, tmp_path) -> None:
+        source = tmp_path / "file_01.txt"
+        target = tmp_path / "uppercase" / "file_01.txt"
+        source.write_text("Hello world", encoding="utf-8")
+
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "read_multiple_files",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"paths": {"type": "array"}},
+                },
+            },
+            {
+                "name": "write_file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            },
+        ]
+        mock_client.acall_tool = AsyncMock(
+            side_effect=[
+                {"content": [{"type": "text", "text": f"{source}:\nHello world\n"}]},
+                {"result": "ok"},
+            ]
+        )
+
+        async def scenario() -> None:
+            with patch.object(mgr, "_get_client", return_value=mock_client):
+                await mgr.acall_tool(
+                    "filesystem",
+                    "read_multiple_files",
+                    {"paths": [str(source)]},
+                )
+                await mgr.acall_tool(
+                    "filesystem",
+                    "write_file",
+                    {"path": str(target), "content": "HELLO WORLD\n"},
+                )
+
+        asyncio.run(scenario())
+
+        mock_client.acall_tool.assert_any_await(
+            "write_file",
+            {"path": str(target), "content": "HELLO WORLD"},
+        )
+
+    def test_manager_acall_tool_keeps_newline_when_cached_source_has_one(self, tmp_path) -> None:
+        source = tmp_path / "file_01.txt"
+        target = tmp_path / "uppercase" / "file_01.txt"
+        source.write_text("Hello world\n", encoding="utf-8")
+
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.list_tools.return_value = [
+            {
+                "name": "read_multiple_files",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"paths": {"type": "array"}},
+                },
+            },
+            {
+                "name": "write_file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            },
+        ]
+        mock_client.acall_tool = AsyncMock(
+            side_effect=[
+                {"content": [{"type": "text", "text": f"{source}:\nHello world\n"}]},
+                {"result": "ok"},
+            ]
+        )
+
+        async def scenario() -> None:
+            with patch.object(mgr, "_get_client", return_value=mock_client):
+                await mgr.acall_tool(
+                    "filesystem",
+                    "read_multiple_files",
+                    {"paths": [str(source)]},
+                )
+                await mgr.acall_tool(
+                    "filesystem",
+                    "write_file",
+                    {"path": str(target), "content": "HELLO WORLD\n"},
+                )
+
+        asyncio.run(scenario())
+
+        mock_client.acall_tool.assert_any_await(
+            "write_file",
+            {"path": str(target), "content": "HELLO WORLD\n"},
+        )
+
+    def test_normalised_mcp_tool_adds_exact_read_warning(self) -> None:
+        tool = _normalise_mcp_tool(
+            {
+                "name": "read_multiple_files",
+                "description": "Read several files.",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        )
+
+        assert "tracks local source EOF metadata" in tool["description"]
+        assert "input_schema" in tool
 
 
 class TestMCPFallbackHints:


### PR DESCRIPTION
## Summary
- Record the GEODE + GPT-5.5 xhigh MCPMark filesystem/easy benchmark result in the public docs.
- Add GEODE MCP dispatch compatibility fixes for filesystem benchmark paths, including EOF offload for same-name text writes.
- Rename public docs terminology to Closed-Loop and Seed Scenario Generation, with a new scenario-generation diagram.

## Why
GEODE needed a verifier-backed benchmark ledger before mixing subscription/Codex measurements with public frontier-agent benchmark tables. The live MCPMark smoke exposed deterministic MCP filesystem mismatches: `file_path` versus `path`, conflicting read windows, and display-induced EOF drift from combined file reads.

## Changes
| File | Change |
|------|--------|
| `core/mcp/manager.py` | Normalizes `file_path -> path` when the MCP schema requires `path`, drops conflicting `read_text_file` `head`/`tail`, annotates filesystem tool descriptions, and offloads EOF preservation into MCP dispatch. |
| `tests/core/mcp/test_mcp_lifecycle.py` | Adds regression tests for schema aliasing, read-window normalization, EOF trim, newline preservation, and description notes. |
| `docs/eval/frontier-agentic-tool-use-benchmark-cases.md` | Adds the external benchmark evidence ledger, harness inventory, live smoke, EOF offload smoke, and filesystem/easy 10-task result. |
| `site/src/app/docs/benchmarks/mcpmark/filesystem-easy/page.tsx` | Adds the official benchmark page under Benchmarks -> MCPMark: filesystem/easy. |
| `site/src/lib/geode-docs/sitemap.ts` | Adds the Benchmarks docs category and updates public terminology. |
| `site/public/diagrams/seed-scenario-generation-cycle.svg` | Adds the Seed Scenario Generation flow diagram. |
| `site/src/app/docs/**` | Re-labels public docs from `Co-scientist seed generation` to `Seed Scenario Generation` and from `closed loop` / `폐루프` to `Closed-Loop`; keeps Co-Scientist only as the cited source pattern. |
| `CHANGELOG.md` | Records the MCP filesystem dispatch compatibility and EOF offload fix. |

## Benchmark Evidence
- MCPMark `filesystem/easy`, GEODE `gpt-5.5`, provider `openai-codex`, source `subscription`, reasoning effort `xhigh`: 10 / 10, 100.0%.
- Total task execution time: 1706.044s; average task execution time: 170.604s.
- Token usage: 234,483 input / 32,296 output / 266,779 total.
- EOF offload smoke improved `file_context/uppercase` from 398.6s / 12 rounds / 11 tool calls to 167.9s / 3 rounds / 7 tool calls while preserving verifier correctness.

## Verification
- `uv run pytest tests/core/mcp/test_mcp_lifecycle.py` -> 37 passed
- `uv run ruff check core/mcp/manager.py tests/core/mcp/test_mcp_lifecycle.py` -> passed
- `uv run ruff format --check core/mcp/manager.py tests/core/mcp/test_mcp_lifecycle.py` -> passed
- `uv run mypy core/mcp/manager.py` -> passed
- `npx eslint <changed docs files>` -> 0 errors; existing `<img>` warnings remain on docs pages
- `npm run build` -> passed; `/docs/benchmarks/mcpmark/filesystem-easy` generated
- `git diff --check` -> passed

## Notes
- This PR does not claim a full MCPMark Verified score. The public benchmark page labels the result as MCPMark `filesystem/easy` only.
- Full repo `npm run lint` still reports pre-existing unrelated lint errors in existing docs/portfolio files; changed docs files were linted directly.
