### PR TITLE
docs: reconcile architecture R0 bootstrap

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -212,7 +212,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
-| R0.1 | GOV-001, GOV-003 | `session=codex-2026-07-17 task=architecture-extensibility-roadmap` | `feature/architecture-extensibility-roadmap` | Bootstrap exception: roadmap-establishing PR | 2026-07-17 |
+| _none yet_ | — | — | — | — | — |
 
 ## 1. Program objective
 
@@ -480,9 +480,9 @@ package. Delivery and closure evidence are appended in §10.
 
 | ID | Audit | Baseline evidence | Exit condition | Closure package | Depends on | Status |
 |---|---|---|---|---|---|---|
-| GOV-001 | `ABSENT` | Status is fragmented across dated plans and architecture docs | This file is linked from contributor entry points and governs status | R0.1 | — | `IN_PROGRESS` |
-| GOV-002 | `PARTIAL` | Hand-audited counts disagree with `AGENTS.md` (78 tools/56 hooks vs 67/65 prose) | One generated architecture baseline and a drift check own the counts | R0.2 | GOV-001 | `OPEN` |
-| GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `IN_PROGRESS` |
+| GOV-001 | `ABSENT` | Status is fragmented across dated plans and architecture docs | This file is linked from contributor entry points and governs status | R0.1 | — | `IN_DEVELOP` |
+| GOV-002 | `PARTIAL` | Hand-audited counts disagree with `AGENTS.md` (78 tools/56 hooks vs 67/65 prose) | One generated architecture baseline and a drift check own the counts | R0.2 | GOV-001 | `READY` |
+| GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `IN_DEVELOP` |
 | GOV-004 | `PARTIAL` | 24 import ignores and very high global Ruff ceilings lack uniform owner/expiry metadata | Every exception is removed or recorded per symbol/edge with owner, rationale, expiry, and ratchet | R0.3 | GOV-002 | `OPEN` |
 | BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `OPEN` |
 | BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `OPEN` |
@@ -516,7 +516,7 @@ package. Delivery and closure evidence are appended in §10.
 | TRUST-003 | `ABSENT` | Mutation serialization is not derived from explicit tool resource metadata | `resource_keys(args)` drives per-resource serialization; no argument-name heuristic | R2.4 | CAP-004 | `OPEN` |
 | VER-001 | `PARTIAL` | Quality gates pass but lack core-only, reverse-import, exception-budget, and tool-plan drift tests | All architecture gates in §9 run in CI and locally | R7.1 | BND-003, BND-004, CAP-005, LOOP-004, DI-003, LLM-002, PROTO-002, GOV-004, VER-003 | `OPEN` |
 | VER-002 | `ABSENT` | No contract suite measures how many central edits each extension type requires | Six extension scenarios in §8 pass without forbidden edits | R7.2 | CAP-006, LLM-002, BND-004 | `OPEN` |
-| VER-003 | `PARTIAL` | Public/internal metric prose drifts from executable counts | `sync-stats` or one shared generator updates site, AGENTS facts, and roadmap baseline; check mode is green | R0.2 | GOV-001 | `OPEN` |
+| VER-003 | `PARTIAL` | Public/internal metric prose drifts from executable counts | `sync-stats` or one shared generator updates site, AGENTS facts, and roadmap baseline; check mode is green | R0.2 | GOV-001 | `READY` |
 | VER-004 | `PARTIAL` | Cold-start and runtime metrics exist, but refactors lack one architecture regression baseline | Startup, first-turn, tool-plan build, memory, and event-write budgets are pinned and non-regressing | R7.3 | CAP-005, LOOP-003, DI-004, LLM-004, PROTO-002, STORE-002 | `OPEN` |
 
 ## 6. Dependency and merge sequence
@@ -1099,7 +1099,7 @@ pre-release delivery evidence survives after the claim row is gone.
 
 | Closure package | GAP IDs | Feature PR | Develop merge commit | Verification / handoff evidence |
 |---|---|---|---|---|
