### PR TITLE
fix(mcp): ReAct 루프 stateless 하드닝 R1-R5 + E2E 궤적·관측값 기록

### DIFF
--- a/.claude/skills/geode-changelog/SKILL.md
+++ b/.claude/skills/geode-changelog/SKILL.md
@@ -161,6 +161,15 @@ uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/
 uv run mypy core/ plugins/
 uv run geode version   # confirms version stamp lands
 
+# 3b. Derived-SoT regeneration (CI blocks on any of these being stale)
+uv run python scripts/architecture_baseline.py --update   # CHANGELOG/[Unreleased] edits + core LOC drift
+node site/scripts/sync-stats.mjs
+uv run python scripts/check_llms_version.py --fix
+(cd site && npm ci && npm run build && npm run export-md) # llms-full body + size markers
+# Incident: v1.0.2 train (2026-07-29) — CHANGELOG growth alone drifted the
+# changelog page size marker in llms-full.txt (1460→1462 KB) and the
+# architecture baseline; two CI rounds were spent rediscovering this list.
+
 # 4. PR release → develop (NOT main — rotation pattern)
 gh pr create --base develop --head release/vX.Y.Z \
   --title "release: vX.Y.Z — <summary>" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,15 @@ register in `registry.py`, expose schema in `definitions.json`.
 
 MCP server adapters plus 25K result guard.
 
-- `manager.py` — `MCPManager`.
-- `stdio_client.py` — STDIO transport.
+- `manager.py` — `MCPServerManager`.
+- `stdio_client.py` — STDIO transport. Declares protocol revision
+  `2025-06-18`, records the server-negotiated revision in
+  `server_protocol_version`, and fail-loud-rejects revisions outside the
+  supported classic set (ADR-014; SDK pinned `mcp>=1.28,<2`). Live E2E
+  2026-07-28: loopback negotiation + agent-level MCP dispatch verified on the
+  subscription backend.
+- Client-path MCP tools surface under their **raw server-side names** — the
+  `mcp__geode__*` prefix appears only on external hosts consuming geode-mcp.
 - Calendar / Steam / etc. adapters.
 
 ### `core/memory/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP stdio stream can no longer be permanently poisoned by unsolicited
+  server frames.** `StdioMCPClient` now matches JSON-RPC response ids and
+  skips interleaved notifications (`notifications/message`, progress,
+  `tools/list_changed`); previously a single server-initiated frame
+  desynchronized the stream forever while `is_connected()` kept reporting
+  healthy. A daemon thread now drains child stderr, removing the 64 KB
+  pipe-buffer wedge chatty servers could hit (ADR-014 R1/R2).
+
+- **MCP server recycle mid-session now recovers instead of failing the
+  round.** `MCPServerManager.acall_tool` retries once on a freshly respawned
+  client when the subprocess died mid-call, dead clients are reaped
+  (`close()`) when popped, a down server's tools are reported to the model as
+  "currently unavailable" instead of the misinforming "Unknown tool", and
+  `AgenticLoop` re-snapshots its MCP tool list when the manager's connection
+  epoch changes — a recycle previously left long-lived sessions with stale
+  schemas for their whole lifetime (ADR-014 R3/R4/R5).
+
+### Architecture
+
+- **ADR-014 verification + records.** Live E2E trajectory (subscription
+  backend, loopback geode-mcp + stateless-only rejection) published to the
+  external evidence store as the first normalized `trajectories/` release;
+  ADR-014, `AGENTS.md` (core/mcp), the stability contract §C line refs, and
+  the geode-changelog skill's derived-SoT regeneration checklist updated with
+  the observations.
+
 ## [1.0.2] - 2026-07-29
 
 > MCP 2026-07-28 stateless spec response (SDK v1 pin + client negotiation validation, ADR-014), riding with the accumulated develop train: roadmap sync trust resolver, architecture exception ledger, generated architecture baseline gate, gateway computer-use opt-in, fresh-install REPL fixes, and macOS computer-use input verification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ See `geode-changelog` skill.
 |-------------|--------------|
 | Version across 5 locations | CHANGELOG, CLAUDE.md, README.md, README.ko.md, pyproject.toml |
 | Metrics | Tests, Modules, Commands — measured values |
-| 사이트 버전 SoT | `site/public/llms.txt` + `llms-full.txt`의 `Version vX` 헤더 **및** `site/src/data/geode/sot.ts`의 `version` == pyproject. 버전 범프 시 `node site/scripts/sync-stats.mjs` (llms.txt + sot.ts + changelog.ts 재생성) + `uv run python scripts/check_llms_version.py --fix` (llms-full 헤더). 드리프트는 ci.yml `check_llms_version.py` ratchet가 3파일 전부 차단(committed 스냅샷이 12버전 stale했던 사건). llms-full 본문은 배포 빌드(pages.yml)가 갱신. |
+| 사이트 버전 SoT | `site/public/llms.txt` + `llms-full.txt`의 `Version vX` 헤더 **및** `site/src/data/geode/sot.ts`의 `version` == pyproject. 버전 범프 시 `node site/scripts/sync-stats.mjs` (llms.txt + sot.ts + changelog.ts 재생성) + `uv run python scripts/check_llms_version.py --fix` (llms-full 헤더). 드리프트는 ci.yml `check_llms_version.py` ratchet가 3파일 전부 차단(committed 스냅샷이 12버전 stale했던 사건). llms-full **본문·크기 마커도 로컬 재생성 대상** — `site/`에서 `npm run build && npm run export-md` 후 커밋해야 pages.yml의 public-doc 생성기 검증 게이트를 통과(v1.0.2 트레인: CHANGELOG 성장만으로 changelog 페이지 크기 마커 1460→1462 KB 드리프트, CI 1회 반려 실측). CHANGELOG/[Unreleased] 편집이나 core LOC 변동 시 `scripts/architecture_baseline.py --update`(baseline JSON+AGENTS.md+roadmap §2.1)도 같은 커밋에. |
 
 **Versioning**: post-1.0 default = **PATCH for every routine landing** (features included — the 0.99.x patch-train continues as 1.0.x). MINOR/MAJOR are operator-declared milestones only; before proposing one, grep `removed in v` for pledged numbers and get explicit operator approval. Docs only = none. Full policy + mis-stamp correction procedure: `geode-changelog` skill.
 

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -470,6 +470,9 @@ class AgenticLoop:
         # merge native + MCP tools; allowlist as force_include so the global
         # tool_policy can't strip a tool the sub-agent's toolkit granted
         mcp_tool_list = mcp_manager.get_all_tools() if mcp_manager is not None else None
