### PR TITLE
Add tau2 benchmark runner and queue docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **tau2 GEODE benchmark runner.** Added `scripts/eval/tau2_geode_agent.py`, a
+  reproducible runner that registers GEODE as an in-process tau2
+  `HalfDuplexAgent`, wraps tau2 domain tools into GEODE's `ToolRegistry` and
+  `ToolExecutor`, and preserves tau2's native simulator/evaluator/output path.
+
 ### Fixed
 
 - **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,10 @@ functional change.
 
 - **tau2 GEODE benchmark runner.** Added `scripts/eval/tau2_geode_agent.py`, a
   reproducible runner that registers GEODE as an in-process tau2
-  `HalfDuplexAgent`, wraps tau2 domain tools into GEODE's `ToolRegistry` and
-  `ToolExecutor`, and preserves tau2's native simulator/evaluator/output path.
+  `HalfDuplexAgent` and `HalfDuplexUser`, wraps tau2 domain tools into
+  GEODE's `ToolRegistry` and `ToolExecutor`, and preserves tau2's native
+  evaluator/output path while letting both agent and simulated user run through
+  the subscription route.
 
 ### Fixed
 

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -2,7 +2,7 @@
 
 > Action/tool-execution 4종 벤치마크. GEODE의 quality ratchet(P4)에 통합 예정.
 > 각 문서는 **사례 + 필요 인프라 + 4-Phase 진행 시나리오**를 담음.
-> 마지막 갱신: 2026-05-07
+> 마지막 갱신: 2026-07-03
 
 ## 채택 4종
 
@@ -26,6 +26,21 @@
 운영 스캐폴드: [benchmark-publishing-cycle.md](benchmark-publishing-cycle.md),
 [benchmark-run-record.template.md](benchmark-run-record.template.md)
 
+## 다음 측정 큐
+
+현재 남은 agentic tool-use benchmark는 아래 순서로 진행한다. 사용자가
+`tau2-bench`를 2순위로 올리도록 지정했으므로, BFCL V4는 tau2 smoke와
+Telecom small run 이후로 둔다.
+
+| 순위 | 벤치 | 첫 목표 | 완료 기준 |
+|---:|---|---|---|
+| 1 | MCPMark Verified | `easy` across available MCPs, then Verified filesystem slice | GEODE adapter로 verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
+| 2 | τ²-bench | `mock` smoke, then Telecom small run; run `gpt-4.1` user simulator for legacy GPT-5.5 comparators and `gpt-5.2` user simulator for current leaderboard comparability | tau2 result directory와 domain split을 보존하고, user simulator / trial 수를 public page에 명시 |
+| 3 | BFCL V4 | Agentic subset first | native/prompt function-calling route와 aggregation을 고정한 뒤 result/score artifact 보존 |
+| 4 | HAL Reliability | tau-bench airline single-rerun smoke | τ² adapter 재사용 여부와 rerun consistency schema 확인 |
+| 5 | Terminal-Bench 2.0 | 1-task Docker/tmux smoke | post-run test artifact와 shell transcript 보존 |
+| 6 | Toolathlon | credential-free or lowest-credential smoke | MCP app surface, turn cap, and credential caveats 기록 |
+
 ## 의존성 그래프
 
 ```
@@ -34,8 +49,10 @@
 HAL Reliability (τ-bench airline rerun) ← 절반 무료
 ```
 
-τ² 어댑터를 먼저 만들면 HAL Reliability의 tau-bench 부분이 그대로 따라옴. 우선순위:
-**τ² → HAL Reliability → Terminal-Bench → Toolathlon** (lift 가벼운 순).
+τ² 어댑터를 먼저 만들면 HAL Reliability의 tau-bench 부분이 그대로 따라옴.
+장기 로드맵의 lift 순서는 **τ² → HAL Reliability → Terminal-Bench →
+Toolathlon**이지만, 현재 agentic tool-use 3종 측정 큐에서는 MCPMark
+Verified 다음에 τ²-bench를 둔다.
 
 ## 채택 안 한 것
 
@@ -73,6 +90,8 @@ HAL Reliability (τ-bench airline rerun) ← 절반 무료
 
 | 일자 | 변경 |
 |---|---|
+| 2026-07-03 | 남은 벤치마크 측정 큐를 추가하고 `tau2-bench`를 2순위로 승격 |
+| 2026-07-03 | 최신 tau2 하네스의 `gpt-5.2` user simulator 권장 설정을 별도 비교군으로 보정 |
 | 2026-07-03 | Benchmark Publishing Cycle 스캐폴드와 run-record 템플릿 추가 |
 | 2026-07-03 | MCPMark filesystem easy에서 GEODE + GPT-5.5 xhigh 10/10 실측 및 EOF offload 결과 기록 |
 | 2026-07-02 | GPT-5.5 subscription 측정 준비용 MCPMark/BFCL V4/tau2 공개 사례 ledger 추가 |

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -35,7 +35,7 @@ Telecom small run 이후로 둔다.
 | 순위 | 벤치 | 첫 목표 | 완료 기준 |
 |---:|---|---|---|
 | 1 | MCPMark Verified | `easy` across available MCPs, then Verified filesystem slice | GEODE adapter로 verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
-| 2 | τ²-bench | `mock` smoke, then Telecom small run; run `gpt-4.1` user simulator for legacy GPT-5.5 comparators and `gpt-5.2` user simulator for current leaderboard comparability | tau2 result directory와 domain split을 보존하고, user simulator / trial 수를 public page에 명시 |
+| 2 | τ²-bench | `mock` smoke with `geode_agent` + `geode_user` over subscription, then Telecom small run; native tau2 `gpt-4.1` / `gpt-5.2` user-simulator runs are optional comparator tracks | tau2 result directory와 domain split을 보존하고, user route / trial 수를 public page에 명시 |
 | 3 | BFCL V4 | Agentic subset first | native/prompt function-calling route와 aggregation을 고정한 뒤 result/score artifact 보존 |
 | 4 | HAL Reliability | tau-bench airline single-rerun smoke | τ² adapter 재사용 여부와 rerun consistency schema 확인 |
 | 5 | Terminal-Bench 2.0 | 1-task Docker/tmux smoke | post-run test artifact와 shell transcript 보존 |

--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -531,12 +531,24 @@ The relevant GEODE injection points already exist:
 
 ## Suggested First Measurement Pass
 
+The active queue after the 2026-07-03 priority update is:
+
 1. MCPMark Verified `easy` suite across all available MCPs using the GEODE
    adapter, starting with filesystem.
-2. tau2 `mock` smoke, then Telecom small run using GPT-4.1 as user simulator.
+2. tau2 `mock` smoke, then Telecom small run. Use GPT-4.1 as the user simulator
+   for legacy GPT-5.5 comparator alignment, and add a separate GPT-5.2 user
+   simulator run for current tau2 leaderboard comparability. This is now ahead
+   of BFCL V4 so that the user-simulator contract and domain split are fixed
+   before broader function-calling aggregation work.
+   GEODE's agent side can use `source=subscription`, but tau2's
+   `user_simulator` still needs a real LiteLLM provider credential.
 3. BFCL V4 agentic subset first; full BFCL V4 only after the function-calling
    route is stable.
-4. Archive every run under `artifacts/eval/<bench>/<date>/` and add only
+4. HAL Reliability tau-bench airline smoke, reusing the tau2 adapter shape where
+   possible.
+5. Terminal-Bench 2.0 smoke.
+6. Toolathlon smoke.
+7. Archive every run under `artifacts/eval/<bench>/<date>/` and add only
    verifier-backed scores to the public docs.
 
 ## Sources

--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -535,13 +535,11 @@ The active queue after the 2026-07-03 priority update is:
 
 1. MCPMark Verified `easy` suite across all available MCPs using the GEODE
    adapter, starting with filesystem.
-2. tau2 `mock` smoke, then Telecom small run. Use GPT-4.1 as the user simulator
-   for legacy GPT-5.5 comparator alignment, and add a separate GPT-5.2 user
-   simulator run for current tau2 leaderboard comparability. This is now ahead
-   of BFCL V4 so that the user-simulator contract and domain split are fixed
-   before broader function-calling aggregation work.
-   GEODE's agent side can use `source=subscription`, but tau2's
-   `user_simulator` still needs a real LiteLLM provider credential.
+2. tau2 `mock` smoke, then Telecom small run. The default GEODE route uses
+   `geode_agent` + `geode_user`, both with `source=subscription`, so no
+   LiteLLM credential is required for the first GEODE-owned run. Native tau2
+   `user_simulator` runs with GPT-4.1 or GPT-5.2 are optional comparator tracks
+   and must stay separate from the subscription-only score.
 3. BFCL V4 agentic subset first; full BFCL V4 only after the function-calling
    route is stable.
 4. HAL Reliability tau-bench airline smoke, reusing the tau2 adapter shape where

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -46,7 +46,7 @@ Sierra 분석: telecom은 **patient diagnostic dialog**를 보상 — Chinese re
 | Sandbox | **순수 Python in-process** — Docker 불필요 |
 | Scoring | Pydantic world state diff (oracle) — LLM judge 미사용 |
 | Trace | `results/<run_id>/` JSONL (메시지+tool call+task reward) |
