### PR TITLE
feat(subagent): delegate_task best-of-N 후보 샘플링 + 다양성 렌즈 + judge 선별 (v0.99.278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,26 @@ functional change.
 
 ---
 
+## [0.99.278] - 2026-07-06
+
+### Added
+
+- **`delegate_task` best-of-N candidate sampling with diversity
+  lenses.** New opt-in `best_of` parameter (2..4, single-task mode):
+  the same task runs as N parallel sub-agent candidates, each with a
+  distinct built-in reasoning lens
+  (`core/agent/candidate_sampling.py:DIVERSITY_LENSES` — lens forcing
+  is bundled because N clones of one model+prompt fail together), then
+  one structured-output judge call (`select_candidate` tool;
+  `settings.judge_model` → delegating loop's model precedence) picks
+  the winner. The tool result carries a `best_of` block (`n`, `judged`,
+  `winner`, `reason`); every judge failure shape is an observable
+  fallback (`judge_error`), never silent. This gives the runtime
+  same-task width — buying accuracy with parallel compute where
+  verification is cheap — alongside the existing task-decomposition
+  fan-out, and gives `settings.judge_model` its first in-loop consumer
+  beyond the per-turn verify mode.
+
 ## [0.99.277] - 2026-07-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.277
+- **Version**: 0.99.278
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 405 core + 77 plugins = 482
+- **Modules**: 407 core + 78 plugins = 485
 - **Tests**: 9264 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.277 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.278 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.277 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.278 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/candidate_sampling.py
+++ b/core/agent/candidate_sampling.py
@@ -42,6 +42,7 @@ __all__ = [
     "DIVERSITY_LENSES",
     "MAX_BEST_OF",
     "CandidateVerdict",
+    "candidate_text",
     "judge_candidates",
     "lensed_description",
 ]
@@ -136,14 +137,43 @@ def _extract_verdict_input(result: Any) -> dict[str, Any] | None:
     return None
 
 
+def candidate_text(output: Any) -> str:
+    """Extract judge-readable text from a ``SubResult.output`` payload.
+
+    Prefers the common text-carrying keys; falls back to compact JSON so
+    the judge reads content, not a Python dict repr (Codex MCP LOW,
+    2026-07-06).
+    """
+    if isinstance(output, dict):
+        for key in ("text", "summary", "raw", "result"):
+            val = output.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+        try:
+            import json
+
+            return json.dumps(output, ensure_ascii=False, default=str)
+        except Exception:
+            return str(output)
+    return str(output or "")
+
+
 async def judge_candidates(
     task_description: str,
     candidates: list[str],
     *,
     model: str,
+    provider: str | None = None,
+    source: str | None = None,
     max_tokens: int = 512,
 ) -> CandidateVerdict:
     """Pick the best of *candidates* with one judge LLM call.
+
+    ``provider`` / ``source`` should carry the delegating loop's live
+    adapter route (``ToolContext``) so the judge does not re-run
+    resolution and land on a different credential source than the
+    session's main calls (Codex MCP MED, 2026-07-06); ``None`` falls
+    back to settings-driven inference like the reflection node.
 
     Never raises. Every failure path (adapter error, tool declined,
     non-int / out-of-range index) returns the candidate-0 fallback with
@@ -153,10 +183,11 @@ async def judge_candidates(
     if len(candidates) == 1:
         return CandidateVerdict(0, "only one successful candidate; judge call skipped")
     try:
-        provider = _resolve_provider(model)
+        provider = provider or _resolve_provider(model)
         from core.llm.adapters._source_inference import infer_source
 
-        adapter = resolve_for(normalize_registry_provider(provider), infer_source(provider))
+        resolved_source = source or infer_source(provider)
+        adapter = resolve_for(normalize_registry_provider(provider), resolved_source)
         user_prompt = _build_judge_prompt(task_description, candidates)
         log.info(
             "candidate judge dispatch: model=%s provider=%s n=%d",

--- a/core/agent/candidate_sampling.py
+++ b/core/agent/candidate_sampling.py
@@ -1,0 +1,217 @@
+"""Best-of-N candidate sampling + judge selection for ``delegate_task``.
+
+GAP 2+4 of the test-time compute allocation audit (2026-07-06). The
+runtime already had task-decomposition width (``SubAgentManager`` fans
+out DIFFERENT subtasks in parallel) but no same-task N-candidate
+sampling: there was no way to buy accuracy with width on a single task,
+and ``settings.judge_model`` had no runtime consumer outside the
+per-turn verify mode. This module owns the two missing pieces:
+
+- **Diversity lenses** — each candidate of the SAME task gets a distinct
+  reasoning-lens suffix. Ensemble gain scales with error decorrelation;
+  N clones of one model + one prompt fail together, so lens forcing is
+  bundled with sampling rather than left optional.
+- **Judge selection** — one structured-output LLM call (the
+  ``select_candidate`` tool) picks the winner among successful
+  candidates. Judge failure is an OBSERVABLE fallback, never silent:
+  the verdict falls back to the first successful candidate and carries
+  ``judge_error`` so the caller (and the model reading the tool result)
+  sees that selection degraded.
+
+Dispatch mirrors ``core/agent/loop/_reflection.py`` (PR-B structured
+tool_use pattern): ``resolve_for`` + ``AdapterCallRequest`` +
+``call_with_failover``, ``tool_choice="auto"`` (forced tool choice is
+incompatible with extended/adaptive thinking across models).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from core.config import _resolve_provider
+from core.llm.adapters import resolve_for
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+from core.llm.adapters.registry import normalize_registry_provider
+from core.llm.router import call_with_failover
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DIVERSITY_LENSES",
+    "MAX_BEST_OF",
+    "CandidateVerdict",
+    "judge_candidates",
+    "lensed_description",
+]
+
+# Hard cap on N — best-of-N costs N sub-agent runs + 1 judge call; the
+# marginal candidate past 4 rarely survives a majority-style judge while
+# the cost stays linear.
+MAX_BEST_OF = 4
+
+# One lens per candidate index (i % len). Deliberately terse imperative
+# framings — the lens must bend the approach, not restate the task.
+DIVERSITY_LENSES: tuple[str, ...] = (
+    "Approach: execute directly with the most conventional method.",
+    "Approach: enumerate the likely failure modes first, then solve while guarding against them.",
+    "Approach: find the smallest viable solution — prefer the simplest path that fully answers.",
+    "Approach: ground every claim in verifiable evidence; cite what you checked.",
+)
+
+_JUDGE_TOOL_NAME = "select_candidate"
+
+_JUDGE_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "winner_index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based index of the best candidate.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "One-sentence justification (<= 200 chars).",
+        },
+    },
+    "required": ["winner_index", "reason"],
+}
+
+_JUDGE_SYSTEM_PROMPT = (
+    "You are the candidate-selection judge of an autonomous execution "
+    "agent. N sub-agents solved the SAME task with different approaches. "
+    f"Compare their results and invoke the ``{_JUDGE_TOOL_NAME}`` tool "
+    "with the index of the best one. Judge on: correctness, completeness "
+    "against the task, and evidence quality. Do NOT reward verbosity. "
+    "The tool call is the only required output."
+)
+
+# Per-candidate excerpt cap in the judge prompt — the judge compares
+# outcomes, it does not re-read transcripts (clean-context discipline).
+_CANDIDATE_EXCERPT_CHARS = 2000
+
+
+def lensed_description(description: str, index: int) -> str:
+    """Return *description* with the index-th diversity lens appended."""
+    lens = DIVERSITY_LENSES[index % len(DIVERSITY_LENSES)]
+    return f"{description}\n\n{lens}"
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateVerdict:
+    """Outcome of one judge pass over N candidate results.
+
+    ``judge_error`` empty = the judge actually selected. Non-empty =
+    observable fallback (winner defaults to candidate 0 of the
+    successful set); callers surface it in the tool result so degraded
+    selection is never mistaken for a judged one.
+    """
+
+    winner_index: int
+    reason: str
+    judge_error: str = ""
+
+
+def _build_judge_prompt(task_description: str, candidates: list[str]) -> str:
+    lines = [f"Task given to every candidate:\n{task_description}\n"]
+    for i, text in enumerate(candidates):
+        head = text.strip().replace("\r", "")
+        if len(head) > _CANDIDATE_EXCERPT_CHARS:
+            head = head[:_CANDIDATE_EXCERPT_CHARS] + "…(truncated)"
+        lines.append(f"--- Candidate {i} ---\n{head or '(empty result)'}\n")
+    lines.append(f"Invoke the {_JUDGE_TOOL_NAME} tool now.")
+    return "\n".join(lines)
+
+
+def _extract_verdict_input(result: Any) -> dict[str, Any] | None:
+    """Find the ``select_candidate`` tool_use payload (Path-B shape)."""
+    tool_uses = getattr(result, "tool_uses", None)
+    if isinstance(tool_uses, tuple | list):
+        for entry in tool_uses:
+            if isinstance(entry, dict) and entry.get("name") == _JUDGE_TOOL_NAME:
+                payload = entry.get("input")
+                if isinstance(payload, dict):
+                    return payload
+    return None
+
+
+async def judge_candidates(
+    task_description: str,
+    candidates: list[str],
+    *,
+    model: str,
+    max_tokens: int = 512,
+) -> CandidateVerdict:
+    """Pick the best of *candidates* with one judge LLM call.
+
+    Never raises. Every failure path (adapter error, tool declined,
+    non-int / out-of-range index) returns the candidate-0 fallback with
+    ``judge_error`` set — the graceful contract applies at every
+    schema-typed cast, not just the outer try.
+    """
+    if len(candidates) == 1:
+        return CandidateVerdict(0, "only one successful candidate; judge call skipped")
+    try:
+        provider = _resolve_provider(model)
+        from core.llm.adapters._source_inference import infer_source
+
+        adapter = resolve_for(normalize_registry_provider(provider), infer_source(provider))
+        user_prompt = _build_judge_prompt(task_description, candidates)
+        log.info(
+            "candidate judge dispatch: model=%s provider=%s n=%d",
+            model,
+            provider,
+            len(candidates),
+        )
+
+        async def _do_call(m: str) -> object:
+            from core.config import settings as _settings
+
+            req = AdapterCallRequest(
+                model=m,
+                messages=(Message(role="user", content=user_prompt),),
+                system_prompt=_JUDGE_SYSTEM_PROMPT,
+                tools=(
+                    ToolSpec(
+                        name=_JUDGE_TOOL_NAME,
+                        description="Select the best candidate by 0-based index.",
+                        input_schema=_JUDGE_TOOL_SCHEMA,
+                    ),
+                ),
+                tool_choice="auto",
+                max_tokens=max_tokens,
+                temperature=_settings.temperature_reflection,
+            )
+            return await adapter.acomplete(req)
+
+        response, _used_model = await call_with_failover([model], _do_call)
+    except Exception as exc:
+        log.warning("candidate judge call failed: %s", exc, exc_info=True)
+        return CandidateVerdict(
+            0, "fallback: first successful candidate", f"judge call failed: {exc}"
+        )
+
+    parsed = _extract_verdict_input(response)
+    if parsed is None:
+        return CandidateVerdict(
+            0, "fallback: first successful candidate", "judge declined the select_candidate tool"
+        )
+
+    raw_index = parsed.get("winner_index")
+    if not isinstance(raw_index, int) or isinstance(raw_index, bool):
+        return CandidateVerdict(
+            0,
+            "fallback: first successful candidate",
+            f"non-integer winner_index: {raw_index!r}",
+        )
+    if not 0 <= raw_index < len(candidates):
+        return CandidateVerdict(
+            0,
+            "fallback: first successful candidate",
+            f"winner_index {raw_index} out of range 0..{len(candidates) - 1}",
+        )
+
+    raw_reason = parsed.get("reason")
+    reason = raw_reason.strip()[:200] if isinstance(raw_reason, str) else ""
+    return CandidateVerdict(raw_index, reason or "(judge gave no reason)")

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -506,6 +506,10 @@ class ToolExecutor:
         default_model = getattr(context, "model", "") or ""
 
         tasks_raw: list[dict[str, Any]] = tool_input.get("tasks", [])
