### PR TITLE
Restore safe CLI live activity status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ functional change.
 
 ---
 
+## [0.99.282] - 2026-07-07
+
+### Fixed
+
+- **Default CLI live activity restoration.** The thin CLI now restores the
+  live `Working...` / `Running <tool>...` status in TTY sessions with a
+  carriage-return-only inline renderer, while keeping plan and activity output
+  append-only. This preserves the pre-full-screen interaction feel without
+  reintroducing cursor-up prompt overpaint.
+- **Plan rendering no longer suppresses activity status.** Progress-plan
+  updates clear only the renderer-owned current status line before printing
+  transcript rows, so the live status resumes under the updated plan instead
+  of disappearing for the rest of the turn.
+
 ## [0.99.281] - 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.281
+- **Version**: 0.99.282
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.282 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.281 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.282 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -206,6 +206,10 @@ class EventRenderer:
         self._activity_surface = _ActivitySurface()
         self._activity_spinner_line = ""
         self._activity_spinner_at_bottom = False
+        self._inline_status_enabled = False
+        self._inline_status_visible = False
+        self._inline_status_label = "Working..."
+        self._inline_status_started_at = time.monotonic()
         self._activity_seq = 0
         # Stage 1 fleet view — per-sub-agent live state fed by subagent_state
         # events; read by the one-line fleet summary in the activity region.
@@ -216,6 +220,14 @@ class EventRenderer:
     def start_activity(self) -> None:
         """Start persistent activity spinner. Call before send_prompt()."""
         if not self._live_regions:
+            if self._out.isatty():
+                self._inline_status_enabled = True
+                self._activity = True
+                self._activity_suppressed = False
+                self._set_inline_status("Working...")
+                self._activity_thread = threading.Thread(target=self._animate_activity, daemon=True)
+                self._activity_thread.start()
+                return
             self._out.write(f"  {spinner_glyph.ROSE}{spinner_glyph.GLYPH}{RESET} Working...\n")
             self._out.flush()
             return
@@ -284,7 +296,9 @@ class EventRenderer:
         # Clear any leftover spinner line.
         with self._render_lock:
             self._erase_activity_locked()
-            if self._live_regions:
+            if self._inline_status_enabled:
+                self._clear_inline_status_locked()
+            elif self._live_regions:
                 self._out.write(f"\r{ERASE_LINE}")
         # Clear the transient Markdown stream region BEFORE any live-region
         # render — _flush_repeat may redraw the region at the cursor, and the
