### PR TITLE
refactor(agent): Plan DAG 잔재 제거 재착륙 — depends_on·성공전진 경로 삭제 (v0.99.332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,21 @@ functional change.
 
 ---
 
-## [Unreleased]
+## [0.99.332] - 2026-07-15
+
+### Removed
+- **Plan DAG remnants** (PR-PLAN-DAG-CLEANUP): `SubGoal.depends_on` /
+  `PlanStep.depends_on` deleted — fields survived the v0.99.46
+  GoalDecomposer removal (v0.13 DAG/TaskGraph lineage) with zero runtime
+  consumers; plan steps are consumed strictly in `current`-index order.
+  `Plan.advance(completed=...)` replaced by `Plan.abandon_and_advance()`:
+  the success-advance branch was never wired in production (tests only),
+  so the API now states the single real path. Replan prompt template and
+  parser no longer emit/read `depends_on`. `update_plan` tool description
+  now states it is display-only and separate from the internal
+  auto-generated Plan. `CognitiveState` doc table corrected: `subgoals`
+  producer is the reflection node (next_action hints), not a
+  decomposition node.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.331
+- **Version**: 0.99.332
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.331 — A Self-improving Autonomous Execution Agent
+# GEODE v0.99.332 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.331: A Self-improving Autonomous Execution Agent
+# GEODE v0.99.332: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/core/agent/cognitive_state.py
+++ b/core/agent/cognitive_state.py
@@ -19,7 +19,7 @@ round. Field producers land incrementally across PR-2 → PR-6:
   last_action    tool-call list of the last round       PR-2
   last_observation tool-result summary                   PR-2
   observations   running list of round summaries        PR-2
-  subgoals       LLM decomposition node                 PR-3
+  subgoals       reflection node next_action hints      PR-3 (C-2)
   hypotheses     reflection node output                 PR-3 (C-2)
   confidence     reflection node output                 PR-3 (C-2)
   ============== ====================================== =========

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1383,7 +1383,7 @@ class AgenticLoop:
                 metrics.record_step_attempt()
                 cap = _replan_max_attempts()
                 if metrics.replan_attempts_on_current_step > cap:
-                    advanced = metrics.active_plan.advance(completed=False)
+                    advanced = metrics.active_plan.abandon_and_advance()
                     # new step → reset the per-step counter
                     metrics.set_active_plan(advanced, reset_attempts=True)
                     self._prompt_dirty = True

--- a/core/agent/plan.py
+++ b/core/agent/plan.py
@@ -85,9 +85,6 @@ class SubGoal(BaseModel):
     tool_args: dict[str, Any] = PydanticField(
         default_factory=dict, description="Arguments for the tool"
     )
-    depends_on: list[str] = PydanticField(
-        default_factory=list, description="IDs of sub-goals that must complete first"
-    )
     difficulty: Literal["low", "medium", "high"] = PydanticField(
         default="medium",
         description="Complexity: low=lookup, medium=analysis, high=reasoning",
@@ -126,8 +123,9 @@ class PlanStep:
     """One executable step in a :class:`Plan`.
 
     Frozen so the step is safe to share across threads and serialize to
-    JSON without races. ``depends_on`` carries other step ``id`` values
-    that must finish before this one is eligible. ``expected_outcome``
+    JSON without races. Steps are consumed strictly in ``current``-index
+    order (the v0.13 DAG/topological execution was retired with
+    GoalDecomposer in v0.99.46). ``expected_outcome``
     is the comparison anchor PR-CL-A3 verify's
     ``step_expected_mismatch`` rubric uses — if the turn's output text
     contains none of the expected keywords, the step is flagged.
@@ -138,7 +136,6 @@ class PlanStep:
     expected_outcome: str = ""
     tool_name: str = ""
     tool_args: dict[str, Any] = field(default_factory=dict)
-    depends_on: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -147,7 +144,6 @@ class PlanStep:
             "expected_outcome": self.expected_outcome,
             "tool_name": self.tool_name,
             "tool_args": dict(self.tool_args),
-            "depends_on": list(self.depends_on),
         }
 
 
@@ -189,24 +185,23 @@ class Plan:
     def remaining_steps(self) -> tuple[PlanStep, ...]:
         return tuple(self.steps[self.current :])
 
-    def advance(self, *, completed: bool = True) -> Plan:
-        """Move to the next step. ``completed=False`` marks the current
-        step as ``abandoned`` instead — used after exceeding
-        ``GEODE_REPLAN_MAX_ATTEMPTS`` retries on the same step."""
+    def abandon_and_advance(self) -> Plan:
+        """Mark the current step ``abandoned`` and move to the next one.
+
+        Used after exceeding ``GEODE_REPLAN_MAX_ATTEMPTS`` retries on the
+        same step. There is no success-advance counterpart by design:
+        step completion is expressed by replan (plan replacement) or by
+        the plan simply being consumed to the end, never by a
+        ``completed`` marker (the unwired ``advance(completed=True)``
+        path was removed together with the v0.13 DAG remnants).
+        """
         if self.current >= len(self.steps):
             return self
-        bucket = "completed" if completed else "abandoned"
-        if bucket == "completed":
-            new_completed = tuple(sorted({*self.completed, self.current}))
-            new_abandoned = self.abandoned
-        else:
-            new_completed = self.completed
-            new_abandoned = tuple(sorted({*self.abandoned, self.current}))
         return Plan(
             steps=self.steps,
             current=self.current + 1,
-            completed=new_completed,
-            abandoned=new_abandoned,
+            completed=self.completed,
+            abandoned=tuple(sorted({*self.abandoned, self.current})),
             reasoning=self.reasoning,
             revision=self.revision,
         )
@@ -244,7 +239,6 @@ def build_plan_from_decomposition(decomp_result: Any) -> Plan | None:
                     expected_outcome=str(getattr(goal, "expected_outcome", "")),
                     tool_name=str(getattr(goal, "tool_name", "")),
                     tool_args=dict(getattr(goal, "tool_args", {}) or {}),
-                    depends_on=tuple(str(d) for d in (getattr(goal, "depends_on", None) or [])),
                 )
             )
         return Plan(
@@ -431,7 +425,7 @@ JSON object — no prose:
   {
     "steps": [
       {"id": "step_1", "description": "...", "expected_outcome": "...",
-       "tool_name": "...", "depends_on": []},
+       "tool_name": "..."},
       ...
     ],
     "reasoning": "<one sentence>"
@@ -471,7 +465,6 @@ def parse_replan_response(raw: str) -> tuple[list[PlanStep], str] | None:
                 expected_outcome=str(raw_step.get("expected_outcome") or ""),
                 tool_name=str(raw_step.get("tool_name") or ""),
                 tool_args=dict(raw_step.get("tool_args") or {}),
-                depends_on=tuple(str(d) for d in (raw_step.get("depends_on") or [])),
             )
         )
     if not steps:

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -628,7 +628,7 @@
   },
   {
     "name": "update_plan",
-    "description": "Show or update the current turn's progress checklist. Use for complex, multi-step work to keep the user informed while continuing execution. This is NOT an approval gate and does not persist an execution plan; after calling it, keep working unless the user explicitly asked to stop for review. Keep 3-7 concise steps, exactly one in_progress step while work remains, and update statuses as steps complete. Sibling: create_plan is only for an explicit review checkpoint that should wait for approve_plan.",
+    "description": "Show or update the current turn's progress checklist. Use for complex, multi-step work to keep the user informed while continuing execution. This is NOT an approval gate and does not persist an execution plan; after calling it, keep working unless the user explicitly asked to stop for review. It is also separate from the runtime's internal auto-generated Plan (decomposition/replan): this checklist is display-only and never feeds the loop. Keep 3-7 concise steps, exactly one in_progress step while work remains, and update statuses as steps complete. Sibling: create_plan is only for an explicit review checkpoint that should wait for approve_plan.",
     "category": "planning",
     "cost_tier": "free",
     "input_schema": {

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -50,7 +50,7 @@
         "runtime",
         "while-tool-use"
       ],
-      "contentSha256": "42b9ed70bc27ec856a031baeaa56a6b73e8a101e9b0d57a28abd4ea997844af4"
+      "contentSha256": "4344d0abdbd802492930b77cef0f6ae8ab51b3d9bf75fcbe2484eac938fdc136"
     },
     {
       "id": "file:core/agent/tool_executor/processor.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.331"
+version = "0.99.332"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.331. Last sync 2026-07-14. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v0.99.332. Last sync 2026-07-14. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.331. Last sync 2026-07-14. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v0.99.332. Last sync 2026-07-15. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-14
+ * Last sync: 2026-07-15
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -17,9 +17,9 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    "version": "Unreleased",
-    "date": "",
-    "body": "### Fixed\n\n- **Release documentation remains reproducible after a promotion merge.**\n  `sync-stats` now preserves the committed generation date when the package\n  version is unchanged instead of replacing it with `SOURCE_DATE_EPOCH`. A final\n  `develop -> main` merge can therefore change the release commit timestamp\n  without dirtying `sot.ts`, `changelog.ts`, `llms.txt`, or `llms-full.txt`;\n  genuinely new versions still take their date from the reproducible source\n  epoch.\n\n### Changed\n\n- **Stable installation now uses PyPI/uv as the sole advertised package\n  channel.** The public install surface and stable release workflow no longer\n  expose or publish the custom Homebrew tap, so users are not given a\n  namespace-qualified command or an unqualified command that fails on a clean\n  machine. The repository retains a `geode-agent` formula template for a\n  future Homebrew/core submission; `brew install geode-agent` will return only\n  after that command is independently available and verified."
+    "version": "0.99.332",
+    "date": "2026-07-15",
+    "body": "### Removed\n- **Plan DAG remnants** (PR-PLAN-DAG-CLEANUP): `SubGoal.depends_on` /\n  `PlanStep.depends_on` deleted — fields survived the v0.99.46\n  GoalDecomposer removal (v0.13 DAG/TaskGraph lineage) with zero runtime\n  consumers; plan steps are consumed strictly in `current`-index order.\n  `Plan.advance(completed=...)` replaced by `Plan.abandon_and_advance()`:\n  the success-advance branch was never wired in production (tests only),\n  so the API now states the single real path. Replan prompt template and\n  parser no longer emit/read `depends_on`. `update_plan` tool description\n  now states it is display-only and separate from the internal\n  auto-generated Plan. `CognitiveState` doc table corrected: `subgoals`\n  producer is the reflection node (next_action hints), not a\n  decomposition node.\n\n### Fixed\n\n- **Release documentation remains reproducible after a promotion merge.**\n  `sync-stats` now preserves the committed generation date when the package\n  version is unchanged instead of replacing it with `SOURCE_DATE_EPOCH`. A final\n  `develop -> main` merge can therefore change the release commit timestamp\n  without dirtying `sot.ts`, `changelog.ts`, `llms.txt`, or `llms-full.txt`;\n  genuinely new versions still take their date from the reproducible source\n  epoch.\n\n### Changed\n\n- **Stable installation now uses PyPI/uv as the sole advertised package\n  channel.** The public install surface and stable release workflow no longer\n  expose or publish the custom Homebrew tap, so users are not given a\n  namespace-qualified command or an unqualified command that fails on a clean\n  machine. The repository retains a `geode-agent` formula template for a\n  future Homebrew/core submission; `brew install geode-agent` will return only\n  after that command is independently available and verified."
   },
   {
     "version": "0.99.331",
@@ -2383,4 +2383,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-14";
+export const CHANGELOG_SYNCED_AT = "2026-07-15";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-14
+ * Last sync: 2026-07-15
  */
 
 export const GEODE_SOT = {
-  version: "0.99.331",
-  syncedAt: "2026-07-14",
+  version: "0.99.332",
+  syncedAt: "2026-07-15",
 } as const;

--- a/tests/core/agent/test_replan.py
+++ b/tests/core/agent/test_replan.py
@@ -2,7 +2,7 @@
 
 Coverage:
 - :class:`Plan` + :class:`PlanStep` dataclass shape (frozen, slots,
-  to_dict / to_json / current_step / advance / done).
+  to_dict / to_json / current_step / abandon_and_advance / done).
 - :func:`build_plan_from_decomposition` survives mocked / partial inputs.
 - :func:`render_plan_for_prompt` emits a ``<plan>...</plan>`` block with
   current-step marker; empty plan → empty string.
@@ -120,25 +120,17 @@ def test_plan_current_step() -> None:
     assert done.done is True
 
 
-def test_plan_advance_completed_marks_step() -> None:
+def test_plan_abandon_and_advance_marks_step() -> None:
     plan = _make_plan("s1", "s2", "s3")
-    advanced = plan.advance(completed=True)
-    assert advanced.current == 1
-    assert advanced.completed == (0,)
-    assert advanced.abandoned == ()
-
-
-def test_plan_advance_abandoned_marks_step() -> None:
-    plan = _make_plan("s1", "s2", "s3")
-    advanced = plan.advance(completed=False)
+    advanced = plan.abandon_and_advance()
     assert advanced.current == 1
     assert advanced.abandoned == (0,)
     assert advanced.completed == ()
 
 
-def test_plan_advance_when_done_is_noop() -> None:
+def test_plan_abandon_and_advance_when_done_is_noop() -> None:
     plan = Plan(steps=(PlanStep(id="s1", description="x"),), current=1)
-    assert plan.advance(completed=True) is plan
+    assert plan.abandon_and_advance() is plan
 
 
 def test_remaining_steps() -> None:
@@ -166,7 +158,6 @@ def test_build_plan_extracts_goals() -> None:
         description="first",
         tool_name="search",
         tool_args={"q": "x"},
-        depends_on=[],
         expected_outcome="found",
     )
     g2 = SimpleNamespace(
@@ -174,7 +165,6 @@ def test_build_plan_extracts_goals() -> None:
         description="second",
         tool_name="fetch",
         tool_args={},
-        depends_on=["g1"],
         expected_outcome="",
     )
     decomp = SimpleNamespace(goals=[g1, g2], reasoning="my plan")
@@ -183,7 +173,7 @@ def test_build_plan_extracts_goals() -> None:
     assert len(plan.steps) == 2
     assert plan.steps[0].id == "g1"
     assert plan.steps[0].expected_outcome == "found"
-    assert plan.steps[1].depends_on == ("g1",)
+    assert plan.steps[1].id == "g2"
     assert plan.reasoning == "my plan"
 
 
@@ -767,14 +757,12 @@ def test_decompose_async_passes_response_schema() -> None:
                             "description": "Search for current release notes",
                             "tool_name": "general_web_search",
                             "tool_args": {"query": "current release notes"},
-                            "depends_on": [],
                         },
                         {
                             "id": "step_2",
                             "description": "Summarize the results",
                             "tool_name": "summarize",
                             "tool_args": {},
-                            "depends_on": ["step_1"],
                         },
                     ],
                     "reasoning": "search then summarize",

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.331"
+version = "0.99.332"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

공유 체크아웃 main에 직접 커밋되어 미착륙 상태로 남아 있던 2011e659a(Plan DAG 잔재 제거)를 GitFlow로 재착륙. 이 커밋이 리빌드를 봉인하고 있어 데몬이 v0.99.319에 정체 — Slack 수리 사이클(후속 PR)의 선행 조건.

## Why

- v0.13 GoalDecomposer/TaskGraph 계보의 depends_on 필드가 소비자 0인 채 잔존해 이해 혼선 유발.
- advance(completed=True)는 프로덕션 미배선 — abandon_and_advance()로 실경로만 남김.
- 원커밋이 공유 체크아웃 로컬 main에만 존재(버전 스탬프 v0.99.324가 released 0.99.324와 충돌)해 pull/rebuild 불가 상태 지속.

## Changes

- cherry-pick 2011e659a (코드 5파일 무충돌 적용): core/agent/plan.py(depends_on 필드·파서·프롬프트 제거, abandon_and_advance 단일화), cognitive_state.py·agent_loop.py(subgoals producer 정정), core/tools/definitions.json(update_plan 설명), tests/core/agent/test_replan.py
- 버전 충돌 해소: 0.99.332 재스탬프(CHANGELOG 엔트리 이전 + 5곳 + 사이트 SoT), 동시세션 [Unreleased](sync-stats 재현성·PyPI 단일 채널) 폴드
- crucible context_graph agent_loop 해시 재증명

## Verification

- ruff check/format(1213)·mypy(527)·lint-imports(4 kept)·slop ratchet(252/82) 전부 clean
- pytest tests/core/agent/ rc=0 (실패 0 — test_replan 갱신 포함)
- 원커밋과 코드 내용 동일(cherry-pick, 코드 파일 무충돌)

🤖 Generated with [Claude Code](https://claude.com/claude-code)