### PR TITLE
fix(adapters): 레지스트리 조회 경계에서 provider 어휘 정규화 (v0.99.280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ functional change.
 
 ---
 
+## [0.99.280] - 2026-07-06
+
+### Fixed
+
+- **Adapter lookups normalize provider vocabulary at the boundary.**
+  `resolve_for` and `_select_adapter` now accept BOTH the adapter
+  registry's family names (`openai` / `glm`) and the routing layer's
+  variant ids (`openai-codex` / `glm-coding` / `zhipuai`), translating
+  via `normalize_registry_provider` at the lookup entry instead of
+  relying on every caller to translate first. Incident: a fast-chat
+  path forwarded `loop._provider='openai-codex'` verbatim as
+  `prefer_provider`, matched zero registered adapters, and every
+  codex-subscription fast-chat turn failed with
+  AdapterUnavailableError (2026-07-06). `glm-coding` (a live provider
+  value in strategy plans and auth config) joins the normalization map;
+  the drift-anchor pin is updated deliberately.
+
 ## [0.99.279] - 2026-07-06
 
 ### Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.279
+- **Version**: 0.99.280
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.279 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.279 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/llm/adapters/dispatch.py
+++ b/core/llm/adapters/dispatch.py
@@ -58,7 +58,7 @@ from core.llm.adapters.base import (
     TextCompletionResult,
     WebSearchResult,
 )
-from core.llm.adapters.registry import list_adapters
+from core.llm.adapters.registry import list_adapters, normalize_registry_provider
 from core.llm.errors import BillingError, is_billing_fatal
 
 log = logging.getLogger(__name__)
@@ -247,7 +247,15 @@ def _select_adapter(
     through to the default-resolved path, which contradicted the
     docstring claim that partial preferences raise unavailable and was an
     uncovered widening surface.
+
+    ``prefer_provider`` accepts both the registry family names and the
+    routing layer's variant ids (``openai-codex`` / ``glm-coding`` /
+    ``zhipuai``) — normalized here so a caller forwarding
+    ``loop._provider`` verbatim cannot miss every registered adapter
+    (fast-chat incident, 2026-07-06).
     """
+    if prefer_provider:
+        prefer_provider = normalize_registry_provider(prefer_provider)
     capable = _capability_adapters(capability_attr)
     if not capable:
         return None

--- a/core/llm/adapters/registry.py
+++ b/core/llm/adapters/registry.py
@@ -128,6 +128,7 @@ def adapter_health(name: str) -> EnvironmentReport:
 # sync'd. Add new aliases HERE only.
 PROVIDER_REGISTRY_NORMALIZATION: dict[str, str] = {
     "openai-codex": "openai",
+    "glm-coding": "glm",
     "zhipuai": "glm",
 }
 
@@ -141,6 +142,17 @@ def normalize_registry_provider(provider: str) -> str:
 def resolve_for(provider: str, source: str) -> LLMAdapter:
     """Find the unique adapter matching ``(provider, source)``.
 
+    ``provider`` accepts BOTH vocabularies — the registry's family names
+    (``openai`` / ``glm``) and the routing layer's variant ids
+    (``openai-codex`` / ``glm-coding`` / ``zhipuai``) — normalized here at
+    the boundary. Callers used to be responsible for calling
+    :func:`normalize_registry_provider` themselves; the fast-chat incident
+    (2026-07-06 — ``loop._provider='openai-codex'`` passed through
+    unnormalized, every codex-subscription fast-chat turn failed with
+    AdapterUnavailableError) showed convention-enforced translation does
+    not survive new callers. Normalizing at the lookup entry kills the
+    bug class.
+
     ``source`` MUST be a concrete value (one of
     ``core.llm.adapters.base.CONCRETE_SOURCES``). The picker collapses
     ``"auto"`` → concrete before calling. Passing ``"auto"`` here raises
@@ -149,6 +161,7 @@ def resolve_for(provider: str, source: str) -> LLMAdapter:
 
     Raises :class:`AdapterNotFoundError` when no adapter matches.
     """
+    provider = normalize_registry_provider(provider)
     if source == SOURCE_AUTO:
         raise ValueError(
             "resolve_for: source='auto' is a picker sentinel — collapse it to a "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.279"
+version = "0.99.280"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.279. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.280. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.279. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.280. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.280",
+    "date": "2026-07-06",
+    "body": "### Fixed\n\n- **Adapter lookups normalize provider vocabulary at the boundary.**\n  `resolve_for` and `_select_adapter` now accept BOTH the adapter\n  registry's family names (`openai` / `glm`) and the routing layer's\n  variant ids (`openai-codex` / `glm-coding` / `zhipuai`), translating\n  via `normalize_registry_provider` at the lookup entry instead of\n  relying on every caller to translate first. Incident: a fast-chat\n  path forwarded `loop._provider='openai-codex'` verbatim as\n  `prefer_provider`, matched zero registered adapters, and every\n  codex-subscription fast-chat turn failed with\n  AdapterUnavailableError (2026-07-06). `glm-coding` (a live provider\n  value in strategy plans and auth config) joins the normalization map;\n  the drift-anchor pin is updated deliberately."
+  },
+  {
     "version": "0.99.279",
     "date": "2026-07-06",
     "body": "### Architecture\n\n- **CLI style SoT: `core/ui/palette.py`.** The CLI had two disconnected\n  style systems — the Rich brand theme in `console.py` and a raw-ANSI\n  thin-client path (`event_renderer` / `tool_tracker` / `status`) that\n  inlined 150+ escape literals across 17 distinct SGR codes, including\n  the same style written two ways (`36;1` vs `1;36`). All brand hexes,\n  SGR style/control tokens, the renderer glyph vocabulary, and\n  truncation/width metrics now live in one palette module: `console.py`\n  derives the Rich theme from the same hex anchors, `spinner_glyph`\n  keeps only its animation-owned dynamic rose, and every swept renderer\n  emits palette tokens. Token values are byte-identical to the literals\n  they replaced (zero visual diff by construction — full\n  `tests/core/ui` suite green unchanged); re-skinning the raw path onto\n  the brand truecolor identity is now a one-line-per-semantic value\n  change. Drift ratchets in `tests/core/ui/test_style_sot.py`: new\n  inline `\\033[`/`\\x1b[` literals in the swept modules fail CI, hex\n  restatement in `console.py` fails, token/glyph values are pinned, and\n  denormalized SGR spellings are banned."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.279",
+  version: "0.99.280",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/llm/adapters/test_registry.py
+++ b/tests/core/llm/adapters/test_registry.py
@@ -256,3 +256,18 @@ def test_adapter_health_runs_on_every_builtin() -> None:
             f"adapter_health({adapter.name!r}) returned {type(report).__name__}; "
             "every built-in must honor the EnvironmentReport contract."
         )
+
+
+def test_resolve_for_normalizes_routing_variant_ids() -> None:
+    """Boundary normalization (fast-chat incident 2026-07-06) — the
+    routing layer's variant vocabulary resolves without the caller
+    translating first."""
+    codex = _Stub("codex-oauth", "openai", SOURCE_SUBSCRIPTION)
+    glm = _Stub("glm-coding-plan", "glm", SOURCE_SUBSCRIPTION)
+    register_adapter(codex)
+    register_adapter(glm)
+    assert resolve_for("openai-codex", SOURCE_SUBSCRIPTION) is codex
+    assert resolve_for("glm-coding", SOURCE_SUBSCRIPTION) is glm
+    assert resolve_for("zhipuai", SOURCE_SUBSCRIPTION) is glm
+    # identity for already-normalized family names
+    assert resolve_for("openai", SOURCE_SUBSCRIPTION) is codex

--- a/tests/core/llm/test_drift_anchors.py
+++ b/tests/core/llm/test_drift_anchors.py
@@ -30,6 +30,11 @@ class TestProviderNormalizationAnchor:
 
         assert PROVIDER_REGISTRY_NORMALIZATION == {
             "openai-codex": "openai",
+            # PR-ADAPTER-BOUNDARY-NORMALIZE (2026-07-06) — glm-coding is a
+            # live provider value (strategies/plans.py, auth_toml.py); folded
+            # to its family alongside the boundary normalization in
+            # resolve_for/_select_adapter.
+            "glm-coding": "glm",
             "zhipuai": "glm",
         }
 
@@ -37,6 +42,7 @@ class TestProviderNormalizationAnchor:
         from core.llm.adapters.registry import normalize_registry_provider
 
         assert normalize_registry_provider("openai-codex") == "openai"
+        assert normalize_registry_provider("glm-coding") == "glm"
         assert normalize_registry_provider("zhipuai") == "glm"
         assert normalize_registry_provider("anthropic") == "anthropic"
         assert normalize_registry_provider("glm") == "glm"

--- a/tests/core/llm/test_tool_exec_context.py
+++ b/tests/core/llm/test_tool_exec_context.py
@@ -389,3 +389,27 @@ def test_web_search_via_adapters_no_fallback_on_billing(
 
     selected.aweb_search.assert_called_once()
     fallback.aweb_search.assert_not_called()
+
+
+def test_select_adapter_normalizes_prefer_provider_variant_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller forwarding ``loop._provider='openai-codex'`` verbatim must
+    still match the ``openai``-family adapter (fast-chat incident,
+    2026-07-06 — unnormalized prefer_provider missed every registered
+    adapter and broke codex-subscription fast-chat turns)."""
+    from core.llm.adapters.dispatch import _select_adapter
+
+    cands = [
+        _fake_adapter("codex-oauth", "openai", "subscription"),
+        _fake_adapter("openai-payg", "openai", "payg"),
+    ]
+    monkeypatch.setattr("core.llm.adapters.dispatch.list_adapters", lambda: cands)
+
+    picked = _select_adapter(
+        "supports_web_search",
+        prefer_provider="openai-codex",
+        prefer_source="subscription",
+        provider_order=("openai",),
+    )
+    assert picked is not None and picked.name == "codex-oauth"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.279"
+version = "0.99.280"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `resolve_for`/`_select_adapter`가 입구에서 `normalize_registry_provider`를 적용 — 라우팅 변형 id(`openai-codex`/`glm-coding`/`zhipuai`)와 family 명(`openai`/`glm`) 어느 어휘로 조회해도 동일 결과
- 번역을 호출자 예절에 맡기던 관례 의존 제거 — fast-chat류 신규 호출자가 `loop._provider`를 그대로 넘겨도 어댑터 매치 실패가 불가능해짐
- `glm-coding`(strategies/plans.py·auth_toml.py에 실사용) 정규화 맵 합류, 드리프트 앵커 핀 의도적 갱신

## Why
2026-07-06 fast-chat 사건: 리빌드된 데몬의 fast-chat 경로가 `loop._provider='openai-codex'`를 정규화 없이 `prefer_provider`로 전달 → 레지스트리(family 명 색인)에서 매치 0 → codex 구독 세션의 모든 fast-chat 턴이 `AdapterUnavailableError`. 동일 정규화 누락이 4곳 사본으로 존재했던 전례(PR-DRIFT-ANCHORS)가 있어, 경계 1곳 정규화로 버그 클래스를 소멸시킴.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters/registry.py` | `resolve_for` 입구 정규화 + 계약 docstring(양 어휘 수용, 사건 인용) + 맵에 `glm-coding` |
| `core/llm/adapters/dispatch.py` | `_select_adapter` prefer_provider 정규화(top-level import) |
| `tests/core/llm/adapters/test_registry.py` | `resolve_for` 변형 id 3종+identity 핀 |
| `tests/core/llm/test_tool_exec_context.py` | `_select_adapter` openai-codex→codex-oauth 핀 |
| `tests/core/llm/test_drift_anchors.py` | 앵커 핀 갱신(glm-coding, 사유 주석) |
| CHANGELOG + 버전 5개소 + site SoT | v0.99.280 |

## Verification
- [x] ruff check / format --check clean
- [x] mypy clean (486 files)
- [x] lint-imports 4 contracts kept
- [x] pytest tests/core/llm 전체 pass (드리프트 앵커 갱신 포함)
- [x] Codex MCP 리뷰(gpt-5.5 high): No findings — 변형 id로 등록되는 어댑터 없음·PR-NO-FALLBACK 무위반·glm-coding 보존 경로 확인

## Reference
fast-chat AdapterUnavailableError 사건(2026-07-06, crucible 브랜치 서빙 중 발현), PR-DRIFT-ANCHORS(2026-06-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bcmTPPi6LUNWiJJtDw2hv