### PR TITLE
Fix HITL approval input and plan activity UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ functional change.
 
 ---
 
+## [0.99.284] - 2026-07-07
+
+### Fixed
+
+- **HITL approval input no longer swallows Enter.** The thin IPC client now
+  restores cooked terminal mode and reads approval choices directly from
+  stdin instead of Rich `console.input()`, so approval prompts accept Enter
+  normally even after prompt_toolkit raw-mode interaction. Carriage-return
+  bytes are stripped before parsing, and approval suspend/resume callbacks
+  now run in a `finally` block so the renderer cannot stay stranded if
+  approval input fails.
+- **`update_plan` no longer displaces the live plan UI.** Plan updates are
+  treated as renderer state rather than normal tool activity, so they do not
+  create `Activity · update_plan -> ok` blocks or push the checklist out of
+  its in-place update surface.
+
 ## [0.99.283] - 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.283
+- **Version**: 0.99.284
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.283 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.284 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.283 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.284 — A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import socket
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -270,12 +271,14 @@ class IPCClient:
             if rtype == "approval_request":
                 if on_approval_start is not None:
                     on_approval_start()
-                if on_approval_request is not None:
-                    decision = str(on_approval_request(response))
-                else:
-                    decision = self._handle_approval_request(response)
-                if on_approval_end is not None:
-                    on_approval_end()
+                try:
+                    if on_approval_request is not None:
+                        decision = str(on_approval_request(response))
+                    else:
+                        decision = self._handle_approval_request(response)
+                finally:
+                    if on_approval_end is not None:
+                        on_approval_end()
                 # Echo the approval_id so the serve side can match this reply
                 # to the exact prompt it answers — a stale reply from a
                 # previous (timed-out) prompt is discarded instead of
@@ -375,6 +378,23 @@ class IPCClient:
         except (ValueError, OSError, termios.error) as exc:
             log.warning("HITL: _restore_terminal failed: %s", exc)
 
+    def _read_approval_line(self, prompt: str) -> str:
+        """Read one HITL approval line from the real terminal.
+
+        Rich ``console.input`` can inherit a raw prompt_toolkit terminal state,
+        where Enter arrives as a literal carriage return instead of submitting
+        the line. The thin client owns this prompt, so keep the read path
+        deliberately simple: restore cooked mode, write a plain prompt, then
+        read one line from stdin.
+        """
+        self._restore_terminal()
+        sys.stdout.write(prompt)
+        sys.stdout.flush()
+        line = sys.stdin.readline()
+        if line == "":
+            raise EOFError
+        return line
+
     def _handle_approval_request(self, msg: dict[str, Any]) -> str:
         """Display approval prompt to user."""
         import time
@@ -411,7 +431,7 @@ class IPCClient:
 
         t0 = time.monotonic()
         try:
-            resp = c.input("  [muted]y allow · n deny · a always-allow[/muted] ").strip().lower()
+            resp = self._read_approval_line("  y allow · n deny · a always-allow > ")
         except (KeyboardInterrupt, EOFError):
             c.print()
             log.info(
@@ -422,6 +442,7 @@ class IPCClient:
             return "n"
 
         elapsed = time.monotonic() - t0
+        resp = resp.replace("\r", "").strip().lower()
         if resp in ("a", "always"):
             decision = "a"
         elif resp in ("", "y", "yes"):

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -75,6 +75,7 @@ _ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _MARKDOWN_TEXT_MARKER = re.compile(
     r"(\*\*[^*\n][\s\S]*?\*\*|__[^_\n][\s\S]*?__|`[^`\n]+`|^#{1,6}\s|\n#{1,6}\s)"
 )
+_PLAN_STATE_TOOLS = frozenset({"update_plan"})
 
 
 def _fmt_tokens(n: int) -> str:
@@ -378,9 +379,17 @@ class EventRenderer:
 
     def _handle_tool_start(self, event: dict[str, Any]) -> None:
         name = str(event.get("name", ""))
+        if name in _PLAN_STATE_TOOLS:
+            self._stop_thinking()
+            self._set_inline_status("Updating plan...")
+            return
 
         # Detect repeat onset: same tool as last single-tool batch
-        if self._last_batch_tool and name == self._last_batch_tool:
+        if (
+            name not in _PLAN_STATE_TOOLS
+            and self._last_batch_tool
+            and name == self._last_batch_tool
+        ):
             # Enter repeat mode — suppress this tool_start
             self._in_repeat = True
             self._repeat_name = name
@@ -397,7 +406,11 @@ class EventRenderer:
 
     def _handle_tool_end(self, event: dict[str, Any]) -> None:
         name = str(event.get("name", ""))
-        self._record_tool_activity(event)
+        if name in _PLAN_STATE_TOOLS:
+            self._set_inline_status("Working...")
+            return
+        if name not in _PLAN_STATE_TOOLS:
+            self._record_tool_activity(event)
         self._tool_tracker.on_tool_end(event)
         # Resume activity when all tools done
         with self._tool_tracker._lock:
@@ -414,7 +427,7 @@ class EventRenderer:
             # The plan is not re-emitted at phase end (it lives in scrollback).
             self._render_activity_region()
             # Track last single-tool batch for repeat detection
-            if is_single:
+            if is_single and name not in _PLAN_STATE_TOOLS:
                 dur = event.get("duration_s")
                 self._last_batch_tool = name
                 self._repeat_count = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.283"
+version = "0.99.284"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.283. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.284. Last sync 2026-06-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.283. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.284. Last sync 2026-07-06. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.284",
+    "date": "2026-07-07",
+    "body": "### Fixed\n\n- **HITL approval input no longer swallows Enter.** The thin IPC client now\n  restores cooked terminal mode and reads approval choices directly from\n  stdin instead of Rich `console.input()`, so approval prompts accept Enter\n  normally even after prompt_toolkit raw-mode interaction. Carriage-return\n  bytes are stripped before parsing, and approval suspend/resume callbacks\n  now run in a `finally` block so the renderer cannot stay stranded if\n  approval input fails.\n- **`update_plan` no longer displaces the live plan UI.** Plan updates are\n  treated as renderer state rather than normal tool activity, so they do not\n  create `Activity · update_plan -> ok` blocks or push the checklist out of\n  its in-place update surface."
+  },
+  {
     "version": "0.99.283",
     "date": "2026-07-07",
     "body": "### Fixed\n\n- **Default CLI plan updates refresh in place.** In TTY sessions using the\n  prompt-safe inline `Working...` status, progress-plan updates now keep the\n  plan as renderer-owned bottom content and redraw it in place after clearing\n  the status line. This prevents updated plans from stacking duplicate\n  checklist blocks in the transcript while preserving append-only output for\n  pipes and logs."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.283",
+  version: "0.99.284",
   syncedAt: "2026-07-06",
 } as const;

