### PR TITLE
Geodi: 얼굴만 둥글게 크롭, welcome과 높이 맞춤 (v0.99.262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ functional change.
   exposed MCP tool descriptions, and offloading source EOF preservation from
   model turns into the MCP dispatch layer for same-name text writes.
 
+## [0.99.262] - 2026-07-03
+
+### Changed
+- **Welcome Geodi cropped to a round face** — operator review: even forehead-trimmed, the full body sat too tall beside the 3-line welcome text. `GEODI_PIXELS` is now the head-down-to-mouth crop of the source (22x12 → 6 half-block rows): 3 separated gill stalks per side, 2px eyes with catchlights, cheek blush, mouth, and a rounded chin close — belly patch and feet removed so the face reads level with the welcome block. `GEODI_SOURCE_PIXELS` (full 22x20 body) unchanged.
+
 ## [0.99.261] - 2026-07-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.261
+- **Version**: 0.99.262
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.261 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.262 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.261 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.262 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/geodi_art.py
+++ b/core/ui/geodi_art.py
@@ -6,11 +6,12 @@ side, deeper rose, visibly separated), simple symmetric 2x2 dark eyes with a
 lighter belly patch, and a subtle deep-rose cheek blush beside the eyes.
 
 The canonical sprite is authored as a 22x20 pixel grid
-(``GEODI_SOURCE_PIXELS``). The welcome screen renders a forehead-trimmed 22x18 pixel
+(``GEODI_SOURCE_PIXELS``). The welcome screen renders a face-only 22x12 pixel
 derivative (``GEODI_PIXELS``) that preserves the original silhouette while
 matching the adjacent three-line brand block. Pixels render as truecolor
 half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two pixels per
-terminal cell — so the compact mascot draws as 22 cols x 9 rows — the full-detail source minus two forehead rows — in ANY
+terminal cell — so the mascot draws as 22 cols x 6 rows — the head down to the mouth, cropped
+to a round face (belly/feet removed) so it sits level with the 3-line welcome — in ANY
 truecolor terminal. Transparent pixels reset to the terminal's default
 background.
 
