### PR TITLE
chore(llm): 레거시 삭제 재점검 — 고아 async 클라이언트 제거 + lazy-import liveness 가드

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
 The current snapshot records 538 production Python files,
-672 test Python files,
+673 test Python files,
 78 tool definitions, and
 56 `HookEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@ functional change.
 
 ## [Unreleased]
 
+### Removed
+
+- **Orphaned async provider-client chain deleted.** `providers.anthropic`'s
+  `get_async_anthropic_client` / `areset_clients` / its loop-affine cache and
+  `providers.openai`'s `_get_async_openai_client` / cache had zero production
+  consumers after the v1.0.4 legacy-adapter removal — Anthropic and OpenAI
+  traffic builds clients in `core/llm/adapters`. GLM's provider getter stays
+  (consumed by `core/tools/computer_grounding`), and the loop-affinity
+  guardrail was narrowed to it plus the adapter-level pin.
+
+### Fixed
+
+- **Lazy provider imports in adapters are now pinned.** A prune pass nearly
+  deleted `_async_response_hook`, which `build_async_anthropic_client`
+  imports *inside the function* — invisible to ruff and mypy, and untouched
+  by unit tests, so every Anthropic subscription call would have failed with
+  ImportError at runtime. A new liveness test walks the adapters' AST and
+  resolves every `core.llm.providers` import (lazy ones included) and
+  constructs the real async client; it was verified to fail on a replay of
+  the incident. Two docstrings naming since-deleted consumers of the OpenAI
+  client singleton were corrected to the live one (`provider_dispatch`).
+
 ## [1.0.5] - 2026-07-29
 
 > Live verification of the v1.0.4 prompt-cache wiring (7,590-token writes read back across process restarts) plus the two deferred Anthropic re-wires: server-side context management, and hosted web tools behind a default-off opt-in because provider-executed tools escape GEODE's tool policy.

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -5,7 +5,6 @@ Owns sync/async Anthropic clients with configured httpx connection pool.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import threading
 from typing import TYPE_CHECKING, Any
@@ -15,7 +14,6 @@ from core.llm.fallback import (
     retry_with_backoff_generic,
     retry_with_backoff_generic_async,
 )
-from core.llm.loop_affinity import LoopAffineClientCache
 from core.llm.model_capabilities import (
     ANTHROPIC_ADAPTIVE_MODELS,
     ANTHROPIC_CONTEXT_MGMT_MODELS,
@@ -150,7 +148,6 @@ _sync_client_lock = threading.Lock()
 
 # PR-LOOP-POLLUTION-FIX (2026-06-12) — async client is per-event-loop, not
 # process-global (see core/llm/loop_affinity.py).
-_async_clients = LoopAffineClientCache("anthropic-provider")
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +250,12 @@ def _sync_response_hook(response: object) -> None:
 
 
 async def _async_response_hook(response: object) -> None:
-    """httpx async event hook — delegates to the banner feeder."""
+    """httpx async event hook — delegates to the banner feeder.
+
+    Consumed by ``core/llm/adapters/_anthropic_common.build_async_anthropic_client``
+    via a lazy in-function import (the live Anthropic client path), NOT by
+    this module — a 2026-07-29 prune pass nearly dropped it as an orphan.
+    """
     _feed_banner_from_anthropic_response(response)
 
 
@@ -356,60 +358,6 @@ def get_anthropic_client() -> anthropic.Anthropic:
                 http_client=http_client,
             )
         return _sync_client
-
-
-def get_async_anthropic_client(api_key: str | None = None) -> anthropic.AsyncAnthropic:
-    """Return the async Anthropic client bound to the CURRENT event loop.
-
-    PR-LOOP-POLLUTION-FIX (2026-06-12) — previously a process-global
-    singleton. The serve daemon runs multiple event loops (main serve loop
-    for gateway turns, CLIPoller thread loop for CLI sessions); httpx
-    connection-pool primitives bind to the loop that first drives them, so
-    one shared client poisoned the pool across loops (instant
-    APIConnectionError / eternal hang — see ``core/llm/loop_affinity.py``).
-    Now one client per owning loop; same key-resolution and pool settings.
-    SDK-level retries stay disabled (max_retries=0) — app-level retry
-    (AgenticLoop) and the dispatch connection-transient retry own that.
-
-    Args:
-        api_key: Optional API key override. If None, uses settings.
-        Note: the override only affects the loop that triggers the build
-        (same first-caller-wins semantics as the old singleton).
-    """
-    import anthropic
-    import httpx
-
-    def _build() -> anthropic.AsyncAnthropic:
-        key = api_key or _resolve_anthropic_key()
-        http_client = httpx.AsyncClient(
-            limits=_build_httpx_limits(),
-            timeout=_build_httpx_timeout(),
-            event_hooks={"response": [_async_response_hook]},
-        )
-        return anthropic.AsyncAnthropic(
-            api_key=key,
-            max_retries=0,  # app-level retry handles this
-            http_client=http_client,
-        )
-
-    client: anthropic.AsyncAnthropic = _async_clients.get(_build)
-    return client
-
-
-async def areset_clients() -> None:
-    """Reset cached clients. Used in tests and on API key change.
-
-    Async clients are dropped (not closed) — ``aclose()`` requires each
-    client's owning event loop, which may not be the current one; GC
-    finalizers reclaim the sockets (see core/llm/loop_affinity.py).
-    """
-    global _sync_client
-    with _sync_client_lock:
-        if _sync_client is not None:
-            with contextlib.suppress(Exception):
-                _sync_client.close()
-            _sync_client = None
-    _async_clients.invalidate()
 
 
 def system_with_cache(system: str) -> list[TextBlockParam]:

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -1,6 +1,10 @@
-"""Anthropic provider — singleton clients + retry wrapper.
+"""Anthropic provider — low-level client + retry/quota utilities.
 
-Owns sync/async Anthropic clients with configured httpx connection pool.
+Owns the SYNC Anthropic client (configured httpx pool), retry/backoff, quota
+banner feeding, prompt-cache helpers, and native-tool shaping consumed by
+``core/llm/adapters``. Async clients live in the adapters layer
+(``build_async_anthropic_client``) — the provider-level async getter was
+removed 2026-07-29 once its last caller (the legacy agentic adapter) was gone.
 """
 
 from __future__ import annotations
@@ -145,9 +149,6 @@ def _build_httpx_limits() -> httpx.Limits:
 # ---------------------------------------------------------------------------
 _sync_client: anthropic.Anthropic | None = None
 _sync_client_lock = threading.Lock()
-
-# PR-LOOP-POLLUTION-FIX (2026-06-12) — async client is per-event-loop, not
-# process-global (see core/llm/loop_affinity.py).
 
 
 # ---------------------------------------------------------------------------
@@ -692,7 +693,7 @@ async def retry_with_backoff_async(
 
 
 # ---------------------------------------------------------------------------
-# ClaudeAgenticAdapter — Anthropic LLM adapter for agentic loop
+# Request shaping helpers consumed by core/llm/adapters/_anthropic_common
 # ---------------------------------------------------------------------------
 
 _API_ALLOWED_KEYS = frozenset(

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -9,8 +9,6 @@ import logging
 import threading
 from typing import Any
 
-from core.llm.loop_affinity import LoopAffineClientCache
-
 log = logging.getLogger(__name__)
 
 # Retry policy values (max_retries / retry_base_delay / retry_max_delay) are
@@ -30,7 +28,6 @@ _openai_client: Any = None  # openai.OpenAI | None — lazy import
 _openai_lock = threading.Lock()
 # PR-LOOP-POLLUTION-FIX (2026-06-12) — async client is per-event-loop, not
 # process-global (see core/llm/loop_affinity.py).
-_async_openai_clients = LoopAffineClientCache("openai-provider")
 
 
 def _resolve_openai_key() -> str:
@@ -46,10 +43,10 @@ def _get_openai_client() -> Any:
 
     PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28, Codex MCP MED) —
     ``max_retries=0`` matches the adapter-side invariant
-    (``_openai_common.build_async_openai_client``) so legacy callers that
-    still hit this singleton (paperclip ``OpenAIAdapter``,
-    ``llm_extract_learning``, ``models.py``) don't compound SDK + app
-    retry loops on stalled streams.
+    (``_openai_common.build_async_openai_client``) so the callers that hit
+    this singleton don't compound SDK + app retry loops on stalled streams.
+    Live consumer today: ``core/llm/provider_dispatch.py`` (the named
+    ``OpenAIAdapter`` / ``models.py`` consumers were deleted by 2026-07-29).
     """
     global _openai_client
     if _openai_client is None:
@@ -61,27 +58,11 @@ def _get_openai_client() -> Any:
     return _openai_client
 
 
-def _get_async_openai_client() -> Any:
-    """Return the async OpenAI client bound to the CURRENT event loop.
-
-    See :func:`_get_openai_client` for the ``max_retries=0`` rationale and
-    ``core/llm/loop_affinity.py`` for why the cache is per-loop.
-    """
-
-    def _build() -> Any:
-        import openai
-
-        return openai.AsyncOpenAI(api_key=_resolve_openai_key(), max_retries=0)
-
-    return _async_openai_clients.get(_build)
-
-
 def reset_openai_client() -> None:
     """Reset cached OpenAI client (e.g. after /key openai changes)."""
     global _openai_client
     with _openai_lock:
         _openai_client = None
-    _async_openai_clients.invalidate()
 
 
 # ── 2026-07-29 prune ───────────────────────────────────────────────────────

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -26,8 +26,6 @@ log = logging.getLogger(__name__)
 
 _openai_client: Any = None  # openai.OpenAI | None — lazy import
 _openai_lock = threading.Lock()
-# PR-LOOP-POLLUTION-FIX (2026-06-12) — async client is per-event-loop, not
-# process-global (see core/llm/loop_affinity.py).
 
 
 def _resolve_openai_key() -> str:

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -284,9 +284,9 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 538 |
 | Test Python files | 673 |
-| `core/` Python LOC | 131,823 |
+| `core/` Python LOC | 131,822 |
 | `plugins/` Python LOC | 40,262 |
-| Test Python LOC | 174,254 |
+| Test Python LOC | 174,255 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `HookEvent` members | 56 |
 | Built-in LLM adapters | 8 |

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -283,10 +283,10 @@ machine-readable artifact is
 | Measure | Current tree |
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 538 |
-| Test Python files | 672 |
-| `core/` Python LOC | 131,894 |
+| Test Python files | 673 |
+| `core/` Python LOC | 131,823 |
 | `plugins/` Python LOC | 40,262 |
-| Test Python LOC | 174,197 |
+| Test Python LOC | 174,254 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `HookEvent` members | 56 |
 | Built-in LLM adapters | 8 |

--- a/docs/plans/2026-07-29-legacy-residue-recheck.md
+++ b/docs/plans/2026-07-29-legacy-residue-recheck.md
@@ -1,0 +1,175 @@
+# 레거시 삭제 재점검 (8674c418f, 2026-07-29T00:36:09Z)
+
+## R1. 삭제 선언 심볼의 실행 코드 잔존 (주석/문자열 제외)
+```
+--- ClaudeAgenticAdapter
+core/llm/adapters/_anthropic_common.py:171:    ``ClaudeAgenticAdapter.agentic_call`` (PR-MAINPATH-67, 2026-05-24 removed
+core/llm/adapters/_anthropic_common.py:228:    Ported from the deleted ClaudeAgenticAdapter (stranded, never live);
+core/llm/adapters/_anthropic_common.py:258:    Ported from the deleted ClaudeAgenticAdapter; live-verified on
+core/llm/adapters/_anthropic_common.py:301:    Ported 2026-07-29 from the never-registered ``ClaudeAgenticAdapter``
+--- OpenAIAdapter
+core/llm/fallback.py:235:    (the since-deleted ``OpenAIAdapter._retry_with_backoff``) to eliminate DRY violation.
+core/llm/providers/openai.py:50:    still hit this singleton (paperclip ``OpenAIAdapter``,
+core/llm/adapters/__init__.py:20:hierarchy (sync ``ClaudeAdapter`` / ``OpenAIAdapter.generate*`` surface
+--- _resolve_plan_meta
+--- _get_retryable_errors
+--- _is_system_reminder
+--- decomposition_hint
+```
+
+## R2. 테스트/문서 잔존 참조
+```
+--- ClaudeAgenticAdapter (tests+docs)
+tests/core/llm/test_provider_parity_v0532.py:56:    ``ClaudeAgenticAdapter`` was deleted (never registered); the live
+tests/core/llm/test_anthropic_reasoning_v056.py:86:        # ClaudeAgenticAdapter to the LIVE builder module.
+tests/core/llm/test_anthropic_cache_live_path.py:4:``ClaudeAgenticAdapter`` — these tests pin it to ``build_create_kwargs`` /
+tests/core/llm/test_anthropic_sampling_params.py:3:Repointed 2026-07-29: previously drove the deleted ``ClaudeAgenticAdapter``;
+--- OpenAIAdapter (tests+docs)
+tests/core/llm/test_h11_constant_reload.py:41:    # 2026-07-29: OpenAIAdapter deleted; the H11 invariant (routing constants
+tests/core/llm/test_adapter_max_retries.py:50:    paperclip ``OpenAIAdapter`` + llm_extract_learning + models.py — same
+docs/progress.md:23:- [x] 프롬프트 문법 정렬 + adapters 단일 진입점화 (#2810 → release #2811 → 프리싱크 #2812 → 승격 #2813, main v1.0.4, 2026-07-29) — Phase-0 bash 원장(docs/plans/2026-07-29-prompt-grammar-alignment-ledger.md, S1-S18) 선분류 후 착수. 핵심: Anthropic 캐시 장치 전체(STATIC/DYNAMIC 1h-TTL split·메시지 브레이크포인트·T5 cache_policy·S5 in-context 슬롯·adaptive thinking display=summarized)가 미등록 ClaudeAgenticAdapter에 좌초해 프로덕션 미작동이었음을 라이브 build_create/stream_kwargs로 이식(slots는 dynamic 존, reminder는 브레이크포인트 제외, 봉투 open 태그 wire 보존). XML 주입 통일=inject_runtime_hints 단일 헬퍼(<dynamic_context> 내 삽입, 재빌드 preflight 유실 수정, decomposition_hint 사배관 삭제). 버그: reflection str payload 폐기(OpenAI계 전체)·codex shape WARNING 상시 오발·extended thinking budget<max_tokens 계약. 삭제: ClaudeAgenticAdapter(~360L)+OpenAIAdapter(~160L)+레거시 reminder strip, 순수 −540줄, providers/=저수준 유틸 층. 복잡도 ceiling 래칫 인하(C901 54→52, PLR0912 56→52). Codex(gpt-5.6-sol high) 2라운드: R1 6건(platform id 오염 HIGH·thinking 계약 HIGH·슬롯 static 오염·테스트 약화·rfind·native-tools 분류) 전건 반영 후 PASS. 보류(명시): context-management·native web_search/fetch 재배선 — 라이브 검증 필요(providers/anthropic.py 주석+원장 S18). 리빌드 v1.0.4+kickstart 완료.
+docs/progress.md:111:- [x] PR-PRE10-H11-TAIL — v1.0.0 전 punch-list #1: 모델해석 call path의 routing 상수를 boot-frozen 복사본이 아니라 live로 읽도록(운영자: punch-list 전체, Codex 검증). `reload_routing_constants()`가 core.config.* 를 in-place 재바인드하고 function-local import는 live로 재해석하지만, 여러 module-level by-value importer가 부트 복사본을 들고 있어 세션 중 routing.toml 편집이 재시작 전까지 stale였음. call path 전반 해동: providers/{anthropic,openai,glm} + provider_dispatch lambda(codex entry의 live `__import__` 패턴에 일치), OpenAIAdapter.__init__ OPENAI_PRIMARY lazy, streaming retry chain, agent_loop no-act_model ANTHROPIC_PRIMARY fallback, skills/agents.py(AgentDefinition.model default_factory + 빌트인 3 spec의 frozen "model" 키 제거→factory가 live 채움). 죽은 DEFAULT_*_MODEL/*_FALLBACK_MODELS provider alias(소비자 0) 제거. Codex catch 4: semantics 회귀(explicit `model:""` 보존, `get(k,default)`로 복구) + kanban 명시 외 3곳(provider_dispatch·agent_loop·_state) — call-path 2곳 수정. **범위 주석(Codex 합의)**: 런타임 모델해석 경로 한정. 잔존 frozen 1곳=`_state.py` MODEL_PROFILES(/model 피커 라벨·id 목록, ~12 CLI 소비자)=display+picker-id 후속(코어 해석경로 아님). 가드 test_h11_constant_reload(core.config.* 패치→소비자 live 확인)+test_failover live SoT 재지정. 게이트 green+CI 6/6. (PR #2329→#2331, v0.99.220)
+```
+
+## R3. providers/ 잔존 심볼의 프로덕션 소비자 수 (0 = 삭제로 새로 죽은 후보)
+```
+== anthropic (     941L)
+  DEAD? _resolve_anthropic_exception prod=0 testfiles=0
+  DEAD? _extract_anthropic_quota prod=0 testfiles=1
+  DEAD? _feed_banner_from_anthropic_response prod=0 testfiles=1
+  DEAD? _sync_response_hook prod=0 testfiles=0
+  DEAD? get_async_anthropic_client prod=0 testfiles=1
+  DEAD? _content_block_count prod=0 testfiles=1
+  DEAD? _is_volatile_reminder prod=0 testfiles=0
+  DEAD? _is_markable prod=0 testfiles=0
+  DEAD? _select_breakpoint_targets prod=0 testfiles=2
+== openai (      92L)
+  DEAD? _resolve_openai_key prod=0 testfiles=1
+  DEAD? _get_async_openai_client prod=0 testfiles=1
+== codex (     236L)
+  DEAD? _ResolvedCodexToken prod=0 testfiles=1
+  DEAD? _extract_account_id prod=0 testfiles=1
+== glm (     140L)
+```
+
+## R4. 진짜 고아 판정 (정의 1회 = 어디서도 호출/참조 안 됨)
+```
+(출력 없으면 고아 0)
+```
+
+## R5. stale 주석 — 삭제된 심볼을 '현존'처럼 서술하는 곳
+```
+50:    still hit this singleton (paperclip ``OpenAIAdapter``,
+    """Lazy import and return cached OpenAI client (thread-safe).
+
+    PR-ADAPTER-TIMEOUT-AND-SERIALIZATION (2026-05-28, Codex MCP MED) —
+    ``max_retries=0`` matches the adapter-side invariant
+    (``_openai_common.build_async_openai_client``) so legacy callers that
+    still hit this singleton (paperclip ``OpenAIAdapter``,
+    ``llm_extract_learning``, ``models.py``) don't compound SDK + app
+    retry loops on stalled streams.
+    """
+    global _openai_client
+    if _openai_client is None:
+--- adapters/__init__.py 도입부
+
+PR-LLMCLIENTPORT-COLLAPSE (2026-05-28) — the parallel ``LLMClientPort``
+hierarchy (sync ``ClaudeAdapter`` / ``OpenAIAdapter.generate*`` surface
++ ``LLMJsonCallable`` / ``LLMTextCallable`` / ``LLMParsedCallable``
+node-DI Protocols + the ``set_llm_callable`` / ``get_llm_json`` ContextVar
+chain + ``cross_llm.py`` re-score) is gone. The :class:`LLMAdapter`
+Protocol + central dispatch (``core.llm.adapters.dispatch``) is the
+--- test_adapter_max_retries.py:50
+
+
+def test_legacy_openai_provider_singleton_pins_max_retries_zero() -> None:
+    """Legacy ``core/llm/providers/openai.py`` singleton is still consumed by
+    paperclip ``OpenAIAdapter`` + llm_extract_learning + models.py — same
+    spinning risk if SDK retry compounds with app retry."""
+    src = (
+        Path(__file__).resolve().parents[3] / "core" / "llm" / "providers" / "openai.py"
+    ).read_text(encoding="utf-8")
+```
+
+## R6. providers/openai.py 싱글턴의 실제 소비자 (주석 주장 검증)
+```
+$ grep -rn '_get_openai_client\|_get_async_openai_client\|reset_openai_client' core/ plugins/ scripts/ --include='*.py' | grep -v 'providers/openai.py'
+core/llm/fallback.py:150:            from core.llm.providers.openai import reset_openai_client
+core/llm/fallback.py:153:                reset_openai_client()
+core/llm/provider_dispatch.py:88:            "core.llm.providers.openai", fromlist=["_get_openai_client"]
+core/llm/provider_dispatch.py:89:        )._get_openai_client(),
+core/llm/providers/glm.py:100:    Uses double-checked locking pattern consistent with _get_openai_client().
+core/cli/commands/key.py:74:            from core.llm.providers.openai import reset_openai_client
+core/cli/commands/key.py:76:            reset_openai_client()
+core/cli/commands/key.py:114:            from core.llm.providers.openai import reset_openai_client
+core/cli/commands/key.py:116:            reset_openai_client()
+core/orchestration/compaction.py:561:    builders (``_get_openai_client`` / ``_get_glm_client``). Now delegates
+
+$ 주석이 지목한 소비자 3종 생존 확인
+-- llm_extract_learning:
+core/llm/providers/openai.py:51:    ``llm_extract_learning``, ``models.py``) don't compound SDK + app
+core/config/_settings.py:75:            "(``core.hooks.llm_extract_learning``), run outside the main "
+core/wiring/bootstrap.py:458:        from core.hooks.llm_extract_learning import make_llm_extract_handler
+-- models.py:
+  core/llm/models.py 부재
+```
+
+## R7. async 클라이언트 빌더 실소비자 (OpenAIAdapter 삭제로 고아화 후보)
+```
+== _get_async_openai_client
+  prod refs:
+  test refs:
+tests/core/llm/test_loop_pollution_guardrails.py
+== get_async_anthropic_client
+  prod refs:
+  test refs:
+tests/core/llm/test_loop_pollution_guardrails.py
+== system_with_cache
+  prod refs:
+core/llm/providers/anthropic.py:445:    ephemeral default). One-shot call shapes (``system_with_cache``) and the
+core/llm/router/calls/text.py:18:    system_with_cache as _system_with_cache,
+  test refs:
+```
+
+## R8. adapters가 자체 클라이언트를 만드나 (providers 빌더 우회 여부)
+```
+core/llm/adapters/anthropic_oauth.py:5:if both are configured. Owns its own ``AsyncAnthropic`` client (Codex MCP
+core/llm/adapters/anthropic_oauth.py:24:    build_async_anthropic_client,
+core/llm/adapters/anthropic_oauth.py:82:    """Subscription-routed Anthropic adapter — owns its own AsyncAnthropic client."""
+core/llm/adapters/anthropic_oauth.py:120:    def _get_client(self) -> Any:
+core/llm/adapters/anthropic_oauth.py:139:        return self._clients.get(lambda: build_async_anthropic_client(auth_token=token))
+core/llm/adapters/anthropic_oauth.py:142:        client = self._get_client()
+core/llm/adapters/anthropic_oauth.py:173:            self._get_client(),
+core/llm/adapters/anthropic_oauth.py:193:            self._get_client(),
+```
+
+## R9. 광역 스윕 — 스프린트 후 남은 legacy/deprecated/compat 표면
+```
+-- (a) '레거시'라 자칭하는 프로덕션 심볼
+core/llm/prompt_assembler.py:3:The legacy ``PromptAssembler`` class was removed because production prompt
+core/llm/providers/codex.py:207:        # legacy provider path is also safe on openai >= 2.26.
+core/llm/adapters/dispatch.py:476:    legacy_result: WebSearchResult = await adapter.aweb_search(query, max_results=max_results)
+core/agent/loop/agent_loop.py:353:        thinking_budget: int = 0,  # 0 = disabled; >0 = Extended Thinking tokens (legacy)
+core/agent/loop/_tool_factory.py:81:MAX_TOOL_RESULT_TOKENS = 0  # backward-compat alias; canonical: settings.max_tool_result_tokens
+
+-- (b) providers/ 최종 형상
+     879 core/llm/providers/anthropic.py
+     236 core/llm/providers/codex.py
+     140 core/llm/providers/glm.py
+      73 core/llm/providers/openai.py
+    1329 total
+
+-- (c) 라우터 층 text.py 생존(캐시 헬퍼 소비자)
+core/llm/adapters/_openai_common.py:361:    # AgenticLoop's ``_call_llm`` retry path.
+core/self_improving/loop/__init__.py:28:dispatches through ``core.llm.router.call_with_failover`` so the
+core/self_improving/loop/mutate/runner.py:20:   ``core.llm.router.call_with_failover``.
+core/self_improving/loop/mutate/runner.py:787:    from core.llm.router import call_with_failover
+```
+
+## R10. 삭제 검증 요약
+```
+-- 삭제된 async 체인 재확인(참조 0이어야 함)
+core/llm/adapters/_anthropic_common.py:61:        _async_response_hook,
+core/llm/adapters/_anthropic_common.py:69:        event_hooks={"response": [_async_response_hook]},
+(출력 없음 = 전부 제거됨)
+```

--- a/docs/plans/2026-07-29-legacy-residue-recheck.md
+++ b/docs/plans/2026-07-29-legacy-residue-recheck.md
@@ -173,3 +173,19 @@ core/llm/adapters/_anthropic_common.py:61:        _async_response_hook,
 core/llm/adapters/_anthropic_common.py:69:        event_hooks={"response": [_async_response_hook]},
 (출력 없음 = 전부 제거됨)
 ```
+
+
+## R11. Codex 라운드1 반영 (2026-07-29)
+Codex 판정 FAIL(LOW) — "레거시 잔존은 주석·이력뿐"이라는 감사 결론이 부정확했다. stale 서술 4곳 정정:
+
+| 위치 | 내용 | 처분 |
+|------|------|------|
+| `tests/core/agent/test_arun_model_drift_sync.py` | 삭제된 `decomposition_hint`가 모듈 독스트링+실행 테스트 함수명 3개에 현재형으로 잔존(실제 대상은 reflection hint) | 함수명·서술 전부 reflection로 정정 |
+| `core/llm/providers/anthropic.py:3` | 모듈 독스트링 "sync/async clients 소유" — async는 adapters 층 소유 | 저수준 유틸 층 실태로 재작성 |
+| `core/llm/providers/{anthropic,openai}.py` | 제거된 async 캐시를 설명하는 고아 주석 | 삭제 |
+| `core/llm/providers/anthropic.py` | `ClaudeAgenticAdapter` 섹션 헤더 | 실제 내용(adapters가 소비하는 request shaping 헬퍼)로 개명 |
+| `tests/core/llm/test_loop_pollution_guardrails.py` | 존재하지 않는 형제 테스트명 참조 | 실제 이름으로 정정 |
+
+Codex PASS 판정 항목: 제거 5심볼 소비자 0(getattr/`__import__`/import_module 패턴 포함 재검색), `_async_response_hook` 복원 정확성(실행 본문 동일), liveness 가드 실효성(hook 삭제 재현 시 ImportError 검출, adapter provider import 15노드/19심볼 커버), 가드레일 축소의 커버리지 보존, 연쇄 고아 0.
+
+가드 한계(문서화): AST 워크는 직접 파일의 absolute `ImportFrom`만 처리 — 상대/동적 import는 미커버, `TYPE_CHECKING` 조건부는 오탐 가능(현재 해당 형태 없음).

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5299,7 +5299,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1468 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1470 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -5460,7 +5460,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 | 측정값 | 현재 트리 |
 | --- | --- |
 | 프로덕션 Python 파일 | 538 |
-| 테스트 Python 파일 | 672 |
+| 테스트 Python 파일 | 673 |
 | 도구 정의 / 실행 등록 / 유효 스키마 | 78 / 81 / 78 |
 | HookEvent 멤버 | 56 |
 | 기본 LLM 어댑터 | 8 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -506,7 +506,7 @@
   "packages": {
     "core": {
       "python_files": 429,
-      "python_loc": 131823
+      "python_loc": 131822
     },
     "plugins": {
       "python_files": 109,
@@ -514,7 +514,7 @@
     },
     "tests": {
       "python_files": 673,
-      "python_loc": 174254
+      "python_loc": 174255
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -506,15 +506,15 @@
   "packages": {
     "core": {
       "python_files": 429,
-      "python_loc": 131894
+      "python_loc": 131823
     },
     "plugins": {
       "python_files": 109,
       "python_loc": 40262
     },
     "tests": {
-      "python_files": 672,
-      "python_loc": 174197
+      "python_files": 673,
+      "python_loc": 174254
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Removed\n\n- **Orphaned async provider-client chain deleted.** `providers.anthropic`'s\n  `get_async_anthropic_client` / `areset_clients` / its loop-affine cache and\n  `providers.openai`'s `_get_async_openai_client` / cache had zero production\n  consumers after the v1.0.4 legacy-adapter removal — Anthropic and OpenAI\n  traffic builds clients in `core/llm/adapters`. GLM's provider getter stays\n  (consumed by `core/tools/computer_grounding`), and the loop-affinity\n  guardrail was narrowed to it plus the adapter-level pin.\n\n### Fixed\n\n- **Lazy provider imports in adapters are now pinned.** A prune pass nearly\n  deleted `_async_response_hook`, which `build_async_anthropic_client`\n  imports *inside the function* — invisible to ruff and mypy, and untouched\n  by unit tests, so every Anthropic subscription call would have failed with\n  ImportError at runtime. A new liveness test walks the adapters' AST and\n  resolves every `core.llm.providers` import (lazy ones included) and\n  constructs the real async client; it was verified to fail on a replay of\n  the incident. Two docstrings naming since-deleted consumers of the OpenAI\n  client singleton were corrected to the live one (`provider_dispatch`)."
   },
   {
     "version": "1.0.5",

--- a/tests/core/agent/test_arun_model_drift_sync.py
+++ b/tests/core/agent/test_arun_model_drift_sync.py
@@ -10,7 +10,7 @@ exact pre-refactor semantics:
   * OR-chained with ``_prompt_dirty`` so direct
     ``update_model_async`` callers (v0.52.5) still trigger rebuild.
   * On rebuild: ``_build_system_prompt()`` produces a new prompt;
-    ``decomposition_hint`` (if present) appended.
+    ``reflection_hint`` / preflight / plan hints (if present) re-applied.
   * Side effect: ``_prompt_dirty`` cleared post-rebuild.
 """
 
@@ -144,15 +144,15 @@ def test_no_rebuild_leaves_prompt_dirty_flag_untouched() -> None:
     assert stub._prompt_dirty is False
 
 
-def test_decomposition_hint_appended_when_rebuilding() -> None:
-    """If a decomposition hint exists, it's appended to the rebuilt
-    prompt with two newline separator (matches pre-refactor)."""
+def test_reflection_hint_applied_when_rebuilding() -> None:
+    """If a reflection hint exists, the rebuild re-applies it.
+    (2026-07-29: was ``decomposition_hint``, whose plumbing was deleted.)"""
     stub = _StubLoop(sync_returns_drifted=True)
     result = _call_helper(stub, "ORIGINAL", "HINT_TEXT")
     assert result == "REBUILT_PROMPT\n\nHINT_TEXT"
 
 
-def test_decomposition_hint_none_not_appended() -> None:
+def test_reflection_hint_none_not_applied() -> None:
     """No hint = no append (no ``None`` string concatenation
     accident)."""
     stub = _StubLoop(sync_returns_drifted=True)
@@ -161,7 +161,7 @@ def test_decomposition_hint_none_not_appended() -> None:
     assert "None" not in result
 
 
-def test_decomposition_hint_ignored_when_not_rebuilding() -> None:
+def test_reflection_hint_ignored_when_not_rebuilding() -> None:
     """If no rebuild happens, the hint doesn't matter — original
     prompt returned unchanged."""
     stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=False)

--- a/tests/core/llm/test_adapter_max_retries.py
+++ b/tests/core/llm/test_adapter_max_retries.py
@@ -46,9 +46,10 @@ def test_codex_oauth_builder_pins_max_retries_zero() -> None:
 
 
 def test_legacy_openai_provider_singleton_pins_max_retries_zero() -> None:
-    """Legacy ``core/llm/providers/openai.py`` singleton is still consumed by
-    paperclip ``OpenAIAdapter`` + llm_extract_learning + models.py — same
-    spinning risk if SDK retry compounds with app retry."""
+    """``core/llm/providers/openai.py`` singleton is still consumed by
+    ``core/llm/provider_dispatch.py`` — same spinning risk if SDK retry
+    compounds with app retry. (2026-07-29: the previously-named
+    ``OpenAIAdapter`` / ``models.py`` consumers no longer exist.)"""
     src = (
         Path(__file__).resolve().parents[3] / "core" / "llm" / "providers" / "openai.py"
     ).read_text(encoding="utf-8")

--- a/tests/core/llm/test_loop_pollution_guardrails.py
+++ b/tests/core/llm/test_loop_pollution_guardrails.py
@@ -250,21 +250,19 @@ def test_builtin_adapters_with_get_client_use_loop_affine_cache() -> None:
 
 
 def test_provider_async_clients_are_per_loop(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The provider-level getters (main agentic path — crosses the gateway
-    main loop and the CLIPoller loop) must ALL be loop-affine. Covers
-    anthropic + openai + glm (Codex MCP review 2026-06-12 — the original
-    pin only exercised anthropic)."""
-    from core.llm.providers import anthropic as anthropic_provider
-    from core.llm.providers import glm as glm_provider
-    from core.llm.providers import openai as openai_provider
+    """Every LIVE provider-level async getter must be loop-affine.
 
-    monkeypatch.setattr(anthropic_provider, "_resolve_anthropic_key", lambda: "test-key")
-    monkeypatch.setattr(openai_provider, "_resolve_openai_key", lambda: "test-key")
+    2026-07-29: the anthropic/openai provider getters were deleted — their
+    only caller was the legacy adapter pair removed in v1.0.4, and
+    Anthropic/OpenAI traffic now builds clients in ``core/llm/adapters``
+    (covered by ``test_all_registry_adapters_use_loop_affine_cache`` above).
+    GLM's getter is still consumed directly (``core/tools/computer_grounding``)
+    so the provider-level pin survives for it."""
+    from core.llm.providers import glm as glm_provider
+
     monkeypatch.setattr(glm_provider, "_resolve_glm_endpoint", lambda: ("test-key", "https://e"))
 
     getters = [
-        (anthropic_provider._async_clients, anthropic_provider.get_async_anthropic_client),
-        (openai_provider._async_openai_clients, openai_provider._get_async_openai_client),
         (glm_provider._async_glm_clients, glm_provider._get_async_glm_client),
     ]
     for cache, getter in getters:

--- a/tests/core/llm/test_loop_pollution_guardrails.py
+++ b/tests/core/llm/test_loop_pollution_guardrails.py
@@ -255,7 +255,8 @@ def test_provider_async_clients_are_per_loop(monkeypatch: pytest.MonkeyPatch) ->
     2026-07-29: the anthropic/openai provider getters were deleted — their
     only caller was the legacy adapter pair removed in v1.0.4, and
     Anthropic/OpenAI traffic now builds clients in ``core/llm/adapters``
-    (covered by ``test_all_registry_adapters_use_loop_affine_cache`` above).
+    (covered by ``test_builtin_adapters_with_get_client_use_loop_affine_cache``
+    above).
     GLM's getter is still consumed directly (``core/tools/computer_grounding``)
     so the provider-level pin survives for it."""
     from core.llm.providers import glm as glm_provider

--- a/tests/core/llm/test_provider_symbol_liveness.py
+++ b/tests/core/llm/test_provider_symbol_liveness.py
@@ -1,0 +1,58 @@
+"""Cross-module symbol liveness for the low-level provider layer.
+
+2026-07-29 incident: a legacy-prune pass deleted
+``providers.anthropic._async_response_hook`` as an apparent orphan. It is in
+fact consumed by ``adapters._anthropic_common.build_async_anthropic_client``
+through a **lazy in-function import**, which neither ruff nor mypy resolves —
+every Anthropic subscription call would have died with ImportError at runtime,
+and no unit test touched the path. These pins exercise the real builders.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_ADAPTERS = _REPO / "core" / "llm" / "adapters"
+
+
+def test_anthropic_async_client_builder_constructs() -> None:
+    """The live async client builder must import + run end to end."""
+    from core.llm.adapters._anthropic_common import build_async_anthropic_client
+
+    client = build_async_anthropic_client(auth_token="probe-token")
+    assert type(client).__name__ == "AsyncAnthropic"
+
+
+def test_lazy_provider_imports_in_adapters_all_resolve() -> None:
+    """Every ``from core.llm.providers.X import Y`` inside adapters — including
+    the in-function (lazy) ones — must resolve. This is the check that would
+    have caught the prune incident."""
+    import importlib
+
+    missing: list[str] = []
+    for path in sorted(_ADAPTERS.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or not node.module:
+                continue
+            if not node.module.startswith("core.llm.providers"):
+                continue
+            module = importlib.import_module(node.module)
+            for alias in node.names:
+                if not hasattr(module, alias.name):
+                    missing.append(f"{path.name}: {node.module}.{alias.name}")
+    assert not missing, f"adapters import provider symbols that no longer exist: {missing}"
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    ["_feed_banner_from_anthropic_response", "_build_httpx_limits", "_build_httpx_timeout"],
+)
+def test_provider_helpers_consumed_by_adapters_exist(symbol: str) -> None:
+    import core.llm.providers.anthropic as anthropic_provider
+
+    assert hasattr(anthropic_provider, symbol)


### PR DESCRIPTION
## Summary
- v1.0.4/v1.0.5의 레거시 삭제가 **실제로 완결됐는지** 재점검했다. 결과: 삭제 선언 심볼의 실행 코드 잔존은 0이었으나, 삭제로 **새로 고아가 된 심볼 5개**와 stale 서술 5개소가 남아 있었다.
- 재점검 중 **실사고 1건을 만들고 잡았다**: 고아로 오판해 지운 `_async_response_hook`이 실은 adapters의 **함수 내 lazy import** 소비자였고, ruff·mypy·유닛테스트 전부 이를 못 잡았다. 복원 + 재발 가드 신설.

## Why
`ClaudeAgenticAdapter`/`OpenAIAdapter` 삭제 후 provider 층의 async 클라이언트 빌더는 소비자가 사라졌지만 코드는 남아 있었다. 반대로 일부 주석은 삭제된 심볼을 *현재 소비자*로 계속 서술해 CLAUDE.md의 grep-provable 규칙을 위반했다.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` | `get_async_anthropic_client`·`areset_clients`·`_async_clients` 제거(소비자 0). 모듈 독스트링을 실태(저수준 유틸 층)로 재작성, `ClaudeAgenticAdapter` 섹션 헤더 개명, 고아 캐시 주석 삭제. **`_async_response_hook`은 유지** — adapters lazy import 소비자 명시 주석 추가 |
| `core/llm/providers/openai.py` | `_get_async_openai_client`·`_async_openai_clients` 제거. 싱글턴 독스트링이 지목하던 소비자(삭제된 `OpenAIAdapter`/부재 `models.py`)를 실제 소비자 `provider_dispatch`로 정정 |
| `tests/core/llm/test_provider_symbol_liveness.py` | **신규 가드** — adapters/*.py AST를 걸어 `core.llm.providers` import를 전수(lazy 포함) 해석 + 실제 async client 생성. 사고 재현(hook 재삭제)으로 FAIL 확인 |
| `tests/core/llm/test_loop_pollution_guardrails.py` | provider-level 핀을 생존 대상(GLM — `computer_grounding`이 직접 소비)으로 축소, 사유 명시. 형제 테스트명 정정 |
| `tests/core/agent/test_arun_model_drift_sync.py` | 삭제된 `decomposition_hint`를 현재형으로 서술하던 독스트링+테스트 함수명 3개를 `reflection_hint`(실제 대상)로 개명 |
| `tests/core/llm/test_adapter_max_retries.py` | 동일 stale 소비자 서술 정정 |
| `docs/plans/2026-07-29-legacy-residue-recheck.md` | 재점검 원장(R1-R11): bash 증거·고아 census·사고 기록·Codex 판정 |

## Verification
- [x] ruff check/format·mypy(538)·lint-imports·bandit·architecture baseline/exceptions — clean
- [x] llm+agent 스위트 0 fail
- [x] **가드의 가드**: hook을 다시 지워 사고를 재현하면 신규 테스트 2종이 FAIL, 복원하면 PASS
- [x] 런타임 증명: `build_async_anthropic_client(auth_token=...)` → `AsyncAnthropic` 생성 확인
- [x] Codex(gpt-5.6-sol high) 2라운드 — R1 FAIL(stale 서술 4건, 감사 결론 부정확) 전건 정정 후 **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)