### PR TITLE
release: v1.0.0 — first stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-16
+
+> First stable GEODE release, adding self-managed Google Workspace OAuth and
+> hardening stable distribution verification.
+
 ### Added
 
 - **Native Google Workspace OAuth and tools.** `/login google` now imports a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.333
+- **Version**: 1.0.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 418 core + 109 plugins = 527
-- **Tests**: 9965 (+1 live)
+- **Modules**: 426 core + 109 plugins = 535
+- **Tests**: 10068 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v0.99.333 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.0 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.333: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.0: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.333"
+version = "1.0.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.333. Last sync 2026-07-15. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.0. Last sync 2026-07-16. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -4141,11 +4141,39 @@ GEODE는 프로바이더마다 두 종류의 자격을 받습니다. 구독 OAut
 | --- | --- |
 | `/login openai` | ChatGPT 구독 OAuth 로그인. device-code 플로우는 `core/auth/oauth_login.py`이고, 결과는 `auth.toml`에 OAUTH\_BORROWED 플랜 + 프로파일 쌍으로 저장됩니다. |
 | `/login anthropic` | Claude 구독 OAuth. macOS 키체인의 `"Claude Code-credentials"` 항목을 읽습니다(routing.toml `[credentials.keychain]`, override는 `GEODE_ANTHROPIC_KEYCHAIN_SERVICE`). |
+| `/login google` | Gmail, Calendar, Drive, Docs, Sheets, Tasks, Contacts용 Google Workspace OAuth. 사용자가 만든 Desktop 앱 클라이언트를 가져오며 LLM 프로바이더 자격과 분리됩니다. |
 | `/login add` | 자격 추가. 키 모양(`sk-ant-`, `sk-proj-`, GLM {id}.{secret})으로 프로바이더를 추정합니다. |
 | `/login use` / `remove` | 프로파일 선택과 제거. |
 | `/login route` | 프로바이더와 플랜 라우팅 확인. |
 | `/login quota` | 구독 쿼터 상태. |
 | `/login source <provider> <type>` | 자격 소스 영속화. config.toml `[llm]`에 기록. |
+
+## Google Workspace
+
+uv나 GitHub에서 설치한 사용자도 중앙 GEODE OAuth 앱 없이 자신의 Google Cloud Desktop 클라이언트로 연결할 수 있습니다. 권장 진입점은`/login google`입니다. 첫 연결에서는 client JSON 경로와 필요한 서비스 번들을 명시적으로 고릅니다. 자동화하려면 다음처럼 한 줄로 지정할 수 있습니다.
+
+```
+/login google --client-json ~/Downloads/client_secret.json \
+  --services gmail-send,calendar-read,workspace-files
+
+/login google services
+/login google status
+/login google use user@example.com
+/login google --new-account --services calendar-read
+/login google --services calendar-read --replace-services
+/login google logout user@example.com
+```
+
+인증은 시스템 브라우저, 임의의 `127.0.0.1` 포트, Authorization Code + PKCE S256 + state 검증을 씁니다. Google이 Desktop 앱의 incremental auth를 지원하지 않으므로 서비스를 더할 때는 대상 활성 계정의 기존 번들과 새 번들의 합집합으로 재동의합니다. 브라우저에서 다른 계정을 고르면 저장하지 않고 실패하며, 두 번째 계정은 `--new-account`로 연결합니다. 권한을 줄일 때는 유지할 전체 번들과 `--replace-services`를 함께 지정합니다.`gmail-read`는 Restricted scope라 기본 권장 묶음에 포함되지 않습니다. Drive·Docs·Sheets는 전체 Drive 대신 non-sensitive `drive.file`로 GEODE가 만들거나 파일별로 허용된 항목만 다룹니다.
+
+| 저장소 | 내용 |
+| --- | --- |
+| OS keyring<br>`geode.google.oauth` | refresh token, client secret, 계정 이메일과 표시 이름. 안전한 백엔드가 없으면 로그인은 실패하며 평문 fallback은 없습니다. |
+| `~/.geode/google/accounts.json` | schema version, 단조 증가 revision, 활성 account id, client/project id, 서비스 번들, 실제 granted scopes, 상태와 시각만. 프로세스 간 `.accounts.lock` 뒤 atomic write, 디렉터리 0700·파일 0600. |
+| 프로세스 메모리 | 짧은 수명의 access token과 expiry. 데몬 auth reload와 logout 때 폐기. |
+| 세션 영속 저장소 | Workspace 도구의 원문 입력·결과는 JSON·SQLite·도구 로그에 저장하지 않고 호출 ID가 붙은 `_personal_data_omitted` 표식으로 치환합니다. API 오류 상세도 영속 telemetry·회전 로그에서 생략하고, 개인 도구가 포함된 batch는 별도 reflection provider 호출을 건너뜁니다. 사용자가 직접 쓴 대화문과 모델이 대화문으로 작성한 요약은 일반 세션 보존 정책을 따릅니다. |
+
+Workspace 읽기 결과는 선택한 LLM 프로바이더로 전달될 수 있으므로 매 도구 호출 직전에 개인 데이터 disclosure와 affirmative consent가 뜹니다. 이 승인은 always-allow할 수 없고 headless·서브에이전트에서는 닫힌 채로 거부됩니다. Gmail 전송과 Drive/Docs/Sheets/Tasks/Calendar 변경도 같은 비캐시형 매 호출 승인을 거쳐 HITL 0·권한 건너뛰기로 우회할 수 없습니다. 자세한 스키마와 Hermes 비교는 설계 기록`docs/architecture/google-workspace-oauth.md`에 있습니다.
 
 ## Codex 토큰 감지
 