@@ -76,14 +77,8 @@ GEODI_PIXELS: list[str] = [
     "....pppeeppppeeppp....",
     "....prrpppppppprrp....",
     "....ppppppeepppppp....",
-    "....ppppllllllpppp....",
-    "....pppllllllllppp....",
-    "....pppllllllllppp....",
-    ".....pppllllllppp.....",
+    ".....pppppppppppp.....",
     "......pppppppppp......",
-    ".......pppppppp.......",
-    "......ppp....ppp......",
-    "......ppp....ppp......",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.261"
+version = "0.99.262"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.261. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.262. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.261. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.262. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 
@@ -39,8 +39,8 @@ Version v0.99.261. Last sync 2026-07-02. Docs links point to clean markdown twin
 
 ## The Self-Improving Loop
 
-- [The closed loop](https://mangowhoiscloud.github.io/geode/docs/capabilities/autoresearch.md): The outer loop end to end. Mutate the scaffold, audit with Petri, gate the fitness gain on a margin, then promote or revert. No model weight or parameter ever changes.
-- [Co-scientist seed generation](https://mangowhoiscloud.github.io/geode/docs/capabilities/co-scientist.md): A nine-role agent loop that grows the evaluation seed corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer.
+- [Closed-Loop](https://mangowhoiscloud.github.io/geode/docs/capabilities/autoresearch.md): The outer loop end to end. Mutate the scaffold, audit with Petri, gate the fitness gain on a margin, then promote or revert. No model weight or parameter ever changes.
+- [Seed Scenario Generation](https://mangowhoiscloud.github.io/geode/docs/capabilities/co-scientist.md): A nine-role generation loop that grows the evaluation scenario corpus. Supervisor, literature review, generator, proximity, critic, pilot, ranker, evolver, meta-reviewer.
 - [Seed pipeline](https://mangowhoiscloud.github.io/geode/docs/capabilities/seed-pipeline.md): The plugin that regenerates the seed corpus each generation. Picker, orchestrator, manifest, cost preview, and the blend survivor selection.
 - [Outer-loop configuration](https://mangowhoiscloud.github.io/geode/docs/capabilities/outer-loop.md): The shared schema and loader for autoresearch, seed generation, Petri roles, and the auto-trigger scheduler. Strict by default.
 - [Petri × GEODE](https://mangowhoiscloud.github.io/geode/docs/petri/overview.md): Anthropic Alignment Science's evaluation framework, wrapped over the GEODE agent as the loop's measurement layer.
@@ -62,6 +62,10 @@ Version v0.99.261. Last sync 2026-07-02. Docs links point to clean markdown twin
 - [Cost monitoring](https://mangowhoiscloud.github.io/geode/docs/ops/cost.md): Session and monthly budgets. The usage ledger, geode history, and /cost.
 - [Observability](https://mangowhoiscloud.github.io/geode/docs/verification/observability.md): The lenses on a run. Hooks, run logs, transcripts, session metrics, and the logging switchboard.
 - [Troubleshooting](https://mangowhoiscloud.github.io/geode/docs/run/troubleshooting.md): Common failure modes and where to look. Logs, hooks, runlog.
+
+## Benchmarks
+
+- [MCPMark: filesystem/easy](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark/filesystem-easy.md): Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.
 
 ## Guides and How-to
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,16 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "Unreleased",
+    "date": "",
+    "body": "### Fixed\n\n- **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes\n  common schema mismatches before server calls, including mapping `file_path`\n  to `path` when the MCP schema requires `path`, dropping conflicting\n  `read_text_file` `head`/`tail` pairs, annotating exact-read caveats in\n  exposed MCP tool descriptions, and offloading source EOF preservation from\n  model turns into the MCP dispatch layer for same-name text writes."
+  },
+  {
+    "version": "0.99.262",
+    "date": "2026-07-03",
+    "body": "### Changed\n- **Welcome Geodi cropped to a round face** — operator review: even forehead-trimmed, the full body sat too tall beside the 3-line welcome text. `GEODI_PIXELS` is now the head-down-to-mouth crop of the source (22x12 → 6 half-block rows): 3 separated gill stalks per side, 2px eyes with catchlights, cheek blush, mouth, and a rounded chin close — belly patch and feet removed so the face reads level with the welcome block. `GEODI_SOURCE_PIXELS` (full 22x20 body) unchanged."
+  },
+  {
     "version": "0.99.261",
     "date": "2026-07-03",
     "body": "### Changed\n- **Welcome Geodi keeps the full 0.99.256 detail, minus the forehead** — operator review: the 14x8 chibi traded away too much character. `GEODI_PIXELS` is now the 22x20 source art with two forehead rows removed (one head-top rounding row, one upper-gill thickness row) → 22x18, rendering 9 half-block rows. All source detail retained: 3 separated gill stalks per side, 2px eyes with catchlights, blush, smile, belly, feet."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.261",
+  version: "0.99.262",
   syncedAt: "2026-07-02",
 } as const;

--- a/tests/core/ui/test_mascot.py
+++ b/tests/core/ui/test_mascot.py
@@ -20,7 +20,7 @@ class TestGeodiPixels:
         assert all(len(row) == 22 for row in GEODI_SOURCE_PIXELS)
 
     def test_grid_dimensions(self) -> None:
-        assert len(GEODI_PIXELS) == 18  # even row count — pairs into half-blocks
+        assert len(GEODI_PIXELS) == 12  # even row count — pairs into half-blocks
         assert all(len(row) == 22 for row in GEODI_PIXELS)
 
     def test_only_palette_chars(self) -> None:
@@ -28,8 +28,9 @@ class TestGeodiPixels:
 
     def test_character_canon(self) -> None:
         joined = "".join(GEODI_PIXELS)
-        # Deep-rose gills/blush, dark eyes/smile, light belly patch present.
-        assert "r" in joined and "e" in joined and "l" in joined
+        # Deep-rose gills/blush, dark eyes/mouth present (belly/feet cropped
+        # in the face-only welcome derivative).
+        assert "r" in joined and "e" in joined
         assert joined.count("w") == 2  # one 1px catchlight per eye
 
     def test_exactly_three_separated_gill_stalks_per_side(self) -> None:
@@ -47,7 +48,7 @@ class TestGeodiPixels:
 
     def test_pixel_lines_render_constant_width(self) -> None:
         lines = geodi_pixel_lines()
-        assert len(lines) == 9  # 18 px tall -> 9 half-block rows (forehead-trimmed source)
+        assert len(lines) == 6  # 12 px tall -> 6 half-block rows (face-only: head to mouth)
         for line in lines:
             assert len(_ANSI.sub("", line)) == 22  # text can align beside it
             assert "▀" in line or "▄" in line or " " in line
@@ -57,7 +58,7 @@ class TestGeodiPixels:
     def test_sprite_stays_compact(self) -> None:
         """Keep the welcome mascot as a Claude Code-scale accent, not a splash panel."""
         lines = geodi_pixel_lines()
-        assert len(lines) <= 9
+        assert len(lines) <= 6
         assert max(len(_ANSI.sub("", line)) for line in lines) <= 22
 
     def test_compact_keeps_source_silhouette_cues(self) -> None:
@@ -66,11 +67,11 @@ class TestGeodiPixels:
         assert GEODI_SOURCE_PIXELS[5].startswith(".rrr")
         assert "ppew" in GEODI_SOURCE_PIXELS[8]
         assert "llllll" in "".join(GEODI_SOURCE_PIXELS)
-        # Compact derivative (14x8): gill rows hug the edges, eyes keep the
-        # e+w catchlight pair twice, belly patch present.
+        # Face-only derivative (22x12, head→mouth): 3 separated gill rows per
+        # side, e+w catchlight pair twice, mouth (ee) present; belly/feet cropped.
         assert sum(1 for row in GEODI_PIXELS if row.lstrip(".").startswith("rr")) == 3
         assert "".join(GEODI_PIXELS).count("ew") == 2
-        assert "llll" in "".join(GEODI_PIXELS)
+        assert "ppeepp" in "".join(GEODI_PIXELS)  # mouth row
 
 
 class TestMascotBrandBlock:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.261"
+version = "0.99.262"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 운영자 요청: 이마 축소본도 몸통 때문에 3줄 welcome 옆에서 너무 큼 → `GEODI_PIXELS`를 **머리~입 크롭(22×12, 6 half-block 행)**으로 교체. 아가미 3+3·눈+캐치라이트·볼 블러시·입·둥근 턱 마감, 배/발 제거로 얼굴이 welcome 텍스트와 수평 균형. 원본 전신(`GEODI_SOURCE_PIXELS` 22×20) 불변.

## Why
- "입까지만 남기고 아래는 둥글게 얼굴로만, 옆 welcome이랑 맞춰라."

## Changes
| File | Change |
|------|--------|
| `core/ui/geodi_art.py` | GEODI_PIXELS 얼굴 크롭 22×12 + docstring |
| `tests/core/ui/test_mascot.py` | 크기 6행/22폭, canon/silhouette를 face-only 계약으로(belly cue→mouth cue) |
| CHANGELOG 외 5위치+site | v0.99.262 |

## Verification
- [x] PNG 프리뷰 + mascot render side-by-side 시각검수(얼굴 6행이 welcome 3줄과 중앙정렬 호응)
- [x] ruff/format/lint-imports/hygiene/slop/UI 테스트 전부 exit 0(각각 단언)