-| _none yet_ | — | — | — | — |
+| R0.1 | GOV-001, GOV-003 | [#2767](https://github.com/mangowhoiscloud/geode/pull/2767) | `ab1a80e91f9947defc15fa97f5b4ce66126c0c13` | CI Gate, lint/format, security, tests, type check, and macOS/Ubuntu install smoke passed; committed-diff re-review returned no findings |
 
 ### 10.2 Main closure evidence
 
@@ -1205,17 +1205,13 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-After the roadmap bootstrap merges, the next governance action is one
-roadmap-only reconciliation with an ordered, package-atomic result:
+After this reconciliation merges, the next governance action is a separate
+roadmap-only claim PR that atomically moves GOV-002 and VER-003 from `READY` to
+`IN_PROGRESS` and records the R0.2 owner and implementation branch. Only after
+that claim merges may the generated-baseline implementation worktree be
+allocated.
 
-1. move GOV-001 and GOV-003 together from `IN_PROGRESS` to `IN_DEVELOP`;
-2. append the R0.1 feature PR and exact develop merge commit in §10.1;
-3. remove the R0.1 active claim;
-4. re-audit R0.2 against that updated state and, because GOV-001 is now
-   `IN_DEVELOP`, move GOV-002 and VER-003 together from `OPEN` to `READY`.
-
-A separate claim PR must then move all of R0.2 to `IN_PROGRESS`. Only after
-that claim merges is R0.2 the next implementation worktree. It turns the
-hand-measured baseline in §2 into executable data and prevents the new SOT from
-becoming another stale plan. R1 does not start until that check can detect
-reverse imports, exception debt, ledger corruption, and metric drift.
+R0.2 turns the hand-measured baseline in §2 into executable data and prevents
+the new SOT from becoming another stale plan. R1 does not start until that
+implementation can detect reverse imports, exception debt, ledger corruption,
+and metric drift.


### PR DESCRIPTION
## Summary

- Reconcile the merged R0.1 bootstrap from `IN_PROGRESS` to `IN_DEVELOP`.
- Remove the completed R0.1 active claim and record durable develop evidence.
- Re-audit and promote the dependency-satisfied R0.2 package from `OPEN` to
  `READY`.

## Why

PR #2767 established the canonical roadmap on `develop`. The ledger must now
trail that merge accurately before a separate R0.2 claim can authorize the
generated-baseline implementation.

## Changes

| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | Moves GOV-001/GOV-003 to `IN_DEVELOP`, records #2767 and `ab1a80e91`, removes the R0.1 claim, moves GOV-002/VER-003 to `READY`, and points §14 to the separate claim PR |

## GAP Audit

| Package | GAPs | Transition | Evidence |
|---|---|---|---|
| R0.1 | GOV-001, GOV-003 | `IN_PROGRESS` → `IN_DEVELOP` | #2767 merged at `ab1a80e91f9947defc15fa97f5b4ce66126c0c13`; all required CI and install smoke checks passed |
| R0.2 | GOV-002, VER-003 | `OPEN` → `READY` | External dependency GOV-001 is now `IN_DEVELOP`; §7 contains measurable acceptance and validator scope |

## Manual Ledger Invariants

| Invariant | Result |
|---|---|
| Unique IDs / exact package selection | PASS — 38 GAPs, 27 packages, every GAP selected once |
| Dependency existence / acyclicity | PASS — all edges resolve; DAG walk completed |
| Package-atomic status | PASS — R0.1 and R0.2 members move together |
| Active-claim parity | PASS — no `IN_PROGRESS` package and no active claim |
| Evidence parity | PASS — R0.1 §10.1 row contains feature PR and exact develop commit |
| Legal transitions | PASS — only R0.1 `IN_PROGRESS`→`IN_DEVELOP` and R0.2 `OPEN`→`READY` |

## Verification

- `git diff --check` — passed
- focused `pymarkdown` scan — passed
- `scripts/lint_pages_markdown.sh` — passed
- `uv run python scripts/check_docs_links.py --quiet` — 645 links, no broken
  internal links
- `uv run python scripts/check_repo_hygiene.py` — passed
- read-only base/current ledger invariant audit — passed
- independent committed-diff review — `No findings`

Full runtime suites were not run locally because this PR changes only the
canonical roadmap; required CI remains authoritative.
