### PR TITLE
docs(eval): 원시 실로그 공개 저장소 링크 게시

### DIFF
--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -240,6 +240,13 @@ coordinates, pinned commits, preflight env names, and GEODE adapters. The
 third-party benchmark repositories themselves are still fetched under ignored
 local artifacts so GEODE does not vendor external harness code.
 
+Raw run logs cited by this ledger are published as append-only snapshots at
+<https://github.com/mangowhoiscloud/geode-eval-artifacts> (MCPMark result
+directories with per-task `meta.json` / `messages.json` / verifier output,
+pipeline logs, and GEODE-owned tau2 simulation JSONs). Local
+`artifacts/eval/harnesses/**` paths cited below map to the same relative paths
+in that repository. A secret scan gates every upload.
+
 The benchmark harnesses were fetched under ignored local artifacts so they can
 be used for setup and smoke testing without vendoring third-party repos into
 GEODE:

--- a/docs/eval/mcpmark-agentworld-comparison-runbook.md
+++ b/docs/eval/mcpmark-agentworld-comparison-runbook.md
@@ -92,3 +92,10 @@ xhigh 기준 리셋 창 여러 개에 걸친다.
 schema를 따른다. Agent-World 비교 표에 넣을 때 최소 라벨: harness commit,
 suite(Verified/standard), k, route(`openai-subscription/codex`), effort(xhigh),
 그리고 "decoding params not controllable" 주석.
+
+원시 실로그는 공개 저장소에 스냅샷으로 게시한다:
+<https://github.com/mangowhoiscloud/geode-eval-artifacts> (MCPMark run
+디렉토리 전체 + 파이프라인 로그 + tau2 simulations). 로컬
+`artifacts/eval/harnesses/**` 경로를 인용하는 run record는 이 저장소의 동일
+상대 경로에서 원본을 볼 수 있다. 게시 전 시크릿 스캔이 게이트이며, 스냅샷은
+append-only로 유지한다.


### PR DESCRIPTION
MCPMark·tau2 실로그를 https://github.com/mangowhoiscloud/geode-eval-artifacts 에 게시(시크릿 스캔 2회 클린, 17M+274M, append-only). evidence ledger와 런북에 매핑 계약 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)