### PR TITLE
docs(scaffold): CLAUDE.md 실측 재동기화 (모듈 480 · 테스트 9239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ A general-purpose autonomous execution agent. The core runtime is an **AgenticLo
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 403 core + 71 plugins = 474
-- **Tests**: 9018 (+1 live)
+- **Modules**: 403 core + 77 plugins = 480
+- **Tests**: 9239 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -394,7 +394,7 @@ Update project tracking from main. Backlog → In Progress → Done.
 | Format | `uv run ruff format --check core/ tests/ plugins/ scripts/` | 0 reformats |
 | Type | `uv run mypy core/ plugins/` | 0 errors |
 | Imports | `uv run lint-imports` | contracts kept |
-| Test | `uv run pytest tests/ -m "not live"` | 3900+ pass |
+| Test | `uv run pytest tests/ -m "not live"` | 9200+ pass |
 | CLI smoke | `uv run geode version` | version prints |
 
 > 게이트 명령을 파이프로 감싸지 말 것 — `ruff check … \| tail -1` 은 zsh 기본
@@ -406,7 +406,7 @@ Update project tracking from main. Backlog → In Progress → Done.
 
 Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate from GEODE runtime's `core/skills/` SkillRegistry.
 
-> `.claude/skills/` is gitignored (scaffold-local); the rows below are the repo-tracked set that ships with a clone. Additional local-only skills (e.g. `model-onboarding`, `codex-mcp-verify`, `smoke-green-loop`, `workflow-orchestrator`) may exist per machine and are intentionally not listed.
+> `.claude/skills/` is gitignored (scaffold-local); the rows below are the repo-tracked set that ships with a clone. Additional local-only skills (e.g. `model-onboarding`, `codex-mcp-verify`, `smoke-green-loop`) may exist per machine and are intentionally not listed.
 
 | Skill | Triggers | Content |
 |-------|----------|---------|


### PR DESCRIPTION
## Summary
- 스캐폴드 outdated 검수: CLAUDE.md 메트릭 3곳을 실측값으로 재동기화
- 로컬 스킬 예시 목록에서 삭제된 `workflow-orchestrator` 제거

## Why
스캐폴드 전수 검수(운영자 지시)에서 CLAUDE.md 메트릭 드리프트 발견: plugins 모듈 71 → 실측 77 (benchmark-harness 플러그인 등 증가분 미반영), 테스트 9018 → 실측 9239. Quality Gates의 "3900+ pass" 기준도 스위트 성장 대비 절반 이하로 낡음. `workflow-orchestrator` 스킬은 `geode-workflow`와 같은 도메인의 구형 중복 레지스트리(상태 파일 idle)라 스캐폴드에서 삭제됨.

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | Modules 403+71=474 → 403+77=480, Tests 9018 → 9239 (+1 live), Test gate 3900+ → 9200+, 로컬 스킬 예시에서 workflow-orchestrator 제거 |

## Verification
- [x] `find core/ -name "*.py" | wc -l` = 403, `find plugins/ -name "*.py" | wc -l` = 77 (main·develop 트리 동일)
- [x] `pytest --collect-only` 합산 = 9240 (live 1 포함) → 9239 (+1 live)
- [x] docs-only — 코드/버전 무변경 (Docs only = no version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)