### PR TITLE
fix(site): tau2 측정 전표 디자인 (release 0.99.304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ functional change.
 
 ---
 
+## [0.99.304] - 2026-07-12
+
+### Changed
+
+- **Tau2 spec block reset as a measurement slip (operator-directed design
+  pass).** The centered text lines become the same key-value table object
+  as the memory core sample: hairline-separated mono rows (measured,
+  harness, agent, user-sim, airline, control) closing on a solid deep-rose
+  VERDICT row ("same band · ±8pt limit"), so the comparison verdict reads
+  like the winning band of a lab record instead of a floating caption.
+
+---
+
 ## [0.99.303] - 2026-07-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.303
+- **Version**: 0.99.304
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.303 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.304 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.303: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.304: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.303"
+version = "0.99.304"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.303. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.304. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.303. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.304. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -439,36 +439,54 @@ function PerceiveBanner() {
   );
 }
 
+/**
+ * Tau2 numbers over a measurement slip: the same key-value table object as
+ * the memory core sample, ending in control/verdict rows so the comparison
+ * band lives inside the record instead of a floating caption. Values from
+ * benchmark-measurements.ts and docs/architecture/crucible.md §2.
+ */
 function MeasureBanner() {
   const tau2 = BENCHMARK_GROUPS.find((group) => group.id === "tau2");
   const cells = (tau2?.matrix ?? []).filter((cell) => ["Retail", "Telecom", "Airline"].includes(cell.label));
-  // Environment spec + comparison band, transcribed from the measurement
-  // records (benchmark-measurements.ts) and docs/architecture/crucible.md §2.
-  const spec = [
-    "measured 2026-07-03 · tau2@1901a30 · geode v0.99.269",
-    "agent gpt-5.2 high (payg) · user-sim gpt-4.1 · pass^1 k=1",
-    "airline: trend-reference (ground-truth quality)",
+  const slip: { key: string; value: string; verdict?: boolean }[] = [
+    { key: "measured", value: "2026-07-03 · geode v0.99.269" },
+    { key: "harness", value: "tau2 @ 1901a30" },
+    { key: "agent", value: "gpt-5.2 high · payg" },
+    { key: "user-sim", value: "gpt-4.1 · pass^1 k=1" },
+    { key: "airline", value: "trend-reference" },
+    { key: "control", value: "agent-world vanilla 0.802" },
+    { key: "verdict", value: "same band · ±8pt limit", verdict: true },
   ];
   return (
-    <div className="flex h-full w-full flex-col justify-center gap-3.5 px-6">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6">
       <div className="flex items-baseline justify-center gap-6">
         {cells.map((cell) => (
           <div key={cell.label} className="text-center">
-            <p className="font-serif-display text-[26px] font-black" style={{ color: ROSE_INK }}>{cell.value}</p>
-            <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em]" style={{ color: ROSE_INK_70 }}>{cell.label}</p>
+            <p className="font-serif-display text-[24px] font-black" style={{ color: ROSE_INK }}>{cell.value}</p>
+            <p className="mt-1 font-mono text-[9.5px] uppercase tracking-[0.2em]" style={{ color: ROSE_INK_70 }}>{cell.label}</p>
           </div>
         ))}
       </div>
-      <div className="space-y-1" style={{ color: ROSE_INK_70 }}>
-        {spec.map((line) => (
-          <p key={line} className="text-center font-mono text-[9.5px] leading-[1.5]">
-            {line}
-          </p>
+      <div className="w-full max-w-[300px] overflow-hidden border" style={{ borderColor: ROSE_INK_70 }}>
+        {slip.map(({ key, value, verdict }, i) => (
+          <div
+            key={key}
+            className={`flex items-baseline justify-between gap-3 px-3 py-[5px] font-mono text-[9.5px] ${verdict ? "bg-[#C2447F] text-[#FFF0F8]" : ""}`}
+            style={
+              verdict
+                ? undefined
+                : { borderTop: i ? "1px solid color-mix(in srgb, #C2447F 25%, transparent)" : undefined }
+            }
+          >
+            <span className="uppercase tracking-[0.14em]" style={verdict ? { opacity: 0.85 } : { color: ROSE_INK_70 }}>
+              {key}
+            </span>
+            <span className={verdict ? "font-semibold" : ""} style={verdict ? undefined : { color: ROSE_INK }}>
+              {value}
+            </span>
+          </div>
         ))}
       </div>
-      <p className="border-t pt-2 text-center font-mono text-[9.5px]" style={{ color: ROSE_INK, borderColor: "color-mix(in srgb, #C2447F 30%, transparent)" }}>
-        vs agent-world gpt-5.2 vanilla 0.802: same band, ±8pt detection limit
-      </p>
     </div>
   );
 }

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.304",
+    "date": "2026-07-12",
+    "body": "### Changed\n\n- **Tau2 spec block reset as a measurement slip (operator-directed design\n  pass).** The centered text lines become the same key-value table object\n  as the memory core sample: hairline-separated mono rows (measured,\n  harness, agent, user-sim, airline, control) closing on a solid deep-rose\n  VERDICT row (\"same band · ±8pt limit\"), so the comparison verdict reads\n  like the winning band of a lab record instead of a floating caption."
+  },
+  {
     "version": "0.99.303",
     "date": "2026-07-12",
     "body": "### Fixed\n\n- **Tau2 bench card carries the real environment spec and comparison group\n  (operator-directed).** The measure plate's route line previously read\n  \"gpt-5.5 · openai-codex subscription\", which described the MCPMark runs,\n  not the tau2 base runs; the card now transcribes the measurement records\n  (`benchmark-measurements.ts`, crucible.md §2): measured 2026-07-03,\n  tau2@1901a30, GEODE v0.99.269, agent gpt-5.2 high (PAYG), native user-sim\n  gpt-4.1, pass^1 k=1, airline flagged trend-reference. A separated rule\n  line names the comparison group: Agent-World's vanilla gpt-5.2 (0.802),\n  same band within the ±8pt pass^1 detection limit; the plate caption\n  repeats the band claim in both locales."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.303",
+  version: "0.99.304",
   syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.303"
+version = "0.99.304"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
tau2 카드의 환경 스펙을 가운데 정렬 텍스트 3줄+룰 라인에서, 페이지의 기존 오브제 언어(메모리 코어 샘플 표)와 같은 **측정 전표**로 재설계한다(운영자 지시). measured/harness/agent/user-sim/airline/control 키·값 행이 헤어라인으로 구분되고, 마지막 VERDICT 행은 솔리드 딥로즈+흰 글자(코어 샘플의 session 승자 밴드와 동일 문법)로 "same band · ±8pt limit"를 닫는다.

## Why
텍스트 덤프는 결이 어긋난다. 측정 기록이라는 내용물엔 실험실 전표 형태가 맞고, 비교 판정은 전표 안의 최종 행이어야 떠다니는 캡션이 되지 않는다.

## Changes
- `site/src/app/portfolio/page.tsx` MeasureBanner: 전표 테이블 재작성(수치는 유지, 내용 동일 — 형태만 변경)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.304, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1배너 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 캡처로 전표 렌더 확인(행 구분·VERDICT 밴드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)