+        # ``best_of`` applies ONLY to single-task mode. Keyed on the caller's
+        # actual call shape, not len(tasks_raw) — a one-item ``tasks`` batch is
+        # still batch mode (Codex MCP MED, 2026-07-06).
+        single_task_mode = not tasks_raw
         if not tasks_raw:
             tasks_raw = [
                 {
@@ -518,9 +522,9 @@ class ToolExecutor:
                 }
             ]
 
-        # Best-of-N candidate sampling (single-task mode only) — expand the
-        # one task into N copies, each with a distinct diversity lens, then
-        # judge-select the winner after the fan-out (GAP 2+4, 2026-07-06).
+        # Best-of-N candidate sampling — expand the one task into N copies,
+        # each with a distinct diversity lens, then judge-select the winner
+        # after the fan-out (GAP 2+4, 2026-07-06).
         # ``bool`` excluded: True would silently mean best_of=1.
         raw_best_of = tool_input.get("best_of", 1)
         best_of = (
@@ -529,7 +533,7 @@ class ToolExecutor:
         from core.agent.candidate_sampling import MAX_BEST_OF, lensed_description
 
         best_of = max(1, min(best_of, MAX_BEST_OF))
-        if best_of > 1 and len(tasks_raw) == 1:
+        if best_of > 1 and single_task_mode:
             base_task = tasks_raw[0]
             base_description = base_task.get("task_description", "")
             tasks_raw = [
@@ -692,7 +696,7 @@ class ToolExecutor:
             payload["best_of"] = await self._select_best_candidate(
                 task_description=tool_input.get("task_description", ""),
                 results=results,
-                judge_model=default_model,
+                context=context,
             )
         return payload
 
@@ -701,7 +705,7 @@ class ToolExecutor:
         *,
         task_description: str,
         results: list[Any],
-        judge_model: str,
+        context: ToolContext | None,
     ) -> dict[str, Any]:
         """Judge-select the winner among best-of-N candidate SubResults.
 
@@ -709,8 +713,14 @@ class ToolExecutor:
         the winning candidate's full ``to_dict()`` so the model reads
         the selected result without re-scanning ``tasks``. Judge model
         precedence mirrors verify's llm_judge: ``settings.judge_model``
-        → the delegating loop's live model → ``settings.model``. All
-        failure shapes are observable (``judge_error``), never silent.
+        → the delegating loop's live model → ``settings.model``. When
+        the judge INHERITS the loop model, the ToolContext's live
+        provider/source route is forwarded so the judge cannot land on
+        a different credential source than the session's main calls
+        (Codex MCP MED, 2026-07-06); an operator-pinned judge_model
+        re-infers its own route (same rule as the reflection node's
+        configured-model path). All failure shapes are observable
+        (``judge_error``), never silent.
         """
         successful = [r for r in results if getattr(r, "success", False)]
         if not successful:
@@ -719,16 +729,23 @@ class ToolExecutor:
                 "winner": None,
                 "judge_error": "no successful candidates to judge",
             }
