### PR TITLE
fix(loop): cost.limit_usd를 집행 가드에 배선 (v0.99.276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.276] - 2026-07-06
+
+### Fixed
+
+- **`cost_limit_usd` now reaches the enforced loop guard.** The config
+  knob (`cost.limit_usd` / `GEODE_COST_LIMIT_USD`) previously only fired
+  the COST_WARNING / COST_LIMIT_EXCEEDED hook events; the AgenticLoop's
+  enforced cost guard (80% warn, 100% hard stop) was reachable only via
+  the constructor's `cost_budget` param, which no config path seeded
+  outside the supervised daemon's monthly-budget wiring. The loop now
+  falls back to `settings.cost_limit_usd` when no explicit `cost_budget`
+  is given, so setting the knob alone hard-stops a runaway session
+  (`termination_reason="cost_budget_exceeded"`). An explicit caller
+  value still wins.
+
 ## [0.99.275] - 2026-07-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.275
+- **Version**: 0.99.276
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.275 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.276 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.275 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.276 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -257,7 +257,7 @@ class AgenticLoop:
         thinking_budget: int = 0,  # 0 = disabled; >0 = Extended Thinking tokens (legacy)
         effort: str = "high",  # "low" | "medium" | "high" | "max" (adaptive thinking)
         time_budget_s: float = 0.0,  # 0 = no time limit (OpenClaw pattern)
-        cost_budget: float = 0.0,  # 0 = no cost limit (Karpathy P3)
+        cost_budget: float = 0.0,  # 0 = defer to settings.cost_limit_usd (0 there too = no limit)
         model: str | None = None,
         provider: str = "anthropic",
         tool_registry: ToolRegistry | None = None,
@@ -294,11 +294,14 @@ class AgenticLoop:
         # Adaptive compute: track consecutive text-only rounds for overthinking detection
         self._consecutive_text_only_rounds = 0
         self._total_empty_rounds = 0
-        # No explicit cost_budget → fall back to settings.cost_limit_usd so
+        # No positive cost_budget → fall back to settings.cost_limit_usd so
         # the config knob (`cost.limit_usd`) reaches the enforced guard 3
         # (80% warn / 100% hard stop), not just the COST_WARNING /
-        # COST_LIMIT_EXCEEDED hook events. An explicit caller value (e.g.
-        # supervised services' monthly-budget wiring) always wins.
+        # COST_LIMIT_EXCEEDED hook events. A positive caller value (e.g.
+        # supervised services' monthly-budget wiring) always wins; there is
+        # deliberately no "explicit 0 disables the settings knob" escape.
+        # Snapshot at construction is intentional (session-bound budget);
+        # the hook path in _response.py live-reads the knob instead.
         if cost_budget <= 0.0:
             try:
                 from core.config import settings as _settings

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -294,6 +294,21 @@ class AgenticLoop:
         # Adaptive compute: track consecutive text-only rounds for overthinking detection
         self._consecutive_text_only_rounds = 0
         self._total_empty_rounds = 0
+        # No explicit cost_budget → fall back to settings.cost_limit_usd so
+        # the config knob (`cost.limit_usd`) reaches the enforced guard 3
+        # (80% warn / 100% hard stop), not just the COST_WARNING /
+        # COST_LIMIT_EXCEEDED hook events. An explicit caller value (e.g.
+        # supervised services' monthly-budget wiring) always wins.
+        if cost_budget <= 0.0:
+            try:
+                from core.config import settings as _settings
+
+                limit_raw = getattr(_settings, "cost_limit_usd", 0.0)
+                # isinstance filters MagicMock auto-attrs in fixtures
+                if isinstance(limit_raw, int | float) and limit_raw > 0:
+                    cost_budget = float(limit_raw)
+            except Exception:
+                log.debug("settings.cost_limit_usd read failed", exc_info=True)
         self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
         # No explicit model → prefer settings.act_model (Plan/Act split),

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -434,8 +434,11 @@ class Settings(BaseSettings):
             raise ValueError(f"computer_use_env must be 'host' or 'sandbox', got {v!r}")
         return normalized
 
