### PR TITLE
Fix routing prompt CI expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ functional change.
   model, instead of defaulting through Anthropic → OpenAI → GLM. `delegate_task`
   now forwards the parent source into spawned sub-agents so child web searches
   and other LLM-backed tools inherit the session route rather than re-resolving
-  to unrelated PAYG credentials.
+  to unrelated PAYG credentials. Live-session model sync also tolerates
+  lightweight loop objects that do not expose a source axis while still keeping
+  full AgenticLoop source propagation intact.
 - **Runtime prompts now follow metadata-style identity clauses.** GEODE-owned
   system prompts, model/platform hints, benchmark prompts, and seed-generation
   agent prompts now use `Agent:`, `Role:`, `Task:`, or `Surface:` clauses

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -149,20 +149,25 @@ def _apply_model_update(
             from core.llm.adapters._source_inference import infer_source
 
             new_source = infer_source(new_provider)
-            if new_source != loop._source:
+            old_source = getattr(loop, "_source", "")
+            if new_source != old_source:
                 log.info(
                     "AgenticLoop source re-inferred on provider switch: %s (%s) -> %s (%s)",
-                    loop._source,
+                    old_source,
                     old_model,
                     new_source,
                     model,
                 )
                 loop._source = new_source
-        loop._new_adapter = _resolve_path_b_adapter(new_provider, loop._source)
+        loop._new_adapter = _resolve_path_b_adapter(new_provider, getattr(loop, "_source", ""))
     loop.model = model
     loop._tool_processor._model = model
-    loop._tool_processor._provider = getattr(loop._new_adapter, "provider", loop._provider)
-    loop._tool_processor._source = getattr(loop._new_adapter, "source", loop._source)
+    loop._tool_processor._provider = getattr(
+        loop._new_adapter, "provider", getattr(loop, "_provider", "")
+    )
+    loop._tool_processor._source = getattr(
+        loop._new_adapter, "source", getattr(loop, "_source", "")
+    )
     loop._tool_processor._adapter_name = getattr(loop._new_adapter, "name", "")
     if old_model != model:
         loop._prompt_dirty = True

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -270,7 +270,7 @@ def render_plan_for_prompt(plan: Plan) -> str:
         return ""
     lines = ["<plan>"]
     lines.append(
-        f"Current execution step: {plan.current + 1}/{len(plan.steps)} "
+        f"Current step {plan.current + 1}/{len(plan.steps)} "
         f"(revision {plan.revision}): {cur.description}"
     )
     if cur.expected_outcome:

--- a/core/agent/verify.py
+++ b/core/agent/verify.py
@@ -384,9 +384,8 @@ def _verify_rule_based(result: AgenticResult) -> VerifyResult:
 
 
 _LLM_JUDGE_SYSTEM_PROMPT = """\
-Task: strict, concise verification for one agent turn. Read the turn
-output below and emit a single-line JSON object — nothing else — with
-these keys:
+Task: strict, concise verifier for one agent turn. Read the turn output
+below and emit a single-line JSON object — nothing else — with these keys:
 
     {"passed": <true|false>, "score": <0.0-1.0>, "reason": "<short>"}
 


### PR DESCRIPTION
## Summary
- Fix full-CI regressions discovered while promoting develop to main after PR #2578.
- Preserve metadata-style prompt wording while keeping legacy test substrings stable.
- Make model switch route sync tolerate lightweight loop doubles without weakening full AgenticLoop source propagation.

## Why
PR #2579 exposed three full-suite failures that were not covered by the targeted pre-merge suite:
- `render_plan_for_prompt` no longer contained the expected `step 2/3` substring.
- The LLM verifier prompt no longer contained the word `verifier`.
- `_apply_model_update` evaluated `loop._source` as a fallback default even when a lightweight fake loop did not expose that attribute, causing live-session sync to soft-fail.

## Changes
| File | Change |
|------|--------|
| `core/agent/plan.py` | Use `Current step N/M` metadata wording, preserving the existing substring contract. |
| `core/agent/verify.py` | Keep `verifier` in the metadata-style LLM judge prompt. |
| `core/agent/loop/_model_switching.py` | Avoid eager `_source` fallback access for lightweight loop objects. |
| `CHANGELOG.md` | Document the live-session model sync tolerance update. |

## Verification
- `uv run pytest -q tests/core/agent/test_replan.py::test_render_plan_includes_current_step_marker tests/core/agent/test_model_split.py::test_verify_llm_judge_calls_loop_call_llm tests/core/server/test_model_switch_live_session.py::test_sync_repoints_live_loop_model tests/core/agent/test_model_switch_source_reinfer.py`
- `uv run ruff check CHANGELOG.md core/agent/plan.py core/agent/verify.py core/agent/loop/_model_switching.py`
- `uv run mypy core/agent/plan.py core/agent/verify.py core/agent/loop/_model_switching.py`
- `uv run ruff format --check core/agent/plan.py core/agent/verify.py core/agent/loop/_model_switching.py tests/core/agent/test_replan.py tests/core/agent/test_model_split.py tests/core/server/test_model_switch_live_session.py`
- `git diff --check`