### PR TITLE
docs: eval artifact와 GitFlow 설명 정합화

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -187,12 +187,16 @@ gh pr create --base main --head develop \
 
 There is no automatic backmerge workflow. Before every `develop -> main`
 promotion, fetch both protected branches and compare their content. If main
-has unique tracking work, merge current main into a branch created from
-current develop and open a CI-gated PR back to develop.
+has unique tracking work and the sync is conflict-free, open a CI-gated PR
+directly from the current `main` head to `develop`. Do not put that clean sync
+behind the trusted sync-branch prefix: a merge from current main may simply
+fast-forward and therefore has no two-parent head.
 
-When the roadmap conflicts, the sync head must be one merge commit whose first
-parent is exactly `refs/remotes/origin/develop` and whose second parent is
-exactly `refs/remotes/origin/main`. CI grants main-ledger trust only to that
+When conflict resolution is required, create
+`sync/main-into-develop-<task>` from current develop and make an explicit merge
+commit from current main. The sync head must have first parent exactly
+`refs/remotes/origin/develop` and second parent exactly
+`refs/remotes/origin/main`. CI grants main-ledger trust only to that
 same-repository graph. Pull-request events do not rerun merely because the
 unrelated main branch advances, so fetch and run the same resolver immediately
 before merge:
@@ -202,7 +206,7 @@ git fetch origin
 uv run python scripts/resolve_architecture_roadmap_trust.py \
   --event-mode pull_request \
   --target-branch develop \
-  --head-ref "<sync-branch>" \
+  --head-ref "sync/main-into-develop-<task>" \
   --head-repo mangowhoiscloud/geode \
   --repository mangowhoiscloud/geode \
   --head-sha "$(git rev-parse HEAD)" \

--- a/.claude/skills/geode-workflow/references/gitflow.md
+++ b/.claude/skills/geode-workflow/references/gitflow.md
@@ -39,6 +39,13 @@ That PR targets `main`, changes only the canonical roadmap, records
 package-atomic `DONE` plus per-GAP closure evidence, and carries no
 implementation code. After it merges, open and merge a CI-gated
 `main -> develop` sync PR before further develop-targeted ledger work.
+If it is conflict-free, use the current `main` head directly as the PR head.
+If it needs conflict resolution, create it from current
+`origin/develop` with a branch name starting `sync/main-into-develop-`, merge
+current `origin/main` in an explicit merge commit as the exact second parent,
+and rerun
+`scripts/resolve_architecture_roadmap_trust.py --require-trust main`
+immediately before merge.
 
 ## Merge Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,13 @@ Claude Code compatible scaffold.
   `origin/main`, targets `main`, and is followed by a CI-gated
   `main -> develop` sync PR. Other main-maintained tracking documents use their
   own dedicated `origin/main` worktree under the repository's tracking rules.
+- **Clean syncs use the canonical head**: when `main -> develop` is
+  conflict-free, open the PR directly from the current `main` head. Do not put
+  a fast-forwarded copy of `main` behind the trusted sync-branch prefix.
+- **Trusted sync branch naming**: a conflict-resolved roadmap sync branch must
+  start with `sync/main-into-develop-`. Its head must be the exact two-parent
+  merge of the current `origin/develop` and `origin/main` tips, in that order,
+  and the trust resolver must pass again immediately before merge.
 - **No branch switching inside a worktree**: never use `git checkout` to reuse
   a checkout for another branch. Allocate or enter the correct worktree instead.
 - **Fetch before allocating branches**: run `git fetch origin` before creating

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,18 @@ See `geode-changelog` skill.
 
 See `geode-gitflow` skill. **Flow**: `feature → develop` **squash-merged** (one commit per change — collapses Codex-round fix commits; no per-feature merge commit on main), then `develop → main` pass-through `--merge`. HEREDOC PR. CI 5/5 required.
 
