### PR TITLE
feat(loop): reflection confidence 소비 배선 — 적응 캐던스 + replan 트리거 (v0.99.277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ functional change.
 
 ---
 
+## [0.99.277] - 2026-07-06
+
+### Added
+
+- **Reflection confidence now steers compute allocation.** The
+  reflection node's `CognitiveState.confidence` (produced every round
+  since PR-3 but consumed only by the CLI session display) gains two
+  control-flow consumers: (1) confidence-adaptive reflection cadence —
+  `>= 0.8` doubles the effective `cognitive_reflection_interval`
+  (fewer belief-update LLM calls while the loop is on track), `< 0.4`
+  forces a reflection every round; opt-out via the new
+  `cognitive_reflection_adaptive` knob (`cognitive.reflection_adaptive`).
+  (2) A `low_confidence` replan trigger — edge-triggered on the drop
+  below 0.4 (re-arms only after recovery, so a persistently unsure
+  session replans once, not every round). Trigger priority:
+  `verify_fail` > `low_confidence` > `cadence`.
+
 ## [0.99.276] - 2026-07-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.276
+- **Version**: 0.99.277
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.276 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.277 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.276 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.277 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -48,6 +48,17 @@ from ._tool_factory import (
 )
 from .models import AgenticResult, _context_exhausted_message, _ContextExhaustedError
 
+# Confidence-adaptive compute allocation — the reflection node's
+# ``CognitiveState.confidence`` (0..1) steers how much extra LLM compute
+# the loop spends on itself. High stable confidence stretches the
+# reflection cadence (fewer belief-update calls); low confidence forces
+# a reflection every round and edge-triggers a replan. Thresholds are
+# deliberately module constants, not settings knobs — one adaptive
+# on/off knob exists (``cognitive_reflection_adaptive``).
+REFLECTION_STRETCH_CONFIDENCE = 0.8  # confidence >= → interval doubled
+REFLECTION_FORCE_CONFIDENCE = 0.4  # confidence < → reflect every round
+REPLAN_LOW_CONFIDENCE = 0.4  # confidence < → edge-triggered replan
+
 if TYPE_CHECKING:
     from core.agent.capability_graph import CapabilityGraph
     from core.agent.task_preflight import TaskPreflight
@@ -294,6 +305,11 @@ class AgenticLoop:
         # Adaptive compute: track consecutive text-only rounds for overthinking detection
         self._consecutive_text_only_rounds = 0
         self._total_empty_rounds = 0
+        # Low-confidence replan is edge-triggered: fires once when
+        # confidence drops below REPLAN_LOW_CONFIDENCE, re-arms only
+        # after confidence recovers — prevents a replan storm while
+        # confidence stays low.
+        self._low_confidence_replan_armed = True
         self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
         # No explicit model → prefer settings.act_model (Plan/Act split),
@@ -624,6 +640,19 @@ class AgenticLoop:
         if not settings.cognitive_reflection_enabled:
             return
         interval = max(1, int(settings.cognitive_reflection_interval))
+        # Confidence-adaptive cadence: high stable confidence buys fewer
+        # belief-update calls (interval doubled), low confidence forces a
+        # reflection every round. Reads the LAST reflection's confidence —
+        # staleness during a stretch is the accepted trade (verify still
+        # watches every turn). None (no reflection yet) → base interval.
+        confidence = self.cognitive_state.confidence
+        if getattr(settings, "cognitive_reflection_adaptive", True) and isinstance(
+            confidence, int | float
+        ):
+            if confidence >= REFLECTION_STRETCH_CONFIDENCE:
+                interval *= 2
+            elif confidence < REFLECTION_FORCE_CONFIDENCE:
+                interval = 1
         # round_count is 1-based (record_round ran just before this);
         # (round_count - 1) % interval == 0 → rounds 1, 1+N, 1+2N, ...
         round_count = self.cognitive_state.round_count
@@ -891,14 +920,34 @@ class AgenticLoop:
             from core.observability.session_metrics import current_session_metrics
 
             metrics = current_session_metrics()
