### PR TITLE
Add benchmark publishing cycle scaffold

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -20,8 +20,11 @@
 | GUI Trajectory Eval | observation coverage, classified failures, coordinate sanity, final screenshot availability | `computer`/`computer_use` trajectory rows를 모델 prose와 분리해 사후 평가 |
 | Capability/Evidence Preflight | provider/source/tool support, required evidence classes | 작업 시작 전 route mismatch를 드러내고 evidence ledger에 남김 |
 | Frontier agentic tool-use benchmark cases | MCPMark/BFCL V4/tau2 공개 사례와 GEODE 측정 계약 | GPT-5.5 subscription 결과를 공개 baseline과 섞기 전 비교 가능성 분리 |
+| Benchmark Publishing Cycle | live benchmark run -> internal ledger -> official docs -> PR -> Pages deploy | 실측과 공식문서 배포를 하나의 반복 가능한 사이클로 고정 |
 
 참고: [frontier-agentic-tool-use-benchmark-cases.md](frontier-agentic-tool-use-benchmark-cases.md)
+운영 스캐폴드: [benchmark-publishing-cycle.md](benchmark-publishing-cycle.md),
+[benchmark-run-record.template.md](benchmark-run-record.template.md)
 
 ## 의존성 그래프
 
@@ -70,6 +73,7 @@ HAL Reliability (τ-bench airline rerun) ← 절반 무료
 
 | 일자 | 변경 |
 |---|---|
+| 2026-07-03 | Benchmark Publishing Cycle 스캐폴드와 run-record 템플릿 추가 |
 | 2026-07-03 | MCPMark filesystem easy에서 GEODE + GPT-5.5 xhigh 10/10 실측 및 EOF offload 결과 기록 |
 | 2026-07-02 | GPT-5.5 subscription 측정 준비용 MCPMark/BFCL V4/tau2 공개 사례 ledger 추가 |
 | 2026-05-07 | 초기 작성 — 4종 채택, 각 벤치별 사례/인프라/시나리오 |

