### PR TITLE
feat(site): 포트폴리오 기본 로케일 ko 전환 (release 0.99.297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.297] - 2026-07-11
+
+### Changed
+
+- **Portfolio defaults to Korean (operator-directed).** The page opens in
+  the KO register (`defaultLocale="ko"`, matching the site-wide
+  `<html lang="ko">`); the full KO copy deck was already wired through
+  `t(locale, ko, en)` pairs, and English stays one toggle away.
+
+---
+
 ## [0.99.296] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.296
+- **Version**: 0.99.297
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.296 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.297 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.296: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.297: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.296"
+version = "0.99.297"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.296. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.297. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5124,7 +5124,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1401 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1402 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.296. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.297. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -977,7 +977,7 @@ function DistillationAct() {
 
 export default function GeodePortfolioPage() {
   return (
-    <LocaleProvider defaultLocale="en">
+    <LocaleProvider defaultLocale="ko">
       <main
         data-astryx-theme="neutral"
         className={`${galmuri.variable} ${serifDisplay.variable} min-h-screen overflow-x-clip bg-[var(--acc-artifact)] text-[#FFF0F8]`}

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.297",
+    "date": "2026-07-11",
+    "body": "### Changed\n\n- **Portfolio defaults to Korean (operator-directed).** The page opens in\n  the KO register (`defaultLocale=\"ko\"`, matching the site-wide\n  `<html lang=\"ko\">`); the full KO copy deck was already wired through\n  `t(locale, ko, en)` pairs, and English stays one toggle away."
+  },
+  {
     "version": "0.99.296",
     "date": "2026-07-11",
     "body": "### Changed\n\n- **Portfolio legibility pass: deep-rose ink grade (operator-directed).**\n  The signature rose `#F49BC4` read at ~1.8:1 as ink on the white postcards,\n  washing out every diagram; plates now write with a darkened same-hue ink\n  `#C2447F` (~4.5:1) across line-art strokes, titles, captions, chips, the\n  Geodi stamp, and the winning memory band, while the signature stays the\n  field and fill color. Plate textures drop behind an 80% paper scrim and\n  white copy on the rose field rises to 90% alpha."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.296",
+  version: "0.99.297",
   syncedAt: "2026-07-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.296"
+version = "0.99.297"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
포트폴리오 첫 화면을 국문으로 연다(운영자 지시). `<html lang=\"ko\">`와 전역 LocaleProvider 기본값은 이미 ko였고 포트폴리오만 en 오버라이드였다 — 한 줄 전환. KO 카피덱은 t(locale, ko, en) 쌍으로 전 섹션에 이미 배선돼 있고 EN은 토글 한 번.

## Why
사이트 lang·문서 본문이 모두 KO 기준인데 포트폴리오만 EN-first라 첫인상이 갈라졌다.

## Changes
- `site/src/app/portfolio/page.tsx`: `defaultLocale=\"en\"` → `\"ko\"` (1줄)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.297, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1줄 / **하위 호환**: 유지(EN 토글) / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · puppeteer 실스크롤 8샷으로 KO 렌더(히어로·도판·증류·피날레) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)