### PR TITLE
Modernize runtime prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Runtime prompt modernization for GPT-family models.** GEODE now omits the
+  dynamic current-date block and per-request date reminder for OpenAI GPT/Codex
+  routes, while retaining the stale-year recency guard for Anthropic, GLM, and
+  unknown providers. The goal-decomposition planner now sends its
+  `DecompositionResult` schema through the runtime response-schema path instead
+  of relying only on an inline JSON example in the prompt.
+
 ### Fixed
 
 - **LLM-backed tools no longer scan a cross-provider fallback order.**

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -2108,6 +2108,7 @@ class AgenticLoop:
         *,
         round_idx: int = 0,
         model: str | None = None,
+        response_schema: dict[str, Any] | None = None,
     ) -> AgenticResponse | None:
         """Multi-provider LLM call via :class:`LLMAdapter` (P1 Gateway pattern).
 
@@ -2115,7 +2116,10 @@ class AgenticLoop:
         conversion, retry, failover). Returns a normalized
         ``AgenticResponse`` or None on failure. Raises ``UserCancelledError``
         on Ctrl+C (caught by ``arun()``). Optional ``model`` overrides the
-        request model for one call without mutating ``self.model``.
+        request model for one call without mutating ``self.model``. Optional
+        ``response_schema`` overrides the loop-level schema for this call only,
+        so auxiliary planner / judge calls can use structured outputs without
+        changing the main agent turn.
 
         Invariants:
           * the context-overflow check mutates the SHARED messages list in
@@ -2189,7 +2193,9 @@ class AgenticLoop:
             effort=adaptive_effort,
             resume_session_id=prior_session_id,
             # per-loop schema → claude-cli --json-schema / codex --output-schema
-            response_schema=self._response_schema,
+            response_schema=(
+                response_schema if response_schema is not None else self._response_schema
+            ),
         )
         # Fire LLM_CALL_STARTED/ENDED with usage+cost for the SQLite
         # token/cost accumulator.

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -55,6 +55,7 @@ __all__ = [
     "_replan_max_attempts",
     "build_plan_from_decomposition",
     "decompose_async",
+    "decomposition_response_schema",
     "parse_replan_response",
     "render_plan_for_prompt",
     "replan_async",
@@ -104,6 +105,11 @@ class DecompositionResult(BaseModel):
         default_factory=list, description="Ordered list of sub-goals"
     )
     reasoning: str = PydanticField(default="", description="Brief explanation of the decomposition")
+
+
+def decomposition_response_schema() -> dict[str, Any]:
+    """Return the structured-output schema for goal decomposition."""
+    return DecompositionResult.model_json_schema()
 
 
 # Cadence interval (number of rounds between forced replan calls). ``0``
@@ -679,8 +685,9 @@ async def decompose_async(
     2. **System prompt**: ``load_prompt("decomposer", "system")`` +
        ``apply_decomposition_policy`` (ADR-012 SoT — preserves the
        operator-tunable policy surface; only the call site moves).
-    3. **LLM call**: ``loop._call_llm`` with the active loop model,
-       bounded by ``_DECOMPOSE_CALL_TIMEOUT_S``
+    3. **LLM call**: ``loop._call_llm`` with the active loop model and
+       the ``DecompositionResult`` response schema, bounded by
+       ``_DECOMPOSE_CALL_TIMEOUT_S``
        (180s post-PR-CHECKPOINT-RESUME-TIMEBUDGET, 2026-05-25).
     4. **Parse**: pydantic ``DecompositionResult.model_validate_json``
        — schema-validated, error-on-malformed.
@@ -723,6 +730,7 @@ async def decompose_async(
                 system_prompt,
                 [{"role": "user", "content": user_prompt}],
                 model=loop.model,
+                response_schema=decomposition_response_schema(),
             ),
             timeout=_DECOMPOSE_CALL_TIMEOUT_S,
         )

--- a/core/agent/system_injection.py
+++ b/core/agent/system_injection.py
@@ -51,19 +51,22 @@ def build_system_reminder(
     """Build a system reminder string for end-adjacent injection.
 
     Assembles a concise context block containing:
