### PR TITLE
test: 머신상태 누수 6건 격리 (test-only)

### DIFF
--- a/tests/core/cli/conftest.py
+++ b/tests/core/cli/conftest.py
@@ -1,0 +1,31 @@
+"""Test isolation for CLI self-improving viewers.
+
+The runtime ``baseline.json`` lives OUTSIDE the repo at
+``~/.geode/self-improving/baseline.json`` (``core.paths.BASELINE_JSON_PATH``,
+derived from ``RUNTIME_ROOT`` at import time). The global
+``_isolate_state_root`` fixture (``tests/conftest.py``) redirects the
+``STATE_ROOT`` / ``AUTORESEARCH_STATE_DIR`` family but NOT this
+import-time-frozen constant, so a developer box with a real promoted
+baseline leaks it into ``outer_bundle.load_bundle_events`` (a synthetic
+``baseline`` event) and ``_cmd_status`` (a "promoted" block instead of
+"no baseline yet"). CI passes only because a clean HOME has no baseline.
+
+Redirect it to a fresh empty tmp dir for every CLI test so the readers
+observe the fixture-supplied state, never the machine's. Tests that stage
+their own baseline still ``monkeypatch.setattr("core.paths.BASELINE_JSON_PATH", ...)``
+after this fixture, which simply overrides the redirect.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_baseline(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import core.paths as cp
+
+    sandbox = tmp_path_factory.mktemp("baseline-isolation")
+    monkeypatch.setattr(cp, "BASELINE_JSON_PATH", sandbox / "baseline.json")

--- a/tests/core/cli/test_login_command.py
+++ b/tests/core/cli/test_login_command.py
@@ -9,12 +9,40 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from core.cli.commands import cmd_login
 from core.llm.strategies.plan_registry import (
     get_plan_registry,
     reset_plan_registry,
 )
 from core.llm.strategies.plans import GLM_CODING_TIERS, default_plan_for_payg
+
+
+@pytest.fixture(autouse=True)
+def _scrub_real_provider_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the machine's real credentials from the auth/profile store.
+
+    ``build_auth`` seeds ``<provider>-payg:env`` profiles from
+    ``settings.{openai,anthropic,zai}_api_key`` (``migrate_env_to_toml`` +
+    the legacy-provider loop in ``core.wiring.container``). ``Settings``
+    resolves those from the process env AND an ``env_file`` fallback
+    (``.env`` + ``~/.geode/.env``), so on a developer box with real keys
+    present the store gains a real-key profile the test never created —
+    ``test_set_key_updates_existing_plan`` then reads that leaked key
+    instead of the one it bound. CI passes only because a clean HOME has
+    no keys.
+
+    Empty-string values (not ``delenv``) are required: pydantic prefers
+    the env var over the ``env_file``, so an empty var shadows the file,
+    whereas ``delenv`` lets pydantic fall back to ``~/.geode/.env``.
+    Resetting the cached ``Settings`` singleton forces a re-read with the
+    scrubbed values before ``build_auth`` runs.
+    """
+    import core.config as cfg
+
+    for _var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ZAI_API_KEY"):
+        monkeypatch.setenv(_var, "")
+    monkeypatch.setattr(cfg, "_settings_instance", None, raising=False)
 
 
 def _reset_state() -> None:


### PR DESCRIPTION
## Summary
- CI에선 green이나 실 머신(실 `~/.geode`+실 env)에서만 실패하던 6건을 격리. 프로덕션 무접촉(test-only).

## Why
- 여러 세션이 "unmodified develop 동일 재현"으로 넘겨온 검증 노이즈. 실제 원인=테스트 격리 결함.

## Root cause
- login 1건: `.env`/`~/.geode/.env` env_file 폴백이라 `monkeypatch.delenv`로 안 지워짐 → 빈문자열 setenv + settings 싱글턴 리셋 필요. 실 `OPENAI_API_KEY`가 rotator 오염.
- outer_bundle 4 + status_slash 1: 프로즌 `BASELINE_JSON_PATH`(실 `~/.geode/self-improving/baseline.json`)를 글로벌 격리 픽스처가 안 덮음.

## Changes
| File | Change |
|------|--------|
| `tests/core/cli/test_login_command.py` | 파일스코프 autouse 키-스크럽 픽스처 |
| `tests/core/cli/conftest.py` (신규) | baseline 리다이렉트 autouse 픽스처 |

## Verification
- [x] 6건 before FAIL → after PASS (실 머신), tests/core/cli 577 pass
- [x] `git diff` test-only(core/plugins 0), ruff/format/slop/hygiene exit 0
- [x] 부수영향 테스트(paths_env_override·audit_log_gitignored) pass