### PR TITLE
fix(site): 피날레 크레딧 edited by 표기 (release 0.99.293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [0.99.293] - 2026-07-10
+
+### Fixed
+
+- **Portfolio finale credit reads "edited by".** The end-credit roll line
+  over the MANGO card is corrected from "edit by" (operator-directed).
+
+---
+
 ## [0.99.292] - 2026-07-10
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.292
+- **Version**: 0.99.293
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.292 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.293 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.292: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.293: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.292"
+version = "0.99.293"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.292. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.293. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.292. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.293. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -933,7 +933,7 @@ function DistillationAct() {
               </p>
               <div>
                 <p className="font-mono text-[10.5px] uppercase tracking-[0.42em]" style={{ color: PAPER_75 }}>
-                  edit by
+                  edited by
                 </p>
                 <h2 className="font-serif-display mt-2 text-balance text-[clamp(2.6rem,6.4vw,4.5rem)] font-black leading-[1.05] tracking-[0.04em] text-[#FFF0F8]">
                   MANGO

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.293",
+    "date": "2026-07-10",
+    "body": "### Fixed\n\n- **Portfolio finale credit reads \"edited by\".** The end-credit roll line\n  over the MANGO card is corrected from \"edit by\" (operator-directed)."
+  },
+  {
     "version": "0.99.292",
     "date": "2026-07-10",
     "body": "### Changed\n\n- **Docs surface aligned with the portfolio register (operator-directed).**\n  Docs page titles and prose h2 headings now carry the Noto Serif KR\n  editorial display (`--font-serif-display`, mounted via `docs-shell.tsx`)\n  over the existing dark substrate, matching the portfolio's serif register\n  while reference density stays sans. README.md drops every em-dash\n  (headings to colons, definition bullets to colons, prose clauses to\n  commas) per the dash-slop rule."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.292",
+  version: "0.99.293",
   syncedAt: "2026-07-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.292"
+version = "0.99.293"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
포트폴리오 피날레 엔딩 크레딧 롤 라인을 "edit by"에서 "edited by"로 교정한다(운영자 지시). uppercase 렌더로 화면에는 EDITED BY / MANGO로 표시된다.

## Why
영화 엔딩 크레딧 문법상 과거분사형이 맞다.

## Changes
- `site/src/app/portfolio/page.tsx`: 크레딧 롤 라인 1단어 교정
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.293, `sync-stats.mjs`/`check_llms_version.py --fix` 재생성

## Impact Scope
- **영향 모듈**: site/ 카피 1곳
- **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ · `check_llms_version.py` clean (v0.99.293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)