### PR TITLE
test(crucible): inexhaustible clock mock for the elapsed-time flake (v0.99.317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.317] - 2026-07-13
+
+### Fixed
+
+- **Release-train flake hardened.** The tau2 elapsed-time test mocked
+  `time.monotonic` with a finite two-value iterator; an extra clock read
+  under xdist+coverage load raised `StopIteration` and blocked the release
+  train twice on 2026-07-13. The mock is now an inexhaustible clock (first
+  read anchors, later reads repeat), preserving the asserted delta for any
+  call count.
+
 ## [0.99.316] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.316
+- **Version**: 0.99.317
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,7 +25,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.316 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.317 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.316: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.317: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.316"
+version = "0.99.317"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.316. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.317. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.316. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.317. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.317",
+    "date": "2026-07-13",
+    "body": "### Fixed\n\n- **Release-train flake hardened.** The tau2 elapsed-time test mocked\n  `time.monotonic` with a finite two-value iterator; an extra clock read\n  under xdist+coverage load raised `StopIteration` and blocked the release\n  train twice on 2026-07-13. The mock is now an inexhaustible clock (first\n  read anchors, later reads repeat), preserving the asserted delta for any\n  call count."
+  },
+  {
     "version": "0.99.316",
     "date": "2026-07-13",
     "body": "### Added\n\n- **GPT-5.6 family model support (Sol/Terra/Luna), dual-lane.** `/model`\n  picker, adapter request-shaping, pricing, and routing for OpenAI's\n  GPT-5.6 series (GA 2026-07-09): `gpt-5.6-sol`, `gpt-5.6-terra`,\n  `gpt-5.6-luna` resolve to the `openai` family and the operator's\n  credential source picks the backend per call — subscription OAuth\n  (slugs artifact-verified against `openai/codex`\n  `models-manager/models.json`) or Platform API key (models GA on the\n  API). The bare `gpt-5.6` Platform alias is registered for spec and\n  pricing but stays off the picker (aliases sol; absent from the Codex\n  models.json).\n  Spec entries carry the new `max` reasoning-effort level (doc-verified),\n  1.05M-token context windows, and short-context pricing with the >272K\n  long-context tier noted. Computer-use GA membership is deliberately\n  excluded as `unverified — live test required` (gpt-5.4 doc-vs-backend\n  precedent). Guard: `tests/core/llm/test_gpt56_support.py`.\n\n### Changed\n\n- **Effort picker: per-family OpenAI effort enums.** `gpt-5.6*` models\n  surface the documented `max` level above `xhigh`; older gpt-5.x\n  families keep the existing enum. Added the missing `claude-fable-5`\n  picker description (functional Fable 5 support landed in June)."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.316",
+  version: "0.99.317",
   syncedAt: "2026-07-13",
 } as const;

--- a/tests/plugins/crucible/test_tau2_live.py
+++ b/tests/plugins/crucible/test_tau2_live.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 import json
 import subprocess
 from pathlib import Path
@@ -421,7 +422,12 @@ def test_run_arm_accounts_for_actual_subprocess_elapsed_time(
         captured["usage"] = usage
         return evidence
 
-    moments = iter((10.0, 13.5))
+    # An inexhaustible clock: the first read anchors at 10.0 and every later
+    # read returns 13.5, so the measured delta stays 3.5 regardless of how
+    # many times the runner consults the clock. A finite two-value iterator
+    # here raised StopIteration under xdist+coverage load (release-train CI,
+    # 2026-07-13) whenever an extra monotonic() call slipped in.
+    moments = itertools.chain((10.0,), itertools.repeat(13.5))
     monkeypatch.setattr("plugins.crucible.tau2_live.time.monotonic", lambda: next(moments))
     monkeypatch.setattr("plugins.crucible.tau2_live.normalize_tau2_results", normalize)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.316"
+version = "0.99.317"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Hardens `test_run_arm_accounts_for_actual_subprocess_elapsed_time`: the `time.monotonic` mock was a finite two-value iterator, so any extra clock read under xdist+coverage raised `StopIteration`.

## Why

This flake failed the release train twice on 2026-07-13 (run 29214428445; green on rerun, 5/5 green locally in serial) — a scheduling-dependent mock exhaustion, not a product defect.

## Changes

- `tests/plugins/crucible/test_tau2_live.py`: `itertools.chain((10.0,), itertools.repeat(13.5))` — first read anchors, later reads repeat; the asserted 3.5s delta holds for any call count.

## Verification

- `tests/plugins/crucible/test_tau2_live.py` under `-n 4` (xdist): green. ruff/format: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)