### PR TITLE
fix(crucible): resume only clean checkpoint rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ functional change.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Crucible infrastructure-safe checkpoint resume.** Tau2 row checkpoints now
+  reject source-attested pre-execution retries both when harvesting and when
+  loading legacy cache entries. A contaminated-arm fail-fast still terminates
+  the paid process group immediately, but now emits hash-bound INVALID
+  evidence and observed marginal usage so the supervisor records
+  `infrastructure_contamination` and can authorize an exact-candidate replay
+  without scoring or reusing the contaminated row.
+
 ## [0.99.323] - 2026-07-13
 
 ### Added

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -68,25 +68,25 @@
       "id": "file:plugins/crucible/tau2_live.py",
       "filePath": "plugins/crucible/tau2_live.py",
       "name": "Paired tau2 evaluator",
-      "summary": "Derives frozen runner arguments, screens unreachable train arms at zero candidate cost, isolates measurement state, and projects structural failure codes. Reuses identity-proven cached rows across relaunches, aborts the paid process group after finalized infrastructure contamination, and reports historical evidence usage separately from current marginal spend.",
+      "summary": "Derives frozen runner arguments, screens unreachable train arms at zero candidate cost, isolates measurement state, and projects structural failure codes. Reuses identity-proven cached rows across relaunches, stops the paid process group after finalized infrastructure contamination, and converts that stop into structured INVALID evidence with observed marginal usage.",
       "tags": [
         "crucible",
         "evaluator",
         "paired"
       ],
