### PR TITLE
fix(release): resolve Homebrew formula through tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,8 +606,11 @@ jobs:
       - name: Refresh pinned Python resources from the published PyPI package
         if: steps.tap-release-state.outputs.current != 'true'
         run: |
+          tap_name=mangowhoiscloud/tap
+          brew tap "$tap_name" "$PWD/tap"
+          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
           resource_args=(
-            tap/Formula/geode.rb
+            "$tap_name/geode"
             --package-name geode-agent
             --version "$GEODE_VERSION"
           )
@@ -615,6 +618,7 @@ jobs:
             resource_args+=(--ignore-main-package-cooldown)
           fi
           brew update-python-resources "${resource_args[@]}"
+          cp "$tap_formula" tap/Formula/geode.rb
 
       - name: Revalidate the complete generated formula
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ functional change.
 - **Homebrew resource refresh spans the CLI transition safely.** Stable
   publication now detects whether the runner's `update-python-resources`
   supports the new main-package cooldown override and only passes that option
-  when available, while retaining exact resource pins on older Homebrew.
+  when available. It registers the checked-out repository as a local tap and
+  resolves its qualified formula name, retaining exact resource pins across
+  both older and current Homebrew.
 
 ## [0.99.330] - 2026-07-14
 

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -87,7 +87,9 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
     assert "skip-existing: true" in text
 
 
-def test_homebrew_resource_refresh_adapts_to_brew_cli(tmp_path: Path) -> None:
+def test_homebrew_resource_refresh_uses_local_tap_and_adapts_cli(
+    tmp_path: Path,
+) -> None:
     jobs = _workflow()["jobs"]
     assert isinstance(jobs, dict)
     publish = jobs["publish-homebrew"]
@@ -104,15 +106,29 @@ def test_homebrew_resource_refresh_adapts_to_brew_cli(tmp_path: Path) -> None:
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    checkout_formula = tmp_path / "tap" / "Formula" / "geode.rb"
+    checkout_formula.parent.mkdir(parents=True)
+    tap_repo = tmp_path / "homebrew-tap"
+    (tap_repo / "Formula").mkdir(parents=True)
     brew = bin_dir / "brew"
     brew.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == "tap" ]]; then
+  printf '%s\\n' "$@" > "$BREW_TAP_CAPTURE"
+  exit 0
+fi
+if [[ "${1:-}" == "--repo" ]]; then
+  [[ "${2:-}" == "mangowhoiscloud/tap" ]]
+  printf '%s\\n' "$BREW_TAP_REPO"
+  exit 0
+fi
 if [[ "${1:-}" == "update-python-resources" && "${2:-}" == "--help" ]]; then
   printf '%s\\n' "${BREW_HELP_TEXT:-}"
   exit 0
 fi
 printf '%s\\n' "$@" > "$BREW_CAPTURE"
+printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
 """,
         encoding="utf-8",
     )
@@ -120,7 +136,7 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
 
     base_args = [
         "update-python-resources",
-        "tap/Formula/geode.rb",
+        "mangowhoiscloud/tap/geode",
         "--package-name",
         "geode-agent",
         "--version",
@@ -136,11 +152,19 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
     )
     for label, help_text, extra_args in cases:
         capture = tmp_path / f"{label}.args"
+        tap_capture = tmp_path / f"{label}.tap"
+        checkout_formula.write_text("checkout formula\n", encoding="utf-8")
+        (tap_repo / "Formula" / "geode.rb").write_text(
+            "tapped formula\n",
+            encoding="utf-8",
+        )
         env = os.environ.copy()
         env.update(
             {
                 "BREW_CAPTURE": str(capture),
                 "BREW_HELP_TEXT": help_text,
+                "BREW_TAP_CAPTURE": str(tap_capture),
+                "BREW_TAP_REPO": str(tap_repo),
                 "GEODE_VERSION": "0.99.330",
                 "PATH": f"{bin_dir}:{env['PATH']}",
             }
@@ -159,6 +183,12 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
             *base_args,
             *extra_args,
         ]
+        assert tap_capture.read_text(encoding="utf-8").splitlines() == [
+            "tap",
+            "mangowhoiscloud/tap",
+            str(tmp_path / "tap"),
+        ]
+        assert checkout_formula.read_text(encoding="utf-8") == "updated formula\n"
 
 
 def test_release_retry_preserves_release_body_bytes() -> None:


### PR DESCRIPTION
## Summary
- Register the checked-out tap repository with Homebrew before refreshing Python resources.
- Resolve the formula by its qualified tap name, then copy refreshed resources back to the publish checkout.

## Why
Run 29324766401 proved the CLI capability fix worked, then Homebrew rejected `tap/Formula/geode.rb` because formula paths outside registered taps are not accepted. The job stopped before committing or pushing the tap.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Register the checkout as a local tap, update `mangowhoiscloud/tap/geode`, and copy the generated formula back. |
| `tests/integration/test_release_workflow.py` | Mock and assert local tap registration, qualified formula argv, both CLI capability modes, and copy-back. |
| `CHANGELOG.md` | Fold tap-qualified resolution into the Homebrew compatibility note. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Formula address | Relative file path misparsed as tap name | Qualified formula in a registered local tap |
| Resource result | Trapped in Homebrew tap clone | Copied back into the checkout that is committed |
| CLI transition | Old/new flag support covered | Coverage retained |
| Real resolver | Failing on hosted runner | Local mutation-mode probe succeeded for public v0.99.330 |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py` — 8 passed
- ruff check/format, mypy, actionlint, and `git diff --check` — passed
- Temporary real tap probe:
  - local-path `brew tap` — passed
  - `brew update-python-resources codex-geode/path-probe/geode --package-name geode-agent --version 0.99.330 --ignore-main-package-cooldown` — passed
  - generated formula `ruby -c` — Syntax OK
  - temporary tap removed — passed