-        from core.agent.candidate_sampling import judge_candidates
+        from core.agent.candidate_sampling import candidate_text, judge_candidates
         from core.config import settings
 
-        model = (
-            (getattr(settings, "judge_model", "") or "").strip()
-            or judge_model
-            or getattr(settings, "model", "")
+        pinned_judge_model = (getattr(settings, "judge_model", "") or "").strip()
+        context_model = getattr(context, "model", "") or ""
+        model = pinned_judge_model or context_model or getattr(settings, "model", "")
+        inherits_loop_model = not pinned_judge_model and bool(context_model)
+        judge_provider = getattr(context, "provider", None) if inherits_loop_model else None
+        judge_source = getattr(context, "source", None) if inherits_loop_model else None
+        candidate_texts = [candidate_text(getattr(r, "output", None)) for r in successful]
+        verdict = await judge_candidates(
+            task_description,
+            candidate_texts,
+            model=model,
+            provider=judge_provider,
+            source=judge_source,
         )
-        candidate_texts = [str(getattr(r, "output", "") or "") for r in successful]
-        verdict = await judge_candidates(task_description, candidate_texts, model=model)
         winner = successful[verdict.winner_index]
         block: dict[str, Any] = {
             "n": len(results),

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -518,6 +518,27 @@ class ToolExecutor:
                 }
             ]
 
