### PR TITLE
refactor(agent): AgenticLoop 상태머신 형식화 — 폐쇄 종결 알파벳·가드 체인·스냅샷 완전성 (v0.99.328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,40 @@ functional change.
 
 ---
 
+## [0.99.328] - 2026-07-14
+
+### Changed
+
+- **AgenticLoop state-machine formalization — closed terminal alphabet.**
+  `TerminationReason` StrEnum (20 members, including the previously
+  undocumented `session_time_budget_handoff`/`_expired`) replaces the
+  comment-only string dictionary, and every terminal `AgenticResult` is
+  born through the single `_terminal_result` choke-point — the source
+  ratchet pins `AgenticResult(` to exactly one occurrence in
+  agent_loop.py. Post-response/post-tool guards (cost budget,
+  overthinking, model refusal, convergence, repeated-success) moved
+  verbatim into named `_guard_*` methods whose call order in `arun` IS
+  the documented priority order. Behaviour-preserving: StrEnum members
+  compare equal to the legacy strings, serialization unchanged.
+- **Snapshot completeness for resume.** Guard counters the conversation
+  messages don't carry (overthinking streak, LLM-failure counter,
+  diversity tracker, `ConvergenceDetector` state) now persist in the
+  checkpoint (`SessionState.loop_guards`, via
+  `_lifecycle.collect_guard_state`) and restore through the single shared
+  resume surgery `AgenticLoop.restore_from_checkpoint` — used by both the
+  IPC resume handler and the gateway ask continuation, closing the
+  manual-restore drift class a review caught in v0.99.327.
+- **Session-status transition ownership.** `SessionStatus` StrEnum with
+  documented transition owners plus a `mark_paused` primitive; the
+  scheduler drain (one-shot surface) now marks its checkpoint PAUSED when
+  parking behind a pending ask and COMPLETED otherwise, so scheduled
+  sessions stop polluting `list_resumable()` as immortal "active"
+  entries. Documented remaining gap: the gateway multi-turn surface
+  cannot know whether another message follows and stays ACTIVE until
+  cleanup. Guards: `tests/core/agent/test_loop_state_machine.py`
+  (state-space closure ratchet, guard-state roundtrip, status
+  transitions), extended `tests/core/cli/test_scheduler_drain_ask.py`.
+
 ## [0.99.327] - 2026-07-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.327
+- **Version**: 0.99.328
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 418 core + 106 plugins = 524
-- **Tests**: 9842 (+1 live)
+- **Tests**: 9854 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.327 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.328 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.327: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.328: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/convergence.py
+++ b/core/agent/convergence.py
@@ -36,6 +36,27 @@ class ConvergenceDetector:
         self.last_success_tool: str | None = None
         self.last_success_summary: str | None = None
 
+    def to_snapshot(self) -> dict[str, Any]:
+        """Serializable machine state — restored across session resume."""
+        return {
+            "total_consecutive_tool_errors": self.total_consecutive_tool_errors,
+            "recent_errors": list(self.recent_errors),
+            "repeated_success_streak": self.repeated_success_streak,
+            "last_success_fingerprint": self.last_success_fingerprint,
+            "last_success_tool": self.last_success_tool,
+            "last_success_summary": self.last_success_summary,
+        }
+
+    def apply_snapshot(self, data: dict[str, Any]) -> None:
+        """Inverse of :meth:`to_snapshot`; unknown keys are ignored."""
+        self.total_consecutive_tool_errors = int(data.get("total_consecutive_tool_errors", 0))
+        recent = data.get("recent_errors", [])
+        self.recent_errors = [str(e) for e in recent] if isinstance(recent, list) else []
+        self.repeated_success_streak = int(data.get("repeated_success_streak", 0))
+        self.last_success_fingerprint = data.get("last_success_fingerprint")
+        self.last_success_tool = data.get("last_success_tool")
+        self.last_success_summary = data.get("last_success_summary")
+
     def update_tool_error_tracking(
         self, tool_results: list[dict[str, Any]], tool_log: list[dict[str, Any]]
     ) -> None:

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -22,6 +22,61 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def collect_guard_state(loop: AgenticLoop) -> dict[str, Any]:
+    """Serialize the loop's guard counters — the machine state that the
+    conversation messages do NOT carry.
+
+    Snapshot-completeness contract: everything a resumed session needs to
+    keep its guard progress (overthinking streak, retry counter, diversity
+    tracker, convergence detector) lives here, so
+    ``apply_guard_state(collect_guard_state(loop))`` round-trips. Pinned by
+    ``tests/core/agent/test_loop_state_machine.py``.
+    """
+    return {
+        "consecutive_text_only_rounds": loop._consecutive_text_only_rounds,
+        "consecutive_llm_failures": loop._consecutive_llm_failures,
+        "total_empty_rounds": loop._total_empty_rounds,
+        "budget_warned": bool(getattr(loop, "_budget_warned", False)),
+        "consecutive_tool_tracker": [list(sig) for sig in loop._consecutive_tool_tracker],
+        "convergence": loop._convergence.to_snapshot(),
+    }
+
+
+def apply_guard_state(loop: AgenticLoop, data: dict[str, Any]) -> None:
+    """Inverse of :func:`collect_guard_state`; missing keys keep defaults."""
+    if not data:
+        return
+    loop._consecutive_text_only_rounds = int(data.get("consecutive_text_only_rounds", 0))
+    loop._consecutive_llm_failures = int(data.get("consecutive_llm_failures", 0))
+    loop._total_empty_rounds = int(data.get("total_empty_rounds", 0))
+    loop._budget_warned = bool(data.get("budget_warned", False))
+    tracker = data.get("consecutive_tool_tracker", [])
+    if isinstance(tracker, list):
+        loop._consecutive_tool_tracker = [
+            (str(sig[0]), str(sig[1]))
+            for sig in tracker
+            if isinstance(sig, (list, tuple)) and len(sig) == 2
+        ]
+    convergence = data.get("convergence", {})
+    if isinstance(convergence, dict):
+        loop._convergence.apply_snapshot(convergence)
+
+
+def restore_loop_state(loop: AgenticLoop, state: Any) -> None:
+    """Restore a checkpointed session's machine identity onto *loop*.
+
+    The single resume surgery shared by every resume path (IPC
+    ``_handle_resume``, gateway ask continuation) — session id, cognitive
+    state, and guard counters in one place, so no path can forget a field.
+    Model restore stays with the caller (sync vs async contexts differ).
+    """
+    from core.agent.cognitive_state import CognitiveState
+
+    loop._session_id = state.session_id
+    loop.cognitive_state = CognitiveState.from_snapshot(state.cognitive_state)
+    apply_guard_state(loop, getattr(state, "loop_guards", {}) or {})
+
+
 def save_checkpoint(loop: AgenticLoop, user_input: str, round_idx: int = 0) -> None:
     """Persist session checkpoint for resume (per-turn, Claude Code pattern)."""
     if loop._checkpoint is None or not loop._session_id:
@@ -39,6 +94,7 @@ def save_checkpoint(loop: AgenticLoop, user_input: str, round_idx: int = 0) -> N
             tool_log=loop._tool_processor.tool_log,
             cognitive_state=loop.cognitive_state.to_snapshot(),
             user_input=user_input,
+            loop_guards=collect_guard_state(loop),
         )
         loop._checkpoint.save(state)
 
@@ -62,6 +118,18 @@ def mark_session_completed(loop: AgenticLoop) -> None:
         loop._checkpoint.mark_completed(loop._session_id)
     except Exception:
         log.debug("Checkpoint mark_completed failed", exc_info=True)
+
+
+def mark_session_paused(loop: AgenticLoop) -> None:
+    """Mark the current session as paused — a one-shot surface parked it
+    awaiting operator input (pending ask); the checkpoint stays resumable.
+    """
+    if loop._checkpoint is None or not loop._session_id:
+        return
+    try:
+        loop._checkpoint.mark_paused(loop._session_id)
+    except Exception:
+        log.debug("Checkpoint mark_paused failed", exc_info=True)
 
 
 def record_transcript_end(loop: AgenticLoop, result: Any) -> None:

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -37,29 +37,43 @@ def collect_guard_state(loop: AgenticLoop) -> dict[str, Any]:
         "consecutive_llm_failures": loop._consecutive_llm_failures,
         "total_empty_rounds": loop._total_empty_rounds,
         "budget_warned": bool(getattr(loop, "_budget_warned", False)),
+        "low_confidence_replan_armed": bool(getattr(loop, "_low_confidence_replan_armed", True)),
         "consecutive_tool_tracker": [list(sig) for sig in loop._consecutive_tool_tracker],
         "convergence": loop._convergence.to_snapshot(),
     }
 
 
-def apply_guard_state(loop: AgenticLoop, data: dict[str, Any]) -> None:
-    """Inverse of :func:`collect_guard_state`; missing keys keep defaults."""
-    if not data:
-        return
-    loop._consecutive_text_only_rounds = int(data.get("consecutive_text_only_rounds", 0))
-    loop._consecutive_llm_failures = int(data.get("consecutive_llm_failures", 0))
-    loop._total_empty_rounds = int(data.get("total_empty_rounds", 0))
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def apply_guard_state(loop: AgenticLoop, data: Any) -> None:
+    """Inverse of :func:`collect_guard_state` — REPLACEMENT semantics.
+
+    Missing or malformed fields reset to their fresh-loop defaults, never
+    keep the live loop's values: the IPC poller reuses ONE loop across
+    resumes, so a legacy checkpoint (no ``loop_guards``) must not inherit
+    the previous conversation's counters. Field coercion is defensive so a
+    malformed checkpoint can never leave the loop half-restored.
+    """
+    if not isinstance(data, dict):
+        data = {}
+    loop._consecutive_text_only_rounds = _as_int(data.get("consecutive_text_only_rounds"))
+    loop._consecutive_llm_failures = _as_int(data.get("consecutive_llm_failures"))
+    loop._total_empty_rounds = _as_int(data.get("total_empty_rounds"))
     loop._budget_warned = bool(data.get("budget_warned", False))
+    loop._low_confidence_replan_armed = bool(data.get("low_confidence_replan_armed", True))
     tracker = data.get("consecutive_tool_tracker", [])
