### PR TITLE
fix: claude-cli 어댑터 usage 캡처 배선 — 시드생성 uncaptured 갭 해소 (release 0.99.314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,26 @@ functional change.
 
 ---
 
+## [0.99.314] - 2026-07-13
+
+### Fixed
+
+- **claude-cli sub-agents no longer report zero usage (cost-audit gap
+  closed).** The adapter returned an empty `UsageSummary()` with a stale
+  "subscription path does not expose token usage" comment, leaving every
+  claude-cli-backed seed-generation role flagged "uncaptured" on the hub.
+  The claude CLI's terminal `result` stream-json event does carry token
+  usage (petri's parser, live-verified against CLI 2.1.140) — the petri
+  extractor is now public (`extract_usage_from_events`, one parser for both
+  registries) and the adapter surfaces input/output/cache-read tokens, which
+  flow through translation and TokenTracker into `session_end` and
+  `per_phase_costs.json`. codex-cli stays honestly at zero: plain-text
+  `codex exec` stdout has no usage block (JSON-mode migration noted as
+  unverified, live test required). Stale capture-coverage comments in
+  worker.py, _lifecycle.py, and transcript.py corrected.
+
+---
+
 ## [0.99.313] - 2026-07-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.313
+- **Version**: 0.99.314
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 415 core + 92 plugins = 507
-- **Tests**: 9529 (+1 live)
+- **Tests**: 9512
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.313 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.314 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.313: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.314: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -77,10 +77,10 @@ def record_transcript_end(loop: AgenticLoop, result: Any) -> None:
         # Read accumulated cost + tokens from TokenTracker (was missing →
         # always $0 / 0 tokens). PR-SEEDGEN-TOKENS (2026-05-30) adds the
         # token reads so the session_end event carries prompt/completion
-        # tokens for the seed-generation per-phase cost grid. These are 0
-        # for subscription / CLI calls (the subscription adapters return an
-        # empty UsageSummary — usage is not exposed), so the accumulator
-        # only reflects API-key / payg calls. Never fabricated.
+        # tokens for the seed-generation per-phase cost grid. payg and
+        # claude-cli calls populate real numbers (PR-CLI-USAGE-CAPTURE,
+        # 2026-07-13); codex-cli remains 0 (plain-text stdout carries no
+        # usage block). Never fabricated.
         total_cost = 0.0
         prompt_tokens = 0
         completion_tokens = 0

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -178,12 +178,12 @@ class WorkerResult:
     ``WorkerResult`` had no usage fields, so everything serialized to the
     parent reported zeros.
 
-    HARD LIMITATION: subscription / CLI-routed calls (claude-cli,
-    codex-cli) return an empty ``UsageSummary()`` — the subscription path
-    does not expose token usage (see ``core/llm/adapters/claude_cli.py``
-    and ``core/llm/adapters/codex_cli.py``). For those calls these fields
-    are honestly left at 0; only API-key / payg calls populate real
-    numbers. We never fabricate counts.
+    Capture coverage: payg / API-key adapters and claude-cli (PR-CLI-
+    USAGE-CAPTURE, 2026-07-13 — the CLI's terminal ``result`` stream-json
+    event carries token usage even on subscription) populate real numbers.
+    codex-cli remains 0 — its plain-text ``codex exec`` stdout has no usage
+    block (see ``core/llm/adapters/codex_cli.py``). We never fabricate
+    counts; unmetered calls stay honestly at 0.
     """
 
     task_id: str

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -246,12 +246,26 @@ class ClaudeCliAdapter:
         # next turn's ``resume_session_id`` (cross-call cache hit).
         from plugins.petri_audit.claude_cli_provider import (
             extract_session_id_from_events,
+            extract_usage_from_events,
         )
 
         emitted_session_id = extract_session_id_from_events(stream_events)
+        # PR-CLI-USAGE-CAPTURE (2026-07-13) — the claude CLI's terminal
+        # ``result`` stream-json event carries real token usage even on the
+        # subscription path (petri's parser, live-verified against claude
+        # CLI 2.1.140). Wiring it closes the seed-generation per-phase
+        # "uncaptured role" gap: tokens flow AdapterCallResult → translation
+        # → TokenTracker → session_end → per_phase_costs.json. Counts are
+        # read from the event, never fabricated; a stream without a result
+        # event still yields zeros.
+        usage_tokens = extract_usage_from_events(stream_events)
         return AdapterCallResult(
             text=assistant_text,
-            usage=UsageSummary(),  # subscription path does not expose token usage
+            usage=UsageSummary(
+                input_tokens=usage_tokens["input_tokens"],
+                output_tokens=usage_tokens["output_tokens"],
+                cached_input_tokens=usage_tokens["cache_read_input_tokens"],
+            ),
             stop_reason=stop_reason,
             session_id=emitted_session_id,
         )

--- a/core/llm/adapters/codex_cli.py
+++ b/core/llm/adapters/codex_cli.py
@@ -122,6 +122,11 @@ class CodexCliAdapter:
                 raise RuntimeError(f"codex-cli subprocess exited rc={rc}: {err_excerpt}")
             return AdapterCallResult(
                 text=stdout,
+                # Plain-text ``codex exec`` stdout carries no usage block, so
+                # this stays honestly zero. Capture requires migrating to the
+                # CLI's ``--json`` event stream (``turn.completed.usage`` —
+                # parsed by plugins/petri_audit/codex_cli_provider.py) —
+                # unverified for this adapter's text path, live test required.
                 usage=UsageSummary(),
                 stop_reason="end_turn",
             )

--- a/core/observability/transcript.py
+++ b/core/observability/transcript.py
@@ -186,10 +186,10 @@ class SessionTranscript:
         ``completion_tokens`` are written so the seed-generation
         orchestrator's per-phase cost grid can sum them off each
         sub-agent's ``dialogue.jsonl`` (``_persist_per_phase_costs``
-        already reads these keys). They are 0 for subscription / CLI
-        calls (the subscription path does not expose token usage), so
-        only API-key / payg sub-agents contribute non-zero values —
-        counts are never fabricated.
+        already reads these keys). payg and claude-cli sub-agents
+        contribute real values (the CLI's ``result`` event exposes
+        usage — PR-CLI-USAGE-CAPTURE, 2026-07-13); codex-cli calls
+        remain 0 — counts are never fabricated.
         """
         self._append(
             {

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -902,7 +902,7 @@ def _extract_stop_reason(events: list[StreamJsonEvent]) -> str:
     return mapping.get(raw, "unknown")
 
 
-def _extract_usage(events: list[StreamJsonEvent]) -> dict[str, int]:
+def extract_usage_from_events(events: list[StreamJsonEvent]) -> dict[str, int]:
     """Sum input/output tokens across the event stream.
 
     claude CLI emits ``usage`` on multiple events (``message_start``,
@@ -1109,7 +1109,7 @@ def register() -> None:
                 )
             text = _extract_assistant_text(events)
             stop_reason = _extract_stop_reason(events)
-            usage = _build_usage(_extract_usage(events))
+            usage = _build_usage(extract_usage_from_events(events))
             choice = ChatCompletionChoice(
                 message=ChatMessageAssistant(content=text),
                 stop_reason=stop_reason,
@@ -1165,7 +1165,7 @@ def register() -> None:
                 # inspect_ai-blessed sentinel for the solver's
                 # tool-dispatch path.
                 stop_reason = "tool_calls" if tool_calls else _extract_stop_reason(events)
-                usage = _build_usage(_extract_usage(events))
+                usage = _build_usage(extract_usage_from_events(events))
                 choice = ChatCompletionChoice(
                     message=ChatMessageAssistant(
                         content=text,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.313"
+version = "0.99.314"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.313. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.314. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.313. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.314. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.314",
+    "date": "2026-07-13",
+    "body": "### Fixed\n\n- **claude-cli sub-agents no longer report zero usage (cost-audit gap\n  closed).** The adapter returned an empty `UsageSummary()` with a stale\n  \"subscription path does not expose token usage\" comment, leaving every\n  claude-cli-backed seed-generation role flagged \"uncaptured\" on the hub.\n  The claude CLI's terminal `result` stream-json event does carry token\n  usage (petri's parser, live-verified against CLI 2.1.140) — the petri\n  extractor is now public (`extract_usage_from_events`, one parser for both\n  registries) and the adapter surfaces input/output/cache-read tokens, which\n  flow through translation and TokenTracker into `session_end` and\n  `per_phase_costs.json`. codex-cli stays honestly at zero: plain-text\n  `codex exec` stdout has no usage block (JSON-mode migration noted as\n  unverified, live test required). Stale capture-coverage comments in\n  worker.py, _lifecycle.py, and transcript.py corrected."
+  },
+  {
     "version": "0.99.313",
     "date": "2026-07-13",
     "body": "### Changed\n\n- **Seed-generation cost granularity extended to the sub-index and per-run\n  pages (cost-audit follow-up).** The \"All runs\" table cell and the hub index\n  now share the same tokens-and-USD cell; the run page's phase table replaces\n  the never-wired samples/score dash columns with agents / tokens / cost read\n  from `per_phase_costs.json` (dagger on roles that ran agents without usage\n  capture); the run-page cost grid falls back to per-phase sums for runs that\n  never wrote state.json usage and gains a `usd (metered floor)` row; the\n  index usage rollup adds USD ($18.61 floor) and the uncaptured-role count."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.313",
+  version: "0.99.314",
   syncedAt: "2026-07-12",
 } as const;

--- a/tests/core/llm/adapters/test_claude_cli_adapter.py
+++ b/tests/core/llm/adapters/test_claude_cli_adapter.py
@@ -146,6 +146,89 @@ def test_adapter_returns_parsed_text_not_raw_stdout() -> None:
     assert result.stop_reason == "stop"
 
 
+def test_adapter_captures_usage_from_result_event() -> None:
+    """PR-CLI-USAGE-CAPTURE (2026-07-13) — the terminal ``result``
+    stream-json event carries real token usage on the subscription path;
+    the adapter must surface it (previously always an empty
+    ``UsageSummary()``, leaving every claude-cli sub-agent phase
+    "uncaptured" in the seed-generation per-phase cost grid)."""
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+
+    adapter = ClaudeCliAdapter()
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "ok"}]},
+            },
+            {
+                "type": "result",
+                "stop_reason": "end_turn",
+                "result": "ok",
+                "usage": {
+                    "input_tokens": 1200,
+                    "output_tokens": 340,
+                    "cache_read_input_tokens": 900,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+        ]
+    )
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            return_value=(stdout, "", 0),
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+    ):
+        result = asyncio.run(adapter.acomplete(_build_request()))
+    assert result.usage.input_tokens == 1200
+    assert result.usage.output_tokens == 340
+    assert result.usage.cached_input_tokens == 900
+
+
+def test_adapter_usage_zero_without_result_usage() -> None:
+    """A stream whose result event has no usage block stays honestly at
+    zero — counts are never fabricated."""
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+
+    adapter = ClaudeCliAdapter()
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "ok"}]},
+            },
+            {"type": "result", "stop_reason": "end_turn", "result": "ok"},
+        ]
+    )
+    with (
+        patch(
+            "plugins.petri_audit.claude_cli_provider._resolve_claude_binary",
+            return_value="/fake/claude",
+        ),
+        patch(
+            "plugins.petri_audit.claude_cli_provider._run_claude_subprocess",
+            return_value=(stdout, "", 0),
+        ),
+        patch(
+            "core.orchestration.claude_cli_lane.acquire_claude_cli_lane_async",
+            _passthrough_lane,
+        ),
+    ):
+        result = asyncio.run(adapter.acomplete(_build_request()))
+    assert result.usage.input_tokens == 0
+    assert result.usage.output_tokens == 0
+    assert result.usage.cached_input_tokens == 0
+
+
 def test_adapter_raises_when_rc_zero_no_events() -> None:
     """rc=0 + empty stdout is the silent-empty-content path —
     must fail loud rather than return ``text=""`` as a normal reply."""

--- a/tests/plugins/petri_audit/test_claude_cli_provider.py
+++ b/tests/plugins/petri_audit/test_claude_cli_provider.py
@@ -570,9 +570,9 @@ def test_extract_stop_reason_unknown_when_absent() -> None:
     assert _extract_stop_reason(parse_stream_json_events(stdout)) == "unknown"
 
 
-def test_extract_usage_from_result_event() -> None:
+def testextract_usage_from_events_from_result_event() -> None:
     from plugins.petri_audit.claude_cli_provider import (
-        _extract_usage,
+        extract_usage_from_events,
         parse_stream_json_events,
     )
 
@@ -589,20 +589,20 @@ def test_extract_usage_from_result_event() -> None:
             }
         ]
     )
-    usage = _extract_usage(parse_stream_json_events(stdout))
+    usage = extract_usage_from_events(parse_stream_json_events(stdout))
     assert usage["input_tokens"] == 100
     assert usage["output_tokens"] == 50
     assert usage["cache_read_input_tokens"] == 200
     assert usage["cache_creation_input_tokens"] == 300
 
 
-def test_extract_usage_zero_when_absent() -> None:
+def testextract_usage_from_events_zero_when_absent() -> None:
     from plugins.petri_audit.claude_cli_provider import (
-        _extract_usage,
+        extract_usage_from_events,
         parse_stream_json_events,
     )
 
-    usage = _extract_usage(parse_stream_json_events("{}"))
+    usage = extract_usage_from_events(parse_stream_json_events("{}"))
     assert usage == {
         "input_tokens": 0,
         "output_tokens": 0,

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.313"
+version = "0.99.314"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
비용 감사(#2648/#2652)가 표기만 하고 남겨둔 런타임 metering 갭을 배선한다. claude-cli 어댑터가 빈 `UsageSummary()`를 반환해 claude-cli 기반 시드 생성 역할 전부가 허브에서 "uncaptured"로 남았는데, claude CLI의 종단 `result` stream-json 이벤트는 구독 경로에서도 실토큰 usage를 담는다(petri 프로바이더가 이미 파싱, CLI 2.1.140 라이브 검증 주석 보유). 그 파서를 공개명으로 승격해 core 어댑터에 배선했다.

## Why
- GAP audit 결과 배관 전체(WorkerResult usage 필드, translation→ResponseUsage, TokenTracker, session_end, per_phase_costs rollup)는 PR-SEEDGEN-TOKENS(2026-05-30)에 이미 존재 — 끊긴 고리는 어댑터 반환값 한 곳.
- "subscription path does not expose token usage" 주석은 낡은 가정 — 같은 레포의 petri `extract_usage_from_events`가 반증(레지스트리 중복 파서 금지 원칙에 따라 공유).

## Changes

### Core Changes (Code)
- `plugins/petri_audit/claude_cli_provider.py`: `_extract_usage` → `extract_usage_from_events` 공개 승격(내부 호출 2곳 갱신, shim 없음).
- `core/llm/adapters/claude_cli.py`: 종단 result 이벤트에서 input/output/cache-read 토큰 추출해 `UsageSummary` 채움. result 이벤트에 usage 없으면 0 유지(조작 금지).
- `core/llm/adapters/codex_cli.py`: 0 유지 사유 주석 정정 — plain-text `codex exec` stdout엔 usage 블록이 없고, `--json` 이벤트 스트림 이행은 unverified(live test required)로 명시.

### Secondary Changes (Code)
- `core/agent/worker.py` / `core/agent/loop/_lifecycle.py` / `core/observability/transcript.py`: "HARD LIMITATION(구독=0)" 낡은 주석을 실캡처 범위로 정정.

### Documentation/Config Changes
- `CHANGELOG.md` [0.99.314] + 5-location 스탬프 + sync-stats/llms 재생성.
- CLAUDE.md Tests 메트릭 실측 교정: 9529(+1 live) → 9512 (collect-only 실측, live 마커 테스트 현재 0개).

## Impact Scope
- **Affected modules**: core/llm/adapters, core/agent, core/observability, plugins/petri_audit
- **Backward compatibility**: 유지 — UsageSummary 필드 채움은 additive. claude-cli 경유 토큰이 이제 TokenTracker에 기록되어 세션 비용 표시가 payg 환산 추정치를 포함(codex_oauth 구독 어댑터와 동일 semantics).
- **Test changes**: 신규 2 (usage 캡처 + usage 부재 시 0 유지), 수정 1(petri 테스트 import 명 변경)

## Design Decisions
- 파서 이중화 대신 petri 것을 공개 승격 — Registry CANNOT(같은 도메인 파서 2개 금지).
- codex-cli는 배선하지 않음 — stdout에 데이터가 없고, JSON 모드 이행은 doc-before-behaviour 게이트(4d) 대상이라 unverified 표기 + 별도 사이클.

## Verification
- `pytest tests/core/llm/adapters/test_claude_cli_adapter.py tests/plugins/petri_audit/test_claude_cli_provider.py -q` → 11 passed
- `pytest tests/plugins/petri_audit/ tests/core/agent/ tests/core/observability/` → 2083 passed, 37 skipped
- `ruff check core/ tests/ plugins/ scripts/` → clean; `ruff format --check` → 1189 already formatted; `mypy core/ plugins/` → 0 errors (519 files); `lint-imports` → 4 kept, 0 broken
- `check_llms_version.py` → clean (v0.99.314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)