### PR TITLE
Promote CLI live task surface to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ functional change.
   evaluator/output path while letting both agent and simulated user run through
   the subscription route.
 
+### Changed
+
+- **CLI live task surface compacted.** The IPC event renderer now treats
+  `update_plan` like a Claude Code-scale task list: at most five visible tasks
+  around the active item, a `Tasks · done/total` header, and no phase-start
+  plan reprint. Thinking/tool phases carry the active step in the spinner label
+  and restore one compact task list after the phase, avoiding the repeated
+  `Plan:` blocks seen in long runs. The REPL prompt now renders as `geode >`
+  instead of a bare chevron.
+
 ### Fixed
 
 - **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -173,7 +173,7 @@ def _thin_interactive_loop(
         while True:
             console.show_cursor(True)
             try:
-                user_input = _read_multiline_input("[header]>[/header] ")
+                user_input = _read_multiline_input("[header]geode[/header] [muted]>[/muted] ")
             except (KeyboardInterrupt, EOFError):
                 console.print("\n  [muted]Goodbye.[/muted]\n")
                 break

--- a/core/cli/prompt_session.py
+++ b/core/cli/prompt_session.py
@@ -114,7 +114,7 @@ def _build_prompt_session() -> Any:
 
     session: Any = PromptSession(
         history=FileHistory(str(history_path)),
-        message=HTML("<b>&gt;</b> "),
+        message=HTML("<b>geode</b> &gt; "),
         enable_history_search=True,
         multiline=True,
         key_bindings=kb,

--- a/core/ui/agentic_ui/render.py
+++ b/core/ui/agentic_ui/render.py
@@ -142,17 +142,46 @@ def render_progress_plan(plan: list[dict[str, str]], *, explanation: str = "") -
         "in_progress": (spinner_glyph.GLYPH, f"bold {spinner_glyph.ROSE_HEX}", "bold"),
         "completed": ("✓", "success", "dim strike"),
     }
+    total = len(plan)
+    completed = sum(1 for item in plan if item.get("status") == "completed")
     _pkg.console.print()
-    header = "Plan"
+    header = f"Tasks · {completed}/{total} done"
     if explanation:
-        header = f"Plan · {explanation}"
+        header = f"{header} · {explanation}"
     _pkg.console.print(f"  [header]{header}[/header]")
-    for item in plan:
+    visible, hidden_before, hidden_after = _progress_plan_window(plan, max_items=5)
+    if hidden_before:
+        _pkg.console.print(f"    [dim]… {hidden_before} earlier[/dim]")
+    for item in visible:
         status = item.get("status", "pending")
         symbol, style, text_style = status_style.get(status, ("○", "dim", "dim"))
         step = item.get("step", "")
         _pkg.console.print(f"    [{style}]{symbol}[/{style}] [{text_style}]{step}[/{text_style}]")
+    if hidden_after:
+        _pkg.console.print(f"    [dim]… {hidden_after} later[/dim]")
     _pkg.console.print()
+
+
+def _progress_plan_window(
+    plan: list[dict[str, str]], *, max_items: int
+) -> tuple[list[dict[str, str]], int, int]:
+    """Select the visible task-list window around the active item."""
+    if len(plan) <= max_items:
+        return plan, 0, 0
+    active_idx = next(
+        (idx for idx, item in enumerate(plan) if item.get("status") == "in_progress"),
+        -1,
+    )
+    if active_idx < 0:
+        active_idx = next(
+            (idx for idx, item in enumerate(plan) if item.get("status", "pending") == "pending"),
+            len(plan) - 1,
+        )
+    half = max_items // 2
+    start = max(0, active_idx - half)
+    end = min(len(plan), start + max_items)
+    start = max(0, end - max_items)
+    return plan[start:end], start, len(plan) - end
 
 
 def render_subagent_dispatch(task_id: str, task_type: str, description: str) -> None:

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -116,6 +116,7 @@ class EventRenderer:
     )
     _MAX_ACTIVITY_TOOL_LINES = 5
     _MAX_ACTIVITY_NOTICE_LINES = 2
+    _MAX_PLAN_VISIBLE_ITEMS = 5
 
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
@@ -130,8 +131,8 @@ class EventRenderer:
         self._stdin_stop = threading.Event()
         self._stdin_thread: threading.Thread | None = None
         self._out = sys.stdout
