### PR TITLE
[codex] Fix Codex OAuth cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ functional change.
 
 ### Fixed
 
+- **Codex OAuth runtime cache refresh.** The `codex-oauth` adapter and
+  legacy Codex provider now fingerprint the resolved OAuth token and rebuild
+  cached OpenAI SDK clients when `~/.codex/auth.json` or GEODE auth state
+  changes, preventing daemon restarts from being required after Codex CLI
+  refreshes an expired ChatGPT token. `/login refresh` also invalidates the
+  Codex CLI credential reader and legacy Codex client cache.
+
 - **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes
   common schema mismatches before server calls, including mapping `file_path`
   to `path` when the MCP schema requires `path`, dropping conflicting

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -145,6 +145,8 @@ def cmd_login(args: str) -> None:
         # (Codex CLI OAuth) which never appear in auth.toml.
         try:
             from core.auth.auth_toml import auth_toml_path, load_auth_toml
+            from core.auth.codex_cli_oauth import invalidate_cache as invalidate_codex_cli_cache
+            from core.llm.providers.codex import reset_codex_client
             from core.llm.strategies.plan_registry import get_plan_registry
             from core.wiring.container import ensure_profile_store
 
@@ -153,6 +155,8 @@ def cmd_login(args: str) -> None:
             plans_before = {p.id for p in registry.list_all()}
             profiles_before = {p.name for p in store.list_all()}
             ok = load_auth_toml()
+            invalidate_codex_cli_cache()
+            reset_codex_client()
             plans_after = {p.id for p in registry.list_all()}
             profiles_after = {p.name for p in store.list_all()}
             new_plans = plans_after - plans_before

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -20,6 +20,7 @@ Pair with :class:`OpenAIPaygAdapter` (same provider, API key path) and
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -102,6 +103,8 @@ class CodexOAuthAdapter:
     _clients: LoopAffineClientCache = field(
         default_factory=lambda: LoopAffineClientCache("codex-oauth"), init=False, repr=False
     )
+    _token_fingerprint: str = field(default="", init=False, repr=False)
+    _token_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def computer_tool_param(
         self, *, display_width: int, display_height: int
@@ -120,10 +123,10 @@ class CodexOAuthAdapter:
         return None
 
     def _get_client(self) -> Any:
-        from core.llm.providers.codex import _resolve_codex_token
+        from core.llm.providers.codex import _resolve_codex_token_info
 
-        token = _resolve_codex_token()
-        if not token:
+        resolved = _resolve_codex_token_info(force_refresh=True)
+        if not resolved:
             raise RuntimeError(
                 "CodexOAuthAdapter: ChatGPT OAuth not found. Looked in GEODE "
                 f"ProfileStore ('openai-codex' profile) and {CODEX_AUTH_PATH}. "
@@ -131,7 +134,17 @@ class CodexOAuthAdapter:
                 "Codex CLI to provision credentials, or use the openai-payg / "
                 "codex-cli adapter."
             )
-        return self._clients.get(lambda: build_async_codex_client(token))
+        with self._token_lock:
+            if self._token_fingerprint != resolved.fingerprint:
+                if self._token_fingerprint:
+                    log.info(
+                        "codex-oauth: token changed (%s -> %s); invalidating clients",
+                        self._token_fingerprint,
+                        resolved.fingerprint,
+                    )
+                self._clients.invalidate()
+                self._token_fingerprint = resolved.fingerprint
+        return self._clients.get(lambda: build_async_codex_client(resolved.token))
 
     async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
         """Single Codex Responses API call (streamed; final aggregated).

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -16,8 +16,11 @@ and OpenClaw (openai-codex-provider.ts).
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from core.auth.jwt_claims import decode_jwt_claims
@@ -31,9 +34,28 @@ log = logging.getLogger(__name__)
 # imports so a routing.toml reload is seen without a restart.
 
 _codex_client: Any = None
+_codex_client_fingerprint = ""
 _codex_lock = threading.Lock()
 _async_codex_client: Any = None
+_async_codex_client_fingerprint = ""
 _async_codex_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _ResolvedCodexToken:
+    """Runtime Codex OAuth token plus cache identity metadata."""
+
+    token: str
+    source: str
+    expires_at: float = 0.0
+
+    @property
+    def fingerprint(self) -> str:
+        return hashlib.sha256(self.token.encode("utf-8")).hexdigest()[:16]
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at > 0 and time.time() >= self.expires_at
 
 
 def _extract_account_id(token: str) -> str:
@@ -58,8 +80,8 @@ def build_codex_oauth_headers(token: str) -> dict[str, str]:
     return headers
 
 
-def _resolve_codex_token() -> str:
-    """Resolve Codex OAuth token.
+def _resolve_codex_token_info(*, force_refresh: bool = False) -> _ResolvedCodexToken | None:
+    """Resolve Codex OAuth token with cache metadata.
 
     v0.52.4 — checks two sources, GEODE-issued first:
       1. ProfileStore for an ``openai-codex`` profile (the one created
@@ -71,6 +93,12 @@ def _resolve_codex_token() -> str:
     Without (1) the geode-registered ``openai-codex-geode`` plan would
     be invisible to the actual LLM call path and the OAuth login wizard
     would do nothing for users who don't also run Codex CLI.
+
+    v0.99.x — returns token identity metadata so SDK clients can be
+    rebuilt when Codex CLI refreshes ``~/.codex/auth.json`` after the
+    daemon has already cached a client. This mirrors Hermes' credential
+    pool resync pattern: when the backing auth store changes, stale
+    runtime entries are replaced instead of kept until process restart.
     """
     try:
         from core.wiring.container import get_profile_store
@@ -90,79 +118,119 @@ def _resolve_codex_token() -> str:
                     and profile.key
                     and not profile.managed_by
                 ):
