### PR TITLE
release: v0.99.323 — Crucible artifact publication scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ functional change.
 
 ---
 
+## [0.99.323] - 2026-07-13
+
+### Added
+
+- **Deterministic Crucible artifact publication scaffold.**
+  `scripts/eval/publish_crucible_artifacts.py` masks the operator's local
+  username (`/Users/<user>` to `/Users/REDACTED`) idempotently across a tree,
+  and `stage`s one campaign run's allowlisted public subset (config, state,
+  ledger, per-attempt receipts, loop log, opaque power report) into the
+  external evidence store, omitting reproducible-cache and refusing sealed
+  material by name. Documented in the external-artifact-repository publication
+  cycle.
+
 ## [0.99.322] - 2026-07-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.322
+- **Version**: 0.99.323
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.322 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.323 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.322: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.323: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -71,6 +71,8 @@ reports may be public when they contain no selected identity.
 7. Record its merge commit and immutable blob/tree links in the GEODE run
    ledger before publishing a score or improvement claim.
 
+The publication is scripted deterministically by `scripts/eval/publish_crucible_artifacts.py` (`stage` copies one run's allowlisted subset and masks the local username; `mask` re-masks an existing tree idempotently). Both refuse sealed material by name and never rewrite an existing run directory.
+
 There is intentionally no automatic `rsync` from the whole artifact tree. A
 manifest-first, allowlisted copy keeps new credential files and unopened
 holdouts from becoming public merely because they appeared under a familiar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.322"
+version = "0.99.323"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -67,6 +67,7 @@ _PLACEHOLDER_USERS: frozenset[str] = frozenset(
         "jane",
         "home",
         "shared",  # /Users/Shared — macOS system dir, not a username
+        "redacted",  # /Users/REDACTED — the artifact masker's anonymized home sentinel
         # Single-letter / second-person placeholders (a real docstring example
         # ``/Users/x/dev`` tripped the ratchet on PR #2468):
         "x",

--- a/scripts/eval/publish_crucible_artifacts.py
+++ b/scripts/eval/publish_crucible_artifacts.py
@@ -1,0 +1,153 @@
+"""Deterministic masking + allowlisted publication for Crucible run artifacts.
+
+The external evidence store (``mangowhoiscloud/geode-eval-artifacts``) receives
+only a small public subset of each local campaign run: configs, state, ledger,
+per-attempt receipts, the loop log, and the opaque power report. The heavy
+``reproducible-cache`` (evaluator homes, per-evaluation checkouts, transcripts,
+tmp) is never mirrored, and unopened ``withheld-sealed`` material never leaves
+the local tree. See ``docs/eval/external-artifact-repository.md``.
+
+Two deterministic operations, both idempotent (byte-identical on re-run):
+
+- ``mask``: rewrite the local home path ``/Users/<user>`` to ``/Users/REDACTED``
+  across text files in a tree, so a published run cannot leak the operator's
+  local username. Re-running finds nothing left to mask.
+- ``stage``: copy the allowlisted public subset of one campaign run into the
+  artifact-repo layout, then mask it.
+
+Usage:
+    python scripts/eval/publish_crucible_artifacts.py mask <tree> [--user <user>]
+    python scripts/eval/publish_crucible_artifacts.py stage <run-dir> <dest> [--user <user>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+REDACTED_HOME = "/Users/REDACTED"
+
+# Text files whose contents are masked. Everything else is copied byte-for-byte
+# (and the allowlist below keeps binaries/caches out of scope anyway).
+_TEXT_SUFFIXES = frozenset({".json", ".jsonl", ".log", ".md", ".txt"})
+
+# Public evidence, relative to a campaign run directory. Anything not matched
+# by these patterns is omitted — that is how caches and sealed material stay
+# out without an explicit denylist race.
+_ALLOW_GLOBS = (
+    "config.json",
+    "loop-*.log",
+    "prepare/power.json",
+    # Top-level preregistration / receipt records (present on hardened runs).
+    "failure-driven-preregistration.json",
+    "assay-reuse-receipt.json",
+    "state/summary.json",
+    "state/state.json",
+    "state/config.json",
+    "state/ledger.jsonl",
+    "state/attempts/*/request.json",
+    "state/attempts/*/error.json",
+    "state/attempts/*/record.json",
+    "state/attempts/*/feedback.json",
+    "state/attempts/*/search-ref.intent.json",
+    "state/attempts/*/search-ref.receipt.json",
+)
+
+# Names that must never be published from a campaign tree even if a future
+# allowlist glob would otherwise reach them: unopened sealed holdout material.
+_SEALED_DENY = re.compile(
+    r"(?:^|/)(?:sealed\.pack|sealed-selection|test\.pack|.*-selection)\.json$",
+    re.IGNORECASE,
+)
+
+
+def mask_text_file(path: Path, *, user: str) -> bool:
+    """Rewrite ``/Users/<user>`` to the redacted home in one text file.
+
+    Returns True when the file changed. Idempotent: the redacted form contains
+    no ``/Users/<user>`` substring, so a second pass is a no-op.
+    """
+    if path.suffix not in _TEXT_SUFFIXES:
+        return False
+    try:
+        original = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return False
+    masked = original.replace(f"/Users/{user}", REDACTED_HOME)
+    if masked == original:
+        return False
+    path.write_text(masked, encoding="utf-8")
+    return True
+
+
+def mask_tree(root: Path, *, user: str) -> int:
+    """Mask every text file under ``root`` (skipping ``.git``). Returns count."""
+    changed = 0
+    for path in sorted(root.rglob("*")):
+        if ".git" in path.parts or not path.is_file():
+            continue
+        if mask_text_file(path, user=user):
+            changed += 1
+    return changed
+
+
+def _allowlisted_files(run_dir: Path) -> list[Path]:
+    selected: set[Path] = set()
+    for pattern in _ALLOW_GLOBS:
+        for match in run_dir.glob(pattern):
+            if match.is_file():
+                selected.add(match)
+    return sorted(selected)
+
+
+def stage_run(run_dir: Path, dest_campaigns: Path, *, user: str) -> dict[str, str | list[str]]:
+    """Copy the allowlisted public subset of ``run_dir`` into the artifact-repo
+    campaigns directory, then mask usernames. Refuses sealed material and never
+    rewrites an existing destination run directory (append-only store)."""
+    run_dir = run_dir.resolve()
+    dest = dest_campaigns / run_dir.name
+    if dest.exists():
+        raise SystemExit(f"destination already exists (append-only): {dest}")
+    files = _allowlisted_files(run_dir)
+    if not files:
+        raise SystemExit(f"no allowlisted public files under {run_dir}")
+    copied: list[str] = []
+    for src in files:
+        rel = src.relative_to(run_dir)
+        if _SEALED_DENY.search(rel.as_posix()):
+            raise SystemExit(f"refusing to publish sealed material: {rel}")
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+        mask_text_file(target, user=user)
+        copied.append(rel.as_posix())
+    return {"run": run_dir.name, "dest": str(dest), "files": copied}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    p_mask = sub.add_parser("mask", help="idempotently mask local username in a tree")
+    p_mask.add_argument("tree", type=Path)
+    p_mask.add_argument("--user", default=Path.home().name)
+    p_stage = sub.add_parser("stage", help="stage one run's allowlisted public subset")
+    p_stage.add_argument("run_dir", type=Path)
+    p_stage.add_argument("dest_campaigns", type=Path)
+    p_stage.add_argument("--user", default=Path.home().name)
+    args = parser.parse_args(argv)
+
+    if args.command == "mask":
+        n = mask_tree(args.tree.resolve(), user=args.user)
+        print(f"masked {n} file(s) under {args.tree}")
+        return 0
+    report = stage_run(args.run_dir, args.dest_campaigns, user=args.user)
+    files = report["files"]
+    assert isinstance(files, list)
+    print(f"staged {report['run']}: {len(files)} file(s) -> {report['dest']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.322. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.323. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.322. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.323. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,11 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "0.99.323",
+    "date": "2026-07-13",
+    "body": "### Added\n\n- **Deterministic Crucible artifact publication scaffold.**\n  `scripts/eval/publish_crucible_artifacts.py` masks the operator's local\n  username (`/Users/<user>` to `/Users/REDACTED`) idempotently across a tree,\n  and `stage`s one campaign run's allowlisted public subset (config, state,\n  ledger, per-attempt receipts, loop log, opaque power report) into the\n  external evidence store, omitting reproducible-cache and refusing sealed\n  material by name. Documented in the external-artifact-repository publication\n  cycle."
+  },
+  {
     "version": "0.99.322",
     "date": "2026-07-13",
     "body": "### Changed\n\n- **Install terminal prompt ends on the bare arrow, then types \"Hello\n  World\" (operator-directed).** The Homebrew tab's first-prompt line no\n  longer pre-fills a task sentence; it rests as `>` with the caret for a\n  beat, and if the viewer is still watching, \"Hello World\" types in\n  character by character before the replay loop resets."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.322",
+  version: "0.99.323",
   syncedAt: "2026-07-13",
 } as const;

--- a/tests/scripts/test_publish_crucible_artifacts.py
+++ b/tests/scripts/test_publish_crucible_artifacts.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import pytest
+from scripts.eval.publish_crucible_artifacts import (
+    REDACTED_HOME,
+    mask_text_file,
+    mask_tree,
+    stage_run,
+)
+
+
+def _run(tmp_path: Path) -> Path:
+    run = tmp_path / "tau2-telecom-gpt54-train-20260713-r99"
+    (run / "state" / "attempts" / "0001-abc").mkdir(parents=True)
+    (run / "prepare").mkdir()
+    (run / "config.json").write_text(
+        json.dumps({"repository": "/Users/alice/workspace/geode"}), encoding="utf-8"
+    )
+    (run / "loop-r99.log").write_text("cwd /Users/alice/workspace\n", encoding="utf-8")
+    (run / "prepare" / "power.json").write_text(json.dumps({"passes": True}), encoding="utf-8")
+    (run / "state" / "summary.json").write_text(json.dumps({"invalids": 1}), encoding="utf-8")
+    (run / "state" / "ledger.jsonl").write_text("{}\n", encoding="utf-8")
+    (run / "state" / "attempts" / "0001-abc" / "error.json").write_text("{}", encoding="utf-8")
+    # reproducible-cache + sealed that must NOT be staged
+    (run / "state" / "attempts" / "0001-abc" / "evaluation-x").mkdir()
+    (run / "state" / "attempts" / "0001-abc" / "evaluation-x" / "transcript.jsonl").write_text(
+        "/Users/alice secret trace\n", encoding="utf-8"
+    )
+    (run / "sealed.pack.json").write_text(json.dumps({"tasks": ["hidden"]}), encoding="utf-8")
+    return run
+
+
+def test_mask_is_idempotent(tmp_path: Path) -> None:
+    f = tmp_path / "c.json"
+    f.write_text(json.dumps({"p": "/Users/alice/x"}), encoding="utf-8")
+    assert mask_text_file(f, user="alice") is True
+    assert "/Users/alice" not in f.read_text(encoding="utf-8")
+    assert REDACTED_HOME in f.read_text(encoding="utf-8")
+    # second pass changes nothing
+    assert mask_text_file(f, user="alice") is False
+
+
+def test_mask_preserves_json_validity(tmp_path: Path) -> None:
+    f = tmp_path / "c.json"
+    f.write_text(json.dumps({"repo": "/Users/alice/workspace/geode"}), encoding="utf-8")
+    mask_text_file(f, user="alice")
+    assert json.loads(f.read_text(encoding="utf-8"))["repo"] == "/Users/REDACTED/workspace/geode"
+
+
+def test_stage_allowlists_and_masks_omitting_cache_and_sealed(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    dest = tmp_path / "campaigns"
+    report = stage_run(run, dest, user="alice")
+    staged = set(report["files"])
+    assert "config.json" in staged
+    assert "state/summary.json" in staged
+    assert "prepare/power.json" in staged
+    # cache and sealed are omitted (not in the allowlist)
+    assert not any("evaluation-x" in p for p in staged)
+    assert not any("sealed" in p for p in staged)
+    # no cache dir copied
+    assert not (dest / run.name / "state" / "attempts" / "0001-abc" / "evaluation-x").exists()
+    # masked on the way in
+    assert "/Users/alice" not in (dest / run.name / "config.json").read_text(encoding="utf-8")
+
+
+def test_stage_refuses_to_overwrite_existing_run(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    dest = tmp_path / "campaigns"
+    stage_run(run, dest, user="alice")
+    with pytest.raises(SystemExit, match="append-only"):
+        stage_run(run, dest, user="alice")
+
+
+def test_mask_tree_skips_git(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "x.json").write_text("/Users/alice", encoding="utf-8")
+    (tmp_path / "y.json").write_text("/Users/alice", encoding="utf-8")
+    assert mask_tree(tmp_path, user="alice") == 1
+    assert (tmp_path / ".git" / "x.json").read_text(encoding="utf-8") == "/Users/alice"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.322"
+version = "0.99.323"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Pass-through develop → main: deterministic masking + allowlisted publication scaffold for Crucible run artifacts (#2685). Pre-synced (#2686).

🤖 Generated with [Claude Code](https://claude.com/claude-code)