### PR TITLE
fix(site): three ways in 흰 도판 전환 — 시인성 패스 2 (release 0.99.298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.298] - 2026-07-11
+
+### Changed
+
+- **"Three ways in" joins the postcard language (operator-directed
+  legibility pass).** The rose-field hairline grid with white copy (~1.8:1)
+  is replaced by three white plates written in the deep-rose ink: serif
+  titles and captions in `#C2447F`, command chips flipped to deep-rose
+  fill with white text.
+
+---
+
 ## [0.99.297] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.297
+- **Version**: 0.99.298
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.297 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.298 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.297: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.298: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.297"
+version = "0.99.298"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.297. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.298. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.297. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.298. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -379,7 +379,7 @@ const runModes = [
   },
 ];
 
-/** The three entrances — normal flow, Hermes-style staggered reveal. */
+/** The three entrances — white plates in the postcard language. */
 function RunRow() {
   const locale = useLocale();
   const reduceMotion = useReducedMotion();
@@ -396,10 +396,7 @@ function RunRow() {
         >
           {t(locale, "세 가지 입구", "three ways in")}
         </motion.p>
-        <div
-          className="mt-10 grid gap-px overflow-hidden border md:grid-cols-3"
-          style={{ borderColor: PAPER_55, background: PAPER_55 }}
-        >
+        <div className="mt-10 grid gap-8 md:grid-cols-3">
           {runModes.map((mode, i) => (
             <motion.div
               key={mode.cmd}
@@ -407,16 +404,18 @@ function RunRow() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.65, delay: i * 0.12, ease: [0.22, 1, 0.36, 1] }}
-              className="bg-[var(--acc-artifact)] px-7 py-9 text-center"
+              className="bg-[#FFF0F8] px-7 py-10 text-center"
             >
-              <p className="font-mono text-[10.5px] uppercase tracking-[0.28em]" style={{ color: PAPER_75 }}>{mode.eyebrow}</p>
-              <h2 className="font-serif-display mt-3 text-[28px] font-semibold text-[#FFF0F8]">
+              <p className="font-mono text-[10.5px] uppercase tracking-[0.28em]" style={{ color: ROSE_INK_70 }}>
+                {mode.eyebrow}
+              </p>
+              <h2 className="font-serif-display mt-3 text-[28px] font-semibold" style={{ color: ROSE_INK }}>
                 {locale === "en" ? mode.titleEn : mode.titleKo}
               </h2>
-              <p className="mx-auto mt-4 inline-block rounded bg-[#FFF0F8] px-4 py-2 font-mono text-[13px] font-medium text-[#C2447F]">
+              <p className="mx-auto mt-4 inline-block rounded bg-[#C2447F] px-4 py-2 font-mono text-[13px] font-medium text-[#FFF0F8]">
                 {mode.cmd}
               </p>
-              <p className="mx-auto mt-4 max-w-[260px] text-[13px] leading-[1.7]" style={{ color: PAPER_75 }}>
+              <p className="mx-auto mt-4 max-w-[280px] text-[13px] leading-[1.7]" style={{ color: ROSE_INK_70 }}>
                 {t(locale, mode.ko, mode.en)}
               </p>
             </motion.div>

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.298",
+    "date": "2026-07-11",
+    "body": "### Changed\n\n- **\"Three ways in\" joins the postcard language (operator-directed\n  legibility pass).** The rose-field hairline grid with white copy (~1.8:1)\n  is replaced by three white plates written in the deep-rose ink: serif\n  titles and captions in `#C2447F`, command chips flipped to deep-rose\n  fill with white text."
+  },
+  {
     "version": "0.99.297",
     "date": "2026-07-11",
     "body": "### Changed\n\n- **Portfolio defaults to Korean (operator-directed).** The page opens in\n  the KO register (`defaultLocale=\"ko\"`, matching the site-wide\n  `<html lang=\"ko\">`); the full KO copy deck was already wired through\n  `t(locale, ko, en)` pairs, and English stays one toggle away."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.297",
+  version: "0.99.298",
   syncedAt: "2026-07-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.297"
+version = "0.99.298"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
운영자 리포트: three ways in이 여전히 안 읽힘. 로즈 필드 위 흰 헤어라인 그리드+흰 카피(~1.8:1)를 도판과 같은 언어(흰 플레이트 + 딥로즈 잉크 #C2447F)로 전환한다. 세리프 타이틀·캡션은 잉크, 커맨드 칩은 딥로즈 채움+흰 글자.

## Why
페이지 전체가 흰 카드 위 딥 잉크 문법으로 통일된 상태에서 run row만 구식 저대비 처리로 남아 있었다.

## Changes
- `site/src/app/portfolio/page.tsx`: RunRow를 흰 플레이트 3장으로 재작성(리빌 애니메이션 유지)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.298, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1컴포넌트 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 실스크롤 캡처로 KO 렌더 대비 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)