-    if isinstance(tracker, list):
-        loop._consecutive_tool_tracker = [
-            (str(sig[0]), str(sig[1]))
-            for sig in tracker
-            if isinstance(sig, (list, tuple)) and len(sig) == 2
-        ]
+    loop._consecutive_tool_tracker = [
+        (str(sig[0]), str(sig[1]))
+        for sig in (tracker if isinstance(tracker, list) else [])
+        if isinstance(sig, (list, tuple)) and len(sig) == 2
+    ]
     convergence = data.get("convergence", {})
-    if isinstance(convergence, dict):
-        loop._convergence.apply_snapshot(convergence)
+    loop._convergence.apply_snapshot(convergence if isinstance(convergence, dict) else {})
 
 
 def restore_loop_state(loop: AgenticLoop, state: Any) -> None:
@@ -130,6 +144,17 @@ def mark_session_paused(loop: AgenticLoop) -> None:
         loop._checkpoint.mark_paused(loop._session_id)
     except Exception:
         log.debug("Checkpoint mark_paused failed", exc_info=True)
+
+
+def mark_session_error(loop: AgenticLoop) -> None:
+    """Mark the current session as errored — a one-shot surface died on a
+    timeout or unhandled exception; the checkpoint is not resumable."""
+    if loop._checkpoint is None or not loop._session_id:
+        return
+    try:
+        loop._checkpoint.mark_error(loop._session_id)
+    except Exception:
+        log.debug("Checkpoint mark_error failed", exc_info=True)
 
 
 def record_transcript_end(loop: AgenticLoop, result: Any) -> None:

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -629,6 +629,10 @@ class AgenticLoop:
         """Delegates to :func:`_lifecycle.mark_session_paused`."""
         return _lifecycle.mark_session_paused(self)
 
+    def mark_session_error(self) -> None:
+        """Delegates to :func:`_lifecycle.mark_session_error`."""
+        return _lifecycle.mark_session_error(self)
+
     def restore_from_checkpoint(self, state: Any) -> None:
         """Delegates to :func:`_lifecycle.restore_loop_state` — the single
         resume surgery (session id + cognitive state + guard counters)."""
@@ -2083,11 +2087,13 @@ class AgenticLoop:
                             },
                         )
 
+                self._consecutive_llm_failures += 1
+
                 # auto-checkpoint before retry (resume after a model switch)
+                # — after the increment so the persisted guard state carries
+                # the failure just observed (crash-recovery parity).
                 self._sync_messages_to_context(messages)
                 self._save_checkpoint(user_input, round_idx=round_idx)
-
-                self._consecutive_llm_failures += 1
 
                 # rate_limit → surface to user (no auto-swap; the diagnostic
                 # carries the suggested fallback chain)

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -49,7 +49,12 @@ from ._tool_factory import (
     TOOL_LAZY_LOAD_THRESHOLD,
     get_agentic_tools,
 )
-from .models import AgenticResult, _context_exhausted_message, _ContextExhaustedError
+from .models import (
+    AgenticResult,
+    TerminationReason,
+    _context_exhausted_message,
+    _ContextExhaustedError,
+)
 
 # Confidence-adaptive compute allocation — the reflection node's
 # ``CognitiveState.confidence`` (0..1) steers how much extra LLM compute
@@ -620,6 +625,15 @@ class AgenticLoop:
         """Delegates to :func:`_lifecycle.mark_session_completed`."""
         return _lifecycle.mark_session_completed(self)
 
+    def mark_session_paused(self) -> None:
+        """Delegates to :func:`_lifecycle.mark_session_paused`."""
+        return _lifecycle.mark_session_paused(self)
+
+    def restore_from_checkpoint(self, state: Any) -> None:
+        """Delegates to :func:`_lifecycle.restore_loop_state` — the single
+        resume surgery (session id + cognitive state + guard counters)."""
+        return _lifecycle.restore_loop_state(self, state)
+
     def _record_transcript_end(self, result: Any) -> None:
         """Delegates to :func:`_lifecycle.record_transcript_end`."""
         return _lifecycle.record_transcript_end(self, result)
@@ -817,10 +831,10 @@ class AgenticLoop:
                 {"user_input": user_input, "session_id": self._session_id},
             )
             if intercept.blocked:
