### PR TITLE
fix(release): 패키지 게이트 scripts/macos 허용 (release 0.99.305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ functional change.
 
 ---
 
+## [0.99.305] - 2026-07-12
+
+### Fixed
+
+- **Release package gate carves out `scripts/macos/`.** The gate banned the
+  whole `scripts/` prefix while `pyproject.toml` deliberately force-includes
+  the computer-use helper source (`build_computer_helper.sh`,
+  `geode_computer_helper.swift`), a runtime asset consumed by onboarding and
+  doctor; the 0.99.304 release dispatch failed on exactly this. The gate now
+  allows the `scripts/macos/` prefix and keeps banning the rest.
+
+---
+
 ## [0.99.304] - 2026-07-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.304
+- **Version**: 0.99.305
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.304 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.305 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.304: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.305: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.304"
+version = "0.99.305"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/check_package_artifacts.py
+++ b/scripts/check_package_artifacts.py
@@ -148,13 +148,19 @@ def _check_required(label: str, paths: set[str], required: set[str]) -> list[str
     return [f"{label}: missing required path {path}" for path in sorted(required - paths)]
 
 
+# ``scripts/macos/`` ships on purpose (computer-use helper source + build
+# script; consumed at runtime by core/cli/onboarding.py and doctor), so the
+# blanket ``scripts/`` ban carves it out.
+ALLOWED_PREFIXES = ("scripts/macos/",)
+
+
 def _check_banned(label: str, paths: set[str], prefixes: tuple[str, ...]) -> list[str]:
     problems: list[str] = []
     for path in sorted(paths):
         if _has_banned_common(path):
             problems.append(f"{label}: banned cache/generated path {path}")
             continue
-        if path.startswith(prefixes):
+        if path.startswith(prefixes) and not path.startswith(ALLOWED_PREFIXES):
             problems.append(f"{label}: banned path {path}")
     return problems
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.304. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.305. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.304. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.305. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.305",
+    "date": "2026-07-12",
+    "body": "### Fixed\n\n- **Release package gate carves out `scripts/macos/`.** The gate banned the\n  whole `scripts/` prefix while `pyproject.toml` deliberately force-includes\n  the computer-use helper source (`build_computer_helper.sh`,\n  `geode_computer_helper.swift`), a runtime asset consumed by onboarding and\n  doctor; the 0.99.304 release dispatch failed on exactly this. The gate now\n  allows the `scripts/macos/` prefix and keeps banning the rest."
+  },
+  {
     "version": "0.99.304",
     "date": "2026-07-12",
     "body": "### Changed\n\n- **Tau2 spec block reset as a measurement slip (operator-directed design\n  pass).** The centered text lines become the same key-value table object\n  as the memory core sample: hairline-separated mono rows (measured,\n  harness, agent, user-sim, airline, control) closing on a solid deep-rose\n  VERDICT row (\"same band · ±8pt limit\"), so the comparison verdict reads\n  like the winning band of a lab record instead of a floating caption."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.304",
+  version: "0.99.305",
   syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.304"
+version = "0.99.305"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
release.yml의 0.99.304 PyPI 출간 디스패치가 Package content gate에서 실패했다: 게이트는 `scripts/` 전체를 금지하는데 `pyproject.toml`은 computer-use 헬퍼(`scripts/macos/`)를 의도적으로 wheel/sdist에 포함한다. 게이트에 `scripts/macos/` 정밀 허용을 추가한다.

## Why
`scripts/macos`는 런타임 소비 자산이다(`core/cli/onboarding.py`가 빌드 스크립트를 실행, `doctor_bootstrap`·`computer_use`가 안내). 패키징 포함이 옳고(e96762532에서 도입) 게이트가 갱신되지 않은 드리프트.

## Changes
- `scripts/check_package_artifacts.py`: `ALLOWED_PREFIXES = ("scripts/macos/",)` 도입, prefix 금지 검사에서 제외(주석에 소비처 명기)
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.305, sync-stats/check_llms_version 재생성

## Impact Scope
- **영향 모듈**: scripts/ 게이트 1파일 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- 로컬 `uv build` + `uv run python scripts/check_package_artifacts.py` → wheel OK (578 files) · sdist OK (580 files)
- `ruff check` / `ruff format --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)