-                    return profile.key
+                    return _ResolvedCodexToken(
+                        token=profile.key,
+                        source=f"profile:{profile.name}",
+                        expires_at=float(profile.expires_at or 0.0),
+                    )
             for profile in store.list_all():
                 if profile.provider == "openai-codex" and profile.is_available and profile.key:
-                    return profile.key
+                    return _ResolvedCodexToken(
+                        token=profile.key,
+                        source=f"profile:{profile.name}",
+                        expires_at=float(profile.expires_at or 0.0),
+                    )
     except Exception:
         log.debug("GEODE openai-codex profile lookup failed", exc_info=True)
 
     try:
         from core.auth.codex_cli_oauth import read_codex_cli_credentials
 
-        creds = read_codex_cli_credentials()
+        creds = read_codex_cli_credentials(force_refresh=force_refresh)
         if creds:
-            return creds["access_token"]
+            resolved = _ResolvedCodexToken(
+                token=creds["access_token"],
+                source="codex-cli:~/.codex/auth.json",
+                expires_at=float(creds.get("expires_at", 0.0) or 0.0),
+            )
+            if resolved.is_expired:
+                log.warning("Codex CLI OAuth token is expired; refusing stale runtime token")
+                return None
+            return resolved
     except Exception:
         log.debug("Codex CLI token resolution failed", exc_info=True)
-    return ""
+    return None
+
+
+def _resolve_codex_token() -> str:
+    """Resolve Codex OAuth token."""
+    resolved = _resolve_codex_token_info(force_refresh=True)
+    return resolved.token if resolved else ""
 
 
 def _get_codex_client() -> Any:
     """Lazy import and return cached Codex client (thread-safe)."""
-    global _codex_client
-    if _codex_client is None:
-        with _codex_lock:
-            if _codex_client is None:
-                import openai
+    global _codex_client, _codex_client_fingerprint
+    resolved = _resolve_codex_token_info(force_refresh=True)
+    if not resolved:
+        log.warning("Codex OAuth token not available")
+        return None
+    with _codex_lock:
+        if _codex_client is not None and _codex_client_fingerprint == resolved.fingerprint:
+            return _codex_client
 
-                token = _resolve_codex_token()
-                if not token:
-                    log.warning("Codex OAuth token not available")
-                    return None
+        import openai
 
-                _codex_client = openai.OpenAI(
-                    api_key=token,
-                    base_url=CODEX_BASE_URL,
-                    default_headers=build_codex_oauth_headers(token),
-                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
-                )
+        _codex_client = openai.OpenAI(
+            api_key=resolved.token,
+            base_url=CODEX_BASE_URL,
+            default_headers=build_codex_oauth_headers(resolved.token),
+            max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
+        )
+        _codex_client_fingerprint = resolved.fingerprint
+        log.info(
+            "Codex OAuth client rebuilt from %s token=%s",
+            resolved.source,
+            resolved.fingerprint,
+        )
     return _codex_client
 
 
 def _get_async_codex_client() -> Any:
     """Lazy import and return cached async Codex client (thread-safe)."""
-    global _async_codex_client
-    if _async_codex_client is None:
-        with _async_codex_lock:
-            if _async_codex_client is None:
-                import openai
+    global _async_codex_client, _async_codex_client_fingerprint
+    resolved = _resolve_codex_token_info(force_refresh=True)
+    if not resolved:
+        log.warning("Codex OAuth token not available")
+        return None
+    with _async_codex_lock:
+        if (
+            _async_codex_client is not None
+            and _async_codex_client_fingerprint == resolved.fingerprint
+        ):
+            return _async_codex_client
 