-| External | LLM keys (LiteLLM). User simulator 모델 명시 필수 — leaderboard는 v0.2.0부터 **`gpt-4.1` 고정** |
+| External | LLM keys (LiteLLM). User simulator 모델 명시 필수 — legacy GPT-5.5 비교는 **`gpt-4.1`**, 현재 tau2 leaderboard 비교는 upstream 권장 **`gpt-5.2`**를 별도 run으로 분리 |
 | Cost — smoke | 5-task airline @ Sonnet 4.5 ≈ **<$3** |
 | Cost — full | 4-domain × 4 trial @ Sonnet 4.5 ≈ **$200-400** |
 | CI 적합도 | 5-task smoke GHA 가능 (~10-15분), full은 VM |
@@ -80,27 +80,47 @@ tau2 run --domain mock --agent-llm <ours> --num-tasks 1 --num-trials 1
 
 **Pass criteria**: results/ 폴더에 JSONL 생성, agent contract 호출 trace 확인.
 
-### Phase 1 — PoC 어댑터 (~6-10시간)
+### Phase 1 — GEODE runner adapter
 
-신규 파일:
-- `eval/tau2/__init__.py`
-- `eval/tau2/adapter.py` — `class GeodeTau2Agent(HalfDuplexAgent)`
-- `eval/tau2/factory.py` — `create_agent()` factory
-- `eval/tau2/README.md` — 실행 방법
+Repository script:
+- `scripts/eval/tau2_geode_agent.py`
 
 매핑:
-- `generate_next_message(message, state)` → 한 번의 `AgenticLoop.step()`
-- `tools` constructor 인자 → GEODE tool registry에 wrap (LangGraph tool node 형태)
-- `domain_policy` → AgenticLoop system prompt prefix
-- `state` → AgenticLoop의 conversation state를 Pydantic으로 직렬화
+- `generate_next_message(message, state)` → 한 번의 `AgenticLoop.arun()`
+- tau2 `tools` constructor 인자 → GEODE `ToolRegistry` + `ToolExecutor`
+  handler로 wrap
+- `domain_policy` → `AgenticLoop(system_prompt_override=...)`
+- `state` → per-task `ConversationContext`와 `AgenticLoop` 보존
+
+GEODE smoke command:
+
+```bash
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain mock \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --model gpt-5.5 \
+  --provider openai \
+  --source subscription \
+  --effort xhigh \
+  --save-to geode-gpt-5-5-xhigh-mock-smoke-20260703
+```
 
 ### Phase 2 — First Real Run
 
-- **대상**: telecom 24 tasks × 1 trial × **Sonnet 4.5**
+- **대상**: telecom small/base slice × 1 trial × **GPT-5.5 xhigh**
 - **선정 사유**: dual-control 도메인이 Slack/MCP execution path에 가장 가까움
 - **예상 baseline**: **35-45% pass^1** (비특화 scaffold 평균치 기준)
 - **예상 cost**: $25-40
 - **출력 보관**: `artifacts/eval/tau2/<date>/`
+- **비교 분리**: legacy GPT-5.5 공개 수치와 맞추는 `user-llm=gpt-4.1`
+  run과, 현재 tau2 leaderboard 권장 설정인 `user-llm=gpt-5.2` run을
+  평균내지 않는다.
+- **Auth caveat**: GEODE agent 호출은 `source=subscription`으로 가능하지만,
+  tau2 `user_simulator`는 LiteLLM 경로의 별도 provider credential을
+  요구한다. MCPMark filesystem/easy처럼 `OPENAI_API_KEY=dummy`로
+  user simulator를 우회할 수 없다.
 
 ### Phase 3 — CI / 운영 Ratchet
 

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -46,7 +46,7 @@ Sierra 분석: telecom은 **patient diagnostic dialog**를 보상 — Chinese re
 | Sandbox | **순수 Python in-process** — Docker 불필요 |
 | Scoring | Pydantic world state diff (oracle) — LLM judge 미사용 |
 | Trace | `results/<run_id>/` JSONL (메시지+tool call+task reward) |
-| External | LLM keys (LiteLLM). User simulator 모델 명시 필수 — legacy GPT-5.5 비교는 **`gpt-4.1`**, 현재 tau2 leaderboard 비교는 upstream 권장 **`gpt-5.2`**를 별도 run으로 분리 |
+| External | GEODE subscription route for `geode_agent` + `geode_user`; native tau2 `user_simulator` still needs LiteLLM credentials |
 | Cost — smoke | 5-task airline @ Sonnet 4.5 ≈ **<$3** |
 | Cost — full | 4-domain × 4 trial @ Sonnet 4.5 ≈ **$200-400** |
 | CI 적합도 | 5-task smoke GHA 가능 (~10-15분), full은 VM |
@@ -73,7 +73,7 @@ def create_agent(tools, domain_policy, **kwargs) -> HalfDuplexAgent: ...
 ### Phase 0 — Smoke (≤30분, cost <$1)
 
 ```bash
-tau2 run --domain mock --agent-llm <ours> --num-tasks 1 --num-trials 1
+python scripts/eval/tau2_geode_agent.py --domain mock --num-tasks 1 --num-trials 1
 ```
 
 `mock` 도메인은 LLM cost 거의 없이 `core/agent/loop.py::AgenticLoop` 와이어업만 검증.
@@ -89,6 +89,8 @@ Repository script:
 - `generate_next_message(message, state)` → 한 번의 `AgenticLoop.arun()`
 - tau2 `tools` constructor 인자 → GEODE `ToolRegistry` + `ToolExecutor`
   handler로 wrap
+- tau2 `user_simulator` 대신 기본 `geode_user` 등록 → user side도
+  `source=subscription`으로 실행
 - `domain_policy` → `AgenticLoop(system_prompt_override=...)`
 - `state` → per-task `ConversationContext`와 `AgenticLoop` 보존
 
@@ -104,6 +106,9 @@ python scripts/eval/tau2_geode_agent.py \
   --provider openai \
   --source subscription \
   --effort xhigh \