@@ -314,6 +328,7 @@ class EventRenderer:
 
     def _handle_round_start(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
+        self._set_inline_status("Working...")
 
     def _handle_fast_chat_start(self, event: dict[str, Any]) -> None:
         model = str(event.get("model", "") or "")
@@ -322,11 +337,12 @@ class EventRenderer:
         route = " / ".join(part for part in (provider, source) if part)
         detail = f" · {route}" if route else ""
         label = f"Fast chat · {model}{detail}" if model else f"Fast chat{detail}"
+        self._set_inline_status(label)
         self._append_activity_notice(label)
         self._render_activity_region()
 
     def _handle_thinking_start(self, event: dict[str, Any]) -> None:
-        self._activity_suppressed = True
+        self._activity_suppressed = self._live_regions
         self._tool_tracker.stop()
         # Clear the bottom activity block so the thinking spinner flows below the
         # plan; the plan itself stays in scrollback (never re-emitted per phase).
@@ -338,6 +354,7 @@ class EventRenderer:
             self._thinking_round = int(event.get("round", 1))
             self._thinking_reflection = bool(event.get("reflection", False))
         if not self._live_regions:
+            self._set_inline_status(self._thinking_label())
             return
         self._start_stdin_reader()
         self._thinking_thread = threading.Thread(target=self._animate_thinking, daemon=True)
@@ -353,6 +370,7 @@ class EventRenderer:
                     self._erase_thinking_visible_locked(region)
                     self._record_thought_activity_locked(region)
         self._activity_suppressed = False  # resume activity spinner
+        self._set_inline_status("Working...")
         # Redraw ONLY the activity block (thought/tool summary). The plan
         # checklist is never re-emitted at phase end — that per-phase reprint
         # is exactly what stacked N identical Plan blocks down the transcript.
@@ -369,8 +387,9 @@ class EventRenderer:
             # count/dur/summary already set from last batch's tool_end
             return
 
-        self._activity_suppressed = True
+        self._activity_suppressed = self._live_regions
         self._stop_thinking()
+        self._set_inline_status(f"Running {name}" if name else "Running tool")
         # Clear the bottom activity block so tool rows flow below the plan; the
         # plan itself stays in scrollback (never re-emitted per phase).
         self._erase_live_region()
@@ -387,6 +406,7 @@ class EventRenderer:
             is_single = len(tools) == 1
         if all_done:
             self._activity_suppressed = False
+            self._set_inline_status("Working...")
             self._tool_tracker.suspend()
             with self._tool_tracker._lock:
                 self._tool_tracker._tools.clear()
@@ -1044,6 +1064,10 @@ class EventRenderer:
         """Persistent activity spinner — runs until stop() is called."""
         while self._activity:
             if not self._activity_suppressed:
+                if self._inline_status_enabled:
+                    self._render_inline_status_frame()
+                    time.sleep(0.05)
+                    continue
                 body = spinner_glyph.shimmer(f"{spinner_glyph.GLYPH} Working…", time.monotonic())
                 # Under the render lock: a frame landing mid live-region erase
                 # would corrupt the cursor position the erase math depends on.
@@ -1055,6 +1079,34 @@ class EventRenderer:
                         self._activity_spinner_at_bottom = True
                         self._out.flush()
             time.sleep(0.05)
+
+    def _set_inline_status(self, label: str) -> None:
+        clean = label.strip() or "Working..."
+        if clean == "Working":
+            clean = "Working..."
+        with self._render_lock:
+            self._inline_status_label = clean
+            self._inline_status_started_at = time.monotonic()
+
+    def _render_inline_status_frame(self) -> None:
+        """Render the default CLI's one-line live status without cursor-up.
+
+        The prompt_toolkit CLI cannot safely own a multi-row live region, but a
+        carriage-return-only status line is stable: permanent transcript output
+        clears this current line first, then scrolls normally.
+        """
+        with self._render_lock:
+            if not self._activity or self._activity_suppressed or not self._inline_status_enabled:
+                return
+            elapsed = time.monotonic() - self._inline_status_started_at
+            label = self._inline_status_label
+            if not label.endswith(("...", "\u2026")):
+                label = f"{label}..."
+            body = spinner_glyph.shimmer(f"{spinner_glyph.GLYPH} {label}", elapsed)
+            meta = f" {DIM}({spinner_glyph.elapsed(elapsed)}){RESET}"
+            self._out.write(f"\r{ERASE_LINE}  {body}{meta}")
+            self._inline_status_visible = True
+            self._out.flush()
 
     def _animate_thinking(self) -> None:
         """Thinking spinner — overrides activity spinner."""
@@ -1256,6 +1308,7 @@ class EventRenderer:
         """
         with self._render_lock:
             self._erase_activity_locked()
+            self._clear_inline_status_locked()
             self._release_plan_locked()
 
     def _erase_activity_locked(self) -> None:
@@ -1269,6 +1322,12 @@ class EventRenderer:
             self._erase_lines_locked(surface.visible_lines)
             surface.visible_lines = []
             surface.at_bottom = False
+
+    def _clear_inline_status_locked(self) -> None:
+        if not self._inline_status_visible:
+            return
+        self._out.write(f"\r{ERASE_LINE}")
+        self._inline_status_visible = False
 
     def _release_plan_locked(self) -> None:
         """Release the plan checklist to scrollback (leave it drawn, just not bottom-most)."""
@@ -1285,11 +1344,11 @@ class EventRenderer:
         the new checklist draws fresh below (the prior copy stays in scrollback).
         """
         with self._render_lock:
-            self._suppress_all_spinners()
             plan = self._progress_plan
             # If the activity block sits below the plan, clear it first so the
             # plan never ends up rendered below its own activity summary.
             self._erase_activity_locked()
+            self._clear_inline_status_locked()
             if plan.at_bottom and plan.visible_lines:
                 self._erase_lines_locked(plan.visible_lines)
             plan_lines = self._render_full_progress_plan(plan.items, plan.explanation)
@@ -1316,6 +1375,7 @@ class EventRenderer:
                 return
             surface = self._activity_surface
             if not self._live_regions:
+                self._clear_inline_status_locked()
                 signature = "".join(_ANSI_ESCAPE.sub("", line) for line in activity_lines)
                 if signature == surface.append_signature:
                     return
@@ -1328,6 +1388,7 @@ class EventRenderer:
                 self._out.flush()
                 return
             self._erase_activity_locked()
+            self._clear_inline_status_locked()
             for line in activity_lines:
                 self._out.write(line)
             surface.visible_lines = activity_lines
@@ -1528,6 +1589,7 @@ class EventRenderer:
         self._tool_tracker.suspend()
         with self._render_lock:
             self._erase_activity_locked()
+            self._clear_inline_status_locked()
             if self._live_regions:
                 self._out.write(f"\r{ERASE_LINE}")
             self._out.flush()
@@ -1537,6 +1599,7 @@ class EventRenderer:
         if self._activity and not self._activity_suppressed:
             with self._render_lock:
                 self._erase_activity_locked()
+                self._clear_inline_status_locked()
                 if self._live_regions:
                     self._out.write(f"\r{ERASE_LINE}")
                 self._out.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.281"
+version = "0.99.282"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.281. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.282. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.281. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.282. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.282",
+    "date": "2026-07-07",
+    "body": "### Fixed\n\n- **Default CLI live activity restoration.** The thin CLI now restores the\n  live `Working...` / `Running <tool>...` status in TTY sessions with a\n  carriage-return-only inline renderer, while keeping plan and activity output\n  append-only. This preserves the pre-full-screen interaction feel without\n  reintroducing cursor-up prompt overpaint.\n- **Plan rendering no longer suppresses activity status.** Progress-plan\n  updates clear only the renderer-owned current status line before printing\n  transcript rows, so the live status resumes under the updated plan instead\n  of disappearing for the rest of the turn."
+  },
+  {
     "version": "0.99.281",
     "date": "2026-07-07",
     "body": "### Fixed\n\n- **Fast chat is opt-in again.** The IPC simple-chat path is now disabled\n  unless `GEODE_FAST_CHAT=1` is set, so normal CLI prompts always use the\n  full AgenticLoop identity, plan, tool, and activity event path. The\n  opt-in fast-chat prompt still preserves GEODE identity and avoids generic\n  API-assistant self-introductions.\n- **Append-only CLI activity visibility.** The default thin CLI now renders\n  Activity updates as append-only transcript rows during a turn instead of\n  hiding tool/thought status until the final stop hook. This restores visible\n  run/tool progress without reintroducing cursor-up repainting over the input\n  prompt."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.281",
+  version: "0.99.282",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import re
 import time
 from typing import Any
 from unittest.mock import patch
@@ -23,6 +25,12 @@ from core.ui.agentic_ui import (
     render_tool_result,
     render_turn_summary,
 )
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 class TestFmtTokens:
@@ -1170,8 +1178,6 @@ class TestPlanNotReemittedDuringPhases:
 
 def test_event_renderer_can_run_append_only_without_live_regions() -> None:
     """Legacy prompt_toolkit CLI must not repaint over its input line."""
-    import io
-
     from core.ui.event_renderer import EventRenderer
 
     r = EventRenderer(live_regions=False)
@@ -1201,6 +1207,43 @@ def test_event_renderer_can_run_append_only_without_live_regions() -> None:
     assert out.count("Activity") >= 1
     assert "read_file" in out
     assert "run_tests" in out
+    assert "\033[A" not in out
+    assert "\033[1A" not in out
+
+
+def test_event_renderer_restores_tty_inline_status_without_cursor_up() -> None:
+    """Default CLI gets a live status line without prompt-overpaint cursor-up."""
+    from core.ui.event_renderer import EventRenderer
+
+    class TtyStringIO(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    r = EventRenderer(live_regions=False)
+    r._out = TtyStringIO()
+
+    try:
+        r.start_activity()
+        r._render_inline_status_frame()
+        r.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [{"step": "inspect renderer", "status": "in_progress"}],
+            }
+        )
+        r.on_event({"type": "tool_start", "name": "read_file"})
+        r._render_inline_status_frame()
+        r.on_event({"type": "tool_end", "name": "read_file", "summary": "ok", "duration_s": 0.1})
+    finally:
+        r.stop()
+
+    out = r._out.getvalue()
+    plain = _strip_ansi(out)
+    assert "Working" in plain
+    assert "Running read_file" in plain
+    assert "Tasks" in plain
+    assert "Activity" in plain
+    assert "\r" in out
     assert "\033[A" not in out
     assert "\033[1A" not in out
     assert "\033[2A" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.281"