-                return AgenticResult(
-                    text=intercept.reason,
+                return self._terminal_result(
+                    TerminationReason.INPUT_BLOCKED,
+                    intercept.reason,
                     rounds=0,
-                    termination_reason="input_blocked",
                 )
 
         # goal = first arun()'s input (later calls keep it so observations
@@ -900,18 +914,18 @@ class AgenticLoop:
         except BillingError as exc:
             spinner.stop()
             self._emit_quota_panel(exc)
-            return AgenticResult(
-                text=exc.user_message(),
+            return self._terminal_result(
+                TerminationReason.BILLING_ERROR,
+                exc.user_message(),
                 rounds=round_idx + 1,
-                termination_reason="billing_error",
             )
         except UserCancelledError:
             spinner.stop()
             log.info("LLM call interrupted by user")
-            return AgenticResult(
-                text="Interrupted.",
+            return self._terminal_result(
+                TerminationReason.USER_CANCELLED,
+                "Interrupted.",
                 rounds=round_idx + 1,
-                termination_reason="user_cancelled",
             )
 
     async def _sync_model_and_rebuild_prompt(
@@ -986,12 +1000,245 @@ class AgenticLoop:
                 return handoff_reason
         return None
 
+    def _terminal_result(
+        self,
+        reason: TerminationReason,
+        text: str,
+        *,
+        rounds: int,
+        error: bool = False,
+        tool_calls: list[dict[str, Any]] | None = None,
+    ) -> AgenticResult:
+        """Sole birth-place of terminal results — the loop's exit alphabet.
+
+        Every terminal exit constructs its :class:`AgenticResult` here, so
+        the reachable terminal-state space is exactly
+        :class:`TerminationReason` (pinned by
+        ``tests/core/agent/test_loop_state_machine.py``). ``error=True``
+        mirrors *reason* into ``AgenticResult.error`` — the legacy dual
+        encoding some consumers still read. ``tool_calls=None`` keeps the
+        dataclass default (empty list) for pre-tool exits; pass
+        ``self._tool_processor.tool_log`` explicitly where the exit carries
+        tool work.
+        """
+        result = AgenticResult(
+            text=text,
+            rounds=rounds,
+            error=str(reason) if error else None,
+            termination_reason=reason,
+        )
+        if tool_calls is not None:
+            result.tool_calls = tool_calls
+        return result
+
+    # ------------------------------------------------------------------
+    # Guard chain — the loop's transition guards, in priority order
+    # ------------------------------------------------------------------
+    # Call order in ``arun`` IS the priority order:
+    #   post-response: cost_budget → overthinking → model_refusal
+    #   post-tool:     convergence → repeated_success_no_progress
+    # Each guard returns a terminal AgenticResult (born via
+    # ``_terminal_result``) or None to proceed. Guard counters live on
+    # ``self`` and are checkpointed via ``_lifecycle.collect_guard_state``
+    # so a resumed session keeps its guard progress.
+
+    def _guard_cost_budget(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        round_idx: int,
+    ) -> AgenticResult | None:
+        """Cost budget guard (Karpathy P3 — resource budget).
+
+        Warns once at 80% of budget; terminates with
+        ``cost_budget_exceeded`` at 100%.
+        """
+        if self._cost_budget <= 0:
+            return None
+        try:
+            from core.llm.token_tracker import get_tracker as _get_cost_tracker
+
+            _cost_tracker = _get_cost_tracker()
+            _session_cost = _cost_tracker.accumulator.total_cost_usd
+
+            _warn_threshold = self._cost_budget * 0.8
+            if (
+                _session_cost >= _warn_threshold
+                and _session_cost < self._cost_budget
+                and not getattr(self, "_budget_warned", False)
+            ):
+                self._budget_warned = True
+                if not self._quiet:
+                    from core.ui.agentic_ui import emit_budget_warning
+
+                    emit_budget_warning(
+                        self._cost_budget,
+                        _session_cost,
+                        pct=_session_cost / self._cost_budget * 100,
+                    )
+
+            if _session_cost >= self._cost_budget:
+                from core.ui.agentic_ui import emit_cost_budget_exceeded
+
+                emit_cost_budget_exceeded(self._cost_budget, _session_cost)
+                self._op_logger.finalize()
+                self._sync_messages_to_context(messages)
+                text = (
+                    f"Cost budget (${self._cost_budget:.2f}) exceeded. "
+                    f"Session cost: ${_session_cost:.2f}"
+                )
+                log.warning(text)
+                return self._terminal_result(
+                    TerminationReason.COST_BUDGET_EXCEEDED,
+                    text,
+                    rounds=round_idx + 1,
+                    error=True,
+                    tool_calls=self._tool_processor.tool_log,
+                )
+        except Exception:
+            log.debug("Cost budget check failed", exc_info=True)
+        return None
+
+    async def _guard_overthinking(
+        self,
+        response: Any,
+        *,
+        messages: list[dict[str, Any]],
+        round_idx: int,
+    ) -> AgenticResult | None:
+        """Overthinking guard — N consecutive long-text/no-tool rounds stop
+        the loop with ``user_clarification_needed`` (threshold is
+        context-proportional, 1% / floor 1024). Owns the counter reset on
+        tool-use rounds.
+        """
+        if response.stop_reason != "tool_use":
+            out_tok = getattr(response.usage, "output_tokens", 0) if response.usage else 0
+            threshold = self._overthinking_token_threshold()
+            if out_tok > threshold:
+                self._consecutive_text_only_rounds += 1
+            else:
+                self._consecutive_text_only_rounds = 0
+            if self._consecutive_text_only_rounds >= 2:
+                # count this flagged round ONCE — adding the running
+                # consec would inflate the total quadratically
+                self._total_empty_rounds += 1
+                log.warning(
+                    "Overthinking detected: %d consecutive text-only rounds "
+                    "(>%d tok each) — surfacing user_clarification_needed",
+                    self._consecutive_text_only_rounds,
+                    threshold,
+                )
+                self._op_logger.finalize()
+                self._sync_messages_to_context(messages)
+                last_text = self._extract_text(response).strip()
+                summary = last_text[:400] + ("…" if len(last_text) > 400 else "")
+                clarification = (
+                    f"~ I've spent {self._consecutive_text_only_rounds} consecutive "
+                    f"rounds reasoning without taking any action "
+                    f"(>{threshold} output tokens each). "
+                    "Could you narrow the request — point at a specific file, "
+                    "behaviour, or step you want me to focus on next?\n\n"
+                    f"Most recent reasoning (truncated):\n{summary}"
+                )
+                await self._record_text_only_round(round_idx, text=last_text)
+                return self._terminal_result(
+                    TerminationReason.USER_CLARIFICATION_NEEDED,
+                    clarification,
+                    rounds=round_idx + 1,
+                    tool_calls=self._tool_processor.tool_log,
+                )
+        else:
+            self._consecutive_text_only_rounds = 0
+        return None
+
+    def _guard_model_refusal(
+        self,
+        response: Any,
+        *,
+        messages: list[dict[str, Any]],
+        round_idx: int,
+    ) -> AgenticResult | None:
+        """Fable 5 safety decline (HTTP 200, often empty) — surface it
+        honestly instead of a silent empty turn.
+
+        ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+        """
+        if response.stop_reason != "refusal":
+            return None
+        self._op_logger.finalize()
+        self._sync_messages_to_context(messages)
+        stop_details = getattr(response, "stop_details", None)
+        category = stop_details.get("category") if isinstance(stop_details, dict) else None
+        refusal_text = self._extract_text(response).strip() or (
+            "The model declined this request"
+            + (f" (safety classifier category: {category})" if category else "")
+            + ". Rephrase the request or retry on another model via /model."
+        )
+        return self._terminal_result(
+            TerminationReason.MODEL_REFUSAL,
+            refusal_text,
+            rounds=round_idx + 1,
+            tool_calls=self._tool_processor.tool_log,
+        )
+
+    def _guard_convergence(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        round_idx: int,
+    ) -> AgenticResult | None:
+        """Convergence guard — 3 identical tool errors break the loop."""
+        if not self._check_convergence_break():
+            return None
+        from core.ui.agentic_ui import emit_convergence_detected
+
+        last_err = (
+            self._convergence.recent_errors[-1] if self._convergence.recent_errors else "unknown"
+        )
+        emit_convergence_detected(last_err, round_idx + 1)
+        self._op_logger.finalize()
+        self._sync_messages_to_context(messages)
+        return self._terminal_result(
+            TerminationReason.CONVERGENCE_DETECTED,
+            "Detected repeating failure pattern. Breaking loop to avoid infinite retry.",
+            rounds=round_idx + 1,
+            error=True,
+            tool_calls=self._tool_processor.tool_log,
+        )
+
+    def _guard_repeated_success(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        round_idx: int,
+    ) -> AgenticResult | None:
+        """Repeated-success guard — identical successful results without new
+        progress stop the loop (polling the same state indefinitely).
+        """
+        if not self._check_repeated_success_no_progress():
+            return None
+        from core.ui.agentic_ui import emit_repeated_success_no_progress
+
+        tool_name = self._convergence.last_success_tool or "unknown"
+        streak = self._convergence.repeated_success_streak
+        emit_repeated_success_no_progress(tool_name, streak, round_idx + 1)
+        self._op_logger.finalize()
+        self._sync_messages_to_context(messages)
+        return self._terminal_result(
+            TerminationReason.REPEATED_SUCCESS_NO_PROGRESS,
+            "Detected repeated successful tool results without new progress. "
+            "Breaking loop to avoid polling the same state indefinitely.",
+            rounds=round_idx + 1,
+            error=True,
+            tool_calls=self._tool_processor.tool_log,
+        )
+
     def _guard_exit_result(
         self,
         guard_reason: str | None,
         *,
         rounds: int,
-    ) -> tuple[str, str]:
+    ) -> tuple[TerminationReason, str]:
         """Map a loop-entry guard reason to a terminal result.
 
         The guard helper returns precise internal reasons. Preserve that
@@ -1000,7 +1247,7 @@ class AgenticLoop:
         """
         if guard_reason == "time_budget":
             return (
-                "time_budget_expired",
+                TerminationReason.TIME_BUDGET_EXPIRED,
                 f"Time budget ({self._time_budget_s:.0f}s) expired after {rounds} rounds.",
             )
         if guard_reason in {"session_time_budget_handoff", "session_time_budget_expired"}:
@@ -1027,7 +1274,7 @@ class AgenticLoop:
                         "Session time budget is in the handoff window. "
                         "Start a new GEODE session or restart GEODE to continue safely."
                     )
-                return "session_time_budget_handoff", text
+                return TerminationReason.SESSION_TIME_BUDGET_HANDOFF, text
 
             if remaining is not None and total is not None and total > 0:
                 text = (
@@ -1040,11 +1287,14 @@ class AgenticLoop:
                     "Session time budget expired. "
                     "Start a new GEODE session or restart GEODE to continue."
                 )
-            return "session_time_budget_expired", text
+            return TerminationReason.SESSION_TIME_BUDGET_EXPIRED, text
 
         # Back-compat: an exhausted positive max_rounds cap keeps the legacy
         # result text/termination reason.
-        return "max_rounds", "Max agentic rounds reached. Please try a more specific request."
+        return (
+            TerminationReason.MAX_ROUNDS,
+            "Max agentic rounds reached. Please try a more specific request.",
+        )
 
     def _persist_handoff_request(self) -> None:
         """Flip the ``sessions`` row to ``handoff_state='pending'`` via the
@@ -1376,12 +1626,12 @@ class AgenticLoop:
             suggested_models=self._fallback_chain_suggestions() or None,
             detail=clean_detail,
         )
-        return AgenticResult(
-            text=text,
-            tool_calls=self._tool_processor.tool_log,
+        return self._terminal_result(
+            TerminationReason.MODEL_ACTION_REQUIRED,
+            text,
             rounds=rounds,
-            error="model_action_required",
-            termination_reason="model_action_required",
+            error=True,
+            tool_calls=self._tool_processor.tool_log,
         )
 
     async def _afinalize_actionable_partial_on_empty(
@@ -1413,11 +1663,11 @@ class AgenticLoop:
         )
         self._op_logger.finalize()
         self._sync_messages_to_context(messages)
-        result = AgenticResult(
-            text="",
-            tool_calls=list(self._tool_processor.tool_log),
+        result = self._terminal_result(
+            TerminationReason.ACTIONABLE_PARTIAL,
+            "",
             rounds=round_idx,
-            termination_reason="actionable_partial",
+            tool_calls=list(self._tool_processor.tool_log),
         )
         return await self._afinalize_and_return(result, user_input, round_idx)
 
@@ -1439,12 +1689,12 @@ class AgenticLoop:
             new_count=len(messages),
         )
         self._sync_messages_to_context(messages)
-        result = AgenticResult(
-            text=await _context_exhausted_message(user_input),
-            tool_calls=self._tool_processor.tool_log,
+        result = self._terminal_result(
+            TerminationReason.CONTEXT_EXHAUSTED,
+            await _context_exhausted_message(user_input),
             rounds=round_idx + 1,
-            error="context_exhausted",
-            termination_reason="context_exhausted",
+            error=True,
+            tool_calls=self._tool_processor.tool_log,
         )
         return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
@@ -1459,11 +1709,11 @@ class AgenticLoop:
 
         self._op_logger.finalize()
         self._sync_messages_to_context(messages)
-        result = AgenticResult(
-            text="",
-            tool_calls=list(self._tool_processor.tool_log),
+        result = self._terminal_result(
+            TerminationReason.TOOL_USE_YIELD,
+            "",
             rounds=round_idx + 1,
-            termination_reason="tool_use_yield",
+            tool_calls=list(self._tool_processor.tool_log),
         )
         return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
@@ -1601,10 +1851,10 @@ class AgenticLoop:
             decomposition_hint = await self._try_decompose(user_input)
         except BillingError as exc:
             self._emit_quota_panel(exc)
-            return AgenticResult(
-                text=exc.user_message(),
+            return self._terminal_result(
+                TerminationReason.BILLING_ERROR,
+                exc.user_message(),
                 rounds=0,
-                termination_reason="billing_error",
             )
 
         intercept_result = await self._emit_session_start_signals(user_input)
@@ -1921,116 +2171,20 @@ class AgenticLoop:
             # Track usage + Claude Code-style token display
             await self._track_usage_async(response)
 
-            # Guard 3: Cost budget (Karpathy P3 — resource budget)
-            if self._cost_budget > 0:
-                try:
-                    from core.llm.token_tracker import get_tracker as _get_cost_tracker
-
-                    _cost_tracker = _get_cost_tracker()
-                    _session_cost = _cost_tracker.accumulator.total_cost_usd
-
-                    # Proactive warning at 80% of budget (once per session)
-                    _warn_threshold = self._cost_budget * 0.8
-                    if (
-                        _session_cost >= _warn_threshold
-                        and _session_cost < self._cost_budget
-                        and not getattr(self, "_budget_warned", False)
-                    ):
-                        self._budget_warned = True
-                        if not self._quiet:
-                            from core.ui.agentic_ui import emit_budget_warning
-
-                            emit_budget_warning(
-                                self._cost_budget,
-                                _session_cost,
-                                pct=_session_cost / self._cost_budget * 100,
-                            )
-
-                    if _session_cost >= self._cost_budget:
-                        from core.ui.agentic_ui import emit_cost_budget_exceeded
-
-                        emit_cost_budget_exceeded(self._cost_budget, _session_cost)
-                        self._op_logger.finalize()
-                        self._sync_messages_to_context(messages)
-                        text = (
-                            f"Cost budget (${self._cost_budget:.2f}) exceeded. "
-                            f"Session cost: ${_session_cost:.2f}"
-                        )
-                        log.warning(text)
-                        result = AgenticResult(
-                            text=text,
-                            tool_calls=self._tool_processor.tool_log,
-                            rounds=round_idx + 1,
-                            error="cost_budget_exceeded",
-                            termination_reason="cost_budget_exceeded",
-                        )
-                        return await self._afinalize_and_return(result, user_input, round_idx + 1)
-                except Exception:
-                    log.debug("Cost budget check failed", exc_info=True)
-
-            # Overthinking detection — N consecutive long-text/no-tool
-            # rounds stop the loop with user_clarification_needed (threshold
-            # is context-proportional, 1% / floor 1024).
-            if response.stop_reason != "tool_use":
-                out_tok = getattr(response.usage, "output_tokens", 0) if response.usage else 0
-                threshold = self._overthinking_token_threshold()
-                if out_tok > threshold:
-                    self._consecutive_text_only_rounds += 1
-                else:
-                    self._consecutive_text_only_rounds = 0
-                if self._consecutive_text_only_rounds >= 2:
-                    # count this flagged round ONCE — adding the running
-                    # consec would inflate the total quadratically
-                    self._total_empty_rounds += 1
-                    log.warning(
-                        "Overthinking detected: %d consecutive text-only rounds "
-                        "(>%d tok each) — surfacing user_clarification_needed",
-                        self._consecutive_text_only_rounds,
-                        threshold,
-                    )
-                    self._op_logger.finalize()
-                    self._sync_messages_to_context(messages)
-                    last_text = self._extract_text(response).strip()
-                    summary = last_text[:400] + ("…" if len(last_text) > 400 else "")
-                    clarification = (
-                        f"~ I've spent {self._consecutive_text_only_rounds} consecutive "
-                        f"rounds reasoning without taking any action "
-                        f"(>{threshold} output tokens each). "
-                        "Could you narrow the request — point at a specific file, "
-                        "behaviour, or step you want me to focus on next?\n\n"
-                        f"Most recent reasoning (truncated):\n{summary}"
-                    )
-                    await self._record_text_only_round(round_idx, text=last_text)
-                    result = AgenticResult(
-                        text=clarification,
-                        tool_calls=self._tool_processor.tool_log,
-                        rounds=round_idx + 1,
-                        termination_reason="user_clarification_needed",
-                    )
-                    return await self._afinalize_and_return(result, user_input, round_idx + 1)
-            else:
-                self._consecutive_text_only_rounds = 0
-
-            if response.stop_reason == "refusal":
-                # Fable 5 safety decline (HTTP 200, often empty) — surface it
-                # honestly instead of a silent empty turn.
-                # ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
-                self._op_logger.finalize()
-                self._sync_messages_to_context(messages)
-                stop_details = getattr(response, "stop_details", None)
-                category = stop_details.get("category") if isinstance(stop_details, dict) else None
-                refusal_text = self._extract_text(response).strip() or (
-                    "The model declined this request"
-                    + (f" (safety classifier category: {category})" if category else "")
-                    + ". Rephrase the request or retry on another model via /model."
-                )
-                result = AgenticResult(
-                    text=refusal_text,
-                    tool_calls=self._tool_processor.tool_log,
-                    rounds=round_idx + 1,
-                    termination_reason="model_refusal",
-                )
-                return await self._afinalize_and_return(result, user_input, round_idx + 1)
+            # --- Post-response guard chain — priority order IS this call
+            # order; the first terminal outcome wins. Guard bodies live in
+            # the "guard chain" section next to ``_terminal_result``.
+            _terminal = self._guard_cost_budget(messages=messages, round_idx=round_idx)
+            if _terminal is not None:
+                return await self._afinalize_and_return(_terminal, user_input, round_idx + 1)
+            _terminal = await self._guard_overthinking(
+                response, messages=messages, round_idx=round_idx
+            )
+            if _terminal is not None:
+                return await self._afinalize_and_return(_terminal, user_input, round_idx + 1)
+            _terminal = self._guard_model_refusal(response, messages=messages, round_idx=round_idx)
+            if _terminal is not None:
+                return await self._afinalize_and_return(_terminal, user_input, round_idx + 1)
 
             if response.stop_reason != "tool_use":
                 # end_turn or max_tokens → extract text, done
@@ -2055,12 +2209,14 @@ class AgenticLoop:
                 messages.append(_assistant_msg)
                 self._sync_messages_to_context(messages)
                 await self._record_text_only_round(round_idx, text=text)
-                reason = "forced_text" if is_last_round else "natural"
-                result = AgenticResult(
-                    text=text,
-                    tool_calls=self._tool_processor.tool_log,
+                reason = (
+                    TerminationReason.FORCED_TEXT if is_last_round else TerminationReason.NATURAL
+                )
+                result = self._terminal_result(
+                    reason,
+                    text,
                     rounds=round_idx + 1,
-                    termination_reason=reason,
+                    tool_calls=self._tool_processor.tool_log,
                 )
                 return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
@@ -2069,47 +2225,13 @@ class AgenticLoop:
             # backpressure on consecutive tool failures + convergence detection
             self._update_tool_error_tracking(tool_results)
 
-            if self._check_convergence_break():
-                from core.ui.agentic_ui import emit_convergence_detected
-
-                last_err = (
-                    self._convergence.recent_errors[-1]
-                    if self._convergence.recent_errors
-                    else "unknown"
-                )
-                emit_convergence_detected(last_err, round_idx + 1)
-                self._op_logger.finalize()
-                self._sync_messages_to_context(messages)
-                result = AgenticResult(
-                    text=(
-                        "Detected repeating failure pattern. Breaking loop to avoid infinite retry."
-                    ),
-                    tool_calls=self._tool_processor.tool_log,
-                    rounds=round_idx + 1,
-                    error="convergence_detected",
-                    termination_reason="convergence_detected",
-                )
-                return await self._afinalize_and_return(result, user_input, round_idx + 1)
-
-            if self._check_repeated_success_no_progress():
-                from core.ui.agentic_ui import emit_repeated_success_no_progress
-
-                tool_name = self._convergence.last_success_tool or "unknown"
-                streak = self._convergence.repeated_success_streak
-                emit_repeated_success_no_progress(tool_name, streak, round_idx + 1)
-                self._op_logger.finalize()
-                self._sync_messages_to_context(messages)
-                result = AgenticResult(
-                    text=(
-                        "Detected repeated successful tool results without new progress. "
-                        "Breaking loop to avoid polling the same state indefinitely."
-                    ),
-                    tool_calls=self._tool_processor.tool_log,
-                    rounds=round_idx + 1,
-                    error="repeated_success_no_progress",
-                    termination_reason="repeated_success_no_progress",
-                )
-                return await self._afinalize_and_return(result, user_input, round_idx + 1)
+            # --- Post-tool guard chain — same first-terminal-wins contract.
+            _terminal = self._guard_convergence(messages=messages, round_idx=round_idx)
+            if _terminal is not None:
+                return await self._afinalize_and_return(_terminal, user_input, round_idx + 1)
+            _terminal = self._guard_repeated_success(messages=messages, round_idx=round_idx)
+            if _terminal is not None:
+                return await self._afinalize_and_return(_terminal, user_input, round_idx + 1)
 
             if self._convergence.total_consecutive_tool_errors >= 3:
                 # backpressure cooldown hint
@@ -2204,12 +2326,12 @@ class AgenticLoop:
             }
         )
         self._sync_messages_to_context(messages)
-        result = AgenticResult(
-            text=text,
-            tool_calls=self._tool_processor.tool_log,
+        result = self._terminal_result(
+            reason,
+            text,
             rounds=round_idx,
-            error=reason,
-            termination_reason=reason,
+            error=True,
+            tool_calls=self._tool_processor.tool_log,
         )
         return await self._afinalize_and_return(result, user_input, round_idx)
 

--- a/core/agent/loop/models.py
+++ b/core/agent/loop/models.py
@@ -8,12 +8,62 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from core.llm.token_tracker import LLMUsage
 
 log = logging.getLogger(__name__)
+
+
+class TerminationReason(StrEnum):
+    """Closed alphabet of AgenticLoop terminal states.
+
+    Every terminal :class:`AgenticResult` is born through
+    ``AgenticLoop._terminal_result`` with one of these members — the loop's
+    exit state space is this enum, nothing else. ``StrEnum`` keeps every
+    existing string comparison and JSON serialization working unchanged.
+
+    Consumers that persist or transport results (worker sub-agent protocol,
+    checkpoints, transcripts) see plain strings; parse back leniently with
+    ``TerminationReason(value)`` and catch ``ValueError`` for forward
+    compatibility.
+    """
+
+    # Ordinary completion
+    NATURAL = "natural"  # model produced a final text answer
+    FORCED_TEXT = "forced_text"  # last allowed round forced a text answer
+
+    # Round/time budget guards (while-condition exits)
+    MAX_ROUNDS = "max_rounds"
+    TIME_BUDGET_EXPIRED = "time_budget_expired"
+    SESSION_TIME_BUDGET_HANDOFF = "session_time_budget_handoff"
+    SESSION_TIME_BUDGET_EXPIRED = "session_time_budget_expired"
+
+    # Resource/limit terminals
+    CONTEXT_EXHAUSTED = "context_exhausted"
+    COST_BUDGET_EXCEEDED = "cost_budget_exceeded"
+    BILLING_ERROR = "billing_error"
+
+    # Model-behaviour guards
+    MODEL_ACTION_REQUIRED = "model_action_required"  # LLM error retry cap hit
+    MODEL_REFUSAL = "model_refusal"  # safety classifier declined (HTTP 200)
+    USER_CLARIFICATION_NEEDED = "user_clarification_needed"  # overthinking
+    CONVERGENCE_DETECTED = "convergence_detected"  # repeating failure pattern
+    REPEATED_SUCCESS_NO_PROGRESS = "repeated_success_no_progress"
+
+    # Caller-driven exits
+    INPUT_BLOCKED = "input_blocked"  # USER_INPUT_RECEIVED interceptor
+    USER_CANCELLED = "user_cancelled"
+    ACTIONABLE_PARTIAL = "actionable_partial"  # opted-in partial preserve
+    TOOL_USE_YIELD = "tool_use_yield"  # external orchestrator owns next turn
+
+    # Legacy — documented consumers exist (worker retry catalogue, UI event
+    # lists) but no current producer site constructs it.
+    LLM_ERROR = "llm_error"
+
+    UNKNOWN = "unknown"
 
 
 class _ContextExhaustedError(Exception):
@@ -107,20 +157,10 @@ class AgenticResult:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     rounds: int = 0
     error: str | None = None
-    # "natural" | "forced_text" | "max_rounds" | "time_budget_expired"
-    # | "llm_error" | "context_exhausted" | "cost_budget_exceeded"
-    # | "model_action_required" — LLM error retried up to cap; user must
-    #   switch model/provider via /model and re-run. Diagnostic in ``text``.
-    # | "model_refusal" — Fable 5 safety classifier declined (stop_reason
-    #   "refusal", HTTP 200); text carries the category when reported.
-    # | "user_clarification_needed" — overthinking detected (consecutive
-    #   high-token text-only rounds with no tool use). Loop stops and asks
-    #   the user to narrow the request.
-    # | "actionable_partial" — an opted-in evaluator caller preserves tool
-    #   actions from completed rounds after an empty continuation.
-    # | "tool_use_yield" — an opted-in external orchestrator owns the next
-    #   model turn after one completed tool batch.
-    termination_reason: str = "unknown"
+    # Closed value space — see :class:`TerminationReason`. StrEnum members
+    # ARE strings, so serialized results and string comparisons are
+    # unchanged; deserializers may still carry plain str.
+    termination_reason: TerminationReason | str = TerminationReason.UNKNOWN
     summary: str = ""  # Tier 1 compact action summary (auto-generated)
     reasoning_metrics: dict[str, object] | None = None
     usage: "LLMUsage | None" = None  # noqa: UP037 — forward-ref for cycle avoidance

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -685,8 +685,9 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
 #
 # The fallback path always sets ``termination_reason`` to one of the
 # explicit failure sentinels below — gate ``success`` on the absence of
-# those plus the absence of ``error``. Sentinels enumerated from
-# ``agent_loop.py`` (search ``termination_reason="``):
+# those plus the absence of ``error``. Sentinels are members of
+# ``core.agent.loop.models.TerminationReason`` (the loop's closed terminal
+# alphabet; every terminal is born in ``AgenticLoop._terminal_result``):
 #
 # * Failure exits (text is fallback / diagnostic UI, NOT a real answer):
 #   ``model_action_required``, ``context_exhausted``, ``llm_error``,

--- a/core/cli/scheduler_drain.py
+++ b/core/cli/scheduler_drain.py
@@ -147,8 +147,14 @@ async def drain_scheduler_queue(
                                 _cb(r, job_id=_jid)
                         except TimeoutError:
                             log.warning("Scheduler job %s timed out after 300s", _jid)
+                            _mark_err = getattr(_loop, "mark_session_error", None)
+                            if callable(_mark_err):
+                                _mark_err()
                         except Exception:
                             log.warning("Scheduler job %s execution failed", _jid, exc_info=True)
+                            _mark_err = getattr(_loop, "mark_session_error", None)
+                            if callable(_mark_err):
+                                _mark_err()
                         finally:
                             _glob.manual_release(_key)
                             _sess.manual_release(_key)

--- a/core/cli/scheduler_drain.py
+++ b/core/cli/scheduler_drain.py
@@ -110,9 +110,11 @@ async def drain_scheduler_queue(
                     ) -> None:
                         try:
                             r = await asyncio.wait_for(_loop.arun(_p), timeout=300.0)
-                            # A clarification question from a headless run
-                            # would otherwise die with the run — persist it
-                            # as a pending ask and notify the operator.
+                            # One-shot surface owns the session lifecycle: a
+                            # clarification question parks the checkpoint as
+                            # PAUSED behind a pending ask; every other
+                            # terminal marks it COMPLETED. (getattr-guarded:
+                            # tests drive stub loops without these methods.)
                             try:
                                 if (
                                     r is not None
@@ -128,6 +130,13 @@ async def drain_scheduler_queue(
                                         session_id=getattr(_loop, "_session_id", ""),
                                         source=f"scheduled:{_jid}",
                                     )
+                                    _mark_paused = getattr(_loop, "mark_session_paused", None)
+                                    if callable(_mark_paused):
+                                        _mark_paused()
+                                else:
+                                    _mark_done = getattr(_loop, "mark_session_completed", None)
+                                    if callable(_mark_done):
+                                        _mark_done()
                             except Exception:
                                 log.warning(
                                     "Pending-ask publish failed for job %s",

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -156,6 +156,23 @@ def serve(
         if state.model and state.model != _ask_loop.model:
             await _ask_loop.update_model_async(state.model)
         _res = await _ask_loop.arun(answer)
+        # Close the one-shot lifecycle (finalize re-wrote status "active"):
+        # a fresh clarification re-parks the checkpoint behind a NEW ask;
+        # any other terminal completes it.
+        try:
+            if _res is not None and _res.termination_reason == "user_clarification_needed":
+                from core.memory.pending_ask import apublish_clarification_ask
+
+                await apublish_clarification_ask(
+                    _res.text,
+                    session_id=state.session_id,
+                    source=f"ask-continuation:{state.session_id}",
+                )
+                _ask_loop.mark_session_paused()
+            else:
+                _ask_loop.mark_session_completed()
+        except Exception:
+            log.warning("Ask continuation lifecycle close failed", exc_info=True)
         return _res.text if _res else ""
 
     async def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -149,14 +149,10 @@ def serve(
             time_budget_override=_gw_time_budget,
             propagate_context=True,
         )
-        # Checkpoint continuity — restore session id, cognitive state, and
-        # model like the IPC resume handler, so the continuation runs under
-        # the paused run's identity (arun() re-binds the ContextVars from
-        # these restored objects).
-        from core.agent.cognitive_state import CognitiveState
-
-        _ask_loop._session_id = state.session_id
-        _ask_loop.cognitive_state = CognitiveState.from_snapshot(state.cognitive_state)
+        # Checkpoint continuity — the single shared resume surgery (same
+        # path as the IPC resume handler); arun() re-binds the ContextVars
+        # from the restored objects.
+        _ask_loop.restore_from_checkpoint(state)
         if state.model and state.model != _ask_loop.model:
             await _ask_loop.update_model_async(state.model)
         _res = await _ask_loop.arun(answer)

--- a/core/memory/session_checkpoint.py
+++ b/core/memory/session_checkpoint.py
@@ -14,6 +14,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field, replace
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,28 @@ DEFAULT_SESSION_DIR = _get_default_session_dir()
 CLEANUP_AGE_HOURS = 72
 
 
+class SessionStatus(StrEnum):
+    """Closed session-status space with explicit transition owners.
+
+    - ACTIVE: written by every per-turn ``save()`` — the session may take
+      more turns.
+    - PAUSED: a one-shot surface (scheduler drain) parked the session
+      awaiting operator input (pending ask); resumable.
+    - COMPLETED: clean REPL exit, or a one-shot run that terminated with
+      no pending ask; ``cleanup()`` may remove it.
+    - ERROR: unrecoverable session failure.
+
+    Known remaining gap: the gateway multi-turn surface never marks its
+    sessions (it cannot know whether another inbound message follows), so
+    gateway checkpoints stay ACTIVE until the 72h cleanup.
+    """
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
 @dataclass
 class SessionState:
     """Serializable session checkpoint."""
@@ -43,12 +66,16 @@ class SessionState:
     round_idx: int = 0
     model: str = ""
     provider: str = "anthropic"
-    status: str = "active"  # active | paused | completed | error
+    status: str = SessionStatus.ACTIVE  # see SessionStatus
     messages: list[dict[str, Any]] = field(default_factory=list)
     tool_log: list[dict[str, Any]] = field(default_factory=list)
     cognitive_state: dict[str, Any] = field(default_factory=dict)
     system_prompt_hash: str = ""
     user_input: str = ""  # original user request for context
+    # Guard counters the messages don't carry (overthinking streak, LLM
+    # retry counter, diversity tracker, convergence detector) — written by
+    # ``_lifecycle.collect_guard_state``, restored by ``restore_loop_state``.
+    loop_guards: dict[str, Any] = field(default_factory=dict)
 
 
 class SessionCheckpoint:
@@ -95,6 +122,7 @@ class SessionCheckpoint:
             "system_prompt_hash": state.system_prompt_hash,
             "user_input": state.user_input,
             "cognitive_state": state.cognitive_state,
+            "loop_guards": state.loop_guards,
         }
 
         # Write state.json (metadata)
@@ -207,6 +235,9 @@ class SessionCheckpoint:
                 cognitive_state=cognitive_state,
                 system_prompt_hash=data.get("system_prompt_hash", ""),
                 user_input=data.get("user_input", ""),
+                loop_guards=(
+                    data["loop_guards"] if isinstance(data.get("loop_guards"), dict) else {}
+                ),
             )
         except (json.JSONDecodeError, KeyError, OSError) as e:
             log.warning("Failed to load session %s: %s", session_id, e)
@@ -257,22 +288,28 @@ class SessionCheckpoint:
             log.debug("DB-first message load failed for %s", session_id, exc_info=True)
             return None
 
-    def mark_completed(self, session_id: str) -> None:
-        """Mark a session as completed (no longer resumable)."""
-        session_path = self._dir / session_id
-        state_file = session_path / "state.json"
+    def _write_status(self, session_id: str, status: SessionStatus) -> None:
+        """Rewrite one session's persisted status (transition primitive)."""
+        state_file = self._dir / session_id / "state.json"
         if not state_file.exists():
             return
         try:
             data = json.loads(state_file.read_text(encoding="utf-8"))
-            data["status"] = "completed"
+            data["status"] = str(status)
             data["updated_at"] = time.time()
             atomic_write_json(state_file, data, indent=2)
         except (json.JSONDecodeError, OSError):
             pass
 
+    def mark_completed(self, session_id: str) -> None:
+        """Mark a session as completed (no longer resumable)."""
+        self._write_status(session_id, SessionStatus.COMPLETED)
         # Clear active pointer if it points to this session
         self._clear_active_if_matches(session_id)
+
+    def mark_paused(self, session_id: str) -> None:
+        """Mark a session as paused — parked awaiting operator input."""
+        self._write_status(session_id, SessionStatus.PAUSED)
 
     def list_resumable(self) -> list[SessionState]:
         """List sessions that can be resumed (status=active or paused)."""

--- a/core/memory/session_checkpoint.py
+++ b/core/memory/session_checkpoint.py
@@ -289,7 +289,12 @@ class SessionCheckpoint:
             return None
 
     def _write_status(self, session_id: str, status: SessionStatus) -> None:
-        """Rewrite one session's persisted status (transition primitive)."""
+        """Rewrite one session's persisted status (transition primitive).
+
+        Updates BOTH SoTs: ``state.json`` and the SQLite index row —
+        ``geode session list`` reads the index first, so a JSON-only write
+        would keep showing parked/finished sessions as active.
+        """
         state_file = self._dir / session_id / "state.json"
         if not state_file.exists():
             return
@@ -300,6 +305,16 @@ class SessionCheckpoint:
             atomic_write_json(state_file, data, indent=2)
         except (json.JSONDecodeError, OSError):
             pass
+        try:
+            from core.memory.session_manager import SessionManager
+
+            mgr = SessionManager(self._dir / "sessions.db")
+            try:
+                mgr.update_status(session_id, str(status))
+            finally:
+                mgr.close()
+        except Exception:
+            log.debug("SQLite status sync failed for %s", session_id, exc_info=True)
 
     def mark_completed(self, session_id: str) -> None:
         """Mark a session as completed (no longer resumable)."""
@@ -310,6 +325,10 @@ class SessionCheckpoint:
     def mark_paused(self, session_id: str) -> None:
         """Mark a session as paused — parked awaiting operator input."""
         self._write_status(session_id, SessionStatus.PAUSED)
+
+    def mark_error(self, session_id: str) -> None:
+        """Mark a session as errored (one-shot run died; not resumable)."""
+        self._write_status(session_id, SessionStatus.ERROR)
 
     def list_resumable(self) -> list[SessionState]:
         """List sessions that can be resumed (status=active or paused)."""

--- a/core/memory/session_manager.py
+++ b/core/memory/session_manager.py
@@ -677,6 +677,19 @@ class SessionManager:
             )
             self._conn.commit()
 
+    def update_status(self, session_id: str, status: str) -> None:
+        """Update one session's status in place (no-op when the row is
+        absent) — keeps the SQLite index in step with the state.json
+        transition primitives (``SessionCheckpoint._write_status``)."""
+        import time as _time
+
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET status = ?, updated_at = ? WHERE session_id = ?",
+                (status, _time.time(), session_id),
+            )
+            self._conn.commit()
+
     def get(self, session_id: str) -> SessionMeta | None:
         """Fetch a single session by ID."""
         row = self._conn.execute(

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -1241,13 +1241,11 @@ class CLIPoller:
             conversation.messages.clear()
             conversation.messages.extend(state.messages)
 
-            # Sync loop session_id for checkpoint continuity
-            loop._session_id = state.session_id
-
-            from core.agent.cognitive_state import CognitiveState
+            # Machine identity — session id + cognitive state + guard
+            # counters through the single shared resume surgery.
             from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
 
-            loop.cognitive_state = CognitiveState.from_snapshot(state.cognitive_state)
+            loop.restore_from_checkpoint(state)
             set_cognitive_state(loop.cognitive_state)
             set_session_id(state.session_id)
 

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -50,7 +50,7 @@
         "runtime",
         "while-tool-use"
       ],