--- a/docs/eval/benchmark-publishing-cycle.md
+++ b/docs/eval/benchmark-publishing-cycle.md
@@ -1,0 +1,160 @@
+# Benchmark Publishing Cycle
+
+> Scaffold for turning a live GEODE benchmark run into a published official
+> docs page. Use this for MCPMark, BFCL V4, tau2-bench, and later benchmark
+> suites that need a reproducible ledger plus GitHub Pages deployment.
+
+## Cycle Contract
+
+One complete cycle has six gates:
+
+| Gate | Exit evidence |
+|---|---|
+| 1. Scope | Benchmark, suite, model route, reasoning setting, budget, and live-test approval are written down |
+| 2. Harness | Upstream source, version, local path, install command, and smoke result are recorded |
+| 3. Run | Raw result artifacts, verifier outputs, transcripts, token/time totals, and failures are preserved |
+| 4. Interpret | Comparability boundaries and external baselines are separated from GEODE scores |
+| 5. Publish | Internal ledger and public docs page are updated from the same run record |
+| 6. Deploy | Feature PR merges to `develop`, `develop` merges to `main`, Pages deploy succeeds, live URL is checked |
+
+The cycle is not complete until the public GitHub Pages URL returns the new
+score and the final report names the merge commit and Pages workflow run.
+
+## Required Fields
+
+Each benchmark run must record these fields before publication:
+
+| Field | Required content |
+|---|---|
+| Run ID | Stable slug: `<benchmark>-<suite>-<model>-<reasoning>-<yyyymmdd>` |
+| GEODE revision | Commit SHA, branch, and whether local changes were present |
+| Harness revision | Repo URL, commit/package version, server versions, and task-set label |
+| Model route | Provider, model label, subscription/API route, and auth caveat |
+| Reasoning setting | Exact setting as passed to GEODE or the benchmark harness |
+| Task scope | Domain, suite, task count, `k`, pass@k or accuracy definition |
+| User simulator | Required for tau2-style benchmarks |
+| Tool path | Native provider tools, GEODE function tools, MCP server, browser, or emulation |
+| Budget | Timeout, wall time, cost estimate or subscription-limit note |
+| Artifacts | Raw result directory, transcripts, verifier reports, logs, and generated summaries |
+| Result | Passed/failed counts, aggregate score, per-task rows, and category/domain rollups |
+| Comparability | What can be compared directly, what is directional only, and what must not be averaged |
+
+Use `docs/eval/benchmark-run-record.template.md` for the run record.
+
+## Directory Convention
+
+Keep third-party harnesses and heavy outputs out of git unless a small artifact
+is intentionally promoted.
+
+```text
+artifacts/eval/harnesses/<benchmark>/        # ignored third-party checkout
+artifacts/eval/runs/<run-id>/                # ignored raw run collection
+docs/eval/<benchmark-or-cluster>.md          # internal evidence ledger
+site/src/app/docs/benchmarks/<...>/page.tsx  # public page
+```
+
+Do not publish machine-local absolute paths, API keys, OAuth tokens, or copied
+subscription credentials. Public docs should use `<geode-worktree>` and route
+labels such as `source=subscription` instead.
+
+## Operator Loop
+
+### 1. Scope and Ground
+
+1. Confirm branch/worktree state and create a feature worktree from `develop`.
+2. Record the exact benchmark objective and non-goals.
+3. Confirm live-test approval if a model call, web service, account quota, or
+   paid API may be used.
+4. Verify current harness instructions from upstream primary sources.
+5. Search for same-suite external cases before claiming novelty or comparison.
+
+### 2. Prepare the Harness
+
+1. Install the harness under `artifacts/eval/harnesses/<benchmark>`.
+2. Pin the upstream commit or package version.
+3. Run the cheapest no-LLM or single-task smoke that proves setup and verifier
+   wiring.
+4. Record setup commands and any environment placeholder, such as
+   `OPENAI_API_KEY=dummy`, separately from the actual GEODE auth route.
+
+### 3. Run and Preserve
+
+1. Use a stable `--exp-name` / output directory that includes run ID fields.
+2. Preserve raw verifier output before summarizing.
+3. Extract per-task result, time, rounds, tokens, and errors.
+4. Capture any code change needed to make the benchmark valid, such as MCP
+   argument normalization or EOF offload.
+5. If a task fails, keep the failure as data unless the harness setup itself is
+   invalid.
+
+### 4. Interpret
+
+1. Separate the raw benchmark score from smoke/regression interpretation.
+2. State direct comparators and directional-only comparators.
+3. Do not average across benchmark families.
+4. Do not mix MCPMark Verified with pre-Verified MCP-Mark or an `easy` smoke
+   score without a version label.
+5. For subscription routes, state that the result is product-route evidence,
+   not API-key leaderboard evidence.
+
+### 5. Publish
+
+1. Update the internal ledger in `docs/eval/`.
+2. Add or update a public docs page under `site/src/app/docs/benchmarks/`.
+3. Add the page to `site/src/lib/geode-docs/sitemap.ts`.
+4. If a public page includes commands, scrub local usernames and secrets.
+5. Run site checks before opening the PR.
+
+### 6. Merge and Deploy
+
+Use the normal GEODE GitFlow:
+
+```text
+feature/<benchmark-cycle> -> develop -> main
+```
+
+Feature PRs squash into `develop`. Before promoting `develop -> main`, sync
+`main -> develop` if `main` has progressed. The final `develop -> main` PR uses
+a merge commit. After main merge, watch the Pages workflow and verify the live
+URL with `curl`.
+
+## Verification Checklist
+
+Run the narrowest useful checks for the changed surface:
+
+```bash
+git diff --check
+npx eslint site/src/app/docs/benchmarks/<path>/page.tsx
+cd site && npm run build
+```
+
+For functional GEODE changes that were needed by the benchmark, also run the
+touched Python checks, for example:
+
+```bash
+uv run pytest tests/<target>.py
+uv run ruff check <changed-python-files>
+uv run ruff format --check <changed-python-files>
+uv run mypy <changed-python-modules>
+```
+
+After merge to `main`:
+
+```bash
+gh run list --workflow "Deploy site to GitHub Pages" --branch main --limit 5
+gh run watch <run-id> --exit-status
+curl -L https://mangowhoiscloud.github.io/geode/docs/benchmarks/<path> | rg "<score|run-id|model>"
+```
+
+## Done Definition
+
+A benchmark publishing cycle is done when all of these are true:
+
+- Raw artifacts are preserved in an ignored artifact directory.
+- Internal ledger explains setup, result, and comparability.
+- Public docs page exposes the score, command, artifact pointer, and caveats.
+- CI passed on the feature PR.
+- Feature PR was merged to `develop`.
+- `develop` was promoted to `main`.
+- GitHub Pages deployment succeeded.
+- The live URL was fetched and contains the new result.