-      "contentSha256": "26bd5e744206ccdda7f2e5d7ba466b423176fa8cef11572cc4ba5bd568211070"
+      "contentSha256": "afdec9ac53cba90beb30db5bfb43ba64ce391ca34a79e51f94599212b6cb9d62"
     },
     {
       "id": "file:plugins/crucible/row_cache.py",
       "filePath": "plugins/crucible/row_cache.py",
       "name": "Hash-bound row cache",
-      "summary": "Reuses only semantic tau2 rows whose full measurement identity and row/context payload hashes verify; infrastructure placeholders remain missing work.",
+      "summary": "Reuses only infrastructure-clean semantic tau2 rows whose full measurement identity and row/context payload hashes verify; placeholders and source-attested retry rows remain missing work.",
       "tags": [
         "cache",
         "crucible",
         "recovery"
       ],
-      "contentSha256": "0d00c23707464900c956fd280c77406a7e825520b1cb866ec3c79b1b9a79043a"
+      "contentSha256": "d82eb18f8c24eb7a694653ef09b63d84b299ebf3981a4e4012e84be42943beaa"
     },
     {
       "id": "file:plugins/crucible/supervisor.py",
@@ -127,13 +127,13 @@
       "id": "file:plugins/crucible/program.md",
       "filePath": "plugins/crucible/program.md",
       "name": "Crucible program",
-      "summary": "Centralizes experimentation, constraints, preferences, setup, power admission, deduplication, usage accounting, and the closed dynamic-feedback boundary; only its candidate_program section is model-facing.",
+      "summary": "Centralizes experimentation, constraints, preferences, setup, power admission, deduplication, infrastructure-safe checkpoint reuse, usage accounting, and the closed dynamic-feedback boundary; only its candidate_program section is model-facing.",
       "tags": [
         "crucible",
         "producer",
         "program"
       ],
-      "contentSha256": "e65ffb18e00c929ec0eefbacd3961308fe3d1d1f0ac42f7b630b11b11c59aad1"
+      "contentSha256": "89da5d165957532038c02d93a3e1c9d0bce867103545ce20e49ab2f652dbbc81"
     },
     {
       "id": "file:plugins/crucible/producers/replay.py",

--- a/plugins/crucible/program.md
+++ b/plugins/crucible/program.md
@@ -72,7 +72,8 @@ and fail closed when prose and bytes disagree.
   test is required before eligibility; neither verdict can move a repository
   branch or release.
 - Cached rows are reusable only when revision, evaluator, harness, task pack,
-  and assay hashes match and both row and context payload hashes verify.
+  and assay hashes match, both payload hashes verify, and the row carries no
+  infrastructure termination or source-attested pre-execution retry.
 - A scoreless infrastructure `INVALID` replay preserves the exact candidate
   revision when its parent is unchanged, so candidate-side cached rows remain
   addressable. An evaluator-revision replay becomes a new child commit.
@@ -109,9 +110,12 @@ and fail closed when prose and bytes disagree.
    a provider guarantee.
 5. Run the supervisor. Baseline executes first, and an unreachable promotion
    rejects the candidate arm without spending it.
-6. With `CRUCIBLE_ROW_CACHE_ROOT` explicitly allowlisted, identity-proven
-   semantic rows may be reused. Missing tasks run again and exact full coverage
-   remains mandatory. Historical evidence usage stays attached to the verdict;
+6. With `CRUCIBLE_ROW_CACHE_ROOT` explicitly allowlisted, identity-proven,
+   infrastructure-clean semantic rows may be reused. Missing tasks run again
+   and exact full coverage remains mandatory. A fail-fast infrastructure stop
+   emits structured INVALID evidence and observed marginal usage, allowing a
+   new campaign to replay the exact candidate without making the interrupted
+   row score-bearing. Historical evidence usage stays attached to the verdict;
    only fresh marginal usage consumes the current campaign budget.
 7. Build a train bundle only after `KEEP`. Burn the sealed test attempt once,
    then require a separate human-reviewed core promotion change.

--- a/plugins/crucible/row_cache.py
+++ b/plugins/crucible/row_cache.py
@@ -34,7 +34,11 @@ from typing import Any, Literal
 from .artifacts import load_json_object, write_exclusive_json
 from .contract import ContractError, ExperimentContract
 from .evidence import expected_pairs
-from .verifiers.tau2 import SNAPSHOT_SCHEMA, TAU2_ADAPTER
+from .verifiers.tau2 import (
+    SNAPSHOT_SCHEMA,
+    TAU2_ADAPTER,
+    tau2_has_infrastructure_contamination,
+)
 
 ROW_SCHEMA = "crucible.cached-row.v1"
 CONTEXT_SCHEMA = "crucible.cached-arm-context.v2"
@@ -67,6 +71,20 @@ def _row_filename(task_id: str, trial: int) -> str:
     return f"{safe}__{digest}__{trial}.json"
 
 
+def _cacheable_simulation(row: Mapping[str, Any]) -> bool:
+    """Return whether one finalized row is safe to reuse as a measurement."""
+
+    reason = str(row.get("termination_reason") or "").strip()
+    if not reason:
+        return False
+    try:
+        if TAU2_ADAPTER.classify_termination(reason) != "semantic":
+            return False
+        return not tau2_has_infrastructure_contamination({"simulations": [row]})
+    except ContractError:
+        return False
+
+
 def _completed_simulations(raw: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     """Return only finalized semantic rows that may be reused as measurements.
 
@@ -88,14 +106,7 @@ def _completed_simulations(raw: Mapping[str, Any]) -> list[Mapping[str, Any]]:
             continue
         if isinstance(row.get("trial"), bool) or not isinstance(row.get("trial"), int):
             continue
-        reason = str(row.get("termination_reason") or "").strip()
-        if not reason:
-            continue
-        try:
-            termination_class = TAU2_ADAPTER.classify_termination(reason)
-        except ContractError:
-            continue
-        if termination_class == "infra":
+        if not _cacheable_simulation(row):
             continue
         rows.append(row)
     return rows
@@ -182,6 +193,8 @@ def _verified_row(path: Path, identity: Mapping[str, str]) -> Mapping[str, Any] 
     if stored.get("task_id") != str(task_id) or stored.get("trial") != trial:
         return None
     if stored.get("row_sha256") != _canonical_sha256(json.loads(json.dumps(simulation))):
+        return None
+    if not _cacheable_simulation(simulation):
         return None
     return simulation
 

--- a/plugins/crucible/tau2_live.py
+++ b/plugins/crucible/tau2_live.py
@@ -38,6 +38,7 @@ from .row_cache import (
 from .sealed import SEALED_RESPONSE_SCHEMA, SealedInfrastructureError, SealedPlan
 from .supervisor import CandidateProposal, FailureFeedback, _file_sha256
 from .verifiers.tau2 import (
+    SNAPSHOT_SCHEMA,
     TAU2_ADAPTER,
     normalize_tau2_results,
     tau2_has_infrastructure_contamination,
@@ -69,6 +70,7 @@ _AFFIRMATIVE = re.compile(
 _SKIPPED_ARM_SCHEMA = "crucible.skipped-arm.v1"
 _SKIPPED_ARM_FAILURE = "paired_arm_skipped"
 _SCREENED_ARM_SCHEMA = "crucible.screened-arm.v1"
+_INFRASTRUCTURE_FAILURE = "tau2_infrastructure_error"
 
 
 class Tau2InfrastructureError(RuntimeError):
@@ -361,6 +363,32 @@ def _terminate_process_group(process: subprocess.Popen[bytes]) -> int:
         return process.wait()
 
 
+def _infrastructure_abort_snapshot(
+    contract: ExperimentContract,
+    *,
+    arm: Literal["baseline", "candidate"],
+    raw_sha256: str,
+) -> dict[str, Any]:
+    """Bind a fail-fast partial artifact to the frozen measurement identity."""
+
+    revision_field = "baseline_sha" if arm == "baseline" else "candidate_sha"
+    revision = contract.baseline_sha if arm == "baseline" else contract.candidate_sha
+    return {
+        "schema": SNAPSHOT_SCHEMA,
+        "experiment_contract_id": contract.contract_id,
+        "evaluator_sha256": contract.evaluator_sha256,
+        "harness_sha256": contract.harness_sha256,
+        "task_pack_sha256": contract.task_pack_sha256,
+        "assay_config_sha256": contract.assay_config_sha256,
+        "arm": arm,
+        revision_field: revision,
+        "raw_artifact_sha256": raw_sha256,
+        "assay_config": json.loads(json.dumps(contract.assay_config)),
+        "execution_status": "invalid",
+        "failure_class": _INFRASTRUCTURE_FAILURE,
+    }
+
+
 def _run_tau2_command(
     command: list[str],
     *,
@@ -525,13 +553,8 @@ def _run_arm(
             raise TimeoutError(f"tau2 {arm} arm timed out") from exc
         elapsed = time.monotonic() - started
         runner_returncode = completed.returncode
-        if infrastructure_abort:
-            _harvest_partial(cache_root, contract, revision_sha, harness_root, run_id)
-            raise Tau2InfrastructureError(
-                f"tau2 {arm} arm aborted after finalized infrastructure contamination"
-            )
         snapshot = snapshot_dir / f"{run_id}.snapshot.json"
-        if not source_raw.is_file() or not snapshot.is_file():
+        if not source_raw.is_file() or (not infrastructure_abort and not snapshot.is_file()):
             # tau2 finalizes each simulation into results.json incrementally;
             # an interrupted arm still donates its completed rows (r23: 18
             # finished executions were discarded for want of this line).
@@ -568,6 +591,16 @@ def _run_arm(
             )
         else:
             shutil.copyfile(source_raw, raw_path)
+        if infrastructure_abort:
+            snapshot = snapshot_dir / f"{run_id}.aborted.snapshot.json"
+            write_exclusive_json(
+                snapshot,
+                _infrastructure_abort_snapshot(
+                    contract,
+                    arm=arm,
+                    raw_sha256=_file_sha256(raw_path, f"{arm} aborted raw"),
+                ),
+            )
         if cache_root is not None:
             harvest_arm_rows(cache_root, contract, revision_sha=revision_sha, raw_results=fresh)
     raw = load_json_object(raw_path, f"tau2 {arm} raw", max_bytes=512 * 1024 * 1024)

--- a/tests/plugins/crucible/test_row_cache.py
+++ b/tests/plugins/crucible/test_row_cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +47,19 @@ def _simulation(
         "reward_info": {"reward": reward},
         "messages": [],
     }
+
+
+def _with_pre_execution_retry(row: dict) -> dict:
+    row["messages"] = [
+        {
+            "role": "assistant",
+            "raw_data": {
+                "geode_pre_execution_retry_count": 1,
+                "geode_pre_execution_retry_errors": ["APITimeoutError"],
+            },
+        }
+    ]
+    return row
 
 
 def _partial_raw(rows: list[dict]) -> dict:
@@ -107,6 +121,49 @@ def test_harvest_excludes_r23_infrastructure_placeholders(tmp_path: Path) -> Non
     rows = cached_rows(tmp_path, contract, revision_sha=contract.candidate_sha)
     assert set(rows) == {("task-b", 0)}
     assert missing_task_ids(contract, rows) == ["task-a", "task-c"]
+
+
+def test_harvest_excludes_finalized_pre_execution_retry_rows(tmp_path: Path) -> None:
+    contract = _StubContract(trials_per_task=1)
+    stored = harvest_arm_rows(
+        tmp_path,
+        contract,
+        revision_sha=contract.baseline_sha,
+        raw_results=_partial_raw(
+            [
+                _simulation("task-b", 0, reward=1.0),
+                _with_pre_execution_retry(_simulation("task-a", 0, reward=1.0)),
+            ]
+        ),
+    )
+
+    assert stored == 1
+    rows = cached_rows(tmp_path, contract, revision_sha=contract.baseline_sha)
+    assert set(rows) == {("task-b", 0)}
+    assert missing_task_ids(contract, rows) == ["task-a", "task-c"]
+
+
+def test_lookup_rejects_integrity_valid_legacy_retry_row(tmp_path: Path) -> None:
+    contract = _StubContract(trials_per_task=1)
+    harvest_arm_rows(
+        tmp_path,
+        contract,
+        revision_sha=contract.baseline_sha,
+        raw_results=_partial_raw([_simulation("task-a", 0, reward=1.0)]),
+    )
+    row_path = next(path for path in tmp_path.rglob("*.json") if path.name != "context.json")
+    stored = json.loads(row_path.read_text(encoding="utf-8"))
+    _with_pre_execution_retry(stored["simulation"])
+    encoded = json.dumps(
+        stored["simulation"],
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    stored["row_sha256"] = hashlib.sha256(encoded).hexdigest()
+    row_path.write_text(json.dumps(stored), encoding="utf-8")
+
+    assert cached_rows(tmp_path, contract, revision_sha=contract.baseline_sha) == {}
 
 
 def test_harvest_ignores_unknown_termination_instead_of_masking_abort(tmp_path: Path) -> None:

--- a/tests/plugins/crucible/test_tau2_live.py
+++ b/tests/plugins/crucible/test_tau2_live.py
@@ -34,6 +34,7 @@ from plugins.crucible.row_cache import harvest_arm_rows
 from plugins.crucible.tau2_live import (
     Tau2InfrastructureError,
     _index_simulations,
+    _infrastructure_abort_snapshot,
     _run_arm,
     _run_tau2_command,
     _train_evaluation_response,
@@ -43,6 +44,7 @@ from plugins.crucible.tau2_live import (
     tau2_failure_feedback,
     tau2_trace_checks,
 )
+from plugins.crucible.verifiers.tau2 import _verify_snapshot
 
 TASKS = (
     TaskUnit("task-1", "1" * 64, "a" * 64),
@@ -124,6 +126,25 @@ def test_command_evaluator_entrypoint_uses_the_frozen_uv_runtime() -> None:
         .splitlines()[0]
         == "#!/usr/bin/env -S uv run --frozen --no-dev python"
     )
+
+
+def test_infrastructure_abort_snapshot_is_accepted_by_frozen_verifier() -> None:
+    contract = _contract()
+    raw_sha256 = "a" * 64
+
+    status, failure_class = _verify_snapshot(
+        contract,
+        arm="baseline",
+        raw_sha256=raw_sha256,
+        snapshot=_infrastructure_abort_snapshot(
+            contract,
+            arm="baseline",
+            raw_sha256=raw_sha256,
+        ),
+    )
+
+    assert status == "invalid"
+    assert failure_class == "tau2_infrastructure_error"
 
 
 def test_command_evaluator_emits_paths_relative_to_response_directory(
@@ -452,7 +473,7 @@ def test_run_arm_preserves_finalized_invalid_evidence_after_nonzero_exit(
     assert (output / "baseline.evidence.json").is_file()
 
 
-def test_run_arm_aborts_immediately_after_infrastructure_contamination(
+def test_run_arm_emits_invalid_evidence_after_infrastructure_fail_fast(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -469,17 +490,27 @@ def test_run_arm_aborts_immediately_after_infrastructure_contamination(
         ),
     )
 
-    with pytest.raises(Tau2InfrastructureError, match="aborted after finalized"):
-        _run_arm(
-            contract,
-            arm="baseline",
-            checkout=checkout,
-            harness_root=harness,
-            contract_path=tmp_path / "contract.json",
-            output_dir=output,
-            run_id="fixture-run",
-            timeout=10.0,
-        )
+    evidence, raw_path, marginal_usage = _run_arm(
+        contract,
+        arm="baseline",
+        checkout=checkout,
+        harness_root=harness,
+        contract_path=tmp_path / "contract.json",
+        output_dir=output,
+        run_id="fixture-run",
+        timeout=10.0,
+    )
+
+    snapshot = json.loads(
+        (output / "snapshots" / "fixture-run.aborted.snapshot.json").read_text(encoding="utf-8")
+    )
+    assert evidence.execution_status == "invalid"
+    assert raw_path == output / "baseline.raw.json"
+    assert marginal_usage.calls == 1
+    assert marginal_usage.tokens == 10
+    assert snapshot["execution_status"] == "invalid"
+    assert snapshot["failure_class"] == "tau2_infrastructure_error"
+    assert snapshot["raw_artifact_sha256"] == hashlib.sha256(raw_path.read_bytes()).hexdigest()
 
 
 def test_run_arm_accounts_for_actual_subprocess_elapsed_time(


### PR DESCRIPTION
## Summary
- Reject infrastructure-contaminated tau2 rows at both checkpoint harvest and cache load.
- Convert contaminated-arm fail-fast into structured INVALID evidence with observed marginal usage.
- Preserve exact-candidate replay while keeping the interrupted row non-score-bearing.

## Why
r34 recovered from an `APITimeoutError`, correctly fail-fast stopped the paid arm, but the retry-bearing row was cached and the evaluator exited before emitting a structured verdict. That combination could re-inject the contaminated row and prevented mechanically authorized replay.

## GAP Audit
| Gap | Before | After |
|---|---|---|
| Cache admission | Semantic termination alone could admit retry-bearing rows | Harvest and load both require infrastructure-clean telemetry |
| Fail-fast receipt | Process exit produced generic `invalid_attempt` | Hash-bound INVALID evidence and marginal usage reach the supervisor |
| Resume authority | Source attempt could not satisfy replay attestation | Normal `infrastructure_contamination` verdict authorizes exact replay |

## Changes
| File | Change |
|---|---|
| `plugins/crucible/row_cache.py` | Fail-closed write/read filtering for retry-bearing rows |
| `plugins/crucible/tau2_live.py` | Invalid snapshot and structured fail-fast completion |
| `plugins/crucible/program.md` | Document infrastructure-clean checkpoint semantics |
| `plugins/crucible/producers/context_graph.json` | Refresh source attestations |
| tests / CHANGELOG | Regression coverage and release note |

## Verification
- Crucible test suite passed.
- ruff check/format passed across core, tests, plugins, and scripts.
- mypy passed across 521 source files.
- lint-imports 4/4, repo hygiene, version, and diff checks passed.
- Full non-live run: 9,491 passed, 64 skipped; one transient Git fixture and four audit-extra tests were rerun successfully (the latter with `--extra audit`).
- No live/provider test was run in this feature branch.