### PR TITLE
fix(release): seed rendered Homebrew candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,10 +608,11 @@ jobs:
         run: |
           tap_name=mangowhoiscloud/tap
           brew tap "$tap_name" "$PWD/tap"
+          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
+          cp tap/Formula/geode.rb "$tap_formula"
           if brew trust --help >/dev/null 2>&1; then
             brew trust --formula "$tap_name/geode"
           fi
-          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
           resource_args=("$tap_name/geode")
           if [[ "$(brew update-python-resources --help)" == *"--ignore-main-package-cooldown"* ]]; then
             resource_args+=(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Homebrew resource refresh preserves the rendered release candidate.** The
+  workflow now seeds Homebrew's registered local tap with the newly rendered
+  formula before dependency resolution, rather than letting `brew tap` reload
+  the older committed formula and overwrite the release URL and metadata.
+
 ## [0.99.331] - 2026-07-14
 
 ### Changed

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -82,6 +82,7 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
     assert "brew update-python-resources --help" in text
     assert "--ignore-main-package-cooldown" in text
     assert 'brew trust --formula "$tap_name/geode"' in text
+    assert 'cp tap/Formula/geode.rb "$tap_formula"' in text
     assert text.count("--template geode/packaging/homebrew/geode.rb.in") == 3
     assert "git pull --rebase" not in text
     assert "steps.tap-base.outputs.sha" in text
@@ -136,6 +137,7 @@ if [[ "${1:-}" == "update-python-resources" && "${2:-}" == "--help" ]]; then
   exit 0
 fi
 printf '%s\\n' "$@" > "$BREW_CAPTURE"
+cp "$BREW_TAP_REPO/Formula/geode.rb" "$BREW_SEED_CAPTURE"
 printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
 """,
         encoding="utf-8",
@@ -166,6 +168,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
         capture = tmp_path / f"{label}.args"
         tap_capture = tmp_path / f"{label}.tap"
         trust_capture = tmp_path / f"{label}.trust"
+        seed_capture = tmp_path / f"{label}.seed"
         checkout_formula.write_text("checkout formula\n", encoding="utf-8")
         (tap_repo / "Formula" / "geode.rb").write_text(
             "tapped formula\n",
@@ -176,6 +179,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
             {
                 "BREW_CAPTURE": str(capture),
                 "BREW_HELP_TEXT": help_text,
+                "BREW_SEED_CAPTURE": str(seed_capture),
                 "BREW_TAP_CAPTURE": str(tap_capture),
                 "BREW_TAP_REPO": str(tap_repo),
                 "BREW_TRUST_CAPTURE": str(trust_capture),
@@ -204,6 +208,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
             "--formula",
             "mangowhoiscloud/tap/geode",
         ]
+        assert seed_capture.read_text(encoding="utf-8") == "checkout formula\n"
         assert checkout_formula.read_text(encoding="utf-8") == "updated formula\n"
 
 


### PR DESCRIPTION
## Summary
- Seed Homebrew's registered local tap with the rendered release candidate before refreshing Python resources.

## Why
The production recovery run proved cooldown handling and formula-scoped trust work. It then caught a deterministic mismatch because `brew tap <name> <path>` cloned the source repository's committed v0.99.319 formula, not the uncommitted v0.99.330 candidate rendered in the checkout. Copy-back therefore restored stale header metadata before publication; no tap mutation occurred.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Copy the rendered candidate into Homebrew's resolved tap formula path before trust and resource generation. |
| `tests/integration/test_release_workflow.py` | Assert both legacy and current CLI paths receive the checkout candidate, then copy the refreshed formula back. |
| `CHANGELOG.md` | Record candidate preservation under Unreleased. |

## GAP Audit
| Area | Before | After |
|------|--------|-------|
| Registered tap contents | Homebrew loaded the tap repository's previous committed formula. | The exact rendered release candidate is seeded before formula loading. |
| Deterministic revalidation | Failed at line 4 because old header metadata was copied back. | Resource-only mutation preserves the release URL, SHA, description, and template contract. |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py -q` (8 passed)
- `uv run ruff check tests/integration/test_release_workflow.py`
- `uv run ruff format --check tests/integration/test_release_workflow.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `git diff --check`
- Production run 29379039360: resource refresh passed; deterministic revalidation caught the stale formula before commit or push.
