### PR TITLE
Make the face-only sprite the Geodi dot-art canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ functional change.
 
 ---
 
+## [0.99.275] - 2026-07-05
+
+### Changed
+
+- **Geodi dot-art canon is now the face-only sprite.** The hand-authored
+  22x12 face grid (`GEODI_PIXELS`) — already what the welcome screen
+  renders — is promoted to the single canonical Geodi sprite; hand-edits
+  now go to it directly.
+
+### Removed
+
+- **Full-body Geodi source grid.** The 22x20 `GEODI_SOURCE_PIXELS`
+  (belly/feet variant) and the now-unused belly-patch palette entry
+  (`l`) are deleted; the face-only sprite no longer derives from a
+  body-included source.
+
 ## [0.99.274] - 2026-07-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.274
+- **Version**: 0.99.275
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.274 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.275 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.274 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.275 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/geodi_art.py
+++ b/core/ui/geodi_art.py
@@ -1,22 +1,20 @@
 """Geodi pixel art — the hand-authored native sprite (no image protocol).
 
-Character canon: a round rose axolotl with EXACTLY six gill stalks (three per
-side, deeper rose, visibly separated), simple symmetric 2x2 dark eyes with a
-1px white catchlight in the top-right corner of each, a tiny 2px mouth, a
-lighter belly patch, and a subtle deep-rose cheek blush beside the eyes.
+Character canon: a round rose axolotl FACE with EXACTLY six gill stalks
+(three per side, deeper rose, visibly separated), simple symmetric 2x2 dark
+eyes with a 1px white catchlight in the top-right corner of each, a subtle
+deep-rose cheek blush beside the eyes, and a tiny 2px mouth. The face-only
+sprite IS the canon — no full-body (belly/feet) variant is kept.
 
-The canonical sprite is authored as a 22x20 pixel grid
-(``GEODI_SOURCE_PIXELS``). The welcome screen renders a face-only 22x12 pixel
-derivative (``GEODI_PIXELS``) that preserves the original silhouette while
-matching the adjacent three-line brand block. Pixels render as truecolor
-half-blocks — ``▀`` with fg = upper pixel, bg = lower pixel, two pixels per
-terminal cell — so the mascot draws as 22 cols x 6 rows — the head down to the mouth, cropped
-to a round face (belly/feet removed) so it sits level with the 3-line welcome — in ANY
+The sprite is authored as a 22x12 pixel grid (``GEODI_PIXELS``). Pixels
+render as truecolor half-blocks — ``▀`` with fg = upper pixel, bg = lower
+pixel, two pixels per terminal cell — so the mascot draws as 22 cols x 6
+rows, sitting level with the three-line welcome brand block in ANY
 truecolor terminal. Transparent pixels reset to the terminal's default
 background.
 
-Hand-edit ``GEODI_SOURCE_PIXELS`` first; keep ``GEODI_PIXELS`` as a compact
-derivative of that shape. Every compact row must stay exactly 22 chars.
+Hand-edit ``GEODI_PIXELS`` directly; every row must stay exactly 22 chars
+and the row count must stay even (rows pair into half-block cells).
 Live preview: ``python -m core.ui.geodi_art``.
 """
 
@@ -29,43 +27,17 @@ GEODI_PALETTE: dict[str, str | None] = {
     ".": None,
     "p": "#F49BC4",  # body — signature Axolotl Rose
     "r": "#E0699F",  # deep rose — gill stalks, cheek blush
-    "l": "#FCD9E8",  # light rose — belly patch
-    "e": "#2B2233",  # near-black — eyes, smile
+    "e": "#2B2233",  # near-black — eyes, mouth
     "w": "#FFFFFF",  # white — eye catchlight
 }
 
