### PR TITLE
fix: 설치 터미널 프롬프트를 빈 화살표+Hello World 타이핑으로 (release 0.99.322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [0.99.322] - 2026-07-13
+
+### Changed
+
+- **Install terminal prompt ends on the bare arrow, then types "Hello
+  World" (operator-directed).** The Homebrew tab's first-prompt line no
+  longer pre-fills a task sentence; it rests as `>` with the caret for a
+  beat, and if the viewer is still watching, "Hello World" types in
+  character by character before the replay loop resets.
+
+---
+
 ## [0.99.321] - 2026-07-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.321
+- **Version**: 0.99.322
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.321 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.322 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.321: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.322: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.321"
+version = "0.99.322"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.321. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.322. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.321. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.322. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -84,7 +84,7 @@ const installChannels: {
       { kind: "out", text: "==> Installing geode from mangowhoiscloud/tap" },
       { kind: "cmd", text: "geode" },
       { kind: "welcome", text: "" },
-      { kind: "prompt", text: "" },
+      { kind: "prompt", text: "Hello World" },
     ],
   },
   {
@@ -138,7 +138,6 @@ const CMD_SETTLE_MS = 380;
 const REPLAY_MS = 4800;
 
 function InstallTerminal({ lines }: { lines: InstallLine[] }) {
-  const locale = useLocale();
   const reduceMotion = useReducedMotion();
   const [lineIndex, setLineIndex] = useState(reduceMotion ? lines.length : 0);
   const [charCount, setCharCount] = useState(0);
@@ -163,10 +162,14 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
         return;
       }
       const current = lines[line];
-      if (current.kind === "cmd" && chars < current.text.length) {
+      if ((current.kind === "cmd" || current.kind === "prompt") && chars < current.text.length) {
+        // The prompt line sits as a bare "> " beat first, then types in
+        // (operator direction 2026-07-13: end on the arrow; if the viewer
+        // is still watching, type a Hello World).
+        const delay = current.kind === "prompt" && chars === 0 ? 1600 : TYPE_MS;
         chars += 1;
         setCharCount(chars);
-        timer = window.setTimeout(step, TYPE_MS);
+        timer = window.setTimeout(step, delay);
         return;
       }
       line += 1;
@@ -228,12 +231,11 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
       );
     }
     if (line.kind === "prompt") {
+      const shown = partial ? line.text.slice(0, charCount) : line.text;
       return (
         <p key={i} className="border-t border-[var(--rule-soft)] pt-3 font-mono text-[12px] sm:text-[13px]">
           <span className="text-[var(--acc-artifact)]">&gt;</span>{" "}
-          <span className="text-[var(--ink-2)]">
-            {t(locale, "이 레포 점검하고 릴리스 블로커 요약해줘", "inspect this repo and summarize release blockers")}
-          </span>
+          <span className="text-[var(--ink-2)]">{shown}</span>
           <span className="geodi-caret ml-1 inline-block h-[13px] w-[7px] translate-y-[2px] bg-[var(--acc-artifact)]" />
         </p>
       );
@@ -257,7 +259,8 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
       </div>
       <div ref={bodyRef} className="h-[248px] overflow-hidden px-5 py-4 sm:px-7">
         {lines.slice(0, lineIndex).map((line, i) => renderLine(line, i, false))}
-        {lineIndex < lines.length && lines[lineIndex].kind === "cmd" && charCount > 0
+        {lineIndex < lines.length &&
+        ((lines[lineIndex].kind === "cmd" && charCount > 0) || lines[lineIndex].kind === "prompt")
           ? renderLine(lines[lineIndex], lineIndex, true)
           : null}
       </div>

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.322",
+    "date": "2026-07-13",
+    "body": "### Changed\n\n- **Install terminal prompt ends on the bare arrow, then types \"Hello\n  World\" (operator-directed).** The Homebrew tab's first-prompt line no\n  longer pre-fills a task sentence; it rests as `>` with the caret for a\n  beat, and if the viewer is still watching, \"Hello World\" types in\n  character by character before the replay loop resets."
+  },
+  {
     "version": "0.99.321",
     "date": "2026-07-13",
     "body": "### Changed\n\n- **Portfolio hero terminal folded into the install section\n  (operator-directed).** The standalone hero terminal (brew install, first\n  launch, welcome, first prompt) and the \"every way to install\" Homebrew tab\n  showed near-duplicate transcripts; the install section now carries the full\n  hero sequence on its Homebrew tab (typed command, install output, Geodi\n  welcome banner, first prompt with caret) and the hero keeps only the\n  statement and calls to action. The abridged-transcript caption moved into\n  the channel note; dead `TerminalMock`/`INSTALL_LINES` removed."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.321",
+  version: "0.99.322",
   syncedAt: "2026-07-13",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.321"
+version = "0.99.322"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
운영자 지시: Homebrew 탭 첫 프롬프트 라인에서 "inspect this repo..." 프리필 제거. `>`+캐럿으로 잠시 머문 뒤(1.6s 비트), 계속 보고 있으면 "Hello World"가 한 글자씩 타이핑된다.

## Why
프리필 문장은 프롬프트가 이미 입력된 인상 — 빈 화살표가 "여기에 자연어를 친다"는 초대에 가깝다.

## Changes

### Core Changes (Code)
- `site/src/app/portfolio/page.tsx`: prompt 라인에 `text: "Hello World"`; 타이핑 브랜치가 cmd·prompt 겸용(prompt 첫 글자 전 1600ms 홀드); prompt 렌더가 typed slice+상시 캐럿; partial 렌더 조건에 prompt 포함(charCount 0에서 빈 화살표 비트); InstallTerminal의 미사용 locale 제거.

### Documentation/Config Changes
- CHANGELOG [0.99.322] + 5-location 스탬프 + sync-stats/llms 재생성.

## Impact Scope
- **Affected**: site/(포트폴리오 페이지). 런타임 0.
- **Backward compatibility**: N/A.
- **Test changes**: 0.

## Design Decisions
- reduced-motion은 완성 상태("> Hello World") 정적 렌더 — 기존 계약 유지.

## Verification
- `npx next build` → 232 pages, 0 error
- puppeteer 실스크롤 캡처: 빈 화살표 비트, "Hello World" 풀 타이핑+캐럿 확인
- `check_llms_version.py` → clean (v0.99.322)

🤖 Generated with [Claude Code](https://claude.com/claude-code)