-                token = _resolve_codex_token()
-                if not token:
-                    log.warning("Codex OAuth token not available")
-                    return None
+        import openai
 
-                # PR-CODEX-OUTPUT-NULL (2026-05-28) — mirror the adapter
-                # builder: install the parse_response workaround so the
-                # legacy provider path is also safe on openai >= 2.26.
-                from core.llm.adapters._codex_sdk_workaround import install as _install
+        # PR-CODEX-OUTPUT-NULL (2026-05-28) — mirror the adapter
+        # builder: install the parse_response workaround so the
+        # legacy provider path is also safe on openai >= 2.26.
+        from core.llm.adapters._codex_sdk_workaround import install as _install
 
-                _install()
+        _install()
 
-                _async_codex_client = openai.AsyncOpenAI(
-                    api_key=token,
-                    base_url=CODEX_BASE_URL,
-                    default_headers=build_codex_oauth_headers(token),
-                    max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
-                )
+        _async_codex_client = openai.AsyncOpenAI(
+            api_key=resolved.token,
+            base_url=CODEX_BASE_URL,
+            default_headers=build_codex_oauth_headers(resolved.token),
+            max_retries=0,  # PR-ADAPTER-TIMEOUT-AND-SERIALIZATION
+        )
+        _async_codex_client_fingerprint = resolved.fingerprint
+        log.info(
+            "Async Codex OAuth client rebuilt from %s token=%s",
+            resolved.source,
+            resolved.fingerprint,
+        )
     return _async_codex_client
 
 
 def reset_codex_client() -> None:
     """Reset cached client (e.g. after token refresh)."""
-    global _async_codex_client, _codex_client
+    global _async_codex_client, _async_codex_client_fingerprint, _codex_client
+    global _codex_client_fingerprint
     with _codex_lock:
         _codex_client = None
+        _codex_client_fingerprint = ""
     with _async_codex_lock:
         _async_codex_client = None
+        _async_codex_client_fingerprint = ""