--- a/docs/eval/benchmark-run-record.template.md
+++ b/docs/eval/benchmark-run-record.template.md
@@ -1,0 +1,108 @@
+# Benchmark Run Record Template
+
+Copy this file into the relevant eval ledger or run note, then replace every
+placeholder before publication.
+
+## Identity
+
+| Field | Value |
+|---|---|
+| Run ID | `<benchmark>-<suite>-<model>-<reasoning>-<yyyymmdd>` |
+| Date | `<YYYY-MM-DD>` |
+| Operator | `<name or role>` |
+| GEODE commit | `<sha>` |
+| GEODE branch | `<branch>` |
+| Dirty worktree? | `<clean / explain local changes>` |
+
+## Benchmark
+
+| Field | Value |
+|---|---|
+| Benchmark | `<MCPMark / BFCL V4 / tau2-bench / other>` |
+| Suite/domain | `<suite>` |
+| Task count | `<n>` |
+| Trials | `<k / pass@k>` |
+| Harness source | `<repo URL>` |
+| Harness revision | `<commit / package version>` |
+| Server versions | `<MCP or service versions>` |
+| User simulator | `<tau2 only, or n/a>` |
+
+## Model Route
+
+| Field | Value |
+|---|---|
+| Provider | `<openai-codex / openai-api / anthropic / other>` |
+| Model label | `<exact label>` |
+| Route source | `<subscription / api / local / other>` |
+| Reasoning setting | `<xhigh / high / medium / none / n/a>` |
+| Auth note | `<for example: OPENAI_API_KEY=dummy was harness placeholder; actual calls used source=subscription>` |
+
+## Command
+
+```bash
+<redacted command>
+```
+
+## Artifacts
+
+| Artifact | Path |
+|---|---|
+| Raw result directory | `<artifacts/eval/...>` |
+| Verifier output | `<path>` |
+| Transcript | `<path>` |
+| Summary JSON/CSV | `<path>` |
+| Logs | `<path>` |
+
+## Result
+
+| Metric | Value |
+|---|---:|
+| Passed | `<n>` |
+| Failed | `<n>` |
+| Accuracy / pass rate | `<percent>` |
+| Total wall time | `<seconds>` |
+| Average task time | `<seconds>` |
+| Total GEODE rounds | `<n>` |
+| Average GEODE rounds | `<n>` |
+| Input tokens | `<n>` |
+| Output tokens | `<n>` |
+| Total tokens | `<n>` |
+
+## Per-Task Rows
+
+| Task | Result | Time | Rounds | Tokens | Notes |
+|---|---|---:|---:|---:|---|
+| `<task>` | `<PASS/FAIL>` | `<s>` | `<n>` | `<n>` | `<note>` |
+
+## Rollup
+
+| Category/domain | Tasks | Accuracy | Average time | Tokens | Average rounds |
+|---|---:|---:|---:|---:|---:|
+| `<category>` | `<n>` | `<percent>` | `<s>` | `<n>` | `<n>` |
+
+## Comparability
+
+| Comparator | Status |
+|---|---|
+| `<same suite>` | `<directly comparable / directional / not comparable>` |
+| `<leaderboard>` | `<directly comparable / directional / not comparable>` |
+
+## Interpretation
+
+- `<What this score means.>`
+- `<What it does not mean.>`
+- `<Whether this is a smoke baseline, verified score, or full benchmark.>`
+
+## Publication Checklist
+
+- [ ] Internal ledger updated under `docs/eval/`.
+- [ ] Public docs page added or updated under `site/src/app/docs/benchmarks/`.
+- [ ] Sitemap entry added in `site/src/lib/geode-docs/sitemap.ts`.
+- [ ] Local usernames, keys, tokens, and account identifiers scrubbed.
+- [ ] `git diff --check` passed.
+- [ ] Targeted site lint passed.
+- [ ] `site` build passed.
+- [ ] Feature PR merged to `develop`.
+- [ ] `develop -> main` PR merged.
+- [ ] Pages deploy succeeded.
+- [ ] Live URL checked with `curl`.

