### PR TITLE
Plan UI: Claude Code식 — 상태변경 시에만 렌더, 민트→rose (v0.99.266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,9 @@ functional change.
   `update_plan` like a Claude Code-scale task list: at most five visible tasks
   around the active item, a `Tasks · done/total` header, and no phase-start
   plan reprint. Thinking/tool phases carry the active step in the spinner label
-  and restore one compact task list after the phase, avoiding the repeated
-  `Plan:` blocks seen in long runs. The REPL prompt now renders as `geode >`
-  instead of a bare chevron.
+  and flow below a single checklist that is drawn once per state change,
+  avoiding the repeated `Plan:` blocks seen in long runs. The REPL prompt now
+  renders as `geode >` instead of a bare chevron.
 
 ### Fixed
 
@@ -85,6 +85,24 @@ functional change.
   `read_text_file` `head`/`tail` pairs, annotating exact-read caveats in
   exposed MCP tool descriptions, and offloading source EOF preservation from
   model turns into the MCP dispatch layer for same-name text writes.
+
+## [0.99.266] - 2026-07-03
+
+### Fixed
+
+- **Plan checklist no longer re-stacks across thinking/tool rounds.** The IPC
+  event renderer previously re-rendered the whole `update_plan` checklist at
+  every `thinking_end`/`tool_end`, so a multi-round turn stacked N identical
+  `Tasks · …` blocks down the transcript (6+ copies on long runs). Plan
+  rendering is now split from the activity block: the checklist is drawn only
+  from plan events (`progress_plan` / `plan_step` / `replan` /
+  `goal_decomposition`) and deduped against the last drawn state (identical
+  steps, statuses, and explanation → no reprint), while thinking/tool phases
+  redraw only the activity summary and flow below the checklist, which scrolls
+  up with the transcript like a Claude Code todo list. The checklist header
+  also switches from mint (`1;36m`) to the signature rose. Guards:
+  `tests/core/ui/test_event_schema_v2.py` (regression, dedup, header colour)
+  and `tests/core/ui/test_agentic_ui.py` (plan not re-emitted during phases).
 
 ## [0.99.265] - 2026-07-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.265
+- **Version**: 0.99.266
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.265 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.266 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.265 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.266 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -56,6 +56,11 @@ class _ProgressPlanSurface:
     items: list[dict[str, str]] = field(default_factory=list)
     explanation: str = ""
     at_bottom: bool = False
+    # Signature of the last checklist actually drawn (items + statuses +
+    # explanation). Consecutive plan events carrying an identical state are
+    # deduped against this so a re-emitted-but-unchanged plan never reprints.
+    signature: str = ""
+    rendered: bool = False
 
 
 @dataclass
@@ -131,9 +136,6 @@ class EventRenderer:
         self._stdin_stop = threading.Event()
         self._stdin_thread: threading.Thread | None = None
         self._out = sys.stdout
-        # True while a phase (thinking/tool) owns the bottom rows. The compact
-        # task list is hidden during the phase and restored afterward.
-        self._plan_pinned = False
         # Persistent activity spinner state
         self._activity = False
         self._activity_suppressed = False
@@ -231,21 +233,13 @@ class EventRenderer:
         self._clear_markdown_stream_region()
         self._out.flush()
         self._flush_repeat()
-        # Freeze the compact live region as the turn's final state: if answer
-        # streaming already erased it, print one last permanent copy, then
-        # release it to scrollback so the final answer renders below it.
+        # Freeze the activity block as the turn's final state, then release both
+        # surfaces to scrollback so the final answer renders below them. The plan
+        # checklist is transcript content — it was drawn by its own events and
+        # already sits in scrollback, so it is never redrawn here.
         with self._render_lock:
-            # A phase interrupted mid-flight (Ctrl+C, error) may leave legacy
-            # pinned state set. Clear it before rendering the final live region.
-            self._restore_pinned_plan_locked()
-            has_content = bool(self._progress_plan.items) or bool(
-                self._activity_surface.tool_stats or self._activity_surface.notices
-            )
-            visible = bool(
-                self._progress_plan.visible_lines or self._activity_surface.visible_lines
-            )
-            if has_content and not visible:
-                self._render_live_region()
+            if self._activity_surface.tool_stats or self._activity_surface.notices:
+                self._render_activity_region()
             self._progress_plan.at_bottom = False
             self._activity_surface.at_bottom = False
         # Render accumulated turn status (Claude Code style)
@@ -259,7 +253,9 @@ class EventRenderer:
     def _handle_thinking_start(self, event: dict[str, Any]) -> None:
         self._activity_suppressed = True
         self._tool_tracker.stop()
-        self._pin_plan_for_phase()
+        # Clear the bottom activity block so the thinking spinner flows below the
+        # plan; the plan itself stays in scrollback (never re-emitted per phase).
+        self._erase_live_region()
         with self._render_lock:
             self._thinking_region = _ThinkingRegion(start_ts=time.monotonic())
             self._thinking = True
@@ -272,7 +268,6 @@ class EventRenderer:
 
     def _handle_thinking_end(self, _event: dict[str, Any]) -> None:
         self._stop_thinking()
-        should_render_activity = False
         with self._render_lock:
             region = self._thinking_region
             if region:
@@ -280,14 +275,11 @@ class EventRenderer:
                 if self._tty:
                     self._erase_thinking_visible_locked(region)
                     self._record_thought_activity_locked(region)
-                    should_render_activity = True
-            # The phase ended; restore the compact task list + activity as one
-            # bottom unit.
-            if self._restore_pinned_plan_locked():
-                should_render_activity = True
         self._activity_suppressed = False  # resume activity spinner
-        if should_render_activity:
-            self._render_live_region()
+        # Redraw ONLY the activity block (thought/tool summary). The plan
+        # checklist is never re-emitted at phase end — that per-phase reprint
+        # is exactly what stacked N identical Plan blocks down the transcript.
+        self._render_activity_region()
 
     def _handle_tool_start(self, event: dict[str, Any]) -> None:
         name = str(event.get("name", ""))
@@ -302,7 +294,9 @@ class EventRenderer:
 
         self._activity_suppressed = True
         self._stop_thinking()
-        self._pin_plan_for_phase()
+        # Clear the bottom activity block so tool rows flow below the plan; the
+        # plan itself stays in scrollback (never re-emitted per phase).
+        self._erase_live_region()
         self._tool_tracker.on_tool_start(event)
 
     def _handle_tool_end(self, event: dict[str, Any]) -> None:
@@ -319,10 +313,9 @@ class EventRenderer:
             self._tool_tracker.suspend()
             with self._tool_tracker._lock:
                 self._tool_tracker._tools.clear()
-            # suspend() erased the tool rows; redraw the compact live region.
-            with self._render_lock:
-                self._restore_pinned_plan_locked()
-            self._render_live_region()
+            # suspend() erased the tool rows; redraw ONLY the activity block.
+            # The plan is not re-emitted at phase end (it lives in scrollback).
+            self._render_activity_region()
             # Track last single-tool batch for repeat detection
             if is_single:
                 dur = event.get("duration_s")
@@ -597,11 +590,22 @@ class EventRenderer:
         if not normalized:
             return
 
+        signature = self._plan_signature(normalized, explanation)
         with self._render_lock:
-            self._suppress_all_spinners()
-            self._progress_plan.items = list(normalized)
-            self._progress_plan.explanation = explanation
-            self._render_live_region()
+            plan = self._progress_plan
+            # Dedup: a re-emitted plan carrying an identical state (same steps,
+            # statuses, explanation) never reprints — only genuine state changes
+            # draw a fresh checklist.
+            if plan.rendered and signature == plan.signature:
+                return
+            plan.items = list(normalized)
+            plan.explanation = explanation
+            self._render_plan_region(signature)
+
+    @staticmethod
+    def _plan_signature(items: list[dict[str, str]], explanation: str) -> str:
+        steps = "\x1e".join(f"{it.get('step', '')}\x1f{it.get('status', '')}" for it in items)
+        return f"{steps}\x1d{explanation}"
 
     def _handle_tool_backpressure(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
@@ -616,7 +620,7 @@ class EventRenderer:
             f"\033[1;33m\u27f3 Diversity: {tool} called {count}x"
             " \u2014 hinting alternate path\033[0m"
         )
-        self._render_live_region()
+        self._render_activity_region()
 
     def _handle_model_switched(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
@@ -912,7 +916,7 @@ class EventRenderer:
         self._last_batch_tool = ""
         if count <= 1:
             return
-        self._render_live_region()
+        self._render_activity_region()
 
     # -- HITL approval spinner coordination ------------------------------------
 
@@ -1134,76 +1138,80 @@ class EventRenderer:
         return rows
 
     def _erase_live_region(self) -> None:
-        """Erase the bottom-anchored live surfaces while they are still bottom-most.
+        """Prepare the bottom rows for foreign output printing immediately after.
 
-        Callers print scrollback content immediately after, so the region never
-        gets buried — the pre-fix pathology was mark-obscured-without-erase,
-        which left a stale full copy behind on every obscure (stacked walls of
-        near-identical Plan/Activity blocks).
+        The activity block is a genuine bottom-anchored live surface, so it is
+        erased in place (cursor-up) while still bottom-most. The plan checklist
+        is transcript content — it is never cursor-erased; it is only *released*
+        (marked no-longer-bottom-most) so it scrolls up with the foreign output
+        and the next plan event draws a fresh copy below instead of stacking.
         """
         with self._render_lock:
-            if self._plan_pinned:
-                # A phase-owned live region is being buried by foreign output.
-                # Release it without cursor-up erase sequences; phase output
-                # below it makes that math unsafe.
-                self._progress_plan.visible_lines = []
-                self._plan_pinned = False
-            # Reverse render order: activity sits below the plan checklist.
-            for surface in (self._activity_surface, self._progress_plan):
-                if surface.at_bottom and surface.visible_lines:
-                    self._erase_lines_locked(surface.visible_lines)
-                    surface.visible_lines = []
-                    surface.at_bottom = False
+            self._erase_activity_locked()
+            self._release_plan_locked()
 
-    def _pin_plan_for_phase(self) -> None:
-        """Clear the bottom live region before a thinking/tool phase runs.
+    def _erase_activity_locked(self) -> None:
+        """Cursor-up erase the activity block if it is still the bottom-most row."""
+        surface = self._activity_surface
+        if surface.at_bottom and surface.visible_lines:
+            self._erase_lines_locked(surface.visible_lines)
+            surface.visible_lines = []
+            surface.at_bottom = False
 
-        Claude Code keeps the current step in the spinner label and exposes the
-        full task list as a separate compact surface. Re-printing the checklist
-        above every tool/thinking phase leaves duplicate Plan blocks in
-        scrollback, so phases now run with only the contextual spinner/tool row;
-        the compact task list returns after the phase ends.
+    def _release_plan_locked(self) -> None:
+        """Release the plan checklist to scrollback (leave it drawn, just not bottom-most)."""
+        self._progress_plan.at_bottom = False
+
+    def _render_plan_region(self, signature: str) -> None:
+        """Draw the compact task list once per state change (Claude Code todo).
+
+        Drawn only from plan events (progress_plan / plan_step / replan /
+        goal_decomposition), never from a thinking/tool phase. If the previous
+        checklist is still the bottom-most thing (a rapid consecutive update with
+        nothing printed since), it is erased in place and redrawn so an update
+        does not duplicate; the moment anything else printed it is released, and
+        the new checklist draws fresh below (the prior copy stays in scrollback).
         """
         with self._render_lock:
-            self._erase_live_region()
-            self._plan_pinned = True
-
-    def _restore_pinned_plan_locked(self) -> bool:
-        """Clear legacy pinned state after a phase.
-
-        The plan is no longer physically pinned during phases; it is redrawn as
-        part of the compact live region at phase end.
-        """
-        if not self._plan_pinned:
-            return False
-        self._plan_pinned = False
-        return True
-
-    def _render_live_region(self) -> None:
-        """Redraw compact task list + activity block at the bottom as ONE unit.
-
-        The scrollback equivalent of Claude Code's live todo widget: a single
-        moving copy, capped at five visible tasks and erased before any other
-        output prints.
-        """
-        with self._render_lock:
-            self._erase_live_region()
+            self._suppress_all_spinners()
             plan = self._progress_plan
-            plan_lines = (
-                self._render_full_progress_plan(plan.items, plan.explanation) if plan.items else []
-            )
-            activity_lines = self._render_activity_lines()
-            if not plan_lines and not activity_lines:
-                return
-            for line in (*plan_lines, *activity_lines):
+            # If the activity block sits below the plan, clear it first so the
+            # plan never ends up rendered below its own activity summary.
+            self._erase_activity_locked()
+            if plan.at_bottom and plan.visible_lines:
+                self._erase_lines_locked(plan.visible_lines)
+            plan_lines = self._render_full_progress_plan(plan.items, plan.explanation)
+            for line in plan_lines:
                 self._out.write(line)
+            plan.visible_lines = plan_lines
             # Non-TTY (piped/log) output is append-only: never mark at_bottom,
             # so no cursor-up erase sequences are ever emitted into a pipe.
-            plan.visible_lines = plan_lines
-            plan.at_bottom = bool(plan_lines) and self._tty
+            plan.at_bottom = self._tty
+            plan.signature = signature
+            plan.rendered = True
+            self._out.flush()
+
+    def _render_activity_region(self) -> None:
+        """Redraw the bottom-anchored activity block (tool/thought summary) in place.
+
+        The activity block legitimately updates as tools/thoughts accumulate, so
+        it keeps its own single moving copy. It never carries the plan checklist,
+        which is drawn separately by plan events and scrolls up independently.
+        """
+        with self._render_lock:
+            self._erase_activity_locked()
+            activity_lines = self._render_activity_lines()
+            if not activity_lines:
+                return
+            for line in activity_lines:
+                self._out.write(line)
             surface = self._activity_surface
             surface.visible_lines = activity_lines
-            surface.at_bottom = bool(activity_lines) and self._tty
+            # Non-TTY (piped/log) output is append-only: never mark at_bottom.
+            surface.at_bottom = self._tty
+            # The activity block is now the bottom-most row; the plan (above it)
+            # is no longer erasable in place.
+            self._progress_plan.at_bottom = False
             self._out.flush()
 
     def _record_tool_activity(self, event: dict[str, Any]) -> None:
@@ -1296,7 +1304,9 @@ class EventRenderer:
         header = f"Tasks · {completed}/{total} done"
         if explanation:
             header = f"{header} · {explanation}"
-        lines = ["\n", f"  \033[1;36m{header}\033[0m\n"]
+        # Signature rose (not mint) for the checklist header — the plan surface
+        # shares GEODE's one hue with the spinner and the active-step mark.
+        lines = ["\n", f"  {spinner_glyph.ROSE}{header}\033[0m\n"]
         visible_items, hidden_before, hidden_after = self._visible_plan_window(items)
         if hidden_before:
             lines.append(f"    \033[2m… {hidden_before} earlier\033[0m\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.265"
+version = "0.99.266"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.265. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.266. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.265. Last sync 2026-07-02. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.266. Last sync 2026-07-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 
@@ -65,7 +65,11 @@ Version v0.99.265. Last sync 2026-07-02. Docs links point to clean markdown twin
 
 ## Benchmarks
 
+- [Benchmark publishing cycle](https://mangowhoiscloud.github.io/geode/docs/benchmarks/publishing-cycle.md): Repeatable runbook for measuring GEODE, recording the evidence ledger, publishing official docs, and verifying GitHub Pages.
+- [Benchmark measurements](https://mangowhoiscloud.github.io/geode/docs/benchmarks/results.md): Grouped GEODE benchmark measurement ledger for MCPMark and Tau2, with clickable run records and model-route metadata.
+- [Benchmark queue](https://mangowhoiscloud.github.io/geode/docs/benchmarks/queue.md): Current GEODE benchmark execution order: MCPMark Verified, tau2-bench, BFCL V4, then roadmap benchmarks.
 - [MCPMark: filesystem/easy](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark/filesystem-easy.md): Verifier-backed GEODE run record for MCPMark's filesystem easy subset, including run spec, artifacts, task scores, and the EOF offload note.
+- [tau2: mock smoke](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2/mock-smoke.md): Verifier-backed tau2 mock smoke run with GEODE as both agent and simulated user through the subscription route.
 
 ## Guides and How-to
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-02
+ * Last sync: 2026-07-03
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes\n  common schema mismatches before server calls, including mapping `file_path`\n  to `path` when the MCP schema requires `path`, dropping conflicting\n  `read_text_file` `head`/`tail` pairs, annotating exact-read caveats in\n  exposed MCP tool descriptions, and offloading source EOF preservation from\n  model turns into the MCP dispatch layer for same-name text writes."
+    "body": "### Added\n\n- **tau2 GEODE benchmark runner.** Added `scripts/eval/tau2_geode_agent.py`, a\n  reproducible runner that registers GEODE as an in-process tau2\n  `HalfDuplexAgent` and `HalfDuplexUser`, wraps tau2 domain tools into\n  GEODE's `ToolRegistry` and `ToolExecutor`, and preserves tau2's native\n  evaluator/output path while letting both agent and simulated user run through\n  the subscription route.\n\n### Changed\n\n- **CLI live task surface compacted.** The IPC event renderer now treats\n  `update_plan` like a Claude Code-scale task list: at most five visible tasks\n  around the active item, a `Tasks · done/total` header, and no phase-start\n  plan reprint. Thinking/tool phases carry the active step in the spinner label\n  and flow below a single checklist that is drawn once per state change,\n  avoiding the repeated `Plan:` blocks seen in long runs. The REPL prompt now\n  renders as `geode >` instead of a bare chevron.\n\n### Fixed\n\n- **Serve CLI channel startup order.** `geode serve` now starts the local thin\n  CLI Unix socket before external gateway pollers, so blocking gateway adapters\n  cannot prevent `geode` clients from reconnecting after a daemon restart.\n\n- **Codex OAuth runtime cache refresh.** The `codex-oauth` adapter and\n  legacy Codex provider now fingerprint the resolved OAuth token and rebuild\n  cached OpenAI SDK clients when `~/.codex/auth.json` or GEODE auth state\n  changes, preventing daemon restarts from being required after Codex CLI\n  refreshes an expired ChatGPT token. `/login refresh` also invalidates the\n  Codex CLI credential reader and legacy Codex client cache.\n\n- **MCP filesystem argument compatibility.** MCP tool dispatch now normalizes\n  common schema mismatches before server calls, including mapping `file_path`\n  to `path` when the MCP schema requires `path`, dropping conflicting\n  `read_text_file` `head`/`tail` pairs, annotating exact-read caveats in\n  exposed MCP tool descriptions, and offloading source EOF preservation from\n  model turns into the MCP dispatch layer for same-name text writes."
+  },
+  {
+    "version": "0.99.266",
+    "date": "2026-07-03",
+    "body": "### Fixed\n\n- **Plan checklist no longer re-stacks across thinking/tool rounds.** The IPC\n  event renderer previously re-rendered the whole `update_plan` checklist at\n  every `thinking_end`/`tool_end`, so a multi-round turn stacked N identical\n  `Tasks · …` blocks down the transcript (6+ copies on long runs). Plan\n  rendering is now split from the activity block: the checklist is drawn only\n  from plan events (`progress_plan` / `plan_step` / `replan` /\n  `goal_decomposition`) and deduped against the last drawn state (identical\n  steps, statuses, and explanation → no reprint), while thinking/tool phases\n  redraw only the activity summary and flow below the checklist, which scrolls\n  up with the transcript like a Claude Code todo list. The checklist header\n  also switches from mint (`1;36m`) to the signature rose. Guards:\n  `tests/core/ui/test_event_schema_v2.py` (regression, dedup, header colour)\n  and `tests/core/ui/test_agentic_ui.py` (plan not re-emitted during phases)."
   },
   {
     "version": "0.99.265",
@@ -2053,4 +2058,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-02";
+export const CHANGELOG_SYNCED_AT = "2026-07-03";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-02
+ * Last sync: 2026-07-03
  */
 
 export const GEODE_SOT = {
-  version: "0.99.265",
-  syncedAt: "2026-07-02",
+  version: "0.99.266",
+  syncedAt: "2026-07-03",
 } as const;

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -1045,8 +1045,10 @@ class TestPlanSurfaceVisualLanguage:
         assert "… 3 earlier" in lines
         assert "Tasks · 0/8 done" in lines
 
-    def test_live_region_erased_before_foreign_output(self) -> None:
-        """Any non-surface event erases the live region first — no stale copies."""
+    def test_plan_released_to_scrollback_on_foreign_output(self) -> None:
+        """Foreign output releases the plan to scrollback (it scrolls up) — the
+        checklist is transcript content, never cursor-erased. Releasing it just
+        marks it no-longer-bottom-most so the next plan event draws fresh."""
         r = self._renderer()
         r._tty = True
         r.on_event(
@@ -1056,13 +1058,20 @@ class TestPlanSurfaceVisualLanguage:
             }
         )
         assert r._progress_plan.at_bottom is True
+        before = r._out.getvalue()
+        assert "only step" in before
         r.on_stream("some daemon output\n")
+        after = r._out.getvalue()
+        # Released for a fresh redraw next time, but NOT re-emitted or lost.
         assert r._progress_plan.at_bottom is False
-        assert r._progress_plan.visible_lines == []  # erased, not just marked
+        assert "some daemon output" in after
+        # The daemon output printed after the plan (plan scrolls up, not erased).
+        assert after.index("only step") < after.index("some daemon output")
 
 
-class TestPinnedPlanDuringPhases:
-    """Task list hides during phases and returns as one compact bottom copy."""
+class TestPlanNotReemittedDuringPhases:
+    """The plan is drawn once by its own events and scrolls up; thinking/tool
+    phases flow BELOW it and never re-emit the checklist."""
 
     def _renderer(self) -> Any:
         import io
@@ -1074,8 +1083,9 @@ class TestPinnedPlanDuringPhases:
         r._tty = True
         return r
 
-    def test_thinking_start_hides_task_list_without_reprinting_it(self) -> None:
-        """thinking_start clears the task list; spinner label carries active step."""
+    def test_thinking_start_does_not_reprint_the_plan(self) -> None:
+        """thinking_start leaves the plan in scrollback (not re-emitted); the
+        spinner label carries the active step and flows below it."""
         r = self._renderer()
         r.on_event(
             {
@@ -1086,16 +1096,17 @@ class TestPinnedPlanDuringPhases:
         marker = len(r._out.getvalue())
         r.on_event({"type": "thinking_start", "model": "m", "round": 1})
         try:
-            assert r._plan_pinned is True
-            assert r._progress_plan.visible_lines == []
+            # The plan stays drawn in scrollback — released, not cursor-erased.
+            assert r._progress_plan.visible_lines != []
             assert r._progress_plan.at_bottom is False
             written_after = r._out.getvalue()[marker:]
-            assert "pinned step" not in written_after
+            # No fresh checklist header is emitted for the phase.
+            assert "Tasks ·" not in written_after
         finally:
             r._stop_thinking()
 
-    def test_thinking_cycle_leaves_single_bottom_copy(self) -> None:
-        """progress_plan → thinking_start → thinking_end: ONE plan copy at bottom."""
+    def test_thinking_cycle_leaves_single_plan_copy(self) -> None:
+        """progress_plan → thinking_start → thinking_end: exactly ONE plan copy."""
         r = self._renderer()
         r.on_event(
             {
@@ -1106,13 +1117,13 @@ class TestPinnedPlanDuringPhases:
         r.on_event({"type": "thinking_start", "model": "m", "round": 1})
         r.on_event({"type": "thinking_end"})
         out = r._out.getvalue()
+        assert out.count("Tasks ·") == 1
         tail = out[out.rindex("Tasks") :]  # after the LAST Tasks header
         assert tail.count("cycle step") == 1
-        assert r._plan_pinned is False
-        assert r._progress_plan.at_bottom is True  # bottom copy is erasable again
 
-    def test_tool_cycle_restores_task_list_to_bottom(self) -> None:
-        """tool_start clears the task list; tool_end all-done redraws it."""
+    def test_tool_cycle_does_not_reprint_the_plan(self) -> None:
+        """tool_start/tool_end flow below the plan; the checklist is not
+        re-emitted, and the activity summary renders separately."""
         r = self._renderer()
         r.on_event(
             {
@@ -1121,12 +1132,11 @@ class TestPinnedPlanDuringPhases:
             }
         )
         r.on_event({"type": "tool_start", "name": "web_search"})
-        assert r._plan_pinned is True
         r.on_event({"type": "tool_end", "name": "web_search", "summary": "ok", "duration_s": 0.1})
-        assert r._plan_pinned is False
-        assert r._progress_plan.at_bottom is True
         out = r._out.getvalue()
+        assert out.count("Tasks ·") == 1  # plan drawn once, never re-emitted
         assert "tool step" in out[out.rindex("Tasks") :]
+        assert "Activity" in out  # activity summary rendered on its own surface
 
 
 def test_tool_tracker_running_row_uses_signature_shimmer() -> None:

--- a/tests/core/ui/test_event_schema_v2.py
+++ b/tests/core/ui/test_event_schema_v2.py
@@ -379,6 +379,91 @@ class TestEventRendererV2:
         assert "revised · cadence · 2 steps · rev 1" in tail
         assert "inspect" in tail
 
+    def test_plan_not_restacked_across_thinking_rounds(self, renderer) -> None:
+        """Regression: a plan drawn once must NOT be re-emitted on every thinking
+        round. Before the fix this stacked N identical 'Tasks ·' blocks down the
+        transcript (one per round); now the checklist appears exactly once."""
+        renderer._tty = True
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "explanation": "implementation",
+                "plan": [
+                    {"step": "Inspect UX", "status": "completed"},
+                    {"step": "Patch renderer", "status": "in_progress"},
+                    {"step": "Run tests", "status": "pending"},
+                ],
+            }
+        )
+        # 5 thinking rounds with an UNCHANGED plan, with a round-transition
+        # stream between them (this is what pushed the block up / at_bottom=False
+        # so the old in-place erase could not keep up and copies stacked).
+        for i in range(5):
+            renderer.on_event({"type": "thinking_start", "model": "m", "round": i + 1})
+            renderer.on_event({"type": "thinking_end"})
+            renderer.on_stream("assistant round text\n")
+        renderer.stop()
+
+        out = renderer._out.getvalue()
+        assert out.count("Tasks ·") == 1  # exactly one checklist, not 6+
+        assert out.count("Patch renderer") == 1  # the plan step text, once
+
+    def test_plan_redraws_on_changed_status(self, renderer) -> None:
+        """A second progress_plan with a CHANGED status draws a new checklist."""
+        renderer._tty = True
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "Inspect UX", "status": "in_progress"},
+                    {"step": "Run tests", "status": "pending"},
+                ],
+            }
+        )
+        renderer.on_stream("tool output\n")  # push it up so a fresh copy is drawn
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "Inspect UX", "status": "completed"},
+                    {"step": "Run tests", "status": "in_progress"},
+                ],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert out.count("Tasks ·") == 2  # genuine state change → new checklist
+
+    def test_plan_dedups_identical_consecutive_state(self, renderer) -> None:
+        """A second progress_plan with the SAME state does NOT add a checklist."""
+        renderer._tty = True
+        plan_event = {
+            "type": "progress_plan",
+            "explanation": "same",
+            "plan": [
+                {"step": "Inspect UX", "status": "in_progress"},
+                {"step": "Run tests", "status": "pending"},
+            ],
+        }
+        renderer.on_event(dict(plan_event))
+        renderer.on_stream("tool output\n")  # even after being pushed up…
+        renderer.on_event(dict(plan_event))  # …an identical plan is deduped
+        out = renderer._out.getvalue()
+        assert out.count("Tasks ·") == 1
+
+    def test_plan_header_uses_rose_not_mint(self, renderer) -> None:
+        """Header uses the signature rose SGR, never the old mint '1;36m'."""
+        from core.ui import spinner_glyph
+
+        renderer.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "Only step", "status": "in_progress"}],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert spinner_glyph.ROSE in out
+        assert "\033[1;36m" not in out  # no mint on the plan surface
+
     def test_tool_backpressure(self, renderer) -> None:
         renderer.on_event({"type": "tool_backpressure", "consecutive_errors": 3})
         assert "3" in renderer._out.getvalue()

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.265"
+version = "0.99.266"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- thin-CLI plan 체크리스트가 매 thinking/tool 라운드마다 재인쇄돼 6+개 쌓이던 문제 수정(운영자 스크린샷). Claude Code todo처럼 **상태 변경 이벤트(progress_plan/plan_step/replan) 때만** 렌더 + 동일상태 dedup. thinking/tool phase는 plan을 재렌더하지 않음.
- 헤더색 민트(`\033[1;36m`) → 시그니처 rose(`spinner_glyph.ROSE`).

