### PR TITLE
docs(site): seed-pipeline 런 흐름 다이어그램 (release 0.99.301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ functional change.
 
 ---
 
+## [0.99.301] - 2026-07-11
+
+### Added
+
+- **Seed-pipeline run diagram in the docs (operator-directed).** The
+  `capabilities/seed-pipeline` page gains a hand-drawn SVG in the docs
+  signature language (`site/public/diagrams/seed-pipeline-run.svg`): the
+  entry ladder (picker, cost preview and confirm, pre-flight), the nine-role
+  pipeline frame with per-phase checkpoints, blend survivor selection
+  splitting into the cycle-input pool and the published bundle, the
+  version-frozen held-out bench below a dashed line, and the meta-review
+  priors looping back to the next run's picker. Mounted in both locales
+  with alt text and captions.
+
+---
+
 ## [0.99.300] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.300
+- **Version**: 0.99.301
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.300 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.301 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.300: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.301: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.300"
+version = "0.99.301"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/diagrams/seed-pipeline-run.svg
+++ b/site/public/diagrams/seed-pipeline-run.svg
@@ -1,0 +1,122 @@
+<svg width="100%" viewBox="0 0 760 620" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="spr-title spr-desc">
+  <title id="spr-title">Seed pipeline run flow</title>
+  <desc id="spr-desc">How one geode audit-seeds run progresses: picker, cost preview and confirm, pre-flight, the nine-role pipeline with per-phase checkpoints, blend survivor selection, bundle sync, seed pools, and the priors loop back into the picker.</desc>
+  <defs>
+    <marker id="spr-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0L10 4L0 8Z" fill="#ABA4BC"/>
+    </marker>
+    <marker id="spr-arrow-accent" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0L10 4L0 8Z" fill="#F49BC4"/>
+    </marker>
+    <style>
+      .label { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #F2EEF5; font-size: 14px; font-weight: 600; }
+      .sub { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #ABA4BC; font-size: 10px; }
+      .tag { font-family: Fira Code, ui-monospace, SFMono-Regular, Menlo, monospace; fill: #F49BC4; font-size: 8px; letter-spacing: .12em; }
+      .node { fill: #14121B; stroke: rgba(244,155,196,.45); stroke-width: 1; }
+      .node-soft { fill: rgba(244,155,196,.06); stroke: rgba(244,155,196,.35); stroke-width: 1; }
+      .store { fill: rgba(171,164,188,.07); stroke: rgba(171,164,188,.45); stroke-width: 1; }
+      .edge { stroke: #ABA4BC; stroke-width: 1.5; marker-end: url(#spr-arrow); }
+      .edge-accent { stroke: #F49BC4; stroke-width: 1.8; marker-end: url(#spr-arrow-accent); }
+      .dash { stroke-dasharray: 5 5; }
+    </style>
+  </defs>
+
+  <rect width="760" height="620" fill="transparent"/>
+
+  <!-- entry -->
+  <rect x="30" y="24" width="230" height="54" rx="6" class="node-soft"/>
+  <text x="145" y="47" text-anchor="middle" class="label">geode audit-seeds</text>
+  <text x="145" y="65" text-anchor="middle" class="sub">generate · resume</text>
+
+  <!-- picker -->
+  <rect x="30" y="120" width="230" height="58" rx="6" class="node"/>
+  <text x="145" y="143" text-anchor="middle" class="label">picker</text>
+  <text x="145" y="162" text-anchor="middle" class="sub">target dimension + prior gaps</text>
+
+  <!-- cost preview / confirm -->
+  <rect x="30" y="220" width="230" height="58" rx="6" class="node"/>
+  <text x="145" y="243" text-anchor="middle" class="label">cost preview → confirm</text>
+  <text x="145" y="262" text-anchor="middle" class="sub">cost_preview.py · dry-run first</text>
+
+  <!-- pre-flight -->
+  <rect x="30" y="320" width="230" height="58" rx="6" class="node"/>
+  <text x="145" y="343" text-anchor="middle" class="label">pre-flight</text>
+  <text x="145" y="362" text-anchor="middle" class="sub">credentials · quota · deps</text>
+
+  <!-- entry chain -->
+  <line x1="145" y1="78" x2="145" y2="118" class="edge"/>
+  <line x1="145" y1="178" x2="145" y2="218" class="edge"/>
+  <line x1="145" y1="278" x2="145" y2="318" class="edge"/>
+  <line x1="260" y1="349" x2="322" y2="349" class="edge"/>
+
+  <!-- nine-role pipeline frame -->
+  <rect x="326" y="108" width="404" height="330" rx="8" class="node-soft"/>
+  <text x="342" y="130" class="tag">NINE-ROLE PIPELINE · ORCHESTRATOR.PY</text>
+
+  <rect x="346" y="146" width="170" height="44" rx="6" class="node"/>
+  <text x="431" y="164" text-anchor="middle" class="label">supervisor</text>
+  <text x="431" y="180" text-anchor="middle" class="sub">phase guidance</text>
+
+  <rect x="540" y="146" width="170" height="44" rx="6" class="node"/>
+  <text x="625" y="164" text-anchor="middle" class="label">literature</text>
+  <text x="625" y="180" text-anchor="middle" class="sub">review priors</text>
+
+  <rect x="346" y="212" width="170" height="44" rx="6" class="node"/>
+  <text x="431" y="230" text-anchor="middle" class="label">generator</text>
+  <text x="431" y="246" text-anchor="middle" class="sub">draft in bulk</text>
+
+  <rect x="540" y="212" width="170" height="44" rx="6" class="node"/>
+  <text x="625" y="230" text-anchor="middle" class="label">proximity · critic</text>
+  <text x="625" y="246" text-anchor="middle" class="sub">dedupe · cull</text>
+
+  <rect x="346" y="278" width="170" height="44" rx="6" class="node"/>
+  <text x="431" y="296" text-anchor="middle" class="label">pilot</text>
+  <text x="431" y="312" text-anchor="middle" class="sub">measured difficulty</text>
+
+  <rect x="540" y="278" width="170" height="44" rx="6" class="node"/>
+  <text x="625" y="296" text-anchor="middle" class="label">ranker · evolver</text>
+  <text x="625" y="312" text-anchor="middle" class="sub">Elo · mutate survivors</text>
+
+  <rect x="346" y="344" width="364" height="44" rx="6" class="node"/>
+  <text x="528" y="362" text-anchor="middle" class="label">meta-review</text>
+  <text x="528" y="378" text-anchor="middle" class="sub">next-generation priors</text>
+
+  <!-- pipeline internal edges -->
+  <line x1="516" y1="168" x2="538" y2="168" class="edge"/>
+  <line x1="431" y1="190" x2="431" y2="210" class="edge"/>
+  <line x1="516" y1="234" x2="538" y2="234" class="edge"/>
+  <line x1="431" y1="256" x2="431" y2="276" class="edge"/>
+  <line x1="516" y1="300" x2="538" y2="300" class="edge"/>
+  <line x1="625" y1="322" x2="625" y2="342" class="edge"/>
+
+  <!-- checkpoints note -->
+  <text x="342" y="424" class="sub">checkpointer.py: per-phase checkpoints, resume continues here</text>
+
+  <!-- tournament -->
+  <rect x="326" y="470" width="230" height="58" rx="6" class="node"/>
+  <text x="441" y="493" text-anchor="middle" class="label">survivor blend</text>
+  <text x="441" y="512" text-anchor="middle" class="sub">z(elo) + confidence·z(difficulty)</text>
+  <line x1="528" y1="438" x2="528" y2="452" class="edge"/>
+  <line x1="528" y1="452" x2="441" y2="452" class="edge" marker-end="none"/>
+  <line x1="441" y1="452" x2="441" y2="468" class="edge"/>
+
+  <!-- bundle + pools -->
+  <rect x="586" y="470" width="144" height="58" rx="6" class="store"/>
+  <text x="658" y="493" text-anchor="middle" class="label">bundle_sync</text>
+  <text x="658" y="512" text-anchor="middle" class="sub">published run page</text>
+  <line x1="556" y1="499" x2="584" y2="499" class="edge"/>
+
+  <rect x="30" y="470" width="230" height="58" rx="6" class="store"/>
+  <text x="145" y="493" text-anchor="middle" class="label">cycle-input pool</text>
+  <text x="145" y="512" text-anchor="middle" class="sub">geode seeds assemble</text>
+  <line x1="326" y1="499" x2="262" y2="499" class="edge-accent"/>
+
+  <rect x="30" y="552" width="230" height="44" rx="6" class="store"/>
+  <text x="145" y="570" text-anchor="middle" class="label">held-out bench</text>
+  <text x="145" y="586" text-anchor="middle" class="sub">version-frozen · never mixed</text>
+  <line x1="145" y1="528" x2="145" y2="550" class="edge dash" marker-end="none"/>
+
+  <!-- priors loop back to picker -->
+  <path d="M730 372 L744 372 L744 92 L145 92 L145 118" class="edge-accent" fill="none"/>
+  <text x="640" y="86" class="tag">PRIORS → NEXT RUN</text>
+</svg>

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.300. Last sync 2026-07-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.301. Last sync 2026-07-11. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -1365,6 +1365,10 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/capabilities/seed-pipelin
 | `bundle_sync.py` | 완료 런을 `docs/self-improving/petri-bundle/seeds/<run_id>/`로 동기화 |
 
 `geode audit-seeds generate`는 picker → cost preview → pre-flight → confirm → pipeline 순서로 진행하고, `geode audit-seeds resume`이 체크포인트에서 이어 갑니다.
+
+![Seed pipeline 런 흐름. geode audit-seeds가 picker, cost preview와 confirm, pre-flight를 지나 9-역할 파이프라인으로 들어가고, blend 생존자 선택을 거쳐 cycle-input 풀과 번들로 나뉘며, meta-review priors가 다음 런의 picker로 되돌아간다](https://mangowhoiscloud.github.io/geode/diagrams/seed-pipeline-run.svg)
+
+한 런의 진행. 좌측 사다리(picker, cost preview, pre-flight)를 지나 9-역할 파이프라인이 돌고, 생존자는 blend 선택을 거쳐 cycle-input 풀과 공개 번들로 갈라집니다. held-out 벤치는 점선 아래에서 변이되지 않고, meta-review의 prior만 다음 런의 picker로 돌아갑니다.
 
 ## 생존자 선택: blend가 기본
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.300. Last sync 2026-07-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.301. Last sync 2026-07-11. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/docs/capabilities/seed-pipeline/page.tsx
+++ b/site/src/app/docs/capabilities/seed-pipeline/page.tsx
@@ -43,6 +43,19 @@ export default function Page() {
               <code>geode audit-seeds resume</code>이 체크포인트에서 이어
               갑니다.
             </p>
+            <figure>
+              <img
+                src="/geode/diagrams/seed-pipeline-run.svg"
+                alt="Seed pipeline 런 흐름. geode audit-seeds가 picker, cost preview와 confirm, pre-flight를 지나 9-역할 파이프라인으로 들어가고, blend 생존자 선택을 거쳐 cycle-input 풀과 번들로 나뉘며, meta-review priors가 다음 런의 picker로 되돌아간다"
+              />
+              <figcaption>
+                한 런의 진행. 좌측 사다리(picker, cost preview, pre-flight)를
+                지나 9-역할 파이프라인이 돌고, 생존자는 blend 선택을 거쳐
+                cycle-input 풀과 공개 번들로 갈라집니다. held-out 벤치는 점선
+                아래에서 변이되지 않고, meta-review의 prior만 다음 런의
+                picker로 돌아갑니다.
+              </figcaption>
+            </figure>
 
             <h2>생존자 선택: blend가 기본</h2>
             <p>
@@ -131,6 +144,20 @@ confidence = pilot stderr 기반 가중치      # 노이즈가 크면 자동 감
               preview, pre-flight, confirm, then the pipeline;{" "}
               <code>geode audit-seeds resume</code> continues from checkpoints.
             </p>
+            <figure>
+              <img
+                src="/geode/diagrams/seed-pipeline-run.svg"
+                alt="Seed pipeline run flow: geode audit-seeds passes picker, cost preview and confirm, pre-flight, enters the nine-role pipeline, then blend survivor selection splits into the cycle-input pool and the published bundle, with meta-review priors looping back to the picker"
+              />
+              <figcaption>
+                One run, end to end. The left ladder (picker, cost preview,
+                pre-flight) leads into the nine-role pipeline; survivors pass
+                the blend selection and split into the cycle-input pool and
+                the published bundle. The held-out bench stays below the
+                dashed line, never mutated; only meta-review priors loop back
+                to the next run&apos;s picker.
+              </figcaption>
+            </figure>
 
             <h2>Survivor selection: blend by default</h2>
             <p>

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-10
+ * Last sync: 2026-07-11
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.301",
+    "date": "2026-07-11",
+    "body": "### Added\n\n- **Seed-pipeline run diagram in the docs (operator-directed).** The\n  `capabilities/seed-pipeline` page gains a hand-drawn SVG in the docs\n  signature language (`site/public/diagrams/seed-pipeline-run.svg`): the\n  entry ladder (picker, cost preview and confirm, pre-flight), the nine-role\n  pipeline frame with per-phase checkpoints, blend survivor selection\n  splitting into the cycle-input pool and the published bundle, the\n  version-frozen held-out bench below a dashed line, and the meta-review\n  priors looping back to the next run's picker. Mounted in both locales\n  with alt text and captions."
+  },
   {
     "version": "0.99.300",
     "date": "2026-07-11",
@@ -2223,4 +2228,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-10";
+export const CHANGELOG_SYNCED_AT = "2026-07-11";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-10
+ * Last sync: 2026-07-11
  */
 
 export const GEODE_SOT = {
-  version: "0.99.300",
-  syncedAt: "2026-07-10",
+  version: "0.99.301",
+  syncedAt: "2026-07-11",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.300"
+version = "0.99.301"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
운영자 지시: 시드 시나리오 문서에 다른 페이지들처럼 루프 진행 다이어그램을 싣는다. `capabilities/seed-pipeline` 페이지 상단(양 로케일)에 시그니처 손수 SVG를 추가했다.

## Why
Seed Scenario Generation(co-scientist) 페이지에는 사이클 SVG가 있지만, 런 절차를 다루는 seed-pipeline 페이지는 표·코드 블록뿐이라 한 런이 어떻게 진행되는지 시각 근거가 없었다.

## Changes
- `site/public/diagrams/seed-pipeline-run.svg` (신규, 손수 SVG — 기존 seed-scenario-generation-cycle.svg와 동일 시각 언어): 진입 사다리(picker → cost preview·confirm → pre-flight) → 9-역할 파이프라인 프레임(supervisor/literature/generator/proximity·critic/pilot/ranker·evolver/meta-review + per-phase checkpoint 주석) → survivor blend(z(elo)+confidence·z(difficulty)) → cycle-input 풀·published 번들 분기, 점선 아래 version-frozen held-out, meta-review priors의 picker 루프백(액센트 엣지)
- `site/src/app/docs/capabilities/seed-pipeline/page.tsx`: 양 로케일 figure 마운트(alt + figcaption)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.301, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ docs 1페이지 + SVG 1점(시그니처 손수 SVG 5점째, DESIGN 예산 3~5 내) / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 캡처로 다크 기판 위 렌더 확인
- 도식 근거: 페이지 본문 모듈 표(picker/orchestrator/cost_preview/pre_flight/tournament/checkpointer/bundle_sync)와 pool 단락(cycle-input=`geode seeds assemble` 기본 out, held-out=버전 고정)에 1:1 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)