### PR TITLE
Start CLI channel before gateway pollers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ functional change.
 
 ### Fixed
 
+- **Serve CLI channel startup order.** `geode serve` now starts the local thin
+  CLI Unix socket before external gateway pollers, so blocking gateway adapters
+  cannot prevent `geode` clients from reconnecting after a daemon restart.
+
 - **Codex OAuth runtime cache refresh.** The `codex-oauth` adapter and
   legacy Codex provider now fingerprint the resolved OAuth token and rebuild
   cached OpenAI SDK clients when `~/.codex/auth.json` or GEODE auth state

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -238,11 +238,9 @@ def serve(
         except Exception as _wh_exc:
             log.warning("Webhook server failed to start: %s", _wh_exc)
 
-    # Start pollers
-    gateway.start()
-    console.print("  [success]Gateway started. Listening...[/success]")
-
-    # CLI Channel — Unix socket for thin CLI client IPC
+    # CLI Channel — Unix socket for thin CLI client IPC.
+    # Start this before external gateway pollers: some gateway adapters run a
+    # blocking poll loop from start(), but thin CLI clients still need a socket.
     _cli_poller = None
     try:
         from core.server.ipc_server.poller import CLIPoller
@@ -252,6 +250,10 @@ def serve(
         console.print(f"  [success]CLI channel: {_cli_poller.socket_path}[/success]")
     except Exception:
         log.warning("CLI channel init failed", exc_info=True)
+
+    # Start gateway pollers
+    gateway.start()
+    console.print("  [success]Gateway started. Listening...[/success]")
 
     console.print()
 

--- a/tests/core/cli/test_typer_serve_cli_channel_order.py
+++ b/tests/core/cli/test_typer_serve_cli_channel_order.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_cli_channel_starts_before_gateway_pollers() -> None:
+    """Source pin: gateway pollers may block in start(), so CLI opens first."""
+    src = (REPO_ROOT / "core" / "cli" / "typer_serve.py").read_text(encoding="utf-8")
+    cli_start = src.index("_cli_poller.start()")
+    gateway_start = src.index("gateway.start()")
+    assert cli_start < gateway_start


### PR DESCRIPTION
## Summary
- Start the local thin CLI Unix socket before external gateway pollers in `geode serve`.
- Add a source-order regression test for the startup sequence.

## Why
Some gateway adapters can block inside `start()`, which prevented `CLIPoller` from opening `~/.geode/cli.sock` after a daemon restart. That left thin CLI clients disconnected even though the daemon process was alive.

## Changes
| File | Change |
|------|--------|
| `core/cli/typer_serve.py` | Starts `CLIPoller` before `gateway.start()`. |
| `tests/core/cli/test_typer_serve_cli_channel_order.py` | Pins CLI startup before gateway poller startup. |
| `CHANGELOG.md` | Records the runtime fix. |

## Verification
- `uv run pytest tests/core/cli/test_typer_serve_cli_channel_order.py`
- `uv run ruff check core/cli/typer_serve.py tests/core/cli/test_typer_serve_cli_channel_order.py`
- `uv run ruff format --check core/cli/typer_serve.py tests/core/cli/test_typer_serve_cli_channel_order.py`
- `uv run mypy core/cli/typer_serve.py`