+        # Epoch snapshot pairs with the arun refresh gate: a server recycle
+        # bumps the manager epoch and invalidates this tool snapshot.
+        self._mcp_epoch = mcp_manager.connection_epoch if mcp_manager is not None else 0
         self._tools = get_agentic_tools(
             tool_registry,
             mcp_tools=mcp_tool_list,
@@ -1854,9 +1857,15 @@ class AgenticLoop:
 
         set_conversation_context(self.context)
 
-        # Lazy MCP tool refresh — load tools empty at init (startup timing gap)
-        if self._mcp_manager is not None and len(self._tools) < TOOL_LAZY_LOAD_THRESHOLD:
+        # Lazy MCP tool refresh — load tools empty at init (startup timing
+        # gap), and re-snapshot after any server recycle (epoch drift): a
+        # reconnected server may advertise a different tool set (ADR-014 R5).
+        if self._mcp_manager is not None and (
+            len(self._tools) < TOOL_LAZY_LOAD_THRESHOLD
+            or self._mcp_manager.connection_epoch != self._mcp_epoch
+        ):
             added = self.refresh_tools()
+            self._mcp_epoch = self._mcp_manager.connection_epoch
             if added > 0:
                 log.info("MCP tools lazy-loaded: +%d tools (total %d)", added, len(self._tools))
 

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -293,6 +293,22 @@ class ToolExecutor:
                             ),
                             "timeout": True,
                         }
+                known = self._mcp_manager.last_known_server_for_tool(tool_name)
+                if known is not None:
+                    # The tool IS in the model's schema list — telling the
+                    # model it doesn't exist would misinform it (ADR-014 R3).
+                    log.warning(
+                        "MCP tool %s unavailable: server '%s' down or cooling",
+                        tool_name,
+                        known,
+                    )
+                    return {
+                        "error": (
+                            f"MCP server '{known}' providing '{tool_name}' is "
+                            "currently unavailable (down or in retry cooldown). "
+                            "Retry later or use an alternative tool."
+                        )
+                    }
             log.warning("No handler for tool: %s", tool_name)
             return {"error": f"Unknown tool: '{tool_name}'. Use 'show_help' for available tools."}
 

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -216,6 +216,12 @@ class MCPServerManager:
         self._servers: dict[str, dict[str, Any]] = {}
         self._clients: dict[str, StdioMCPClient] = {}
         self._failed_at: dict[str, float] = {}
+        # Bumped whenever a NEW client connects — lets long-lived AgenticLoop
+        # sessions detect a server recycle and refresh their tool snapshot.
+        self._connection_epoch = 0
+        # tool name -> server that last advertised it; distinguishes "server
+        # down" from "tool never existed" when find_server_for_tool misses.
+        self._last_seen_tools: dict[str, str] = {}
         self._dotenv_cache: dict[str, str | None] = {}
         self._text_read_cache: dict[tuple[str, str], str] = {}
         self._signal_installed = False
@@ -498,7 +504,9 @@ class MCPServerManager:
             client = self._clients[server_name]
             if client.is_connected():
                 return client
-            self._clients.pop(server_name, None)
+            stale = self._clients.pop(server_name, None)
+            if stale is not None:
+                stale.close()  # reap the dead Popen instead of leaking it
 
         failed_at = self._failed_at.get(server_name)
         if failed_at is not None and (time.monotonic() - failed_at) < _FAILED_RETRY_COOLDOWN_S:
@@ -528,6 +536,7 @@ class MCPServerManager:
         client = StdioMCPClient(command=command, args=args, env=env)
         if client.connect():
             self._clients[server_name] = client
+            self._connection_epoch += 1
             self._failed_at.pop(server_name, None)
             _fire_mcp_hook(HookEvent.MCP_SERVER_CONNECTED, {"server_name": server_name})
             return client
@@ -569,8 +578,20 @@ class MCPServerManager:
             for tool in tools:
                 normalised = _normalise_mcp_tool(tool)
                 normalised["_mcp_server"] = server_name
+                name = normalised.get("name")
+                if isinstance(name, str):
+                    self._last_seen_tools[name] = server_name
                 all_tools.append(normalised)
         return all_tools
+
+    @property
+    def connection_epoch(self) -> int:
+        """Monotonic count of client connects — changes signal a recycle."""
+        return self._connection_epoch
+
+    def last_known_server_for_tool(self, tool_name: str) -> str | None:
+        """Server that previously advertised ``tool_name`` (may be down now)."""
+        return self._last_seen_tools.get(tool_name)
 
     # MCP server fallback hints: when a server is unavailable or fails,
     # the error message includes a hint so the LLM can try an alternative.
@@ -607,7 +628,33 @@ class MCPServerManager:
                 tool_name=tool_name,
                 args=normalised_args,
             )
