### PR TITLE
feat(skills): frontier-ui-ux-catalog 번들 스킬 + AgenticLoop E2E 케이스 스펙 랜딩 (v0.99.274)

### DIFF
--- a/.geode/skills/frontier-ui-ux-catalog/SKILL.md
+++ b/.geode/skills/frontier-ui-ux-catalog/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: frontier-ui-ux-catalog
+visibility: public
+triggers: terminal ui, spinner, status line, CLI UX, animation, shimmer, 터미널 UI, 스피너
+description: Source-grounded catalog of dynamic terminal UI/UX patterns in Claude Code 2.1.170 and Codex CLI 0.142.4 — live status lines, spinner verb sets, streaming and progress affordances. Reference for GEODE CLI/REPL UX work.
+---
+
+# Frontier Terminal UI/UX Catalog
+
+Survey of the live, animated terminal UI in the latest installed frontier CLIs
+(captured 2026-06-30): Claude Code 2.1.170 (strings extracted directly from
+the binary) and Codex CLI 0.142.4 (official docs + GitHub issues).
+
+Use when designing or reviewing GEODE CLI/REPL surfaces — spinners, live
+status lines, token/elapsed readouts, streaming updates, progress affordances.
+The motivating example is the composite live status line that updates several
+times a second:
+
+```
+✢ Hyperspacing… (7m 29s · ↓ 27.7k tokens · thought for 7s)
+```
+
+## Reference (load on demand)
+
+- `reference.md` — the full catalog: status-line composition, spinner verb
+  sets and cadences, streaming/interrupt affordances, and per-surface
+  behaviour notes for both CLIs.