+  --user geode_user \
+  --user-llm gpt-5.5 \
+  --user-source subscription \
   --save-to geode-gpt-5-5-xhigh-mock-smoke-20260703
 ```
 
@@ -114,13 +119,13 @@ python scripts/eval/tau2_geode_agent.py \
 - **예상 baseline**: **35-45% pass^1** (비특화 scaffold 평균치 기준)
 - **예상 cost**: $25-40
 - **출력 보관**: `artifacts/eval/tau2/<date>/`
-- **비교 분리**: legacy GPT-5.5 공개 수치와 맞추는 `user-llm=gpt-4.1`
-  run과, 현재 tau2 leaderboard 권장 설정인 `user-llm=gpt-5.2` run을
-  평균내지 않는다.
-- **Auth caveat**: GEODE agent 호출은 `source=subscription`으로 가능하지만,
-  tau2 `user_simulator`는 LiteLLM 경로의 별도 provider credential을
-  요구한다. MCPMark filesystem/easy처럼 `OPENAI_API_KEY=dummy`로
-  user simulator를 우회할 수 없다.
+- **비교 분리**: subscription-only 기본 run은 `user=geode_user`로 기록한다.
+  legacy GPT-5.5 공개 수치와 맞추는 native `user_simulator` +
+  `user-llm=gpt-4.1` run, 현재 tau2 leaderboard 권장 native
+  `user_simulator` + `user-llm=gpt-5.2` run과 평균내지 않는다.
+- **Auth caveat**: `geode_user` 경로는 GEODE subscription route를 사용한다.
+  native tau2 `user_simulator`를 선택한 경우에만 LiteLLM provider
+  credential이 별도로 필요하다.
 
 ### Phase 3 — CI / 운영 Ratchet
 
@@ -131,6 +136,69 @@ python scripts/eval/tau2_geode_agent.py \
 | Monthly (main) | telecom × 4 trial pass^k | pass^4 −5pp → release block | ~$80 |
 
 선정 사유: telecom = GEODE Slack-ops day job에 가장 근접.
+
+## 2026-07-03 GEODE subscription-only mock smoke
+
+| Field | Value |
+|---|---|
+| Run ID | `geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5` |
+| GEODE revision | `6db5b7ade3410eff6ea7718d2f65347fce164eff` plus local runner/doc changes |
+| Harness | `sierra-research/tau2-bench` `1901a30`, package `tau2==1.0.0` |
+| Domain / task | `mock`, `create_task_1`, `num_trials=1`, `num_tasks=1` |
+| Agent route | `geode_agent`, `gpt-5.5`, provider `openai`, source `subscription`, effort `xhigh` |
+| User route | `geode_user`, `gpt-5.5`, provider `openai`, source `subscription`, effort `high` |
+| Result | **1 / 1**, reward `1.0`, pass^1 `1.000` |
+| DB check | `1.0` |
+| Action check | `create_task` write action `1.0` |
+| Termination | `user_stop` |
+| Duration | `54.90s` |
+| Artifact | `artifacts/eval/harnesses/tau2-bench/data/simulations/geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5/results.json` |
+
+Command:
+
+```bash
+uv run python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain mock \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 8 \
+  --timeout 900 \
+  --model gpt-5.5 \
+  --provider openai \
+  --source subscription \
+  --effort xhigh \
+  --time-budget-s 180 \
+  --user geode_user \
+  --user-llm gpt-5.5 \
+  --user-provider openai \
+  --user-source subscription \
+  --user-effort high \
+  --user-time-budget-s 120 \
+  --save-to geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5 \
+  --log-level INFO \
+  --verbose-logs
+```
+
+Adapter calibration notes:
+
+- r1 exposed GEODE default tools (`grep_files`) to the tau2 agent surface.
+- r2 restricted visible tools to tau2 domain tools.
+- r3 projected GEODE internal tool logs back to tau2 `ToolCall` messages.
+- r4 made mutating tools dry-run inside GEODE so tau2 orchestrator applies the
+  official state mutation exactly once.
+- r5 stripped empty optional arguments before projection, matching tau2's
+  action comparator exactly.
+
+Comparability:
+
+- This is a GEODE-owned subscription-only smoke, not a tau2 leaderboard score.
+- It should not be averaged with native tau2 `user_simulator` runs using
+  `gpt-4.1` or `gpt-5.2`.
+- It proves the full tau2 cycle wiring: GEODE agent route, GEODE user route,
+  tau2 tool projection, tau2 DB diff, artifact preservation, and docs
+  publication.
 
 ## 참고
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -538,8 +538,18 @@ module = [
     "pixelmatch.*",
     # P4 D 단계 — [reason] optional extra (DSPy).
     "dspy.*",
+    # tau2-bench harness lives under artifacts/eval/harnesses and is opt-in.
+    # CI default sync does not install tau2 or its untyped in-tree modules.
+    "tau2.*",
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# tau2's runtime base classes are imported from the external harness checkout
+# and do not ship stubs in GEODE's default CI environment. Keep the relaxation
+# scoped to this opt-in runner instead of disabling checks for scripts/eval.
+module = ["scripts.eval.tau2_geode_agent"]
+disallow_subclassing_any = false
 
 [[tool.mypy.overrides]]
 # Manim visualization scripts subclass Scene (Any) and use literal lists /

--- a/scripts/eval/tau2_geode_agent.py
+++ b/scripts/eval/tau2_geode_agent.py
@@ -19,6 +19,7 @@ import json
 import site
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -248,9 +249,12 @@ def _usage_dict(result: Any) -> dict[str, Any] | None:
         return None
     to_dict = getattr(result_usage, "to_dict", None)
     if callable(to_dict):
-        return to_dict()
+        maybe_dict = to_dict()
+        if isinstance(maybe_dict, Mapping):
+            return {str(key): value for key, value in maybe_dict.items()}
+        return None
     raw = getattr(result_usage, "__dict__", None)
-    return dict(raw) if isinstance(raw, dict) else None
+    return {str(key): value for key, value in raw.items()} if isinstance(raw, dict) else None
 
 
 def _tau2_tool_calls(result: Any, *, requestor: str) -> list[Any]:

--- a/scripts/eval/tau2_geode_agent.py
+++ b/scripts/eval/tau2_geode_agent.py
@@ -2,12 +2,13 @@
 """Run tau2 with GEODE as the agent under test.
 
 This script intentionally does not patch the upstream tau2 checkout. It imports
-the harness from ``--harness-dir``, registers a ``geode_agent`` factory in
-tau2's in-process registry, and then calls ``tau2.run.run_domain``.
+the harness from ``--harness-dir``, registers ``geode_agent`` and
+``geode_user`` implementations in tau2's in-process registry, and then calls
+``tau2.run.run_domain``.
 
 The resulting run still uses tau2's native simulator, domain tools, world-state
-diff evaluator, and output directory layout. Only the assistant side is routed
-through GEODE's AgenticLoop.
+diff evaluator, and output directory layout. The default route sends both the
+assistant and simulated user through GEODE's subscription-backed AgenticLoop.
 """
 
 from __future__ import annotations
@@ -92,6 +93,7 @@ class Tau2GeodeTool:
     """GEODE tool wrapper around a tau2 environment tool."""
 
     tau2_tool: Any
+    mutates_state: bool = True
 
     @property
     def name(self) -> str:
@@ -107,6 +109,14 @@ class Tau2GeodeTool:
 
     async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
         kwargs.pop("_tool_context", None)
+        if self.mutates_state:
+            return {
+                "result": (
+                    f"Recorded {self.name} for tau2 orchestrator execution. "
+                    "The official tau2 environment will apply this tool call."
+                ),
+                "projected_to_tau2": True,
+            }
         raw = await asyncio.to_thread(self.tau2_tool, **kwargs)
         return {"result": _jsonish(raw)}
 
@@ -117,18 +127,50 @@ class GeodeTau2State:
     messages_seen: int = 0
 
 
-def _message_to_prompt(message: Any) -> str:
+def _message_to_prompt(message: Any, *, recipient: str) -> str:
     role = str(getattr(message, "role", "user") or "user")
+    tool_messages = getattr(message, "tool_messages", None)
+    if tool_messages:
+        payload = [
+            {
+                "id": getattr(tool_message, "id", ""),
+                "requestor": getattr(tool_message, "requestor", ""),
+                "content": getattr(tool_message, "content", ""),
+                "error": getattr(tool_message, "error", False),
+            }
+            for tool_message in tool_messages
+        ]
+        return f"Tool results to {recipient} from tau2 orchestrator:\n{_jsonish(payload)}"
     content = str(getattr(message, "content", "") or "").strip()
     if content:
-        return content
+        if role == "tool":
+            return f"Tool result to {recipient} from tau2 orchestrator:\n{content}"
+        return f"Message to {recipient} from {role}:\n{content}"
     tool_calls = getattr(message, "tool_calls", None)
     if tool_calls:
-        return f"[{role} tool calls]\n{_jsonish([tc.model_dump() for tc in tool_calls])}"
-    return f"[{role} sent an empty message]"
+        return (
+            f"Message to {recipient} from {role} containing tool calls:\n"
+            f"{_jsonish([tc.model_dump() for tc in tool_calls])}"
+        )
+    return f"Message to {recipient} from {role}: [empty]"
 
 
-def _build_system_prompt(domain_policy: str) -> str:
+def _tool_mutates_state(tool_name: str) -> bool:
+    non_mutating_prefixes = (
+        "get_",
+        "list_",
+        "search_",
+        "find_",
+        "lookup_",
+        "read_",
+        "check_",
+        "validate_",
+    )
+    non_mutating_exact = {"transfer_to_human_agents"}
+    return not (tool_name in non_mutating_exact or tool_name.startswith(non_mutating_prefixes))
+
+
+def _agent_system_prompt(domain_policy: str) -> str:
     return (
         "You are the GEODE agent running inside tau2-bench.\n"
         "Follow the domain policy exactly. Use the provided tools to change the "
@@ -140,50 +182,139 @@ def _build_system_prompt(domain_policy: str) -> str:
     )
 
 
-def register_geode_agent(
+def _user_system_prompt(instructions: str | None, *, use_tools: bool) -> str:
+    from tau2.user.user_simulator import get_global_user_sim_guidelines
+
+    guidelines = get_global_user_sim_guidelines(use_tools=use_tools)
+    return (
+        "You are the simulated tau2 benchmark user running through GEODE.\n"
+        "You are NOT the assistant. You are the customer/user in the scenario.\n"
+        "Follow the scenario and simulator guidelines exactly. If the task is "
+        "complete or the conversation should end, use tau2's required stop token "
+        "when the guidelines call for it.\n\n"
+        f"{guidelines}\n\n"
+        "<scenario>\n"
+        f"{instructions or ''}\n"
+        "</scenario>"
+    )
+
+
+def _build_loop(
     *,
+    tools: list[Any] | None,
+    system_prompt: str,
     model: str,
     provider: str,
     source: str,
     effort: str,
     time_budget_s: float,
     max_tokens: int,
-) -> None:
+) -> Any:
     from core.agent.conversation import ConversationContext
     from core.agent.loop import AgenticLoop
     from core.agent.tool_executor import ToolExecutor
-    from core.llm.adapters.registry import bootstrap_builtins
     from core.tools.registry import ToolRegistry
+
+    tool_registry = ToolRegistry()
+    handlers: dict[str, Any] = {}
+    for tau2_tool in tools or []:
+        wrapped = Tau2GeodeTool(tau2_tool, mutates_state=_tool_mutates_state(str(tau2_tool.name)))
+        tool_registry.register(wrapped)
+        handlers[wrapped.name] = wrapped.aexecute
+
+    executor = ToolExecutor(action_handlers=handlers, auto_approve=True, hitl_level=0)
+    allowed_tool_names = set(handlers)
+    return AgenticLoop(
+        ConversationContext(max_turns=200),
+        executor,
+        model=model,
+        provider=provider,
+        source=source,
+        effort=effort,
+        max_tokens=max_tokens,
+        max_rounds=0,
+        time_budget_s=time_budget_s,
+        tool_registry=tool_registry,
+        allowed_tool_names=allowed_tool_names,
+        system_prompt_override=system_prompt,
+        quiet=True,
+        enable_goal_decomposition=False,
+    )
+
+
+def _usage_dict(result: Any) -> dict[str, Any] | None:
+    result_usage = getattr(result, "usage", None)
+    if result_usage is None:
+        return None
+    to_dict = getattr(result_usage, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+    raw = getattr(result_usage, "__dict__", None)
+    return dict(raw) if isinstance(raw, dict) else None
+
+
+def _tau2_tool_calls(result: Any, *, requestor: str) -> list[Any]:
+    from tau2.data_model.message import ToolCall
+
+    calls = []
+    for idx, entry in enumerate(getattr(result, "tool_calls", []) or []):
+        if not isinstance(entry, dict):
+            continue
+        result_payload = entry.get("result")
+        if isinstance(result_payload, dict) and result_payload.get("error"):
+            continue
+        tool_name = str(entry.get("tool", "") or "")
+        tool_input = entry.get("input")
+        if not tool_name or not isinstance(tool_input, dict):
+            continue
+        projected_args = {
+            key: value for key, value in tool_input.items() if value is not None and value != ""
+        }
+        calls.append(
+            ToolCall(
+                id=str(entry.get("tool_use_id") or f"geode_{requestor}_{idx}"),
+                name=tool_name,
+                arguments=projected_args,
+                requestor=requestor,
+            )
+        )
+    return calls
+
+
+def register_geode_tau2_participants(
+    *,
+    agent_model: str,
+    agent_provider: str,
+    agent_source: str,
+    agent_effort: str,
+    agent_time_budget_s: float,
+    agent_max_tokens: int,
+    user_model: str,
+    user_provider: str,
+    user_source: str,
+    user_effort: str,
+    user_time_budget_s: float,
+    user_max_tokens: int,
+) -> None:
+    from core.llm.adapters.registry import bootstrap_builtins
     from tau2.agent.base_agent import HalfDuplexAgent
-    from tau2.data_model.message import AssistantMessage
+    from tau2.data_model.message import AssistantMessage, UserMessage
     from tau2.registry import registry
+    from tau2.user.user_simulator_base import HalfDuplexUser
 
     bootstrap_builtins()
 
     class GeodeTau2Agent(HalfDuplexAgent[GeodeTau2State]):
         def get_init_state(self, message_history: list[Any] | None = None) -> GeodeTau2State:
-            tool_registry = ToolRegistry()
-            handlers: dict[str, Any] = {}
-            for tau2_tool in self.tools:
-                wrapped = Tau2GeodeTool(tau2_tool)
-                tool_registry.register(wrapped)
-                handlers[wrapped.name] = wrapped.aexecute
-
-            executor = ToolExecutor(action_handlers=handlers, auto_approve=True, hitl_level=0)
-            loop = AgenticLoop(
-                ConversationContext(max_turns=200),
-                executor,
-                model=model,
-                provider=provider,
-                source=source,
-                effort=effort,
-                max_tokens=max_tokens,
-                max_rounds=0,
-                time_budget_s=time_budget_s,
-                tool_registry=tool_registry,
-                system_prompt_override=_build_system_prompt(self.domain_policy),
-                quiet=True,
-                enable_goal_decomposition=False,
+            loop = _build_loop(
+                tools=self.tools,
+                system_prompt=_agent_system_prompt(self.domain_policy),
+                model=agent_model,
+                provider=agent_provider,
+                source=agent_source,
+                effort=agent_effort,
+                time_budget_s=agent_time_budget_s,
+                max_tokens=agent_max_tokens,
             )
             state = GeodeTau2State(loop=loop)
             if message_history:
@@ -194,17 +325,27 @@ def register_geode_agent(
             self, message: Any, state: GeodeTau2State
         ) -> tuple[Any, GeodeTau2State]:
             started = time.monotonic()
-            prompt = _message_to_prompt(message)
+            prompt = _message_to_prompt(message, recipient="assistant agent")
             result = asyncio.run(state.loop.arun(prompt))
             state.messages_seen += 1
-            usage = None
-            result_usage = getattr(result, "usage", None)
-            if result_usage is not None:
-                to_dict = getattr(result_usage, "to_dict", None)
-                usage = to_dict() if callable(to_dict) else getattr(result_usage, "__dict__", None)
+            tool_calls = _tau2_tool_calls(result, requestor="assistant")
+            if tool_calls:
+                assistant = AssistantMessage(
+                    role="assistant",
+                    tool_calls=tool_calls,
+                    usage=_usage_dict(result),
+                    raw_data={
+                        "geode_rounds": getattr(result, "rounds", 0),
+                        "geode_termination_reason": getattr(result, "termination_reason", ""),
+                        "geode_tool_call_count": len(tool_calls),
+                        "geode_tool_projection": "tau2_orchestrator",
+                    },
+                    generation_time_seconds=time.monotonic() - started,
+                )
+                return assistant, state
             assistant = AssistantMessage.text(
                 _result_text(result),
-                usage=usage,
+                usage=_usage_dict(result),
                 raw_data={
                     "geode_rounds": getattr(result, "rounds", 0),
                     "geode_termination_reason": getattr(result, "termination_reason", ""),
@@ -214,10 +355,78 @@ def register_geode_agent(
             )
             return assistant, state
 
+        def set_seed(self, seed: int) -> None:
+            return None
+
     def create_geode_agent(tools: list[Any], domain_policy: str, **_: Any) -> Any:
         return GeodeTau2Agent(tools=tools, domain_policy=domain_policy)
 
+    class GeodeTau2User(HalfDuplexUser[GeodeTau2State]):
+        def __init__(
+            self,
+            instructions: str | None = None,
+            tools: list[Any] | None = None,
+            **_: Any,
+        ) -> None:
+            super().__init__(instructions=instructions, tools=tools)
+
+        def get_init_state(self, message_history: list[Any] | None = None) -> GeodeTau2State:
+            loop = _build_loop(
+                tools=self.tools,
+                system_prompt=_user_system_prompt(self.instructions, use_tools=bool(self.tools)),
+                model=user_model,
+                provider=user_provider,
+                source=user_source,
+                effort=user_effort,
+                time_budget_s=user_time_budget_s,
+                max_tokens=user_max_tokens,
+            )
+            state = GeodeTau2State(loop=loop)
+            if message_history:
+                state.messages_seen = len(message_history)
+            return state
+
+        def generate_next_message(
+            self, message: Any, state: GeodeTau2State
+        ) -> tuple[Any, GeodeTau2State]:
+            started = time.monotonic()
+            prompt = _message_to_prompt(message, recipient="simulated user")
+            result = asyncio.run(state.loop.arun(prompt))
+            state.messages_seen += 1
+            tool_calls = _tau2_tool_calls(result, requestor="user")
+            if tool_calls:
+                user_message = UserMessage(
+                    role="user",
+                    tool_calls=tool_calls,
+                    usage=_usage_dict(result),
+                    raw_data={
+                        "geode_role": "user_simulator",
+                        "geode_rounds": getattr(result, "rounds", 0),
+                        "geode_termination_reason": getattr(result, "termination_reason", ""),
+                        "geode_tool_call_count": len(tool_calls),
+                        "geode_tool_projection": "tau2_orchestrator",
+                    },
+                    generation_time_seconds=time.monotonic() - started,
+                )
+                return user_message, state
+            user_message = UserMessage.text(
+                _result_text(result),
+                usage=_usage_dict(result),
+                raw_data={
+                    "geode_role": "user_simulator",
+                    "geode_rounds": getattr(result, "rounds", 0),
+                    "geode_termination_reason": getattr(result, "termination_reason", ""),
+                    "geode_tool_call_count": len(getattr(result, "tool_calls", []) or []),
+                },
+                generation_time_seconds=time.monotonic() - started,
+            )
+            return user_message, state
+
+        def set_seed(self, seed: int) -> None:
+            return None
+
     registry.register_agent_factory(create_geode_agent, "geode_agent")
+    registry.register_user(GeodeTau2User, "geode_user")
 
 
 def parse_args() -> argparse.Namespace:
@@ -233,13 +442,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-steps", type=int, default=20)
     parser.add_argument("--timeout", type=float, default=None)
     parser.add_argument("--save-to", default=None)
-    parser.add_argument("--user", default="user_simulator")
-    parser.add_argument("--user-llm", default="gpt-4.1-2025-04-14")
+    parser.add_argument("--user", default="geode_user")
+    parser.add_argument("--user-llm", default="gpt-5.5")
     parser.add_argument("--user-llm-args", default='{"temperature": 0.0}')
     parser.add_argument("--model", default="gpt-5.5")
     parser.add_argument("--provider", default="openai")
     parser.add_argument("--source", default="subscription")
     parser.add_argument("--effort", default="xhigh")
+    parser.add_argument("--user-provider", default="openai")
+    parser.add_argument("--user-source", default="subscription")
+    parser.add_argument("--user-effort", default="high")
+    parser.add_argument("--user-time-budget-s", type=float, default=120.0)
+    parser.add_argument("--user-max-tokens", type=int, default=8192)
     parser.add_argument("--time-budget-s", type=float, default=180.0)
     parser.add_argument("--max-tokens", type=int, default=32768)
     parser.add_argument("--log-level", default="INFO")
@@ -255,13 +469,19 @@ def main() -> int:
     from tau2.data_model.simulation import TextRunConfig
     from tau2.run import run_domain
 
-    register_geode_agent(
-        model=args.model,
-        provider=args.provider,
-        source=args.source,
-        effort=args.effort,
-        time_budget_s=args.time_budget_s,
-        max_tokens=args.max_tokens,
+    register_geode_tau2_participants(
+        agent_model=args.model,
+        agent_provider=args.provider,
+        agent_source=args.source,
+        agent_effort=args.effort,
+        agent_time_budget_s=args.time_budget_s,
+        agent_max_tokens=args.max_tokens,
+        user_model=args.user_llm,
+        user_provider=args.user_provider,
+        user_source=args.user_source,
+        user_effort=args.user_effort,
+        user_time_budget_s=args.user_time_budget_s,
+        user_max_tokens=args.user_max_tokens,
     )
 
     config = TextRunConfig(

--- a/scripts/eval/tau2_geode_agent.py
+++ b/scripts/eval/tau2_geode_agent.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Run tau2 with GEODE as the agent under test.
+
+This script intentionally does not patch the upstream tau2 checkout. It imports
+the harness from ``--harness-dir``, registers a ``geode_agent`` factory in
+tau2's in-process registry, and then calls ``tau2.run.run_domain``.
+
+The resulting run still uses tau2's native simulator, domain tools, world-state
+diff evaluator, and output directory layout. Only the assistant side is routed
+through GEODE's AgenticLoop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import site
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_HARNESS_DIR = REPO_ROOT / "artifacts" / "eval" / "harnesses" / "tau2-bench"
+
+
+def _prepend_tau2_src(harness_dir: Path) -> None:
+    src_dir = harness_dir / "src"
+    if not src_dir.exists():
+        raise SystemExit(f"tau2 source directory not found: {src_dir}")
+    venv_dir = harness_dir / ".venv"
+    if venv_dir.exists():
+        for site_packages in site.getsitepackages([str(venv_dir)]):
+            site_path = Path(site_packages)
+            if site_path.exists():
+                sys.path.insert(0, str(site_path))
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(src_dir))
+
+
+def _result_text(result: Any) -> str:
+    text = str(getattr(result, "text", "") or "").strip()
+    if text:
+        return text
+    reason = str(getattr(result, "termination_reason", "") or "unknown")
+    return f"GEODE ended without user-visible text. termination_reason={reason}"
+
+
+def _tool_description(tool: Any) -> str:
+    schema = getattr(tool, "openai_schema", None)
+    if isinstance(schema, dict):
+        fn = schema.get("function")
+        if isinstance(fn, dict):
+            desc = fn.get("description")
+            if isinstance(desc, str) and desc.strip():
+                return desc.strip()
+    short = str(getattr(tool, "short_desc", "") or "").strip()
+    long = str(getattr(tool, "long_desc", "") or "").strip()
+    return "\n\n".join(part for part in (short, long) if part) or str(tool.name)
+
+
+def _tool_parameters(tool: Any) -> dict[str, Any]:
+    schema = getattr(tool, "openai_schema", None)
+    if isinstance(schema, dict):
+        fn = schema.get("function")
+        if isinstance(fn, dict):
+            params = fn.get("parameters")
+            if isinstance(params, dict):
+                return params
+    params_model = getattr(tool, "params", None)
+    model_json_schema = getattr(params_model, "model_json_schema", None)
+    if callable(model_json_schema):
+        maybe_schema = model_json_schema()
+        if isinstance(maybe_schema, dict):
+            return maybe_schema
+    return {"type": "object", "properties": {}, "additionalProperties": False}
+
+
+def _jsonish(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except TypeError:
+        return str(value)
+
+
+@dataclass
+class Tau2GeodeTool:
+    """GEODE tool wrapper around a tau2 environment tool."""
+
+    tau2_tool: Any
+
+    @property
+    def name(self) -> str:
+        return str(self.tau2_tool.name)
+
+    @property
+    def description(self) -> str:
+        return _tool_description(self.tau2_tool)
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return _tool_parameters(self.tau2_tool)
+
+    async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
+        kwargs.pop("_tool_context", None)
+        raw = await asyncio.to_thread(self.tau2_tool, **kwargs)
+        return {"result": _jsonish(raw)}
+
+
+@dataclass
+class GeodeTau2State:
+    loop: Any
+    messages_seen: int = 0
+
+
+def _message_to_prompt(message: Any) -> str:
+    role = str(getattr(message, "role", "user") or "user")
+    content = str(getattr(message, "content", "") or "").strip()
+    if content:
+        return content
+    tool_calls = getattr(message, "tool_calls", None)
+    if tool_calls:
+        return f"[{role} tool calls]\n{_jsonish([tc.model_dump() for tc in tool_calls])}"
+    return f"[{role} sent an empty message]"
+
+
+def _build_system_prompt(domain_policy: str) -> str:
+    return (
+        "You are the GEODE agent running inside tau2-bench.\n"
+        "Follow the domain policy exactly. Use the provided tools to change the "
+        "environment state when the user asks for an operation. Do not invent "
+        "tool results. When the task is complete, answer the user concisely.\n\n"
+        "<policy>\n"
+        f"{domain_policy}\n"
+        "</policy>"
+    )
+
+
+def register_geode_agent(
+    *,
+    model: str,
+    provider: str,
+    source: str,
+    effort: str,
+    time_budget_s: float,
+    max_tokens: int,
+) -> None:
+    from core.agent.conversation import ConversationContext
+    from core.agent.loop import AgenticLoop
+    from core.agent.tool_executor import ToolExecutor
+    from core.llm.adapters.registry import bootstrap_builtins
+    from core.tools.registry import ToolRegistry
+    from tau2.agent.base_agent import HalfDuplexAgent
+    from tau2.data_model.message import AssistantMessage
+    from tau2.registry import registry
+
+    bootstrap_builtins()
+
+    class GeodeTau2Agent(HalfDuplexAgent[GeodeTau2State]):
+        def get_init_state(self, message_history: list[Any] | None = None) -> GeodeTau2State:
+            tool_registry = ToolRegistry()
+            handlers: dict[str, Any] = {}
+            for tau2_tool in self.tools:
+                wrapped = Tau2GeodeTool(tau2_tool)
+                tool_registry.register(wrapped)
+                handlers[wrapped.name] = wrapped.aexecute
+
+            executor = ToolExecutor(action_handlers=handlers, auto_approve=True, hitl_level=0)
+            loop = AgenticLoop(
+                ConversationContext(max_turns=200),
+                executor,
+                model=model,
+                provider=provider,
+                source=source,
+                effort=effort,
+                max_tokens=max_tokens,
+                max_rounds=0,
+                time_budget_s=time_budget_s,
+                tool_registry=tool_registry,
+                system_prompt_override=_build_system_prompt(self.domain_policy),
+                quiet=True,
+                enable_goal_decomposition=False,
+            )
+            state = GeodeTau2State(loop=loop)
+            if message_history:
+                state.messages_seen = len(message_history)
+            return state
+
+        def generate_next_message(
+            self, message: Any, state: GeodeTau2State
+        ) -> tuple[Any, GeodeTau2State]:
+            started = time.monotonic()
+            prompt = _message_to_prompt(message)
+            result = asyncio.run(state.loop.arun(prompt))
+            state.messages_seen += 1
+            usage = None
+            result_usage = getattr(result, "usage", None)
+            if result_usage is not None:
+                to_dict = getattr(result_usage, "to_dict", None)
+                usage = to_dict() if callable(to_dict) else getattr(result_usage, "__dict__", None)
+            assistant = AssistantMessage.text(
+                _result_text(result),
+                usage=usage,
+                raw_data={
+                    "geode_rounds": getattr(result, "rounds", 0),
+                    "geode_termination_reason": getattr(result, "termination_reason", ""),
+                    "geode_tool_call_count": len(getattr(result, "tool_calls", []) or []),
+                },
+                generation_time_seconds=time.monotonic() - started,
+            )
+            return assistant, state
+
+    def create_geode_agent(tools: list[Any], domain_policy: str, **_: Any) -> Any:
+        return GeodeTau2Agent(tools=tools, domain_policy=domain_policy)
+
+    registry.register_agent_factory(create_geode_agent, "geode_agent")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--harness-dir", type=Path, default=DEFAULT_HARNESS_DIR)
+    parser.add_argument("--domain", default="mock")
+    parser.add_argument("--task-set-name", default=None)
+    parser.add_argument("--task-split-name", default="base")
+    parser.add_argument("--task-ids", nargs="*", default=None)
+    parser.add_argument("--num-tasks", type=int, default=1)
+    parser.add_argument("--num-trials", type=int, default=1)
+    parser.add_argument("--max-concurrency", type=int, default=1)
+    parser.add_argument("--max-steps", type=int, default=20)
+    parser.add_argument("--timeout", type=float, default=None)
+    parser.add_argument("--save-to", default=None)
+    parser.add_argument("--user", default="user_simulator")
+    parser.add_argument("--user-llm", default="gpt-4.1-2025-04-14")
+    parser.add_argument("--user-llm-args", default='{"temperature": 0.0}')
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--provider", default="openai")
+    parser.add_argument("--source", default="subscription")
+    parser.add_argument("--effort", default="xhigh")
+    parser.add_argument("--time-budget-s", type=float, default=180.0)
+    parser.add_argument("--max-tokens", type=int, default=32768)
+    parser.add_argument("--log-level", default="INFO")
+    parser.add_argument("--auto-resume", action="store_true")
+    parser.add_argument("--verbose-logs", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    _prepend_tau2_src(args.harness_dir.resolve())
+
+    from tau2.data_model.simulation import TextRunConfig
+    from tau2.run import run_domain
+
+    register_geode_agent(
+        model=args.model,
+        provider=args.provider,
+        source=args.source,
+        effort=args.effort,
+        time_budget_s=args.time_budget_s,
+        max_tokens=args.max_tokens,
+    )
+
+    config = TextRunConfig(
+        domain=args.domain,
+        agent="geode_agent",
+        user=args.user,
+        llm_agent=args.model,
+        llm_args_agent={"reasoning_effort": args.effort},
+        llm_user=args.user_llm,
+        llm_args_user=json.loads(args.user_llm_args),
+        task_set_name=args.task_set_name,
+        task_split_name=args.task_split_name,
+        task_ids=args.task_ids,
+        num_tasks=args.num_tasks,
+        num_trials=args.num_trials,
+        max_concurrency=args.max_concurrency,
+        max_steps=args.max_steps,
+        timeout=args.timeout,
+        save_to=args.save_to,
+        log_level=args.log_level,
+        auto_resume=args.auto_resume,
+        verbose_logs=args.verbose_logs,
+    )
+    run_domain(config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/app/docs/benchmarks/queue/page.tsx
+++ b/site/src/app/docs/benchmarks/queue/page.tsx
@@ -40,8 +40,8 @@ export default function Page() {
                 <tr>
                   <td>2</td>
                   <td>τ²-bench</td>
-                  <td><code>mock</code> smoke, then Telecom small runs with separate <code>gpt-4.1</code> and <code>gpt-5.2</code> user simulators</td>
-                  <td>domain split, user simulator, trial 수를 result page에 명시</td>
+                  <td><code>mock</code> smoke with <code>geode_agent</code> + <code>geode_user</code> over subscription, then Telecom small run</td>
+                  <td>domain split, user route, trial 수를 result page에 명시</td>
                 </tr>
                 <tr>
                   <td>3</td>
@@ -75,7 +75,8 @@ export default function Page() {
               <li>각 benchmark는 <code>Benchmark publishing cycle</code>을 하나씩 통과합니다.</li>
               <li>τ²-bench는 사용자 지시에 따라 BFCL V4보다 먼저 진행합니다.</li>
               <li>Live run은 model route, subscription/API 구분, user simulator를 결과에 남깁니다.</li>
-              <li>τ²-bench의 <code>gpt-4.1</code> user run과 <code>gpt-5.2</code> user run은 별도 비교군으로 보관합니다.</li>
+              <li>τ²-bench의 기본 run은 agent와 user 모두 GEODE subscription route로 실행합니다.</li>
+              <li>native tau2 <code>gpt-4.1</code>/<code>gpt-5.2</code> user simulator run은 별도 비교군으로 보관합니다.</li>
               <li>공개 점수는 verifier-backed artifact가 있는 경우에만 추가합니다.</li>
             </ul>
 
@@ -115,8 +116,8 @@ export default function Page() {
                 <tr>
                   <td>2</td>
                   <td>τ²-bench</td>
-                  <td><code>mock</code> smoke, then Telecom small runs with separate <code>gpt-4.1</code> and <code>gpt-5.2</code> user simulators</td>
-                  <td>Domain split, user simulator, and trial count published</td>
+                  <td><code>mock</code> smoke with <code>geode_agent</code> + <code>geode_user</code> over subscription, then Telecom small run</td>
+                  <td>Domain split, user route, and trial count published</td>
                 </tr>
                 <tr>
                   <td>3</td>
@@ -150,7 +151,8 @@ export default function Page() {
               <li>Each benchmark passes through one <code>Benchmark publishing cycle</code>.</li>
               <li>τ²-bench runs before BFCL V4 by operator priority.</li>
               <li>Live runs record model route, subscription/API source, and user simulator.</li>
-              <li>τ²-bench <code>gpt-4.1</code> user runs and <code>gpt-5.2</code> user runs stay in separate comparator groups.</li>
+              <li>τ²-bench defaults to GEODE subscription route for both agent and user.</li>
+              <li>Native tau2 <code>gpt-4.1</code>/<code>gpt-5.2</code> user simulator runs stay in separate comparator groups.</li>
               <li>Public scores are added only when backed by verifier artifacts.</li>
             </ul>
 

--- a/site/src/app/docs/benchmarks/queue/page.tsx
+++ b/site/src/app/docs/benchmarks/queue/page.tsx
@@ -1,0 +1,166 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Benchmark queue — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="benchmarks/queue"
+      title="Benchmark queue"
+      titleKo="Benchmark queue"
+      summary="The current GEODE benchmark execution order after the MCPMark filesystem/easy baseline."
+      summaryKo="MCPMark filesystem/easy baseline 이후의 현재 GEODE benchmark 실행 순서입니다."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              이 큐는 GEODE benchmark를 한 번에 섞어 평균내지 않기 위한 운영
+              순서입니다. 각 항목은 별도 harness revision, model route, artifact
+              path, 비교 가능성 판정을 가진 독립 run record로 공개합니다.
+            </p>
+
+            <h2>현재 순서</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>순위</th>
+                  <th>Benchmark</th>
+                  <th>첫 목표</th>
+                  <th>완료 기준</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>MCPMark Verified</td>
+                  <td><code>easy</code> across available MCPs, then Verified filesystem slice</td>
+                  <td>GEODE adapter로 verifier-backed result 생성</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>τ²-bench</td>
+                  <td><code>mock</code> smoke, then Telecom small runs with separate <code>gpt-4.1</code> and <code>gpt-5.2</code> user simulators</td>
+                  <td>domain split, user simulator, trial 수를 result page에 명시</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td>BFCL V4</td>
+                  <td>Agentic subset first</td>
+                  <td>function-calling route와 aggregation을 고정</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>HAL Reliability</td>
+                  <td>tau-bench airline single-rerun smoke</td>
+                  <td>rerun consistency schema 확인</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Terminal-Bench 2.0</td>
+                  <td>1-task Docker/tmux smoke</td>
+                  <td>post-run test artifact와 shell transcript 보존</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>Toolathlon</td>
+                  <td>credential-free or lowest-credential smoke</td>
+                  <td>MCP app surface, turn cap, credential caveats 기록</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>진행 규칙</h2>
+            <ul>
+              <li>각 benchmark는 <code>Benchmark publishing cycle</code>을 하나씩 통과합니다.</li>
+              <li>τ²-bench는 사용자 지시에 따라 BFCL V4보다 먼저 진행합니다.</li>
+              <li>Live run은 model route, subscription/API 구분, user simulator를 결과에 남깁니다.</li>
+              <li>τ²-bench의 <code>gpt-4.1</code> user run과 <code>gpt-5.2</code> user run은 별도 비교군으로 보관합니다.</li>
+              <li>공개 점수는 verifier-backed artifact가 있는 경우에만 추가합니다.</li>
+            </ul>
+
+            <p className="text-[var(--ink-3)] text-sm">
+              내부 큐는 <code>docs/eval/README.md</code>와{" "}
+              <code>docs/eval/frontier-agentic-tool-use-benchmark-cases.md</code>에
+              기록됩니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <p>
+              This queue keeps GEODE benchmark publication sequential instead of
+              mixing unrelated scores into one average. Each item gets its own
+              harness revision, model route, artifact path, and comparability
+              decision.
+            </p>
+
+            <h2>Current order</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Rank</th>
+                  <th>Benchmark</th>
+                  <th>First target</th>
+                  <th>Exit criterion</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>MCPMark Verified</td>
+                  <td><code>easy</code> across available MCPs, then Verified filesystem slice</td>
+                  <td>Verifier-backed result through the GEODE adapter</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>τ²-bench</td>
+                  <td><code>mock</code> smoke, then Telecom small runs with separate <code>gpt-4.1</code> and <code>gpt-5.2</code> user simulators</td>
+                  <td>Domain split, user simulator, and trial count published</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td>BFCL V4</td>
+                  <td>Agentic subset first</td>
+                  <td>Function-calling route and aggregation pinned</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>HAL Reliability</td>
+                  <td>tau-bench airline single-rerun smoke</td>
+                  <td>Rerun consistency schema validated</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Terminal-Bench 2.0</td>
+                  <td>1-task Docker/tmux smoke</td>
+                  <td>Post-run test artifact and shell transcript preserved</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>Toolathlon</td>
+                  <td>credential-free or lowest-credential smoke</td>
+                  <td>MCP app surface, turn cap, and credential caveats recorded</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Rules</h2>
+            <ul>
+              <li>Each benchmark passes through one <code>Benchmark publishing cycle</code>.</li>
+              <li>τ²-bench runs before BFCL V4 by operator priority.</li>
+              <li>Live runs record model route, subscription/API source, and user simulator.</li>
+              <li>τ²-bench <code>gpt-4.1</code> user runs and <code>gpt-5.2</code> user runs stay in separate comparator groups.</li>
+              <li>Public scores are added only when backed by verifier artifacts.</li>
+            </ul>
+
+            <p className="text-[var(--ink-3)] text-sm">
+              The internal queue is tracked in <code>docs/eval/README.md</code>{" "}
+              and <code>docs/eval/frontier-agentic-tool-use-benchmark-cases.md</code>.
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/benchmarks/tau2/mock-smoke/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/mock-smoke/page.tsx
@@ -1,0 +1,162 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "tau2 mock smoke — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="benchmarks/tau2/mock-smoke"
+      title="tau2: mock smoke"
+      titleKo="tau2: mock smoke"
+      summary="Verifier-backed tau2 mock smoke run with GEODE as both agent and simulated user through the subscription route."
+      summaryKo="GEODE가 agent와 simulated user 양쪽을 subscription route로 실행한 tau2 mock smoke verifier-backed 기록입니다."
+    >
+      <Bi
+        ko={
+          <>
+            <h2>결과 요약</h2>
+            <p>
+              이 페이지는 tau2-bench의 <code>mock</code> domain 1-task smoke를
+              GEODE subscription-only 경로로 실행한 첫 공식 run record입니다.
+              측정 대상은 <code>geode_agent</code>와 <code>geode_user</code>가
+              모두 <code>gpt-5.5</code> subscription route를 사용하는 구성입니다.
+            </p>
+            <table>
+              <tbody>
+                <tr><td>Benchmark</td><td>tau2-bench</td></tr>
+                <tr><td>Domain / task</td><td><code>mock</code> / <code>create_task_1</code></td></tr>
+                <tr><td>Run date</td><td>2026-07-03</td></tr>
+                <tr><td>Harness revision</td><td><code>sierra-research/tau2-bench@1901a30</code>, <code>tau2==1.0.0</code></td></tr>
+                <tr><td>Agent route</td><td><code>geode_agent</code>, <code>gpt-5.5</code>, source <code>subscription</code>, effort <code>xhigh</code></td></tr>
+                <tr><td>User route</td><td><code>geode_user</code>, <code>gpt-5.5</code>, source <code>subscription</code>, effort <code>high</code></td></tr>
+                <tr><td>Trials / tasks</td><td>1 / 1</td></tr>
+                <tr><td>Reward</td><td><strong>1.0000</strong></td></tr>
+                <tr><td>Pass^1</td><td><strong>1.000</strong></td></tr>
+                <tr><td>DB check</td><td>1.0</td></tr>
+                <tr><td>Action check</td><td><code>create_task</code> write action 1.0</td></tr>
+                <tr><td>Termination</td><td><code>user_stop</code></td></tr>
+                <tr><td>Duration</td><td>54.90s</td></tr>
+              </tbody>
+            </table>
+
+            <h2>실행 명령</h2>
+            <pre><code>{`uv run python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain mock \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 8 \\
+  --timeout 900 \\
+  --model gpt-5.5 \\
+  --provider openai \\
+  --source subscription \\
+  --effort xhigh \\
+  --time-budget-s 180 \\
+  --user geode_user \\
+  --user-llm gpt-5.5 \\
+  --user-provider openai \\
+  --user-source subscription \\
+  --user-effort high \\
+  --user-time-budget-s 120 \\
+  --save-to geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5 \\
+  --log-level INFO \\
+  --verbose-logs`}</code></pre>
+
+            <h2>Artifact</h2>
+            <p>
+              Raw result:
+              <br />
+              <code>artifacts/eval/harnesses/tau2-bench/data/simulations/geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5/results.json</code>
+            </p>
+
+            <h2>비교 가능성</h2>
+            <p>
+              이 수치는 tau2 leaderboard 점수가 아닙니다. <code>mock</code> 1-task
+              smoke는 GEODE와 tau2 harness의 연결, subscription-backed user,
+              tool projection, DB diff verifier가 동작하는지 보는 regression
+              baseline입니다.
+            </p>
+            <ul>
+              <li>native tau2 <code>user_simulator</code> + <code>gpt-4.1</code> run과 평균내지 않습니다.</li>
+              <li>native tau2 <code>user_simulator</code> + <code>gpt-5.2</code> leaderboard-compatible run과 평균내지 않습니다.</li>
+              <li>다음 실측은 같은 adapter로 Telecom small run을 별도 페이지에 기록합니다.</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>Result Summary</h2>
+            <p>
+              This is GEODE&apos;s first official run record for a tau2-bench
+              <code>mock</code> domain smoke using a subscription-only route.
+              Both <code>geode_agent</code> and <code>geode_user</code> run
+              through GEODE&apos;s <code>gpt-5.5</code> subscription path.
+            </p>
+            <table>
+              <tbody>
+                <tr><td>Benchmark</td><td>tau2-bench</td></tr>
+                <tr><td>Domain / task</td><td><code>mock</code> / <code>create_task_1</code></td></tr>
+                <tr><td>Run date</td><td>2026-07-03</td></tr>
+                <tr><td>Harness revision</td><td><code>sierra-research/tau2-bench@1901a30</code>, <code>tau2==1.0.0</code></td></tr>
+                <tr><td>Agent route</td><td><code>geode_agent</code>, <code>gpt-5.5</code>, source <code>subscription</code>, effort <code>xhigh</code></td></tr>
+                <tr><td>User route</td><td><code>geode_user</code>, <code>gpt-5.5</code>, source <code>subscription</code>, effort <code>high</code></td></tr>
+                <tr><td>Trials / tasks</td><td>1 / 1</td></tr>
+                <tr><td>Reward</td><td><strong>1.0000</strong></td></tr>
+                <tr><td>Pass^1</td><td><strong>1.000</strong></td></tr>
+                <tr><td>DB check</td><td>1.0</td></tr>
+                <tr><td>Action check</td><td><code>create_task</code> write action 1.0</td></tr>
+                <tr><td>Termination</td><td><code>user_stop</code></td></tr>
+                <tr><td>Duration</td><td>54.90s</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Command</h2>
+            <pre><code>{`uv run python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain mock \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 8 \\
+  --timeout 900 \\
+  --model gpt-5.5 \\
+  --provider openai \\
+  --source subscription \\
+  --effort xhigh \\
+  --time-budget-s 180 \\
+  --user geode_user \\
+  --user-llm gpt-5.5 \\
+  --user-provider openai \\
+  --user-source subscription \\
+  --user-effort high \\
+  --user-time-budget-s 120 \\
+  --save-to geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5 \\
+  --log-level INFO \\
+  --verbose-logs`}</code></pre>
+
+            <h2>Artifact</h2>
+            <p>
+              Raw result:
+              <br />
+              <code>artifacts/eval/harnesses/tau2-bench/data/simulations/geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5/results.json</code>
+            </p>
+
+            <h2>Comparability</h2>
+            <p>
+              This is not a tau2 leaderboard score. The <code>mock</code>
+              one-task smoke is a regression baseline for GEODE/tau2 harness
+              wiring, subscription-backed user simulation, tool projection, and
+              the DB diff verifier.
+            </p>
+            <ul>
+              <li>Do not average it with native tau2 <code>user_simulator</code> + <code>gpt-4.1</code> runs.</li>
+              <li>Do not average it with native tau2 <code>user_simulator</code> + <code>gpt-5.2</code> leaderboard-compatible runs.</li>
+              <li>The next measured step is a Telecom small run through the same adapter, recorded on a separate page.</li>
+            </ul>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -133,6 +133,7 @@ export const DOCS_SITEMAP: DocSection[] = [
       { slug: "benchmarks/publishing-cycle", title: "Benchmark publishing cycle", titleKo: "Benchmark publishing cycle", summary: "Repeatable runbook for measuring GEODE, recording the evidence ledger, publishing official docs, and verifying GitHub Pages.", summaryKo: "GEODE 측정, evidence ledger 기록, 공식문서 배포, GitHub Pages 검증을 하나로 묶은 반복 runbook입니다.", quadrant: "how-to" },
       { slug: "benchmarks/queue", title: "Benchmark queue", titleKo: "Benchmark queue", summary: "Current GEODE benchmark execution order: MCPMark Verified, tau2-bench, BFCL V4, then roadmap benchmarks.", summaryKo: "현재 GEODE benchmark 실행 순서입니다. MCPMark Verified, tau2-bench, BFCL V4 이후 로드맵 benchmark로 진행합니다.", quadrant: "how-to" },
       { slug: "benchmarks/mcpmark/filesystem-easy", title: "MCPMark: filesystem/easy", titleKo: "MCPMark: filesystem/easy", summary: "Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.", summaryKo: "MCPMark filesystem easy 하위 suite에 대한 GEODE verifier-backed 실측 기록입니다. run spec, 산출물, task별 점수, EOF offload 기록을 포함합니다.", quadrant: "reference" },
+      { slug: "benchmarks/tau2/mock-smoke", title: "tau2: mock smoke", titleKo: "tau2: mock smoke", summary: "Verifier-backed tau2 mock smoke run with GEODE as both agent and simulated user through the subscription route.", summaryKo: "GEODE가 agent와 simulated user 양쪽을 subscription route로 실행한 tau2 mock smoke verifier-backed 기록입니다.", quadrant: "reference" },
     ],
   },
   {

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -131,6 +131,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     titleKo: "벤치마크",
     pages: [
       { slug: "benchmarks/publishing-cycle", title: "Benchmark publishing cycle", titleKo: "Benchmark publishing cycle", summary: "Repeatable runbook for measuring GEODE, recording the evidence ledger, publishing official docs, and verifying GitHub Pages.", summaryKo: "GEODE 측정, evidence ledger 기록, 공식문서 배포, GitHub Pages 검증을 하나로 묶은 반복 runbook입니다.", quadrant: "how-to" },
+      { slug: "benchmarks/queue", title: "Benchmark queue", titleKo: "Benchmark queue", summary: "Current GEODE benchmark execution order: MCPMark Verified, tau2-bench, BFCL V4, then roadmap benchmarks.", summaryKo: "현재 GEODE benchmark 실행 순서입니다. MCPMark Verified, tau2-bench, BFCL V4 이후 로드맵 benchmark로 진행합니다.", quadrant: "how-to" },
       { slug: "benchmarks/mcpmark/filesystem-easy", title: "MCPMark: filesystem/easy", titleKo: "MCPMark: filesystem/easy", summary: "Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.", summaryKo: "MCPMark filesystem easy 하위 suite에 대한 GEODE verifier-backed 실측 기록입니다. run spec, 산출물, task별 점수, EOF offload 기록을 포함합니다.", quadrant: "reference" },
     ],
   },


### PR DESCRIPTION
## Summary
- Adds a GEODE tau2 runner that registers both `geode_agent` and `geode_user` inside the upstream tau2 harness.
- Promotes tau2-bench to benchmark priority #2 after MCPMark, with subscription-only GEODE routing as the default first pass.
- Records the 2026-07-03 tau2 `mock` smoke result in eval docs and the public docs sitemap/page.

## Why
GEODE needs the benchmark cycle to run MCPMark first, then tau2-bench, while preserving the official tau2 evaluator/output path. The previous runner shape only covered the assistant side and still depended on native tau2/LiteLLM user simulator credentials. This update lets the agent and simulated user both run through GEODE subscription routing for the first GEODE-owned tau2 cycle.

## Changes
| File | Change |
|------|--------|
| `scripts/eval/tau2_geode_agent.py` | Registers `geode_agent` and `geode_user`; wraps tau2 tools in GEODE; restricts the visible tool surface to tau2 domain tools; projects GEODE tool calls back into tau2; dry-runs mutating tools inside GEODE so the tau2 orchestrator applies official state changes once; defaults the user route to `source=subscription`. |
| `pyproject.toml` | Treats `tau2.*` as an opt-in harness dependency for default CI and scopes the untyped external base-class relaxation to the tau2 runner. |
| `docs/eval/tau2-bench.md` | Adds the subscription-only mock smoke run record, command, artifact path, calibration notes, and comparability caveats. |
| `docs/eval/README.md` / `docs/eval/frontier-agentic-tool-use-benchmark-cases.md` | Updates the benchmark queue so tau2 is second after MCPMark, with native tau2 user-simulator runs kept as separate comparators. |
| `site/src/app/docs/benchmarks/queue/page.tsx` | Reflects the updated public queue and tau2 user-route policy. |
| `site/src/app/docs/benchmarks/tau2/mock-smoke/page.tsx` | Adds the public official-docs record for the tau2 mock smoke result. |
| `site/src/lib/geode-docs/sitemap.ts` | Adds the tau2 mock smoke page to the docs sitemap. |
| `CHANGELOG.md` | Notes the functional tau2 runner capability. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| tau2 runner | Assistant-side GEODE adapter only | Agent and simulated user both support GEODE subscription routing |
| tau2 auth path | Native user simulator still required LiteLLM credentials for user side | First GEODE-owned route can run without LiteLLM user credentials |
| Tool execution | GEODE internal tool logs were not enough for tau2 action scoring | Tool calls are projected back to tau2 and official mutating actions are applied by tau2 once |
| Public docs | Queue listed tau2 priority but no tau2 run record | Queue plus `mock` smoke result page are published in docs |

## Live Result
- Run ID: `geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5`
- Harness: `sierra-research/tau2-bench@1901a30`, `tau2==1.0.0`
- Domain/task: `mock` / `create_task_1`, `num_tasks=1`, `num_trials=1`
- Agent: `geode_agent`, `gpt-5.5`, provider `openai`, source `subscription`, effort `xhigh`
- User: `geode_user`, `gpt-5.5`, provider `openai`, source `subscription`, effort `high`
- Result: `1 / 1`, reward `1.0`, pass^1 `1.000`
- Checks: DB check `1.0`; `create_task` write action check `1.0`; termination `user_stop`; duration `54.90s`
- Artifact: `artifacts/eval/harnesses/tau2-bench/data/simulations/geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5/results.json`

## Verification
- `uv run python scripts/eval/tau2_geode_agent.py --harness-dir artifacts/eval/harnesses/tau2-bench --domain mock --num-tasks 1 --num-trials 1 --max-concurrency 1 --max-steps 8 --timeout 900 --model gpt-5.5 --provider openai --source subscription --effort xhigh --time-budget-s 180 --user geode_user --user-llm gpt-5.5 --user-provider openai --user-source subscription --user-effort high --user-time-budget-s 120 --save-to geode-gpt-5-5-xhigh-geode-user-mock-smoke-20260703-r5 --log-level INFO --verbose-logs`
- `uv run mypy core/ plugins/ scripts/`
- `uv run ruff check scripts/eval/tau2_geode_agent.py`
- `uv run ruff format --check scripts/eval/tau2_geode_agent.py`
- `scripts/lint_pages_markdown.sh`
- `npx eslint src/app/docs/benchmarks/queue/page.tsx src/app/docs/benchmarks/tau2/mock-smoke/page.tsx src/lib/geode-docs/sitemap.ts`
- `git diff --check`
- `cd site && npm run build` (passes; existing Petri seed broad file-pattern warnings remain)

## Comparability Notes
- The tau2 `mock` smoke result is a GEODE wiring/regression baseline, not a tau2 leaderboard score.
- Do not average this subscription-only score with native tau2 `user_simulator` runs using `gpt-4.1` or `gpt-5.2`.