+            # Low-confidence replan (edge-triggered; see constructor
+            # comment on _low_confidence_replan_armed). Re-arm on
+            # recovery, fire only on an armed drop below threshold.
+            # getattr tolerates stub loops (same convention as
+            # _check_round_guards' handoff check).
+            raw_confidence = getattr(getattr(self, "cognitive_state", None), "confidence", None)
+            confidence: float | None = (
+                float(raw_confidence) if isinstance(raw_confidence, int | float) else None
+            )
+            if confidence is not None and confidence >= REPLAN_LOW_CONFIDENCE:
+                self._low_confidence_replan_armed = True
+            low_confidence = (
+                getattr(self, "_low_confidence_replan_armed", True)
+                and confidence is not None
+                and confidence < REPLAN_LOW_CONFIDENCE
+            )
             trigger = should_replan(
                 round_idx=round_idx,
                 plan=metrics.active_plan,
                 verify_failed=not metrics.last_verify_passed,
                 verify_should_retry=metrics.last_verify_should_retry,
+                low_confidence=low_confidence,
             )
             if trigger is None:
                 return
+            if trigger == "low_confidence":
+                # consume the edge — no refire until confidence recovers
+                self._low_confidence_replan_armed = False
             # Abandon path: a verify_fail past replan_max_attempts on one
             # step advances the plan instead of calling the planner (step
             # is stuck). The cadence trigger isn't capped.

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -374,13 +374,16 @@ def should_replan(
     plan: Plan | None,
     verify_failed: bool,
     verify_should_retry: bool,
+    low_confidence: bool = False,
 ) -> str | None:
     """Decide whether to call replan this round.
 
-    Returns the trigger name (``"verify_fail"`` / ``"cadence"``) when
-    replan should fire, ``None`` otherwise. Dual-trigger policy per
-    operator decision (PR-CL-A1 plan): verify FAIL takes priority,
-    cadence is a secondary safety net.
+    Returns the trigger name (``"verify_fail"`` / ``"low_confidence"`` /
+    ``"cadence"``) when replan should fire, ``None`` otherwise. Trigger
+    priority: verify FAIL (concrete failure evidence) > low_confidence
+    (the reflection node's belief dropped — the loop computes the edge
+    condition, this pure function only ranks it) > cadence (secondary
+    safety net, PR-CL-A1).
 
     The pure-function signature lets tests assert the trigger logic
     without instantiating the loop.
@@ -399,6 +402,10 @@ def should_replan(
     # without a plan to revise.
     if plan is None:
         return None
+    # Low-confidence trigger — same no-plan guard as cadence: a belief
+    # drop revises an existing plan, it does not synthesize one.
+    if low_confidence:
+        return "low_confidence"
     interval = _replan_interval()
     if interval > 0 and round_idx > 0 and round_idx % interval == 0:
         return "cadence"

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -77,6 +77,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "cognitive.reflection_model": "cognitive_reflection_model",
     "cognitive.reflection_max_tokens": "cognitive_reflection_max_tokens",
     "cognitive.reflection_interval": "cognitive_reflection_interval",
+    "cognitive.reflection_adaptive": "cognitive_reflection_adaptive",
     "output.verbose": "verbose",
     "agentic.thinking_budget": "agentic_thinking_budget",
     "agentic.effort": "agentic_effort",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -97,6 +97,21 @@ class Settings(BaseSettings):
             "with no extra LLM call. PR-3 C-2."
         ),
     )
+    cognitive_reflection_adaptive: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "cognitive_reflection_adaptive",
+            "GEODE_COGNITIVE_REFLECTION_ADAPTIVE",
+        ),
+        description=(
+            "When True (default) the reflection cadence adapts to the "
+            "last reflection's confidence: >= 0.8 doubles the effective "
+            "interval (fewer belief-update calls), < 0.4 forces a "
+            "reflection every round. Thresholds are module constants in "
+            "core/agent/loop/agent_loop.py. When False the fixed "
+            "cognitive_reflection_interval applies unconditionally."
+        ),
+    )
     cognitive_reflection_model: str = Field(
         default="",
         validation_alias=AliasChoices(

--- a/core/observability/session_metrics.py
+++ b/core/observability/session_metrics.py
@@ -378,7 +378,8 @@ class SessionMetrics:
 
     def record_replan(self, trigger: str) -> None:
         """PR-CL-A1 — increment the replan counter and remember the