-      - Current date/time (prevents year hallucination in tool calls)
-      - Active analysis rules (from ProjectMemory, if any)
-      - Round index (helps the model track progress)
-      - Extra context (caller-provided key-value pairs)
+
+    - Provider-gated current date/time (prevents year hallucination in tool
+      calls for models that need the guard)
+    - Active analysis rules (from ProjectMemory, if any)
+    - Round index (helps the model track progress)
+    - Extra context (caller-provided key-value pairs)
 
     Returns empty string if nothing meaningful to inject.
     """
     parts: list[str] = []
 
     # 1. Date context (shared helper — prevents stale year in searches)
-    from core.agent.system_prompt import format_current_date
+    from core.agent.system_prompt import _should_include_current_date, format_current_date
 
-    parts.append(f"Current date: {format_current_date()}")
+    if _should_include_current_date(model):
+        parts.append(f"Current date: {format_current_date()}")
 
     # 2. Round awareness
     if round_idx > 0:

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -216,6 +216,26 @@ def _generic_static_prefix() -> str:
     return _SYSTEM_PROMPT_TEMPLATE.format()
 
 
+def _should_include_current_date(model: str = "") -> bool:
+    """Return whether the runtime prompt should inject ``<current_date>``.
+
+    OpenAI's current GPT guidance recommends leaving the current date out of
+    the prompt because the model already knows the current UTC date. Keep the
+    legacy date guard for Anthropic, GLM, and unknown providers, where it still
+    prevents stale-year assumptions during "latest" lookups.
+    """
+    if not model:
+        return True
+    try:
+        from core.config import _resolve_provider
+
+        provider = _resolve_provider(model)
+    except Exception:
+        log.debug("Failed to resolve provider for current-date policy", exc_info=True)
+        return True
+    return provider not in {"openai", "openai-codex"}
+
+
 def build_system_prompt(model: str = "") -> str:
     """Build the AgenticLoop system prompt.
 
@@ -227,7 +247,7 @@ def build_system_prompt(model: str = "") -> str:
       </static_context>
       <dynamic_context>    ──── changes per turn → no cache
         <model_card>       (always present when ``model`` argument set)