-            result = await client.acall_tool(tool_name, normalised_args)
+            try:
+                result = await client.acall_tool(tool_name, normalised_args)
+                died_mid_call = (
+                    isinstance(result, dict)
+                    and bool(result.get("error"))
+                    and not client.is_connected()
+                )
+            except ConnectionError:
+                result = {}
+                died_mid_call = True
+            if died_mid_call:
+                # Stateless-era servers may recycle between rounds (ADR-014):
+                # retry ONCE on a fresh client before surfacing the failure.
+                stale = self._clients.pop(server_name, None)
+                if stale is not None:
+                    stale.close()
+                fresh = await asyncio.to_thread(self._get_client, server_name)
+                if fresh is None:
+                    raise ConnectionError(
+                        f"MCP server '{server_name}' died mid-call and did not reconnect"
+                    )
+                log.info(
+                    "MCP server '%s' respawned mid-call; retrying %s",
+                    server_name,
+                    tool_name,
+                )
+                result = await fresh.acall_tool(tool_name, normalised_args)
             self._record_text_read_result(
                 server_name=server_name,
                 tool_name=tool_name,
@@ -749,8 +796,9 @@ class MCPServerManager:
 
             if not alive and auto_restart:
                 log.info("MCP server '%s' is down, attempting restart", name)
-                # Remove dead client reference
-                self._clients.pop(name, None)
+                dead = self._clients.pop(name, None)
+                if dead is not None:
+                    dead.close()  # reap the dead Popen instead of leaking it
                 self._failed_at.pop(name, None)
                 new_client = self._get_client(name)
                 alive = new_client is not None and new_client.is_connected()

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import signal
+import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -222,6 +223,9 @@ class MCPServerManager:
         # tool name -> server that last advertised it; distinguishes "server
         # down" from "tool never existed" when find_server_for_tool misses.
         self._last_seen_tools: dict[str, str] = {}
+        # Serializes mid-call respawns so concurrent failures on the same
+        # server can't each spawn a subprocess and orphan the loser.
+        self._respawn_lock = threading.Lock()
         self._dotenv_cache: dict[str, str | None] = {}
         self._text_read_cache: dict[tuple[str, str], str] = {}
         self._signal_installed = False
@@ -640,11 +644,17 @@ class MCPServerManager:
                 died_mid_call = True
             if died_mid_call:
                 # Stateless-era servers may recycle between rounds (ADR-014):
-                # retry ONCE on a fresh client before surfacing the failure.
-                stale = self._clients.pop(server_name, None)
-                if stale is not None:
-                    stale.close()
-                fresh = await asyncio.to_thread(self._get_client, server_name)
+                # retry ONCE on a fresh client — but only for tools annotated
+                # read-only/idempotent. The death is no proof the original
+                # call did NOT execute, so blind retry would be at-least-once.
+                annotations = (raw_tool or {}).get("annotations") or {}
+                if not (annotations.get("readOnlyHint") or annotations.get("idempotentHint")):
+                    raise ConnectionError(
+                        f"MCP server '{server_name}' died during '{tool_name}'; "
+                        "the tool is not marked read-only/idempotent so it was "
+                        "not retried — outcome unknown"
+                    )
+                fresh = await asyncio.to_thread(self._respawn_after_death, server_name)
                 if fresh is None:
                     raise ConnectionError(
                         f"MCP server '{server_name}' died mid-call and did not reconnect"
@@ -666,12 +676,29 @@ class MCPServerManager:
             log.error("MCP async tool call failed: %s/%s: %s", server_name, tool_name, exc)
             hint = self._FALLBACK_HINTS.get(server_name, "")
             is_timeout = "timeout" in str(exc).lower()
+            detail = f" ({exc})" if str(exc) else ""
             return tool_error(
-                f"MCP tool call failed: {tool_name}",
+                f"MCP tool call failed: {tool_name}{detail}",
                 error_type="timeout" if is_timeout else "connection",
                 hint=f"Use {hint} instead" if hint else "Retry or use an alternative tool.",
                 context={"server": server_name, "tool": tool_name},
             )
+
+    def _respawn_after_death(self, server_name: str) -> StdioMCPClient | None:
+        """Replace a mid-call-dead client under the respawn lock.
+
+        Concurrent callers observing the same death serialize here; the
+        second caller reuses the first one's fresh client instead of
+        spawning a competing subprocess and orphaning one of them.
+        """
+        with self._respawn_lock:
+            existing = self._clients.get(server_name)
+            if existing is not None and existing.is_connected():
+                return existing
+            stale = self._clients.pop(server_name, None)
+            if stale is not None:
+                stale.close()
+            return self._get_client(server_name)
 
     def _raw_tool_for_client(self, client: StdioMCPClient, tool_name: str) -> dict[str, Any] | None:
         try:
@@ -759,6 +786,10 @@ class MCPServerManager:
                 continue
             for tool in client.list_tools():
                 if tool.get("name") == tool_name:
+                    # Memo here too — sessions that never called
+                    # get_all_tools still get the honest "unavailable"
+                    # error (instead of "Unknown tool") after a recycle.
+                    self._last_seen_tools[tool_name] = server_name
                     return server_name
         return None
 

--- a/core/mcp/stdio_client.py
+++ b/core/mcp/stdio_client.py
@@ -93,12 +93,18 @@ class StdioMCPClient:
             env = dict(os.environ)
             env.update(self._env)
 
+            # bufsize=0: stdout stays UNBUFFERED so readline() never pulls a
+            # second frame into a Python-side buffer select() cannot see —
+            # with default buffering, a notification+response arriving
+            # together left the response invisible to the next select() and
+            # the call timed out despite the data being buffered.
             self._process = subprocess.Popen(  # noqa: S603  # nosec B603
                 [self._command, *self._args],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=env,
+                bufsize=0,
             )
             self._pid = self._process.pid
             log.debug(
@@ -300,7 +306,10 @@ class StdioMCPClient:
                             log.warning("MCP timeout waiting for %s response", method)
                             return None
                     except (TypeError, ValueError):
-                        pass  # mock/non-real fd — fall through to blocking read
+                        # Mock/non-real fd (tests) — fall through to a blocking
+                        # read. Real pipes always take the select() path above,
+                        # so the timeout contract holds outside of mocks.
+                        pass
 
                     line = self._process.stdout.readline()
                     if not line:

--- a/core/mcp/stdio_client.py
+++ b/core/mcp/stdio_client.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess  # nosec B404 — intentional: MCP server launch from trusted config
 import threading
+import time
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -105,6 +106,23 @@ class StdioMCPClient:
                 self._command,
                 self._pid,
             )
+
+            # Drain stderr in a daemon thread — an undrained PIPE wedges the
+            # child at the 64 KB buffer while is_connected() keeps reporting
+            # healthy (every call then times out). Skipped for mocked pipes.
+            stderr_pipe = self._process.stderr
+            if stderr_pipe is not None:
+                try:
+                    real_fd = isinstance(stderr_pipe.fileno(), int)
+                except Exception:
+                    real_fd = False
+                if real_fd:
+                    threading.Thread(
+                        target=self._drain_stderr,
+                        args=(stderr_pipe,),
+                        daemon=True,
+                        name=f"mcp-stderr-{self._pid}",
+                    ).start()
 
             # Wait for server to be ready (npx may download packages first)
             import time
@@ -257,36 +275,72 @@ class StdioMCPClient:
                 self._process.stdin.write(message.encode("utf-8"))
                 self._process.stdin.flush()
 
-                # Read response with timeout (select-based, fallback to blocking)
-                try:
-                    import select
-
-                    ready, _, _ = select.select(
-                        [self._process.stdout],
-                        [],
-                        [],
-                        self._timeout_s,
-                    )
-                    if not ready:
+                # Read frames until the response matching OUR request id.
+                # Servers may interleave unsolicited traffic (notifications/
+                # message, progress, tools/list_changed); before id matching a
+                # single such frame permanently desynchronized the stream while
+                # is_connected() kept reporting healthy.
+                deadline = time.monotonic() + self._timeout_s
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
                         log.warning("MCP timeout waiting for %s response", method)
                         return None
-                except (TypeError, ValueError):
-                    pass  # mock/non-real fd — fall through to blocking read
 
-                line = self._process.stdout.readline()
-                if not line:
-                    return None
+                    try:
+                        import select
 
-                response = json.loads(line.decode("utf-8"))
-                if "error" in response:
-                    log.warning("MCP error: %s", response["error"])
-                    return None
+                        ready, _, _ = select.select(
+                            [self._process.stdout],
+                            [],
+                            [],
+                            remaining,
+                        )
+                        if not ready:
+                            log.warning("MCP timeout waiting for %s response", method)
+                            return None
+                    except (TypeError, ValueError):
+                        pass  # mock/non-real fd — fall through to blocking read
 
-                result: dict[str, Any] | None = response.get("result")
-                return result
-            except (json.JSONDecodeError, OSError, BrokenPipeError) as exc:
+                    line = self._process.stdout.readline()
+                    if not line:
+                        return None
+
+                    try:
+                        response = json.loads(line.decode("utf-8"))
+                    except json.JSONDecodeError:
+                        log.debug("MCP: skipping non-JSON frame on stdout")
+                        continue
+
+                    if response.get("id") != request["id"]:
+                        log.debug(
+                            "MCP: skipping unsolicited frame (method=%s, id=%s)",
+                            response.get("method"),
+                            response.get("id"),
+                        )
+                        continue
+
+                    if "error" in response:
+                        log.warning("MCP error: %s", response["error"])
+                        return None
+
+                    result: dict[str, Any] | None = response.get("result")
+                    return result
+            except (OSError, BrokenPipeError) as exc:
                 log.warning("MCP communication error: %s", exc)
                 return None
+
+    def _drain_stderr(self, pipe: Any) -> None:
+        """Consume the child's stderr so it can never block on a full pipe."""
+        with contextlib.suppress(Exception):  # drain thread must never propagate
+            for raw in iter(pipe.readline, b""):
+                log.debug(
+                    "MCP stderr[%s]: %s",
+                    self._command,
+                    raw.decode("utf-8", "replace").rstrip(),
+                )
+        with contextlib.suppress(Exception):
+            pipe.close()
 
     def _send_notification(self, method: str, params: dict[str, Any]) -> None:
         """Send a JSON-RPC notification (no response expected)."""

--- a/core/mcp/stdio_client.py
+++ b/core/mcp/stdio_client.py
@@ -263,6 +263,20 @@ class StdioMCPClient:
         self._request_id += 1
         return self._request_id
 
+    @staticmethod
+    def _write_all(stdin: Any, data: bytes) -> None:
+        """Write the whole frame — unbuffered stdin (bufsize=0) may short-write.
+
+        Buffered/mocked streams return None (or a non-int) from write() and
+        are treated as complete; raw FileIO returns the byte count and loops.
+        """
+        offset = 0
+        while offset < len(data):
+            n = stdin.write(data[offset:])
+            if not isinstance(n, int):
+                return
+            offset += n
+
     def _send_request(self, method: str, params: dict[str, Any]) -> dict[str, Any] | None:
         """Send a JSON-RPC request and wait for response with timeout."""
         with self._request_lock:
@@ -278,7 +292,7 @@ class StdioMCPClient:
 
             try:
                 message = json.dumps(request) + "\n"
-                self._process.stdin.write(message.encode("utf-8"))
+                self._write_all(self._process.stdin, message.encode("utf-8"))
                 self._process.stdin.flush()
 
                 # Read frames until the response matching OUR request id.
@@ -364,7 +378,7 @@ class StdioMCPClient:
 
         try:
             message = json.dumps(notification) + "\n"
-            self._process.stdin.write(message.encode("utf-8"))
+            self._write_all(self._process.stdin, message.encode("utf-8"))
             self._process.stdin.flush()
         except (OSError, BrokenPipeError):
             pass

--- a/core/tools/jobs.py
+++ b/core/tools/jobs.py
@@ -10,7 +10,7 @@ Why an internal tool rather than an MCP server:
 * Wanted's endpoint is a single GET with JSON response — running a separate
   subprocess for that is pure overhead.
 * GEODE already has ``httpx`` as a runtime dep.
-* The MCP layer adds ``mcp__<server>__<tool>`` naming + per-call permission
+* The MCP layer adds a separate server subprocess + per-call dispatch
   overhead the user does not want for a low-risk read-only HTTP call.
 
 Frontier reference: Manus / Devin lean on paid scraping providers (Apify,

--- a/docs/adr/ADR-014-mcp-2026-07-28-stateless-spec.md
+++ b/docs/adr/ADR-014-mcp-2026-07-28-stateless-spec.md
@@ -44,6 +44,21 @@ Accepted (2026-07-29)
 | petri bridge | low-level `Server` API의 v2 대응 (`서버는 양시대 서빙`이므로 v1 핀 유지 중엔 무변경) |
 | HTTP transport | v2의 stateless 기본값 재검토 — 정적 bearer 토큰 검증(`_StaticTokenVerifier`)은 per-request라 stateless 친화적, 변경 불요 예상 |
 | 테스트 격리 | MCP 테스트의 `importorskip("mcp")` — extra 미설치 CI job에서 조용히 skip되므로, v2 마이그레이션 PR은 `[mcp]` extra가 설치된 잡에서 게이트되는지 확인 |
+| 주기 헬스 스윕 (R6) | `check_health(auto_restart=True)`의 프로덕션 호출자 부재 — 복구는 호출-시점 반응형(미드콜 1회 재시도)뿐. serve 데몬 주기 스윕은 후속 |
+
+### ReAct 루프 stateless 감사 (2026-07-29, 후속 하드닝)
+
+서버 recycle 관점의 루프↔MCP 배선 감사 결과와 처분. R1~R5는 같은 트레인에서 수정, R6·R7은 위 보류 표.
+
+| # | 결함 | 처분 |
+|---|------|------|
+| R1 | JSON-RPC 응답 id 미대조 — 서버발 notification 1프레임이 스트림을 영구 오염, health는 계속 정상 보고 | 수정: id 매칭 + 비대상 프레임 skip (`stdio_client._send_request`) |
+| R2 | 자식 stderr 미배수 — 64 KB 버퍼에서 웨지, 전 호출 타임아웃 | 수정: 데몬 배수 스레드 (`_drain_stderr`) |
+| R3 | 다운/쿨다운 서버의 도구가 모델에 "Unknown tool"로 오보(스키마에는 존재) | 수정: `last_known_server_for_tool` 메모 + executor "currently unavailable" 응답 |
+| R4 | 미드콜 사망 시 재시도 부재 — 일시 recycle이 라운드를 소실 | 수정: fresh 클라이언트로 1회 재시도 (`manager.acall_tool`) |
+| R5 | 루프 도구 스냅샷이 재연결 후 stale (IPC 세션 수명 동안) | 수정: `connection_epoch` + arun 리프레시 게이트 |
+| R6 | 주기 헬스 스윕 부재 | 보류 (위 표) |
+| R7 | `_pending_proposals` 프로세스 친화성 | 보류 (기존 체크리스트 항목) |
 
 v2 마이그레이션 시점: 고정 기한 없음 (스펙의 10주 검증 윈도우는 RC→GA 구간으로 2026-07-28에 이미 종료). 외부 압력 신호가 트리거 — (a) 주요 원격 MCP 서버의 classic 개정판 서빙 중단, (b) v1 라인 유지보수(critical bug fix·보안 패치) 종료 공지.
 
@@ -52,6 +67,14 @@ v2 마이그레이션 시점: 고정 기한 없음 (스펙의 10주 검증 윈�
 - 신규 설치(`uv sync --extra mcp` / `--extra audit`, `pip install geode-agent[mcp]`)가 v2 SDK를 우발적으로 받는 경로가 차단된다.
 - GEODE가 붙는 외부 MCP 서버에 대해 협상된 개정판이 처음으로 관측 가능해지고 (`server_protocol_version`), 미지원 개정판은 generic 실패 대신 명시적 warning으로 표면화된다.
 - v2 신기능(`server/discover`, MRTR, Extensions)은 마이그레이션 전까지 사용 불가 — 현재 GEODE 표면은 어느 것도 요구하지 않는다.
+
+## Verification (live E2E, 2026-07-28 UTC)
+
+착지 직후 구독 백엔드(gpt-5.5, codex-oauth)로 라이브 E2E 프로브를 실행해 전 경로를 검증했다: 루프백 `geode-mcp`(python-sdk 1.29.0) 협상 `2025-06-18` 기록·도구 6종, stateless-only 가짜 서버(`2026-07-28` 응답) fail-loud 거부, AgenticLoop의 MCP 디스패치 2회(natural 종료, rounds 3/6). 정규화 궤적과 검증 리포트는 외부 증거 저장소에 발행:
+
+- `mangowhoiscloud/geode-eval-artifacts` @ `647583b3455d16e0769c2b2dc21b380aa24f7bde`
+  - `trajectories/geode-agenticloop-mcp-2026-07-28-spec-e2e-20260728T202349Z-7acb62a4184c/` — `trajectory.json` sha256 `8b77e3b05eeba51374cef5b640ddf1109c323f4e3defe869934bbadd43138b42` (9 events, dialogue+tool)
+  - `reports/e2e-validation/2026-07-28-mcp-stateless-spec-e2e.md`
 
 ## References
 

--- a/docs/adr/ADR-014-mcp-2026-07-28-stateless-spec.md
+++ b/docs/adr/ADR-014-mcp-2026-07-28-stateless-spec.md
@@ -52,11 +52,11 @@ Accepted (2026-07-29)
 
 | # | 결함 | 처분 |
 |---|------|------|
-| R1 | JSON-RPC 응답 id 미대조 — 서버발 notification 1프레임이 스트림을 영구 오염, health는 계속 정상 보고 | 수정: id 매칭 + 비대상 프레임 skip (`stdio_client._send_request`) |
+| R1 | JSON-RPC 응답 id 미대조 — 서버발 notification 1프레임이 스트림을 영구 오염, health는 계속 정상 보고 | 수정: id 매칭 + 비대상 프레임 skip + **stdout unbuffered(`bufsize=0`)** — 기본 버퍼링에선 notification+응답이 한 write로 오면 select가 Python 버퍼 속 응답을 못 봐 타임아웃(Codex 재현) |
 | R2 | 자식 stderr 미배수 — 64 KB 버퍼에서 웨지, 전 호출 타임아웃 | 수정: 데몬 배수 스레드 (`_drain_stderr`) |
-| R3 | 다운/쿨다운 서버의 도구가 모델에 "Unknown tool"로 오보(스키마에는 존재) | 수정: `last_known_server_for_tool` 메모 + executor "currently unavailable" 응답 |
-| R4 | 미드콜 사망 시 재시도 부재 — 일시 recycle이 라운드를 소실 | 수정: fresh 클라이언트로 1회 재시도 (`manager.acall_tool`) |
-| R5 | 루프 도구 스냅샷이 재연결 후 stale (IPC 세션 수명 동안) | 수정: `connection_epoch` + arun 리프레시 게이트 |
+| R3 | 다운/쿨다운 서버의 도구가 모델에 "Unknown tool"로 오보(스키마에는 존재) | 수정: `last_known_server_for_tool` 메모(get_all_tools + find_server_for_tool 양쪽 기록) + executor "currently unavailable" 응답 |
+| R4 | 미드콜 사망 시 재시도 부재 — 일시 recycle이 라운드를 소실 | 수정: **`readOnlyHint`/`idempotentHint` 도구만** fresh 클라이언트로 1회 재시도(사망≠미실행 증거 — 무조건 재시도는 at-least-once 중복 실행 위험), 비멱등은 "outcome unknown" connection 오류. 동시 사망은 `_respawn_lock`으로 직렬화 |
+| R5 | 루프 도구 스냅샷이 재연결 후 stale (IPC 세션 수명 동안) | 수정: `connection_epoch` + arun 리프레시 게이트. 잔여: 같은 arun 내 recycle은 다음 arun에서 반영 |
 | R6 | 주기 헬스 스윕 부재 | 보류 (위 표) |
 | R7 | `_pending_proposals` 프로세스 친화성 | 보류 (기존 체크리스트 항목) |
 

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -284,16 +284,16 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 538 |
 | Test Python files | 671 |
-| `core/` Python LOC | 131,949 |
+| `core/` Python LOC | 132,076 |
 | `plugins/` Python LOC | 40,262 |
-| Test Python LOC | 174,068 |
+| Test Python LOC | 174,190 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `HookEvent` members | 56 |
 | Built-in LLM adapters | 8 |
 | Module-level `ContextVar` declarations under `core/` | 27 |
 | `core` → `plugins` import sites | 31 across 14 files |
 | Import-linter contracts / ignored edges | 4 / 24 |
-| `AgenticLoop` file LOC / methods / constructor args | 2,713 / 67 / 27 |
+| `AgenticLoop` file LOC / methods / constructor args | 2,722 / 67 / 27 |
 | `SubAgentManager` file LOC / methods / constructor args | 1,277 / 15 / 15 |
 | `RuntimeCoreConfig` fields | 17 |
 | Global Ruff ratchets | complexity 54; args 23; branches 56; returns 18; statements 223 |

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -284,9 +284,9 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 538 |
 | Test Python files | 671 |
-| `core/` Python LOC | 132,076 |
+| `core/` Python LOC | 132,130 |
 | `plugins/` Python LOC | 40,262 |
-| Test Python LOC | 174,190 |
+| Test Python LOC | 174,254 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `HookEvent` members | 56 |
 | Built-in LLM adapters | 8 |

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -24,6 +24,7 @@ artifact-repository commit.
 | `docs/audits/` dated Petri analysis reports + score matrices (migrated 2026-07-13) | `sil/audit-reports/` |
 | `docs/e2e/` dated validation records (migrated 2026-07-13) | `reports/e2e-validation/` |
 | `docs/eval/crucible-power-admission-2026-07-13.md` (migrated 2026-07-13) | `crucible/gate-provenance/` |
+| normalized trajectory releases (`TRAJECTORIES.md` contract; first release 2026-07-28, MCP spec-response E2E) | `trajectories/<source>-<scope>-<published-utc>-<digest12>/` |
 
 Still in the GEODE repository after the 2026-07-13 migration: the live
 `docs/audits/eval-logs/` manifest ledger (`core/audit/manifest.py` appends to

--- a/docs/v1.0.0-stability-contract.md
+++ b/docs/v1.0.0-stability-contract.md
@@ -74,18 +74,18 @@ SoT: `Settings` 모델(`core/config/_settings.py`) + `_TOML_TO_SETTINGS` 매핑(
 
 ## C. MCP 도구 (`geode-mcp` 서버)
 
-SoT: `core/mcp_server.py` (`FastMCP("geode")`, `mcp_server.py:165`). 서버는 정확히 6개 도구를 노출하며, 클라이언트에는 `mcp__geode__<name>`으로 보인다.
+SoT: `core/mcp_server.py` (`FastMCP("geode")`, `mcp_server.py:153`). 서버는 정확히 6개 도구를 노출하며, 클라이언트에는 `mcp__geode__<name>`으로 보인다.
 
 | MCP 도구 | 등록 | 시그니처 |
 |----------|------|----------|
-| `run_agent` | `mcp_server.py:182` | `(prompt: str, time_budget_s: float = 120.0) -> dict` |
-| `self_improving_status` | `mcp_server.py:195` | `() -> dict` |
-| `self_improving_propose` | `mcp_server.py:200` | `() -> dict` |
-| `self_improving_apply` | `mcp_server.py:220` | `(mutation_id: str) -> dict` |
-| `query_memory` | `mcp_server.py:236` | `(query: str) -> dict` |
-| `get_health` | `mcp_server.py:247` | `() -> dict` |
+| `run_agent` | `mcp_server.py:171` | `(prompt: str, time_budget_s: float = 120.0) -> dict` |
+| `self_improving_status` | `mcp_server.py:184` | `() -> dict` |
+| `self_improving_propose` | `mcp_server.py:189` | `() -> dict` |
+| `self_improving_apply` | `mcp_server.py:209` | `(mutation_id: str) -> dict` |
+| `query_memory` | `mcp_server.py:225` | `(query: str) -> dict` |
+| `get_health` | `mcp_server.py:236` | `() -> dict` |
 
-서버는 추가로 `geode://soul` **리소스**(도구 아님, `mcp_server.py:269`)를 노출한다. `self_improving_propose` → `self_improving_apply`는 2단계 확인 게이트다 — propose가 `mutation_id`로 park하면 apply가 소비한다(`mcp_server.py:178-180`).
+서버는 추가로 `geode://soul` **리소스**(도구 아님, `mcp_server.py:257`)를 노출한다. `self_improving_propose` → `self_improving_apply`는 2단계 확인 게이트다 — propose가 `mutation_id`로 park하면 apply가 소비한다(`_pending_proposals`, `mcp_server.py:168`).
 
 **계약**: 위 6개 도구 이름 + 시그니처는 안정 표면이다. breaking 변경은 MINOR 이상.
 

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -50,7 +50,7 @@
         "runtime",
         "while-tool-use"
       ],
-      "contentSha256": "268ad68b6c78e6c76f95360a8480af3e424b1326102a255b4d98d5451edd133e"
+      "contentSha256": "f6e98419d3edc37531b0039d6999d8807f411adff0615fb543df5f55f88eabf0"
     },
     {
       "id": "file:core/agent/tool_executor/processor.py",

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5299,7 +5299,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1462 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1463 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -506,7 +506,7 @@
   "packages": {
     "core": {
       "python_files": 429,
-      "python_loc": 132076
+      "python_loc": 132130
     },
     "plugins": {
       "python_files": 109,
@@ -514,7 +514,7 @@
     },
     "tests": {
       "python_files": 671,
-      "python_loc": 174190
+      "python_loc": 174254
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -216,7 +216,7 @@
   "coordinators": {
     "AgenticLoop": {
       "constructor_arg_count": 27,
-      "file_loc": 2713,
+      "file_loc": 2722,
       "method_count": 67,
       "path": "core/agent/loop/agent_loop.py"
     },
@@ -506,7 +506,7 @@
   "packages": {
     "core": {
       "python_files": 429,
-      "python_loc": 131949
+      "python_loc": 132076
     },
     "plugins": {
       "python_files": 109,
@@ -514,7 +514,7 @@
     },
     "tests": {
       "python_files": 671,
-      "python_loc": 174068
+      "python_loc": 174190
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Fixed\n\n- **MCP stdio stream can no longer be permanently poisoned by unsolicited\n  server frames.** `StdioMCPClient` now matches JSON-RPC response ids and\n  skips interleaved notifications (`notifications/message`, progress,\n  `tools/list_changed`); previously a single server-initiated frame\n  desynchronized the stream forever while `is_connected()` kept reporting\n  healthy. A daemon thread now drains child stderr, removing the 64 KB\n  pipe-buffer wedge chatty servers could hit (ADR-014 R1/R2).\n\n- **MCP server recycle mid-session now recovers instead of failing the\n  round.** `MCPServerManager.acall_tool` retries once on a freshly respawned\n  client when the subprocess died mid-call, dead clients are reaped\n  (`close()`) when popped, a down server's tools are reported to the model as\n  \"currently unavailable\" instead of the misinforming \"Unknown tool\", and\n  `AgenticLoop` re-snapshots its MCP tool list when the manager's connection\n  epoch changes — a recycle previously left long-lived sessions with stale\n  schemas for their whole lifetime (ADR-014 R3/R4/R5).\n\n### Architecture\n\n- **ADR-014 verification + records.** Live E2E trajectory (subscription\n  backend, loopback geode-mcp + stateless-only rejection) published to the\n  external evidence store as the first normalized `trajectories/` release;\n  ADR-014, `AGENTS.md` (core/mcp), the stability contract §C line refs, and\n  the geode-changelog skill's derived-SoT regeneration checklist updated with\n  the observations."
   },
   {
     "version": "1.0.2",

--- a/tests/core/mcp/test_mcp_lifecycle.py
+++ b/tests/core/mcp/test_mcp_lifecycle.py
@@ -140,6 +140,50 @@ class TestStdioMCPClientLifecycle:
         assert client.server_protocol_version is None
         mock_proc.terminate.assert_called_once()
 
+    def test_unsolicited_notification_frame_skipped(self) -> None:
+        """A server-initiated notification interleaved before the response
+        must not desynchronize the stream (JSON-RPC id matching, ADR-014 R1)."""
+        client = StdioMCPClient(command="echo", timeout_s=2.0)
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        client._process = mock_proc
+        client._connected = True
+        client._pid = 111
+
+        notif = b'{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}\n'
+        resp = b'{"jsonrpc":"2.0","id":1,"result":{"content":[]}}\n'
+        mock_proc.stdout.readline.side_effect = [notif, resp]
+
+        result = asyncio.run(client.acall_tool("some_tool", {}))
+        assert result == {"content": []}
+
+    def test_chatty_stderr_does_not_wedge_connect(self) -> None:
+        """A child writing >64 KB to stderr before serving must not deadlock —
+        the drain thread keeps the pipe moving (ADR-014 R2). Real subprocess."""
+        import sys as _sys
+
+        script = (
+            "import sys\n"
+            "sys.stderr.write('x'*262144)\n"
+            "sys.stderr.flush()\n"
+            "import json\n"
+            "req=json.loads(sys.stdin.readline())\n"
+            "sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':req['id'],"
+            "'result':{'protocolVersion':'2025-06-18'}})+'\\n')\n"
+            "sys.stdout.flush()\n"
+            "sys.stdin.readline()\n"
+            "req=json.loads(sys.stdin.readline())\n"
+            "sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':req['id'],"
+            "'result':{'tools':[]}})+'\\n')\n"
+            "sys.stdout.flush()\n"
+            "sys.stdin.readline()\n"
+        )
+        client = StdioMCPClient(command=_sys.executable, args=["-c", script], timeout_s=3.0)
+        try:
+            assert client.connect() is True
+        finally:
+            client.close()
+
     def test_missing_negotiated_version_disconnects(self) -> None:
         """An initialize result without protocolVersion is nonconforming —
         rejected instead of silently accepted."""
@@ -819,3 +863,81 @@ class TestMCPFallbackHints:
         assert "error" in result
         # Hint is in dedicated field (LLM-friendly structured error)
         assert "playwright" in result.get("hint", "")
+
+
+class TestServerRecycleResilience:
+    """Stateless-era hardening (ADR-014 R3/R4/R5): server subprocesses may
+    recycle mid-session; the manager retries, the executor stays honest, and
+    the loop can detect the recycle via the connection epoch."""
+
+    def test_acall_tool_retries_once_after_mid_call_death(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+
+        dead = MagicMock()
+        dead.list_tools.return_value = [{"name": "t", "input_schema": {}}]
+        dead.acall_tool = AsyncMock(return_value={"error": "MCP tool call failed: t"})
+        dead.is_connected.return_value = False
+        mgr._clients["srv"] = dead
+
+        fresh = MagicMock()
+        fresh.acall_tool = AsyncMock(return_value={"content": [{"type": "text", "text": "ok"}]})
+
+        with patch.object(mgr, "_get_client", side_effect=[dead, fresh]):
+            result = asyncio.run(mgr.acall_tool("srv", "t", {}))
+
+        assert result == {"content": [{"type": "text", "text": "ok"}]}
+        dead.close.assert_called_once()
+
+    def test_acall_tool_mid_call_death_without_respawn_is_connection_error(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+
+        dead = MagicMock()
+        dead.list_tools.return_value = [{"name": "t", "input_schema": {}}]
+        dead.acall_tool = AsyncMock(return_value={"error": "MCP tool call failed: t"})
+        dead.is_connected.return_value = False
+
+        with patch.object(mgr, "_get_client", side_effect=[dead, None]):
+            result = asyncio.run(mgr.acall_tool("srv", "t", {}))
+
+        assert result.get("error_type") == "connection"
+        assert "MCP tool call failed" in result.get("error", "")
+
+    def test_connection_epoch_bumps_on_new_client(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+        assert mgr.connection_epoch == 0
+
+        good = MagicMock()
+        good.connect.return_value = True
+        with patch("core.mcp.manager.StdioMCPClient", return_value=good):
+            client = mgr._get_client("srv")
+
+        assert client is good
+        assert mgr.connection_epoch == 1
+
+    def test_unavailable_mcp_tool_not_reported_as_unknown(self) -> None:
+        from core.agent.tool_executor import ToolExecutor
+
+        mgr = MCPServerManager()
+        mgr._last_seen_tools["gone_tool"] = "srv"
+
+        executor = ToolExecutor(action_handlers={}, mcp_manager=mgr, hitl_level=0)
+        with patch.object(mgr, "find_server_for_tool", return_value=None):
+            result = asyncio.run(executor._dispatch_async("gone_tool", {}))
+
+        assert "currently unavailable" in result.get("error", "")
+        assert "Unknown tool" not in result.get("error", "")
+
+    def test_last_seen_tools_recorded_by_get_all_tools(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+        client = MagicMock()
+        client.is_connected.return_value = True
+        client.list_tools.return_value = [{"name": "t1", "inputSchema": {}}]
+        mgr._clients["srv"] = client
+
+        _tools = mgr.get_all_tools()
+        assert mgr.last_known_server_for_tool("t1") == "srv"
+        assert mgr.last_known_server_for_tool("nope") is None

--- a/tests/core/mcp/test_mcp_lifecycle.py
+++ b/tests/core/mcp/test_mcp_lifecycle.py
@@ -875,7 +875,9 @@ class TestServerRecycleResilience:
         mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
 
         dead = MagicMock()
-        dead.list_tools.return_value = [{"name": "t", "input_schema": {}}]
+        dead.list_tools.return_value = [
+            {"name": "t", "input_schema": {}, "annotations": {"idempotentHint": True}}
+        ]
         dead.acall_tool = AsyncMock(return_value={"error": "MCP tool call failed: t"})
         dead.is_connected.return_value = False
         mgr._clients["srv"] = dead
@@ -894,7 +896,9 @@ class TestServerRecycleResilience:
         mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
 
         dead = MagicMock()
-        dead.list_tools.return_value = [{"name": "t", "input_schema": {}}]
+        dead.list_tools.return_value = [
+            {"name": "t", "input_schema": {}, "annotations": {"readOnlyHint": True}}
+        ]
         dead.acall_tool = AsyncMock(return_value={"error": "MCP tool call failed: t"})
         dead.is_connected.return_value = False
 
@@ -941,3 +945,63 @@ class TestServerRecycleResilience:
         _tools = mgr.get_all_tools()
         assert mgr.last_known_server_for_tool("t1") == "srv"
         assert mgr.last_known_server_for_tool("nope") is None
+
+    def test_acall_tool_no_retry_for_non_idempotent_tool(self) -> None:
+        """Mid-call death of an unannotated tool must NOT auto-retry — the
+        original call may have executed (at-least-once hazard)."""
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+        dead = MagicMock()
+        dead.list_tools.return_value = [{"name": "t", "input_schema": {}}]
+        dead.acall_tool = AsyncMock(return_value={"error": "MCP tool call failed: t"})
+        dead.is_connected.return_value = False
+
+        with patch.object(mgr, "_get_client", side_effect=[dead]) as getc:
+            result = asyncio.run(mgr.acall_tool("srv", "t", {}))
+
+        assert result.get("error_type") == "connection"
+        assert "outcome unknown" in result.get("error", "")
+        assert getc.call_count == 1
+
+    def test_find_server_for_tool_records_last_seen(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers["srv"] = {"command": "echo", "args": [], "env": {}}
+        client = MagicMock()
+        client.is_connected.return_value = True
+        client.list_tools.return_value = [{"name": "t9"}]
+        mgr._clients["srv"] = client
+
+        assert mgr.find_server_for_tool("t9") == "srv"
+        assert mgr.last_known_server_for_tool("t9") == "srv"
+
+    def test_coalesced_notification_and_response_single_write(self) -> None:
+        """Notification + response arriving in ONE stdout write must not
+        starve the next select() — stdout is unbuffered (ADR-014 R1).
+        Real subprocess."""
+        import sys as _sys
+
+        script = (
+            "import sys,json\n"
+            "def serve(result):\n"
+            "    req=json.loads(sys.stdin.readline())\n"
+            "    sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':req['id'],"
+            "'result':result})+'\\n')\n"
+            "    sys.stdout.flush()\n"
+            "serve({'protocolVersion':'2025-06-18'})\n"
+            "sys.stdin.readline()\n"
+            "serve({'tools':[{'name':'t','inputSchema':{}}]})\n"
+            "req=json.loads(sys.stdin.readline())\n"
+            "notif=json.dumps({'jsonrpc':'2.0','method':'notifications/message','params':{}})\n"
+            "resp=json.dumps({'jsonrpc':'2.0','id':req['id'],"
+            "'result':{'content':[{'type':'text','text':'ok'}]}})\n"
+            "sys.stdout.write(notif+'\\n'+resp+'\\n')\n"
+            "sys.stdout.flush()\n"
+            "sys.stdin.readline()\n"
+        )
+        client = StdioMCPClient(command=_sys.executable, args=["-c", script], timeout_s=3.0)
+        try:
+            assert client.connect() is True
+            result = asyncio.run(client.acall_tool("t", {}))
+            assert result == {"content": [{"type": "text", "text": "ok"}]}
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary
- MCP 2026-07-28 stateless 전환(서버 recycle 상시화)에 대비해 ReAct 루프↔MCP 배선을 하드닝: 스트림 영구 오염 2경로 제거, 미드콜 사망 복구, 모델 오보 제거, 세션 도구 스냅샷 리프레시.
- 직전 v1.0.2 랜딩의 라이브 E2E 관측값을 스캐폴드에 기록: ADR-014 검증 절(외부 증거 저장소 궤적 포인터), CLAUDE.md 파생 SoT 재생성 규칙, AGENTS.md core/mcp, geode-changelog 스킬 3b, 계약 §C 라인 정정.

## Why
루프 감사에서 서버 recycle 시 실파손 7건(R1-R7)을 확인. R1(응답 id 미대조 — notification 1프레임이 스트림 영구 오염, Codex가 BufferedReader 선읽기 변종까지 재현)·R2(stderr 미배수 64KB 웨지)는 "죽은 게 아니라 웨지됐는데 health는 정상"인 최악 형상. R3는 모델에 존재하는 도구를 "Unknown tool"로 오보. R6(주기 헬스 스윕)·R7(propose/apply 게이트)은 ADR-014 보류 표로 이관.

## Changes
| File | Change |
|------|--------|
| `core/mcp/stdio_client.py` | JSON-RPC id 매칭+알림 skip, `bufsize=0`(select 정합), `_write_all` short-write 가드, `_drain_stderr` 스레드 |
| `core/mcp/manager.py` | 멱등 도구(readOnlyHint/idempotentHint) 한정 미드콜 1회 재시도, `_respawn_after_death`+락, dead client reap, `connection_epoch`, `last_seen_tools` 메모(양경로 기록) |
| `core/agent/tool_executor/executor.py` | 다운 서버 도구 → "currently unavailable"(Unknown tool 오보 제거) |
| `core/agent/loop/agent_loop.py` | epoch 드리프트 시 arun 도구 스냅샷 리프레시 |
| `tests/core/mcp/test_mcp_lifecycle.py` | +10종: 알림 skip·병합프레임(실서브프로세스)·chatty stderr(실서브프로세스)·멱등 게이트 재시도/비재시도·epoch·honest error·memo |
| `docs/adr/ADR-014...md` | 검증 절(E2E 궤적 발행 포인터: geode-eval-artifacts@647583b3, trajectory sha256 8b77e3b0…) + R1-R7 처분 표 |
| `CLAUDE.md` / `AGENTS.md` / `.claude/skills/geode-changelog` / `docs/v1.0.0-stability-contract.md` / `core/tools/jobs.py` / `docs/eval/external-artifact-repository.md` | 관측값·규칙 기록, 라인 참조·주석 드리프트 정정 |

## E2E 관측값 (2026-07-28 UTC, gpt-5.5 구독)
협상 2025-06-18 기록(루프백 geode-mcp/python-sdk 1.29.0), stateless-only 서버 fail-loud 거부, AgenticLoop MCP 디스패치 2회 natural 종료(rounds 3/6, in 4794+9638/out 89+290 tokens). 궤적: `geode-eval-artifacts` `trajectories/geode-agenticloop-mcp-2026-07-28-spec-e2e-20260728T202349Z-7acb62a4184c/`.

## Verification
- [x] ruff check / format --check (core·tests·plugins·scripts) — clean
- [x] mypy core/ plugins/ — Success (538 files)
- [x] lint-imports — 4 contracts kept
- [x] MCP·agent 테스트 — 전부 통과 exit 0 (실서브프로세스 회귀 3종 포함)
- [x] architecture_baseline --check / check_llms_version — clean
- [x] Codex(gpt-5.6-sol high) 4라운드 — R1 BufferedReader 변종(HIGH)·비멱등 재시도(HIGH)·short-write(HIGH)·MED 3건 전부 해소, 최종 **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)