### PR TITLE
release: promote docs date stability fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release documentation remains reproducible after a promotion merge.**
+  `sync-stats` now preserves the committed generation date when the package
+  version is unchanged instead of replacing it with `SOURCE_DATE_EPOCH`. A final
+  `develop -> main` merge can therefore change the release commit timestamp
+  without dirtying `sot.ts`, `changelog.ts`, `llms.txt`, or `llms-full.txt`;
+  genuinely new versions still take their date from the reproducible source
+  epoch.
+
 ### Changed
 
 - **Stable installation now uses PyPI/uv as the sole advertised package

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -4868,7 +4868,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1442 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1443 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/scripts/sync-stats.mjs
+++ b/site/scripts/sync-stats.mjs
@@ -47,22 +47,27 @@ function fail(msg) {
 
 function generationDate(version) {
   const epoch = process.env.SOURCE_DATE_EPOCH;
+  let sourceDate;
   if (epoch !== undefined) {
     if (!/^\d+$/.test(epoch)) fail(`invalid SOURCE_DATE_EPOCH: ${epoch}`);
     const date = new Date(Number(epoch) * 1000);
     if (Number.isNaN(date.getTime())) fail(`invalid SOURCE_DATE_EPOCH: ${epoch}`);
-    return date.toISOString().slice(0, 10);
+    sourceDate = date.toISOString().slice(0, 10);
   }
 
   // A same-version verification or repair run must not dirty committed docs
   // merely because the wall clock advanced. Preserve the existing sync date;
-  // a new version (or a missing snapshot) receives today's UTC date.
+  // a new version (or a missing snapshot) receives the reproducible source
+  // date when available, otherwise today's UTC date.
   if (existsSync(SOT_FILE)) {
     const previous = readFileSync(SOT_FILE, "utf8");
     const previousVersion = previous.match(/version:\s*"([^"]+)"/)?.[1];
     const previousDate = previous.match(/syncedAt:\s*"(\d{4}-\d{2}-\d{2})"/)?.[1];
     if (previousVersion === version && previousDate) return previousDate;
   }
+
+  if (sourceDate !== undefined) return sourceDate;
+
   return new Date().toISOString().slice(0, 10);
 }
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Changed\n\n- **Stable installation now uses PyPI/uv as the sole advertised package\n  channel.** The public install surface and stable release workflow no longer\n  expose or publish the custom Homebrew tap, so users are not given a\n  namespace-qualified command or an unqualified command that fails on a clean\n  machine. The repository retains a `geode-agent` formula template for a\n  future Homebrew/core submission; `brew install geode-agent` will return only\n  after that command is independently available and verified."
+    "body": "### Fixed\n\n- **Release documentation remains reproducible after a promotion merge.**\n  `sync-stats` now preserves the committed generation date when the package\n  version is unchanged instead of replacing it with `SOURCE_DATE_EPOCH`. A final\n  `develop -> main` merge can therefore change the release commit timestamp\n  without dirtying `sot.ts`, `changelog.ts`, `llms.txt`, or `llms-full.txt`;\n  genuinely new versions still take their date from the reproducible source\n  epoch.\n\n### Changed\n\n- **Stable installation now uses PyPI/uv as the sole advertised package\n  channel.** The public install surface and stable release workflow no longer\n  expose or publish the custom Homebrew tap, so users are not given a\n  namespace-qualified command or an unqualified command that fails on a clean\n  machine. The repository retains a `geode-agent` formula template for a\n  future Homebrew/core submission; `brew install geode-agent` will return only\n  after that command is independently available and verified."
   },
   {
     "version": "0.99.331",

--- a/tests/integration/test_sync_stats.py
+++ b/tests/integration/test_sync_stats.py
@@ -1,0 +1,92 @@
+"""Regression tests for the public-site metadata generator."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_project_version(root: Path, version: str) -> None:
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "geode-agent"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def _prepare_site_fixture(root: Path) -> Path:
+    site = root / "site"
+    scripts = site / "scripts"
+    data = site / "src" / "data" / "geode"
+    sitemap = site / "src" / "lib" / "geode-docs"
+    public = site / "public"
+    scripts.mkdir(parents=True)
+    data.mkdir(parents=True)
+    sitemap.mkdir(parents=True)
+    public.mkdir(parents=True)
+
+    for name in ("sync-stats.mjs", "sitemap-pages.mjs"):
+        shutil.copy2(REPO_ROOT / "site" / "scripts" / name, scripts / name)
+
+    (sitemap / "sitemap.ts").write_text(
+        """export const sitemap = [
+  {
+    title: "Start",
+    titleKo: "시작",
+    pages: [
+      { slug: "quick-start", title: "Quick start", titleKo: "빠른 시작", summary: "Install GEODE", summaryKo: "GEODE 설치" },
+    ],
+  },
+];
+""",
+        encoding="utf-8",
+    )
+    (data / "sot.ts").write_text(
+        'export const GEODE_SOT = {\n  version: "0.99.331",\n  syncedAt: "2026-07-14",\n} as const;\n',
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n- Pending.\n\n## [0.99.331] - 2026-07-14\n\n- Released.\n",
+        encoding="utf-8",
+    )
+    return site
+
+
+def _run_sync_stats(node: str, root: Path, site: Path, epoch: int) -> str:
+    env = {
+        **os.environ,
+        "GEODE_REPO": str(root),
+        "SOURCE_DATE_EPOCH": str(epoch),
+    }
+    subprocess.run(  # noqa: S603 - fixed local script and isolated fixture
+        [node, str(site / "scripts" / "sync-stats.mjs")],
+        cwd=site,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return (site / "src" / "data" / "geode" / "sot.ts").read_text(encoding="utf-8")
+
+
+def test_sync_stats_preserves_same_version_date_before_source_epoch(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the site metadata generator")
+
+    site = _prepare_site_fixture(tmp_path)
+    epoch = int(datetime(2030, 1, 2, tzinfo=UTC).timestamp())
+    _write_project_version(tmp_path, "0.99.331")
+
+    same_version = _run_sync_stats(node, tmp_path, site, epoch)
+    assert 'syncedAt: "2026-07-14"' in same_version
+
+    _write_project_version(tmp_path, "0.99.332")
+    next_version = _run_sync_stats(node, tmp_path, site, epoch)
+    assert 'syncedAt: "2030-01-02"' in next_version


### PR DESCRIPTION
## Summary
- Promote the release-docs date-stability fix from `develop` to `main`.
- Unblock the stable `0.99.331` GitHub Release and PyPI publication.

## Why
The first stable release attempt stopped safely before publishing because the official-docs generation gate rewrote same-version sync dates from the merge commit epoch. #2735 fixes the deterministic generation rule and adds regression coverage; #2736 synchronized main back into develop before this promotion.

## Changes
| File | Change |
|------|--------|
| `site/scripts/sync-stats.mjs` | Preserve an existing sync date for same-version regeneration |
| `tests/integration/test_sync_stats.py` | Cover same-version stability and version-bump epoch behavior |
| `CHANGELOG.md` and generated data | Document and synchronize the fix |

## Verification
- Full CI passed on #2735
- macOS and Ubuntu install/update/uninstall smoke tests passed on #2735
- Static docs render/build passed on #2735
- Exact release docs gate passed locally with `SOURCE_DATE_EPOCH`
- Topology sync #2736 passed
- `origin/main` is an ancestor of this branch
- Content delta against `origin/main` is limited to the five #2735 files