-    # Cost guard — session-level cost limit (0 = no limit)
-    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
+    # Cost guard — session-level cost limit (0 = no limit). Fires
+    # COST_WARNING at 80% / COST_LIMIT_EXCEEDED at 100%, AND seeds
+    # AgenticLoop's enforced cost guard (hard stop) when the loop gets no
+    # explicit cost_budget (core/agent/loop/agent_loop.py guard 3).
+    cost_limit_usd: float = 0.0
 
     # Computer Use — desktop automation (requires pyautogui)
     computer_use_enabled: bool = True  # default on; pyautogui import guard handles missing dep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.275"
+version = "0.99.276"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.275. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.276. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.275. Last sync 2026-07-04. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.276. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-04
+ * Last sync: 2026-07-06
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.276",
+    "date": "2026-07-06",
+    "body": "### Fixed\n\n- **`cost_limit_usd` now reaches the enforced loop guard.** The config\n  knob (`cost.limit_usd` / `GEODE_COST_LIMIT_USD`) previously only fired\n  the COST_WARNING / COST_LIMIT_EXCEEDED hook events; the AgenticLoop's\n  enforced cost guard (80% warn, 100% hard stop) was reachable only via\n  the constructor's `cost_budget` param, which no config path seeded\n  outside the supervised daemon's monthly-budget wiring. The loop now\n  falls back to `settings.cost_limit_usd` when no explicit `cost_budget`\n  is given, so setting the knob alone hard-stops a runaway session\n  (`termination_reason=\"cost_budget_exceeded\"`). An explicit caller\n  value still wins."
+  },
   {
     "version": "0.99.275",
     "date": "2026-07-05",
@@ -2098,4 +2103,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-04";
+export const CHANGELOG_SYNCED_AT = "2026-07-06";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-04
+ * Last sync: 2026-07-06
  */
 
 export const GEODE_SOT = {
-  version: "0.99.275",
-  syncedAt: "2026-07-04",
+  version: "0.99.276",
+  syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/agent/test_autonomous_safety.py
+++ b/tests/core/agent/test_autonomous_safety.py
@@ -206,7 +206,7 @@ class TestCostBudgetAutoStop:
         mock_module = MagicMock(get_tracker=lambda: mock_tracker)
         with (
             patch.object(loop, "_call_llm", return_value=response),
-            patch.object(loop, "_track_usage"),
+            patch.object(loop, "_track_usage_async"),
             patch.dict("sys.modules", {"core.llm.token_tracker": mock_module}),
         ):
             result = asyncio.run(loop.arun("test cost via settings"))

--- a/tests/core/agent/test_autonomous_safety.py
+++ b/tests/core/agent/test_autonomous_safety.py
@@ -140,9 +140,15 @@ class TestCostBudgetAutoStop:
         assert "1.50" in result.text
 
     def test_cost_budget_zero_no_check(
-        self, context: ConversationContext, executor: ToolExecutor
+        self,
+        context: ConversationContext,
+        executor: ToolExecutor,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When cost_budget=0 (default), no cost check should happen."""
+        """When cost_budget=0 AND settings.cost_limit_usd=0, no cost check happens."""
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "cost_limit_usd", 0.0, raising=False)
         loop = AgenticLoop(context, executor, cost_budget=0.0)
         assert loop._cost_budget == 0.0
 
@@ -154,6 +160,58 @@ class TestCostBudgetAutoStop:
             result = asyncio.run(loop.arun("test no budget"))
 
         assert result.termination_reason == "natural"
+
+    def test_cost_limit_usd_seeds_budget(
+        self,
+        context: ConversationContext,
+        executor: ToolExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No explicit cost_budget → settings.cost_limit_usd seeds the enforced guard."""
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "cost_limit_usd", 2.5, raising=False)
+        loop = AgenticLoop(context, executor)
+        assert loop._cost_budget == 2.5
+
+    def test_explicit_cost_budget_wins_over_settings(
+        self,
+        context: ConversationContext,
+        executor: ToolExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit caller cost_budget overrides settings.cost_limit_usd."""
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "cost_limit_usd", 2.5, raising=False)
+        loop = AgenticLoop(context, executor, cost_budget=7.0)
+        assert loop._cost_budget == 7.0
+
+    def test_cost_limit_usd_terminates_loop(
+        self,
+        context: ConversationContext,
+        executor: ToolExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The config knob alone (no constructor param) hard-stops the loop."""
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "cost_limit_usd", 1.00, raising=False)
+        loop = AgenticLoop(context, executor)
+
+        mock_tracker = MagicMock()
+        mock_tracker.accumulator.total_cost_usd = 1.50
+
+        response = _make_text_response("Hello")
+        mock_module = MagicMock(get_tracker=lambda: mock_tracker)
+        with (
+            patch.object(loop, "_call_llm", return_value=response),
+            patch.object(loop, "_track_usage"),
+            patch.dict("sys.modules", {"core.llm.token_tracker": mock_module}),
+        ):
+            result = asyncio.run(loop.arun("test cost via settings"))
+
+        assert result.termination_reason == "cost_budget_exceeded"
 
     def test_cost_budget_under_limit_continues(
         self, context: ConversationContext, executor: ToolExecutor

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.275"
+version = "0.99.276"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `settings.cost_limit_usd`(config `cost.limit_usd`)가 hook 이벤트(COST_WARNING/COST_LIMIT_EXCEEDED)만 발화하고, AgenticLoop의 집행 cost 가드(guard 3: 80% 경고/100% 하드 스톱)에는 도달하지 못하던 이중 노브 단절 수정
- 생성자에서 양수 `cost_budget` 미지정 시 `settings.cost_limit_usd`로 폴백 — 노브만 설정해도 폭주 세션이 `cost_budget_exceeded`로 종료

## Why
test-time compute 배분 레버 점검(2026-07-06)에서 발견: 시간 예산은 루프 가드로 집행되는데 비용 예산은 config 경로가 자문형(이벤트만)이었다. 집행 경로(`cost_budget` 생성자 파라미터)는 supervised 데몬의 monthly-budget 배선 외에는 시드하는 곳이 없어, 운영자가 `cost.limit_usd`를 설정해도 루프는 멈추지 않았다.

## Changes
| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | 생성자: `cost_budget <= 0` 시 `settings.cost_limit_usd` 폴백(양수 caller 값 우선, 스냅샷은 의도적 construction-time) + 파라미터 계약 주석 갱신 |
| `core/config/_settings.py` | `cost_limit_usd` 주석: 집행 가드 시드 명시 |
| `tests/core/agent/test_autonomous_safety.py` | 폴백 3핀(시드/명시우선/노브 단독 종료) + zero-check 결정론화 |
| CHANGELOG/CLAUDE.md/README*/pyproject + site SoT | v0.99.276 스탬프 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| cost 하드 스톱 가드 | Already exists | agent_loop.py guard 3 (1615행대) — 감사 초기 판정 정정 |
| config 노브 → 가드 배선 | Implemented | 이 PR |

## Verification
- [x] ruff check clean (core/tests/plugins/scripts)
- [x] ruff format --check clean
- [x] mypy clean (484 files)
- [x] lint-imports 4 contracts kept
- [x] pytest 대상 스위트: test_autonomous_safety 19 + test_agentic_loop/test_shared_services/test_worker 195 pass
- [x] Codex MCP 리뷰(gpt-5.5 high): MED 1(0=defer 계약 문서화로 해소)+LOW 2 반영, HIGH 0

## Reference
test-time compute 배분 GAP 점검 (kanban 2026-07-06 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bcmTPPi6LUNWiJJtDw2hv