### PR TITLE
fix(site): tau2 전표 Agentic/평가 Harness 분리 (release 0.99.307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.307] - 2026-07-12
+
+### Changed
+
+- **Tau2 slip separates the agentic harness from the eval harness
+  (operator-directed).** The measurement slip gains labeled sections so the
+  claim reads unambiguously: what is measured is gpt-5.2 wrapped in the
+  GEODE loop (agentic harness: loop geode v0.99.269, model gpt-5.2 high ·
+  payg); the ruler is tau2-bench (eval harness: bench @ 1901a30, user-sim
+  gpt-4.1 · pass^1 k=1, airline trend-reference); the control is the same
+  model with no loop (Agent-World vanilla 0.802) before the verdict band.
+  The plate caption restates it in both locales.
+
+---
+
 ## [0.99.306] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.306
+- **Version**: 0.99.307
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.306 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.307 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.306: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.307: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.306"
+version = "0.99.307"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.306. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.307. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5128,7 +5128,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1406 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1407 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.306. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.307. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -504,25 +504,26 @@ function PerceiveBanner() {
 }
 
 /**
- * Tau2 numbers over a measurement slip: the same key-value table object as
- * the memory core sample, ending in control/verdict rows so the comparison
- * band lives inside the record instead of a floating caption. Values from
- * benchmark-measurements.ts and docs/architecture/crucible.md §2.
+ * Tau2 numbers over a measurement slip that separates what is being
+ * measured (the agentic harness: GEODE's loop wrapped around a vanilla
+ * model) from the ruler (the tau2-bench eval harness), closing on the
+ * control and verdict. Values from benchmark-measurements.ts and
+ * docs/architecture/crucible.md §2.
  */
 function MeasureBanner() {
   const tau2 = BENCHMARK_GROUPS.find((group) => group.id === "tau2");
   const cells = (tau2?.matrix ?? []).filter((cell) => ["Retail", "Telecom", "Airline"].includes(cell.label));
-  const slip: { key: string; value: string; verdict?: boolean }[] = [
-    { key: "measured", value: "2026-07-03 · geode v0.99.269" },
-    { key: "harness", value: "tau2 @ 1901a30" },
-    { key: "agent", value: "gpt-5.2 high · payg" },
+  const slip: { key: string; value: string; section?: string; verdict?: boolean }[] = [
+    { key: "loop", value: "geode v0.99.269", section: "agentic harness · measured" },
+    { key: "model", value: "gpt-5.2 high · payg" },
+    { key: "bench", value: "tau2 @ 1901a30 · 2026-07-03", section: "eval harness · the ruler" },
     { key: "user-sim", value: "gpt-4.1 · pass^1 k=1" },
     { key: "airline", value: "trend-reference" },
-    { key: "control", value: "agent-world vanilla 0.802" },
+    { key: "control", value: "gpt-5.2 vanilla · no loop · 0.802", section: "agent-world reference" },
     { key: "verdict", value: "same band · ±8pt limit", verdict: true },
   ];
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3.5 px-6">
       <div className="flex items-baseline justify-center gap-6">
         {cells.map((cell) => (
           <div key={cell.label} className="text-center">
@@ -531,23 +532,38 @@ function MeasureBanner() {
           </div>
         ))}
       </div>
-      <div className="w-full max-w-[300px] overflow-hidden border" style={{ borderColor: ROSE_INK_70 }}>
-        {slip.map(({ key, value, verdict }, i) => (
-          <div
-            key={key}
-            className={`flex items-baseline justify-between gap-3 px-3 py-[5px] font-mono text-[9.5px] ${verdict ? "bg-[#C2447F] text-[#FFF0F8]" : ""}`}
-            style={
-              verdict
-                ? undefined
-                : { borderTop: i ? "1px solid color-mix(in srgb, #C2447F 25%, transparent)" : undefined }
-            }
-          >
-            <span className="uppercase tracking-[0.14em]" style={verdict ? { opacity: 0.85 } : { color: ROSE_INK_70 }}>
-              {key}
-            </span>
-            <span className={verdict ? "font-semibold" : ""} style={verdict ? undefined : { color: ROSE_INK }}>
-              {value}
-            </span>
+      <div className="w-full max-w-[310px] overflow-hidden border" style={{ borderColor: ROSE_INK_70 }}>
+        {slip.map(({ key, value, section, verdict }, i) => (
+          <div key={key}>
+            {section && (
+              <p
+                className="px-3 pb-[2px] pt-[6px] text-left font-mono text-[8px] uppercase tracking-[0.22em]"
+                style={{
+                  color: ROSE_INK_70,
+                  background: "color-mix(in srgb, #C2447F 8%, transparent)",
+                  borderTop: i ? "1px solid color-mix(in srgb, #C2447F 25%, transparent)" : undefined,
+                }}
+              >
+                {section}
+              </p>
+            )}
+            <div
+              className={`flex items-baseline justify-between gap-3 px-3 py-[4px] font-mono text-[9.5px] ${verdict ? "bg-[#C2447F] text-[#FFF0F8]" : ""}`}
+              style={
+                verdict || section
+                  ? section && !verdict
+                    ? { background: "color-mix(in srgb, #C2447F 8%, transparent)" }
+                    : undefined
+                  : { borderTop: i ? "1px solid color-mix(in srgb, #C2447F 18%, transparent)" : undefined }
+              }
+            >
+              <span className="uppercase tracking-[0.14em]" style={verdict ? { opacity: 0.85 } : { color: ROSE_INK_70 }}>
+                {key}
+              </span>
+              <span className={verdict ? "font-semibold" : ""} style={verdict ? undefined : { color: ROSE_INK }}>
+                {value}
+              </span>
+            </div>
           </div>
         ))}
       </div>
@@ -743,8 +759,8 @@ const features: {
     index: "#9 measure",
     headKo: "정직하게 잽니다",
     headEn: "KEEPS HONEST SCORE",
-    ko: "개선에 실패한 캠페인도 기록에 남습니다. 비교군은 Agent-World의 gpt-5.2 바닐라. pass^1 검출 한계 안에서 같은 밴드입니다.",
-    en: "The campaigns that failed to improve it stay on the record. The comparison group is Agent-World's vanilla gpt-5.2; within the pass^1 detection limit the bands match.",
+    ko: "재는 것은 GEODE 루프를 씌운 gpt-5.2, 재는 자는 tau2-bench. 비교군은 루프 없는 같은 모델(Agent-World 바닐라)이고, pass^1 검출 한계 안에서 같은 밴드입니다.",
+    en: "Measured: gpt-5.2 wrapped in the GEODE loop. Ruler: tau2-bench. The control is the same model without the loop (Agent-World vanilla); within the pass^1 detection limit the bands match.",
     banner: <MeasureBanner />,
   },
 ];

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.307",
+    "date": "2026-07-12",
+    "body": "### Changed\n\n- **Tau2 slip separates the agentic harness from the eval harness\n  (operator-directed).** The measurement slip gains labeled sections so the\n  claim reads unambiguously: what is measured is gpt-5.2 wrapped in the\n  GEODE loop (agentic harness: loop geode v0.99.269, model gpt-5.2 high ·\n  payg); the ruler is tau2-bench (eval harness: bench @ 1901a30, user-sim\n  gpt-4.1 · pass^1 k=1, airline trend-reference); the control is the same\n  model with no loop (Agent-World vanilla 0.802) before the verdict band.\n  The plate caption restates it in both locales."
+  },
+  {
     "version": "0.99.306",
     "date": "2026-07-12",
     "body": "### Added\n\n- **GEODE ships on Homebrew, and the hero replays the install\n  (operator-directed).** New tap `mangowhoiscloud/homebrew-tap` carries a\n  `geode` formula (GitHub source tarball into an isolated python@3.12\n  virtualenv, `geode` + `geode-mcp` symlinked; `brew audit` clean, fetch and\n  sha256 verified; the same venv+pip path smoke-tested via an isolated uv\n  sandbox: `geode version` prints). The portfolio hero terminal replaces the\n  static welcome with the abridged real transcript — brew install, first\n  launch, welcome screen, first prompt — revealed line by line with\n  auto-scroll when lines stack; reduced motion renders the finished\n  transcript statically."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.306",
+  version: "0.99.307",
   syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.306"
+version = "0.99.307"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
tau2 측정 전표가 "GEODE 루프를 씌운 측정"임이 드러나지 않던 문제(운영자 지시)를 해소한다. 전표를 세 개의 라벨 섹션으로 분리: AGENTIC HARNESS · MEASURED(loop=geode v0.99.269, model=gpt-5.2 high · payg), EVAL HARNESS · THE RULER(bench=tau2@1901a30 · 2026-07-03, user-sim=gpt-4.1 · pass^1 k=1, airline=trend-reference), AGENT-WORLD REFERENCE(control=gpt-5.2 vanilla · no loop · 0.802), VERDICT 밴드. 캡션도 "재는 것=GEODE 루프를 씌운 gpt-5.2, 재는 자=tau2-bench, 비교군=루프 없는 같은 모델"로 재서술(KO/EN).

## Why
측정 주체(에이전틱 하네스)와 측정 도구(평가 하네스)가 한 덩어리로 읽히면 수치의 주장 구조가 사라진다. 같은 모델 바닐라 대비라는 비교 설계가 전표 구조 자체에 드러나야 한다.

## Changes
- `site/src/app/portfolio/page.tsx` MeasureBanner: 섹션 헤더 행(8px 모노 대문자, 8% 틴트 배경) 도입, 행 재구성, 캡션 재서술
- `CHANGELOG.md` + 5개소 버전 스탬프 0.99.307, sync-stats/check_llms_version/export-md 재생성

## Impact Scope
- **영향 모듈**: site/ 1배너 / **하위 호환**: 유지 / **테스트 변화**: 없음

## Verification
- `npx next build` ✓ (238/238) · `tsc --noEmit` ✓ · puppeteer 캡처로 섹션 구분 렌더 확인
- 값 전부 measurement 레코드(route: geode_agent + native tau2 user_simulator)와 crucible.md §2에 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)