-        trigger ("verify_fail" or "cadence") for telemetry.
+        trigger ("verify_fail" / "low_confidence" / "cadence") for
+        telemetry.
 
         Does NOT reset ``replan_attempts_on_current_step`` — the caller
         controls reset semantics via :meth:`set_active_plan`'s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.276"
+version = "0.99.277"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.276. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.277. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.276. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.277. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.277",
+    "date": "2026-07-06",
+    "body": "### Added\n\n- **Reflection confidence now steers compute allocation.** The\n  reflection node's `CognitiveState.confidence` (produced every round\n  since PR-3 but consumed only by the CLI session display) gains two\n  control-flow consumers: (1) confidence-adaptive reflection cadence —\n  `>= 0.8` doubles the effective `cognitive_reflection_interval`\n  (fewer belief-update LLM calls while the loop is on track), `< 0.4`\n  forces a reflection every round; opt-out via the new\n  `cognitive_reflection_adaptive` knob (`cognitive.reflection_adaptive`).\n  (2) A `low_confidence` replan trigger — edge-triggered on the drop\n  below 0.4 (re-arms only after recovery, so a persistently unsure\n  session replans once, not every round). Trigger priority:\n  `verify_fail` > `low_confidence` > `cadence`."
+  },
+  {
     "version": "0.99.276",
     "date": "2026-07-06",
     "body": "### Fixed\n\n- **`cost_limit_usd` now reaches the enforced loop guard.** The config\n  knob (`cost.limit_usd` / `GEODE_COST_LIMIT_USD`) previously only fired\n  the COST_WARNING / COST_LIMIT_EXCEEDED hook events; the AgenticLoop's\n  enforced cost guard (80% warn, 100% hard stop) was reachable only via\n  the constructor's `cost_budget` param, which no config path seeded\n  outside the supervised daemon's monthly-budget wiring. The loop now\n  falls back to `settings.cost_limit_usd` when no explicit `cost_budget`\n  is given, so setting the knob alone hard-stops a runaway session\n  (`termination_reason=\"cost_budget_exceeded\"`). An explicit caller\n  value still wins."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.276",
+  version: "0.99.277",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/agent/test_replan.py
+++ b/tests/core/agent/test_replan.py
@@ -280,6 +280,99 @@ def test_should_replan_cadence_off_when_interval_zero(monkeypatch: pytest.Monkey
     )
 
 
+def test_should_replan_low_confidence_with_plan() -> None:
+    trigger = should_replan(
+        round_idx=2,  # not a cadence boundary
+        plan=_make_plan("s1"),
+        verify_failed=False,
+        verify_should_retry=False,
+        low_confidence=True,
+    )
+    assert trigger == "low_confidence"
+
+
+def test_should_replan_verify_fail_beats_low_confidence() -> None:
+    trigger = should_replan(
+        round_idx=2,
+        plan=_make_plan("s1"),
+        verify_failed=True,
+        verify_should_retry=True,
+        low_confidence=True,
+    )
+    assert trigger == "verify_fail"
+
+
+def test_should_replan_low_confidence_requires_plan() -> None:
+    """Same no-plan guard as cadence — belief drop revises, never synthesizes."""
+    assert (
+        should_replan(
+            round_idx=2,
+            plan=None,
+            verify_failed=False,
+            verify_should_retry=False,
+            low_confidence=True,
+        )
+        is None
+    )
+
+
+def test_should_replan_low_confidence_beats_cadence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_REPLAN_INTERVAL", "3")
+    trigger = should_replan(
+        round_idx=3,  # cadence boundary AND low confidence
+        plan=_make_plan("s1"),
+        verify_failed=False,
+        verify_should_retry=False,
+        low_confidence=True,
+    )
+    assert trigger == "low_confidence"
+
+
+# -- low-confidence edge trigger (loop side) ---------------------------
+
+
+def test_low_confidence_replan_edge_trigger(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loop fires low_confidence ONCE per drop below threshold and
+    re-arms only after confidence recovers — no replan storm while
+    confidence stays low."""
+    import asyncio
+
+    from core.agent import plan as plan_mod
+    from core.agent.cognitive_state import CognitiveState
+    from core.agent.loop.agent_loop import AgenticLoop
+    from core.observability.session_metrics import session_metrics_scope
+
+    observed_flags: list[bool] = []
+
+    def fake_should_replan(**kwargs: object) -> str | None:
+        low = bool(kwargs["low_confidence"])
+        observed_flags.append(low)
+        return "low_confidence" if low else None
+
+    async def fake_replan_async(*_args: object, **_kwargs: object) -> None:
+        return None  # planner "fails" — edge must still be consumed
+
+    monkeypatch.setattr(plan_mod, "should_replan", fake_should_replan)
+    monkeypatch.setattr(plan_mod, "replan_async", fake_replan_async)
+
+    state = CognitiveState()
+
+    class _StubSelf:
+        cognitive_state = state
+        _low_confidence_replan_armed = True
+
+    stub = _StubSelf()
+    bound = AgenticLoop._maybe_replan_async.__get__(stub, _StubSelf)
+
+    with session_metrics_scope():
+        for conf in (0.2, 0.2, 0.9, 0.2):
+            state.confidence = conf
+            asyncio.run(bound(1))
+
+    # drop → fire; still low → silent; recovered → re-armed; drop → fire
+    assert observed_flags == [True, False, False, True]
+
+
 def test_should_replan_verify_fail_without_should_retry_is_skipped() -> None:
     """Hard fail (e.g. model_action_required) → no retry recommended →
     no replan even though verify_failed is True."""

--- a/tests/core/config/test_reflection_cost_gate.py
+++ b/tests/core/config/test_reflection_cost_gate.py
@@ -89,11 +89,15 @@ def _maybe_reflect_runner(
     recorder: _Recorder,
     *,
     interval: int,
+    adaptive: bool = False,
 ) -> None:
-    """Synchronous helper — stamps interval, runs _maybe_reflect."""
+    """Synchronous helper — stamps interval + adaptive knob, runs
+    _maybe_reflect. ``adaptive=False`` default keeps the pre-existing
+    fixed-interval tests deterministic regardless of state.confidence."""
     from core.config import settings
 
     object.__setattr__(settings, "cognitive_reflection_interval", interval)
+    object.__setattr__(settings, "cognitive_reflection_adaptive", adaptive)
 
     # Build a minimal stub for AgenticLoop._maybe_reflect — bypass
     # __init__ (which wires the entire runtime). Bind the bound
@@ -208,3 +212,85 @@ def test_maybe_reflect_reads_interval_setting() -> None:
     # a future refactor doesn't accidentally flip to ``round_count %
     # interval`` (which would skip round 1).
     assert "(round_count - 1) % interval" in src or "(round_count-1) % interval" in src
+
+
+# ---------------------------------------------------------------------------
+# Confidence-adaptive cadence (GAP 1 — confidence consumers)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_carries_reflection_adaptive_default_true() -> None:
+    from core.config._settings import Settings
+
+    fields = Settings.model_fields
+    assert "cognitive_reflection_adaptive" in fields
+    assert fields["cognitive_reflection_adaptive"].default is True
+
+
+def test_toml_map_carries_reflection_adaptive_key() -> None:
+    from core.config import _TOML_TO_SETTINGS
+
+    assert _TOML_TO_SETTINGS["cognitive.reflection_adaptive"] == "cognitive_reflection_adaptive"
+
+
+def test_high_confidence_stretches_interval(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """confidence >= 0.8 doubles the effective interval (3 → 6):
+    reflections land on rounds 1, 7 instead of 1, 4, 7, 10."""
+    state = CognitiveState()
+    state.confidence = 0.9
+    for r in range(1, 11):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=3, adaptive=True)
+    assert _stub_reflect_async.calls == [1, 7]
+
+
+def test_low_confidence_forces_every_round(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """confidence < 0.4 collapses the interval to 1 — belief updates
+    every round while the loop is unsure."""
+    state = CognitiveState()
+    state.confidence = 0.2
+    for r in range(1, 6):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=5, adaptive=True)
+    assert _stub_reflect_async.calls == [1, 2, 3, 4, 5]
+
+
+def test_mid_confidence_keeps_base_interval(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """0.4 <= confidence < 0.8 — neither stretch nor force."""
+    state = CognitiveState()
+    state.confidence = 0.6
+    for r in range(1, 8):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=3, adaptive=True)
+    assert _stub_reflect_async.calls == [1, 4, 7]
+
+
+def test_confidence_none_uses_base_interval(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """No reflection has run yet (confidence None) — base interval."""
+    state = CognitiveState()
+    assert state.confidence is None
+    for r in range(1, 5):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=3, adaptive=True)
+    assert _stub_reflect_async.calls == [1, 4]
+
+
+def test_adaptive_off_ignores_confidence(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """cognitive_reflection_adaptive=False — fixed interval wins even
+    at high confidence."""
+    state = CognitiveState()
+    state.confidence = 0.95
+    for r in range(1, 8):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=3, adaptive=False)
+    assert _stub_reflect_async.calls == [1, 4, 7]

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.276"
+version = "0.99.277"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- reflection이 매 라운드 생산하는 `CognitiveState.confidence`가 CLI 표시 외 소비처 0이던 반쪽 배선(Read-Write parity 위반) 해소 — 제어 소비처 2곳 신설
- ① confidence-적응 reflection 캐던스: >=0.8이면 유효 interval 2배(궤도에 있을 때 belief-update 호출 절약), <0.4면 매 라운드 강제. 신규 노브 `cognitive_reflection_adaptive`(기본 True, `cognitive.reflection_adaptive`)
- ② `low_confidence` replan 트리거: 0.4 아래로 떨어지는 순간 1회 발화(edge-trigger), 회복 후에만 재장전 — 지속 저신뢰 세션이 라운드마다 replan하는 폭풍 방지. 우선순위 `verify_fail` > `low_confidence` > `cadence`

## Why
test-time compute 배분 레버 점검(2026-07-06)의 GAP 1: reflection 비용(라운드당 LLM 1콜)을 지불하면서 제어 수익이 0 — "그만 생각/더 생각" 레버 부재. 난이도-적응 배분의 최소 슬라이스이기도 함.

## Changes
| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | 모듈 상수 3종(STRETCH 0.8/FORCE 0.4/REPLAN_LOW 0.4) + `_maybe_reflect` 적응 캐던스 + `_maybe_replan_async` edge-trigger(armed 상태기계, stub-loop getattr 관용) |
| `core/agent/plan.py` | `should_replan(low_confidence=)` 파라미터 + 트리거 랭킹(plan 필수 — belief drop은 개정만, 합성 안 함) |
| `core/config/_settings.py` | `cognitive_reflection_adaptive` Field |
| `core/config/__init__.py` | TOML 맵 `cognitive.reflection_adaptive` |
| `core/observability/session_metrics.py` | record_replan docstring 트리거 목록 갱신 |
| `tests/core/config/test_reflection_cost_gate.py` | 적응 캐던스 6핀(stretch/force/mid/None/knob-off/settings·TOML) — 기존 러너는 adaptive=False 기본으로 결정론 유지 |
| `tests/core/agent/test_replan.py` | should_replan 4핀 + loop-side edge-trigger 상태기계 핀(`[True, False, False, True]`) |
| CHANGELOG + 버전 5개소 + site SoT | v0.99.277 |

## Verification
- [x] ruff check / format --check clean
- [x] mypy clean (484 files)
- [x] lint-imports 4 contracts kept
- [x] pytest: reflection_cost_gate + replan + autonomous_safety + agentic_loop + reflection_node + config 전체 pass
- [x] Codex MCP 리뷰(gpt-5.5 high): No findings (edge-trigger 상태기계·캐던스 위상·starvation·stub 가드 점검, 대상 테스트 6종 자체 실행 6 passed)

## Reference
test-time compute 배분 GAP 점검 (kanban 2026-07-06), PR #2552 (GAP 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bcmTPPi6LUNWiJJtDw2hv