### PR TITLE
release: promote PyPI convergence hardening

### DIFF
--- a/.claude/skills/geode-distribution/SKILL.md
+++ b/.claude/skills/geode-distribution/SKILL.md
@@ -127,6 +127,13 @@ The workflow serializes stable promotions and performs:
 5. a read-only cross-channel verifier for the annotated tag, release assets,
    exact PyPI files, and SHA-256 parity.
 
+PyPI's simple index and exact-version JSON endpoint can converge at different
+times. Keep the bounded `uvx` retry as the installability gate, then let
+`verify_public_distribution.py` retry the complete JSON/tag/assets/checksum
+snapshot. Do not insert a one-shot JSON/digest check between those two gates;
+it duplicates the final verifier and can fail after a successful upload solely
+because one CDN surface still returns 404.
+
 ### 3. Watch to completion
 
 ```bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,12 +455,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: geode-${{ inputs.version }}-release-artifacts
-          path: release-artifacts
-
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: false
 
       - name: Verify the exact package from the public PyPI index
         run: |
@@ -476,39 +473,6 @@ jobs:
           done
           echo "::error::geode-agent==${version} was not installable from public PyPI"
           exit 1
-
-      - name: Verify PyPI files match the validated release artifacts
-        env:
-          GEODE_VERSION: ${{ inputs.version }}
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import os
-          import urllib.request
-          from pathlib import Path
-
-          version = os.environ["GEODE_VERSION"]
-          expected = {}
-          for line in Path("release-artifacts/SHA256SUMS").read_text().splitlines():
-              digest, filename = line.split(maxsplit=1)
-              expected[filename] = digest
-
-          with urllib.request.urlopen(
-              f"https://pypi.org/pypi/geode-agent/{version}/json", timeout=30
-          ) as response:
-              payload = json.load(response)
-          published = {
-              item["filename"]: item["digests"]["sha256"]
-              for item in payload["urls"]
-          }
-          assert published == expected, {"expected": expected, "published": published}
-
-          for artifact in Path("release-artifacts/dist").iterdir():
-              if artifact.name in expected:
-                  actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
-                  assert actual == expected[artifact.name]
-          PY
 
   verify-stable-distribution:
     name: Verify public stable distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stable releases tolerate split PyPI index convergence.** Post-publish
+  verification keeps the bounded exact-version `uvx` install loop, then delegates
+  JSON metadata and SHA-256 parity to the reusable full-snapshot verifier that
+  already retries GitHub and PyPI together. The redundant one-shot PyPI JSON
+  lookup is removed, so a successful upload cannot be reported as failed merely
+  because the exact-version JSON endpoint briefly lags the simple index. The
+  read-only smoke job also disables its unused uv cache instead of warning about
+  a checkout-free cache key.
+
 ## [0.99.333] - 2026-07-15
 
 ### Added

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Fixed\n\n- **Stable releases tolerate split PyPI index convergence.** Post-publish\n  verification keeps the bounded exact-version `uvx` install loop, then delegates\n  JSON metadata and SHA-256 parity to the reusable full-snapshot verifier that\n  already retries GitHub and PyPI together. The redundant one-shot PyPI JSON\n  lookup is removed, so a successful upload cannot be reported as failed merely\n  because the exact-version JSON endpoint briefly lags the simple index. The\n  read-only smoke job also disables its unused uv cache instead of warning about\n  a checkout-free cache key."
   },
   {
     "version": "0.99.333",

--- a/tests/integration/test_release_workflow.py
+++ b/tests/integration/test_release_workflow.py
@@ -95,11 +95,30 @@ def test_stable_release_has_no_custom_homebrew_tap_channel() -> None:
 def test_public_distribution_uses_the_reusable_exact_version_verifier() -> None:
     jobs = _workflow()["jobs"]
     assert isinstance(jobs, dict)
+    verify_pypi = jobs["verify-pypi"]
     verify = jobs["verify-stable-distribution"]
+    assert isinstance(verify_pypi, dict)
     assert isinstance(verify, dict)
+    pypi_steps = verify_pypi["steps"]
     steps = verify["steps"]
+    assert isinstance(pypi_steps, list)
     assert isinstance(steps, list)
 
+    pypi_step_text = "\n".join(
+        str(step.get("run", "")) for step in pypi_steps if isinstance(step, dict)
+    )
+    assert "for attempt in $(seq 1 12)" in pypi_step_text
+    assert "pypi.org/pypi" not in pypi_step_text
+    assert not any(
+        isinstance(step, dict) and "download-artifact" in str(step.get("uses", ""))
+        for step in pypi_steps
+    )
+    assert any(
+        isinstance(step, dict)
+        and "setup-uv" in str(step.get("uses", ""))
+        and step.get("with") == {"enable-cache": False}
+        for step in pypi_steps
+    )
     assert any(
         isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/checkout@")
         for step in steps


### PR DESCRIPTION
## Summary
- Remove the redundant one-shot PyPI JSON/hash check from the post-publish smoke job.
- Keep the bounded exact-version `uvx` install loop and the reusable retrying cross-channel verifier as the two postconditions.
- Record the convergence contract in the distribution skill and add a workflow ratchet.

## Why
The initial `0.99.333` promotion published successfully, but PyPI's exact-version JSON endpoint briefly returned 404 after the simple index was already installable. A repair run then passed unchanged. The one-shot JSON step duplicated the final full-snapshot verifier and could turn normal CDN convergence into a false release failure.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Drop the duplicate one-shot metadata check and unused artifact/cache setup. |
| `tests/integration/test_release_workflow.py` | Pin the bounded install retry and single retrying verifier topology. |
| `.claude/skills/geode-distribution/SKILL.md` | Document independent PyPI surface convergence and the verification SoT. |
| `CHANGELOG.md`, `site/src/data/geode/changelog.ts` | Record and publish the fix. |

## GAP Audit
| Surface | Before | After |
|---------|--------|-------|
| Installability | Bounded exact-version `uvx` retry | Unchanged |
| JSON/digest parity | One-shot duplicate, then retrying full verifier | One retrying full verifier |
| Read-only smoke setup | Downloaded unused artifacts and enabled an unusable cache | No artifact download; uv cache disabled |

## Verification
- `uv run pytest tests/integration/test_release_workflow.py tests/integration/test_verify_public_distribution.py` — 13 passed
- `uv run ruff check tests/integration/test_release_workflow.py`
- `uv run ruff format --check tests/integration/test_release_workflow.py`
- `uv run python scripts/check_official_docs.py --skip-build`
- `uv run python scripts/verify_public_distribution.py --version 0.99.333 --repository mangowhoiscloud/geode --source-sha 0cbd26e7a774794c17d5b2dca18879d95294e62d --attempts 3 --retry-delay 1`
- `git diff --check`
- Repair release run `29413349710` — all jobs passed; public files matched without re-upload
