### PR TITLE
chore(release): v0.99.324 checkpoint resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,6 @@ functional change.
 
 ---
 
-## [Unreleased]
-
 ## [0.99.324] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.324] - 2026-07-13
+
 ### Fixed
 
 - **Crucible infrastructure-safe checkpoint resume.** Tau2 row checkpoints now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.323
+- **Version**: 0.99.324
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.323 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.324 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.323: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.324: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.323"
+version = "0.99.324"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.323. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.324. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.323. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.324. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,11 +17,6 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    "version": "Unreleased",
-    "date": "",
-    "body": ""
-  },
-  {
     "version": "0.99.324",
     "date": "2026-07-13",
     "body": "### Fixed\n\n- **Crucible infrastructure-safe checkpoint resume.** Tau2 row checkpoints now\n  reject source-attested pre-execution retries both when harvesting and when\n  loading legacy cache entries. A contaminated-arm fail-fast still terminates\n  the paid process group immediately, but now emits hash-bound INVALID\n  evidence and observed marginal usage so the supervisor records\n  `infrastructure_contamination` and can authorize an exact-candidate replay\n  without scoring or reusing the contaminated row."

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -17,6 +17,16 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    "version": "Unreleased",
+    "date": "",
+    "body": ""
+  },
+  {
+    "version": "0.99.324",
+    "date": "2026-07-13",
+    "body": "### Fixed\n\n- **Crucible infrastructure-safe checkpoint resume.** Tau2 row checkpoints now\n  reject source-attested pre-execution retries both when harvesting and when\n  loading legacy cache entries. A contaminated-arm fail-fast still terminates\n  the paid process group immediately, but now emits hash-bound INVALID\n  evidence and observed marginal usage so the supervisor records\n  `infrastructure_contamination` and can authorize an exact-candidate replay\n  without scoring or reusing the contaminated row."
+  },
+  {
     "version": "0.99.323",
     "date": "2026-07-13",
     "body": "### Added\n\n- **Deterministic Crucible artifact publication scaffold.**\n  `scripts/eval/publish_crucible_artifacts.py` masks the operator's local\n  username (`/Users/<user>` to `/Users/REDACTED`) idempotently across a tree,\n  and `stage`s one campaign run's allowlisted public subset (config, state,\n  ledger, per-attempt receipts, loop log, opaque power report) into the\n  external evidence store, omitting reproducible-cache and refusing sealed\n  material by name. Documented in the external-artifact-repository publication\n  cycle."

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "0.99.323",
+  version: "0.99.324",
   syncedAt: "2026-07-13",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.323"
+version = "0.99.324"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Publish the infrastructure-safe Crucible checkpoint resume as GEODE v0.99.324.

## Why
- The functional fix is already merged into develop, but release SOT still reported v0.99.323 and the change remained under Unreleased.

## Changes
| File | Change |
|---|---|
| pyproject.toml / uv.lock | Advance package version to 0.99.324. |
| CHANGELOG.md | Publish the checkpoint-resume fix under 0.99.324. |
| README / CLAUDE.md | Synchronize visible version surfaces. |
| site generated SOT | Regenerate version, changelog, and llms indexes; keep llms-full drift scoped to its version header. |

## Verification
- `uv run geode version` → GEODE v0.99.324
- `uv run python scripts/check_llms_version.py`
- `uv run python scripts/check_repo_hygiene.py`
- `uv run python scripts/check_official_docs.py`
- `uv run python scripts/check_docs_canon.py`
- `npm run build` and `npm run export-md` (generation audit; unrelated llms-full drift excluded)
- `uv run pytest tests/ -m "not live" -q` → all non-optional tests pass; four seed-export tests require inspect_ai
- `uv run --extra audit pytest tests/plugins/seed_generation/test_seed_eval_export.py -q` → 6 passed
- `git diff --check`