### PR TITLE
feat(site): install channels section — typed commands, line-by-line output (v0.99.315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.315] - 2026-07-13
+
+### Added
+
+- **Install channels on the landing page.** A new `install` section on the
+  portfolio landing visualizes every distribution path (Homebrew tap,
+  `uv tool`, `uvx` one-shot, source) as a replayed terminal: commands type
+  in character by character, output reveals line by line like the hero
+  terminal, and each channel carries a selectable command with a copy
+  button. Transcripts are abridged from the real 2026-07-13 publication
+  runs; reduced motion renders the finished transcript statically.
+
 ## [0.99.314] - 2026-07-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.314
+- **Version**: 0.99.315
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.314 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.315 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.314: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.315: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.314"
+version = "0.99.315"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.314. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.315. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.314. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.315. Last sync 2026-07-12. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -40,11 +40,273 @@ const ROSE_INK_70 = "color-mix(in srgb, #C2447F 72%, transparent)";
 
 const navItems = [
   { id: "hero", label: "Intro" },
+  { id: "install", label: "Install" },
   { id: "run", label: "Run" },
   { id: "features", label: "Features" },
   { id: "distill", label: "Distill" },
   { id: "lab", label: "Specimen" },
 ];
+
+/* ---------------- install: every channel, typed live ---------------------- */
+
+/**
+ * Every distribution channel as a replayed terminal: the command types in
+ * character by character (operator direction 2026-07-13), then output
+ * reveals line by line exactly like the hero terminal. Transcripts are
+ * abridged from the real 2026-07-13 publication runs (brew source build,
+ * uv tool install, uvx ephemeral env); reduced motion renders the finished
+ * transcript statically.
+ */
+type InstallLine = { kind: "cmd" | "out" | "ok"; text: string };
+
+const installChannels: {
+  id: string;
+  labelKo: string;
+  labelEn: string;
+  noteKo: string;
+  noteEn: string;
+  copy: string;
+  lines: InstallLine[];
+}[] = [
+  {
+    id: "brew",
+    labelKo: "Homebrew",
+    labelEn: "Homebrew",
+    noteKo: "macOS 사용자용. 탭에서 릴리스 태그를 빌드해 설치합니다.",
+    noteEn: "For macOS users. Builds the pinned release tag from the tap.",
+    copy: "brew install mangowhoiscloud/tap/geode",
+    lines: [
+      { kind: "cmd", text: "brew install mangowhoiscloud/tap/geode" },
+      { kind: "out", text: "==> Fetching downloads for: geode" },
+      { kind: "out", text: "==> Installing geode from mangowhoiscloud/tap" },
+      { kind: "out", text: "==> Caveats: hermetic virtualenv under Cellar" },
+      { kind: "cmd", text: "geode version" },
+      { kind: "ok", text: "" },
+    ],
+  },
+  {
+    id: "uv-tool",
+    labelKo: "uv tool",
+    labelEn: "uv tool",
+    noteKo: "파이썬 툴체인 사용자용. 릴리스 태그를 격리 환경에 설치합니다.",
+    noteEn: "For Python-toolchain users. Installs the release tag into an isolated env.",
+    copy: 'uv tool install "geode-agent @ git+https://github.com/mangowhoiscloud/geode"',
+    lines: [
+      { kind: "cmd", text: 'uv tool install "geode-agent @ git+https://github.com/mangowhoiscloud/geode"' },
+      { kind: "out", text: "Installed 2 executables: geode, geode-mcp" },
+      { kind: "cmd", text: "geode version" },
+      { kind: "ok", text: "" },
+    ],
+  },
+  {
+    id: "uvx",
+    labelKo: "uvx · 설치 없이",
+    labelEn: "uvx · no install",
+    noteKo: "설치 없이 1회 실행. 일회성 환경을 만들고 지웁니다.",
+    noteEn: "One-shot run without installing. Ephemeral env, then gone.",
+    copy: "uvx --from git+https://github.com/mangowhoiscloud/geode geode",
+    lines: [
+      { kind: "cmd", text: "uvx --from git+https://github.com/mangowhoiscloud/geode geode version" },
+      { kind: "out", text: "Installed 64 packages in 434ms" },
+      { kind: "ok", text: "" },
+    ],
+  },
+  {
+    id: "source",
+    labelKo: "소스",
+    labelEn: "Source",
+    noteKo: "개발·기여용. 클론한 트리에서 바로 실행합니다.",
+    noteEn: "For development and contributions. Runs straight from the clone.",
+    copy: "git clone https://github.com/mangowhoiscloud/geode && cd geode && uv sync",
+    lines: [
+      { kind: "cmd", text: "git clone https://github.com/mangowhoiscloud/geode && cd geode" },
+      { kind: "out", text: "Cloning into 'geode'..." },
+      { kind: "cmd", text: "uv sync" },
+      { kind: "out", text: "Installed 120 packages in 256ms" },
+      { kind: "cmd", text: "uv run geode version" },
+      { kind: "ok", text: "" },
+    ],
+  },
+];
+
+const TYPE_MS = 26;
+const LINE_MS = 520;
+const CMD_SETTLE_MS = 380;
+const REPLAY_MS = 4800;
+
+function InstallTerminal({ lines }: { lines: InstallLine[] }) {
+  const reduceMotion = useReducedMotion();
+  const [lineIndex, setLineIndex] = useState(reduceMotion ? lines.length : 0);
+  const [charCount, setCharCount] = useState(0);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    // Initial state already reflects reduceMotion; the terminal remounts per
+    // channel (key), so the effect never needs a synchronous reset.
+    if (reduceMotion) return;
+    let line = 0;
+    let chars = 0;
+    let timer: number;
+    const step = () => {
+      if (line >= lines.length) {
+        timer = window.setTimeout(() => {
+          line = 0;
+          chars = 0;
+          setLineIndex(0);
+          setCharCount(0);
+          timer = window.setTimeout(step, 600);
+        }, REPLAY_MS);
+        return;
+      }
+      const current = lines[line];
+      if (current.kind === "cmd" && chars < current.text.length) {
+        chars += 1;
+        setCharCount(chars);
+        timer = window.setTimeout(step, TYPE_MS);
+        return;
+      }
+      line += 1;
+      chars = 0;
+      setLineIndex(line);
+      setCharCount(0);
+      timer = window.setTimeout(step, current.kind === "cmd" ? CMD_SETTLE_MS : LINE_MS);
+    };
+    timer = window.setTimeout(step, 500);
+    return () => window.clearTimeout(timer);
+  }, [lines, reduceMotion]);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (body) body.scrollTop = body.scrollHeight;
+  }, [lineIndex, charCount]);
+
+  const renderLine = (line: InstallLine, i: number, partial: boolean) => {
+    if (line.kind === "cmd") {
+      const shown = partial ? line.text.slice(0, charCount) : line.text;
+      return (
+        <p key={i} className="py-[3px] font-mono text-[12px] sm:text-[13px]">
+          <span className="text-[var(--acc-artifact)]">$</span>{" "}
+          <span className="text-[var(--ink-1)]">{shown}</span>
+          {partial ? (
+            <span className="geodi-caret ml-[2px] inline-block h-[13px] w-[7px] translate-y-[2px] bg-[var(--acc-artifact)]" />
+          ) : null}
+        </p>
+      );
+    }
+    if (line.kind === "ok") {
+      return (
+        <p key={i} className="py-[3px] font-mono text-[12px] sm:text-[13px]">
+          <span className="text-[var(--acc-artifact)]">◆</span>{" "}
+          <span className="font-semibold text-[var(--acc-artifact)]">GEODE</span>{" "}
+          <span className="text-[var(--ink-2)]">v{GEODE_SOT.version}</span>
+        </p>
+      );
+    }
+    return (
+      <p key={i} className="py-[3px] font-mono text-[12px] text-[var(--ink-3)] sm:text-[13px]">
+        {line.text}
+      </p>
+    );
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[color-mix(in_srgb,#FFF0F8_35%,transparent)] bg-[var(--paper-deep)] text-left">
+      <div className="flex items-center gap-2 border-b border-[var(--rule-soft)] px-4 py-2.5">
+        <span className="flex gap-1.5">
+          {["#FF5F57", "#FEBC2E", "#28C840"].map((light) => (
+            <span key={light} className="h-[9px] w-[9px] rounded-full" style={{ background: light }} />
+          ))}
+        </span>
+        <span className="ml-2 font-mono text-[11px] text-[var(--ink-3)]">install</span>
+      </div>
+      <div ref={bodyRef} className="h-[218px] overflow-hidden px-5 py-4 sm:px-7">
+        {lines.slice(0, lineIndex).map((line, i) => renderLine(line, i, false))}
+        {lineIndex < lines.length && lines[lineIndex].kind === "cmd" && charCount > 0
+          ? renderLine(lines[lineIndex], lineIndex, true)
+          : null}
+      </div>
+    </div>
+  );
+}
+
+function InstallChannels() {
+  const locale = useLocale();
+  const reduceMotion = useReducedMotion();
+  const [activeChannel, setActiveChannel] = useState("brew");
+  const [copied, setCopied] = useState(false);
+  const channel = installChannels.find((c) => c.id === activeChannel) ?? installChannels[0];
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(channel.copy);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard unavailable: the command stays selectable below */
+    }
+  };
+
+  return (
+    <section id="install" className="bg-[var(--acc-artifact)]">
+      <div className="mx-auto w-full max-w-3xl px-6 py-20 sm:py-24">
+        <motion.p
+          initial={{ opacity: 0, y: reduceMotion ? 0 : 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+          className="text-center font-mono text-[10.5px] uppercase tracking-[0.3em]"
+          style={{ color: PAPER_75 }}
+        >
+          {t(locale, "네 갈래 설치", "every way to install")}
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: reduceMotion ? 0 : 22 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.65, delay: 0.08, ease: [0.22, 1, 0.36, 1] }}
+          className="mt-8"
+        >
+          <div className="flex flex-wrap justify-center gap-x-1 gap-y-2 border-b border-[color-mix(in_srgb,#FFF0F8_30%,transparent)]">
+            {installChannels.map((entry) => (
+              <button
+                key={entry.id}
+                onClick={() => {
+                  setActiveChannel(entry.id);
+                  setCopied(false);
+                }}
+                className="touch-manipulation px-4 py-2 font-mono text-[12.5px] transition-colors"
+                style={{
+                  color: activeChannel === entry.id ? "#FFF0F8" : PAPER_75,
+                  borderBottom: `2px solid ${activeChannel === entry.id ? "#FFF0F8" : "transparent"}`,
+                  marginBottom: "-1px",
+                }}
+              >
+                {locale === "en" ? entry.labelEn : entry.labelKo}
+              </button>
+            ))}
+          </div>
+          <div className="mt-6">
+            <InstallTerminal key={channel.id} lines={channel.lines} />
+          </div>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <p className="font-mono text-[12px]" style={{ color: PAPER_75 }}>
+              {t(locale, channel.noteKo, channel.noteEn)}
+            </p>
+            <button
+              onClick={handleCopy}
+              className="touch-manipulation rounded border border-[color-mix(in_srgb,#FFF0F8_45%,transparent)] px-3 py-1 font-mono text-[11px] text-[#FFF0F8] transition-opacity hover:opacity-75"
+            >
+              {copied ? t(locale, "복사됨", "copied") : t(locale, "명령 복사", "copy command")}
+            </button>
+          </div>
+          <p className="mt-2 select-all break-all font-mono text-[11.5px]" style={{ color: PAPER_75 }}>
+            {channel.copy}
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
 
 const surfaceChips = ["CLI", "MCP server", "Slack", "cron", "Gateway daemon"];
 
@@ -1126,6 +1388,7 @@ export default function GeodePortfolioPage() {
       >
         <GeodeNav items={navItems} light />
         <HeroField />
+        <InstallChannels />
         <RunRow />
         <FeaturesGrid />
         <DistillationAct />

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.315",
+    "date": "2026-07-13",
+    "body": "### Added\n\n- **Install channels on the landing page.** A new `install` section on the\n  portfolio landing visualizes every distribution path (Homebrew tap,\n  `uv tool`, `uvx` one-shot, source) as a replayed terminal: commands type\n  in character by character, output reveals line by line like the hero\n  terminal, and each channel carries a selectable command with a copy\n  button. Transcripts are abridged from the real 2026-07-13 publication\n  runs; reduced motion renders the finished transcript statically."
+  },
+  {
     "version": "0.99.314",
     "date": "2026-07-13",
     "body": "### Fixed\n\n- **claude-cli sub-agents no longer report zero usage (cost-audit gap\n  closed).** The adapter returned an empty `UsageSummary()` with a stale\n  \"subscription path does not expose token usage\" comment, leaving every\n  claude-cli-backed seed-generation role flagged \"uncaptured\" on the hub.\n  The claude CLI's terminal `result` stream-json event does carry token\n  usage (petri's parser, live-verified against CLI 2.1.140) — the petri\n  extractor is now public (`extract_usage_from_events`, one parser for both\n  registries) and the adapter surfaces input/output/cache-read tokens, which\n  flow through translation and TokenTracker into `session_end` and\n  `per_phase_costs.json`. codex-cli stays honestly at zero: plain-text\n  `codex exec` stdout has no usage block (JSON-mode migration noted as\n  unverified, live test required). Stale capture-coverage comments in\n  worker.py, _lifecycle.py, and transcript.py corrected."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.314",
+  version: "0.99.315",
   syncedAt: "2026-07-12",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.314"
+version = "0.99.315"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

New `install` section on the landing page (root = portfolio): all four distribution paths — Homebrew tap, `uv tool`, `uvx` one-shot, source — visualized as a replayed terminal. Commands type in character by character; output reveals line by line, matching the hero terminal's grammar; each channel carries a channel note plus a selectable command with a copy button. Nav gains an Install anchor.

## Why

The distribution channels shipped this week (tap v0.99.313, uv tag installs) had no surface on the site: the hero shows one brew path narratively, but nothing enumerates every way in. Operator direction: typed input, line-by-line output like the existing terminal.

## Changes

- `site/src/app/portfolio/page.tsx`: `InstallChannels` section (channel tabs + `InstallTerminal` with per-character cmd typing, per-line output reveal, auto-scroll, replay loop, reduced-motion static transcript, clipboard copy), `install` nav item, placed between hero and Run.
- Transcripts abridged from the real 2026-07-13 publication runs (brew source build, `uv tool install` executables line, `uvx` 64-packages line, `uv sync` 120-packages line); the version line renders `GEODE_SOT.version` dynamically.
- Release stamp v0.99.315 across the five locations + regenerated site version SoT.

## Verification

- `next build` green (238 static pages).
- `eslint` on the touched file: clean (one synchronous-setState-in-effect finding fixed by relying on keyed remount; the repo's 8 pre-existing site lint errors are untouched debt).
- Rendered verification on the static export via headless screenshot: mid-typing frame (`$ brew install mangowhoiscloud/tap/…` + caret) and finished transcript (`◆ GEODE v0.99.314` at build time) both captured; tabs, notes, and copy button render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)