-# 22 wide x 20 tall. Full-detail source retained to prevent the compact welcome
-# mascot from drifting into a different character.
-GEODI_SOURCE_PIXELS: list[str] = [
-    "........pppppp........",
-    "......pppppppppp......",
-    ".rr..pppppppppppp..rr.",
-    "..rrpppppppppppppprr..",
-    "....pppppppppppppp....",
-    ".rrrpppppppppppppprrr.",
-    "....pppppppppppppp....",
-    "..rrpppppppppppppprr..",
-    "....pppewppppewppp....",
-    "....pppeeppppeeppp....",
-    "....prrpppppppprrp....",
-    "....ppppppeepppppp....",
-    "....ppppllllllpppp....",
-    "....pppllllllllppp....",
-    "....pppllllllllppp....",
-    ".....pppllllllppp.....",
-    "......pppppppppp......",
-    ".......pppppppp.......",
-    "......ppp....ppp......",
-    "......ppp....ppp......",
-]
-
-# 16 wide x 14 tall. Rows pair top/bottom into half-block cells (7 rows out).
-# Gills: THREE stalks per side — upper diagonal (r2-r3), middle (r5), lower
-# (r7) — with fully transparent side rows (r4, r6) between them so each
-# counts visually. Face (kawaii): symmetric 2x2 dark eyes (r8-r9) with the
-# 1px catchlight in the TOP-RIGHT corner of each, nothing above them but
-# body; cheek blush one row below the eyes (r10); ONE tiny 2px mouth row
-# (r11, cols 8-9). No other dark pixels on the face.
+# 22 wide x 12 tall. Rows pair top/bottom into half-block cells (6 rows out).
+# Gills: THREE stalks per side — upper (r1), middle (r3), lower (r5) — each
+# separated by a gill-free row so the three stalks stay visually distinct.
+# Face (kawaii): symmetric 2x2 dark eyes (r6-r7) with the 1px catchlight in
+# the TOP-RIGHT corner of each, cheek blush beside the eyes (r8), ONE tiny
+# 2px mouth (r9, cols 10-11), rounded chin (r10-r11). No other dark pixels
+# on the face.
 GEODI_PIXELS: list[str] = [
     "........pppppp........",
     ".rr..pppppppppppp..rr.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.274"
+version = "0.99.275"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.274. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.275. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.274. Last sync 2026-07-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.275. Last sync 2026-07-04. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-03
+ * Last sync: 2026-07-04
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.275",
+    "date": "2026-07-05",
+    "body": "### Changed\n\n- **Geodi dot-art canon is now the face-only sprite.** The hand-authored\n  22x12 face grid (`GEODI_PIXELS`) — already what the welcome screen\n  renders — is promoted to the single canonical Geodi sprite; hand-edits\n  now go to it directly.\n\n### Removed\n\n- **Full-body Geodi source grid.** The 22x20 `GEODI_SOURCE_PIXELS`\n  (belly/feet variant) and the now-unused belly-patch palette entry\n  (`l`) are deleted; the face-only sprite no longer derives from a\n  body-included source."
+  },
   {
     "version": "0.99.274",
     "date": "2026-07-04",
@@ -2093,4 +2098,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-03";
+export const CHANGELOG_SYNCED_AT = "2026-07-04";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-03
+ * Last sync: 2026-07-04
  */
 
 export const GEODE_SOT = {
-  version: "0.99.274",
-  syncedAt: "2026-07-03",
+  version: "0.99.275",
+  syncedAt: "2026-07-04",
 } as const;

--- a/tests/core/ui/test_mascot.py
+++ b/tests/core/ui/test_mascot.py
@@ -6,7 +6,7 @@ import re
 from io import StringIO
 from pathlib import Path
 
-from core.ui.geodi_art import GEODI_PALETTE, GEODI_PIXELS, GEODI_SOURCE_PIXELS, geodi_pixel_lines
+from core.ui.geodi_art import GEODI_PALETTE, GEODI_PIXELS, geodi_pixel_lines
 from core.ui.mascot import _collapse_home, _spec_lines, render_mascot
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -15,21 +15,16 @@ _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 class TestGeodiPixels:
     """The hand-authored sprite grid stays well-formed."""
 
-    def test_source_grid_dimensions(self) -> None:
-        assert len(GEODI_SOURCE_PIXELS) == 20
-        assert all(len(row) == 22 for row in GEODI_SOURCE_PIXELS)
-
     def test_grid_dimensions(self) -> None:
         assert len(GEODI_PIXELS) == 12  # even row count — pairs into half-blocks
         assert all(len(row) == 22 for row in GEODI_PIXELS)
 
     def test_only_palette_chars(self) -> None:
-        assert set("".join(GEODI_SOURCE_PIXELS + GEODI_PIXELS)) <= set(GEODI_PALETTE)
+        assert set("".join(GEODI_PIXELS)) <= set(GEODI_PALETTE)
 
     def test_character_canon(self) -> None:
         joined = "".join(GEODI_PIXELS)
-        # Deep-rose gills/blush, dark eyes/mouth present (belly/feet cropped
-        # in the face-only welcome derivative).
+        # Deep-rose gills/blush, dark eyes/mouth present (face-only canon).
         assert "r" in joined and "e" in joined
         assert joined.count("w") == 2  # one 1px catchlight per eye
 
@@ -61,17 +56,17 @@ class TestGeodiPixels:
         assert len(lines) <= 6
         assert max(len(_ANSI.sub("", line)) for line in lines) <= 22
 
-    def test_compact_keeps_source_silhouette_cues(self) -> None:
-        """The compact grid should read like the original, not a redesigned mascot."""
-        assert GEODI_SOURCE_PIXELS[2].startswith(".rr..")
-        assert GEODI_SOURCE_PIXELS[5].startswith(".rrr")
-        assert "ppew" in GEODI_SOURCE_PIXELS[8]
-        assert "llllll" in "".join(GEODI_SOURCE_PIXELS)
-        # Face-only derivative (22x12, head→mouth): 3 separated gill rows per
-        # side, e+w catchlight pair twice, mouth (ee) present; belly/feet cropped.
+    def test_canon_silhouette_cues(self) -> None:
+        """The face-only canon keeps Geodi's identifying features in place."""
+        assert GEODI_PIXELS[1].startswith(".rr..")  # upper gill stalk
+        assert GEODI_PIXELS[3].startswith(".rrr")  # middle gill stalk
+        assert "ppew" in GEODI_PIXELS[6]  # eye with top-right catchlight
+        # 3 separated gill rows per side, e+w catchlight pair twice, mouth
+        # (ee) present; no belly/feet pixels in the face-only canon.
         assert sum(1 for row in GEODI_PIXELS if row.lstrip(".").startswith("rr")) == 3
         assert "".join(GEODI_PIXELS).count("ew") == 2
         assert "ppeepp" in "".join(GEODI_PIXELS)  # mouth row
+        assert "l" not in "".join(GEODI_PIXELS)  # belly patch stays cropped
 
 
 class TestMascotBrandBlock:

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.274"
+version = "0.99.275"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Promote the face-only 22x12 grid (`GEODI_PIXELS`) to the single canonical Geodi sprite; hand-edits now go to it directly.
- Remove the full-body 22x20 `GEODI_SOURCE_PIXELS` (belly/feet variant) and the now-unused belly-patch palette entry (`l`).
- Welcome screen output is unchanged — it already rendered the face-only grid.

## Why
Operator direction: the Geodi dot image should be the face-only version, not the body-included one. The body grid existed only as an authoring source for the face crop, forcing every sprite edit through a derive step and keeping a second, unused variant in the canon.

## Changes
| File | Change |
|------|--------|
| `core/ui/geodi_art.py` | Face-only grid is the canon; body grid + `l` palette entry removed; docstring rewritten |
| `tests/core/ui/test_mascot.py` | Drop source-grid assertions; canon cues now assert against `GEODI_PIXELS` (gills/catchlights/mouth, no belly) |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md`, `CHANGELOG.md` | Version 0.99.275 stamp + changelog entry |
| `uv.lock`, `site/src/data/geode/changelog.ts`, `site/src/data/geode/sot.ts`, `site/public/llms*.txt` | Regenerated derived SoT (`uv lock`, `sync-stats.mjs`, `check_llms_version.py --fix`) |

## Verification
- [x] ruff format --check + ruff check clean (touched files)
- [x] mypy clean (`core/ui/geodi_art.py`, `core/ui/mascot.py`)
- [x] pytest tests/core/ui/test_mascot.py — 10 passed
- [x] CLI smoke: `python -m core.ui.geodi_art` renders the 22x6 face sprite

## Reference
Operator request (2026-07-05): switch the GEODE dot image to the face-only version and merge through gitflow to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)