-      "contentSha256": "8c8ec6c0ca273317d92e08a12b9ba1a82a6cd8fd3ab17b3e315d6c34cb91d783"
+      "contentSha256": "42b9ed70bc27ec856a031baeaa56a6b73e8a101e9b0d57a28abd4ea997844af4"
     },
     {
       "id": "file:core/agent/tool_executor/processor.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.327"
+version = "0.99.328"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.327. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.328. Last sync 2026-07-12. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.327. Last sync 2026-07-13. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.328. Last sync 2026-07-14. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-13
+ * Last sync: 2026-07-14
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -16,6 +16,11 @@ export type ChangelogEntry = {
 };
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    "version": "0.99.328",
+    "date": "2026-07-14",
+    "body": "### Changed\n\n- **AgenticLoop state-machine formalization — closed terminal alphabet.**\n  `TerminationReason` StrEnum (20 members, including the previously\n  undocumented `session_time_budget_handoff`/`_expired`) replaces the\n  comment-only string dictionary, and every terminal `AgenticResult` is\n  born through the single `_terminal_result` choke-point — the source\n  ratchet pins `AgenticResult(` to exactly one occurrence in\n  agent_loop.py. Post-response/post-tool guards (cost budget,\n  overthinking, model refusal, convergence, repeated-success) moved\n  verbatim into named `_guard_*` methods whose call order in `arun` IS\n  the documented priority order. Behaviour-preserving: StrEnum members\n  compare equal to the legacy strings, serialization unchanged.\n- **Snapshot completeness for resume.** Guard counters the conversation\n  messages don't carry (overthinking streak, LLM-failure counter,\n  diversity tracker, `ConvergenceDetector` state) now persist in the\n  checkpoint (`SessionState.loop_guards`, via\n  `_lifecycle.collect_guard_state`) and restore through the single shared\n  resume surgery `AgenticLoop.restore_from_checkpoint` — used by both the\n  IPC resume handler and the gateway ask continuation, closing the\n  manual-restore drift class a review caught in v0.99.327.\n- **Session-status transition ownership.** `SessionStatus` StrEnum with\n  documented transition owners plus a `mark_paused` primitive; the\n  scheduler drain (one-shot surface) now marks its checkpoint PAUSED when\n  parking behind a pending ask and COMPLETED otherwise, so scheduled\n  sessions stop polluting `list_resumable()` as immortal \"active\"\n  entries. Documented remaining gap: the gateway multi-turn surface\n  cannot know whether another message follows and stays ACTIVE until\n  cleanup. Guards: `tests/core/agent/test_loop_state_machine.py`\n  (state-space closure ratchet, guard-state roundtrip, status\n  transitions), extended `tests/core/cli/test_scheduler_drain_ask.py`."
+  },
   {
     "version": "0.99.327",
     "date": "2026-07-14",
@@ -2358,4 +2363,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-13";
+export const CHANGELOG_SYNCED_AT = "2026-07-14";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-13
+ * Last sync: 2026-07-14
  */
 
 export const GEODE_SOT = {
-  version: "0.99.327",
-  syncedAt: "2026-07-13",
+  version: "0.99.328",
+  syncedAt: "2026-07-14",
 } as const;

--- a/tests/core/agent/test_arun_llm_dispatch.py
+++ b/tests/core/agent/test_arun_llm_dispatch.py
@@ -80,6 +80,10 @@ class _StubLoop:
     def _emit_quota_panel(self, _exc: BillingError) -> None:
         self.quota_panel_calls += 1
 
+    # Real choke-point method — terminal results are born through
+    # ``_terminal_result`` even on the stub (FSM formalization).
+    _terminal_result = AgenticLoop._terminal_result
+
 
 def _run_dispatch(
     stub: _StubLoop, spinner: _StubSpinner, round_idx: int = 0
@@ -233,8 +237,8 @@ def test_arun_no_longer_inlines_billing_or_cancelled_handlers() -> None:
     # handler. The billing_error reason is still raised by the
     # session-start _try_decompose handler — verify it remains there
     # exactly once.
-    assert src.count('termination_reason="billing_error"') == 1
-    assert 'termination_reason="user_cancelled"' not in src
+    assert src.count("TerminationReason.BILLING_ERROR") == 1
+    assert "TerminationReason.USER_CANCELLED" not in src
 
 
 def test_arun_still_handles_context_exhausted_inline() -> None:

--- a/tests/core/agent/test_loop_state_machine.py
+++ b/tests/core/agent/test_loop_state_machine.py
@@ -40,9 +40,9 @@ def test_terminal_results_born_in_one_place():
 
 
 def test_no_inline_string_termination_reasons():
-    """No ``termination_reason="..."`` code literals (docstring mentions,
-    wrapped in double backticks, are exempt)."""
-    assert re.search(r'(?<!`)termination_reason="', _AGENT_LOOP_SRC) is None
+    """No ``termination_reason=<string literal>`` in code — either quote
+    style, any spacing (docstring mentions wrapped in backticks exempt)."""
+    assert re.search(r"(?<!`)termination_reason\s*=\s*[\"']", _AGENT_LOOP_SRC) is None
 
 
 def test_enum_covers_documented_terminal_alphabet():
@@ -89,6 +89,7 @@ def _fake_loop() -> SimpleNamespace:
         _consecutive_llm_failures=0,
         _total_empty_rounds=0,
         _budget_warned=False,
+        _low_confidence_replan_armed=True,
         _consecutive_tool_tracker=[],
         _convergence=ConvergenceDetector(),
         _session_id="",
@@ -121,13 +122,40 @@ def test_guard_state_roundtrip():
     assert dst._convergence.to_snapshot() == src._convergence.to_snapshot()
 
 
-def test_apply_guard_state_tolerates_empty_and_partial():
+def test_apply_guard_state_is_replacement_not_merge():
+    """A legacy checkpoint (no loop_guards) must RESET a reused loop's
+    counters — never inherit the previous conversation's guard state."""
     dst = _fake_loop()
+    dst._consecutive_llm_failures = 4
+    dst._budget_warned = True
+    dst._consecutive_tool_tracker = [("grep_files", "sig-a")]
+    dst._convergence.total_consecutive_tool_errors = 3
+
     _lifecycle.apply_guard_state(dst, {})
+
     assert dst._consecutive_llm_failures == 0
-    _lifecycle.apply_guard_state(dst, {"consecutive_llm_failures": 2})
-    assert dst._consecutive_llm_failures == 2
+    assert dst._budget_warned is False
     assert dst._consecutive_tool_tracker == []
+    assert dst._convergence.total_consecutive_tool_errors == 0
+    assert dst._low_confidence_replan_armed is True  # fresh-loop default
+
+
+def test_apply_guard_state_coerces_malformed_values():
+    """A malformed checkpoint can never leave the loop half-restored."""
+    dst = _fake_loop()
+    _lifecycle.apply_guard_state(
+        dst,
+        {
+            "consecutive_llm_failures": None,
+            "consecutive_text_only_rounds": "not-a-number",
+            "consecutive_tool_tracker": "garbage",
+            "convergence": "garbage",
+        },
+    )
+    assert dst._consecutive_llm_failures == 0
+    assert dst._consecutive_text_only_rounds == 0
+    assert dst._consecutive_tool_tracker == []
+    assert dst._convergence.to_snapshot() == ConvergenceDetector().to_snapshot()
 
 
 def test_restore_loop_state_is_the_single_surgery():
@@ -165,6 +193,17 @@ def test_checkpoint_persists_loop_guards(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _index_status(tmp_path, session_id: str) -> str:
+    from core.memory.session_manager import SessionManager
+
+    mgr = SessionManager(tmp_path / "sessions" / "sessions.db")
+    try:
+        meta = mgr.get(session_id)
+        return meta.status if meta else "missing"
+    finally:
+        mgr.close()
+
+
 def test_session_status_transitions(tmp_path):
     cp = SessionCheckpoint(tmp_path / "sessions")
     cp.save(SessionState(session_id="s-status", messages=[]))
@@ -172,11 +211,17 @@ def test_session_status_transitions(tmp_path):
 
     cp.mark_paused("s-status")
     assert cp.load("s-status").status == SessionStatus.PAUSED
+    # Both SoTs move together — geode session list reads the SQLite index.
+    assert _index_status(tmp_path, "s-status") == SessionStatus.PAUSED
     assert any(s.session_id == "s-status" for s in cp.list_resumable())
 
     cp.mark_completed("s-status")
     assert cp.load("s-status").status == SessionStatus.COMPLETED
+    assert _index_status(tmp_path, "s-status") == SessionStatus.COMPLETED
     assert all(s.session_id != "s-status" for s in cp.list_resumable())
+
+    cp.mark_error("s-status")
+    assert cp.load("s-status").status == SessionStatus.ERROR
 
 
 def test_mark_paused_missing_session_is_noop(tmp_path):

--- a/tests/core/agent/test_loop_state_machine.py
+++ b/tests/core/agent/test_loop_state_machine.py
@@ -1,0 +1,184 @@
+"""AgenticLoop state-machine contracts.
+
+Three invariants introduced by the FSM formalization:
+
+1. State-space closure — every terminal ``AgenticResult`` is born in
+   exactly ONE place (``AgenticLoop._terminal_result``) with a
+   :class:`TerminationReason` member; no inline string reasons remain.
+2. Snapshot completeness — ``collect_guard_state``/``apply_guard_state``
+   round-trip the guard counters the conversation messages don't carry,
+   and the checkpoint persists them.
+3. Session-status transitions — ``SessionStatus`` writes go through the
+   transition primitives (save→active, mark_paused, mark_completed).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.agent.convergence import ConvergenceDetector
+from core.agent.loop import _lifecycle
+from core.agent.loop.models import TerminationReason
+from core.memory.session_checkpoint import SessionCheckpoint, SessionState, SessionStatus
+
+_AGENT_LOOP_SRC = (
+    Path(__file__).resolve().parents[3] / "core" / "agent" / "loop" / "agent_loop.py"
+).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. State-space closure (source ratchet)
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_results_born_in_one_place():
+    """``AgenticResult(`` appears once in agent_loop.py — inside
+    ``_terminal_result``. New exits must route through the choke-point."""
+    assert _AGENT_LOOP_SRC.count("AgenticResult(") == 1
+
+
+def test_no_inline_string_termination_reasons():
+    """No ``termination_reason="..."`` code literals (docstring mentions,
+    wrapped in double backticks, are exempt)."""
+    assert re.search(r'(?<!`)termination_reason="', _AGENT_LOOP_SRC) is None
+
+
+def test_enum_covers_documented_terminal_alphabet():
+    expected = {
+        "natural",
+        "forced_text",
+        "max_rounds",
+        "time_budget_expired",
+        "session_time_budget_handoff",
+        "session_time_budget_expired",
+        "context_exhausted",
+        "cost_budget_exceeded",
+        "billing_error",
+        "model_action_required",
+        "model_refusal",
+        "user_clarification_needed",
+        "convergence_detected",
+        "repeated_success_no_progress",
+        "input_blocked",
+        "user_cancelled",
+        "actionable_partial",
+        "tool_use_yield",
+        "llm_error",
+        "unknown",
+    }
+    assert {member.value for member in TerminationReason} == expected
+
+
+def test_enum_members_compare_equal_to_legacy_strings():
+    """StrEnum keeps every existing string comparison working."""
+    assert TerminationReason.USER_CLARIFICATION_NEEDED == "user_clarification_needed"
+    assert TerminationReason.CONTEXT_EXHAUSTED == "context_exhausted"
+    assert str(TerminationReason.MAX_ROUNDS) == "max_rounds"
+
+
+# ---------------------------------------------------------------------------
+# 2. Snapshot completeness
+# ---------------------------------------------------------------------------
+
+
+def _fake_loop() -> SimpleNamespace:
+    return SimpleNamespace(
+        _consecutive_text_only_rounds=0,
+        _consecutive_llm_failures=0,
+        _total_empty_rounds=0,
+        _budget_warned=False,
+        _consecutive_tool_tracker=[],
+        _convergence=ConvergenceDetector(),
+        _session_id="",
+        cognitive_state=None,
+    )
+
+
+def test_guard_state_roundtrip():
+    src = _fake_loop()
+    src._consecutive_text_only_rounds = 1
+    src._consecutive_llm_failures = 3
+    src._total_empty_rounds = 2
+    src._budget_warned = True
+    src._consecutive_tool_tracker = [("grep_files", "sig-a"), ("read_file", "sig-b")]
+    src._convergence.total_consecutive_tool_errors = 2
+    src._convergence.recent_errors = ["boom", "boom"]
+    src._convergence.repeated_success_streak = 4
+    src._convergence.last_success_tool = "list_dir"
+
+    snapshot = _lifecycle.collect_guard_state(src)
+
+    dst = _fake_loop()
+    _lifecycle.apply_guard_state(dst, snapshot)
+
+    assert dst._consecutive_text_only_rounds == 1
+    assert dst._consecutive_llm_failures == 3
+    assert dst._total_empty_rounds == 2
+    assert dst._budget_warned is True
+    assert dst._consecutive_tool_tracker == [("grep_files", "sig-a"), ("read_file", "sig-b")]
+    assert dst._convergence.to_snapshot() == src._convergence.to_snapshot()
+
+
+def test_apply_guard_state_tolerates_empty_and_partial():
+    dst = _fake_loop()
+    _lifecycle.apply_guard_state(dst, {})
+    assert dst._consecutive_llm_failures == 0
+    _lifecycle.apply_guard_state(dst, {"consecutive_llm_failures": 2})
+    assert dst._consecutive_llm_failures == 2
+    assert dst._consecutive_tool_tracker == []
+
+
+def test_restore_loop_state_is_the_single_surgery():
+    dst = _fake_loop()
+    state = SimpleNamespace(
+        session_id="s-resume-1",
+        cognitive_state={},
+        loop_guards={"consecutive_text_only_rounds": 1, "budget_warned": True},
+    )
+    _lifecycle.restore_loop_state(dst, state)
+    assert dst._session_id == "s-resume-1"
+    assert dst.cognitive_state is not None
+    assert dst._consecutive_text_only_rounds == 1
+    assert dst._budget_warned is True
+
+
+def test_checkpoint_persists_loop_guards(tmp_path):
+    cp = SessionCheckpoint(tmp_path / "sessions")
+    guards = {
+        "consecutive_text_only_rounds": 1,
+        "consecutive_llm_failures": 2,
+        "total_empty_rounds": 1,
+        "budget_warned": True,
+        "consecutive_tool_tracker": [["grep_files", "sig-a"]],
+        "convergence": ConvergenceDetector().to_snapshot(),
+    }
+    cp.save(SessionState(session_id="s-guards", messages=[], loop_guards=guards))
+    loaded = cp.load("s-guards")
+    assert loaded is not None
+    assert loaded.loop_guards == guards
+
+
+# ---------------------------------------------------------------------------
+# 3. Session-status transitions
+# ---------------------------------------------------------------------------
+
+
+def test_session_status_transitions(tmp_path):
+    cp = SessionCheckpoint(tmp_path / "sessions")
+    cp.save(SessionState(session_id="s-status", messages=[]))
+    assert cp.load("s-status").status == SessionStatus.ACTIVE
+
+    cp.mark_paused("s-status")
+    assert cp.load("s-status").status == SessionStatus.PAUSED
+    assert any(s.session_id == "s-status" for s in cp.list_resumable())
+
+    cp.mark_completed("s-status")
+    assert cp.load("s-status").status == SessionStatus.COMPLETED
+    assert all(s.session_id != "s-status" for s in cp.list_resumable())
+
+
+def test_mark_paused_missing_session_is_noop(tmp_path):
+    cp = SessionCheckpoint(tmp_path / "sessions")
+    cp.mark_paused("does-not-exist")  # must not raise

--- a/tests/core/cli/test_scheduler_drain_ask.py
+++ b/tests/core/cli/test_scheduler_drain_ask.py
@@ -37,6 +37,9 @@ class _FakeLoop:
     def mark_session_completed(self) -> None:
         self.status_marks.append("completed")
 
+    def mark_session_error(self) -> None:
+        self.status_marks.append("error")
+
 
 class _FakeServices:
     def __init__(self, result: Any) -> None:
@@ -100,3 +103,23 @@ def test_natural_termination_publishes_nothing_and_completes(monkeypatch):
     published, services = _run_drain(monkeypatch, "natural")
     assert published == []
     assert services.loops[0].status_marks == ["completed"]
+
+
+class _ExplodingLoop(_FakeLoop):
+    async def arun(self, _prompt: str) -> Any:
+        raise RuntimeError("run blew up")
+
+
+def test_run_failure_marks_error():
+    services = _FakeServices(None)
+
+    def _create_exploding(_mode: Any, **_kwargs: Any) -> tuple[Any, Any]:
+        loop = _ExplodingLoop(None)
+        services.loops.append(loop)
+        return None, loop
+
+    services.create_session = _create_exploding  # type: ignore[method-assign]
+    action_queue: queue.Queue = queue.Queue()
+    action_queue.put(("job1", "boom", True, ""))
+    asyncio.run(_drain_and_settle(action_queue, services))
+    assert services.loops[0].status_marks == ["error"]

--- a/tests/core/cli/test_scheduler_drain_ask.py
+++ b/tests/core/cli/test_scheduler_drain_ask.py
@@ -26,17 +26,27 @@ class _FakeLoop:
     def __init__(self, result: Any) -> None:
         self._result = result
         self._session_id = "s-sched-test"
+        self.status_marks: list[str] = []
 
     async def arun(self, _prompt: str) -> Any:
         return self._result
+
+    def mark_session_paused(self) -> None:
+        self.status_marks.append("paused")
+
+    def mark_session_completed(self) -> None:
+        self.status_marks.append("completed")
 
 
 class _FakeServices:
     def __init__(self, result: Any) -> None:
         self._result = result
+        self.loops: list[_FakeLoop] = []
 
     def create_session(self, _mode: Any, **_kwargs: Any) -> tuple[Any, Any]:
-        return None, _FakeLoop(self._result)
+        loop = _FakeLoop(self._result)
+        self.loops.append(loop)
+        return None, loop
 
 
 async def _drain_and_settle(action_queue: Any, services: Any) -> None:
@@ -51,7 +61,7 @@ async def _drain_and_settle(action_queue: Any, services: Any) -> None:
         await asyncio.gather(*list(_INFLIGHT_SCHEDULED_TASKS), return_exceptions=True)
 
 
-def _run_drain(monkeypatch, termination_reason: str) -> list[dict[str, Any]]:
+def _run_drain(monkeypatch, termination_reason: str) -> tuple[list[dict[str, Any]], _FakeServices]:
     published: list[dict[str, Any]] = []
 
     async def _fake_publish(question: str, *, session_id: str, source: str, store: Any = None):
@@ -68,12 +78,13 @@ def _run_drain(monkeypatch, termination_reason: str) -> list[dict[str, Any]]:
     action_queue: queue.Queue = queue.Queue()
     action_queue.put(("job1", "do the nightly thing", True, ""))
 
-    asyncio.run(_drain_and_settle(action_queue, _FakeServices(result)))
-    return published
+    services = _FakeServices(result)
+    asyncio.run(_drain_and_settle(action_queue, services))
+    return published, services
 
 
-def test_clarification_termination_publishes_ask(monkeypatch):
-    published = _run_drain(monkeypatch, "user_clarification_needed")
+def test_clarification_termination_publishes_ask_and_pauses(monkeypatch):
+    published, services = _run_drain(monkeypatch, "user_clarification_needed")
     assert published == [
         {
             "question": "Which repository should I target?",
@@ -81,7 +92,11 @@ def test_clarification_termination_publishes_ask(monkeypatch):
             "source": "scheduled:job1",
         }
     ]
+    # One-shot lifecycle owner: checkpoint parked for the ask continuation.
+    assert services.loops[0].status_marks == ["paused"]
 
 
-def test_natural_termination_publishes_nothing(monkeypatch):
-    assert _run_drain(monkeypatch, "natural") == []
+def test_natural_termination_publishes_nothing_and_completes(monkeypatch):
+    published, services = _run_drain(monkeypatch, "natural")
+    assert published == []
+    assert services.loops[0].status_marks == ["completed"]

--- a/tests/core/llm/test_fable5_support.py
+++ b/tests/core/llm/test_fable5_support.py
@@ -13,6 +13,7 @@ Official refs:
 
 from __future__ import annotations
 
+import inspect
 import tomllib
 from pathlib import Path
 
@@ -66,12 +67,21 @@ def test_plugin_allowlists_include_fable() -> None:
 
 
 def test_refusal_stop_reason_flows_to_result() -> None:
-    """normalize_anthropic carries stop_details; the loop branch exists."""
+    """normalize_anthropic carries stop_details; the refusal guard exists.
+
+    v0.99.328 FSM formalization moved the branch into the named guard
+    ``_guard_model_refusal`` (early-return on non-refusal stop reasons)
+    terminating with ``TerminationReason.MODEL_REFUSAL``.
+    """
+    from core.agent.loop.agent_loop import AgenticLoop
+    from core.agent.loop.models import TerminationReason
     from core.llm.agentic_response import AgenticResponse
 
     resp = AgenticResponse(stop_reason="refusal", stop_details={"category": "cyber"})
     assert resp.stop_details == {"category": "cyber"}
 
-    loop_src = (REPO_ROOT / "core" / "agent" / "loop" / "agent_loop.py").read_text(encoding="utf-8")
-    assert 'response.stop_reason == "refusal"' in loop_src
-    assert '"model_refusal"' in loop_src
+    assert callable(getattr(AgenticLoop, "_guard_model_refusal", None))
+    guard_src = inspect.getsource(AgenticLoop._guard_model_refusal)
+    assert 'response.stop_reason != "refusal"' in guard_src
+    assert "TerminationReason.MODEL_REFUSAL" in guard_src
+    assert TerminationReason.MODEL_REFUSAL == "model_refusal"

--- a/tests/integration/test_phase3_ipc.py
+++ b/tests/integration/test_phase3_ipc.py
@@ -507,6 +507,16 @@ class TestCLIChannelIntegration:
         mock_services = MagicMock()
         mock_loop = MagicMock()
         mock_loop.model = "claude-opus-4-6"
+
+        # v0.99.328 resume contract — the poller delegates the machine-state
+        # surgery to loop.restore_from_checkpoint; the double implements it.
+        def _restore(state_arg):
+            from core.agent.cognitive_state import CognitiveState
+
+            mock_loop._session_id = state_arg.session_id
+            mock_loop.cognitive_state = CognitiveState.from_snapshot(state_arg.cognitive_state)
+
+        mock_loop.restore_from_checkpoint = _restore
         mock_services.create_session.return_value = (MagicMock(), mock_loop)
 
         poller = CLIPoller(mock_services, socket_path=sock_path)
@@ -566,6 +576,14 @@ class TestCLIChannelIntegration:
         mock_services = MagicMock()
         mock_loop = MagicMock()
         mock_loop.model = "claude-opus-4-6"
+
+        def _restore(state_arg):
+            from core.agent.cognitive_state import CognitiveState
+
+            mock_loop._session_id = state_arg.session_id
+            mock_loop.cognitive_state = CognitiveState.from_snapshot(state_arg.cognitive_state)
+
+        mock_loop.restore_from_checkpoint = _restore
         mock_services.create_session.return_value = (MagicMock(), mock_loop)
 
         poller = CLIPoller(mock_services, socket_path=sock_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.327"
+version = "0.99.328"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

에이전트 파편화 감사(2026-07-14)에서 확인한 "오토마타로 다루기 어려운 지점" 중 상위 3개를 형식화: 종결 상태 공간 폐쇄(TerminationReason StrEnum + 단일 생성자), 가드 우선순위의 명시화(_guard_* 체인), 스냅샷 완전성(가드 카운터 체크포인트 + 단일 resume 수술). 동작 보존 리팩터 — StrEnum이 기존 문자열 비교·직렬화와 완전 호환.

## Why

- 종결 상태가 인라인 문자열 17곳에서 태어나 상태 공간이 타입으로 닫히지 않았고(주석 사전은 session_time_budget_* 2종 누락으로 이미 낡음), 새 소비자마다 grep으로 사전을 재발견해야 했다.
- 가드 발화 우선순위가 while 본문 배치 순서에 암묵 인코딩되어 전이 규칙이 명세가 아니었다.
- resume가 부분 스냅샷 위의 속성 수술이라 복원 누락이 구조적으로 재발한다 — v0.99.327에서 리뷰가 잡은 continuation의 cognitive state 복원 누락이 실증.
- 스케줄 세션이 영원히 "active"로 남아 list_resumable을 오염시키고, ask/reply resume이 그 느슨함에 의존하고 있었다.

## Changes

- `core/agent/loop/models.py`: `TerminationReason` StrEnum 20종(생산자 없는 llm_error는 legacy 명시) — 주석 사전 대체
- `core/agent/loop/agent_loop.py`: `_terminal_result` 단일 초크포인트(파일 내 `AgenticResult(` 생성 1곳 소스 래칫), 전 종결 사이트 이관, 가드 5종(`_guard_cost_budget/overthinking/model_refusal/convergence/repeated_success`)을 이름 있는 메서드로 verbatim 추출 — arun의 호출 순서=우선순위 명세, `restore_from_checkpoint`/`mark_session_paused` 위임 추가
- `core/agent/loop/_lifecycle.py`: `collect_guard_state`/`apply_guard_state`(카운터 6종+ConvergenceDetector 스냅샷), `restore_loop_state` 단일 resume 수술, `mark_session_paused`; save_checkpoint가 loop_guards 기록
- `core/agent/convergence.py`: `to_snapshot`/`apply_snapshot`
- `core/memory/session_checkpoint.py`: `SessionStatus` StrEnum(전이 소유자 문서화), `SessionState.loop_guards`, `_write_status` 전이 프리미티브 + `mark_paused`
- `core/server/ipc_server/poller.py` + `core/cli/typer_serve.py`: 수동 복원 나열 → `restore_from_checkpoint` 공유 경로
- `core/cli/scheduler_drain.py`: 원샷 표면의 status 전이 소유 — pending ask 발행 시 PAUSED, 그 외 종결 시 COMPLETED (게이트웨이 멀티턴 표면은 설계상 ACTIVE 유지 — SessionStatus docstring에 잔여 갭 명시)
- 테스트: `tests/core/agent/test_loop_state_machine.py` 신규 11종(단일 생성지 소스 래칫, 인라인 문자열 부재, enum 알파벳 일치, 레거시 문자열 동등성, 가드 상태 왕복, 체크포인트 영속, status 전이), `test_scheduler_drain_ask.py` status 전이 단언 확장, `test_arun_llm_dispatch.py` 스텁·소스스캔을 초크포인트 기준으로 갱신

## Verification

- `uv run ruff check core/ tests/ plugins/ scripts/` → All checks passed
- `uv run ruff format --check` 동일 범위 → 1204 files already formatted
- `uv run mypy core/ plugins/` → 0 errors (524 files)
- `uv run lint-imports` → 4 kept, 0 broken
- `uv run pytest tests/core/agent tests/core/memory tests/core/cli tests/core/server` → rc=0 (실패 0; 기존 dispatch 추출 핀 테스트 5건은 초크포인트 도입에 맞춰 의도 보존 갱신)
- slop ratchet OK (254/254 — 신규 억제 마커 0)
- CLI 스모크 `geode version` v0.99.328
- 후속 검증 예정(이 PR 프로세스): Codex MCP(gpt-5.6-sol xhigh) 누수·중복·slop 개괄 점검 → gpt subscription 레인 라이브 E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)