### PR TITLE
Polish portfolio install surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Portfolio now presents one English-only surface.** The portfolio fixes its
+  locale to English and ignores language query overrides, while documentation
+  keeps its bilingual behavior. The install copy action stays pinned to the
+  right of concise channel guidance; the landing demo identifies the Anthropic
+  Fable 5 route and lists the three supported provider families in a compact
+  rail. The minimal hero keeps its static pixel sky in a right-side crop, with
+  a solid rose copy-safe zone and a contrast-safe deep-rose headline outline
+  preventing white pixels from obscuring the title. Static English language
+  semantics and accessible field-label contrast cover assistive technology and
+  no-JavaScript rendering.
+
 ## [1.0.0] - 2026-07-16
 
 > First stable GEODE release, adding self-managed Google Workspace OAuth and

--- a/site/DESIGN.md
+++ b/site/DESIGN.md
@@ -103,6 +103,11 @@ curtain-stack sections over a pinned hero, `StageLight` scroll-linked
 dimming, the distillation act (token rain converging band-by-band through
 hairline filters labeled with Astryx `Token` chips, piling onto the GEODE
 word as a top-down fill), and the wordmark-to-laboratory crossfade finale.
+The hero keeps decorative pixels inside a right-side crop. A solid rose
+copy-safe layer clears the title area without a gradient, while a deep-rose
+outline preserves the warm-white letterforms at unusual zoom levels or aspect
+ratios. Compact field labels use the same accessible deep-rose ink
+(`#7F1747`, 4.88:1 against the signature field).
 The docs surface keeps the single dark substrate rule.
 
 **Texture.** `.rose-grid` (globals.css) is a 1px rose dot grid at 5% opacity,
@@ -251,7 +256,7 @@ When asked to build or modify UI in this portfolio repo:
 3. **Single substrate.** Every page wraps in `bg-[var(--paper)] text-[var(--ink)]`. Section-level dark or light overrides are forbidden.
 4. **Mascot images sit naturally on the substrate** — do not wrap in inset containers. Geodi was authored for dark mediums.
 5. **Two-mode accents.** When emitting an artifact (OS, runtime, prompt, hash) reference, use `--acc-artifact`. When emitting a line (scaffold, ratchet, CI, kanban) reference, use `--acc-line`. Mixing them within a single section is acceptable only when comparing the two modes (recursion table).
-6. **Korean default.** `<html lang="ko">` from `src/app/layout.tsx`. Bilingual content uses `<Bi ko={...} en={...} />` for the docs site or the `t(locale, ko, en)` helper for components.
+6. **English portfolio, Korean-first docs.** `<html lang="ko">` comes from `src/app/layout.tsx`. The portfolio fixes its surface locale to English, marks its content root with `lang="en"`, hides the locale control, and disables query-string language overrides. Docs remain fully bilingual through `<Bi ko={...} en={...} />`, and localized component prose uses `t(locale, ko, en)`.
 7. **Verification**: after edits, run `node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.json` and `next build`. Both must exit 0.
 
 **Forbidden additions** (without explicit user approval):

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -37,6 +37,9 @@ const PAPER_55 = "color-mix(in srgb, #FFF0F8 55%, transparent)";
 // white plates (~4.5:1 vs #FFF0F8; the signature itself is ~1.8:1 as ink).
 const ROSE_INK = "#C2447F";
 const ROSE_INK_70 = "color-mix(in srgb, #C2447F 72%, transparent)";