-> **Before EVERY `develop → main` merge, sync `main → develop` first** (`gh pr create --base develop --head main` → merge) so develop ⊇ main and never merges while lagging. The only recurring main-only drift is the kanban (`docs/progress.md`, committed on main post-merge); the pre-sync pulls the prior cycle's kanban into develop each time, so it self-heals and never accumulates. *This replaces the deleted `auto-backmerge.yml` workflow, which fired on every push to main and piled up unmerged main→develop PRs (10 open at once, 2026-06-14) because the feature/main divergence is never a fast-forward. Manual pre-sync is the single, deliberate back-merge per cycle.*
+> **Before EVERY `develop → main` merge, fetch and compare `origin/main` with
+> `origin/develop`.** If main has unique tracking work and a direct sync is
+> conflict-free, open a CI-gated PR from the current `main` head to `develop`.
+> If conflict resolution is required, create `sync/main-into-develop-<task>`
+> from the current `origin/develop` and make an explicit merge commit from the
+> current `origin/main`. That sync head must be the exact two-parent merge of
+> those remote tips (develop first, main second), and
+> `scripts/resolve_architecture_roadmap_trust.py --require-trust main` must pass
+> immediately before merge. This deliberate pre-sync covers both the kanban and
+> main-maintained architecture closure records. It replaces the deleted
+> `auto-backmerge.yml`, whose per-push PRs accumulated against divergent
+> histories.
 
 > **Architecture closure exception**: only a tracking-only roadmap PR that
 > records package-atomic `DONE` after release starts from `origin/main` and

--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ Docker images/browser service stack.
 Raw run logs are preserved in
 [`geode-eval-artifacts/mcpmark/results-geode-agentworld/`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/results-geode-agentworld)
 (`geode-gpt55-xhigh-20260704-mcpmark-verified-*` — per-task `meta.json`
-verifier results and `messages.json` full agent transcripts).
+verifier results, `messages.json` final answers or empty placeholders, and
+`execution.log` ordered MCP action/result records where produced). The public
+MCPMark snapshot does not retain full model dialogue; see its
+[trajectory contract](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/main/TRAJECTORIES.md).
 These rows are directly comparable only to the same MCPMark commit, service
 set, GEODE adapter, model route, and timeout settings.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -69,8 +69,11 @@ feature/<name> -> develop -> main
   fetched `origin/develop` tip.
 - A roadmap tracking-only `DONE` branch starts from `origin/main`, targets
   `main`, and is followed by a CI-gated `main -> develop` sync.
-- When that sync needs conflict resolution, its head must be the exact
-  two-parent merge of the current `refs/remotes/origin/develop` and
+- A conflict-free sync uses the current `main` head directly as the PR head;
+  do not wrap it in a prefixed branch that would merely fast-forward.
+- When that sync needs conflict resolution, its branch name must start with
+  `sync/main-into-develop-` and its head must be the exact two-parent merge of
+  the current `refs/remotes/origin/develop` and
   `refs/remotes/origin/main` tips, in that order. Immediately before merge,
   fetch both refs and rerun `scripts/resolve_architecture_roadmap_trust.py`
   with `--require-trust main`; if either tip moved, rebuild the sync head and

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3548,7 +3548,7 @@ OPENAI_API_KEY=dummy \
 
 ## Run 로그
 
