### PR TITLE
release: v1.0.6 — 레거시 삭제 재점검·lazy-import 가드

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-07-29
+
+> Legacy-removal recheck: orphaned async provider clients pruned, and a lazy-import liveness guard added after a near-miss where deleting an apparent orphan would have broken every Anthropic subscription call at runtime (ruff, mypy, and the unit suite all missed it).
+
 ### Removed
 
 - **Orphaned async provider-client chain deleted.** `providers.anthropic`'s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.5
+- **Version**: 1.0.6
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.5 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.6 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.5: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.6: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.5"
+version = "1.0.6"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.5. Last sync 2026-07-28. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.6. Last sync 2026-07-29. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.5. Last sync 2026-07-28. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.6. Last sync 2026-07-29. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-28
+ * Last sync: 2026-07-29
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Removed\n\n- **Orphaned async provider-client chain deleted.** `providers.anthropic`'s\n  `get_async_anthropic_client` / `areset_clients` / its loop-affine cache and\n  `providers.openai`'s `_get_async_openai_client` / cache had zero production\n  consumers after the v1.0.4 legacy-adapter removal — Anthropic and OpenAI\n  traffic builds clients in `core/llm/adapters`. GLM's provider getter stays\n  (consumed by `core/tools/computer_grounding`), and the loop-affinity\n  guardrail was narrowed to it plus the adapter-level pin.\n\n### Fixed\n\n- **Lazy provider imports in adapters are now pinned.** A prune pass nearly\n  deleted `_async_response_hook`, which `build_async_anthropic_client`\n  imports *inside the function* — invisible to ruff and mypy, and untouched\n  by unit tests, so every Anthropic subscription call would have failed with\n  ImportError at runtime. A new liveness test walks the adapters' AST and\n  resolves every `core.llm.providers` import (lazy ones included) and\n  constructs the real async client; it was verified to fail on a replay of\n  the incident. Two docstrings naming since-deleted consumers of the OpenAI\n  client singleton were corrected to the live one (`provider_dispatch`)."
+    "body": ""
+  },
+  {
+    "version": "1.0.6",
+    "date": "2026-07-29",
+    "body": "> Legacy-removal recheck: orphaned async provider clients pruned, and a lazy-import liveness guard added after a near-miss where deleting an apparent orphan would have broken every Anthropic subscription call at runtime (ruff, mypy, and the unit suite all missed it).\n\n### Removed\n\n- **Orphaned async provider-client chain deleted.** `providers.anthropic`'s\n  `get_async_anthropic_client` / `areset_clients` / its loop-affine cache and\n  `providers.openai`'s `_get_async_openai_client` / cache had zero production\n  consumers after the v1.0.4 legacy-adapter removal — Anthropic and OpenAI\n  traffic builds clients in `core/llm/adapters`. GLM's provider getter stays\n  (consumed by `core/tools/computer_grounding`), and the loop-affinity\n  guardrail was narrowed to it plus the adapter-level pin.\n\n### Fixed\n\n- **Lazy provider imports in adapters are now pinned.** A prune pass nearly\n  deleted `_async_response_hook`, which `build_async_anthropic_client`\n  imports *inside the function* — invisible to ruff and mypy, and untouched\n  by unit tests, so every Anthropic subscription call would have failed with\n  ImportError at runtime. A new liveness test walks the adapters' AST and\n  resolves every `core.llm.providers` import (lazy ones included) and\n  constructs the real async client; it was verified to fail on a replay of\n  the incident. Two docstrings naming since-deleted consumers of the OpenAI\n  client singleton were corrected to the live one (`provider_dispatch`)."
   },
   {
     "version": "1.0.5",
@@ -2423,4 +2428,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-28";
+export const CHANGELOG_SYNCED_AT = "2026-07-29";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-28
+ * Last sync: 2026-07-29
  */
 
 export const GEODE_SOT = {
-  version: "1.0.5",
-  syncedAt: "2026-07-28",
+  version: "1.0.6",
+  syncedAt: "2026-07-29",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v1.0.6 릴리스 컷 — #2818(레거시 재점검: 고아 async 클라이언트 제거 + lazy-import liveness 가드, Codex 2라운드 PASS) 승격.

## Verification
- [x] architecture_baseline --check / check_llms_version — clean (v1.0.6)
- [x] uv run geode version — v1.0.6
- [x] 코드 게이트는 #2818에서 CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)