### PR TITLE
Add MCPMark env scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,22 @@ GEODE_VERBOSE=false
 # === MCP: Agent Infra (optional) ===
 # E2B_API_KEY=
 
+# === Benchmark harnesses: MCPMark (optional, local only) ===
+# MCPMark reads `.mcp_env` from the harness working directory. Keep real values
+# in an ignored `.mcp_env` and copy/symlink it into
+# `artifacts/eval/harnesses/mcpmark/.mcp_env` before live runs.
+# SOURCE_NOTION_API_KEY=
+# EVAL_NOTION_API_KEY=
+# SOURCE_PARENT_PAGE_TITLE=MCPMark Source Hub
+# EVAL_PARENT_PAGE_TITLE=GEODE MCPMark Sandbox
+# EVAL_PARENT_PAGE_URL=https://app.notion.com/p/GEODE-MCPMark-392581eae2fc80db80f6edef25672615?source=copy_link
+# EVAL_PARENT_PAGE_ID=392581ea-e2fc-80db-80f6-edef25672615
+# PLAYWRIGHT_BROWSER=chromium
+# PLAYWRIGHT_HEADLESS=True
+# GITHUB_TOKENS=
+# GITHUB_EVAL_ORG=
+# DATABASE_URI=postgresql://mcpmark:mcpmark@127.0.0.1:54329/mcpmark
+
 # === Gateway (optional, for Slack/Discord/Telegram) ===
 # SLACK_BOT_TOKEN=
 # SLACK_BOT_USER_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ media/
 
 # Environment
 .env
+.mcp_env
+.mcp_env.local
 
 # inspect_ai eval logs from `geode audit --live` runs (raw transcripts).
 # SOT 는 docs/audits/<date>-petri-*.md 보고서. logs 자체는 너무 크고 PII /

--- a/.mcp_env.example
+++ b/.mcp_env.example
@@ -1,0 +1,20 @@
+# MCPMark benchmark credentials.
+# Copy this file to `.mcp_env` in the MCPMark harness working directory.
+# Do not commit `.mcp_env`.
+
+# Notion.
+SOURCE_NOTION_API_KEY=
+EVAL_NOTION_API_KEY=
+SOURCE_PARENT_PAGE_TITLE=MCPMark Source Hub
+EVAL_PARENT_PAGE_TITLE=GEODE MCPMark Sandbox
+EVAL_PARENT_PAGE_URL=https://app.notion.com/p/GEODE-MCPMark-392581eae2fc80db80f6edef25672615?source=copy_link
+EVAL_PARENT_PAGE_ID=392581ea-e2fc-80db-80f6-edef25672615
+PLAYWRIGHT_BROWSER=chromium
+PLAYWRIGHT_HEADLESS=True
+
+# GitHub.
+GITHUB_TOKENS=
+GITHUB_EVAL_ORG=
+
+# Postgres.
+DATABASE_URI=postgresql://mcpmark:mcpmark@127.0.0.1:54329/mcpmark


### PR DESCRIPTION
## Summary
- ignore local MCPMark env files
- document MCPMark Notion/GitHub/Postgres variables in .env.example
- add .mcp_env.example with non-secret placeholders and current Eval Hub metadata

## Validation
- git diff --check
- tracked secret pattern scan