-        <current_date>     (always present)
+        <current_date>     (provider-gated; omitted for OpenAI GPT-family models)
         <project_memory>   (G2: from .geode/MEMORY.md if exists)
         <agent_learning>   (G3: from user_profile/learned.md if exists; format
                             sanitized per G9 — pattern + 1-line summary, not raw
@@ -240,7 +260,8 @@ def build_system_prompt(model: str = "") -> str:
 
     - ``GEODE_AUDIT_UNRESTRICTED=1`` (audit-mode, G3): strip every
       GEODE-specific layer — identity, memory, user_context — leaving
-      only model_card + current_date + the caller's ``system_suffix``.
+      only model_card + provider-gated current_date + the caller's
+      ``system_suffix``.
       Petri auditor controls the scenario's identity end-to-end.
     - ``GEODE_PERSONA`` (G10): inject GEODE identity (G1). Default ON so
       the declared soul + runtime guardrails ship; set ``=off`` for a thin
@@ -271,7 +292,8 @@ def build_system_prompt(model: str = "") -> str:
             mc = _build_model_card(model)
             if mc:
                 parts.append(mc)
-        parts.append(_build_date_context())
+        if _should_include_current_date(model):
+            parts.append(_build_date_context())
         dynamic = PROMPT_CACHE_BOUNDARY + "\n\n" + "\n\n".join(parts)
         _emit_scaffold_diag(wrapper_override, audit_mode=True)
         # PR-PROMPT-P2A — AGENTIC_SUFFIX is authored-static (cache zone) and
@@ -318,7 +340,8 @@ def build_system_prompt(model: str = "") -> str:
     if hint:
         dynamic_parts.append(hint)
 
-    dynamic_parts.append(_build_date_context())
+    if _should_include_current_date(model):
+        dynamic_parts.append(_build_date_context())
 
     # G2-G4: Memory hierarchy (may change between turns)
     g2 = _build_geode_memory_context()

--- a/core/llm/prompts/decomposer.md
+++ b/core/llm/prompts/decomposer.md
@@ -1,5 +1,5 @@
 <system>
-Goal decomposition analyzes a user request, determines whether multiple tools are required, and produces a structured execution plan when needed.
+Goal decomposition decides whether a user request needs multiple tool calls and, only when it does, returns the smallest executable plan.
 
 ## Rules
 
@@ -22,31 +22,8 @@ Goal decomposition analyzes a user request, determines whether multiple tools ar
 
 6. **Cost awareness**: Prefer cheaper tools when possible. Mark expensive tools only when explicitly needed.
 
-## Output format
+## Output
 
-Respond with a JSON object matching this schema:
-```json
-{
-  "is_compound": true,
-  "goals": [
-    {
-      "id": "step_1",
-      "description": "Search for recent AI release notes",
-      "tool_name": "general_web_search",
-      "tool_args": {"query": "recent AI release notes"},
-      "depends_on": []
-    },
-    {
-      "id": "step_2",
-      "description": "Fetch the selected source",
-      "tool_name": "web_fetch",
-      "tool_args": {"url": ""},
-      "depends_on": ["step_1"]
-    }
-  ],
-  "reasoning": "User wants search + source inspection, requiring 2 sequential steps."
-}
-```
-
-When `tool_args` values depend on a previous step's output, leave them as empty strings — the orchestrator will fill them at runtime.
+Return only the structured decomposition object requested by the runtime schema.
+When `tool_args` values depend on a previous step's output, leave those values as empty strings; the orchestrator will fill them at runtime.
 </system>

--- a/tests/core/agent/test_model_split.py
+++ b/tests/core/agent/test_model_split.py
@@ -218,7 +218,7 @@ def test_decompose_async_inherits_loop_model(monkeypatch: pytest.MonkeyPatch) ->
     captured: dict[str, str] = {}
 
     async def _fake_call_llm(
-        _system: str, _msgs: list, *, model: str | None = None
+        _system: str, _msgs: list, *, model: str | None = None, **_kwargs: object
     ) -> SimpleNamespace:
         captured["model"] = model or ""
         # Return None so decompose_async early-exits without parsing
@@ -245,7 +245,7 @@ def test_decompose_async_ignores_removed_plan_model(
     captured: dict[str, str] = {}
 
     async def _fake_call_llm(
-        _system: str, _msgs: list, *, model: str | None = None
+        _system: str, _msgs: list, *, model: str | None = None, **_kwargs: object
     ) -> SimpleNamespace:
         captured["model"] = model or ""
         return None

--- a/tests/core/agent/test_replan.py
+++ b/tests/core/agent/test_replan.py
@@ -746,6 +746,50 @@ def test_decompose_async_skips_no_compound(monkeypatch: pytest.MonkeyPatch) -> N
     assert called["hit"] is False
 
 
+def test_decompose_async_passes_response_schema() -> None:
+    """Planner uses runtime structured-output schema, not only prompt prose."""
+    import asyncio
+    import json
+
+    from core.agent.plan import decompose_async
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_call_llm(*_args: Any, **kwargs: Any) -> Any:
+        seen.update(kwargs)
+        return SimpleNamespace(
+            text=json.dumps(
+                {
+                    "is_compound": True,
+                    "goals": [
+                        {
+                            "id": "step_1",
+                            "description": "Search for current release notes",
+                            "tool_name": "general_web_search",
+                            "tool_args": {"query": "current release notes"},
+                            "depends_on": [],
+                        },
+                        {
+                            "id": "step_2",
+                            "description": "Summarize the results",
+                            "tool_name": "summarize",
+                            "tool_args": {},
+                            "depends_on": ["step_1"],
+                        },
+                    ],
+                    "reasoning": "search then summarize",
+                }
+            )
+        )
+
+    loop = SimpleNamespace(_call_llm=_fake_call_llm, _tools=[], model="m")
+    result = asyncio.run(decompose_async(loop, "search release notes and summarize them"))
+
+    assert result is not None
+    assert seen["response_schema"]["title"] == "DecompositionResult"
+    assert "goals" in seen["response_schema"]["properties"]
+
+
 def test_step_expected_mismatch_in_retryable_set() -> None:
     """The new code is in the retryable allowlist so PR-CL-A1 replan
     can recover from it."""

--- a/tests/core/agent/test_system_injection.py
+++ b/tests/core/agent/test_system_injection.py
@@ -31,8 +31,19 @@ class TestBuildSystemReminder:
     """Tests for build_system_reminder()."""
 
     def test_includes_date(self) -> None:
-        """Reminder always includes current date."""
+        """Reminder includes current date by default."""
         result = build_system_reminder()
+        assert "Current date:" in result
+
+    @patch("core.agent.system_prompt.get_active_rule_names", return_value=[])
+    def test_omits_date_for_openai_model(self, _mock: object) -> None:
+        """OpenAI GPT-family reminders inherit the no-current-date policy."""
+        result = build_system_reminder(model="gpt-5.5")
+        assert result == ""
+
+    def test_keeps_date_for_anthropic_model(self) -> None:
+        """Non-OpenAI reminders keep the recency guard."""
+        result = build_system_reminder(model="claude-opus-4-8")
         assert "Current date:" in result
 
     def test_includes_round_when_nonzero(self) -> None:
@@ -86,6 +97,13 @@ class TestAppendSystemReminder:
         assert result[0]["role"] == "user"
         assert f"<{_REMINDER_TAG}>" in result[0]["content"]
         assert f"</{_REMINDER_TAG}>" in result[0]["content"]
+
+    @patch("core.agent.system_prompt.get_active_rule_names", return_value=[])
+    def test_openai_without_other_context_appends_nothing(self, _mock: object) -> None:
+        """No empty reminder is appended after OpenAI date elision."""
+        messages = [{"role": "user", "content": "Hello"}]
+        result = append_system_reminder(messages, model="gpt-5.5")
+        assert result == messages
 
     def test_appends_after_latest_user_message(self) -> None:
         """Reminder is the LAST message, after all history."""

--- a/tests/integration/test_prompt_audit_2026_05_12.py
+++ b/tests/integration/test_prompt_audit_2026_05_12.py
@@ -78,6 +78,28 @@ def test_g3_audit_mode_strips_identity_memory_user(monkeypatch: pytest.MonkeyPat
     assert "<dynamic_context>" in out
 
 
+def test_current_date_omitted_for_openai_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenAI GPT-family prompts omit current_date per current GPT guidance."""
+    monkeypatch.delenv("GEODE_AUDIT_UNRESTRICTED", raising=False)
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+
+    out = build_system_prompt(model="gpt-5.5")
+
+    assert "<model_card>" in out
+    assert "<current_date>" not in out
+    assert "<dynamic_context>" in out
+
+
+def test_current_date_kept_for_anthropic_recency_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-OpenAI prompts retain the stale-year guard."""
+    monkeypatch.delenv("GEODE_AUDIT_UNRESTRICTED", raising=False)
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+
+    out = build_system_prompt(model="claude-opus-4-8")
+
+    assert "<current_date>" in out
+
+
 def test_g3_audit_mode_supersedes_persona(monkeypatch: pytest.MonkeyPatch) -> None:
     """Audit-mode forces persona OFF regardless of GEODE_PERSONA."""
     monkeypatch.setenv("GEODE_AUDIT_UNRESTRICTED", "1")


### PR DESCRIPTION
## Summary
- Omit current-date prompt/reminder injection for OpenAI GPT/Codex routes while preserving the recency guard for Anthropic, GLM, and unknown providers.
- Move goal decomposition toward runtime structured outputs by passing the `DecompositionResult` schema through the AgenticLoop call path.
- Trim the decomposer prompt so schema details live in code, not prompt prose.

## Why
OpenAI's current GPT guidance recommends avoiding redundant current-date injection, and structured-output schemas are more reliable than large inline JSON examples. This keeps GEODE's prompt surface closer to current Fable/GPT prompt best practices without rewriting the larger router contract in this PR.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py` | Adds provider-gated current-date policy. |
| `core/agent/system_injection.py` | Applies the same date policy to per-request reminders. |
| `core/agent/loop/agent_loop.py` | Allows per-call `response_schema` overrides. |
| `core/agent/plan.py` | Sends `DecompositionResult` schema during planner calls. |
| `core/llm/prompts/decomposer.md` | Removes inline JSON schema example and keeps concise planner guidance. |
| `tests/**` | Adds regression coverage for date policy and planner schema wiring. |

## Verification
- `uv run pytest -q tests/core/agent -q`
- `uv run pytest -q tests/core/agent/test_system_injection.py tests/integration/test_prompt_audit_2026_05_12.py tests/core/agent/test_replan.py tests/core/agent/test_model_split.py`
- `uv run ruff check core/agent/system_prompt.py core/agent/system_injection.py core/agent/loop/agent_loop.py core/agent/plan.py tests/integration/test_prompt_audit_2026_05_12.py tests/core/agent/test_replan.py tests/core/agent/test_model_split.py tests/core/agent/test_system_injection.py`
- `uv run ruff format --check core/agent/system_prompt.py core/agent/system_injection.py core/agent/loop/agent_loop.py core/agent/plan.py tests/integration/test_prompt_audit_2026_05_12.py tests/core/agent/test_replan.py tests/core/agent/test_model_split.py tests/core/agent/test_system_injection.py`
- `uv run mypy core/agent/system_prompt.py core/agent/system_injection.py core/agent/plan.py core/agent/loop/agent_loop.py`
- `git diff --check`
