### PR TITLE
fix(cli): restore AgenticLoop as default path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.281] - 2026-07-07
+
+### Fixed
+
+- **Fast chat is opt-in again.** The IPC simple-chat path is now disabled
+  unless `GEODE_FAST_CHAT=1` is set, so normal CLI prompts always use the
+  full AgenticLoop identity, plan, tool, and activity event path. The
+  opt-in fast-chat prompt still preserves GEODE identity and avoids generic
+  API-assistant self-introductions.
+- **Append-only CLI activity visibility.** The default thin CLI now renders
+  Activity updates as append-only transcript rows during a turn instead of
+  hiding tool/thought status until the final stop hook. This restores visible
+  run/tool progress without reintroducing cursor-up repainting over the input
+  prompt.
+
 ## [0.99.280] - 2026-07-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.280
+- **Version**: 0.99.281
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.280 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -292,6 +292,7 @@ class IPCClient:
             if rtype in (
                 "tool_start",
                 "tool_end",
+                "fast_chat_start",
                 "tokens",
                 "round_start",
                 "thinking_start",

--- a/core/server/ipc_server/fast_chat.py
+++ b/core/server/ipc_server/fast_chat.py
@@ -16,15 +16,18 @@ _AGENTIC_VERB_RE = re.compile(
 )
 
 _FAST_CHAT_SYSTEM = (
-    "Lightweight GEODE chat mode. Answer directly and briefly. "
+    "GEODE lightweight chat path. Identity: GEODE, a self-hosting autonomous "
+    "agent harness built around an AgenticLoop. Answer directly and briefly. "
+    "When asked for self-introduction, speak as GEODE, not as a generic API "
+    "assistant or generic chatbot. "
     "Do not claim file inspection, tool execution, browsing, or local-state changes. "
-    "For actions, tools, code edits, research, or execution, say that the full "
-    "agent path is required."
+    "For actions, planning, roadmaps, tools, code edits, research, or execution, "
+    "say that the full agent path is required."
 )
 
 
 def fast_chat_enabled() -> bool:
-    return os.environ.get("GEODE_FAST_CHAT", "1").lower() not in {"0", "false", "off"}
+    return os.environ.get("GEODE_FAST_CHAT", "0").lower() in {"1", "true", "on"}
 
 
 def should_use_fast_chat(text: str) -> bool:

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -989,6 +989,15 @@ class CLIPoller:
         provider_raw = str(getattr(loop, "_provider", "") or "")
         provider = normalize_registry_provider(provider_raw) if provider_raw else None
         source = str(getattr(loop, "_source", "") or "") or None
+        if client is not None:
+            await client.send_json_async(
+                {
+                    "type": "fast_chat_start",
+                    "model": model,
+                    "provider": provider or "",
+                    "source": source or "",
+                }
+            )
         result = await complete_text_via_adapters(
             text,
             system=fast_chat_system_prompt(),

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -123,6 +123,7 @@ class _ActivitySurface:
     thought_count: int = 0
     thought_items: int = 0
     at_bottom: bool = False
+    append_signature: str = ""
 
 
 class EventRenderer:
@@ -159,6 +160,7 @@ class EventRenderer:
             "thinking_start",
             "thinking_end",
             "tokens",
+            "fast_chat_start",
         }
     )
     _MAX_ACTIVITY_TOOL_LINES = 5