+        # Best-of-N candidate sampling (single-task mode only) — expand the
+        # one task into N copies, each with a distinct diversity lens, then
+        # judge-select the winner after the fan-out (GAP 2+4, 2026-07-06).
+        # ``bool`` excluded: True would silently mean best_of=1.
+        raw_best_of = tool_input.get("best_of", 1)
+        best_of = (
+            raw_best_of if isinstance(raw_best_of, int) and not isinstance(raw_best_of, bool) else 1
+        )
+        from core.agent.candidate_sampling import MAX_BEST_OF, lensed_description
+
+        best_of = max(1, min(best_of, MAX_BEST_OF))
+        if best_of > 1 and len(tasks_raw) == 1:
+            base_task = tasks_raw[0]
+            base_description = base_task.get("task_description", "")
+            tasks_raw = [
+                {**base_task, "task_description": lensed_description(base_description, i)}
+                for i in range(best_of)
+            ]
+        else:
+            best_of = 1  # batch mode: ignored (schema documents this)
+
         # Batch items may carry their own ``role``; the top-level ``role``
         # is the default for items that don't declare one.
         default_role = tool_input.get("role", "")
@@ -661,12 +682,64 @@ class ToolExecutor:
         for r in results:
             status = "ok" if r.success else "error"
             summary_parts.append(f"{r.task_id}:{status}")
-        return {
+        payload: dict[str, Any] = {
             "tasks": [r.to_dict() for r in results],
             "total": len(results),
             "succeeded": succeeded,
             "summary": f"{succeeded}/{len(results)} tasks completed. [{', '.join(summary_parts)}]",
         }
+        if best_of > 1:
+            payload["best_of"] = await self._select_best_candidate(
+                task_description=tool_input.get("task_description", ""),
+                results=results,
+                judge_model=default_model,
+            )
+        return payload
+
+    async def _select_best_candidate(
+        self,
+        *,
+        task_description: str,
+        results: list[Any],
+        judge_model: str,
+    ) -> dict[str, Any]:
+        """Judge-select the winner among best-of-N candidate SubResults.
+
+        Judges only the SUCCESSFUL candidates; the winner block carries
+        the winning candidate's full ``to_dict()`` so the model reads
+        the selected result without re-scanning ``tasks``. Judge model
+        precedence mirrors verify's llm_judge: ``settings.judge_model``
+        → the delegating loop's live model → ``settings.model``. All
+        failure shapes are observable (``judge_error``), never silent.
+        """
+        successful = [r for r in results if getattr(r, "success", False)]
+        if not successful:
+            return {
+                "n": len(results),
+                "winner": None,
+                "judge_error": "no successful candidates to judge",
+            }
+        from core.agent.candidate_sampling import judge_candidates
+        from core.config import settings
+
+        model = (
+            (getattr(settings, "judge_model", "") or "").strip()
+            or judge_model
+            or getattr(settings, "model", "")
+        )
+        candidate_texts = [str(getattr(r, "output", "") or "") for r in successful]
+        verdict = await judge_candidates(task_description, candidate_texts, model=model)
+        winner = successful[verdict.winner_index]
+        block: dict[str, Any] = {
+            "n": len(results),
+            "judged": len(successful),
+            "winner_task_id": winner.task_id,
+            "winner": winner.to_dict(),
+            "reason": verdict.reason,
+        }
+        if verdict.judge_error:
+            block["judge_error"] = verdict.judge_error
+        return block
 
     async def _request_approval_async(
         self, command: str, reason: str, record: ApprovalRecord | None = None

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -555,6 +555,12 @@
           ],
           "description": "Optional built-in capability role. Restricts the sub-agent to the role's tool allowlist and validates its result against the role's output schema (repo_researcher: read-only research findings; patcher: file edits + patch list; verifier: run_bash checks + pass/fail; reviewer: read-only review findings). Omit for the default unrestricted sub-agent."
         },