--- a/tests/core/agent/test_approval_fsm.py
+++ b/tests/core/agent/test_approval_fsm.py
@@ -201,12 +201,81 @@ class TestDecisionParse:
         from core.cli.ipc_client import IPCClient
 
         client = IPCClient.__new__(IPCClient)
-        with patch("core.ui.console.console") as mock_console:
-            mock_console.input.return_value = typed
+        with (
+            patch.object(client, "_restore_terminal"),
+            patch.object(client, "_read_approval_line", return_value=typed),
+            patch("core.ui.console.console"),
+        ):
             decision = client._handle_approval_request(
                 {"tool_name": "memory_save", "detail": "", "safety_level": "write"}
             )
         assert decision == parse_decision(typed)[0]
+
+    def test_thin_client_strips_carriage_returns_from_approval_input(self) -> None:
+        """Raw terminal Enter can surface as CR bytes; HITL still accepts it."""
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient.__new__(IPCClient)
+        with (
+            patch.object(client, "_restore_terminal"),
+            patch.object(client, "_read_approval_line", return_value="a\r\r\n"),
+            patch("core.ui.console.console"),
+        ):
+            decision = client._handle_approval_request(
+                {"tool_name": "browser_navigate", "detail": "", "safety_level": "mcp"}
+            )
+        assert decision == "a"
+
+    def test_thin_client_denies_approval_on_eof(self) -> None:
+        """EOF is not the same as pressing Enter; fail closed."""
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient.__new__(IPCClient)
+        with (
+            patch.object(client, "_restore_terminal"),
+            patch.object(client, "_read_approval_line", side_effect=EOFError),
+            patch("core.ui.console.console"),
+        ):
+            decision = client._handle_approval_request(
+                {"tool_name": "browser_navigate", "detail": "", "safety_level": "mcp"}
+            )
+        assert decision == "n"
+
+    def test_thin_client_resumes_renderer_if_approval_callback_raises(self) -> None:
+        """Approval suspend must not strand the renderer if input handling fails."""
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient.__new__(IPCClient)
+        client._sock = object()
+        sent: list[dict[str, Any]] = []
+        ended: list[bool] = []
+
+        def fail_approval(_msg: dict[str, Any]) -> str:
+            raise RuntimeError("approval input failed")
+
+        with (
+            patch.object(client, "_send_client_capability"),
+            patch.object(client, "_send", side_effect=sent.append),
+            patch.object(
+                client,
+                "_recv",
+                return_value={
+                    "type": "approval_request",
+                    "approval_id": "approval-1",
+                    "tool_name": "browser_navigate",
+                },
+            ),
+            pytest.raises(RuntimeError, match="approval input failed"),
+        ):
+            client.send_prompt(
+                "use browser",
+                on_approval_start=lambda: None,
+                on_approval_end=lambda: ended.append(True),
+                on_approval_request=fail_approval,
+            )
+
+        assert ended == [True]
+        assert sent == [{"type": "prompt", "text": "use browser"}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/ui/test_agentic_ui.py
+++ b/tests/core/ui/test_agentic_ui.py
@@ -1293,6 +1293,53 @@ def test_event_renderer_updates_plan_in_place_with_tty_inline_status() -> None:
     assert re.search(r"\x1b\[\d+A", out)
 
 
+def test_update_plan_tool_does_not_displace_live_plan_surface() -> None:
+    """update_plan is plan state, not activity history between plan renders."""
+    from core.ui.event_renderer import EventRenderer
+
+    class TtyStringIO(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    r = EventRenderer(live_regions=False)
+    r._out = TtyStringIO()
+
+    try:
+        r.start_activity()
+        r._render_inline_status_frame()
+        r.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "inspect HITL", "status": "in_progress"},
+                    {"step": "fix approval input", "status": "pending"},
+                ],
+            }
+        )
+        assert r._progress_plan.at_bottom is True
+        r.on_event({"type": "tool_start", "name": "update_plan"})
+        r.on_event({"type": "tool_end", "name": "update_plan", "summary": "ok", "duration_s": 0.0})
+        assert r._progress_plan.at_bottom is True
+        r.on_event(
+            {
+                "type": "progress_plan",
+                "plan": [
+                    {"step": "inspect HITL", "status": "completed"},
+                    {"step": "fix approval input", "status": "in_progress"},
+                ],
+            }
+        )
+    finally:
+        r.stop()
+
+    out = r._out.getvalue()
+    plain = _strip_ansi(out)
+    assert "Activity" not in plain
+    assert "update_plan" not in plain
+    assert "fix approval input" in plain
+    assert re.search(r"\x1b\[\d+A", out)
+
+
 def test_tool_tracker_running_row_uses_signature_shimmer() -> None:
     """Running tool rows render via spinner_glyph (single spinner source)."""
     from core.ui import spinner_glyph

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.283"
+version = "0.99.284"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Fix thin-CLI HITL approval prompts so Enter submits normally instead of rendering raw `^M`.
- Keep `update_plan` out of Activity history so live plan updates remain in-place.
- Bump GEODE to v0.99.284 and sync changelog/site metadata.

