### PR TITLE
release: promote Homebrew candidate preservation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,10 +608,11 @@ jobs:
         run: |
           tap_name=mangowhoiscloud/tap
           brew tap "$tap_name" "$PWD/tap"
+          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
+          cp tap/Formula/geode.rb "$tap_formula"
           if brew trust --help >/dev/null 2>&1; then
             brew trust --formula "$tap_name/geode"
           fi
-          tap_formula="$(brew --repo "$tap_name")/Formula/geode.rb"
           resource_args=("$tap_name/geode")
           if [[ "$(brew update-python-resources --help)" == *"--ignore-main-package-cooldown"* ]]; then
             resource_args+=(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ functional change.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Homebrew resource refresh preserves the rendered release candidate.** The
+  workflow now seeds Homebrew's registered local tap with the newly rendered
+  formula before dependency resolution, rather than letting `brew tap` reload
+  the older committed formula and overwrite the release URL and metadata.
+
 ## [0.99.331] - 2026-07-14
 
 ### Changed

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -82,6 +82,7 @@ def test_homebrew_publish_uses_scoped_key_and_retry_guards() -> None:
     assert "brew update-python-resources --help" in text
     assert "--ignore-main-package-cooldown" in text
     assert 'brew trust --formula "$tap_name/geode"' in text
+    assert 'cp tap/Formula/geode.rb "$tap_formula"' in text
     assert text.count("--template geode/packaging/homebrew/geode.rb.in") == 3
     assert "git pull --rebase" not in text
     assert "steps.tap-base.outputs.sha" in text
@@ -136,6 +137,7 @@ if [[ "${1:-}" == "update-python-resources" && "${2:-}" == "--help" ]]; then
   exit 0
 fi
 printf '%s\\n' "$@" > "$BREW_CAPTURE"
+cp "$BREW_TAP_REPO/Formula/geode.rb" "$BREW_SEED_CAPTURE"
 printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
 """,
         encoding="utf-8",
@@ -166,6 +168,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
         capture = tmp_path / f"{label}.args"
         tap_capture = tmp_path / f"{label}.tap"
         trust_capture = tmp_path / f"{label}.trust"
+        seed_capture = tmp_path / f"{label}.seed"
         checkout_formula.write_text("checkout formula\n", encoding="utf-8")
         (tap_repo / "Formula" / "geode.rb").write_text(
             "tapped formula\n",
@@ -176,6 +179,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
             {
                 "BREW_CAPTURE": str(capture),
                 "BREW_HELP_TEXT": help_text,
+                "BREW_SEED_CAPTURE": str(seed_capture),
                 "BREW_TAP_CAPTURE": str(tap_capture),
                 "BREW_TAP_REPO": str(tap_repo),
                 "BREW_TRUST_CAPTURE": str(trust_capture),
@@ -204,6 +208,7 @@ printf 'updated formula\\n' > "$BREW_TAP_REPO/Formula/geode.rb"
             "--formula",
             "mangowhoiscloud/tap/geode",
         ]
+        assert seed_capture.read_text(encoding="utf-8") == "checkout formula\n"
         assert checkout_formula.read_text(encoding="utf-8") == "updated formula\n"
 
 


### PR DESCRIPTION
## Summary
- Promote the final Homebrew candidate-seeding correction to main.

## Why
Production run 29379039360 proved resource generation works, then safely stopped because Homebrew's locally registered tap still held the previously committed formula header. Seeding the rendered candidate before dependency refresh preserves immutable v0.99.330 metadata.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Copy the rendered formula into Homebrew's resolved tap path before loading and refreshing it. |
| `tests/integration/test_release_workflow.py` | Assert the refresh input is the checkout candidate for both CLI generations. |
| `CHANGELOG.md` | Record the fix under Unreleased. |

## Verification
- PR #2729: full CI gate passed, including all tests, lint, mypy, security, and Ubuntu/macOS install smoke.
- PR #2730: ancestry sync CI and install smoke passed.
- Production run 29379039360 made no tap commit or push; GitHub Release and PyPI remained verified and immutable.