@@ -312,6 +314,16 @@ class EventRenderer:
 
     def _handle_round_start(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
+
+    def _handle_fast_chat_start(self, event: dict[str, Any]) -> None:
+        model = str(event.get("model", "") or "")
+        provider = str(event.get("provider", "") or "")
+        source = str(event.get("source", "") or "")
+        route = " / ".join(part for part in (provider, source) if part)
+        detail = f" · {route}" if route else ""
+        label = f"Fast chat · {model}{detail}" if model else f"Fast chat{detail}"
+        self._append_activity_notice(label)
+        self._render_activity_region()
 
     def _handle_thinking_start(self, event: dict[str, Any]) -> None:
         self._activity_suppressed = True
@@ -1298,16 +1310,26 @@ class EventRenderer:
         it keeps its own single moving copy. It never carries the plan checklist,
         which is drawn separately by plan events and scrolls up independently.
         """
-        if not self._live_regions and not force:
-            return
         with self._render_lock:
-            self._erase_activity_locked()
             activity_lines = self._render_activity_lines()
             if not activity_lines:
                 return
+            surface = self._activity_surface
+            if not self._live_regions:
+                signature = "".join(_ANSI_ESCAPE.sub("", line) for line in activity_lines)
+                if signature == surface.append_signature:
+                    return
+                for line in activity_lines:
+                    self._out.write(line)
+                surface.visible_lines = []
+                surface.at_bottom = False
+                surface.append_signature = signature
+                self._progress_plan.at_bottom = False
+                self._out.flush()
+                return
+            self._erase_activity_locked()
             for line in activity_lines:
                 self._out.write(line)
-            surface = self._activity_surface
             surface.visible_lines = activity_lines
             # Non-TTY (piped/log) output is append-only: never mark at_bottom.
             surface.at_bottom = self._tty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.280"
+version = "0.99.281"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.280. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.281. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.280. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.281. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.281",
+    "date": "2026-07-07",
+    "body": "### Fixed\n\n- **Fast chat is opt-in again.** The IPC simple-chat path is now disabled\n  unless `GEODE_FAST_CHAT=1` is set, so normal CLI prompts always use the\n  full AgenticLoop identity, plan, tool, and activity event path. The\n  opt-in fast-chat prompt still preserves GEODE identity and avoids generic\n  API-assistant self-introductions.\n- **Append-only CLI activity visibility.** The default thin CLI now renders\n  Activity updates as append-only transcript rows during a turn instead of\n  hiding tool/thought status until the final stop hook. This restores visible\n  run/tool progress without reintroducing cursor-up repainting over the input\n  prompt."
+  },
+  {
     "version": "0.99.280",
     "date": "2026-07-06",
     "body": "### Fixed\n\n- **Adapter lookups normalize provider vocabulary at the boundary.**\n  `resolve_for` and `_select_adapter` now accept BOTH the adapter\n  registry's family names (`openai` / `glm`) and the routing layer's\n  variant ids (`openai-codex` / `glm-coding` / `zhipuai`), translating\n  via `normalize_registry_provider` at the lookup entry instead of\n  relying on every caller to translate first. Incident: a fast-chat\n  path forwarded `loop._provider='openai-codex'` verbatim as\n  `prefer_provider`, matched zero registered adapters, and every\n  codex-subscription fast-chat turn failed with\n  AdapterUnavailableError (2026-07-06). `glm-coding` (a live provider\n  value in strategy plans and auth config) joins the normalization map;\n  the drift-anchor pin is updated deliberately."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.280",
+  version: "0.99.281",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/server/test_fast_chat.py
+++ b/tests/core/server/test_fast_chat.py
@@ -7,19 +7,32 @@ import pytest
 from core.server.ipc_server.fast_chat import fast_chat_system_prompt, should_use_fast_chat
 
 
-def test_fast_chat_accepts_short_conversational_prompt() -> None:
+def test_fast_chat_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_FAST_CHAT", raising=False)
+    assert should_use_fast_chat("자기소개 부탁해") is False
+
+
+def test_fast_chat_accepts_short_conversational_prompt_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GEODE_FAST_CHAT", "1")
     assert should_use_fast_chat("자기소개 부탁해") is True
     assert should_use_fast_chat("what is GEODE?") is True
 
 
-def test_fast_chat_rejects_agentic_actions() -> None:
+def test_fast_chat_rejects_agentic_actions_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_FAST_CHAT", "1")
     assert should_use_fast_chat("파일을 읽고 수정해") is False
     assert should_use_fast_chat("search the web and summarize") is False
     assert should_use_fast_chat("계획 세워서 진행해") is False
 
 
-def test_fast_chat_system_prompt_avoids_identity_declaration() -> None:
-    assert "You are" not in fast_chat_system_prompt()
+def test_fast_chat_system_prompt_preserves_geode_identity_without_you_are() -> None:
+    system = fast_chat_system_prompt()
+    assert "GEODE" in system
+    assert "AgenticLoop" in system
+    assert "generic API assistant" in system
+    assert "You are" not in system
 
 
 def test_ipc_poller_fast_chat_uses_text_completion(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,4 +75,51 @@ def test_ipc_poller_fast_chat_uses_text_completion(monkeypatch: pytest.MonkeyPat
     kwargs = cast(dict[str, object], calls["kwargs"])
     assert kwargs["prefer_provider"] == "openai"
     assert kwargs["prefer_source"] == "subscription"
+    assert "GEODE" in str(kwargs["system"])
     assert "You are" not in str(kwargs["system"])
+
+
+def test_ipc_poller_fast_chat_emits_visible_status_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.llm.adapters.base import TextCompletionResult, UsageSummary
+    from core.server.ipc_server.poller import CLIPoller
+
+    async def fake_complete_text(_prompt: str, **_kwargs: object) -> TextCompletionResult:
+        return TextCompletionResult(
+            text="짧은 답변",
+            usage=UsageSummary(input_tokens=10, output_tokens=3),
+            adapter_name="fake",
+            adapter_provider="openai",
+            adapter_source="subscription",
+        )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.events: list[dict[str, object]] = []
+
+        async def send_json_async(self, payload: dict[str, object]) -> None:
+            self.events.append(payload)
+
+        async def drain_pending_sends(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "core.llm.adapters.dispatch.complete_text_via_adapters",
+        fake_complete_text,
+    )
+
+    poller = CLIPoller(services=cast(Any, object()))
+    loop = type(
+        "Loop",
+        (),
+        {"model": "gpt-5.5", "_provider": "openai-codex", "_source": "subscription"},
+    )()
+    client = FakeClient()
+
+    result = asyncio.run(poller._run_fast_chat_async("자기소개 부탁해", loop, cast(Any, client)))
+
+    assert result["type"] == "result"
+    assert client.events[0]["type"] == "fast_chat_start"
+    assert client.events[0]["provider"] == "openai"
+    assert client.events[1]["type"] == "tokens"

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -1192,11 +1192,13 @@ def test_event_renderer_can_run_append_only_without_live_regions() -> None:
     before_stop = r._out.getvalue()
     assert "Working..." in before_stop
     assert "Tasks" in before_stop
-    assert "Activity" not in before_stop
+    assert "Activity" in before_stop
+    assert "read_file" in before_stop
+    assert "run_tests" in before_stop
 
     r.stop()
     out = r._out.getvalue()
-    assert out.count("Activity") == 1
+    assert out.count("Activity") >= 1
     assert "read_file" in out
     assert "run_tests" in out
     assert "\033[A" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.280"
+version = "0.99.281"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Disable the IPC fast-chat shortcut by default so normal CLI prompts use the full GEODE AgenticLoop identity, plan, tool, and activity event path.
- Preserve GEODE identity for opt-in fast chat and surface a fast-chat status event when enabled.
- Restore append-only Activity updates during turns without cursor-up repainting over the input prompt.

## Why
Fast chat was catching prompts such as self-introduction and planning explanations, bypassing GEODE identity and plan/tool UI. The default thin CLI also hid Activity updates until the stop hook, making run/tool status appear missing.

## Changes
| File | Change |
|------|--------|
| core/server/ipc_server/fast_chat.py | Make fast chat opt-in via GEODE_FAST_CHAT=1 and strengthen GEODE identity prompt for that opt-in path. |
| core/server/ipc_server/poller.py | Emit fast_chat_start before opt-in fast-chat completions. |
| core/cli/ipc_client.py | Relay fast_chat_start as a structured event. |
| core/ui/event_renderer.py | Render append-only Activity snapshots as events arrive; add fast-chat status notice. |
| tests/core/server/test_fast_chat.py | Cover default-off behavior, identity prompt, and status event emission. |
| tests/core/ui/test_agentic_ui.py | Assert append-only mode shows Activity during a turn. |

## Verification
- uv run pytest -q tests/core/server/test_fast_chat.py tests/core/ui/test_agentic_ui.py tests/core/cli/test_fullscreen_app.py tests/integration/test_phase3_ipc.py tests/core/agent/test_approval_fsm.py
- uv run ruff check core/server/ipc_server/fast_chat.py core/server/ipc_server/poller.py core/cli/ipc_client.py core/ui/event_renderer.py tests/core/server/test_fast_chat.py tests/core/ui/test_agentic_ui.py
- uv run ruff format --check core/server/ipc_server/fast_chat.py core/server/ipc_server/poller.py core/cli/ipc_client.py core/ui/event_renderer.py tests/core/server/test_fast_chat.py tests/core/ui/test_agentic_ui.py
- uv run mypy core/server/ipc_server/fast_chat.py core/server/ipc_server/poller.py core/cli/ipc_client.py core/ui/event_renderer.py
- uv run geode version
- npm run sync-stats
- npm install
- npm run build
- npm run export-md
- geode doctor bootstrap

Note: geode doctor bootstrap still reports macOS Accessibility is not trusted for the current launching process; dependencies and serve socket are healthy.