### PR TITLE
docs: simplify README navigation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,11 +18,9 @@
 </p>
 
 <p align="center">
+  <a href="https://mangowhoiscloud.github.io/geode/">랜딩</a>
+  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">문서</a>
-  ·
-  <a href="https://mangowhoiscloud.github.io/geode/docs/run/google-workspace">Google Workspace</a>
-  ·
-  <a href="https://github.com/mangowhoiscloud/geode/releases/latest">v1.0.0 릴리스</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving 허브</a>
   ·

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@
 </p>
 
 <p align="center">
+  <a href="https://mangowhoiscloud.github.io/geode/">Landing</a>
+  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">Docs</a>
-  ·
-  <a href="https://mangowhoiscloud.github.io/geode/docs/run/google-workspace">Google Workspace</a>
-  ·
-  <a href="https://github.com/mangowhoiscloud/geode/releases/latest">v1.0.0 release</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving hub</a>
   ·


### PR DESCRIPTION
## Summary
- Simplify the English and Korean README navigation bars.
- Add the public GEODE landing page.

## Why
The header accumulated capability- and release-specific shortcuts. The README should keep only the stable top-level destinations the project wants to foreground.

## Changes
| File | Change |
|---|---|
| README.md | Keep Landing, Docs, Self-improving hub, Eval artifacts, and Korean; remove Google Workspace and release shortcuts |
| README.ko.md | Mirror the same navigation structure in Korean |

## Verification
- git diff --check — passed
- Confirmed Landing, Docs, Self-improving hub, and Eval artifacts each return HTTP 200
- Documentation-only change; no live or runtime tests were run