## Why
The approval prompt could inherit prompt_toolkit raw terminal state; Rich `console.input()` then saw carriage returns as literal terminal bytes and the user could not approve MCP/browser actions. Separately, `update_plan -> ok` Activity rows displaced the live plan surface, causing duplicate plan blocks instead of in-place updates.

## Changes
| File | Change |
|------|--------|
| `core/cli/ipc_client.py` | Read approval choices through a cooked stdin path, strip CR bytes, fail closed on EOF, and always resume approval-suspended renderers. |
| `core/ui/event_renderer.py` | Treat `update_plan` as renderer state rather than tool activity/repeat history. |
| `tests/core/agent/test_approval_fsm.py` | Add CR, EOF, parse parity, and approval-resume regression coverage. |
| `tests/core/ui/test_agentic_ui.py` | Add regression coverage that `update_plan` does not displace the live plan surface. |
| `CHANGELOG.md`, version metadata | Release v0.99.284 and sync site/llms metadata. |

## GAP Audit
| Area | Finding | Fix |
|------|---------|-----|
| HITL approval input | Existing prompt used Rich `console.input()` after prompt_toolkit interaction. | Replace the input read with explicit cooked-terminal stdin line read. |
| Renderer recovery | Approval suspend/resume callbacks were not protected if approval handling raised. | Wrap approval handling in `finally`. |
| Plan UI | `update_plan` was recorded as normal Activity and pushed the plan out of its update surface. | Exclude `update_plan` from tool rows, Activity stats, and repeat compression. |

## Verification
- `uv run pytest -q tests/core/agent/test_approval_fsm.py tests/core/ui/test_agentic_ui.py tests/core/ui/test_event_schema_v2.py tests/core/ui/test_thinking_collapse.py`
- `uv run pytest -q tests/core/cli/test_fullscreen_app.py tests/core/cli/test_plan_tool_handlers.py tests/core/cli/test_ipc_client.py 2>/dev/null || uv run pytest -q tests/core/cli/test_fullscreen_app.py tests/core/cli/test_plan_tool_handlers.py`
- `uv run ruff check core/cli/ipc_client.py core/ui/event_renderer.py tests/core/agent/test_approval_fsm.py tests/core/ui/test_agentic_ui.py`
- `uv run ruff format --check core/cli/ipc_client.py core/ui/event_renderer.py tests/core/agent/test_approval_fsm.py tests/core/ui/test_agentic_ui.py`
- `uv run mypy core/cli/ipc_client.py core/ui/event_renderer.py`
- `uv run python scripts/check_llms_version.py`
- `uv run geode version`