### PR TITLE
Refresh default CLI plans in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.283] - 2026-07-07
+
+### Fixed
+
+- **Default CLI plan updates refresh in place.** In TTY sessions using the
+  prompt-safe inline `Working...` status, progress-plan updates now keep the
+  plan as renderer-owned bottom content and redraw it in place after clearing
+  the status line. This prevents updated plans from stacking duplicate
+  checklist blocks in the transcript while preserving append-only output for
+  pipes and logs.
+
 ## [0.99.282] - 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.282
+- **Version**: 0.99.283
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.282 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.283 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.282 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.283 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -1355,9 +1355,11 @@ class EventRenderer:
             for line in plan_lines:
                 self._out.write(line)
             plan.visible_lines = plan_lines
-            # Non-TTY (piped/log) output is append-only: never mark at_bottom,
-            # so no cursor-up erase sequences are ever emitted into a pipe.
-            plan.at_bottom = self._tty
+            # Piped/log output stays append-only. In the default prompt_toolkit
+            # CLI, however, the carriage-return inline status line is the only
+            # thing below the plan; once that line is cleared, the plan is still
+            # renderer-owned bottom content and can update in place.
+            plan.at_bottom = self._tty or self._inline_status_enabled
             plan.signature = signature
             plan.rendered = True
             self._out.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.282"
+version = "0.99.283"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.282. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.283. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.282. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.283. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.283",
+    "date": "2026-07-07",
+    "body": "### Fixed\n\n- **Default CLI plan updates refresh in place.** In TTY sessions using the\n  prompt-safe inline `Working...` status, progress-plan updates now keep the\n  plan as renderer-owned bottom content and redraw it in place after clearing\n  the status line. This prevents updated plans from stacking duplicate\n  checklist blocks in the transcript while preserving append-only output for\n  pipes and logs."
+  },
+  {
     "version": "0.99.282",
     "date": "2026-07-07",
     "body": "### Fixed\n\n- **Default CLI live activity restoration.** The thin CLI now restores the\n  live `Working...` / `Running <tool>...` status in TTY sessions with a\n  carriage-return-only inline renderer, while keeping plan and activity output\n  append-only. This preserves the pre-full-screen interaction feel without\n  reintroducing cursor-up prompt overpaint.\n- **Plan rendering no longer suppresses activity status.** Progress-plan\n  updates clear only the renderer-owned current status line before printing\n  transcript rows, so the live status resumes under the updated plan instead\n  of disappearing for the rest of the turn."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.282",
+  version: "0.99.283",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -1249,6 +1249,50 @@ def test_event_renderer_restores_tty_inline_status_without_cursor_up() -> None:
     assert "\033[2A" not in out
 
 
+def test_event_renderer_updates_plan_in_place_with_tty_inline_status() -> None:
+    """Default TTY CLI should update the visible plan instead of stacking copies."""
+    from core.ui.event_renderer import EventRenderer
+
+    class TtyStringIO(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    r = EventRenderer(live_regions=False)
+    r._out = TtyStringIO()
+
+    try:
+        r.start_activity()
+        r._render_inline_status_frame()
+        r.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "first step", "status": "in_progress"},
+                    {"step": "second step", "status": "pending"},
+                ],
+            }
+        )
+        assert r._progress_plan.at_bottom is True
+        r._render_inline_status_frame()
+        r.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "first step", "status": "completed"},
+                    {"step": "second step", "status": "in_progress"},
+                ],
+            }
+        )
+    finally:
+        r.stop()
+
+    out = r._out.getvalue()
+    plain = _strip_ansi(out)
+    assert "first step" in plain
+    assert "second step" in plain
+    assert re.search(r"\x1b\[\d+A", out)
+
+
 def test_tool_tracker_running_row_uses_signature_shimmer() -> None:
     """Running tool rows render via spinner_glyph (single spinner source)."""
     from core.ui import spinner_glyph

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.282"
+version = "0.99.283"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Make default TTY CLI progress-plan updates redraw in place when using the prompt-safe inline `Working...` status.
- Preserve append-only behavior for pipes/logs and keep activity output as transcript rows.
- Bump GEODE to v0.99.283 and sync site metadata.

## Why
After restoring the safe inline `Working...` status, progress-plan updates still stacked duplicate checklist blocks because `live_regions=False` kept `plan.at_bottom` false. In the default TTY CLI, the only content below the plan is the renderer-owned carriage-return status line, so the plan can safely remain a bottom-owned surface after that line is cleared.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | Marks progress plans as bottom-owned when TTY inline status is active, enabling in-place refresh. |
| `tests/core/ui/test_agentic_ui.py` | Adds regression coverage for default TTY inline status plan refresh. |
| `CHANGELOG.md`, version files, site data | Records v0.99.283 and syncs generated metadata. |

## Verification
- `uv run pytest -q tests/core/ui/test_agentic_ui.py tests/core/ui/test_event_schema_v2.py tests/core/ui/test_thinking_collapse.py`
- `uv run ruff check core/ui/event_renderer.py tests/core/ui/test_agentic_ui.py`
- `uv run ruff format --check core/ui/event_renderer.py tests/core/ui/test_agentic_ui.py`
- `uv run mypy core/ui/event_renderer.py`
- `uv run python scripts/check_llms_version.py`
- `uv run geode version`
