### PR TITLE
feat(site): 피날레 실험 기록 링크 — 허브·petri 아카이브 (release 0.99.302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ functional change.
 
 ---
 
+## [0.99.302] - 2026-07-12
+
+### Added
+
+- **Portfolio finale links the experiment records (operator-directed).**
+  Under the finale CTAs a mono row labeled "experiment records · zero
+  promotions included" links to the self-improving hub and the Petri audit
+  archive, and the bottom-right "petri audit attached" stamp becomes a live
+  link into the bundle viewer. The framing stays honest: these are published
+  as experiments, zero-promotion campaigns included.
+
+---
+
 ## [0.99.301] - 2026-07-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.301
+- **Version**: 0.99.302
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.301 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.302 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.301: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.302: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.301"
+version = "0.99.302"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.301. Last sync 2026-07-11. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.302. Last sync 2026-07-11. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5128,7 +5128,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1403 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1404 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.301. Last sync 2026-07-11. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.302. Last sync 2026-07-11. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -957,14 +957,39 @@ function DistillationAct() {
                   {t(locale, "전체 기록 보기", "View the full record")}
                 </a>
               </div>
+              <div className="mt-6 flex flex-col items-center gap-2.5">
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em]" style={{ color: PAPER_75 }}>
+                  {t(locale, "실험 기록 · 승격 0회까지 그대로", "experiment records · zero promotions included")}
+                </p>
+                <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 font-mono text-[12px]">
+                  <a
+                    href="/geode/self-improving/"
+                    className="text-[#FFF0F8] underline decoration-[color-mix(in_srgb,#FFF0F8_45%,transparent)] underline-offset-4 transition-opacity hover:opacity-75"
+                  >
+                    {t(locale, "self-improving 허브", "self-improving hub")}
+                  </a>
+                  <a
+                    href="/geode/self-improving/petri-bundle/"
+                    className="text-[#FFF0F8] underline decoration-[color-mix(in_srgb,#FFF0F8_45%,transparent)] underline-offset-4 transition-opacity hover:opacity-75"
+                  >
+                    {t(locale, "petri 감사 아카이브", "petri audit archive")}
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
           <div
-            className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-between px-5 pb-3.5 font-mono text-[10px] uppercase tracking-[0.18em]"
+            className="absolute inset-x-0 bottom-0 z-10 flex items-end justify-between px-5 pb-3.5 font-mono text-[10px] uppercase tracking-[0.18em]"
             style={{ color: ROSE_INK }}
           >
-            <span>specimen · geodi</span>
-            <span>petri audit attached</span>
+            <span className="pointer-events-none">specimen · geodi</span>
+            <a
+              href="/geode/self-improving/petri-bundle/"
+              className="underline decoration-[color-mix(in_srgb,#C2447F_45%,transparent)] underline-offset-4 transition-opacity hover:opacity-75"
+              style={{ color: ROSE_INK }}
+            >
+              petri audit attached
+            </a>
           </div>
         </motion.div>
       </div>

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.302",
+    "date": "2026-07-12",
+    "body": "### Added\n\n- **Portfolio finale links the experiment records (operator-directed).**\n  Under the finale CTAs a mono row labeled \"experiment records · zero\n  promotions included\" links to the self-improving hub and the Petri audit\n  archive, and the bottom-right \"petri audit attached\" stamp becomes a live\n  link into the bundle viewer. The framing stays honest: these are published\n  as experiments, zero-promotion campaigns included."
+  },
+  {
     "version": "0.99.301",
     "date": "2026-07-11",
     "body": "### Added\n\n- **Seed-pipeline run diagram in the docs (operator-directed).** The\n  `capabilities/seed-pipeline` page gains a hand-drawn SVG in the docs\n  signature language (`site/public/diagrams/seed-pipeline-run.svg`): the\n  entry ladder (picker, cost preview and confirm, pre-flight), the nine-role\n  pipeline frame with per-phase checkpoints, blend survivor selection\n  splitting into the cycle-input pool and the published bundle, the\n  version-frozen held-out bench below a dashed line, and the meta-review\n  priors looping back to the next run's picker. Mounted in both locales\n  with alt text and captions."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.301",
+  version: "0.99.302",
   syncedAt: "2026-07-11",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.301"
+version = "0.99.302"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
포트폴리오 피날레(표본 슬라이드)에 실험 기록으로 가는 문을 단다(운영자 지시). CTA 아래 "experiment records · zero promotions included" 모노 행에서 self-improving 허브와 Petri 감사 아카이브로 연결되고, 하단 "petri audit attached" 스탬프도 번들 뷰어로 가는 라이브 링크가 된다.

## Why
포트폴리오의 차별 서사가 정직한 실패 기록인데, 렛저 행(REJECT·PENDING)에서 검증 가능한 실물(26건 감사 아카이브, 세대별 seed-gen 대시보드, autoresearch 렛저)로 이어지는 경로가 없었다. "실험삼아 진행한 기록" 프레이밍은 승격 0회 캐논과 일치한다.

## Changes
- `site/src/app/portfolio/page.tsx`: 피날레 CTA 아래 실험 기록 행(KO/EN, 허브 `/geode/self-improving/` + 아카이브 `/geode/self-improving/petri-bundle/`), 하단 스탬프 링크화(pointer-events 구조 조정)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.302, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1컴포넌트 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 캡처로 피날레 링크 행 렌더 확인
- 링크 타깃은 기존 배포 표면(허브/번들)이라 신규 라우트 없음, lychee가 빌드에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)