### PR TITLE
feat(site): 포트폴리오 기본 EN, ?lang=ko 쿼리 전용 국문 (release 0.99.300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ functional change.
 
 ---
 
+## [0.99.300] - 2026-07-11
+
+### Changed
+
+- **Portfolio serves Korean only on explicit `?lang=ko` (operator-directed).**
+  The default register returns to English; the `lang` query parameter is the
+  sole switch (both `ko` and `en` accepted, never the browser locale), the
+  URL carries the parameter only when the locale differs from the surface
+  default, and the docs surface keeps its Korean default with `?lang=en`
+  unchanged.
+
+---
+
 ## [0.99.299] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.299
+- **Version**: 0.99.300
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.299 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.300 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.299: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.300: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.299"
+version = "0.99.300"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.299. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.300. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5124,7 +5124,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1402 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1403 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.299. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.300. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -976,7 +976,7 @@ function DistillationAct() {
 
 export default function GeodePortfolioPage() {
   return (
-    <LocaleProvider defaultLocale="ko">
+    <LocaleProvider defaultLocale="en">
       <main
         data-astryx-theme="neutral"
         className={`${galmuri.variable} ${serifDisplay.variable} min-h-screen overflow-x-clip bg-[var(--acc-artifact)] text-[#FFF0F8]`}

--- a/site/src/components/geode/locale-context.tsx
+++ b/site/src/components/geode/locale-context.tsx
@@ -29,24 +29,26 @@ export function LocaleProvider({
 }) {
   const [locale, setLocale] = useState<Locale>(defaultLocale);
 
-  // Read ?lang=en from URL on mount
+  // Explicit ?lang= param only — never the browser locale. The param wins
+  // over the surface default (portfolio defaults en, docs defaults ko).
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const lang = params.get("lang");
-    if (lang === "en") setLocale("en");
+    if (lang === "en" || lang === "ko") setLocale(lang);
   }, []);
 
-  // Update html lang attribute + URL param
+  // Update html lang attribute + URL param (param present only when the
+  // locale differs from this surface's default, so default URLs stay clean).
   useEffect(() => {
     document.documentElement.lang = locale;
     const url = new URL(window.location.href);
-    if (locale === "en") {
-      url.searchParams.set("lang", "en");
+    if (locale !== defaultLocale) {
+      url.searchParams.set("lang", locale);
     } else {
       url.searchParams.delete("lang");
     }
     window.history.replaceState({}, "", url.toString());
-  }, [locale]);
+  }, [locale, defaultLocale]);
 
   return (
     <LocaleContext.Provider value={locale}>

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.300",
+    "date": "2026-07-11",
+    "body": "### Changed\n\n- **Portfolio serves Korean only on explicit `?lang=ko` (operator-directed).**\n  The default register returns to English; the `lang` query parameter is the\n  sole switch (both `ko` and `en` accepted, never the browser locale), the\n  URL carries the parameter only when the locale differs from the surface\n  default, and the docs surface keeps its Korean default with `?lang=en`\n  unchanged."
+  },
+  {
     "version": "0.99.299",
     "date": "2026-07-11",
     "body": "### Changed\n\n- **Plates vii-viii shed the self-gaming reading (operator-directed).**\n  \"스스로를 감사합니다\" was a mistranslated audit (reads as self-thanking)\n  and \"시험도 스스로 만듭니다\" invited a self-testing suspicion; the plates\n  now lead with the external judge: \"모든 변이는 심판대에 / EVERY MUTATION\n  ON TRIAL\" (\"it does not grade its own hand\") and \"시험은 점점 어려워집니다\n  / THE EXAM EVOLVES TOO\", whose caption states the pipeline's purpose\n  (draft scenarios in bulk, keep only the high-quality ones, raise the\n  measurement headroom) and that scoring belongs to the version-frozen\n  held-out bench."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.299",
+  version: "0.99.300",
   syncedAt: "2026-07-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.299"
+version = "0.99.300"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
포트폴리오 기본 로케일을 English로 되돌리고, 국문은 사용자가 `?lang=ko`로 명시 접근했을 때만 서빙한다(운영자 지시). 브라우저 로케일 스니핑은 하지 않는다.

## Why
글로벌 방문자 기준 첫 화면은 EN이 맞고, 국문 공유가 필요할 때는 `?lang=ko` 링크로 정확히 지정하는 편이 예측 가능하다.

## Changes
- `site/src/components/geode/locale-context.tsx`: `?lang=` 파라미터를 ko/en 양방향 인정, URL에는 표면 기본값과 다를 때만 파라미터 유지(기본 URL은 깨끗). docs(ko 기본 + `?lang=en`)는 동작 불변
- `site/src/app/portfolio/page.tsx`: `defaultLocale="en"` 복귀 (1줄)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.300, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 2파일 / **하위 호환**: KO/EN 토글 유지, docs URL 규약 불변 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓
- puppeteer 실증: 기본 접근=EN(html lang=en, URL 깨끗), `?lang=ko`=국문 히어로(html lang=ko, 파라미터 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)