### PR TITLE
feat(cli): /model 피커 제목에 러닝 버전 표기 (release 0.99.319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ functional change.
 
 ---
 
+## [0.99.319] - 2026-07-13
+
+### Added
+
+- **Model picker title shows the running version.** `/model` now renders
+  `Select model · GEODE v{version}` so a stale binary lane (for example a
+  Homebrew formula behind the editable install) is visible the moment the
+  picker opens, instead of surfacing as "model X is missing" confusion —
+  the GPT-5.6 rows existed in code while a v0.99.313 brew binary rendered
+  a picker without them.
+
 ## [0.99.318] - 2026-07-13
 
 ### Changed

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -333,7 +333,12 @@ def _render(
     out = sys.stdout
     lines = 0
 
-    out.write("\n  \033[1mSelect model\033[0m\n")
+    # The running version sits in the title so a stale binary (for example a
+    # lagging Homebrew formula lane) is visible the moment the picker opens,
+    # instead of surfacing as "model X is missing" confusion.
+    from core import __version__
+
+    out.write(f"\n  \033[1mSelect model\033[0m \033[2m· GEODE v{__version__}\033[0m\n")
     out.write(
         _fit_to_width(
             "  \033[2mSwitch between LLM models. Applies to this session and future sessions. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.318"
+version = "0.99.319"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/cli/test_effort_picker.py
+++ b/tests/core/cli/test_effort_picker.py
@@ -160,3 +160,22 @@ class TestPerProviderEnumIntegrity:
             else:
                 # Default must be in the enum
                 assert d in levels, f"{p.id} ({p.provider}): default={d} not in {levels}"
+
+
+class TestRenderVersionHeader:
+    """The picker title carries the running version so a stale binary
+    (for example a lagging Homebrew formula) is visible immediately."""
+
+    def test_header_names_running_version(self, capsys) -> None:
+        from core import __version__
+        from core.cli.effort_picker import _render
+
+        _render(
+            [("gpt-5.6-sol", "openai", "GPT-5.6 Sol", "$$", True, None)],
+            cursor=0,
+            effort_per_model={"gpt-5.6-sol": "medium"},
+            initial_model="gpt-5.6-sol",
+        )
+        out = capsys.readouterr().out
+        assert f"GEODE v{__version__}" in out
+        assert "Select model" in out


### PR DESCRIPTION
## 동기
GPT-5.6 패밀리는 v0.99.316부터 피커에 있으나, PATH 우선의 Homebrew 바이너리(v0.99.313)가 5.6 없는 피커를 렌더 → "코드에 추가됐는데 UI에 없다"는 혼동 발생.

## 변경
- `Select model · GEODE v{version}` 제목으로 러닝 버전 상시 노출 (dim 처리)
- 테스트: 헤더가 `core.__version__`을 포함하는지 검증
- 후속 운영 조치(코드 외): tap formula v0.99.319 범프로 brew 레인 동기화

🤖 Generated with [Claude Code](https://claude.com/claude-code)