### PR TITLE
fix(site): 모바일 피날레 스탬프 제거 (release 0.99.294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.294] - 2026-07-10
+
+### Fixed
+
+- **Portfolio finale drops the cultured-since stamp.** On mobile the stamp
+  line above the MANGO credit collided with the pinned top-left distillation
+  headline; the finale now opens directly with the end-credit
+  (operator-directed).
+
+---
+
 ## [0.99.293] - 2026-07-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.293
+- **Version**: 0.99.294
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.293 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.294 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.293: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.294: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.293"
+version = "0.99.294"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.293. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.294. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.293. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.294. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -18,8 +18,6 @@ import { GEODE_SOT } from "@/data/geode/sot";
 import { galmuri } from "@/fonts/galmuri";
 import { serifDisplay } from "@/fonts/serif";
 
-import { firstRelease, latestRelease, releaseCount } from "./growth";
-
 /**
  * GEODE portfolio v26 — The Fixed Point, in rose and white.
  *
@@ -928,9 +926,6 @@ function DistillationAct() {
           </div>
           <div className="absolute inset-x-2 bottom-12 top-2 sm:inset-x-3 sm:top-3">
             <div className="relative z-10 mx-auto flex h-full max-w-5xl flex-col items-center justify-center gap-7 px-6 text-center">
-              <p className="font-mono text-[11px] uppercase tracking-[0.3em]" style={{ color: PAPER_75 }}>
-                cultured since {firstRelease.date} · release #{releaseCount} · v{latestRelease.version}
-              </p>
               <div>
                 <p className="font-mono text-[10.5px] uppercase tracking-[0.42em]" style={{ color: PAPER_75 }}>
                   edited by

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.294",
+    "date": "2026-07-10",
+    "body": "### Fixed\n\n- **Portfolio finale drops the cultured-since stamp.** On mobile the stamp\n  line above the MANGO credit collided with the pinned top-left distillation\n  headline; the finale now opens directly with the end-credit\n  (operator-directed)."
+  },
+  {
     "version": "0.99.293",
     "date": "2026-07-10",
     "body": "### Fixed\n\n- **Portfolio finale credit reads \"edited by\".** The end-credit roll line\n  over the MANGO card is corrected from \"edit by\" (operator-directed)."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.293",
+  version: "0.99.294",
   syncedAt: "2026-07-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.293"
+version = "0.99.294"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
모바일에서 피날레의 cultured-since 스탬프 라인이 좌상단 고정 증류 헤드라인과 겹쳐(운영자 리포트) 스탬프를 제거한다. 피날레는 이제 엔딩 크레딧(edited by / MANGO)으로 바로 시작한다.

## Why
운영자 실기기 확인: 모바일 뷰포트에서 두 고정 요소가 충돌.

## Changes
- `site/src/app/portfolio/page.tsx`: 스탬프 라인 제거 + 미사용 growth import 정리
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.294, sync-stats/check_llms_version 재생성

## Impact Scope
- **영향 모듈**: site/ 1파일 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ · `tsc --noEmit` ✓ · `check_llms_version.py` clean (v0.99.294)

🤖 Generated with [Claude Code](https://claude.com/claude-code)