+        "best_of": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 4,
+          "description": "Single-task mode only: run N candidates of the SAME task in parallel, each with a distinct built-in reasoning lens, then return the judge-selected winner in a 'best_of' result block alongside all candidates. Costs N sub-agent runs plus one judge LLM call — use when the task is verification-friendly (clear correctness criteria) and worth the extra compute. Ignored in batch mode."
+        },
         "tasks": {
           "type": "array",
           "description": "Batch mode: array of tasks to run in parallel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.277"
+version = "0.99.278"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.277. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.278. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.277. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.278. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.278",
+    "date": "2026-07-06",
+    "body": "### Added\n\n- **`delegate_task` best-of-N candidate sampling with diversity\n  lenses.** New opt-in `best_of` parameter (2..4, single-task mode):\n  the same task runs as N parallel sub-agent candidates, each with a\n  distinct built-in reasoning lens\n  (`core/agent/candidate_sampling.py:DIVERSITY_LENSES` — lens forcing\n  is bundled because N clones of one model+prompt fail together), then\n  one structured-output judge call (`select_candidate` tool;\n  `settings.judge_model` → delegating loop's model precedence) picks\n  the winner. The tool result carries a `best_of` block (`n`, `judged`,\n  `winner`, `reason`); every judge failure shape is an observable\n  fallback (`judge_error`), never silent. This gives the runtime\n  same-task width — buying accuracy with parallel compute where\n  verification is cheap — alongside the existing task-decomposition\n  fan-out, and gives `settings.judge_model` its first in-loop consumer\n  beyond the per-turn verify mode."
+  },
+  {
     "version": "0.99.277",
     "date": "2026-07-06",
     "body": "### Added\n\n- **Reflection confidence now steers compute allocation.** The\n  reflection node's `CognitiveState.confidence` (produced every round\n  since PR-3 but consumed only by the CLI session display) gains two\n  control-flow consumers: (1) confidence-adaptive reflection cadence —\n  `>= 0.8` doubles the effective `cognitive_reflection_interval`\n  (fewer belief-update LLM calls while the loop is on track), `< 0.4`\n  forces a reflection every round; opt-out via the new\n  `cognitive_reflection_adaptive` knob (`cognitive.reflection_adaptive`).\n  (2) A `low_confidence` replan trigger — edge-triggered on the drop\n  below 0.4 (re-arms only after recovery, so a persistently unsure\n  session replans once, not every round). Trigger priority:\n  `verify_fail` > `low_confidence` > `cadence`."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.277",
+  version: "0.99.278",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/agent/test_candidate_sampling.py
+++ b/tests/core/agent/test_candidate_sampling.py
@@ -1,0 +1,261 @@
+"""Best-of-N candidate sampling — lens forcing, judge selection, executor wiring.
+
+GAP 2+4 (2026-07-06): same-task N-candidate sampling with diversity
+lenses + judge selection, exposed as ``delegate_task``'s opt-in
+``best_of`` parameter. Mocking mirrors ``test_reflection_node.py``
+(module-attr monkeypatch on ``call_with_failover`` / ``resolve_for`` /
+``_resolve_provider``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from core.agent import candidate_sampling as cs
+from core.agent.candidate_sampling import (
+    DIVERSITY_LENSES,
+    MAX_BEST_OF,
+    CandidateVerdict,
+    judge_candidates,
+    lensed_description,
+)
+
+# ---------------------------------------------------------------------------
+# Diversity lenses
+# ---------------------------------------------------------------------------
+
+
+def test_lensed_descriptions_are_distinct_and_carry_base() -> None:
+    base = "Summarize the auth module's error handling."
+    lensed = [lensed_description(base, i) for i in range(len(DIVERSITY_LENSES))]
+    assert len(set(lensed)) == len(DIVERSITY_LENSES)
+    assert all(base in text for text in lensed)
+
+
+def test_lens_rotation_wraps_past_available_lenses() -> None:
+    base = "task"
+    assert lensed_description(base, len(DIVERSITY_LENSES)) == lensed_description(base, 0)
+
+
+def test_max_best_of_within_lens_count() -> None:
+    """Every candidate up to the cap gets a UNIQUE lens — the diversity
+    guarantee breaks silently if the cap outgrows the lens pool."""
+    assert len(DIVERSITY_LENSES) >= MAX_BEST_OF
+
+
+# ---------------------------------------------------------------------------
+# judge_candidates
+# ---------------------------------------------------------------------------
+
+
+def _judge_response(payload: dict[str, Any] | None) -> SimpleNamespace:
+    tool_uses = () if payload is None else ({"name": "select_candidate", "input": payload},)
+    return SimpleNamespace(tool_uses=tool_uses)
+
+
+def _patch_judge_dispatch(monkeypatch: pytest.MonkeyPatch, response: SimpleNamespace) -> list[str]:
+    """Patch the module-scope LLM plumbing; returns the called-models log."""
+    called: list[str] = []
+
+    async def _fake_call_with_failover(models: list[str], do_call: Any) -> tuple[Any, str]:
+        called.append(models[0])
+        return response, models[0]
+
+    monkeypatch.setattr(cs, "call_with_failover", _fake_call_with_failover)
+    monkeypatch.setattr(cs, "resolve_for", lambda _p, _s: SimpleNamespace())
+    monkeypatch.setattr(cs, "_resolve_provider", lambda _m: "anthropic")
+    return called
+
+
+def test_judge_single_candidate_skips_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _explode(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("judge LLM must not be called for a single candidate")
+
+    monkeypatch.setattr(cs, "call_with_failover", _explode)
+    verdict = asyncio.run(judge_candidates("t", ["only one"], model="m"))
+    assert verdict.winner_index == 0
+    assert verdict.judge_error == ""
+
+
+def test_judge_selects_winner(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = _patch_judge_dispatch(
+        monkeypatch, _judge_response({"winner_index": 2, "reason": "most complete"})
+    )
+    verdict = asyncio.run(judge_candidates("t", ["a", "b", "c"], model="judge-model"))
+    assert verdict == CandidateVerdict(2, "most complete")
+    assert called == ["judge-model"]
+
+
+def test_judge_decline_falls_back_observably(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_judge_dispatch(monkeypatch, _judge_response(None))
+    verdict = asyncio.run(judge_candidates("t", ["a", "b"], model="m"))
+    assert verdict.winner_index == 0
+    assert "declined" in verdict.judge_error
+
+
+def test_judge_out_of_range_index_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_judge_dispatch(monkeypatch, _judge_response({"winner_index": 9, "reason": "x"}))
+    verdict = asyncio.run(judge_candidates("t", ["a", "b"], model="m"))
+    assert verdict.winner_index == 0
+    assert "out of range" in verdict.judge_error
+
+
+def test_judge_bool_index_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bool is an int subclass — True must not select candidate 1."""
+    _patch_judge_dispatch(monkeypatch, _judge_response({"winner_index": True, "reason": "x"}))
+    verdict = asyncio.run(judge_candidates("t", ["a", "b"], model="m"))
+    assert verdict.winner_index == 0
+    assert "non-integer" in verdict.judge_error
+
+
+def test_judge_llm_failure_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("adapter down")
+
+    monkeypatch.setattr(cs, "call_with_failover", _boom)
+    monkeypatch.setattr(cs, "resolve_for", lambda _p, _s: SimpleNamespace())
+    monkeypatch.setattr(cs, "_resolve_provider", lambda _m: "anthropic")
+    verdict = asyncio.run(judge_candidates("t", ["a", "b"], model="m"))
+    assert verdict.winner_index == 0
+    assert "judge call failed" in verdict.judge_error
+
+
+# ---------------------------------------------------------------------------
+# delegate_task wiring (schema + executor expansion + payload)
+# ---------------------------------------------------------------------------
+
+
+def test_definitions_json_carries_best_of() -> None:
+    definitions = json.loads(
+        (Path(__file__).parents[3] / "core" / "tools" / "definitions.json").read_text()
+    )
+    delegate = next(d for d in definitions if d.get("name") == "delegate_task")
+    best_of_schema = delegate["input_schema"]["properties"]["best_of"]
+    assert best_of_schema["type"] == "integer"
+    assert best_of_schema["minimum"] == 2
+    assert best_of_schema["maximum"] == MAX_BEST_OF
+
+
+class _FakeSubAgentManager:
+    """Captures dispatched SubTasks; returns one successful SubResult each."""
+
+    def __init__(self) -> None:
+        self.dispatched: list[Any] = []
+
+    async def adelegate(self, tasks: list[Any], **_kwargs: Any) -> list[Any]:
+        from core.agent.sub_agent import SubResult
+
+        self.dispatched = list(tasks)
+        return [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output={"text": f"answer from {t.task_id}"},
+            )
+            for t in tasks
+        ]
+
+
+def _make_executor(manager: _FakeSubAgentManager) -> Any:
+    from core.agent.tool_executor import ToolExecutor
+
+    return ToolExecutor(action_handlers={}, sub_agent_manager=manager)
+
+
+def test_best_of_expands_single_task_with_distinct_lenses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+
+    async def _fake_judge(
+        _desc: str, candidates: list[str], *, model: str, **_k: Any
+    ) -> CandidateVerdict:
+        assert len(candidates) == 3
+        return CandidateVerdict(1, "middle one wins")
+
+    monkeypatch.setattr(cs, "judge_candidates", _fake_judge)
+
+    payload = asyncio.run(
+        executor._aexecute_delegate({"task_description": "solve X", "best_of": 3}, context=None)
+    )
+
+    descriptions = [t.description for t in manager.dispatched]
+    assert len(descriptions) == 3
+    assert len(set(descriptions)) == 3, "each candidate must get a distinct lens"
+    assert all("solve X" in d for d in descriptions)
+
+    block = payload["best_of"]
+    assert block["n"] == 3
+    assert block["judged"] == 3
+    assert block["reason"] == "middle one wins"
+    assert block["winner_task_id"] == manager.dispatched[1].task_id
+    assert payload["total"] == 3
+
+
+def test_best_of_ignored_in_batch_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+
+    async def _explode(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("judge must not run in batch mode")
+
+    monkeypatch.setattr(cs, "judge_candidates", _explode)
+
+    payload = asyncio.run(
+        executor._aexecute_delegate(
+            {
+                "tasks": [
+                    {"task_description": "a"},
+                    {"task_description": "b"},
+                ],
+                "best_of": 3,
+            },
+            context=None,
+        )
+    )
+    assert "best_of" not in payload
+    assert payload["total"] == 2
+
+
+def test_best_of_clamps_to_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+
+    async def _fake_judge(
+        _desc: str, candidates: list[str], *, model: str, **_k: Any
+    ) -> CandidateVerdict:
+        return CandidateVerdict(0, "first")
+
+    monkeypatch.setattr(cs, "judge_candidates", _fake_judge)
+
+    payload = asyncio.run(
+        executor._aexecute_delegate({"task_description": "solve X", "best_of": 99}, context=None)
+    )
+    assert payload["total"] == MAX_BEST_OF
+
+
+def test_best_of_all_failed_reports_observable_error() -> None:
+    class _AllFailManager(_FakeSubAgentManager):
+        async def adelegate(self, tasks: list[Any], **_kwargs: Any) -> list[Any]:
+            from core.agent.sub_agent import SubResult
+
+            self.dispatched = list(tasks)
+            return [
+                SubResult(task_id=t.task_id, description=t.description, success=False)
+                for t in tasks
+            ]
+
+    executor = _make_executor(_AllFailManager())
+    payload = asyncio.run(
+        executor._aexecute_delegate({"task_description": "solve X", "best_of": 2}, context=None)
+    )
+    block = payload["best_of"]
+    assert block["winner"] is None
+    assert "no successful candidates" in block["judge_error"]

--- a/tests/core/agent/test_candidate_sampling.py
+++ b/tests/core/agent/test_candidate_sampling.py
@@ -259,3 +259,113 @@ def test_best_of_all_failed_reports_observable_error() -> None:
     block = payload["best_of"]
     assert block["winner"] is None
     assert "no successful candidates" in block["judge_error"]
+
+
+def test_best_of_ignored_for_one_item_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A one-item ``tasks`` array is STILL batch mode — best_of must not
+    multiply it (Codex MCP MED, 2026-07-06)."""
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+
+    async def _explode(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("judge must not run in batch mode")
+
+    monkeypatch.setattr(cs, "judge_candidates", _explode)
+
+    payload = asyncio.run(
+        executor._aexecute_delegate(
+            {"tasks": [{"task_description": "a"}], "best_of": 4}, context=None
+        )
+    )
+    assert "best_of" not in payload
+    assert payload["total"] == 1
+
+
+def test_best_of_bool_true_means_disabled() -> None:
+    """``best_of: true`` (bool is an int subclass) must not expand."""
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+    payload = asyncio.run(
+        executor._aexecute_delegate({"task_description": "solve X", "best_of": True}, context=None)
+    )
+    assert "best_of" not in payload
+    assert payload["total"] == 1
+
+
+def test_best_of_winner_maps_through_failed_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Judge indexes the SUCCESSFUL subset — with candidate 0 failed,
+    judged index 1 must map to the third dispatched task overall."""
+
+    class _FirstFailsManager(_FakeSubAgentManager):
+        async def adelegate(self, tasks: list[Any], **_kwargs: Any) -> list[Any]:
+            from core.agent.sub_agent import SubResult
+
+            self.dispatched = list(tasks)
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=(i != 0),
+                    output={"text": f"answer {i}"},
+                )
+                for i, t in enumerate(tasks)
+            ]
+
+    manager = _FirstFailsManager()
+    executor = _make_executor(manager)
+
+    async def _fake_judge(
+        _desc: str, candidates: list[str], *, model: str, **_k: Any
+    ) -> CandidateVerdict:
+        assert candidates == ["answer 1", "answer 2"]
+        return CandidateVerdict(1, "second of the successful")
+
+    monkeypatch.setattr(cs, "judge_candidates", _fake_judge)
+
+    payload = asyncio.run(
+        executor._aexecute_delegate({"task_description": "solve X", "best_of": 3}, context=None)
+    )
+    block = payload["best_of"]
+    assert block["judged"] == 2
+    assert block["winner_task_id"] == manager.dispatched[2].task_id
+
+
+def test_best_of_judge_inherits_tool_context_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no judge_model is pinned, the judge call must carry the
+    ToolContext's live model + provider + source (Codex MCP MED)."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "judge_model", "", raising=False)
+    manager = _FakeSubAgentManager()
+    executor = _make_executor(manager)
+    seen: dict[str, Any] = {}
+
+    async def _fake_judge(
+        _desc: str, candidates: list[str], *, model: str, **kwargs: Any
+    ) -> CandidateVerdict:
+        seen["model"] = model
+        seen["provider"] = kwargs.get("provider")
+        seen["source"] = kwargs.get("source")
+        return CandidateVerdict(0, "ok")
+
+    monkeypatch.setattr(cs, "judge_candidates", _fake_judge)
+
+    live_route = SimpleNamespace(model="claude-opus-4-8", provider="anthropic", source="oauth")
+    asyncio.run(
+        executor._aexecute_delegate(
+            {"task_description": "solve X", "best_of": 2}, context=live_route
+        )
+    )
+    assert seen == {"model": "claude-opus-4-8", "provider": "anthropic", "source": "oauth"}
+
+
+def test_candidate_text_prefers_text_keys_over_dict_repr() -> None:
+    assert cs.candidate_text({"text": "the answer"}) == "the answer"
+    assert cs.candidate_text({"summary": "s"}) == "s"
+    as_json = cs.candidate_text({"count": 3})
+    assert as_json == '{"count": 3}'
+    assert cs.candidate_text(None) == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.277"
+version = "0.99.278"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 같은 과제 N후보 샘플링이 런타임에 부재(fan-out은 과제 분해 병렬만)하고 `judge_model`이 verify 모드 외 미소비이던 GAP 해소
- `delegate_task`에 옵인 `best_of`(2..4, 단일 과제 모드): 같은 과제를 N개 병렬 후보로 실행하되 후보마다 내장 다양성 렌즈를 강제(클론 N개의 오류 상관 방지), `select_candidate` 구조화 출력 judge 1콜로 승자 선별
- 결과에 `best_of` 블록(`n`/`judged`/`winner`/`reason`) — judge 실패 전 형태는 `judge_error`로 관측 가능한 폴백, silent 금지

