### PR TITLE
fix(site): 증류 헤드라인 후퇴 페이드 (release 0.99.308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.308] - 2026-07-12
+
+### Changed
+
+- **The distillation headline recedes under the finale (operator-directed).**
+  While the "edited by MANGO" reveal rises, the pinned corner headline fades
+  and blurs back (opacity to 0.12, 6px blur over the same scroll window as
+  the reveal), so the two pinned layers never compete; reduced motion keeps
+  the fade and drops the blur.
+
+---
+
 ## [0.99.307] - 2026-07-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.307
+- **Version**: 0.99.308
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.307 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.308 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.307: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.308: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.307"
+version = "0.99.308"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.307. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.308. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.307. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.308. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -937,6 +937,10 @@ function DistillationAct() {
   const ledgerOp = useTransform(scrollYProgress, [0.48, 0.64], [0, 1]);
   const labOp = useTransform(scrollYProgress, [0.74, 0.9], [0, 1]);
   const labPointer = useTransform(labOp, (v) => (v > 0.55 ? "auto" : "none") as "auto" | "none");
+  // The pinned headline recedes as the laboratory rises — same scroll window
+  // as labOp so the two pinned layers never compete for the corner.
+  const headOp = useTransform(scrollYProgress, [0.74, 0.9], [1, 0.12]);
+  const headBlur = useTransform(scrollYProgress, [0.74, 0.9], ["blur(0px)", "blur(6px)"]);
   const ledger: { id: string; verdict: string; keep?: boolean }[] = [
     { id: "gen-2606-i1-004", verdict: "REJECT" },
     { id: "gen-2606-i2-001", verdict: "REJECT" },
@@ -948,14 +952,17 @@ function DistillationAct() {
       {/* nav anchor: jumping to #lab lands where the laboratory has revealed */}
       <div id="lab" aria-hidden className="absolute left-0 top-[76%] h-px w-px" />
       <div className="sticky top-0 flex h-screen flex-col overflow-hidden">
-        <div className="pointer-events-none absolute left-5 top-8 z-20 max-w-[360px] text-left sm:left-10 sm:top-12">
+        <motion.div
+          style={{ opacity: headOp, filter: reduceMotion ? undefined : headBlur }}
+          className="pointer-events-none absolute left-5 top-8 z-20 max-w-[360px] text-left sm:left-10 sm:top-12"
+        >
           <p className="font-mono text-[10.5px] uppercase tracking-[0.3em]" style={{ color: PAPER_75 }}>
             {t(locale, "증류", "the distillation")}
           </p>
           <h2 className="font-serif-display mt-3 text-balance text-[clamp(1.6rem,3.1vw,2.3rem)] font-black leading-[1.22] text-[#FFF0F8]">
             {t(locale, "천 번의 토큰을 걸러, 한 방울로.", "A thousand tokens, filtered to a single drop.")}
           </h2>
-        </div>
+        </motion.div>
 
         <div className="flex min-h-0 flex-1 flex-col justify-center">
           <RainBand phase={0} height="12vh" flakes={96} />

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.308",
+    "date": "2026-07-12",
+    "body": "### Changed\n\n- **The distillation headline recedes under the finale (operator-directed).**\n  While the \"edited by MANGO\" reveal rises, the pinned corner headline fades\n  and blurs back (opacity to 0.12, 6px blur over the same scroll window as\n  the reveal), so the two pinned layers never compete; reduced motion keeps\n  the fade and drops the blur."
+  },
+  {
     "version": "0.99.307",
     "date": "2026-07-12",
     "body": "### Changed\n\n- **Tau2 slip separates the agentic harness from the eval harness\n  (operator-directed).** The measurement slip gains labeled sections so the\n  claim reads unambiguously: what is measured is gpt-5.2 wrapped in the\n  GEODE loop (agentic harness: loop geode v0.99.269, model gpt-5.2 high ·\n  payg); the ruler is tau2-bench (eval harness: bench @ 1901a30, user-sim\n  gpt-4.1 · pass^1 k=1, airline trend-reference); the control is the same\n  model with no loop (Agent-World vanilla 0.802) before the verdict band.\n  The plate caption restates it in both locales."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.307",
+  version: "0.99.308",
   syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.307"
+version = "0.99.308"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

증류(DistillationAct) 섹션의 마지막 막에서 "edited by MANGO" 리빌이 올라올 때, 좌상단에 핀 고정된 증류 헤드라인 블록(eyebrow "the distillation" + serif h2)이 뒤로 물러나며 흐릿하게 사라지도록 수정. opacity 1→0.12 + blur 0→6px, labOp와 동일한 스크롤 구간 [0.74, 0.9].

## Why

리빌 막에서 핀 고정된 두 레이어(헤드라인 vs MANGO 카드)가 같은 화면에서 선명도를 두고 경쟁했다. 헤드라인이 물러나야 피날레 카드가 시선을 온전히 가져간다 (operator-directed).

## Changes

- `site/src/app/portfolio/page.tsx` `DistillationAct`:
  - `headOp = useTransform(scrollYProgress, [0.74, 0.9], [1, 0.12])`, `headBlur = useTransform(..., ["blur(0px)", "blur(6px)"])` 추가 (labOp 바로 아래, 동일 구간).
  - 좌상단 헤드라인 컨테이너를 `motion.div`로 전환, `style={{ opacity: headOp, filter: reduceMotion ? undefined : headBlur }}` 적용 (className 유지). reduced motion에서는 페이드 유지, blur만 비활성 (이 페이지의 RM 규칙).
- Release 0.99.308: CHANGELOG + pyproject + CLAUDE.md + README/README.ko + `sync-stats.mjs`/`check_llms_version.py --fix` 재생성 (sot.ts, changelog.ts, llms.txt, llms-full.txt) + uv.lock 버전 반영.

## Impact Scope

- 포트폴리오 `/portfolio` 증류 섹션 시각 연출만 영향. 다른 라우트/런타임 코드 무변경.
- reduced motion 사용자: 페이드는 유지, blur만 생략 — 기존 RM 계약과 일치.

## Verification

- `tsc --noEmit`: 0 에러.
- `npx next build`: ✓ Compiled successfully. `npm run export-md`: 74 twins + llms-full.txt 재생성 성공.
- `check_llms_version.py`: clean (3파일 v0.99.308 일치).
- 시각 검증 (puppeteer 실스크롤, 1440x900): progress≈0.8에서 헤드라인 blur+감쇠 진행 중이며 MANGO 리빌 상승 확인, progress≈0.95에서 MANGO 카드 완전 선명 + 헤드라인 opacity 0.12 유령 상태 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)