### PR TITLE
fix(release): harden Homebrew cooldown fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,14 +608,19 @@ jobs:
         run: |
           tap_name=mangowhoiscloud/tap
           brew tap "$tap_name" "$PWD/tap"
+          if brew trust --help >/dev/null 2>&1; then
+            brew trust --formula "$tap_name/geode"
+          fi
           tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
-          resource_args=(
-            "$tap_name/geode"
-            --package-name geode-agent
-            --version "$GEODE_VERSION"
-          )
+          resource_args=("$tap_name/geode")
           if [[ "$(brew update-python-resources --help)" == *"--ignore-main-package-cooldown"* ]]; then
-            resource_args+=(--ignore-main-package-cooldown)
+            resource_args+=(
+              --package-name geode-agent
+              --version "$GEODE_VERSION"
+              --ignore-main-package-cooldown
+            )
+          else
+            echo "::notice::Using the exact release sdist as the direct main-package reference"
           fi
           brew update-python-resources "${resource_args[@]}"
           cp "$tap_formula" tap/Formula/geode.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,11 @@ functional change.
   conditional, and the release workflow regression suite now runs `bash -n`
   over every `run` block before a publishing change can merge.
 - **Homebrew resource refresh spans the CLI transition safely.** Stable
-  publication now detects whether the runner's `update-python-resources`
-  supports the new main-package cooldown override and only passes that option
-  when available. It registers the checked-out repository as a local tap and
-  resolves its qualified formula name, retaining exact resource pins across
-  both older and current Homebrew.
+  publication uses the main-package cooldown override when available and falls
+  back to the formula's exact GitHub Release sdist on older Homebrew, while
+  dependency resolution retains the 24-hour supply-chain cooldown. The local
+  candidate receives formula-scoped trust before Homebrew loads it, and the
+  qualified tap formula is copied back with exact resource pins.
 
 ## [0.99.330] - 2026-07-14
 

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -81,6 +81,7 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
     assert "HOMEBREW_TAP_DEPLOY_KEY" in text
     assert "brew update-python-resources --help" in text
     assert "--ignore-main-package-cooldown" in text
+    assert 'brew trust --formula "$tap_name/geode"' in text
     assert text.count("--template geode/packaging/homebrew/geode.rb.in") == 3
     assert "git pull --rebase" not in text
     assert "steps.tap-base.outputs.sha" in text
@@ -118,6 +119,13 @@ if [[ "${1:-}" == "tap" ]]; then
   printf '%s\\n' "$@" > "$BREW_TAP_CAPTURE"
   exit 0
 fi
+if [[ "${1:-}" == "trust" && "${2:-}" == "--help" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "trust" ]]; then
+  printf '%s\\n' "$@" > "$BREW_TRUST_CAPTURE"
+  exit 0
+fi
 if [[ "${1:-}" == "--repo" ]]; then
   [[ "${2:-}" == "mangowhoiscloud/tap" ]]
   printf '%s\\n' "$BREW_TAP_REPO"
@@ -134,25 +142,30 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
     )
     brew.chmod(0o755)
 
-    base_args = [
-        "update-python-resources",
-        "mangowhoiscloud/tap/geode",
-        "--package-name",
-        "geode-agent",
-        "--version",
-        "0.99.330",
-    ]
     cases: tuple[tuple[str, str, list[str]], ...] = (
-        ("legacy", "", []),
+        (
+            "legacy",
+            "",
+            ["update-python-resources", "mangowhoiscloud/tap/geode"],
+        ),
         (
             "cooldown",
             "--ignore-main-package-cooldown",
-            ["--ignore-main-package-cooldown"],
+            [
+                "update-python-resources",
+                "mangowhoiscloud/tap/geode",
+                "--package-name",
+                "geode-agent",
+                "--version",
+                "0.99.330",
+                "--ignore-main-package-cooldown",
+            ],
         ),
     )
-    for label, help_text, extra_args in cases:
+    for label, help_text, expected_args in cases:
         capture = tmp_path / f"{label}.args"
         tap_capture = tmp_path / f"{label}.tap"
+        trust_capture = tmp_path / f"{label}.trust"
         checkout_formula.write_text("checkout formula\n", encoding="utf-8")
         (tap_repo / "Formula" / "geode.rb").write_text(
             "tapped formula\n",
@@ -165,6 +178,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
                 "BREW_HELP_TEXT": help_text,
                 "BREW_TAP_CAPTURE": str(tap_capture),
                 "BREW_TAP_REPO": str(tap_repo),
+                "BREW_TRUST_CAPTURE": str(trust_capture),
                 "GEODE_VERSION": "0.99.330",
                 "PATH": f"{bin_dir}:{env['PATH']}",
             }
@@ -179,14 +193,16 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
             env=env,
         )
         assert result.returncode == 0, result.stderr
-        assert capture.read_text(encoding="utf-8").splitlines() == [
-            *base_args,
-            *extra_args,
-        ]
+        assert capture.read_text(encoding="utf-8").splitlines() == expected_args
         assert tap_capture.read_text(encoding="utf-8").splitlines() == [
             "tap",
             "mangowhoiscloud/tap",
             str(tmp_path / "tap"),
+        ]
+        assert trust_capture.read_text(encoding="utf-8").splitlines() == [
+            "trust",
+            "--formula",
+            "mangowhoiscloud/tap/geode",
         ]
         assert checkout_formula.read_text(encoding="utf-8") == "updated formula\n"
 


### PR DESCRIPTION
## Summary
- Make Homebrew release publication work across the cooldown CLI transition.
- Grant only formula-scoped trust to the local tap candidate.

## Why
The production v0.99.330 recovery runner enforces both tap trust and a 24-hour PyPI cooldown, but its Homebrew revision predates the main-package cooldown flag. Resource generation therefore stopped before any tap mutation.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Trust only `mangowhoiscloud/tap/geode`; use the explicit main-package cooldown override when supported and the already-rendered release sdist direct URL otherwise. |
| `tests/integration/test_release_workflow.py` | Execute both legacy and current CLI branches and assert tap registration, formula-scoped trust, qualified formula resolution, arguments, and copy-back. |
| `CHANGELOG.md` | Record the release compatibility and trust hardening. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Main-package cooldown | Legacy runner resolved the new PyPI package through the cooled index and failed. | Legacy runner uses the exact GitHub Release sdist; dependencies remain cooled. Current runner uses Homebrew's dedicated override. |
| Tap trust | Candidate formula was untrusted on hardened runners. | Trust is restricted to the one candidate formula. |
| Regression coverage | CLI argument adaptation only checked optional flag presence. | The exact workflow block is executed for both CLI generations, including trust and formula copy-back. |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py -q` (8 passed)
- `uv run ruff check tests/integration/test_release_workflow.py`
- `uv run ruff format --check tests/integration/test_release_workflow.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `git diff --check origin/develop...HEAD`
- Live local Homebrew probe against v0.99.330: dependency refresh succeeded from the exact release sdist, excluded `geode-agent==0.99.330`, and `ruby -c` passed.