## Why
test-time compute 배분 레버 점검(2026-07-06)의 GAP 2+4: 검증이 싼 과제에서 너비로 정확도를 사는 경로가 없었고, 너비를 쓰더라도 렌즈/모델 다변화 장치가 없어 앙상블 이득이 이론값보다 작아지는 구조였다.

## Changes
| File | Change |
|------|--------|
| `core/agent/candidate_sampling.py` | 신규 — `DIVERSITY_LENSES` 4종 + `lensed_description` + `judge_candidates`(reflection의 PR-B 구조화 tool_use 디스패치 미러, provider/source 인자로 라이브 라우트 상속) + `candidate_text`(dict repr 대신 text/summary/raw/result → JSON 폴백) |
| `core/agent/tool_executor/executor.py` | `_aexecute_delegate` best_of 확장(단일 모드 게이트=호출 형태 기준, bool 제외, cap 4) + `_select_best_candidate`(judge_model 우선순위: settings.judge_model → ToolContext model → settings.model, 상속 시 ToolContext provider/source 전달) |
| `core/tools/definitions.json` | `best_of` 스키마(2..4, 단일 모드 전용 문서화) |
| `tests/core/agent/test_candidate_sampling.py` | 신규 19핀 — 렌즈 구분/회전/cap≤렌즈수, judge 선별/거절/범위밖/bool 인덱스/예외 무전파/단일후보 스킵, 스키마, 확장/1-item batch 무시/bool best_of/clamp/전실패/혼합실패 winner 매핑/ToolContext 라우트 상속/candidate_text |
| CHANGELOG + 버전 5개소 + site SoT | v0.99.278, Modules 실측 407+78=485 |

## Verification
- [x] ruff check / format --check clean (core/tests/plugins/scripts)
- [x] mypy clean (485 files)
- [x] lint-imports 4 contracts kept
- [x] pytest: test_candidate_sampling 19 + subagent 3스위트 + tools 스위트 pass
- [x] Codex MCP 리뷰(gpt-5.5 high) 라운드1: MED 2(1-item batch 오확장, ToolContext 라우트 미상속)+LOW 1(dict repr) → 전부 수정 + 회귀핀 4건 추가

## Reference
test-time compute 배분 GAP 점검 (kanban 2026-07-06), PR #2552/#2553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bcmTPPi6LUNWiJJtDw2hv