### PR TITLE
docs: simplify README navigation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,11 +18,9 @@
 </p>
 
 <p align="center">
+  <a href="https://mangowhoiscloud.github.io/geode/">랜딩</a>
+  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">문서</a>
-  ·
-  <a href="https://mangowhoiscloud.github.io/geode/docs/run/google-workspace">Google Workspace</a>
-  ·
-  <a href="https://github.com/mangowhoiscloud/geode/releases/latest">v1.0.0 릴리스</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving 허브</a>
   ·

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@
 </p>
 
 <p align="center">
+  <a href="https://mangowhoiscloud.github.io/geode/">Landing</a>
+  ·
   <a href="https://mangowhoiscloud.github.io/geode/docs">Docs</a>
-  ·
-  <a href="https://mangowhoiscloud.github.io/geode/docs/run/google-workspace">Google Workspace</a>
-  ·
-  <a href="https://github.com/mangowhoiscloud/geode/releases/latest">v1.0.0 release</a>
   ·
   <a href="https://mangowhoiscloud.github.io/geode/self-improving/">Self-improving hub</a>
   ·


### PR DESCRIPTION
## Summary
- Promote the simplified README navigation from develop to main.

## Why
The public repository header should foreground only the stable top-level destinations: Landing, Docs, Self-improving hub, and Eval artifacts.

## Changes
| File | Change |
|---|---|
| README.md | Add Landing and remove Google Workspace and release shortcuts |
| README.ko.md | Mirror the same simplified navigation in Korean |

## Verification
- Feature PR #2764 passed CI, lint/format, type, tests, security, and macOS/Ubuntu install smoke.
- git diff origin/main...origin/develop contains only README.md and README.ko.md.
- All retained external destinations return HTTP 200.