--- a/site/src/app/docs/benchmarks/publishing-cycle/page.tsx
+++ b/site/src/app/docs/benchmarks/publishing-cycle/page.tsx
@@ -1,0 +1,231 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Benchmark publishing cycle — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="benchmarks/publishing-cycle"
+      title="Benchmark publishing cycle"
+      titleKo="Benchmark publishing cycle"
+      summary="A repeatable cycle for running a GEODE benchmark, recording the evidence ledger, publishing the official docs page, and verifying GitHub Pages."
+      summaryKo="GEODE benchmark 실측, evidence ledger 기록, 공식문서 반영, GitHub Pages 검증을 하나로 묶은 반복 사이클입니다."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              GEODE의 benchmark 결과는 단순히 숫자 하나를 적는 일이 아닙니다.
+              하나의 publish cycle은 harness를 고정하고, live run을 보존하고,
+              비교 가능성을 분리하고, 공식문서에 올린 뒤, main 배포와 Pages
+              응답까지 확인해야 끝납니다.
+            </p>
+
+            <h2>Cycle 정의</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Gate</th>
+                  <th>완료 증거</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Scope</td><td>Benchmark, suite, model route, reasoning setting, live-test 승인, 예산을 기록</td></tr>
+                <tr><td>Harness</td><td>Upstream source, version, local path, install command, smoke 결과를 기록</td></tr>
+                <tr><td>Run</td><td>Raw result, verifier output, transcript, token/time total을 보존</td></tr>
+                <tr><td>Interpret</td><td>직접 비교 가능 score와 방향성 baseline을 분리</td></tr>
+                <tr><td>Publish</td><td><code>docs/eval</code> ledger와 <code>site/src/app/docs/benchmarks</code> 페이지를 갱신</td></tr>
+                <tr><td>Deploy</td><td><code>develop</code>과 <code>main</code> merge 후 Pages workflow와 live URL을 확인</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Run record 필드</h2>
+            <p>
+              모든 benchmark run은 공개 전에 같은 필드를 채워야 합니다. 특히
+              subscription route와 API-key route를 섞어 쓰면 안 됩니다. 예를 들어
+              <code>OPENAI_API_KEY=dummy</code>가 harness placeholder였고 실제
+              호출이 <code>openai-codex</code>의 <code>source=subscription</code>로
+              나갔다면, 그 auth note를 결과 페이지에 그대로 남깁니다.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>내용</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Run ID</td><td><code>{"<benchmark>-<suite>-<model>-<reasoning>-<yyyymmdd>"}</code></td></tr>
+                <tr><td>GEODE revision</td><td>commit SHA, branch, local change 여부</td></tr>
+                <tr><td>Harness revision</td><td>repo URL, commit/package version, server versions, task-set label</td></tr>
+                <tr><td>Model route</td><td>provider, model label, subscription/API route, auth caveat</td></tr>
+                <tr><td>Task scope</td><td>domain, suite, task count, <code>k</code>, pass@k 또는 accuracy 정의</td></tr>
+                <tr><td>Artifacts</td><td>raw result directory, transcripts, verifier reports, logs, generated summaries</td></tr>
+                <tr><td>Comparability</td><td>직접 비교, 방향성 참고, 비교 불가 대상을 분리</td></tr>
+              </tbody>
+            </table>
+
+            <h2>디렉터리 규칙</h2>
+            <pre>{`artifacts/eval/harnesses/<benchmark>/        # ignored third-party checkout
+artifacts/eval/runs/<run-id>/                # ignored raw run collection
+docs/eval/<benchmark-or-cluster>.md          # internal evidence ledger
+site/src/app/docs/benchmarks/<...>/page.tsx  # public page`}</pre>
+            <p>
+              로컬 사용자명, 홈 디렉터리 절대경로, API key, OAuth token, 계정 식별자는
+              공식문서에 싣지 않습니다. 공개 명령에는 <code>{"<geode-worktree>"}</code>
+              같은 placeholder를 씁니다.
+            </p>
+
+            <h2>운영 루프</h2>
+            <ol>
+              <li>Feature worktree를 <code>develop</code>에서 만들고 목적과 non-goal을 기록합니다.</li>
+              <li>Upstream benchmark 문서와 현재 leaderboard/source를 확인합니다.</li>
+              <li>Harness를 <code>artifacts/eval/harnesses</code>에 설치하고 no-LLM 또는 단일 task smoke를 통과시킵니다.</li>
+              <li>Stable run ID로 live benchmark를 실행하고 raw artifacts를 보존합니다.</li>
+              <li>Per-task, category/domain, token, time, round, failure row를 추출합니다.</li>
+              <li>내부 ledger와 public docs page를 같은 run record에서 갱신합니다.</li>
+              <li>PR을 <code>develop</code>으로 squash merge하고, 필요하면 <code>main -&gt; develop</code> sync 후 <code>develop -&gt; main</code> merge를 진행합니다.</li>
+              <li>Pages workflow를 watch하고 live URL에서 새 score와 caveat가 보이는지 확인합니다.</li>
+            </ol>
+
+            <h2>검증</h2>
+            <pre>{`git diff --check
+npx eslint site/src/app/docs/benchmarks/<path>/page.tsx
+cd site && npm run build
+
+gh run list --workflow "Deploy site to GitHub Pages" --branch main --limit 5
+gh run watch <run-id> --exit-status
+curl -L https://mangowhoiscloud.github.io/geode/docs/benchmarks/<path> | rg "<score|run-id|model>"`}</pre>
+            <p>
+              Benchmark를 위해 GEODE core를 수정했다면 targeted pytest, ruff, format
+              check, mypy도 같은 cycle의 verification에 포함합니다.
+            </p>
+
+            <h2>완료 기준</h2>
+            <ul>
+              <li>Raw artifacts가 ignored artifact 경로에 보존되어 있습니다.</li>
+              <li>Internal ledger가 setup, result, comparability를 설명합니다.</li>
+              <li>Public docs page가 score, command, artifact pointer, caveat를 노출합니다.</li>
+              <li>Feature PR CI가 통과했고 <code>develop</code>에 merge됐습니다.</li>
+              <li><code>develop</code>이 <code>main</code>에 merge됐습니다.</li>
+              <li>GitHub Pages deploy가 성공했고 live URL에서 새 결과를 확인했습니다.</li>
+            </ul>
+
+            <p className="text-[var(--ink-3)] text-sm">
+              내부 runbook과 템플릿은 <code>docs/eval/benchmark-publishing-cycle.md</code>와{" "}
+              <code>docs/eval/benchmark-run-record.template.md</code>에 있습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <p>
+              Publishing a GEODE benchmark is not just writing down a number. A
+              complete cycle pins the harness, preserves the live run, separates
+              comparability, updates the official docs, merges through the normal
+              branch flow, and verifies the deployed GitHub Pages URL.
+            </p>
+
+            <h2>Cycle definition</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Gate</th>
+                  <th>Exit evidence</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Scope</td><td>Benchmark, suite, model route, reasoning setting, live-test approval, and budget recorded</td></tr>
+                <tr><td>Harness</td><td>Upstream source, version, local path, install command, and smoke result recorded</td></tr>
+                <tr><td>Run</td><td>Raw result, verifier output, transcript, token totals, and time totals preserved</td></tr>
+                <tr><td>Interpret</td><td>Directly comparable scores separated from directional baselines</td></tr>
+                <tr><td>Publish</td><td><code>docs/eval</code> ledger and <code>site/src/app/docs/benchmarks</code> page updated</td></tr>
+                <tr><td>Deploy</td><td><code>develop</code> and <code>main</code> merges done; Pages workflow and live URL checked</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Run record fields</h2>
+            <p>
+              Every benchmark run uses the same publication fields. In
+              particular, do not blur subscription routes and API-key routes. If
+              <code>OPENAI_API_KEY=dummy</code> was only a harness placeholder and
+              the actual calls went through <code>openai-codex</code> with{" "}
+              <code>source=subscription</code>, keep that auth note on the result
+              page.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>Content</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>Run ID</td><td><code>{"<benchmark>-<suite>-<model>-<reasoning>-<yyyymmdd>"}</code></td></tr>
+                <tr><td>GEODE revision</td><td>commit SHA, branch, and local-change state</td></tr>
+                <tr><td>Harness revision</td><td>repo URL, commit/package version, server versions, and task-set label</td></tr>
+                <tr><td>Model route</td><td>provider, model label, subscription/API route, and auth caveat</td></tr>
+                <tr><td>Task scope</td><td>domain, suite, task count, <code>k</code>, and pass@k or accuracy definition</td></tr>
+                <tr><td>Artifacts</td><td>raw result directory, transcripts, verifier reports, logs, and generated summaries</td></tr>
+                <tr><td>Comparability</td><td>direct, directional, and not-comparable targets separated</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Directory convention</h2>
+            <pre>{`artifacts/eval/harnesses/<benchmark>/        # ignored third-party checkout
+artifacts/eval/runs/<run-id>/                # ignored raw run collection
+docs/eval/<benchmark-or-cluster>.md          # internal evidence ledger
+site/src/app/docs/benchmarks/<...>/page.tsx  # public page`}</pre>
+            <p>
+              Do not publish local usernames, home-directory absolute paths, API
+              keys, OAuth tokens, or account identifiers. Public commands use
+              placeholders such as <code>{"<geode-worktree>"}</code>.
+            </p>
+
+            <h2>Operator loop</h2>
+            <ol>
+              <li>Create a feature worktree from <code>develop</code> and record the objective plus non-goals.</li>
+              <li>Check the upstream benchmark docs and current leaderboard/source.</li>
+              <li>Install the harness under <code>artifacts/eval/harnesses</code> and pass a no-LLM or single-task smoke.</li>
+              <li>Run the live benchmark with a stable run ID and preserve raw artifacts.</li>
+              <li>Extract per-task, category/domain, token, time, round, and failure rows.</li>
+              <li>Update the internal ledger and public docs page from the same run record.</li>
+              <li>Squash the feature PR into <code>develop</code>, sync <code>main -&gt; develop</code> if needed, then merge <code>develop -&gt; main</code>.</li>
+              <li>Watch the Pages workflow and verify that the live URL contains the new score and caveat.</li>
+            </ol>
+
+            <h2>Verification</h2>
+            <pre>{`git diff --check
+npx eslint site/src/app/docs/benchmarks/<path>/page.tsx
+cd site && npm run build
+
+gh run list --workflow "Deploy site to GitHub Pages" --branch main --limit 5
+gh run watch <run-id> --exit-status
+curl -L https://mangowhoiscloud.github.io/geode/docs/benchmarks/<path> | rg "<score|run-id|model>"`}</pre>
+            <p>
+              If the benchmark required a GEODE core change, include targeted
+              pytest, ruff, format check, and mypy in the same cycle&apos;s
+              verification.
+            </p>
+
+            <h2>Done definition</h2>
+            <ul>
+              <li>Raw artifacts are preserved under an ignored artifact path.</li>
+              <li>The internal ledger explains setup, result, and comparability.</li>
+              <li>The public docs page exposes score, command, artifact pointer, and caveat.</li>
+              <li>The feature PR CI passed and merged into <code>develop</code>.</li>
+              <li><code>develop</code> merged into <code>main</code>.</li>
+              <li>GitHub Pages deployed successfully and the live URL contains the new result.</li>
+            </ul>
+
+            <p className="text-[var(--ink-3)] text-sm">
+              The internal runbook and template live at{" "}
+              <code>docs/eval/benchmark-publishing-cycle.md</code> and{" "}
+              <code>docs/eval/benchmark-run-record.template.md</code>.
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -130,6 +130,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     title: "Benchmarks",
     titleKo: "벤치마크",
     pages: [
+      { slug: "benchmarks/publishing-cycle", title: "Benchmark publishing cycle", titleKo: "Benchmark publishing cycle", summary: "Repeatable runbook for measuring GEODE, recording the evidence ledger, publishing official docs, and verifying GitHub Pages.", summaryKo: "GEODE 측정, evidence ledger 기록, 공식문서 배포, GitHub Pages 검증을 하나로 묶은 반복 runbook입니다.", quadrant: "how-to" },
       { slug: "benchmarks/mcpmark/filesystem-easy", title: "MCPMark: filesystem/easy", titleKo: "MCPMark: filesystem/easy", summary: "Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.", summaryKo: "MCPMark filesystem easy 하위 suite에 대한 GEODE verifier-backed 실측 기록입니다. run spec, 산출물, task별 점수, EOF offload 기록을 포함합니다.", quadrant: "reference" },
     ],
   },