-태스크별 `meta.json`(route, 소요시간, 토큰, verifier 결과)과 `messages.json`(전체 agent transcript)은 [geode-eval-artifacts](https://github.com/mangowhoiscloud/geode-eval-artifacts) 레포에 무수정 보존됩니다.
+태스크별 `meta.json`(route, 소요시간, 토큰, verifier 결과)과 `messages.json`(최종 답변 문자열 또는 빈 목록 placeholder), 생성된 경우 `execution.log`(순서가 보존된 MCP action/result)는 민감한 로컬 경로를 마스킹한 공개용 copy로 [geode-eval-artifacts](https://github.com/mangowhoiscloud/geode-eval-artifacts) 레포에 보존됩니다. 이 공개 snapshot에는 전체 model dialogue와 hidden turn이 없으므로 `messages.json`만으로 대화를 복원할 수 없습니다.
 
 -   [`geode-eval-artifacts/mcpmark/results-geode-agentworld`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/results-geode-agentworld): Verified 트랙 run 디렉터리(`geode-gpt55-xhigh-20260704-mcpmark-verified-*`).
 -   [`geode-eval-artifacts/mcpmark/logs`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/logs), [`geode-eval-artifacts/mcpmark/logs-cycle`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/logs-cycle): 파이프라인 stdout 로그(state duplication, verification, cleanup 단계).
@@ -5680,13 +5680,14 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/ops/release-pypi-lifecycl
 
 ## 릴리스 흐름
 
-평소에는 feature가 develop으로 머지됩니다. 릴리스는 `release/*` 브랜치가 버전 스탬프와 CHANGELOG 정리를 싣고 develop에 먼저 머지된 뒤, develop이 main으로 그대로 통과합니다. develop이 main보다 뒤처지지 않게 하는 순서입니다. 어떤 릴리스가 이 로테이션을 건너뛰어 develop이 main보다 뒤처지면 `.github/workflows/auto-backmerge.yml`이 안전망으로 발화합니다.
+평소에는 feature가 develop으로 머지됩니다. 릴리스는 `release/*` 브랜치가 버전 스탬프와 CHANGELOG 정리를 싣고 develop에 먼저 머지된 뒤, develop이 main으로 그대로 통과합니다. 승격 직전에는 두 원격 브랜치를 fetch하고 내용을 비교합니다. main에 추적 전용 변경이 있고 충돌이 없으면 현재 main head에서 develop로 직접 CI-gated PR을 엽니다. 충돌 해결이 필요할 때만 현재 develop에서 `sync/main-into-develop-*` 브랜치를 만들고 현재 main을 명시적 merge commit으로 병합합니다. 이 sync head는 두 원격 tip을 정확한 부모로 가져야 하며 merge 직전에 trust resolver를 다시 통과해야 합니다. 자동 backmerge workflow는 없습니다.
 
 ```
 # 1. CHANGELOG [Unreleased] → [vX.Y.Z] - YYYY-MM-DD
 # 2. 다섯 위치 동시 bump (CHANGELOG / pyproject / CLAUDE.md / README.md / README.ko.md)
-# 3. release PR: release/* → develop → main (develop→main PR은 Summary + Verification 축약형 허용)
-# 4. 패키지 배포는 main 머지로 자동 발화하지 않음. 아래 워크플로우를 수동 dispatch
+# 3. main drift: clean이면 main → develop PR, 충돌 시에만 sync/main-into-develop-*
+# 4. release PR: release/* → develop → main (develop→main PR은 Summary + Verification 축약형 허용)
+# 5. 패키지 배포는 main 머지로 자동 발화하지 않음. 아래 워크플로우를 수동 dispatch
 ```
 
 ## release.yml은 수동 전용입니다
@@ -5723,7 +5724,8 @@ geode serve &                            # 데몬 재기동
 
 -   `.github/workflows/release.yml`. 수동 검증 + 배포 파이프라인.
 -   `.github/workflows/install-smoke.yml`. macOS와 Ubuntu의 설치 회귀.
--   `.github/workflows/auto-backmerge.yml`. develop 뒤처짐 안전망.
+-   `scripts/resolve_architecture_roadmap_trust.py`. 충돌 해결형 main → develop sync의 정확한 부모·출처 검증.
+-   `docs/workflow.md`. pre-sync와 GitFlow 운영 정본.
 -   `scripts/verify_public_distribution.py`. GitHub·PyPI 공개 배포 일치 검증.
 -   `packaging/homebrew`. Homebrew/core 후보 template과 운영 지침.
 -   `CHANGELOG.md`. Keep a Changelog + SemVer 정본.

--- a/site/src/app/docs/benchmarks/mcpmark/page.tsx
+++ b/site/src/app/docs/benchmarks/mcpmark/page.tsx
@@ -108,8 +108,12 @@ export default function Page() {
             <h2>Run 로그</h2>
             <p>
               태스크별 <code>meta.json</code>(route, 소요시간, 토큰, verifier 결과)과{" "}
-              <code>messages.json</code>(전체 agent transcript)은{" "}
-              <EvalArtifactsRepoLink /> 레포에 무수정 보존됩니다.
+              <code>messages.json</code>(최종 답변 문자열 또는 빈 목록 placeholder),
+              생성된 경우 <code>execution.log</code>(순서가 보존된 MCP
+              action/result)는 민감한 로컬 경로를 마스킹한 공개용 copy로{" "}
+              <EvalArtifactsRepoLink /> 레포에 보존됩니다.
+              이 공개 snapshot에는 전체 model dialogue와 hidden turn이 없으므로{" "}
+              <code>messages.json</code>만으로 대화를 복원할 수 없습니다.
             </p>
             <ul>
               <li>
@@ -164,8 +168,13 @@ export default function Page() {
             <h2>Run Logs</h2>
             <p>
               Per-task <code>meta.json</code> (route, timing, tokens, verifier
-              result) and <code>messages.json</code> (full agent transcript) are
-              preserved unmodified in the <EvalArtifactsRepoLink /> repository.
+              result), <code>messages.json</code> (a final-answer string or empty-list
+              placeholder), and, when produced, <code>execution.log</code> (ordered
+              MCP action/result records) are preserved as public copies with
+              sensitive local paths redacted in the <EvalArtifactsRepoLink />{" "}
+              repository. The public snapshot omits full
+              model dialogue and hidden turns, so <code>messages.json</code> cannot
+              reconstruct the conversation.
             </p>
             <ul>
               <li>

--- a/site/src/app/docs/ops/release-pypi-lifecycle/page.tsx
+++ b/site/src/app/docs/ops/release-pypi-lifecycle/page.tsx
@@ -38,15 +38,19 @@ export default function Page() {
               평소에는 feature가 develop으로 머지됩니다. 릴리스는{" "}
               <code>release/*</code> 브랜치가 버전 스탬프와 CHANGELOG 정리를
               싣고 develop에 먼저 머지된 뒤, develop이 main으로 그대로
-              통과합니다. develop이 main보다 뒤처지지 않게 하는 순서입니다.
-              어떤 릴리스가 이 로테이션을 건너뛰어 develop이 main보다 뒤처지면{" "}
-              <code>.github/workflows/auto-backmerge.yml</code>이 안전망으로
-              발화합니다.
+              통과합니다. 승격 직전에는 두 원격 브랜치를 fetch하고 내용을
+              비교합니다. main에 추적 전용 변경이 있고 충돌이 없으면 현재 main
+              head에서 develop로 직접 CI-gated PR을 엽니다. 충돌 해결이 필요할
+              때만 현재 develop에서 <code>sync/main-into-develop-*</code> 브랜치를
+              만들고 현재 main을 명시적 merge commit으로 병합합니다. 이 sync
+              head는 두 원격 tip을 정확한 부모로 가져야 하며 merge 직전에 trust
+              resolver를 다시 통과해야 합니다. 자동 backmerge workflow는 없습니다.
             </p>
             <pre>{`# 1. CHANGELOG [Unreleased] → [vX.Y.Z] - YYYY-MM-DD
 # 2. 다섯 위치 동시 bump (CHANGELOG / pyproject / CLAUDE.md / README.md / README.ko.md)
-# 3. release PR: release/* → develop → main (develop→main PR은 Summary + Verification 축약형 허용)
-# 4. 패키지 배포는 main 머지로 자동 발화하지 않음. 아래 워크플로우를 수동 dispatch`}</pre>
+# 3. main drift: clean이면 main → develop PR, 충돌 시에만 sync/main-into-develop-*
+# 4. release PR: release/* → develop → main (develop→main PR은 Summary + Verification 축약형 허용)
+# 5. 패키지 배포는 main 머지로 자동 발화하지 않음. 아래 워크플로우를 수동 dispatch`}</pre>
 
             <h2>release.yml은 수동 전용입니다</h2>
             <p>
@@ -112,7 +116,8 @@ geode serve &                            # 데몬 재기동`}</pre>
             <ul>
               <li><code>.github/workflows/release.yml</code>. 수동 검증 + 배포 파이프라인.</li>
               <li><code>.github/workflows/install-smoke.yml</code>. macOS와 Ubuntu의 설치 회귀.</li>
-              <li><code>.github/workflows/auto-backmerge.yml</code>. develop 뒤처짐 안전망.</li>
+              <li><code>scripts/resolve_architecture_roadmap_trust.py</code>. 충돌 해결형 main → develop sync의 정확한 부모·출처 검증.</li>
+              <li><code>docs/workflow.md</code>. pre-sync와 GitFlow 운영 정본.</li>
               <li><code>scripts/verify_public_distribution.py</code>. GitHub·PyPI 공개 배포 일치 검증.</li>
               <li><code>packaging/homebrew</code>. Homebrew/core 후보 template과 운영 지침.</li>
               <li><code>CHANGELOG.md</code>. Keep a Changelog + SemVer 정본.</li>
@@ -144,16 +149,22 @@ geode serve &                            # 데몬 재기동`}</pre>
               Day to day, features merge into develop. For a release, a{" "}
               <code>release/*</code> branch carries the version stamp and
               CHANGELOG cleanup, merges into develop first, and develop then
-              passes straight through to main. That order keeps develop from
-              lagging main. If a release ever skips the rotation,{" "}
-              <code>.github/workflows/auto-backmerge.yml</code> fires as the
-              safety net.
+              passes straight through to main. Immediately before promotion,
+              fetch and compare both remote branches. If main contains unique
+              tracking changes and the sync is conflict-free, open a CI-gated PR
+              directly from the current main head to develop. Only when conflict
+              resolution is required, create <code>sync/main-into-develop-*</code>
+              from current develop and merge current main in an explicit merge
+              commit. That sync head must have the two current remote tips as its
+              exact parents and rerun the trust resolver immediately before merge.
+              There is no automatic backmerge workflow.
             </p>
             <pre>{`# 1. CHANGELOG [Unreleased] → [vX.Y.Z] - YYYY-MM-DD
 # 2. bump all five locations (CHANGELOG / pyproject / CLAUDE.md / README.md / README.ko.md)
-# 3. release PR: release/* → develop → main (develop→main PRs may use the
+# 3. main drift: main → develop PR if clean; sync/main-into-develop-* only on conflict
+# 4. release PR: release/* → develop → main (develop→main PRs may use the
 #    abbreviated Summary + Verification body)
-# 4. package publishing does NOT fire on the main merge. dispatch the
+# 5. package publishing does NOT fire on the main merge. dispatch the
 #    workflow below manually`}</pre>
 
             <h2>release.yml is manual-only</h2>
@@ -225,7 +236,8 @@ geode serve &                            # restart the daemon`}</pre>
             <ul>
               <li><code>.github/workflows/release.yml</code>. The manual validate + publish pipeline.</li>
               <li><code>.github/workflows/install-smoke.yml</code>. Install regression on macOS and Ubuntu.</li>
-              <li><code>.github/workflows/auto-backmerge.yml</code>. The develop-lag safety net.</li>
+              <li><code>scripts/resolve_architecture_roadmap_trust.py</code>. Exact-parent and source validation for conflict-resolved main → develop syncs.</li>
+              <li><code>docs/workflow.md</code>. Canonical pre-sync and GitFlow procedure.</li>
               <li><code>scripts/verify_public_distribution.py</code>. Public GitHub/PyPI parity verification.</li>
               <li><code>packaging/homebrew</code>. Homebrew/core candidate template and operating guide.</li>
               <li><code>CHANGELOG.md</code>. Keep a Changelog + SemVer source of truth.</li>


### PR DESCRIPTION
## Summary
- MCPMark 공개 artifact가 실제로 보존하는 데이터와 GEODE 공개 설명을 일치시킵니다.
- 삭제된 자동 backmerge 설명을 현재의 명시적 `main -> develop` pre-sync 절차로 교체합니다.
- clean sync와 conflict-resolved sync의 trust 조건을 구분해 운영 문서 전체에 동기화합니다.

## Why
- `messages.json`은 전체 대화가 아니라 최종 답변 문자열 또는 빈 목록이며, 순서가 있는 MCP action/result는 생성된 `execution.log`에 있습니다.
- 공개 trace에는 민감한 로컬 경로가 마스킹되므로 “무수정 보존”이라는 표현은 정확하지 않습니다.
- 기존 문서 일부는 이미 삭제된 `auto-backmerge.yml`을 현재 안전망처럼 설명했습니다.
- conflict-resolved sync branch는 exact two-parent graph와 `sync/main-into-develop-` prefix가 필요하지만, conflict-free sync는 현재 `main`을 PR head로 직접 써야 합니다.

## Changes
| File | Change |
|------|--------|
| `README.md` | MCPMark 공개 데이터 범위와 trajectory contract 링크 명시 |
| `site/src/app/docs/benchmarks/mcpmark/page.tsx` | full transcript 오표현 제거, final answer/execution trace/redaction 경계 명시 |
| `site/src/app/docs/ops/release-pypi-lifecycle/page.tsx` | 삭제된 자동 backmerge 설명을 clean/conflict pre-sync 절차로 교체 |
| `AGENTS.md`, `CLAUDE.md`, `docs/workflow.md` | canonical-head clean sync와 exact-parent conflict sync 규칙 정합화 |
| `.claude/skills/geode-gitflow/SKILL.md` | 실행 절차, prefix, 직전 trust 재검증 조건 명시 |
| `.claude/skills/geode-workflow/references/gitflow.md` | architecture closure 역동기화 절차 동기화 |
| `site/public/llms-full.txt` | 변경된 공개 문서에서 재생성 |

## GAP Audit
| 항목 | 기존 상태 | 조치 |
|------|-----------|------|
| MCPMark trajectory 설명 | 전체 agent transcript·무수정 보존으로 과대 서술 | 공개 저장소의 `TRAJECTORIES.md` 및 실제 파일 형태에 맞게 정정 |
| 자동 backmerge | 삭제된 workflow를 현재 안전망으로 서술 | 명시적 CI-gated pre-sync로 교체 |
| clean sync | prefixed branch 사용 시 fast-forward되어 trust gate가 요구하는 2-parent graph 부재 가능 | 현재 `main`을 PR head로 직접 사용 |
| conflict sync | branch prefix와 exact-parent 조건이 일부 문서에 누락 | `sync/main-into-develop-*`, develop-first/main-second, merge 직전 resolver 재실행으로 통일 |

## Verification
- `uv run python scripts/check_docs_canon.py` — 통과
- `uv run pytest tests/scripts/test_resolve_architecture_roadmap_trust.py -q` — 8 passed
- 대상 2개 TSX 페이지 ESLint — 통과
- `uv run python scripts/check_official_docs.py` — 통과
  - architecture baseline 정상
  - 내부 링크 645건, broken link 0
  - Next.js 정적 페이지 236개 생성
  - markdown twin 73개 및 `llms-full.txt` 재생성/정합성 확인
- `git diff --check` — 통과
- 독립 committed-diff review — 최초 P1/P2 지적 수정 후 재리뷰에서 추가 지적 없음

문서 전용 변경이므로 CHANGELOG와 버전은 변경하지 않았습니다.
