### PR TITLE
fix(release): promote qualified Homebrew tap resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,8 +606,11 @@ jobs:
       - name: Refresh pinned Python resources from the published PyPI package
         if: steps.tap-release-state.outputs.current != 'true'
         run: |
+          tap_name=mangowhoiscloud/tap
+          brew tap "$tap_name" "$PWD/tap"
+          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
           resource_args=(
-            tap/Formula/geode.rb
+            "$tap_name/geode"
             --package-name geode-agent
             --version "$GEODE_VERSION"
           )
@@ -615,6 +618,7 @@ jobs:
             resource_args+=(--ignore-main-package-cooldown)
           fi
           brew update-python-resources "${resource_args[@]}"
+          cp "$tap_formula" tap/Formula/geode.rb
 
       - name: Revalidate the complete generated formula
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ functional change.
 - **Homebrew resource refresh spans the CLI transition safely.** Stable
   publication now detects whether the runner's `update-python-resources`
   supports the new main-package cooldown override and only passes that option
-  when available, while retaining exact resource pins on older Homebrew.
+  when available. It registers the checked-out repository as a local tap and
+  resolves its qualified formula name, retaining exact resource pins across
+  both older and current Homebrew.
 
 ## [0.99.330] - 2026-07-14
 

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -87,7 +87,9 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
     assert "skip-existing: true" in text
 
 
-def test_homebrew_resource_refresh_adapts_to_brew_cli(tmp_path: Path) -> None:
+def test_homebrew_resource_refresh_uses_local_tap_and_adapts_cli(
+    tmp_path: Path,
+) -> None:
     jobs = _workflow()["jobs"]
     assert isinstance(jobs, dict)
     publish = jobs["publish-homebrew"]
@@ -104,15 +106,29 @@ def test_homebrew_resource_refresh_adapts_to_brew_cli(tmp_path: Path) -> None:
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    checkout_formula = tmp_path / "tap" / "Formula" / "geode.rb"
+    checkout_formula.parent.mkdir(parents=True)
+    tap_repo = tmp_path / "homebrew-tap"
+    (tap_repo / "Formula").mkdir(parents=True)
     brew = bin_dir / "brew"
     brew.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == "tap" ]]; then
+  printf '%s\\n' "$@" > "$BREW_TAP_CAPTURE"
+  exit 0
+fi
+if [[ "${1:-}" == "--repo" ]]; then
+  [[ "${2:-}" == "mangowhoiscloud/tap" ]]
+  printf '%s\\n' "$BREW_TAP_REPO"
+  exit 0
+fi
 if [[ "${1:-}" == "update-python-resources" && "${2:-}" == "--help" ]]; then
   printf '%s\\n' "${BREW_HELP_TEXT:-}"
   exit 0
 fi
 printf '%s\\n' "$@" > "$BREW_CAPTURE"
+printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
 """,
         encoding="utf-8",
     )
@@ -120,7 +136,7 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
 
     base_args = [
         "update-python-resources",
-        "tap/Formula/geode.rb",
+        "mangowhoiscloud/tap/geode",
         "--package-name",
         "geode-agent",
         "--version",
@@ -136,11 +152,19 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
     )
     for label, help_text, extra_args in cases:
         capture = tmp_path / f"{label}.args"
+        tap_capture = tmp_path / f"{label}.tap"
+        checkout_formula.write_text("checkout formula\n", encoding="utf-8")
+        (tap_repo / "Formula" / "geode.rb").write_text(
+            "tapped formula\n",
+            encoding="utf-8",
+        )
         env = os.environ.copy()
         env.update(
             {
                 "BREW_CAPTURE": str(capture),
                 "BREW_HELP_TEXT": help_text,
+                "BREW_TAP_CAPTURE": str(tap_capture),
+                "BREW_TAP_REPO": str(tap_repo),
                 "GEODE_VERSION": "0.99.330",
                 "PATH": f"{bin_dir}:{env['PATH']}",
             }
@@ -159,6 +183,12 @@ printf '%s\\n' "$@" > "$BREW_CAPTURE"
             *base_args,
             *extra_args,
         ]
+        assert tap_capture.read_text(encoding="utf-8").splitlines() == [
+            "tap",
+            "mangowhoiscloud/tap",
+            str(tmp_path / "tap"),
+        ]
+        assert checkout_formula.read_text(encoding="utf-8") == "updated formula\n"
 
 
 def test_release_retry_preserves_release_body_bytes() -> None:


### PR DESCRIPTION
## Summary
- Promote qualified local-tap Homebrew resource resolution to production.
- Resume v0.99.330 Homebrew publication after merge.

## Why
Run 29324766401 validated every release artifact and existing public channel, then Homebrew rejected the relative formula file because update-python-resources requires a formula in a registered tap. No tap commit or push occurred.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Register the checkout as a local tap, update the qualified formula, and copy resources back. |
| `tests/integration/test_release_workflow.py` | Assert the exact local-tap registration, qualified argv, compatibility branches, and copy-back. |
| `CHANGELOG.md` | Keep one cohesive Homebrew compatibility note. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Homebrew formula identity | Invalid relative path | `mangowhoiscloud/tap/geode` |
| Resolver workspace | Unregistered checkout | Explicit local tap |
| Publish checkout | No refreshed resources | Updated formula copied back before commit |
| Real proof | Hosted failure | Public v0.99.330 mutation-mode probe + Ruby syntax passed |

## Verification
- PR #2722 full non-live test, lint, type, security, Gate — passed
- PR #2722 Ubuntu/macOS install smoke — passed
- Targeted workflow suite — 8 passed
- actionlint, ruff, format, mypy, diff check — passed
- Real temporary tap resource refresh for geode-agent 0.99.330 — passed
- Generated formula Ruby syntax — OK
- Temporary tap cleanup — passed
- Production diff contains exactly the three files above