### PR TITLE
fix(release): promote shell-parse repair

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,17 +381,7 @@ jobs:
             gh release view "$tag" \
               --repo "${{ github.repository }}" \
               --json body > published-release/release.json
-            python - <<'PY'
-            import json
-            from pathlib import Path
-
-            payload = json.loads(
-                Path("published-release/release.json").read_text(encoding="utf-8")
-            )
-            Path("published-release/release-notes.md").write_text(
-                payload["body"], encoding="utf-8"
-            )
-            PY
+            python -c 'import json; from pathlib import Path; source = Path("published-release/release.json"); payload = json.loads(source.read_text(encoding="utf-8")); Path("published-release/release-notes.md").write_text(payload["body"], encoding="utf-8")'
             diff -u release-artifacts/release-notes.md published-release/release-notes.md
           else
             gh release create "$tag" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stable-release repair scripts are shell-parse checked.** Existing GitHub
+  release-body extraction no longer embeds an indented heredoc inside a shell
+  conditional, and the release workflow regression suite now runs `bash -n`
+  over every `run` block before a publishing change can merge.
+
 ## [0.99.330] - 2026-07-14
 
 ### Fixed

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -31,6 +32,28 @@ def test_release_actions_are_pinned_to_immutable_commits() -> None:
 
     assert uses
     assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", value) for value in uses)
+
+
+def test_release_run_blocks_parse_as_bash() -> None:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+
+    for job_name, job in jobs.items():
+        assert isinstance(job, dict)
+        for index, step in enumerate(job.get("steps", [])):
+            if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                continue
+            result = subprocess.run(
+                ["/bin/bash", "-n"],
+                input=step["run"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            label = step.get("name", f"step {index}")
+            assert result.returncode == 0, (
+                f"{job_name} / {label} is not valid Bash:\n{result.stderr}"
+            )
 
 
 def test_pypi_oidc_is_isolated_from_public_verification() -> None:


### PR DESCRIPTION
## Summary
- Promote the stable-release shell parsing hotfix from `develop` to `main`.
- Preserve the already-created annotated `v0.99.330` tag and resume publication against that exact source commit after merge.

## Why
The initial stable run completed the commercial release validation/build stages, then stopped before external publication because a heredoc inside the existing-release retry branch made the shell step unparsable. GitHub Release, PyPI, and Homebrew were not partially published.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replace the invalid conditional heredoc with exact JSON body extraction. |
| `tests/integration/test_release_workflow.py` | Add `bash -n` validation for every release workflow shell block. |
| `CHANGELOG.md` | Record the release repair. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| YAML validation | Passed | Passed |
| Shell parse validation | Missing | Every `run` block checked |
| Retry body integrity | Asserted | Asserted and retained |
| Production tracking sync | Main-only state | Synced by #2718 before promotion |

## Verification
- PR #2717 CI: full non-live test gate passed (Test 4m27s), lint, type, security, and final gate passed
- PR #2717 install smoke: Ubuntu and macOS passed
- Targeted workflow suite: 7 passed
- actionlint, ruff, format, mypy, and `git diff --check` passed
- `git diff --name-status origin/main..origin/develop` contains exactly the three files above