### PR TITLE
feat: 포트폴리오 히어로 터미널을 설치 섹션에 통합 (release 0.99.321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ functional change.
 
 ---
 
+## [0.99.321] - 2026-07-13
+
+### Changed
+
+- **Portfolio hero terminal folded into the install section
+  (operator-directed).** The standalone hero terminal (brew install, first
+  launch, welcome, first prompt) and the "every way to install" Homebrew tab
+  showed near-duplicate transcripts; the install section now carries the full
+  hero sequence on its Homebrew tab (typed command, install output, Geodi
+  welcome banner, first prompt with caret) and the hero keeps only the
+  statement and calls to action. The abridged-transcript caption moved into
+  the channel note; dead `TerminalMock`/`INSTALL_LINES` removed.
+
+---
+
 ## [0.99.320] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.320
+- **Version**: 0.99.321
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.320 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.321 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.320: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.321: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.320"
+version = "0.99.321"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.320. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.321. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.320. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.321. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -57,7 +57,7 @@ const navItems = [
  * uv tool install, uvx ephemeral env); reduced motion renders the finished
  * transcript statically.
  */
-type InstallLine = { kind: "cmd" | "out" | "ok"; text: string };
+type InstallLine = { kind: "cmd" | "out" | "ok" | "welcome" | "prompt"; text: string };
 
 const installChannels: {
   id: string;
@@ -69,19 +69,22 @@ const installChannels: {
   lines: InstallLine[];
 }[] = [
   {
+    // Carries the former hero terminal wholesale (operator direction
+    // 2026-07-13, "merge the two terminals into the install section"):
+    // install, first launch, the welcome screen, the first prompt.
     id: "brew",
     labelKo: "Homebrew",
     labelEn: "Homebrew",
-    noteKo: "macOS 사용자용. 탭에서 릴리스 태그를 빌드해 설치합니다.",
-    noteEn: "For macOS users. Builds the pinned release tag from the tap.",
+    noteKo: "macOS 사용자용. brew 설치에서 첫 프롬프트까지, 실행 축약본.",
+    noteEn: "For macOS users. From brew install to the first prompt, abridged.",
     copy: "brew install mangowhoiscloud/tap/geode",
     lines: [
       { kind: "cmd", text: "brew install mangowhoiscloud/tap/geode" },
       { kind: "out", text: "==> Fetching downloads for: geode" },
       { kind: "out", text: "==> Installing geode from mangowhoiscloud/tap" },
-      { kind: "out", text: "==> Caveats: hermetic virtualenv under Cellar" },
-      { kind: "cmd", text: "geode version" },
-      { kind: "ok", text: "" },
+      { kind: "cmd", text: "geode" },
+      { kind: "welcome", text: "" },
+      { kind: "prompt", text: "" },
     ],
   },
   {
@@ -135,6 +138,7 @@ const CMD_SETTLE_MS = 380;
 const REPLAY_MS = 4800;
 
 function InstallTerminal({ lines }: { lines: InstallLine[] }) {
+  const locale = useLocale();
   const reduceMotion = useReducedMotion();
   const [lineIndex, setLineIndex] = useState(reduceMotion ? lines.length : 0);
   const [charCount, setCharCount] = useState(0);
@@ -169,7 +173,12 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
       chars = 0;
       setLineIndex(line);
       setCharCount(0);
-      timer = window.setTimeout(step, current.kind === "cmd" ? CMD_SETTLE_MS : LINE_MS);
+      // The welcome banner gets a longer beat, matching the former hero
+      // terminal's pacing before the first prompt appears.
+      timer = window.setTimeout(
+        step,
+        current.kind === "cmd" ? CMD_SETTLE_MS : current.kind === "welcome" ? 900 : LINE_MS,
+      );
     };
     timer = window.setTimeout(step, 500);
     return () => window.clearTimeout(timer);
@@ -202,6 +211,33 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
         </p>
       );
     }
+    if (line.kind === "welcome") {
+      return (
+        <div key={i} className="flex items-center gap-6 py-3">
+          <PlayfulSprite scale={5} blink className="geodi-bob shrink-0" />
+          <div className="min-w-0 font-mono text-[12px] leading-[1.9] sm:text-[13px]">
+            <p>
+              <span className="text-[var(--acc-artifact)]">◆</span>{" "}
+              <span className="font-semibold text-[var(--acc-artifact)]">GEODE</span>{" "}
+              <span className="text-[var(--ink-2)]">v{GEODE_SOT.version}</span>
+            </p>
+            <p className="text-[var(--ink-3)]">claude-opus-4-8 · ~/workspace</p>
+            <p className="text-[var(--ink-3)]">/help for commands · type naturally</p>
+          </div>
+        </div>
+      );
+    }
+    if (line.kind === "prompt") {
+      return (
+        <p key={i} className="border-t border-[var(--rule-soft)] pt-3 font-mono text-[12px] sm:text-[13px]">
+          <span className="text-[var(--acc-artifact)]">&gt;</span>{" "}
+          <span className="text-[var(--ink-2)]">
+            {t(locale, "이 레포 점검하고 릴리스 블로커 요약해줘", "inspect this repo and summarize release blockers")}
+          </span>
+          <span className="geodi-caret ml-1 inline-block h-[13px] w-[7px] translate-y-[2px] bg-[var(--acc-artifact)]" />
+        </p>
+      );
+    }
     return (
       <p key={i} className="py-[3px] font-mono text-[12px] text-[var(--ink-3)] sm:text-[13px]">
         {line.text}
@@ -219,7 +255,7 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
         </span>
         <span className="ml-2 font-mono text-[11px] text-[var(--ink-3)]">install</span>
       </div>
-      <div ref={bodyRef} className="h-[218px] overflow-hidden px-5 py-4 sm:px-7">
+      <div ref={bodyRef} className="h-[248px] overflow-hidden px-5 py-4 sm:px-7">
         {lines.slice(0, lineIndex).map((line, i) => renderLine(line, i, false))}
         {lineIndex < lines.length && lines[lineIndex].kind === "cmd" && charCount > 0
           ? renderLine(lines[lineIndex], lineIndex, true)
@@ -329,120 +365,6 @@ function PlayfulSprite({ scale, blink, className }: { scale?: number; blink?: bo
   );
 }
 
-/* ---------------- terminal: install-to-prompt, abridged ------------------ */
-
-/**
- * The hero terminal replays the real path in: brew install, first launch,
- * the welcome screen, the first prompt. Lines reveal on a timer and the
- * body auto-scrolls when they stack (operator direction 2026-07-12);
- * reduced motion renders the finished transcript statically.
- */
-// Transcribed from a real `brew install mangowhoiscloud/tap/geode` run
-// (formula: mangowhoiscloud/homebrew-tap, 2026-07-12), abridged.
-const INSTALL_LINES = [
-  { kind: "cmd" as const, text: "brew install mangowhoiscloud/tap/geode" },
-  { kind: "out" as const, text: "==> Fetching downloads for: geode" },
-  { kind: "out" as const, text: "==> Installing geode from mangowhoiscloud/tap" },
-  { kind: "cmd" as const, text: "geode" },
-  { kind: "welcome" as const, text: "" },
-  { kind: "prompt" as const, text: "" },
-];
-
-function TerminalMock() {
-  const locale = useLocale();
-  const reduceMotion = useReducedMotion();
-  const [visibleCount, setVisibleCount] = useState(reduceMotion ? INSTALL_LINES.length : 0);
-  const bodyRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (reduceMotion) return;
-    let line = 0;
-    let timer: number;
-    const tick = () => {
-      line += 1;
-      setVisibleCount(line);
-      if (line < INSTALL_LINES.length) {
-        timer = window.setTimeout(tick, line === 4 ? 900 : 620);
-      } else {
-        timer = window.setTimeout(() => {
-          line = 0;
-          setVisibleCount(0);
-          timer = window.setTimeout(tick, 700);
-        }, 5200);
-      }
-    };
-    timer = window.setTimeout(tick, 700);
-    return () => window.clearTimeout(timer);
-  }, [reduceMotion]);
-
-  useEffect(() => {
-    const body = bodyRef.current;
-    if (body) body.scrollTop = body.scrollHeight;
-  }, [visibleCount]);
-
-  return (
-    <figure className="mx-auto w-full max-w-2xl">
-      <div className="overflow-hidden rounded-lg border border-[color-mix(in_srgb,#FFF0F8_35%,transparent)] bg-[var(--paper-deep)] text-left">
-        <div className="flex items-center gap-2 border-b border-[var(--rule-soft)] px-4 py-2.5">
-          <span className="flex gap-1.5">
-            {["#FF5F57", "#FEBC2E", "#28C840"].map((light) => (
-              <span key={light} className="h-[9px] w-[9px] rounded-full" style={{ background: light }} />
-            ))}
-          </span>
-          <span className="ml-2 font-mono text-[11px] text-[var(--ink-3)]">geode</span>
-        </div>
-        <div ref={bodyRef} className="h-[248px] overflow-hidden px-5 py-4 sm:px-7">
-          {INSTALL_LINES.slice(0, visibleCount).map((line, i) => {
-            if (line.kind === "cmd") {
-              return (
-                <p key={i} className="py-[3px] font-mono text-[12px] sm:text-[13px]">
-                  <span className="text-[var(--acc-artifact)]">$</span>{" "}
-                  <span className="text-[var(--ink-1)]">{line.text}</span>
-                </p>
-              );
-            }
-            if (line.kind === "out") {
-              return (
-                <p key={i} className="py-[3px] font-mono text-[12px] text-[var(--ink-3)] sm:text-[13px]">
-                  {line.text}
-                </p>
-              );
-            }
-            if (line.kind === "welcome") {
-              return (
-                <div key={i} className="flex items-center gap-6 py-3">
-                  <PlayfulSprite scale={5} blink className="geodi-bob shrink-0" />
-                  <div className="min-w-0 font-mono text-[12px] leading-[1.9] sm:text-[13px]">
-                    <p>
-                      <span className="text-[var(--acc-artifact)]">◆</span>{" "}
-                      <span className="font-semibold text-[var(--acc-artifact)]">GEODE</span>{" "}
-                      <span className="text-[var(--ink-2)]">v{GEODE_SOT.version}</span>
-                    </p>
-                    <p className="text-[var(--ink-3)]">claude-opus-4-8 · ~/workspace</p>
-                    <p className="text-[var(--ink-3)]">/help for commands · type naturally</p>
-                  </div>
-                </div>
-              );
-            }
-            return (
-              <p key={i} className="border-t border-[var(--rule-soft)] pt-3 font-mono text-[12px] sm:text-[13px]">
-                <span className="text-[var(--acc-artifact)]">&gt;</span>{" "}
-                <span className="text-[var(--ink-2)]">
-                  {t(locale, "이 레포 점검하고 릴리스 블로커 요약해줘", "inspect this repo and summarize release blockers")}
-                </span>
-                <span className="geodi-caret ml-1 inline-block h-[13px] w-[7px] translate-y-[2px] bg-[var(--acc-artifact)]" />
-              </p>
-            );
-          })}
-        </div>
-      </div>
-      <figcaption className="mx-auto mt-3 w-fit rounded bg-[#FFF0F8] px-3 py-1 text-center font-mono text-[10.5px] text-[#C2447F]">
-        {t(locale, "brew 설치에서 첫 프롬프트까지, 실행 축약본", "from brew install to the first prompt, abridged")}
-      </figcaption>
-    </figure>
-  );
-}
-
 /* ---------------- hero: rose field, white statement ----------------------- */
 
 function HeroField() {
@@ -501,9 +423,6 @@ function HeroField() {
           >
             GitHub
           </Link>
-        </motion.div>
-        <motion.div variants={heroItem} className="mt-14 w-full">
-          <TerminalMock />
         </motion.div>
       </motion.div>
       <div

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.321",
+    "date": "2026-07-13",
+    "body": "### Changed\n\n- **Portfolio hero terminal folded into the install section\n  (operator-directed).** The standalone hero terminal (brew install, first\n  launch, welcome, first prompt) and the \"every way to install\" Homebrew tab\n  showed near-duplicate transcripts; the install section now carries the full\n  hero sequence on its Homebrew tab (typed command, install output, Geodi\n  welcome banner, first prompt with caret) and the hero keeps only the\n  statement and calls to action. The abridged-transcript caption moved into\n  the channel note; dead `TerminalMock`/`INSTALL_LINES` removed."
+  },
+  {
     "version": "0.99.320",
     "date": "2026-07-13",
     "body": "### Added\n\n- **Crucible runtime-budget admission.** Central prepare can bind an opaque,\n  digest-matched runtime pilot and use deterministic family-block bootstrap\n  quantiles to reject train or campaign wall budgets that cannot hold the\n  paired design. Reports retain semantic timeouts, exclude and count\n  infrastructure interruptions, stamp `runtime_audit_id` provenance, and are\n  also available for frozen train or sealed contracts through the\n  `runtime-pilot` and `runtime-audit` CLI surfaces. A pilot-free\n  `contract_ceiling` mode derives the bootstrap campaign envelope directly\n  from the frozen per-row timeout and explicit setup/campaign overhead.\n\n### Fixed\n\n- **Tau2 contaminated-arm fail-fast.** The live evaluator now polls finalized\n  incremental rows and terminates the whole paid process group as soon as an\n  infrastructure termination or recovered transport retry makes the arm\n  scoreless. SIGINT/SIGTERM also clean up the tau2 process group, preventing\n  the orphan evaluator observed after the interrupted r33 campaign.\n- **Slop audit baseline remains offline-operable after artifact migration.**\n  The historical dated report stays in `geode-eval-artifacts`, while the\n  executable audit now reads a local operational baseline beside its script;\n  fresh checkouts and CI no longer depend on the deleted `docs/audits` copy."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.320",
+  version: "0.99.321",
   syncedAt: "2026-07-13",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.320"
+version = "0.99.321"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
운영자 지시: 히어로의 brew 설치 터미널과 "every way to install" 섹션의 두 터미널을 하나로, 아래(설치 섹션)에서 통합. Homebrew 탭이 히어로 시퀀스 전체(타이핑 커맨드, 설치 출력, Geodi 웰컴 배너, 첫 프롬프트+캐럿)를 재생하고, 히어로는 선언문+CTA만 남긴다.

## Why
두 터미널이 거의 같은 brew 설치 사본을 이중 노출 — 병합으로 중복 제거, 설치 섹션이 "설치에서 첫 프롬프트까지" 서사를 단독 소유.

## Changes

### Core Changes (Code)
- `site/src/app/portfolio/page.tsx`:
  - `InstallLine`에 `welcome`/`prompt` kind 추가, `InstallTerminal`이 스프라이트 웰컴 블록·프롬프트 라인 렌더(+locale), welcome 라인 900ms 비트.
  - brew 채널 transcript를 히어로 시퀀스로 교체, note에 "brew 설치에서 첫 프롬프트까지, 실행 축약본" 흡수. 터미널 높이 218→248px.
  - 히어로의 `TerminalMock` 사용 제거 + `TerminalMock`/`INSTALL_LINES` 데드 코드 삭제.

### Documentation/Config Changes
- CHANGELOG [0.99.321] + 5-location 스탬프 + sync-stats/llms 재생성.

## Impact Scope
- **Affected**: site/(포트폴리오 페이지만). 런타임 코드 0.
- **Backward compatibility**: N/A (정적 사이트).
- **Test changes**: 0.

## Design Decisions
- 통합 위치=아래 설치 섹션(운영자 지정). uv tool/uvx/source 탭은 기존 transcript 유지.
- reduced-motion 경로는 기존 계약 그대로(완성 상태 정적 렌더).

## Verification
- `npx next build` → 232 pages, 0 error
- puppeteer 실스크롤 캡처: 히어로(터미널 제거, 선언+CTA), 설치 섹션 Homebrew 탭 풀 시퀀스(웰컴 배너+첫 프롬프트) 렌더 확인
- `check_llms_version.py` → clean (v0.99.321)

🤖 Generated with [Claude Code](https://claude.com/claude-code)