-        # True while a phase (thinking/tool) draws BELOW a pinned plan copy —
-        # the plan stays on screen for the whole phase instead of vanishing.
+        # True while a phase (thinking/tool) owns the bottom rows. The compact
+        # task list is hidden during the phase and restored afterward.
         self._plan_pinned = False
         # Persistent activity spinner state
         self._activity = False
@@ -230,13 +231,12 @@ class EventRenderer:
         self._clear_markdown_stream_region()
         self._out.flush()
         self._flush_repeat()
-        # Freeze the live region as the turn's final state: if answer streaming
-        # already erased it, print one last permanent copy, then release it to
-        # scrollback (at_bottom=False) so the final answer renders below it.
+        # Freeze the compact live region as the turn's final state: if answer
+        # streaming already erased it, print one last permanent copy, then
+        # release it to scrollback so the final answer renders below it.
         with self._render_lock:
-            # A phase interrupted mid-flight (Ctrl+C, error) may leave the plan
-            # pinned; spinner/tool/thinking output is stopped and erased by
-            # now, so the pinned copy is bottom-most again — re-anchor it.
+            # A phase interrupted mid-flight (Ctrl+C, error) may leave legacy
+            # pinned state set. Clear it before rendering the final live region.
             self._restore_pinned_plan_locked()
             has_content = bool(self._progress_plan.items) or bool(
                 self._activity_surface.tool_stats or self._activity_surface.notices
@@ -281,9 +281,8 @@ class EventRenderer:
                     self._erase_thinking_visible_locked(region)
                     self._record_thought_activity_locked(region)
                     should_render_activity = True
-            # Cursor is just below the pinned plan copy again — re-anchor it
-            # so _render_live_region erases it and redraws plan+activity as
-            # ONE bottom unit (never a stale stacked copy).
+            # The phase ended; restore the compact task list + activity as one
+            # bottom unit.
             if self._restore_pinned_plan_locked():
                 should_render_activity = True
         self._activity_suppressed = False  # resume activity spinner
@@ -320,8 +319,7 @@ class EventRenderer:
             self._tool_tracker.suspend()
             with self._tool_tracker._lock:
                 self._tool_tracker._tools.clear()
-            # suspend() erased the tool rows — cursor is back just below the
-            # pinned plan copy, so re-anchor it before the unified redraw.
+            # suspend() erased the tool rows; redraw the compact live region.
             with self._render_lock:
                 self._restore_pinned_plan_locked()
             self._render_live_region()
@@ -576,7 +574,7 @@ class EventRenderer:
         self._render_progress_plan_surface(items, f"revised{suffix} · {step_count} steps{rev}")
 
     def _handle_progress_plan(self, event: dict[str, Any]) -> None:
-        """Render update_plan into the managed live region (full checklist, always)."""
+        """Render update_plan into the managed compact live region."""
         plan = event.get("plan", [])
         if not isinstance(plan, list):
             return
@@ -1145,10 +1143,9 @@ class EventRenderer:
         """
         with self._render_lock:
             if self._plan_pinned:
-                # The pinned plan copy is being buried by foreign output.
-                # Release it to scrollback WITHOUT erase sequences — its
-                # at_bottom is already False, and phase content below it makes
-                # the cursor-up math unsafe.
+                # A phase-owned live region is being buried by foreign output.
+                # Release it without cursor-up erase sequences; phase output
+                # below it makes that math unsafe.
                 self._progress_plan.visible_lines = []
                 self._plan_pinned = False
             # Reverse render order: activity sits below the plan checklist.
@@ -1159,51 +1156,35 @@ class EventRenderer:
                     surface.at_bottom = False
 
     def _pin_plan_for_phase(self) -> None:
-        """Keep the plan checklist visible while a thinking/tool phase runs.
+        """Clear the bottom live region before a thinking/tool phase runs.
 
-        Erases the live region, then immediately re-prints the plan as a
-        PINNED copy (``at_bottom=False`` — never erased mid-phase). The phase
-        content (thinking region / tool tracker rows) draws BELOW it and
-        redraws in place without touching it; the phase end re-anchors the
-        pinned copy via :meth:`_restore_pinned_plan_locked`.
+        Claude Code keeps the current step in the spinner label and exposes the
+        full task list as a separate compact surface. Re-printing the checklist
+        above every tool/thinking phase leaves duplicate Plan blocks in
+        scrollback, so phases now run with only the contextual spinner/tool row;
+        the compact task list returns after the phase ends.
         """
-        # Already pinned (thinking→tool transition) — the copy on screen stays;
-        # printing another without erasing the first stacks duplicates (Codex HIGH).
-        if self._plan_pinned and self._progress_plan.visible_lines:
-            return
         with self._render_lock:
             self._erase_live_region()
-            plan = self._progress_plan
-            if not (self._tty and plan.items):
-                return
-            lines = self._render_full_progress_plan(plan.items, plan.explanation)
-            self._out.write("\r\033[2K")  # clear any spinner residue first
-            for line in lines:
-                self._out.write(line)
-            self._out.flush()
-            plan.visible_lines = lines
-            plan.at_bottom = False
             self._plan_pinned = True
 
     def _restore_pinned_plan_locked(self) -> bool:
-        """Re-anchor the pinned plan copy as the erasable bottom surface.
+        """Clear legacy pinned state after a phase.
 
-        Call ONLY when the cursor sits just below the pinned copy again (phase
-        content erased). Returns True when a pinned copy was restored.
+        The plan is no longer physically pinned during phases; it is redrawn as
+        part of the compact live region at phase end.
         """
         if not self._plan_pinned:
             return False
-        plan = self._progress_plan
-        plan.at_bottom = bool(plan.visible_lines)
         self._plan_pinned = False
         return True
 
     def _render_live_region(self) -> None:
-        """Redraw plan checklist + activity block at the bottom as ONE unit.
+        """Redraw compact task list + activity block at the bottom as ONE unit.
 
         The scrollback equivalent of Claude Code's live todo widget: a single
-        moving copy — always the full checklist, never a compact breadcrumb —
-        erased before any other output prints and redrawn on state change.
+        moving copy, capped at five visible tasks and erased before any other
+        output prints.
         """
         with self._render_lock:
             self._erase_live_region()
@@ -1310,17 +1291,49 @@ class EventRenderer:
     def _render_full_progress_plan(
         self, items: list[dict[Any, Any]], explanation: str
     ) -> list[str]:
-        header = "Plan"
+        total = len(items)
+        completed = sum(1 for item in items if str(item.get("status", "")) == "completed")
+        header = f"Tasks · {completed}/{total} done"
         if explanation:
-            header = f"Plan · {explanation}"
+            header = f"{header} · {explanation}"
         lines = ["\n", f"  \033[1;36m{header}\033[0m\n"]
-        for item in items:
+        visible_items, hidden_before, hidden_after = self._visible_plan_window(items)
+        if hidden_before:
+            lines.append(f"    \033[2m… {hidden_before} earlier\033[0m\n")
+        for item in visible_items:
             status = str(item.get("status", "pending"))
             step = str(item.get("step", ""))
             symbol, style, text_style = self._progress_plan_symbol(status)
             lines.append(f"    {style}{symbol}\033[0m {text_style}{step}\033[0m\n")
+        if hidden_after:
+            lines.append(f"    \033[2m… {hidden_after} later\033[0m\n")
         lines.append("\n")
         return lines
+
+    def _visible_plan_window(
+        self, items: list[dict[Any, Any]]
+    ) -> tuple[list[dict[Any, Any]], int, int]:
+        """Return the Claude Code-scale task-list window around the active item."""
+        if len(items) <= self._MAX_PLAN_VISIBLE_ITEMS:
+            return items, 0, 0
+        active_idx = next(
+            (idx for idx, item in enumerate(items) if str(item.get("status", "")) == "in_progress"),
+            -1,
+        )
+        if active_idx < 0:
+            active_idx = next(
+                (
+                    idx
+                    for idx, item in enumerate(items)
+                    if str(item.get("status", "pending")) == "pending"
+                ),
+                len(items) - 1,
+            )
+        half = self._MAX_PLAN_VISIBLE_ITEMS // 2
+        start = max(0, active_idx - half)
+        end = min(len(items), start + self._MAX_PLAN_VISIBLE_ITEMS)
+        start = max(0, end - self._MAX_PLAN_VISIBLE_ITEMS)
+        return items[start:end], start, len(items) - end
 
     @staticmethod
     def _progress_plan_symbol(status: str) -> tuple[str, str, str]:

--- a/tests/core/cli/test_prompt_session.py
+++ b/tests/core/cli/test_prompt_session.py
@@ -93,6 +93,13 @@ def test_prompt_session_attaches_text_changed_repaint_hook(
     assert _invalidate_on_text_changed in session.default_buffer.on_text_changed
 
 
+def test_prompt_session_uses_named_geode_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The idle prompt names the REPL instead of showing a bare chevron."""
+    _build_with_fakes(monkeypatch)
+
+    assert "geode" in str(_FakePromptSession.captured["message"])
+
+
 def test_invalidate_on_text_changed_invalidates_running_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -167,10 +167,27 @@ class TestRenderPlanSteps:
         )
         calls = [str(c) for c in mock_console.print.call_args_list]
         combined = " ".join(calls)
-        assert "Plan · implementation" in combined
+        assert "Tasks · 1/3 done · implementation" in combined
         assert "Inspect UX" in combined
         assert "Patch tools" in combined
         assert "Run tests" in combined
+
+    @patch("core.ui.agentic_ui.console")
+    def test_progress_plan_direct_path_windows_around_active_step(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        from core.ui.agentic_ui import render_progress_plan
+
+        render_progress_plan(
+            [
+                {"step": f"step {i}", "status": "in_progress" if i == 6 else "pending"}
+                for i in range(1, 9)
+            ]
+        )
+
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+        assert "step 6" in combined
+        assert "step 3" not in combined
+        assert "… 3 earlier" in combined
 
 
 class TestRenderSubagent:
@@ -957,7 +974,7 @@ class TestThreadLocalConsoleIsolation:
 
 
 class TestPlanSurfaceVisualLanguage:
-    """Plan checklist: completed = dim+strike, active = rose GEODE mark, pending = dim."""
+    """Task list: completed = dim+strike, active = rose GEODE mark, pending = dim."""
 
     def _renderer(self) -> Any:
         import io
@@ -968,7 +985,7 @@ class TestPlanSurfaceVisualLanguage:
         r._out = io.StringIO()
         return r
 
-    def test_full_plan_styles_by_status(self) -> None:
+    def test_compact_task_list_styles_by_status(self) -> None:
         from core.ui import spinner_glyph
 
         r = self._renderer()
@@ -982,14 +999,15 @@ class TestPlanSurfaceVisualLanguage:
                 "step 2/3",
             )
         )
+        assert "Tasks · 1/3 done · step 2/3" in lines
         assert "\033[2;9mdone step" in lines  # checked off: dim + strikethrough
         assert f"{spinner_glyph.GLYPH}\033[0m \033[1mactive step" in lines  # rose mark + bold
         assert "\033[2mnext step" in lines  # pending stays quiet
         assert spinner_glyph.ROSE in lines
 
-    def test_plan_rerenders_full_checklist_after_obscure(self) -> None:
-        """Live region: an obscured plan re-renders as the FULL checklist (no
-        compact breadcrumb), and the previous copy is erased, not stacked."""
+    def test_task_list_rerenders_compact_window_after_obscure(self) -> None:
+        """Live region: an obscured task list re-renders as a compact window,
+        and the previous copy is erased, not stacked."""
         r = self._renderer()
         r._tty = True
         r.on_event(
@@ -1009,10 +1027,23 @@ class TestPlanSurfaceVisualLanguage:
             }
         )
         out = r._out.getvalue()
-        tail = out[out.rindex("Plan") :]
-        assert "second step" in tail  # full checklist, not a one-line breadcrumb
+        tail = out[out.rindex("Tasks") :]
+        assert "second step" in tail
         assert "first step" in tail
         assert "complete\033[0m" not in tail  # compact "N/M complete" line is gone
+
+    def test_task_list_shows_five_item_window_around_active_step(self) -> None:
+        r = self._renderer()
+        items = [
+            {"step": f"step {i}", "status": "in_progress" if i == 6 else "pending"}
+            for i in range(1, 9)
+        ]
+        lines = "".join(r._render_full_progress_plan(items, ""))
+        assert "step 4" in lines
+        assert "step 8" in lines
+        assert "step 3" not in lines
+        assert "… 3 earlier" in lines
+        assert "Tasks · 0/8 done" in lines
 
     def test_live_region_erased_before_foreign_output(self) -> None:
         """Any non-surface event erases the live region first — no stale copies."""
@@ -1031,7 +1062,7 @@ class TestPlanSurfaceVisualLanguage:
 
 
 class TestPinnedPlanDuringPhases:
-    """Plan checklist stays visible (pinned) while thinking/tool phases run."""
+    """Task list hides during phases and returns as one compact bottom copy."""
 
     def _renderer(self) -> Any:
         import io
@@ -1043,8 +1074,8 @@ class TestPinnedPlanDuringPhases:
         r._tty = True
         return r
 
-    def test_plan_stays_visible_through_thinking_start(self) -> None:
-        """thinking_start re-prints the plan (pinned) instead of erasing it."""
+    def test_thinking_start_hides_task_list_without_reprinting_it(self) -> None:
+        """thinking_start clears the task list; spinner label carries active step."""
         r = self._renderer()
         r.on_event(
             {
@@ -1056,10 +1087,10 @@ class TestPinnedPlanDuringPhases:
         r.on_event({"type": "thinking_start", "model": "m", "round": 1})
         try:
             assert r._plan_pinned is True
-            assert r._progress_plan.visible_lines  # still tracked on screen
-            assert r._progress_plan.at_bottom is False  # pinned: not erasable mid-phase
+            assert r._progress_plan.visible_lines == []
+            assert r._progress_plan.at_bottom is False
             written_after = r._out.getvalue()[marker:]
-            assert "pinned step" in written_after  # re-written for the phase
+            assert "pinned step" not in written_after
         finally:
             r._stop_thinking()
 
@@ -1075,13 +1106,13 @@ class TestPinnedPlanDuringPhases:
         r.on_event({"type": "thinking_start", "model": "m", "round": 1})
         r.on_event({"type": "thinking_end"})
         out = r._out.getvalue()
-        tail = out[out.rindex("Plan") :]  # after the LAST Plan header
+        tail = out[out.rindex("Tasks") :]  # after the LAST Tasks header
         assert tail.count("cycle step") == 1
         assert r._plan_pinned is False
         assert r._progress_plan.at_bottom is True  # bottom copy is erasable again
 
-    def test_tool_cycle_restores_plan_to_bottom(self) -> None:
-        """tool_start pins the plan; tool_end all-done re-anchors it."""
+    def test_tool_cycle_restores_task_list_to_bottom(self) -> None:
+        """tool_start clears the task list; tool_end all-done redraws it."""
         r = self._renderer()
         r.on_event(
             {
@@ -1095,7 +1126,7 @@ class TestPinnedPlanDuringPhases:
         assert r._plan_pinned is False
         assert r._progress_plan.at_bottom is True
         out = r._out.getvalue()
-        assert "tool step" in out[out.rindex("Plan") :]
+        assert "tool step" in out[out.rindex("Tasks") :]
 
 
 def test_tool_tracker_running_row_uses_signature_shimmer() -> None:

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -267,12 +267,12 @@ class TestEventRendererV2:
 
         renderer.on_event({"type": "goal_decomposition", "steps": ["a", "b"], "count": 2})
         out = renderer._out.getvalue()
-        assert "Plan" in out
+        assert "Tasks" in out
         assert "2 steps" in out
         assert spinner_glyph.GLYPH in out  # active step carries the rose GEODE mark
         assert "a" in out
 
-    def test_progress_plan_first_render_is_full_checklist(self, renderer) -> None:
+    def test_progress_plan_first_render_is_compact_task_list(self, renderer) -> None:
         renderer.on_event(
             {
                 "type": "progress_plan",
@@ -285,7 +285,7 @@ class TestEventRendererV2:
             }
         )
         out = renderer._out.getvalue()
-        assert "Plan · implementation" in out
+        assert "Tasks · 1/3 done · implementation" in out
         assert "✓" in out
         assert "Inspect UX" in out
         assert "Patch renderer" in out
@@ -309,9 +309,9 @@ class TestEventRendererV2:
         assert "\033[" in out and "A" in out
         assert "Second plan" in out
 
-    def test_progress_plan_after_tool_output_rerenders_full_checklist(self, renderer) -> None:
-        """Live-region policy: after other output obscures the plan, the next
-        update re-renders the FULL checklist at the bottom (the old copy was
+    def test_progress_plan_after_tool_output_rerenders_compact_task_list(self, renderer) -> None:
+        """Live-region policy: after other output obscures the task list, the
+        next update re-renders the compact list at the bottom (the old copy was
         erased before the obscuring output printed — never stacked)."""
         renderer.on_event(
             {
@@ -333,10 +333,10 @@ class TestEventRendererV2:
             }
         )
         out = renderer._out.getvalue()
-        tail = out[out.rindex("Plan · fallback") :]
+        tail = out[out.rindex("Tasks · 1/3 done · fallback") :]
         assert "Already done" in tail
         assert "Direct verification" in tail
-        assert "Pending tail step" in tail  # full checklist re-rendered
+        assert "Pending tail step" in tail
         assert "Plan updated" not in out  # compact breadcrumb path removed
 
     def test_plan_step(self, renderer) -> None:
@@ -353,7 +353,7 @@ class TestEventRendererV2:
         )
         out = renderer._out.getvalue()
         assert "\033[" in out and "A" in out
-        assert "Plan" in out
+        assert "Tasks" in out
         assert "step 2/2" in out
         assert "verify the renderer" in out
         assert "✓" in out
@@ -366,18 +366,18 @@ class TestEventRendererV2:
         )
         out = renderer._out.getvalue()
         assert "\033[" in out and "A" in out
-        assert "Plan · revised" in out
+        assert "Tasks · 0/3 done · revised" in out
         assert "verify_fail" in out
         assert "3 steps" in out
 
-    def test_replan_after_tool_output_rerenders_full_checklist(self, renderer) -> None:
+    def test_replan_after_tool_output_rerenders_compact_task_list(self, renderer) -> None:
         renderer.on_event({"type": "goal_decomposition", "steps": ["inspect", "patch"], "count": 2})
         renderer.on_event({"type": "subagent_complete", "count": 2, "elapsed_s": 5.0})
         renderer.on_event({"type": "replan", "trigger": "cadence", "step_count": 2, "revision": 1})
         out = renderer._out.getvalue()
-        tail = out[out.rindex("Plan · revised") :]
+        tail = out[out.rindex("Tasks · 0/2 done · revised") :]
         assert "revised · cadence · 2 steps · rev 1" in tail
-        assert "inspect" in tail  # full checklist re-rendered with revision header
+        assert "inspect" in tail
 
     def test_tool_backpressure(self, renderer) -> None:
         renderer.on_event({"type": "tool_backpressure", "consecutive_errors": 3})


### PR DESCRIPTION
## Summary
- Promote the compact CLI live task surface from `develop` to `main`.
- This includes PR #2503 and the required `main -> develop` sync from PR #2504.

## Why
The CLI UX fix removes repeated `Plan:` blocks during long thinking/tool phases and replaces them with a compact Claude Code-style `Tasks · done/total` surface.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | Compact task-list window, no phase-start plan reprint, one restored live region after phases. |
| `core/ui/agentic_ui/render.py` | Direct `update_plan` rendering matches the IPC task-list surface. |
| `core/cli/prompt_session.py`, `core/cli/__init__.py` | REPL prompt renders as `geode >`. |
| Tests | Updated CLI/UI event-rendering coverage. |
| `CHANGELOG.md` | Adds the CLI UX change under `[Unreleased]`. |

## Verification
Local before PR #2503:
- `uv run pytest -q tests/core/ui tests/core/cli/test_prompt_session.py tests/core/cli/test_plan_tool_handlers.py` PASS
- `uv run ruff check core/ tests/ plugins/ scripts/` PASS
- `uv run ruff format --check core/ tests/ plugins/ scripts/` PASS
- `uv run mypy core/ plugins/` PASS
- `uv run lint-imports` PASS
- `uv build` PASS
- `npm ci` PASS, with existing npm audit warnings from lockfile
- `npm run build` PASS, with existing Turbopack broad-pattern warnings for Petri seed pages

Remote:
- PR #2503 CI PASS
- PR #2504 sync CI PASS

## Notes
- Live provider tests were not run locally.