### PR DESCRIPTION
## Summary
- Add a repeatable benchmark publishing cycle runbook for live GEODE benchmark runs.
- Add a benchmark run-record template and public Benchmarks docs page.
- Wire the new public page into the docs sitemap.

## Why
GEODE benchmark work now includes live execution, internal evidence ledger updates, official docs publication, PR promotion, and GitHub Pages verification. This codifies that end-to-end loop so MCPMark, BFCL V4, tau2-bench, and later suites follow the same record and deployment contract.

## Changes
| File | Change |
|------|--------|
| docs/eval/benchmark-publishing-cycle.md | New internal runbook for scope, harness, run, interpretation, publish, deploy gates |
| docs/eval/benchmark-run-record.template.md | New reusable run-record template |
| docs/eval/README.md | Link the cycle and template from the eval roadmap |
| site/src/app/docs/benchmarks/publishing-cycle/page.tsx | New public docs page for the cycle |
| site/src/lib/geode-docs/sitemap.ts | Add the page under Benchmarks |

## Verification
- git diff --check
- scripts/lint_pages_markdown.sh
- cd site && npx eslint src/app/docs/benchmarks/publishing-cycle/page.tsx src/lib/geode-docs/sitemap.ts
- cd site && npm run build

Build warnings are existing Petri seed broad-pattern warnings and a worktree lockfile root inference warning.