### PR TITLE
fix(release): support Homebrew CLI transition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,10 +606,15 @@ jobs:
       - name: Refresh pinned Python resources from the published PyPI package
         if: steps.tap-release-state.outputs.current != 'true'
         run: |
-          brew update-python-resources tap/Formula/geode.rb \
-            --package-name geode-agent \
-            --version "$GEODE_VERSION" \
-            --ignore-main-package-cooldown
+          resource_args=(
+            tap/Formula/geode.rb
+            --package-name geode-agent
+            --version "$GEODE_VERSION"
+          )
+          if [[ "$(brew update-python-resources --help)" == *"--ignore-main-package-cooldown"* ]]; then
+            resource_args+=(--ignore-main-package-cooldown)
+          fi
+          brew update-python-resources "${resource_args[@]}"
 
       - name: Revalidate the complete generated formula
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ functional change.
   release-body extraction no longer embeds an indented heredoc inside a shell
   conditional, and the release workflow regression suite now runs `bash -n`
   over every `run` block before a publishing change can merge.
+- **Homebrew resource refresh spans the CLI transition safely.** Stable
+  publication now detects whether the runner's `update-python-resources`
+  supports the new main-package cooldown override and only passes that option
+  when available, while retaining exact resource pins on older Homebrew.
 
 ## [0.99.330] - 2026-07-14
 

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import tomllib
@@ -78,11 +79,86 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
 
     assert "HOMEBREW_TAP_TOKEN" not in text
     assert "HOMEBREW_TAP_DEPLOY_KEY" in text
+    assert "brew update-python-resources --help" in text
     assert "--ignore-main-package-cooldown" in text
     assert text.count("--template geode/packaging/homebrew/geode.rb.in") == 3
     assert "git pull --rebase" not in text
     assert "steps.tap-base.outputs.sha" in text
     assert "skip-existing: true" in text
+
+
+def test_homebrew_resource_refresh_adapts_to_brew_cli(tmp_path: Path) -> None:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    publish = jobs["publish-homebrew"]
+    assert isinstance(publish, dict)
+    steps = publish["steps"]
+    assert isinstance(steps, list)
+    run = next(
+        step["run"]
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Refresh pinned Python resources from the published PyPI package"
+    )
+    assert isinstance(run, str)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    brew = bin_dir / "brew"
+    brew.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "update-python-resources" && "${2:-}" == "--help" ]]; then
+  printf '%s\\n' "${BREW_HELP_TEXT:-}"
+  exit 0
+fi
+printf '%s\\n' "$@" > "$BREW_CAPTURE"
+""",
+        encoding="utf-8",
+    )
+    brew.chmod(0o755)
+
+    base_args = [
+        "update-python-resources",
+        "tap/Formula/geode.rb",
+        "--package-name",
+        "geode-agent",
+        "--version",
+        "0.99.330",
+    ]
+    cases: tuple[tuple[str, str, list[str]], ...] = (
+        ("legacy", "", []),
+        (
+            "cooldown",
+            "--ignore-main-package-cooldown",
+            ["--ignore-main-package-cooldown"],
+        ),
+    )
+    for label, help_text, extra_args in cases:
+        capture = tmp_path / f"{label}.args"
+        env = os.environ.copy()
+        env.update(
+            {
+                "BREW_CAPTURE": str(capture),
+                "BREW_HELP_TEXT": help_text,
+                "GEODE_VERSION": "0.99.330",
+                "PATH": f"{bin_dir}:{env['PATH']}",
+            }
+        )
+        result = subprocess.run(
+            ["/bin/bash", "-e"],
+            input=run,
+            text=True,
+            capture_output=True,
+            check=False,
+            cwd=tmp_path,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert capture.read_text(encoding="utf-8").splitlines() == [
+            *base_args,
+            *extra_args,
+        ]
 
 
 def test_release_retry_preserves_release_body_bytes() -> None:


### PR DESCRIPTION
## Summary
- Make Homebrew resource refresh compatible with both sides of the current CLI transition.
- Exercise the exact workflow shell block against mocked legacy and cooldown-aware Homebrew CLIs.

## Why
Stable run 29323179166 successfully published and publicly verified GitHub Release and PyPI v0.99.330, then stopped before mutating the tap because the macOS 26 runner rejected `--ignore-main-package-cooldown` as an unknown option. Homebrew's current source has the new flag, while the hosted runner's installed command does not yet expose it.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Detect the option through `brew update-python-resources --help` and append it only when supported. |
| `tests/integration/test_release_workflow.py` | Execute the exact YAML shell block with mocked old/new Homebrew CLIs and assert argv. |
| `CHANGELOG.md` | Record the Homebrew CLI compatibility repair. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Hosted runner CLI | Unknown flag aborted publication | Uses the supported base command |
| New Homebrew CLI | Cooldown override always requested | Override retained when advertised |
| Regression proof | Static string assertion | Exact shell block executes in both capability modes |
| Tap state | No v0.99.330 mutation occurred | Safe to retry after merge |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py` — 8 passed
- `uv run ruff check tests/integration/test_release_workflow.py` — passed
- `uv run ruff format --check tests/integration/test_release_workflow.py` — passed
- `uv run mypy tests/integration/test_release_workflow.py` — passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml` — passed
- `git diff --check` — passed