## Why
- 근인: `_render_live_region`이 plan+activity를 한 단위로 묶어 매 phase 종료 시 재렌더. 라운드 전환 출력이 사이에 끼면 plan이 스크롤로 밀려 in-place erase 실패 → 새로 쌓임(N라운드=N개). HEAD 재현 7개.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | plan/activity 렌더 분리(`_render_plan_region`+dedup / `_render_activity_region`), `_render_live_region`·`_pin_plan_for_phase`·`_plan_pinned` 제거, plan 이벤트에서만 plan 렌더, 헤더 rose |
| `tests/core/ui/test_event_schema_v2.py` | 회귀 4(비재적층·changed-status·dedup·rose) |
| `tests/core/ui/test_agentic_ui.py` | phase 재발행 안 함/스크롤백 릴리스 계약으로 갱신 |
| CHANGELOG 외 5위치+site | v0.99.266 |

## Verification
- [x] 회귀 테스트 HEAD FAIL(7≠1)→수정 후 PASS, tests/core/ui 333 pass
- [x] ruff/format/mypy/lint-imports/hygiene/slop 전부 exit 0
- [x] Codex MCP: **No findings**(activity/plan 커서 회계 독립성·dedup·비-TTY append 확인)
- [x] 5라운드 시뮬 ANSI-strip: `Tasks ·` 1회(was 7), 민트 부재

## Reference
- 운영자 스크린샷(plan 6+ 스태킹, 민트 헤더), Claude Code todo 인플레이스 갱신