--- a/tests/core/llm/test_codex_oauth_token_refresh.py
+++ b/tests/core/llm/test_codex_oauth_token_refresh.py
@@ -1,0 +1,137 @@
+"""Codex OAuth runtime cache refresh regressions."""
+
+from __future__ import annotations
+
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+
+
+def test_legacy_codex_client_rebuilds_when_cli_token_changes(monkeypatch) -> None:
+    from core.llm.providers import codex
+
+    current_token = {"value": "access-old"}
+    force_refresh_calls: list[bool] = []
+
+    def fake_read_codex_cli_credentials(*, force_refresh: bool = False) -> dict[str, object]:
+        force_refresh_calls.append(force_refresh)
+        return {
+            "access_token": current_token["value"],
+            "refresh_token": "refresh-token",
+            "expires_at": time.time() + 3600,
+        }
+
+    fake_openai = SimpleNamespace(OpenAI=_FakeOpenAI, AsyncOpenAI=_FakeOpenAI)
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setattr("core.wiring.container.get_profile_store", lambda: None)
+    monkeypatch.setattr(
+        "core.auth.codex_cli_oauth.read_codex_cli_credentials",
+        fake_read_codex_cli_credentials,
+    )
+
+    codex.reset_codex_client()
+    try:
+        first = codex._get_codex_client()
+        current_token["value"] = "access-new"
+        second = codex._get_codex_client()
+    finally:
+        codex.reset_codex_client()
+
+    assert first is not None
+    assert second is not None
+    assert first is not second
+    assert first.kwargs["api_key"] == "access-old"
+    assert second.kwargs["api_key"] == "access-new"
+    assert force_refresh_calls == [True, True]
+
+
+def test_codex_oauth_adapter_invalidates_loop_cache_when_token_changes(monkeypatch) -> None:
+    from core.llm.adapters import codex_oauth
+    from core.llm.providers.codex import _ResolvedCodexToken
+
+    current_token = {"value": "access-old"}
+
+    class FakeCache:
+        def __init__(self) -> None:
+            self.client: dict[str, str] | None = None
+            self.invalidations = 0
+
+        def get(self, builder):
+            if self.client is None:
+                self.client = builder()
+            return self.client
+
+        def invalidate(self) -> None:
+            self.invalidations += 1
+            self.client = None
+
+    def fake_resolve(*, force_refresh: bool = False) -> _ResolvedCodexToken:
+        assert force_refresh is True
+        return _ResolvedCodexToken(
+            token=current_token["value"],
+            source="codex-cli:~/.codex/auth.json",
+            expires_at=time.time() + 3600,
+        )
+
+    fake_cache = FakeCache()
+    adapter = codex_oauth.CodexOAuthAdapter()
+    adapter._clients = fake_cache
+    monkeypatch.setattr("core.llm.providers.codex._resolve_codex_token_info", fake_resolve)
+    monkeypatch.setattr(
+        codex_oauth,
+        "build_async_codex_client",
+        lambda token: {"api_key": token},
+    )
+
+    first = adapter._get_client()
+    again = adapter._get_client()
+    current_token["value"] = "access-new"
+    second = adapter._get_client()
+
+    assert first is again
+    assert second is not first
+    assert first["api_key"] == "access-old"
+    assert second["api_key"] == "access-new"
+    assert fake_cache.invalidations == 2
+
+
+def test_login_refresh_invalidates_codex_runtime_caches(
+    capsys,
+    monkeypatch,
+) -> None:
+    from core.cli.commands.login import cmd_login
+
+    plan_store = SimpleNamespace(
+        list_all=lambda: [SimpleNamespace(id="existing-plan")],
+    )
+    profile_store = SimpleNamespace(
+        list_all=lambda: [SimpleNamespace(name="existing:env")],
+    )
+    invalidate_calls: list[str] = []
+    reset_calls: list[str] = []
+
+    monkeypatch.setattr("core.llm.strategies.plan_registry.get_plan_registry", lambda: plan_store)
+    monkeypatch.setattr("core.wiring.container.ensure_profile_store", lambda: profile_store)
+    monkeypatch.setattr("core.auth.auth_toml.load_auth_toml", lambda: True)
+    monkeypatch.setattr("core.auth.auth_toml.auth_toml_path", lambda: "/tmp/auth.toml")  # noqa: S108
+    with (
+        patch(
+            "core.auth.codex_cli_oauth.invalidate_cache",
+            side_effect=lambda: invalidate_calls.append("codex-cli"),
+        ),
+        patch(
+            "core.llm.providers.codex.reset_codex_client",
+            side_effect=lambda: reset_calls.append("codex"),
+        ),
+    ):
+        cmd_login("refresh")
+
+    assert "auth.toml reloaded" in capsys.readouterr().out
+    assert invalidate_calls == ["codex-cli"]
+    assert reset_calls == ["codex"]


### PR DESCRIPTION
## Summary
- Rebuild Codex OAuth SDK clients when the resolved OAuth token changes.
- Invalidate Codex CLI credential and legacy Codex client caches from `/login refresh`.
- Add regression tests for stale token replacement in the legacy provider, adapter cache, and refresh command.

## Why
A long-running GEODE daemon could keep using an expired Codex OAuth bearer even after Codex CLI had refreshed `~/.codex/auth.json`. The observed failure charged no usage (`attempts=0`, `cost_so_far=$0`) and required a daemon restart to pick up the valid token.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/codex.py` | Resolve token metadata with a fingerprint and rebuild cached sync/async clients when the token changes. |
| `core/llm/adapters/codex_oauth.py` | Invalidate loop-affine adapter clients when the Codex OAuth token fingerprint changes. |
| `core/cli/commands/login.py` | Make `/login refresh` invalidate Codex CLI and legacy Codex runtime caches. |
| `tests/core/llm/test_codex_oauth_token_refresh.py` | Cover stale-token replacement paths. |
| `CHANGELOG.md` | Record the fix. |

## Verification
- `uv run pytest tests/core/llm/test_codex_oauth_token_refresh.py tests/core/cli/test_login_refresh_l4_l2.py`
- `uv run pytest tests/core/llm/adapters/test_codex_oauth_backend_invariants.py tests/core/llm/adapters/test_codex_oauth_empty_text_retry_edge.py tests/core/llm/test_provider_parity_v0532.py`
- `uv run ruff check core/llm/providers/codex.py core/llm/adapters/codex_oauth.py core/cli/commands/login.py tests/core/llm/test_codex_oauth_token_refresh.py`
- `uv run ruff format --check core/llm/providers/codex.py core/llm/adapters/codex_oauth.py core/cli/commands/login.py tests/core/llm/test_codex_oauth_token_refresh.py`
- `uv run mypy core/llm/providers/codex.py core/llm/adapters/codex_oauth.py core/cli/commands/login.py`
- `uv run geode doctor`
- `uv run geode adapters list`