### PR TITLE
chore(ci): mcpmark 포맷/외부 하네스 mypy 스코프 정리 (develop 게이트 unblock)

### DIFF
--- a/plugins/benchmark_harness/mcpmark_geode_agent.py
+++ b/plugins/benchmark_harness/mcpmark_geode_agent.py
@@ -33,12 +33,17 @@ def _normalize_tool_arguments(schema: dict[str, Any], kwargs: dict[str, Any]) ->
         kwargs["path"] = kwargs.pop("file_path")
     if "start_cursor" in properties and "start_cursor" in kwargs:
         cursor = kwargs["start_cursor"]
-        if cursor is None or cursor == 0 or str(cursor).strip().lower() in {
-            "",
-            "none",
-            "null",
-            "undefined",
-        }:
+        if (
+            cursor is None
+            or cursor == 0
+            or str(cursor).strip().lower()
+            in {
+                "",
+                "none",
+                "null",
+                "undefined",
+            }
+        ):
             kwargs.pop("start_cursor", None)
     return kwargs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,6 +416,10 @@ DEP001 = [
     # tau2-bench is installed under artifacts/eval/harnesses/tau2-bench by the
     # benchmark_harness plugin when live tau2 measurement is requested.
     "tau2",
+    # MCPMark harness modules resolve via MCPMARK_ROOT sys.path insertion in
+    # plugins/benchmark_harness/run_mcpmark.py; opt-in checkout, absent by default.
+    "src",
+    "pipeline",
 ]
 
 # DEP002 — declared as dep but not imported anywhere by deptry's static scan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -569,6 +569,10 @@ module = [
     # tau2-bench harness lives under artifacts/eval/harnesses and is opt-in.
     # CI default sync does not install tau2 or its untyped in-tree modules.
     "tau2.*",
+    # MCPMark harness modules resolve via MCPMARK_ROOT sys.path insertion in
+    # plugins/benchmark_harness/run_mcpmark.py; opt-in checkout, absent in CI.
+    "src.agents",
+    "pipeline",
     # PR-BROWSER-CDP-BRIDGE — websockets ships no py.typed; used only by the
     # CDP client in core/tools/browser_tools.py (already an installed dep).
     "websockets.*",

--- a/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
+++ b/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
@@ -52,7 +52,9 @@ def test_normalize_tool_arguments_drops_empty_start_cursor() -> None:
     schema = {"inputSchema": {"properties": {"start_cursor": {"type": "string"}}}}
 
     for empty_cursor in ("", "undefined", "null", "none", None, 0):
-        assert _normalize_tool_arguments(schema, {"start_cursor": empty_cursor, "page_size": 100}) == {
+        assert _normalize_tool_arguments(
+            schema, {"start_cursor": empty_cursor, "page_size": 100}
+        ) == {
             "page_size": 100,
         }
 


### PR DESCRIPTION
## Summary
#2597(main 직행)이 남긴 미포맷 파일 2개와 외부 하네스 import의 mypy 실패를 정리해 develop→main 릴리스 PR(#2599)의 CI를 unblock한다.

## Why
main→develop 선동기화(#2598)로 유입된 mcpmark 파일들이 `ruff format --check`와 `mypy`를 깨뜨려 #2599가 머지 불가.

## Changes
- `mcpmark_geode_agent.py`, `test_mcpmark_adapter.py` ruff format 적용
- `run_mcpmark.py`가 MCPMARK_ROOT sys.path로 해석하는 `src.agents`/`pipeline`을 기존 opt-in ignore 목록(tau2.* 선례)에 최소 범위 추가

## Verification
- `uv run mypy core/ plugins/` — 505 files, 0 errors
- `uv run ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)