### PR TITLE
docs(eval): 실로그 저장소 목록에 Crucible·SIL Petri 감사 반영

### DIFF
--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -243,9 +243,12 @@ local artifacts so GEODE does not vendor external harness code.
 Raw run logs cited by this ledger are published as append-only snapshots at
 <https://github.com/mangowhoiscloud/geode-eval-artifacts> (MCPMark result
 directories with per-task `meta.json` / `messages.json` / verifier output,
-pipeline logs, and GEODE-owned tau2 simulation JSONs). Local
-`artifacts/eval/harnesses/**` paths cited below map to the same relative paths
-in that repository. A secret scan gates every upload.
+pipeline logs, GEODE-owned tau2 simulation JSONs, the Crucible campaign run
+store with gate provenance, and the full Petri audit log set under
+`sil/petri-audits/`, 408 `.eval` files of which the self-improving hub serves
+a curated 29-log subset). Local `artifacts/eval/harnesses/**` paths cited
+below map to the same relative paths in that repository. A secret scan gates
+every upload.
 
 The benchmark harnesses were fetched under ignored local artifacts so they can
 be used for setup and smoke testing without vendoring third-party repos into

--- a/docs/eval/mcpmark-agentworld-comparison-runbook.md
+++ b/docs/eval/mcpmark-agentworld-comparison-runbook.md
@@ -95,7 +95,9 @@ suite(Verified/standard), k, route(`openai-subscription/codex`), effort(xhigh),
 
 원시 실로그는 공개 저장소에 스냅샷으로 게시한다:
 <https://github.com/mangowhoiscloud/geode-eval-artifacts> (MCPMark run
-디렉토리 전체 + 파이프라인 로그 + tau2 simulations). 로컬
+디렉토리 전체 + 파이프라인 로그 + tau2 simulations + Crucible campaign
+스토어·gate provenance + SIL Petri 감사 `.eval` 전량 408건, 허브는 선별 29건
+서빙). 로컬
 `artifacts/eval/harnesses/**` 경로를 인용하는 run record는 이 저장소의 동일
 상대 경로에서 원본을 볼 수 있다. 게시 전 시크릿 스캔이 게이트이며, 스냅샷은
 append-only로 유지한다.


### PR DESCRIPTION
geode-eval-artifacts에 crucible 캠페인 스토어와 SIL Petri 감사 .eval 전량(408건, .eval 내부까지 시크릿 스캔 클린)이 추가됨에 따라 evidence ledger·런북의 내용 목록 갱신. 허브(29건 선별 서빙)와의 관계 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)