--- a/.geode/skills/frontier-ui-ux-catalog/reference.md
+++ b/.geode/skills/frontier-ui-ux-catalog/reference.md
@@ -1,0 +1,228 @@
+# Claude Code & Codex CLI — Dynamic Terminal UI/UX Catalog
+
+> Source-grounded survey of the live, animated terminal UI in the **latest installed builds**:
+> **Claude Code 2.1.170** (Bun-compiled native binary, `claude.exe`) and **Codex CLI 0.142.4**.
+> Strings extracted directly from the Claude Code binary; Codex facts from OpenAI's `developers.openai.com/codex/cli/features` + GitHub issues. Captured 2026-06-30.
+
+The motivating example — one composite "live status line" that updates several times a second:
+
+```
+✢ Hyperspacing… (7m 29s · ↓ 27.7k tokens · thought for 7s)
+```
+
+Every token in that line is a separate animated element. The rest of this doc decomposes it, then catalogs every other dynamic surface, then explains the rendering machinery ("how is this made").
+
+---
+
+## 0. Anatomy of the live status line
+
+| Segment | What it is | Update cadence | Source |
+|---------|-----------|----------------|--------|
+| `✢` | **Spinner glyph** — cycles an asterisk family (`✻ ✶ ✳ ✢ ·`) plus brightness dimming | frame timer, ~10–12 fps | frame index `% frames.length` |
+| `Hyperspacing…` | **Random gerund** status word, held a few frames then re-rolled | every few seconds | picked from a ~250-word table (Appendix A) |
+| `(7m 29s)` | **Live elapsed timer** since the turn started | every 1 s | `now - turnStart`, formatted `Xm Ys` |
+| `↓ 27.7k tokens` | **Streamed token counter** (received), humanized `k`/`M` | on each stream chunk | running accumulator from SSE usage deltas |
+| `thought for 7s` | **Thinking duration** — shown while/after extended thinking | on thinking-block close | timestamp delta of the thinking block |
+| `esc to interrupt` | **Interrupt hint** (alternates into the parenthetical) | static within a turn | confirmed string `"type": "interrupt"` |
+
+The whole line is repainted in place using a carriage return (`\r`) + clear-to-EOL, never appended — that's why it animates without scrolling.
+
+---
+
+## 1. Claude Code 2.1.170 — dynamic surfaces
+
+Built with **Ink** (React renderer for terminals, Yoga/flexbox layout) on top of the Bun-compiled binary. Renders in the **normal scrollback buffer** (not alt-screen) so completed output stays in history.
+
+### 1.1 Status / spinner line
+The composite above. Color shifts by phase (idle vs working vs error). The gerund table is whimsical by design — a brand-signature UX. Confirmed words in the binary include `Hyperspacing, Schlepping, Percolating, Noodling, Channelling, Cogitating, Marinating, Vibing, Simmering` (full curated list → Appendix A).
+
+### 1.2 Streaming markdown render
+Assistant text appears token-by-token and is **formatted live** as markdown — bold, inline code, lists, headings, fenced code with syntax highlighting — re-laid-out on every chunk as the buffer grows.
+
+### 1.3 Interleaved thinking blocks
+Extended thinking renders as a dim, collapsible `✻ Thinking…` region; on completion it collapses to `thought for Ns`. Binary confirms `thinking` / `thinking_delta` streaming and `[Thinking...]` rendering.
+
+### 1.4 Tool-use cards
+Each tool call renders as a bullet block:
+```
+⏺ Read(file_path: "…")
+  ⎿  Read 120 lines
+```
+`⏺` = call header, `⎿` = indented result/continuation. Long output is truncated with an expand affordance.
+
+### 1.5 Diff rendering
+`Edit`/`Write` show a colored unified diff (`+`/`-`) with syntax highlighting, framed inside the tool card.
+
+### 1.6 Live to-do widget
+The todo list re-renders in place as state changes — checkbox state (`[ ]` → `[~]` in-progress → `[x]` done), with completed items styled differently. Updates mid-turn without redrawing history.
+
+### 1.7 Permission / approval prompts
+Interactive select menus (`1. Yes  2. Yes, and don't ask again  3. No`), arrow-key navigable, that pause the turn.
+
+### 1.8 Autocomplete dropdowns
+- `/` → **slash-command** fuzzy menu (live-filtered as you type)
+- `@` → **file-mention** picker (fuzzy path search)
+- These overlay the composer and update on each keystroke.
+
+### 1.9 Context / usage visualizations
+- `/context` → a visual grid of the context window broken down by category (system, tools, messages, free).
+- **Auto-compact**: a warning bar near the limit, then an animated "compacting…" pass. Binary confirms `compact-2026-01-12` / `compaction summary` machinery.
+
+### 1.10 Mode + shortcut chrome
+- Bottom hint `Press h + Enter to show shortcuts` (exact string in binary).
+- Mode cycling via `shift+tab` (normal → auto-accept-edits → plan), with the active mode shown in the bottom bar.
+- `esc` interrupts; `esc esc` rewinds to a prior message.
+
+### 1.11 Queued input
+Typing while a turn runs **queues** the message; queued items render below the composer and flush on the next turn.
+
+### 1.12 Startup banner
+Boxed welcome with version, cwd, and tips on launch.
+
+---
+
+## 2. Codex CLI 0.142.4 — dynamic surfaces
+
+Built with **ratatui** (immediate-mode Rust TUI) over a **crossterm** backend, typically in the **alt-screen** with a full render loop and widget tree (paragraphs, gauges).
+
+### 2.1 Configurable status line
+Configured via `[tui] status_line` (ordered item list) in `~/.codex/config.toml`. Available items:
+
+| Item | Shows |
+|------|-------|
+| `model-with-reasoning` | active model + reasoning effort |
+| `current-dir` | working directory |
+| `context-usage` | % of context window used (often a gauge/bar) |
+| `used-tokens` | tokens consumed this session |
+| `five-hour-limit` | rolling 5-hour rate-limit bar |
+| `weekly-limit` | weekly rate-limit bar |
+
+(Feature refs: openai/codex #21324 persistent footer w/ progress bars, #17827 customizable status line.)
+
+### 2.2 Working / reasoning indicator
+A spinner while the model works; Codex "explains its plan before making a change," and renders a **reasoning summary** stream.
+
+### 2.3 Syntax-highlighted markdown + diffs
+Markdown code blocks and review diffs are syntax-highlighted in the TUI.
+
+### 2.4 Theme picker — live preview
+`/theme` opens a picker that **previews themes live** before saving; supports custom `.tmTheme` files.
+
+### 2.5 Approval workflow
+Inline approve/reject of each step before it executes; diffs shown with highlighting during review.
+
+### 2.6 Input / history affordances
+- **Tab** queues follow-up text / slash / shell commands while a turn runs.
+- **Ctrl+R** searches prompt history from the composer.
+- **@** opens workspace-root fuzzy file search.
+- **Ctrl+G** launches `$VISUAL`/`$EDITOR`.
+- **Up/Down** restores prior draft text + image placeholders.
+- **Ctrl+O** copies latest completed output.
+
+### 2.7 Session controls
+`/status` (session info), `/clear` (wipe chat), **Ctrl+L** (clear screen, keep conversation), **Ctrl+C** / `/exit`.
+
+---
+
+### 1.13 Tool-activity density — collapse, don't stretch
+Claude Code groups each tool call into a **collapsed card** and hides the bulk behind progressive disclosure:
+```
+• Ran git worktree list --porcelain
+  └ worktree ~/workspace/geode
+    HEAD 1351742ec5c447d8e71507d26bfd67bd764195d1
+    … +8 lines (ctrl + t to view transcript)
+```
+The `… +N lines (ctrl + t to view transcript)` affordance keeps the timeline scannable no matter how chatty the tool is — the column height stays bounded.
+
+This is the **opposite** of Codex's planner activity stream, which prints **one line per micro-step** and grows a tall single column:
+```
+✓ glob_files → ok (0.0s)
+✓ glob_files → ok (0.0s)
+✓ read_document → ok (0.0s)
+✓ grep_files → ok (0.2s)
+…  (×20+)
+```
+Both are "live", but the UX cost differs: collapse-with-disclosure (Claude Code) bounds vertical space and reads as one action; the per-call stretch (Codex) is honest-but-noisy and pushes context off-screen. **Design rule: collapse tool chatter into a summarized card with an expand affordance; never render one row per internal call.**
+
+## 3. Claude Code vs Codex — side-by-side
+
+| Dimension | Claude Code 2.1.170 | Codex CLI 0.142.4 |
+|-----------|---------------------|-------------------|
+| UI framework | Ink (React/JS, Yoga flexbox) | ratatui (Rust, immediate-mode) + crossterm |
+| Screen model | normal scrollback (history persists) | alt-screen render loop |
+| Spinner identity | whimsical rotating gerund + asterisk glyph | plain working/reasoning spinner |
+| Status line | fixed composite (timer · tokens · thought · interrupt) | **user-configurable** item list (`config.toml`) |
+| Token/context | `/context` grid + auto-compact bar | inline gauge items (context %, used tokens, limits) |
+| Theming | fixed | `/theme` live picker + custom `.tmTheme` |
+| Queue while running | type → queued | **Tab** → queued |
+| Diff/markdown | live syntax-highlighted | syntax-highlighted |
+| Approvals | select-menu prompts | inline approve/reject |
+
+---
+
+## 4. How it's built (the implementation pattern)
+
+The animation is not magic — it's a small set of terminal primitives both tools share:
+
+1. **A frame timer.** A `setInterval`/render-loop (~10–15 fps) increments a frame counter. `glyph = frames[frame % frames.length]` gives the spinning character. Same counter drives any pulsing/dimming.
+2. **In-place repaint.** The live line is rewritten with `\r` (carriage return) + ANSI *erase-to-end-of-line* (`\x1b[K`), so it overwrites itself instead of scrolling. Multi-line widgets save/restore the cursor and clear N lines.
+3. **State → re-render.** Claude Code: Ink diffs a React tree and patches only changed cells (like a virtual DOM for the terminal). Codex: ratatui redraws the whole widget tree each loop iteration but diffs against the previous buffer before emitting bytes.
+4. **ANSI SGR for color/style.** `\x1b[2m` dim, `\x1b[36m` cyan, `\x1b[39;2m` reset-fg-keep-dim, etc. (these exact codes appear in the Claude Code binary's shortcut hint).
+5. **Streaming accumulators.** SSE/stream chunks update counters (tokens) and append text; each update triggers a repaint. Elapsed time is derived from a start timestamp, not stored per frame.
+6. **Unicode glyph sets.** Asterisk family (`✻ ✶ ✳ ✢`) or Braille spinners (`⠋ ⠙ ⠹ ⠸ ⠼ ⠴`); box-drawing for cards (`⏺ ⎿`); bars/gauges (`█ ▓ ░`) for progress.
+7. **Terminal-width awareness.** Width is queried (and watched for resize) to truncate/wrap so the line never wraps mid-animation.
+
+**Minimal reproduction** (the core loop, ~15 lines of any language):
+
+```js
+const frames = ["✻","✶","✳","✢","·"];
+const words  = ["Hyperspacing","Schlepping","Percolating","Noodling"];
+const start  = Date.now();
+let f = 0, tokens = 0;
+setInterval(() => {
+  f++;
+  if (f % 20 === 0) word = words[(Math.random()*words.length)|0]; // re-roll word
+  const s = Math.floor((Date.now()-start)/1000);
+  const t = `${Math.floor(s/60)}m ${s%60}s`;
+  process.stdout.write(
+    `\r\x1b[K\x1b[35m${frames[f%frames.length]}\x1b[0m ${word}… ` +
+    `\x1b[2m(${t} · ↓ ${(tokens/1000).toFixed(1)}k tokens · esc to interrupt)\x1b[0m`
+  );
+}, 80);
+```
+
+For real apps don't hand-roll: use **Ink** + a spinner component (JS/TS), or **ratatui** + `throbber-widgets` (Rust). Both give you the frame loop, layout, and diffed repaint for free — the ladder is: native terminal escape → existing spinner lib → custom only if neither fits.
+
+---
+
+## Appendix A — Claude Code spinner gerund table (curated)
+
+~250+ single-word gerunds live in the binary and are selected at random per status update. The whimsical signature set (extracted, noise-filtered):
+
+```
+Accomplishing Actualizing Architecting Befuddling Bloviating Boondoggling Booping
+Bootstrapping Brewing Calculating Canoodling Caramelizing Cascading Catapulting
+Cerebrating Channelling Choreographing Clauding Cogitating Combobulating Computing
+Concocting Conjuring Contemplating Cooking Crafting Crystallizing Cultivating
+Deciphering Deliberating Discombobulating Dithering Doodling Elucidating Enchanting
+Envisioning Fermenting Finagling Flibbertigibbeting Frolicking Gallivanting Garnishing
+Germinating Gesticulating Honking Hullaballooing Hyperspacing Ideating Imagining
+Improvising Incubating Infusing Interleaving Ionizing Jitterbugging Marinating
+Noodling Orchestrating Osmosing Perambulating Percolating Philosophising
+Photosynthesizing Pollinating Pondering Pontificating Prestidigitating Puttering
+Puzzling Quantumizing Razzmatazzing Recombobulating Reticulating Ruminating
+Scampering Schlepping Shenaniganing Shimmying Simmering Skedaddling Smooshing
+Spelunking Sublimating Symbioting Synthesizing Tempering Tomfoolering Transfiguring
+Transmuting Undulating Unfurling Vibing Waddling Whatchamacalliting Whirlpooling
+Wibbling Wrangling Zigzagging
+```
+
+> The list mixes whimsical (`Flibbertigibbeting`, `Hullaballooing`, `Razzmatazzing`, `Clauding`) with mundane (`Computing`, `Crafting`, `Synthesizing`); random selection per repaint is what makes the spinner feel alive.
+
+## Appendix B — Sources
+
+- Claude Code 2.1.170 binary string extraction (`/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`)
+- [Codex CLI — Features](https://developers.openai.com/codex/cli/features)
+- [openai/codex #21324 — TUI usage status line items](https://github.com/openai/codex/issues/21324)
+- [openai/codex #17827 — Customizable status line](https://github.com/openai/codex/issues/17827)
+- Ink (vadimdemedes/ink) · ratatui (ratatui-org/ratatui) — rendering frameworks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.274] - 2026-07-04
+
+### Added
+
+- **Bundled skill: `frontier-ui-ux-catalog` (progressive disclosure).**
+  Source-grounded catalog of dynamic terminal UI/UX in Claude Code 2.1.170 and
+  Codex CLI 0.142.4 (captured 2026-06-30), skill-ized from an unlanded research
+  doc: compact SKILL.md metadata/summary at startup, full `reference.md` loaded
+  on demand via `use_skill`. Reference for GEODE CLI/REPL UX work.
+- **Plan docs: AgenticLoop E2E case specs.** `docs/plans/agentic-loop-e2e-cases/`
+  lands the 2026-06-30 `smoke.yaml` (phase 1) + `routing.yaml` (phase 2,
+  30-case tool-selection matrix) suite specs as plan documents — no runner
+  consumes them yet; the README marks the harness as pending so they do not
+  masquerade as wired tests.
+
 ## [0.99.273] - 2026-07-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.273
+- **Version**: 0.99.274
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.273 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.274 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.273 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.274 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/plans/agentic-loop-e2e-cases/README.md
+++ b/docs/plans/agentic-loop-e2e-cases/README.md
@@ -1,0 +1,9 @@
+# AgenticLoop E2E case specs (harness pending)
+
+Case-suite specs authored 2026-06-30 for an intent-routing E2E harness that
+does not exist yet: `smoke.yaml` (phase 1, <2min breakage detection) and
+`routing.yaml` (phase 2, 30-case tool-selection regression matrix).
+
+Landed as plan documents — no runner consumes these files. When a harness is
+built, move them next to it and wire a loader; do not leave them here as a
+second copy.

--- a/docs/plans/agentic-loop-e2e-cases/routing.yaml
+++ b/docs/plans/agentic-loop-e2e-cases/routing.yaml
@@ -1,0 +1,154 @@
+suite: agentic_loop_routing_matrix
+phase: 2
+goal: "Prevent regressions in tool selection by intent."
+case_count: 30
+cases:
+  - id: route_001_help_menu
+    intent: explicit_command_help
+    turns: [{user: "명령어 목록 보여줘"}]
+    expect: {tools: {includes: [show_help], excludes: [general_web_search]}}
+
+  - id: route_002_direct_concept_no_tool
+    intent: direct_knowledge
+    turns: [{user: "ReAct 패턴을 짧게 설명해줘"}]
+    expect: {tools: {exact: []}}
+
+  - id: route_003_status_mcp
+    intent: system_status
+    turns: [{user: "어떤 MCP 서버가 연결돼 있어?"}]
+    expect: {tools: {includes: [check_status], excludes: [show_help, general_web_search]}}
+
+  - id: route_004_read_local_file
+    intent: read_file
+    turns: [{user: "pyproject.toml 읽고 프로젝트 버전 알려줘"}]
+    expect: {tools: {includes: [read_document], excludes: [run_bash]}}
+
+  - id: route_005_glob_discovery
+    intent: file_discovery
+    turns: [{user: "tests 아래 pytest 파일 찾아줘"}]
+    expect: {tools: {includes: [glob_files], excludes: [run_bash, grep_files]}}
+
+  - id: route_006_content_search
+    intent: content_search
+    turns: [{user: "AgenticResult 클래스가 어디 있는지 찾아줘"}]
+    expect: {tools: {includes: [grep_files], excludes: [run_bash]}}
+
+  - id: route_007_write_new_file
+    intent: create_file
+    turns: [{user: "tests/tmp/e2e_note.txt 파일을 만들고 hello라고 써줘"}]
+    expect: {tools: {includes: [write_file], excludes: [run_bash, edit_file]}}
+
+  - id: route_008_edit_existing_file
+    intent: edit_file
+    turns: [{user: "기존 README.md에서 GEODE라는 단어 하나를 테스트용 문자열로 바꿔줘"}]
+    expect: {tools: {includes: [edit_file], excludes: [run_bash, write_file]}}
+
+  - id: route_009_shell_system_check
+    intent: shell_command
+    turns: [{user: "현재 git status 확인해줘"}]
+    expect: {tools: {includes: [run_bash]}}
+
+  - id: route_010_specific_url_fetch
+    intent: url_fetch
+    turns: [{user: "https://example.com 페이지 읽어줘"}]
+    expect: {tools: {includes: [web_fetch], excludes: [general_web_search, browser_navigate]}}
+
+  - id: route_011_current_web_search
+    intent: current_info_search
+    turns: [{user: "2026년 최신 LangGraph 릴리스 소식 찾아봐"}]
+    expect: {tools: {includes: [general_web_search], excludes: [web_fetch]}}
+
+  - id: route_012_docs_llms_first
+    intent: documentation_site_research
+    turns: [{user: "Anthropic API docs에서 tool use 문서 찾아서 요약해줘"}]
+    expect: {tools: {includes: [llms_txt_index], excludes: [general_web_search]}}
+
+  - id: route_013_save_user_note
+    intent: save_user_note
+    turns: [{user: "내 주차 위치는 B2라고 기억해"}]
+    expect: {tools: {includes: [note_save], excludes: [memory_save]}}
+
+  - id: route_014_read_user_note
+    intent: read_user_note
+    turns: [{user: "내 주차 위치로 기억한 것 알려줘"}]
+    expect: {tools: {includes: [note_read], excludes: [memory_search]}}
+
+  - id: route_015_search_curated_memory
+    intent: search_geode_memory
+    turns: [{user: "GEODE가 이전에 배운 E2E 관련 insight 찾아줘"}]
+    expect: {tools: {includes: [memory_search], excludes: [note_read]}}
+
+  - id: route_016_session_transcript_search
+    intent: search_prior_transcript
+    turns: [{user: "지난 대화에서 병렬 테스트 얘기한 부분 찾아줘"}]
+    expect: {tools: {includes: [session_search], excludes: [memory_search, note_read]}}
+
+  - id: route_017_generate_report_from_findings
+    intent: report_generation
+    turns: [{user: "방금 찾은 결과를 markdown 보고서로 만들어줘"}]
+    expect: {tools: {includes: [generate_report], excludes: [export_json]}}
+
+  - id: route_018_export_json
+    intent: json_export
+    turns: [{user: "이 결과를 JSON 파일로 저장해줘"}]
+    expect: {tools: {includes: [export_json], excludes: [generate_report]}}
+
+  - id: route_019_sample_data
+    intent: synthetic_data
+    turns: [{user: "테스트용 더미 유저 데이터 5개 만들어줘"}]
+    expect: {tools: {includes: [generate_data], excludes: [general_web_search]}}
+
+  - id: route_020_schedule_agent_job
+    intent: scheduled_agent_action
+    turns: [{user: "매일 오전 9시에 AI 뉴스 찾아서 요약해줘"}]
+    expect: {tools: {includes: [schedule_job], excludes: [calendar_create_event]}}
+
+  - id: route_021_calendar_event
+    intent: calendar_create
+    turns: [{user: "내일 오후 3시에 E2E 리뷰 회의 캘린더에 추가해줘"}]
+    expect: {tools: {includes: [calendar_create_event], excludes: [schedule_job]}}
+
+  - id: route_022_calendar_list
+    intent: calendar_list
+    turns: [{user: "이번 주 내 일정 보여줘"}]
+    expect: {tools: {includes: [calendar_list_events], excludes: [schedule_job]}}
+
+  - id: route_023_notification
+    intent: external_notification
+    turns: [{user: "Slack에 E2E smoke 완료됐다고 알려줘"}]
+    expect: {tools: {includes: [send_notification]}}
+
+  - id: route_024_profile_show
+    intent: user_profile_show
+    turns: [{user: "GEODE가 내 프로필을 어떻게 알고 있어?"}]
+    expect: {tools: {includes: [profile_show], excludes: [memory_search]}}
+
+  - id: route_025_profile_update
+    intent: user_profile_update
+    turns: [{user: "내 역할을 AI Platform Engineer로 바꿔줘"}]
+    expect: {tools: {includes: [profile_update], excludes: [profile_preference]}}
+
+  - id: route_026_profile_preference
+    intent: user_preference_update
+    turns: [{user: "앞으로 답변은 간결한 한국어로 해줘"}]
+    expect: {tools: {includes: [profile_preference], excludes: [profile_update]}}
+
+  - id: route_027_model_switch
+    intent: model_switch
+    turns: [{user: "모델을 opus로 바꿔줘"}]
+    expect: {tools: {includes: [switch_model], excludes: [manage_login]}}
+
+  - id: route_028_login_or_plan
+    intent: credentials_plan
+    turns: [{user: "ChatGPT Plus 로그인 설정해줘"}]
+    expect: {tools: {includes: [manage_login], excludes: [set_api_key, switch_model]}}
+
+  - id: route_029_parallel_delegation
+    intent: parallel_research
+    turns: [{user: "42dot, Upstage, Furiosa를 병렬로 조사해줘"}]
+    expect: {tools: {includes: [delegate_task], excludes: [general_web_search]}}
+
+  - id: route_030_complex_plan_first
+    intent: plan_first
+    turns: [{user: "국내 AI 스타트업 10곳을 조사하고 비교 보고서까지 만들어줘"}]
+    expect: {tools: {includes: [create_plan], excludes: [general_web_search, generate_report]}}

--- a/docs/plans/agentic-loop-e2e-cases/smoke.yaml
+++ b/docs/plans/agentic-loop-e2e-cases/smoke.yaml
@@ -1,0 +1,134 @@
+suite: agentic_loop_smoke
+phase: 1
+goal: "Detect major AgenticLoop/tool-routing breakage in under 2 minutes."
+time_budget_s: 120
+cases:
+  - id: smoke_001_direct_answer_no_tool
+    intent: no_tool_direct_answer
+    turns:
+      - user: "ReAct와 Plan-and-Execute 차이를 짧게 설명해줘"
+    expect:
+      tools:
+        exact: []
+      final_response:
+        contains_any: ["ReAct", "Plan-and-Execute", "도구"]
+      max_rounds: 1
+
+  - id: smoke_002_read_file
+    intent: read_file
+    turns:
+      - user: "README.md 읽고 GEODE가 뭔지 세 줄로 요약해줘"
+    expect:
+      tools:
+        includes: [read_document]
+        excludes: [run_bash, glob_files]
+      final_response:
+        contains_any: ["GEODE", "agent", "에이전트"]
+      max_tool_calls: 2
+
+  - id: smoke_003_glob_files
+    intent: file_discovery
+    turns:
+      - user: "core 아래 Python 파일 몇 개 찾아줘"
+    expect:
+      tools:
+        includes: [glob_files]
+        excludes: [run_bash]
+      max_tool_calls: 2
+
+  - id: smoke_004_grep_symbol
+    intent: content_search
+    turns:
+      - user: "AgenticLoop 정의된 파일 찾아줘"
+    expect:
+      tools:
+        includes: [grep_files]
+        excludes: [run_bash]
+      final_response:
+        contains_any: ["AgenticLoop", "agent_loop"]
+      max_tool_calls: 3
+
+  - id: smoke_005_note_save
+    intent: remember_user_note
+    turns:
+      - user: "내 E2E 선호는 smoke 먼저, matrix는 nightly라고 기억해"
+    expect:
+      tools:
+        includes: [note_save]
+        excludes: [memory_save]
+      final_response:
+        contains_any: ["기억", "저장"]
+      max_tool_calls: 1
+
+  - id: smoke_006_note_read
+    intent: recall_user_note
+    turns:
+      - user: "내 E2E 선호로 기억해둔 것 알려줘"
+    expect:
+      tools:
+        includes: [note_read]
+        excludes: [memory_search, web_fetch]
+      final_response:
+        contains_any: ["smoke", "matrix", "E2E"]
+      max_tool_calls: 1
+
+  - id: smoke_007_status
+    intent: system_status
+    turns:
+      - user: "현재 MCP랑 사용 가능한 도구 상태 보여줘"
+    expect:
+      tools:
+        includes: [check_status]
+        excludes: [general_web_search]
+      final_response:
+        contains_any: ["MCP", "tool", "도구", "connected"]
+      max_tool_calls: 1
+
+  - id: smoke_008_url_fetch
+    intent: url_fetch
+    turns:
+      - user: "http://example.com 내용을 요약해줘"
+    expect:
+      tools:
+        includes: [web_fetch]
+        excludes: [general_web_search, browser_navigate]
+      final_response:
+        contains_any: ["Example Domain", "example.com"]
+      max_tool_calls: 2
+      requires_source_citation: true
+
+  - id: smoke_009_clarification_missing_target
+    intent: clarification
+    turns:
+      - user: "그거 분석해줘"
+    expect:
+      tools:
+        exact: []
+      termination_reason_any: [user_clarification_needed, natural, forced_text]
+      final_response:
+        contains_any: ["무엇", "대상", "URL", "파일", "분석"]
+
+  - id: smoke_010_plan_creation_for_complex_task
+    intent: plan_creation
+    turns:
+      - user: "GEODE 최근 변경사항을 여러 소스로 조사하고 리스크까지 보고서로 정리해줘"
+    expect:
+      tools:
+        includes: [create_plan]
+        excludes: [general_web_search, web_fetch, generate_report]
+      max_tool_calls: 1
+      final_response:
+        contains_any: ["Plan ID", "플랜", "승인"]
+
+  - id: smoke_011_tool_failure_handling
+    intent: tool_failure_fallback
+    turns:
+      - user: "https://nonexistent.invalid/geode-smoke-test 내용을 확인하고 요약해줘"
+    expect:
+      tools:
+        includes: [web_fetch]
+        includes_any_after_failure: [general_web_search]
+      final_response:
+        contains_any: ["확인", "verify", "검증", "실패"]
+        must_not_contain: ["성공적으로 확인했습니다"]
+      max_tool_calls: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.273"
+version = "0.99.274"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.273. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.274. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.273. Last sync 2026-07-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.274. Last sync 2026-07-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.274",
+    "date": "2026-07-04",
+    "body": "### Added\n\n- **Bundled skill: `frontier-ui-ux-catalog` (progressive disclosure).**\n  Source-grounded catalog of dynamic terminal UI/UX in Claude Code 2.1.170 and\n  Codex CLI 0.142.4 (captured 2026-06-30), skill-ized from an unlanded research\n  doc: compact SKILL.md metadata/summary at startup, full `reference.md` loaded\n  on demand via `use_skill`. Reference for GEODE CLI/REPL UX work.\n- **Plan docs: AgenticLoop E2E case specs.** `docs/plans/agentic-loop-e2e-cases/`\n  lands the 2026-06-30 `smoke.yaml` (phase 1) + `routing.yaml` (phase 2,\n  30-case tool-selection matrix) suite specs as plan documents — no runner\n  consumes them yet; the README marks the harness as pending so they do not\n  masquerade as wired tests."
+  },
+  {
     "version": "0.99.273",
     "date": "2026-07-04",
     "body": "### Added\n\n- **Judge ↔ human agreement — external-anchor validation of the LLM judge.**\n  New `geode audit-agreement` sub-app (`extract` / `label` / `report` /\n  `recalibrate`) and `core/audit/judge_agreement.py` measure whether the\n  Petri LLM-judge's per-dim scores track a human's, closing the\n  \"judge validated only by another judge\" loop. A deterministic, stratified\n  pilot is extracted from the `~/.geode/petri/logs/` `.eval` archives across\n  the reliability-critical dims (broken_tool_use, input_hallucination,\n  overrefusal, stuck_in_loops, eval_awareness); a resumable CLI labels each\n  transcript excerpt blind (judge score revealed only after the human commits);\n  agreement is reported as per-dim weighted Cohen's kappa (ordinal, linear +\n  quadratic) plus an overall Krippendorff's alpha (ordinal), with systematic\n  bias direction and disagreement cases feeding a judge-recalibration proposal.\n  Statistics are implemented from their definitions in pure stdlib (no numpy /\n  scipy dependency) and pinned by known-value tests (hand-derived weighted\n  kappa; canonical Hayes & Krippendorff 2007 alpha values). Ships harness +\n  methodology + staged pilot (N=20); human labels are collected separately, so\n  no agreement coefficient is reported until labels exist. Methodology:\n  `docs/audits/judge-human-agreement.md`."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.273",
+  version: "0.99.274",
   syncedAt: "2026-07-03",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.273"
+version = "0.99.274"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 미랜딩 research 문서의 점진적 공개(Progressive Disclosure) 스킬화: `frontier-ui-ux-catalog` 번들 스킬 (SKILL.md 요약 + `reference.md` 전문은 `use_skill`로 온디맨드 로드)
- 미배선 E2E 케이스 스펙 2파일을 `docs/plans/agentic-loop-e2e-cases/`로 랜딩 (러너 부재를 README에 명시 — 배선된 테스트로 위장하지 않음)

## Why
운영자 지시: 미랜딩 docs를 스킬화해 점진적 공개 구조로 올릴 것. 공개 레포 기준으로 개인 지원 맥락이 포함된 research 2건(gleo 정렬 감사, agentic RL 설계)은 personal 티어(비커밋)로 분리 배치했고, 순수 기술 서베이인 UI/UX 카탈로그만 번들 티어에 올림(하드코딩 경로·개인 마커 스캔 clean).

## Changes
| File | Change |
|------|--------|
| `.geode/skills/frontier-ui-ux-catalog/SKILL.md` | 메타데이터+요약 (트리거 8종, 로더 파싱 검증) |
| `.geode/skills/frontier-ui-ux-catalog/reference.md` | Claude Code 2.1.170 + Codex CLI 0.142.4 동적 터미널 UI 카탈로그 전문 |
| `docs/plans/agentic-loop-e2e-cases/` | smoke.yaml + routing.yaml(30케이스) + README(하네스 pending 명시) |
| 릴리스 동기화 | CHANGELOG [0.99.274], 버전 5개소, sync-stats + check_llms --fix |

## Verification
- [x] ruff check/format clean, repo hygiene ratchet clean(하드코딩 경로 0)
- [x] 로더 파싱 검증: frontier-ui-ux-catalog triggers 8종+body 로드 확인
- [x] Python 코드 무변경(콘텐츠·docs만) — mypy/pytest는 CI 게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)