### PR TITLE
fix(fast-chat): 경량 채팅 프롬프트에 GEODE identity 주입 (v0.99.281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ functional change.
 
 ---
 
+## [0.99.281] - 2026-07-06
+
+### Fixed
+
+- **Fast-chat now speaks as GEODE.** The lightweight chat mode shipped
+  without the identity layer, so it introduced itself as a generic "AI
+  assistant used via API" (operator report, 2026-07-06).
+  `fast_chat_system_prompt()` now composes the same GEODE.md identity
+  block the full loop injects (G1 SoT via
+  `core.agent.system_prompt._build_identity_context` — no second
+  literal), honors the `GEODE_PERSONA` opt-out, and keeps the
+  lightweight-mode constraints AFTER the identity so they override its
+  tool-capability claims (the mode still never pretends to run tools).
+
 ## [0.99.280] - 2026-07-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.280
+- **Version**: 0.99.281
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/server/ipc_server/fast_chat.py
+++ b/core/server/ipc_server/fast_chat.py
@@ -16,10 +16,12 @@ _AGENTIC_VERB_RE = re.compile(
 )
 
 _FAST_CHAT_SYSTEM = (
-    "Lightweight GEODE chat mode. Answer directly and briefly. "
-    "Do not claim file inspection, tool execution, browsing, or local-state changes. "
-    "For actions, tools, code edits, research, or execution, say that the full "
-    "agent path is required."
+    "You are currently in GEODE's lightweight chat mode. Answer directly and "
+    "briefly, in GEODE's voice. The tool loop is NOT running in this mode: do "
+    "not claim file inspection, tool execution, browsing, or local-state "
+    "changes. For actions, tools, code edits, research, or execution, say "
+    "that the full agent path is required. These mode constraints override "
+    "any capability claims in the identity above."
 )
 
 
@@ -44,7 +46,25 @@ def should_use_fast_chat(text: str) -> bool:
 
 
 def fast_chat_system_prompt() -> str:
-    return _FAST_CHAT_SYSTEM
+    """GEODE identity (same G1 SoT as the full loop) + lightweight-mode rules.
+
+    Operator report (2026-07-06): fast-chat introduced itself as a generic
+    "AI assistant used via API" because the mode shipped without the
+    identity layer. The identity block reuses
+    :func:`core.agent.system_prompt._build_identity_context` — one GEODE.md
+    SoT, no second literal — and honors the same ``GEODE_PERSONA`` opt-out
+    the full loop uses. The mode constraints come AFTER the identity and
+    explicitly override its tool-capability claims (the identity says GEODE
+    drives a tool loop; this mode does not run one).
+    """
+    from core.agent.system_prompt import _build_identity_context, _persona_on
+
+    if not _persona_on():
+        return _FAST_CHAT_SYSTEM
+    identity = _build_identity_context()
+    if not identity:
+        return _FAST_CHAT_SYSTEM
+    return f"{identity}\n\n{_FAST_CHAT_SYSTEM}"
 
 
 __all__ = ["fast_chat_enabled", "fast_chat_system_prompt", "should_use_fast_chat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.280"
+version = "0.99.281"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.280. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.281. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.280. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.281. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.281",
+    "date": "2026-07-06",
+    "body": "### Fixed\n\n- **Fast-chat now speaks as GEODE.** The lightweight chat mode shipped\n  without the identity layer, so it introduced itself as a generic \"AI\n  assistant used via API\" (operator report, 2026-07-06).\n  `fast_chat_system_prompt()` now composes the same GEODE.md identity\n  block the full loop injects (G1 SoT via\n  `core.agent.system_prompt._build_identity_context` — no second\n  literal), honors the `GEODE_PERSONA` opt-out, and keeps the\n  lightweight-mode constraints AFTER the identity so they override its\n  tool-capability claims (the mode still never pretends to run tools)."
+  },
+  {
     "version": "0.99.280",
     "date": "2026-07-06",
     "body": "### Fixed\n\n- **Adapter lookups normalize provider vocabulary at the boundary.**\n  `resolve_for` and `_select_adapter` now accept BOTH the adapter\n  registry's family names (`openai` / `glm`) and the routing layer's\n  variant ids (`openai-codex` / `glm-coding` / `zhipuai`), translating\n  via `normalize_registry_provider` at the lookup entry instead of\n  relying on every caller to translate first. Incident: a fast-chat\n  path forwarded `loop._provider='openai-codex'` verbatim as\n  `prefer_provider`, matched zero registered adapters, and every\n  codex-subscription fast-chat turn failed with\n  AdapterUnavailableError (2026-07-06). `glm-coding` (a live provider\n  value in strategy plans and auth config) joins the normalization map;\n  the drift-anchor pin is updated deliberately."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.280",
+  version: "0.99.281",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/server/test_fast_chat.py
+++ b/tests/core/server/test_fast_chat.py
@@ -18,8 +18,39 @@ def test_fast_chat_rejects_agentic_actions() -> None:
     assert should_use_fast_chat("계획 세워서 진행해") is False
 
 
-def test_fast_chat_system_prompt_avoids_identity_declaration() -> None:
-    assert "You are" not in fast_chat_system_prompt()
+def test_fast_chat_system_prompt_carries_geode_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator report 2026-07-06 — fast-chat introduced itself as a generic
+    'AI assistant used via API'. The prompt must carry the same GEODE.md
+    identity block the full loop injects (G1 SoT), followed by the
+    lightweight-mode constraints."""
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+    prompt = fast_chat_system_prompt()
+    assert "<agent_identity>" in prompt
+    assert "GEODE" in prompt
+    # mode constraints must FOLLOW the identity so they override its
+    # tool-capability claims
+    assert prompt.index("<agent_identity>") < prompt.index("lightweight chat mode")
+
+
+def test_fast_chat_system_prompt_keeps_no_tool_claims_rule() -> None:
+    """The original intent of the pre-identity pin — fast-chat must never
+    claim tool execution — survives the identity injection."""
+    prompt = fast_chat_system_prompt()
+    assert "do not claim file inspection" in prompt.lower()
+    assert "full agent path" in prompt.lower()
+
+
+def test_fast_chat_system_prompt_honors_persona_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GEODE_PERSONA=off (thin-wrapper mode) strips the identity block from
+    fast-chat exactly as it does from the full loop."""
+    monkeypatch.setenv("GEODE_PERSONA", "off")
+    prompt = fast_chat_system_prompt()
+    assert "<agent_identity>" not in prompt
+    assert "lightweight chat mode" in prompt
 
 
 def test_ipc_poller_fast_chat_uses_text_completion(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,4 +93,6 @@ def test_ipc_poller_fast_chat_uses_text_completion(monkeypatch: pytest.MonkeyPat
     kwargs = cast(dict[str, object], calls["kwargs"])
     assert kwargs["prefer_provider"] == "openai"
     assert kwargs["prefer_source"] == "subscription"
-    assert "You are" not in str(kwargs["system"])
+    # identity ships with the turn; the no-tool-claims rule rides after it
+    assert "GEODE" in str(kwargs["system"])
+    assert "do not claim file inspection" in str(kwargs["system"]).lower()

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.280"
+version = "0.99.281"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- fast-chat이 identity 레이어 없이 출시되어 "API를 통해 사용하는 AI 어시스턴트"로 자기소개하던 문제(운영자 라이브 리포트) 해소
- `fast_chat_system_prompt()`가 풀 루프와 동일한 G1 identity SoT(`_build_identity_context`, GEODE.md 단일 원천)를 합성 — 별도 리터럴 없음, `GEODE_PERSONA` 옵트아웃 존중
- 경량 모드 제약(도구 실행 사칭 금지)은 identity **뒤에** 배치되어 identity의 도구 능력 서술을 명시적으로 오버라이드 — 기존 핀의 원래 의도(능력 사칭 방지) 보존

## Why
운영자 실사용 검증(2026-07-06): "자기소개 부탁해" → fast-chat 응답이 GEODE 정체성 없이 일반 어시스턴트로 응답. 기존 테스트 핀(`"You are" not in prompt`)은 GEODE.md Identity가 "You are GEODE"로 시작하므로 identity 주입과 정면 충돌 — 핀의 실제 의도는 도구 능력 사칭 방지였고, 그 의도는 별도 핀으로 존치.

## Changes
| File | Change |
|------|--------|
| `core/server/ipc_server/fast_chat.py` | identity 합성 + persona 게이트 + 모드 제약 오버라이드 문구, `_FAST_CHAT_SYSTEM`에 "in GEODE's voice" + 제약 우선 명시 |
| `tests/core/server/test_fast_chat.py` | 구 identity-회피 핀 → 3핀 대체(identity 존재+순서 / no-tool-claims 존치 / GEODE_PERSONA=off 스트립) + poller 테스트 시스템 프롬프트 단언 갱신 |
| CHANGELOG + 버전 5개소 + site SoT | v0.99.281 |

## Verification
- [x] ruff check / format --check clean
- [x] mypy clean (491 files)
- [x] lint-imports 4 contracts kept (server→agent 의존은 허용 방향)
- [x] pytest tests/core/server + integration/test_phase3_ipc 전체 pass
- [x] CLI smoke: geode version

## Reference
운영자 라이브 CLI 검증 세션 (2026-07-06), G10 identity 주입(system_prompt.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bcmTPPi6LUNWiJJtDw2hv