### PR TITLE
Relax document_ingest input path policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ functional change.
 
 ### Changed
 
+- **document_ingest can read approved local PDFs outside the project.** The
+  source PDF path now accepts user-approved local files from folders such as
+  Downloads or iCloud Drive, while generated bundles and explicit `output_dir`
+  paths remain constrained to the GEODE project sandbox.
 - **Runtime prompt modernization for GPT-family models.** GEODE now omits the
   dynamic current-date block and per-request date reminder for OpenAI GPT/Codex
   routes, while retaining the stale-year recency guard for Anthropic, GLM, and

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -902,7 +902,7 @@
       "properties": {
         "file_path": {
           "type": "string",
-          "description": "Path to a local PDF inside the GEODE file sandbox."
+          "description": "Path to a local PDF. May be outside the project after document_ingest approval."
         },
         "backend": {
           "type": "string",

--- a/core/tools/document_ingest.py
+++ b/core/tools/document_ingest.py
@@ -97,7 +97,10 @@ class DocumentIngestTool:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to a local PDF inside the GEODE file sandbox.",
+                    "description": (
+                        "Path to a local PDF. May be outside the project after "
+                        "document_ingest approval."
+                    ),
                 },
                 "backend": {
                     "type": "string",
@@ -174,7 +177,7 @@ class DocumentIngestTool:
                 hint=f"Use one of: {', '.join(sorted(_BACKENDS))}.",
             )
 
-        path_result = validate_path(str(kwargs["file_path"]), write=False)
+        path_result = _resolve_input_pdf_path(str(kwargs["file_path"]))
         if isinstance(path_result, dict):
             return path_result
         pdf_path = path_result
@@ -250,6 +253,18 @@ class DocumentIngestTool:
             document=extracted,
         )
         return {"result": bundle}
+
+
+def _resolve_input_pdf_path(raw_path: str) -> Path | dict[str, Any]:
+    """Resolve a user-approved input PDF without forcing project containment.
+
+    `document_ingest` is a HITL-gated write/expensive tool that copies parsed
+    output into the project bundle. The source PDF is read-only input, so it can
+    come from Downloads, iCloud Drive, or another local document folder while
+    output_dir remains project-sandboxed through `_resolve_output_dir`.
+    """
+
+    return validate_path(raw_path, write=False, allowed_roots=[Path(os.path.abspath(os.sep))])
 
 
 def _validate_pdf_path(pdf_path: Path) -> dict[str, Any] | None:

--- a/core/tools/sandbox.py
+++ b/core/tools/sandbox.py
@@ -283,6 +283,8 @@ def _path_in_allowed_roots(path: Path, allowed_roots: list[Path]) -> bool:
 
     for root in allowed_roots:
         normalized_root = normalize_macos_path(str(root)).lower()
+        if normalized_root == "/":
+            return normalized_path.startswith("/")
         # Check: path starts with root (with trailing separator for safety)
         if normalized_path == normalized_root:
             return True

--- a/tests/core/tools/test_document_ingest.py
+++ b/tests/core/tools/test_document_ingest.py
@@ -24,7 +24,7 @@ def _fake_pdf(tmp_path: Path) -> Path:
 
 
 def _patch_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(mod, "validate_path", lambda path, write=False: Path(path))
+    monkeypatch.setattr(mod, "validate_path", lambda path, **_kwargs: Path(path))
 
 
 def test_local_text_backend_writes_manifest_and_pages(
@@ -116,6 +116,22 @@ def test_page_chunk_size_must_be_positive(tmp_path: Path, monkeypatch: pytest.Mo
 
     assert result["error_type"] == "validation"
     assert "page_chunk_size" in result["error"]
+
+
+def test_input_pdf_may_be_outside_project(tmp_path: Path) -> None:
+    pdf = _fake_pdf(tmp_path)
+
+    result = mod._resolve_input_pdf_path(str(pdf))
+
+    assert isinstance(result, Path), f"expected Path, got: {result}"
+    assert result == pdf.resolve()
+
+
+def test_output_dir_remains_project_sandboxed(tmp_path: Path) -> None:
+    result = mod._resolve_output_dir(tmp_path / "external-bundle", "sample")
+
+    assert isinstance(result, dict)
+    assert result["error_type"] == "permission"
 
 
 def test_auto_backend_uses_provider_when_local_text_empty(
@@ -295,6 +311,10 @@ def test_document_ingest_is_wired() -> None:
     assert "openai_pdf" in definition["input_schema"]["properties"]["backend"]["enum"]
     assert "page_range" in definition["input_schema"]["properties"]
     assert definition["input_schema"]["properties"]["page_chunk_size"]["minimum"] == 1
+    assert (
+        "outside the project"
+        in definition["input_schema"]["properties"]["file_path"]["description"]
+    )
     assert "claude_pdf" in definition["description"]
     assert "zhipu_ocr" in definition["description"]
 

--- a/tests/core/tools/test_sandbox.py
+++ b/tests/core/tools/test_sandbox.py
@@ -276,6 +276,15 @@ class TestValidatePath:
         result = sandbox.validate_path(str(target), write=False)
         assert isinstance(result, Path)
 
+    def test_explicit_filesystem_root_allows_absolute_read_path(self, tmp_path: Path):
+        target = tmp_path / "outside.pdf"
+        target.write_text("content")
+
+        result = sandbox.validate_path(str(target), write=False, allowed_roots=[Path("/")])
+
+        assert isinstance(result, Path)
+        assert result == target.resolve()
+
 
 # ---------------------------------------------------------------------------
 # Tilde expansion (G4 — bare ~ / ~/ expansion regression coverage)


### PR DESCRIPTION
## Summary
- Allow `document_ingest` to read approved local PDF source paths outside the project sandbox.
- Keep generated bundles and explicit `output_dir` writes constrained to the project sandbox.
- Add regression coverage for external PDF input and filesystem-root allowlist handling.

## Why
Users can ask GEODE to inspect PDFs from Downloads, iCloud Drive, or other local document folders. The tool already requires approval, but the shared file-tool sandbox rejected those source paths before ingest could run.

## Changes
| File | Change |
|------|--------|
| `core/tools/document_ingest.py` | Resolve input PDFs against the local filesystem root after approval; keep output sandboxed. |
| `core/tools/sandbox.py` | Treat explicit `/` allow roots as containing absolute POSIX paths. |
| `core/tools/definitions.json` | Update `document_ingest.file_path` description. |
| `tests/core/tools/test_document_ingest.py` | Cover external input PDF and sandboxed output dir. |
| `tests/core/tools/test_sandbox.py` | Cover explicit filesystem-root allowlist behavior. |
| `CHANGELOG.md` | Record the behavior change. |

## Verification
- `uv run ruff format --check core/tools/document_ingest.py core/tools/sandbox.py tests/core/tools/test_document_ingest.py tests/core/tools/test_sandbox.py`
- `uv run ruff check core/tools/document_ingest.py core/tools/sandbox.py tests/core/tools/test_document_ingest.py tests/core/tools/test_sandbox.py`
- `uv run pytest -q tests/core/tools/test_document_ingest.py tests/core/tools/test_sandbox.py`
- `uv run mypy core/tools/document_ingest.py core/tools/sandbox.py`
- Exact user PDF path preflight: `_resolve_input_pdf_path(...)` returns `Path`, `_validate_pdf_path(...)` returns `None`.
