### PR TITLE
fix(release): shell-parse retry path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,17 +381,7 @@ jobs:
             gh release view "$tag" \
               --repo "${{ github.repository }}" \
               --json body > published-release/release.json
-            python - <<'PY'
-            import json
-            from pathlib import Path
-
-            payload = json.loads(
-                Path("published-release/release.json").read_text(encoding="utf-8")
-            )
-            Path("published-release/release-notes.md").write_text(
-                payload["body"], encoding="utf-8"
-            )
-            PY
+            python -c 'import json; from pathlib import Path; source = Path("published-release/release.json"); payload = json.loads(source.read_text(encoding="utf-8")); Path("published-release/release-notes.md").write_text(payload["body"], encoding="utf-8")'
             diff -u release-artifacts/release-notes.md published-release/release-notes.md
           else
             gh release create "$tag" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stable-release repair scripts are shell-parse checked.** Existing GitHub
+  release-body extraction no longer embeds an indented heredoc inside a shell
+  conditional, and the release workflow regression suite now runs `bash -n`
+  over every `run` block before a publishing change can merge.
+
 ## [0.99.330] - 2026-07-14
 
 ### Fixed

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -31,6 +32,28 @@ def test_release_actions_are_pinned_to_immutable_commits() -> None:
 
     assert uses
     assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", value) for value in uses)
+
+
+def test_release_run_blocks_parse_as_bash() -> None:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+
+    for job_name, job in jobs.items():
+        assert isinstance(job, dict)
+        for index, step in enumerate(job.get("steps", [])):
+            if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                continue
+            result = subprocess.run(
+                ["/bin/bash", "-n"],
+                input=step["run"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            label = step.get("name", f"step {index}")
+            assert result.returncode == 0, (
+                f"{job_name} / {label} is not valid Bash:\n{result.stderr}"
+            )
 
 
 def test_pypi_oidc_is_isolated_from_public_verification() -> None:


### PR DESCRIPTION
## Summary
- Repair the stable-release retry path so every shell block parses before publication.
- Add a regression test that runs `bash -n` over every workflow `run` block.

## Why
The first v0.99.330 stable run validated and built successfully, then stopped before GitHub Release, PyPI, or Homebrew publication because an indented heredoc terminator made the publish step invalid Bash.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replace the conditional heredoc with byte-preserving one-line JSON extraction. |
| `tests/integration/test_release_workflow.py` | Parse-check every release workflow shell block with Bash. |
| `CHANGELOG.md` | Record the stable-release repair. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Workflow YAML | Parsed successfully | Unchanged |
| Embedded shell | Retry branch could fail at parse time | Every `run` block is checked by `bash -n` |
| Release body | Exact bytes required on retry | Existing byte-preservation assertion remains green |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py` — 7 passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml` — passed
- `uv run ruff check tests/integration/test_release_workflow.py` — passed
- `uv run ruff format --check tests/integration/test_release_workflow.py` — passed
- `uv run mypy tests/integration/test_release_workflow.py` — passed
- `git diff --check` — passed