### PR TITLE
fix(site): tau2 카드 환경 스펙·비교군 기록 (release 0.99.303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ functional change.
 
 ---
 
+## [0.99.303] - 2026-07-12
+
+### Fixed
+
+- **Tau2 bench card carries the real environment spec and comparison group
+  (operator-directed).** The measure plate's route line previously read
+  "gpt-5.5 · openai-codex subscription", which described the MCPMark runs,
+  not the tau2 base runs; the card now transcribes the measurement records
+  (`benchmark-measurements.ts`, crucible.md §2): measured 2026-07-03,
+  tau2@1901a30, GEODE v0.99.269, agent gpt-5.2 high (PAYG), native user-sim
+  gpt-4.1, pass^1 k=1, airline flagged trend-reference. A separated rule
+  line names the comparison group: Agent-World's vanilla gpt-5.2 (0.802),
+  same band within the ±8pt pass^1 detection limit; the plate caption
+  repeats the band claim in both locales.
+
+---
+
 ## [0.99.302] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.302
+- **Version**: 0.99.303
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.302 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.303 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.302: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.303: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.302"
+version = "0.99.303"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.302. Last sync 2026-07-11. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.303. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5128,7 +5128,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1404 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1405 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.302. Last sync 2026-07-11. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.303. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -442,8 +442,15 @@ function PerceiveBanner() {
 function MeasureBanner() {
   const tau2 = BENCHMARK_GROUPS.find((group) => group.id === "tau2");
   const cells = (tau2?.matrix ?? []).filter((cell) => ["Retail", "Telecom", "Airline"].includes(cell.label));
+  // Environment spec + comparison band, transcribed from the measurement
+  // records (benchmark-measurements.ts) and docs/architecture/crucible.md §2.
+  const spec = [
+    "measured 2026-07-03 · tau2@1901a30 · geode v0.99.269",
+    "agent gpt-5.2 high (payg) · user-sim gpt-4.1 · pass^1 k=1",
+    "airline: trend-reference (ground-truth quality)",
+  ];
   return (
-    <div className="flex h-full w-full flex-col justify-center gap-4 px-6">
+    <div className="flex h-full w-full flex-col justify-center gap-3.5 px-6">
       <div className="flex items-baseline justify-center gap-6">
         {cells.map((cell) => (
           <div key={cell.label} className="text-center">
@@ -452,13 +459,19 @@ function MeasureBanner() {
           </div>
         ))}
       </div>
-      <p className="text-center font-mono text-[10px] uppercase tracking-[0.14em]" style={{ color: ROSE_INK_70 }}>
-        tau2-bench base · gpt-5.5 · openai-codex subscription
+      <div className="space-y-1" style={{ color: ROSE_INK_70 }}>
+        {spec.map((line) => (
+          <p key={line} className="text-center font-mono text-[9.5px] leading-[1.5]">
+            {line}
+          </p>
+        ))}
+      </div>
+      <p className="border-t pt-2 text-center font-mono text-[9.5px]" style={{ color: ROSE_INK, borderColor: "color-mix(in srgb, #C2447F 30%, transparent)" }}>
+        vs agent-world gpt-5.2 vanilla 0.802: same band, ±8pt detection limit
       </p>
     </div>
   );
 }
-
 
 function ConnectBanner() {
   return (
@@ -648,8 +661,8 @@ const features: {
     index: "#9 measure",
     headKo: "정직하게 잽니다",
     headEn: "KEEPS HONEST SCORE",
-    ko: "개선에 실패한 캠페인도 기록에 남습니다. 0 승격의 원인 규명까지가 실측 자산입니다.",
-    en: "The campaigns that failed to improve it stay on the record, including why zero got promoted.",
+    ko: "개선에 실패한 캠페인도 기록에 남습니다. 비교군은 Agent-World의 gpt-5.2 바닐라. pass^1 검출 한계 안에서 같은 밴드입니다.",
+    en: "The campaigns that failed to improve it stay on the record. The comparison group is Agent-World's vanilla gpt-5.2; within the pass^1 detection limit the bands match.",
     banner: <MeasureBanner />,
   },
 ];

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-11
+ * Last sync: 2026-07-12
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.303",
+    "date": "2026-07-12",
+    "body": "### Fixed\n\n- **Tau2 bench card carries the real environment spec and comparison group\n  (operator-directed).** The measure plate's route line previously read\n  \"gpt-5.5 · openai-codex subscription\", which described the MCPMark runs,\n  not the tau2 base runs; the card now transcribes the measurement records\n  (`benchmark-measurements.ts`, crucible.md §2): measured 2026-07-03,\n  tau2@1901a30, GEODE v0.99.269, agent gpt-5.2 high (PAYG), native user-sim\n  gpt-4.1, pass^1 k=1, airline flagged trend-reference. A separated rule\n  line names the comparison group: Agent-World's vanilla gpt-5.2 (0.802),\n  same band within the ±8pt pass^1 detection limit; the plate caption\n  repeats the band claim in both locales."
+  },
   {
     "version": "0.99.302",
     "date": "2026-07-12",
@@ -2233,4 +2238,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-11";
+export const CHANGELOG_SYNCED_AT = "2026-07-12";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-11
+ * Last sync: 2026-07-12
  */
 
 export const GEODE_SOT = {
-  version: "0.99.302",
-  syncedAt: "2026-07-11",
+  version: "0.99.303",
+  syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.302"
+version = "0.99.303"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
포트폴리오 tau2 벤치 카드(#9 KEEPS HONEST SCORE)에 실측 환경 스펙과 비교군을 기록한다(운영자 지시). 기존 카드의 "gpt-5.5 · openai-codex subscription" 표기는 MCPMark 런 기술이지 tau2 base 런이 아니었다 — 오기 교정.

## Why
단발 수치는 환경 명시 없이는 노이즈와 구분되지 않는다(crucible.md §2). 측정 기록 SoT(benchmark-measurements.ts: tau2-retail-base-20260703-geode-099269-gpt52-high-payg 등)와 카드 표기를 1:1로 맞춘다.

## Changes
- `site/src/app/portfolio/page.tsx` MeasureBanner:
  - 스펙 3줄: measured 2026-07-03 · tau2@1901a30 · geode v0.99.269 / agent gpt-5.2 high (payg) · user-sim gpt-4.1 · pass^1 k=1 / airline: trend-reference (ground-truth quality)
  - 구분선 아래 비교군: vs agent-world gpt-5.2 vanilla 0.802: same band, ±8pt detection limit
  - 캡션(KO/EN): 비교군=Agent-World 바닐라 gpt-5.2, 검출 한계 내 동일 밴드 명시
  - Astryx base p 규칙이 부모 font-mono 상속을 이기는 캐스케이드 이슈 → 유틸리티를 p에 직접 부여
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.303, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1배너 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 캡처로 카드 렌더(모노 스펙 3줄+비교 룰) 확인
- 수치·스펙 전부 measurement 레코드와 crucible.md §2 실측 표에 grep-대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)