@@ -4823,7 +4851,7 @@ SoT는 `core/cli/commands/_state.py`의 `COMMAND_MAP`이고, 실행 위치는 `c
 | 명령 | 별칭 | 실행 위치 | 용도 | 핸들러 |
 | --- | --- | --- | --- | --- |
 | `/help` |  | THIN | 대화형 도움말 | `core/cli/commands/_state.py` |
-| `/login` |  | THIN | 플랜과 자격 대시보드. `openai`, `anthropic`, `add`, `use`, `route`, `quota`, `source` | `core/cli/commands/login.py` |
+| `/login` |  | THIN | 플랜과 자격 대시보드. `openai`, `anthropic`, `google`, `add`, `use`, `route`, `quota`, `source` | `core/cli/commands/login.py` |
 | `/key <value>` |  | THIN | PAYG API 키 빠른 등록(/login의 legacy 별칭) | `core/cli/commands/key.py` |
 | `/model` |  | THIN | 모델 확인과 전환. Tab으로 역할(primary, reflection, mutator) 순환 | `core/cli/commands/model.py` |
 | `/audit` |  | THIN | `geode audit`의 슬래시 형태 | `plugins/petri_audit/cli_audit.py` |
@@ -5091,7 +5119,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1449 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1451 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v0.99.333. Last sync 2026-07-15. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.0. Last sync 2026-07-16. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-15
+ * Last sync: 2026-07-16
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- **Stable releases tolerate split PyPI index convergence.** Post-publish\n  verification keeps the bounded exact-version `uvx` install loop, then delegates\n  JSON metadata and SHA-256 parity to the reusable full-snapshot verifier that\n  already retries GitHub and PyPI together. The redundant one-shot PyPI JSON\n  lookup is removed, so a successful upload cannot be reported as failed merely\n  because the exact-version JSON endpoint briefly lags the simple index. The\n  read-only smoke job also disables its unused uv cache instead of warning about\n  a checkout-free cache key."
+    "body": ""
+  },
+  {
+    "version": "1.0.0",
+    "date": "2026-07-16",
+    "body": "> First stable GEODE release, adding self-managed Google Workspace OAuth and\n> hardening stable distribution verification.\n\n### Added\n\n- **Native Google Workspace OAuth and tools.** `/login google` now imports a\n  user-owned Google Desktop OAuth client, uses a system-browser loopback\n  Authorization Code flow with PKCE and state, and supports multiple accounts,\n  scope bundles, status, switching, reauthorization, and revocation. Refresh\n  tokens, client secrets, and private account labels live in the OS keyring;\n  the versioned JSON registry contains metadata only and access tokens remain\n  in memory. Eleven Gmail, Drive, Docs, Sheets, Tasks, and Contacts tools join\n  the existing Calendar surface. Personal-data reads require an affirmative\n  confirmation for every invocation, including Workspace mutations; cached\n  write approvals, HITL 0, and skip-permissions cannot bypass it. Raw Calendar\n  MCP tools remain adapter-only, every personal Workspace capability fails\n  closed in headless and sub-agent sessions, and raw tool inputs/results are\n  marker-redacted from durable transcripts, checkpoints, SQLite, and offload\n  storage. Personal API errors are omitted from durable telemetry and rotating\n  logs, and personal-tool batches skip secondary reflection. The metadata\n  registry uses a cross-process lock, monotonic revision, and stale-refresh-safe\n  field patches; `--new-account` separates account scope selection from\n  active-account reauthorization.\n\n### Fixed\n\n- **Stable releases tolerate split PyPI index convergence.** Post-publish\n  verification keeps the bounded exact-version `uvx` install loop, then delegates\n  JSON metadata and SHA-256 parity to the reusable full-snapshot verifier that\n  already retries GitHub and PyPI together. The redundant one-shot PyPI JSON\n  lookup is removed, so a successful upload cannot be reported as failed merely\n  because the exact-version JSON endpoint briefly lags the simple index. The\n  read-only smoke job also disables its unused uv cache instead of warning about\n  a checkout-free cache key."
   },
   {
     "version": "0.99.333",
@@ -2393,4 +2398,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-15";
+export const CHANGELOG_SYNCED_AT = "2026-07-16";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-15
+ * Last sync: 2026-07-16
  */
 
 export const GEODE_SOT = {
-  version: "0.99.333",
-  syncedAt: "2026-07-15",
+  version: "1.0.0",
+  syncedAt: "2026-07-16",
 } as const;

--- a/tests/core/cli/test_doctor_slack.py
+++ b/tests/core/cli/test_doctor_slack.py
@@ -81,6 +81,11 @@ class TestCheckTokenValidity:
 
 
 class TestCheckBindings:
+    @pytest.fixture(autouse=True)
+    def _isolate_global_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep binding diagnostics independent of the operator's config."""
+        monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", tmp_path / "absent-global.toml")
+
     def test_valid_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         geode_dir = tmp_path / ".geode"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.333"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Cut GEODE `v1.0.0` as the first stable release.
- Promote the native Google Workspace OAuth/tool surface and stable-distribution verification hardening from `[Unreleased]`.
- Refresh every version stamp, measured repository metric, lockfile, and generated public-doc snapshot.

## Why
The Google Workspace capability is now on `main`, and the repository has completed its `0.99.x` stabilization series. This release establishes the stable SemVer baseline requested for distribution builds.

## Changes
| File / area | Change |
|-------------|--------|
| `pyproject.toml`, `uv.lock` | Package version `1.0.0` |
| `CHANGELOG.md` | Promote Google Workspace and PyPI convergence entries into `1.0.0` dated 2026-07-16; restore empty `[Unreleased]` |
| `CLAUDE.md` | Version plus measured `426 core + 109 plugins = 535` modules and `10,068 + 1 live` tests |
| `README.md`, `README.ko.md` | Stable release heading |
| Site SoT | Regenerate `sot.ts`, changelog data, `llms.txt`, and `llms-full.txt` |
| Slack doctor tests | Isolate binding diagnostics from the operator's real global config |

## GAP Audit
| Release surface | Before | After |
|-----------------|--------|-------|
| Package metadata | `0.99.333` | `1.0.0` |
| CHANGELOG | Google Workspace and distribution fix unreleased | Both recorded under `1.0.0` |
| Public docs SoT | `v0.99.333` | `v1.0.0`, generated snapshots current |
| Local test determinism | Slack binding tests could read real user config | Global config isolated per test |

## Verification
- `uv run ruff check core plugins tests scripts`
- `uv run ruff format --check core plugins tests scripts`
- `uv run mypy core plugins scripts tests/integration/test_prepare_hf_release_bundle.py tests/integration/test_check_official_docs.py` — 575 files clean
- `uv run lint-imports` — 4 contracts kept
- `uv run deptry .` — no dependency issues
- `uv run pytest -q` — full non-live suite passed; 1 live test not run
- `uv run python scripts/check_official_docs.py` — 235 pages and 72 Markdown twins; generated snapshots clean
- `uv build`; `twine check`; package artifact gate — wheel 608 files, sdist 610 files
- Clean wheel install from outside the repository prints `GEODE v1.0.0`