+// Small text written directly on the signature field needs a deeper value
+// than plate ink (4.88:1 against #F49BC4).
+const ROSE_FIELD_INK = "#7F1747";
 
 const navItems = [
   { id: "hero", label: "Intro" },
@@ -64,6 +67,8 @@ const FIRST_PROMPT_LINES: InstallLine[] = [
   { kind: "prompt", text: "Hello World" },
 ];
 
+const supportedProviders = ["Anthropic", "OpenAI / Codex", "ZhipuAI GLM"] as const;
+
 const installChannels: {
   id: string;
   labelKo: string;
@@ -78,7 +83,7 @@ const installChannels: {
     labelKo: "uv tool",
     labelEn: "uv tool",
     noteKo: "파이썬 툴체인 사용자용. 최신 안정 버전을 격리된 도구 환경에 설치합니다.",
-    noteEn: "For Python-toolchain users. Installs the latest stable release in an isolated tool env.",
+    noteEn: "Latest stable release in an isolated tool environment.",
     copy: "uv tool install geode-agent",
     lines: [
       { kind: "cmd", text: "uv tool install geode-agent" },
@@ -92,7 +97,7 @@ const installChannels: {
     labelKo: "uvx · 설치 없이",
     labelEn: "uvx · no install",
     noteKo: "설치 없이 1회 실행. PATH에 명령을 남기지 않습니다.",
-    noteEn: "One-shot run without installing. Adds no command to your PATH.",
+    noteEn: "One-shot run with no install and no PATH changes.",
     copy: "uvx --from geode-agent geode",
     lines: [
       { kind: "cmd", text: "uvx --from geode-agent geode" },
@@ -105,7 +110,7 @@ const installChannels: {
     labelKo: "소스",
     labelEn: "Source",
     noteKo: "개발·기여용. uv run이 프로젝트 환경을 맞춘 뒤 바로 실행합니다.",
-    noteEn: "For development and contributions. uv run syncs the project env and starts GEODE.",
+    noteEn: "Development checkout with its environment managed by uv.",
     copy: "git clone https://github.com/mangowhoiscloud/geode.git && cd geode && uv run geode",
     lines: [
       { kind: "cmd", text: "git clone https://github.com/mangowhoiscloud/geode.git && cd geode" },
@@ -232,7 +237,7 @@ function InstallTerminal({ lines }: { lines: InstallLine[] }) {
               <span className="font-semibold text-[var(--acc-artifact)]">GEODE</span>{" "}
               <span className="text-[var(--ink-2)]">v{GEODE_SOT.version}</span>
             </p>
-            <p className="text-[var(--ink-3)]">claude-opus-4-8 · ~/workspace</p>
+            <p className="text-[var(--ink-3)]">anthropic / claude-fable-5 · ~/workspace</p>
             <p className="text-[var(--ink-3)]">/help for commands · type naturally</p>
           </div>
         </div>
@@ -336,13 +341,13 @@ function InstallChannels() {
           <div className="mt-6">
             <InstallTerminal key={channel.id} lines={channel.lines} />
           </div>
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-            <p className="font-mono text-[12px]" style={{ color: PAPER_75 }}>
+          <div className="mt-4 flex flex-nowrap items-center justify-between gap-x-4">
+            <p className="min-w-0 flex-1 font-mono text-[12px]" style={{ color: PAPER_75 }}>
               {t(locale, channel.noteKo, channel.noteEn)}
             </p>
             <button
               onClick={handleCopy}
-              className="touch-manipulation rounded border border-[color-mix(in_srgb,#FFF0F8_45%,transparent)] px-3 py-1 font-mono text-[11px] text-[#FFF0F8] transition-opacity hover:opacity-75"
+              className="shrink-0 touch-manipulation rounded border border-[color-mix(in_srgb,#FFF0F8_45%,transparent)] px-3 py-1 font-mono text-[11px] text-[#FFF0F8] transition-opacity hover:opacity-75"
             >
               {copied ? t(locale, "복사됨", "copied") : t(locale, "명령 복사", "copy command")}
             </button>
@@ -350,6 +355,22 @@ function InstallChannels() {
           <p className="mt-2 select-all break-all font-mono text-[11.5px]" style={{ color: PAPER_75 }}>
             {channel.copy}
           </p>
+          <div className="mt-5 flex flex-col gap-2 border-t border-[color-mix(in_srgb,#FFF0F8_25%,transparent)] pt-3.5 sm:flex-row sm:items-center sm:justify-between">
+            <p
+              className="shrink-0 font-mono text-[9px] uppercase tracking-[0.22em]"
+              style={{ color: ROSE_FIELD_INK }}
+            >
+              supported providers
+            </p>
+            <ul className="flex flex-wrap items-center gap-x-3.5 gap-y-1.5" aria-label="Supported providers">
+              {supportedProviders.map((provider) => (
+                <li key={provider} className="inline-flex items-center gap-1.5">
+                  <span aria-hidden="true" className="h-[3px] w-[3px] rotate-45 bg-[#7F1747]" />
+                  <span className="font-mono text-[10.5px] text-[#7F1747]">{provider}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
         </motion.div>
       </div>
     </section>
@@ -388,15 +409,21 @@ function HeroField() {
   };
   return (
     <section id="hero" className="relative overflow-hidden">
-      <Image
-        src="/geode/images/geode-sky.png"
-        alt=""
+      <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[44%] overflow-hidden lg:block">
+        <Image
+          src="/geode/images/geode-sky.png"
+          alt=""
+          aria-hidden
+          fill
+          priority
+          sizes="44vw"
+          className="select-none object-cover object-center opacity-90"
+          style={{ imageRendering: "pixelated" }}
+        />
+      </div>
+      <div
         aria-hidden
-        fill
-        priority
-        sizes="100vw"
-        className="pointer-events-none select-none object-cover opacity-90"
-        style={{ imageRendering: "pixelated" }}
+        className="pointer-events-none absolute inset-y-0 left-0 z-[1] hidden bg-[#F49BC4] lg:block lg:w-[74%] xl:w-[62%]"
       />
       <motion.div
         className="relative z-10 mx-auto max-w-7xl px-5 pb-16 pt-14 sm:px-8 lg:pt-20"
@@ -413,7 +440,8 @@ function HeroField() {
         </motion.p>
         <motion.h1
           variants={heroItem}
-          className="font-serif-display mt-7 max-w-4xl text-balance text-[clamp(2.5rem,5.6vw,4.3rem)] font-black leading-[1.12] text-[#FFF0F8]"
+          className="font-serif-display mt-7 max-w-[700px] text-balance text-[clamp(2.5rem,5.2vw,4.2rem)] font-black leading-[1.12] text-[#FFF0F8]"
+          style={{ WebkitTextStroke: "1.25px #7F1747", paintOrder: "stroke fill" }}
         >
           {t(locale, "일을 맡기면", "The agent that")}
           <br />
@@ -448,8 +476,8 @@ function HeroField() {
         className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-between px-5 pb-4 font-mono text-[10px] uppercase tracking-[0.18em] sm:px-8"
         style={{ color: PAPER_55 }}
       >
-        <span>geode v{GEODE_SOT.version}</span>
-        <span>apache-2.0 · 2026</span>
+        <span className="bg-[#F49BC4] px-1">geode v{GEODE_SOT.version}</span>
+        <span className="bg-[#F49BC4] px-1">apache-2.0 · 2026</span>
       </div>
     </section>
   );
@@ -1320,12 +1348,13 @@ function DistillationAct() {
 
 export default function GeodePortfolioPage() {
   return (
-    <LocaleProvider defaultLocale="en">
+    <LocaleProvider defaultLocale="en" allowQueryOverride={false}>
       <main
+        lang="en"
         data-astryx-theme="neutral"
         className={`${galmuri.variable} ${serifDisplay.variable} min-h-screen overflow-x-clip bg-[var(--acc-artifact)] text-[#FFF0F8]`}
       >
-        <GeodeNav items={navItems} light />
+        <GeodeNav items={navItems} light showLocaleToggle={false} />
         <HeroField />
         <InstallChannels />
         <RunRow />

--- a/site/src/components/geode/locale-context.tsx
+++ b/site/src/components/geode/locale-context.tsx
@@ -23,22 +23,25 @@ export function t(locale: Locale, ko: string, en: string): string {
 export function LocaleProvider({
   children,
   defaultLocale = "ko",
+  allowQueryOverride = true,
 }: {
   children: ReactNode;
   defaultLocale?: Locale;
+  allowQueryOverride?: boolean;
 }) {
   const [locale, setLocale] = useState<Locale>(defaultLocale);
 
   // Explicit ?lang= param only — never the browser locale. The param wins
-  // over the surface default (portfolio defaults en, docs defaults ko).
+  // over the surface default when that surface allows language switching.
   useEffect(() => {
+    if (!allowQueryOverride) return;
     const params = new URLSearchParams(window.location.search);
     const lang = params.get("lang");
     if (lang !== "en" && lang !== "ko") return;
     // Defer until after hydration; the server cannot observe the query string.
     const timer = window.setTimeout(() => setLocale(lang), 0);
     return () => window.clearTimeout(timer);
-  }, []);
+  }, [allowQueryOverride]);
 
   // Update html lang attribute + URL param (param present only when the
   // locale differs from this surface's default, so default URLs stay clean).

--- a/site/src/components/geode/sections/nav.tsx
+++ b/site/src/components/geode/sections/nav.tsx
@@ -17,10 +17,13 @@ const defaultNavItems: NavItem[] = [
 export function GeodeNav({
   items = defaultNavItems,
   light = false,
+  showLocaleToggle = true,
 }: {
   items?: NavItem[];
   /** Light chrome for the white-substrate portfolio surface. */
   light?: boolean;
+  /** Hide language controls on surfaces whose copy is intentionally fixed. */
+  showLocaleToggle?: boolean;
 }) {
   const [activeSection, setActiveSection] = useState(items[0]?.id ?? "hero");
   const [visible, setVisible] = useState(false);
@@ -105,7 +108,7 @@ export function GeodeNav({
             );
           })}
         </div>
-        <LocaleToggle />
+        {showLocaleToggle ? <LocaleToggle /> : null}
       </div>
     </nav>
   );

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Changed\n\n- **Portfolio now presents one English-only surface.** The portfolio fixes its\n  locale to English and ignores language query overrides, while documentation\n  keeps its bilingual behavior. The install copy action stays pinned to the\n  right of concise channel guidance; the landing demo identifies the Anthropic\n  Fable 5 route and lists the three supported provider families in a compact\n  rail. The minimal hero keeps its static pixel sky in a right-side crop, with\n  a solid rose copy-safe zone and a contrast-safe deep-rose headline outline\n  preventing white pixels from obscuring the title. Static English language\n  semantics and accessible field-label contrast cover assistive technology and\n  no-JavaScript rendering."
   },
   {
     "version": "1.0.0",

--- a/tests/integration/test_portfolio_surface_policy.py
+++ b/tests/integration/test_portfolio_surface_policy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PORTFOLIO_PATH = REPO_ROOT / "site/src/app/portfolio/page.tsx"
+LOCALE_CONTEXT_PATH = REPO_ROOT / "site/src/components/geode/locale-context.tsx"
+NAV_PATH = REPO_ROOT / "site/src/components/geode/sections/nav.tsx"
+
+
+def test_portfolio_is_fixed_to_english() -> None:
+    portfolio = PORTFOLIO_PATH.read_text(encoding="utf-8")
+    locale_context = LOCALE_CONTEXT_PATH.read_text(encoding="utf-8")
+    nav = NAV_PATH.read_text(encoding="utf-8")
+
+    assert '<LocaleProvider defaultLocale="en" allowQueryOverride={false}>' in portfolio
+    assert '<main\n        lang="en"' in portfolio
+    assert "<GeodeNav items={navItems} light showLocaleToggle={false} />" in portfolio
+    assert "if (!allowQueryOverride) return;" in locale_context
+    assert "{showLocaleToggle ? <LocaleToggle /> : null}" in nav
+
+
+def test_portfolio_install_surface_and_static_hero() -> None:
+    portfolio = PORTFOLIO_PATH.read_text(encoding="utf-8")
+
+    assert "anthropic / claude-fable-5 · ~/workspace" in portfolio
+    assert (
+        'const supportedProviders = ["Anthropic", "OpenAI / Codex", "ZhipuAI GLM"] as const;'
+        in portfolio
+    )
+    assert "supported providers" in portfolio
+    assert 'aria-label="Supported providers"' in portfolio
+    assert 'noteEn: "Latest stable release in an isolated tool environment."' in portfolio
+    assert "flex flex-nowrap items-center justify-between" in portfolio
+    assert "min-w-0 flex-1" in portfolio
+    assert "shrink-0 touch-manipulation" in portfolio
+
+    hero = portfolio.split("function HeroField()", 1)[1].split("function LoopDiagram()", 1)[0]
+    assert "geode-sky.png" in hero
+    assert 'className="pointer-events-none absolute inset-y-0 right-0 hidden w-[44%]' in hero
+    assert "lg:w-[74%] xl:w-[62%]" in hero
+    assert 'WebkitTextStroke: "1.25px #7F1747"' in hero
+    assert "HeroPixelField" not in hero
+
+    assert 'const ROSE_FIELD_INK = "#7F1747";' in portfolio
+    assert "style={{ color: ROSE_FIELD_INK }}" in portfolio
+    assert "text-[#7F1747]" in portfolio


### PR DESCRIPTION
## Summary
- Keep the portfolio English-only while preserving bilingual docs.
- Tighten install guidance, pin the copy action, show the supported-provider rail, and use the Fable 5 demo route.
- Restore the static right-side pixel sky with a copy-safe hero treatment and accessible text semantics/contrast.

## Why
The operator-approved landing screenshots needed to land on the latest `main` without carrying unrelated worktree or branch drift. The prior surface also allowed a Korean query override, placed the copy action on a new row at narrow widths, omitted providers, showed the older demo model, and let hero pixels compete with the title.

## Changes
| File | Change |
|------|--------|
| `site/src/app/portfolio/page.tsx` | English-only portfolio, concise install copy, pinned copy action, provider rail, Fable 5 demo, static cropped pixel hero, copy-safe title, and explicit English content semantics |
| `site/src/components/geode/locale-context.tsx` | Optional query-language override policy while retaining docs defaults |
| `site/src/components/geode/sections/nav.tsx` | Optional locale-toggle visibility |
| `tests/integration/test_portfolio_surface_policy.py` | Pins locale, install, provider, model, responsive-row, and static-hero policy |
| `site/DESIGN.md`, `CHANGELOG.md`, generated changelog data | Documents and publishes the surface policy |

## GAP Audit
| Surface | Before | After |
|---------|--------|-------|
| Locale | `?lang=ko` could switch the portfolio | Portfolio stays English; docs remain bilingual |
| Install action | Copy action could wrap below its note | Note and copy action stay on one row, including 390px |
| Provider/model signal | No provider rail; Opus 4.8 demo | Anthropic / OpenAI-Codex / ZhipuAI GLM rail; `claude-fable-5` demo |
| Hero | Full-field pixel image could obscure the white title | Static right crop, solid copy-safe zone, thin contrast-safe outline |
| Accessibility | English was identified as Korean in static markup; new rail was low contrast | English content root plus 4.88:1 field-label contrast |

## Verification
- `uv run pytest -q tests/integration/test_portfolio_surface_policy.py` — 2 passed
- `uv run ruff check tests/integration/test_portfolio_surface_policy.py` — passed
- `uv run ruff format --check tests/integration/test_portfolio_surface_policy.py` — passed
- targeted ESLint for the three touched TSX files — passed
- TypeScript `tsc --noEmit --incremental false` — passed
- `npm run lint` — 0 errors (45 pre-existing warnings)
- `npm run build` — passed; 236/236 static pages (5 pre-existing Turbopack tracing warnings)
- `uv run python scripts/check_repo_hygiene.py` — passed
- Playwright at 1440/1880/390px — English query override ignored, no horizontal overflow, copy action stayed on-row, provider rail fit, hero remained static/copy-safe, and console had 0 application errors
- Independent Codex review completed; both findings (static language semantics and contrast) were folded in before push