+version = "0.99.282"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Restore live `Working...` / `Running <tool>...` status in the default thin CLI without cursor-up prompt overpaint.
- Keep progress plan and activity output as transcript-safe append-only rows.
- Bump GEODE to v0.99.282 and sync site version metadata.

## Why
The full-screen rollback left the default CLI on `live_regions=False`, which avoided input-line corruption but also removed the pre-full-screen live activity feel. Progress-plan rendering also suppressed the status spinner for the rest of a turn.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | Adds a TTY-only carriage-return inline status path for append-only mode and prevents plan rendering from suppressing activity status. |
| `tests/core/ui/test_agentic_ui.py` | Adds regression coverage for TTY inline status and no cursor-up escape sequences. |
| `CHANGELOG.md`, version files, site data | Records v0.99.282 and syncs generated site metadata. |

## Verification
- `uv run pytest -q tests/core/ui/test_agentic_ui.py tests/core/ui/test_event_schema_v2.py tests/core/ui/test_thinking_collapse.py`
- `uv run ruff check core/ui/event_renderer.py tests/core/ui/test_agentic_ui.py`
- `uv run ruff format --check core/ui/event_renderer.py tests/core/ui/test_agentic_ui.py`
- `uv run mypy core/ui/event_renderer.py`
- `uv run python scripts/check_llms_version.py`
- `uv run geode version`
