### PR TITLE
docs(roadmap): register hook surfaces and middleware closure

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -551,9 +551,8 @@ and closure evidence are appended in §10.
 | REL-002 | `ABSENT` | No registered gate prevents the v1.0.1 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.1, and every release inside that interval retained them | R8.0 | REL-001 | `OPEN` |
 | BND-007 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-002, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.1 | REL-002, STORE-003 | `OPEN` |
 | STORE-003 | `MISFIT` | Self-improving datasets span tracked `core/self_improving/state`, runtime `~/.geode/self-improving`, actively written `~/.geode/autoresearch/handoff`, and isolated `GEODE_STATE_ROOT/autoresearch` roots without one dataset-level ownership manifest | A feature-owned manifest declares every dataset's lifecycle, schema/version, root, writer/readers, concurrency, retention/redaction, migration, rollback, and rebuild contract; tracked SoT leaves `core` with hash/history parity, while runtime/override/worker roots remain compatible or migrate additively with one writer | R8.2 | REL-002, STORE-001 | `OPEN` |
-| HOOK-001 | `MISFIT` | The 56-member internal `HookEvent` enum is exported at the package root and one registry mixes observer, result-transform, and control-interceptor authority without a stable public allowlist | Exactly 13 versioned public hook contracts expose the Codex 11-event lifecycle plus `PreVerify`/`PostVerify`; typed authority, redaction, correlation, unknown-name rejection, and compatibility tests prevent internal RuntimeEvent growth from expanding the ABI | R6.4 | PROTO-001, STORE-001, TRUST-002 | `OPEN` |
+| HOOK-001 | `MISFIT` | The 56-member internal `HookEvent` enum is exported at the package root, one registry mixes observer, result-transform, and control-interceptor authority without a stable public allowlist, and verification is emitted only inside terminal finalization | Exactly 13 versioned `HookName` contracts expose the Codex 11-event lifecycle plus `PreVerify`/`PostVerify`; typed authority, redaction, correlation, unknown-name rejection, and compatibility tests prevent internal RuntimeEvent growth from expanding the ABI, while one monotone bounded `PreVerify` → verifier → `PostVerify` → `Stop` state machine supports executable external continuation without erasing built-in failure or replaying side effects | R6.4 | PROTO-001, STORE-001, TRUST-002, LOOP-003 | `OPEN` |
 | HOOK-002 | `PARTIAL` | Tool request interception is mixed with `TOOL_EXEC_STARTED`; no typed sequential tool/LLM request transform or async `next_call` chain wraps the accepted executor and provider call across every runtime path | `tool_request`, `tool_execution`, `llm_request`, and `llm_execution` are four typed join points with N→N+1 request composition, original/effective trace, single-use async `next_call`, exception identity, policy-before-execution ordering, and all-path parity tests | R6.4 | CAP-002, LOOP-003, LLM-003, HOOK-001 | `OPEN` |
-| HOOK-003 | `ABSENT` | Turn verification is persisted and emitted only inside terminal finalization, so no external policy can consume one immutable `VerifyResult` and request a bounded same-turn revision before delivery | One finalization state machine executes `PreVerify` → verifier → `PostVerify` → `Stop`; monotone decisions cannot erase built-in failures, retry/idempotency budgets prevent loops or side-effect replay, and a redacted correlated envelope drives an executable continuation test | R6.4 | LOOP-003, HOOK-001 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -1176,7 +1175,7 @@ uses descriptor-provided keys, not argument-name guessing.
 
 #### R6.4 Public hooks, middleware join points, and finalization control
 
-GAPs: HOOK-001, HOOK-002, HOOK-003.
+GAPs: HOOK-001, HOOK-002.
 
 The measured design evidence is carried by
 [#2832](https://github.com/mangowhoiscloud/geode/pull/2832), grounded against
@@ -1195,13 +1194,43 @@ PreVerify, PostVerify, Stop
 ```
 
 The 56 current runtime signals remain internal and retain their stored values.
-Public hook dispatch, trusted request/execution middleware, internal
-RuntimeEvent observation/persistence, and stateful domain services are separate
-planes. Unknown public names fail closed; a versioned JSON-safe schema fixes
-each hook's input, result, authority, redaction, timeout, composition, and
-correlation behavior.
+There are three authority surfaces, not four generic planes:
 
-The four middleware join points are roles, not enum-like extension kinds:
+- `HookName` + `HookRegistry` is the bounded public ABI;
+- `MiddlewareRegistry` owns the four trusted request/execution methods;
+- `RuntimeEvent` + `RuntimeEventBus` is internal observation and persistence.
+
+Stateful compaction, approval, subagent, and verification services remain
+domain owners rather than becoming a fourth extension surface. Unknown public
+names fail closed; a versioned JSON-safe schema fixes each hook's input, result,
+authority, redaction, timeout, composition, and correlation behavior.
+
+The canonical names are deliberately small. No `PublicHookRegistry`,
+`MiddlewarePipeline`, `MiddlewareKind`, `MiddlewarePoint`, or
+`ExtensionRuntime` abstraction is introduced. Request and execution role
+protocols consistently end in `Middleware`. The legacy names `HookEvent` and
+`HookSystem` migrate to `RuntimeEvent` and `RuntimeEventBus`; they are never
+reused for public-hook semantics.
+
+Migration is value-preserving:
+
+| Current surface | Canonical target | Compatibility rule |
+|---|---|---|
+| `HookEvent` / `HookSystem` | `RuntimeEvent` / `RuntimeEventBus` | legacy Python aliases for the declared migration window; stored enum values and rows never change |
+| observer `register` / `trigger*` | `subscribe` / `emit*` | move callers mechanically, keep sinks and prefix subscription internal |
+| `USER_INPUT_RECEIVED` interceptor | `HookName.USER_PROMPT_SUBMIT` | old row remains a legacy observation |
+| `TOOL_EXEC_STARTED` interceptor | `HookName.PRE_TOOL_USE` plus actual execution-start event | emit start only after policy and approval, immediately before the executor |
+| `TOOL_RESULT_TRANSFORM` feedback | `HookName.POST_TOOL_USE` | stop new compatibility-event writes; keep old-reader projection |
+| `CONTEXT_OVERFLOW_ACTION` feedback | typed compaction policy port | `PreCompact`/`PostCompact` surround the domain service, not its strategy selection |
+| per-turn `SESSION_STARTED/ENDED` | durable public session hooks plus internal turn boundaries | do not rewrite historical JSONL/SQLite rows |
+| verify result events | `PostVerify` input plus internal outcomes | preserve the immutable built-in result and stored outcome |
+
+Compatibility control APIs are removable only after production
+`trigger_interceptor*`/`trigger_with_result*` callers reach zero, the declared
+release window ends, and stored-reader fixtures still pass.
+
+The four middleware join points are methods on one registry, not enum-like
+extension kinds:
 
 - `tool_request`: immutable N→N+1 transformation before validation, policy,
   and approval;
@@ -1232,7 +1261,11 @@ Acceptance:
   prove that adding an internal RuntimeEvent does not change the public ABI;
 - all public payloads are bounded and redacted, unknown names are rejected,
   handler authority is type-specific, and compatibility fixtures cover the
-  previous `HookSystem` facade during its declared migration window;
+  previous `HookSystem` facade during its declared migration window without
+  ever reassigning `HookEvent` to public semantics;
+- production callers of `trigger_interceptor*` and `trigger_with_result*`
+  reach zero before those control APIs are removed, while stored-value and
+  historical-row fixtures remain readable;
 - request transforms prove N→N+1 order, immutable original input, invalid
   output rejection, and original/effective trace correlation;
 - execution chains prove onion order, single-use async `next_call`,

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -551,6 +551,9 @@ and closure evidence are appended in §10.
 | REL-002 | `ABSENT` | No registered gate prevents the v1.0.1 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.1, and every release inside that interval retained them | R8.0 | REL-001 | `OPEN` |
 | BND-007 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-002, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.1 | REL-002, STORE-003 | `OPEN` |
 | STORE-003 | `MISFIT` | Self-improving datasets span tracked `core/self_improving/state`, runtime `~/.geode/self-improving`, actively written `~/.geode/autoresearch/handoff`, and isolated `GEODE_STATE_ROOT/autoresearch` roots without one dataset-level ownership manifest | A feature-owned manifest declares every dataset's lifecycle, schema/version, root, writer/readers, concurrency, retention/redaction, migration, rollback, and rebuild contract; tracked SoT leaves `core` with hash/history parity, while runtime/override/worker roots remain compatible or migrate additively with one writer | R8.2 | REL-002, STORE-001 | `OPEN` |
+| HOOK-001 | `MISFIT` | The 56-member internal `HookEvent` enum is exported at the package root and one registry mixes observer, result-transform, and control-interceptor authority without a stable public allowlist | Exactly 13 versioned public hook contracts expose the Codex 11-event lifecycle plus `PreVerify`/`PostVerify`; typed authority, redaction, correlation, unknown-name rejection, and compatibility tests prevent internal RuntimeEvent growth from expanding the ABI | R6.4 | PROTO-001, STORE-001, TRUST-002 | `OPEN` |
+| HOOK-002 | `PARTIAL` | Tool request interception is mixed with `TOOL_EXEC_STARTED`; no typed sequential tool/LLM request transform or async `next_call` chain wraps the accepted executor and provider call across every runtime path | `tool_request`, `tool_execution`, `llm_request`, and `llm_execution` are four typed join points with N→N+1 request composition, original/effective trace, single-use async `next_call`, exception identity, policy-before-execution ordering, and all-path parity tests | R6.4 | CAP-002, LOOP-003, LLM-003, HOOK-001 | `OPEN` |
+| HOOK-003 | `ABSENT` | Turn verification is persisted and emitted only inside terminal finalization, so no external policy can consume one immutable `VerifyResult` and request a bounded same-turn revision before delivery | One finalization state machine executes `PreVerify` → verifier → `PostVerify` → `Stop`; monotone decisions cannot erase built-in failures, retry/idempotency budgets prevent loops or side-effect replay, and a redacted correlated envelope drives an executable continuation test | R6.4 | LOOP-003, HOOK-001 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -578,7 +581,10 @@ R3.1 starts after R2.1 so `StepSnapshot` consumes the new immutable `ToolPlan`
 rather than inventing a competing tool snapshot. The remaining R2 and R3
 packages may then progress in parallel. R5 and most of R6 may progress in
 parallel after the composition root is stable, but R6.3 waits for R5.2 because
-its unified extension lifecycle includes LLM-adapter discovery.
+its unified extension lifecycle includes LLM-adapter discovery. R6.4 begins
+only after its public projection, lifecycle store, trust boundary, tool plan,
+loop phase, and provider-profile dependencies have landed; it does not use a
+hook facade to bypass those owners.
 
 ### 6.1 v1.0.1 boundary-release train
 
@@ -1167,6 +1173,85 @@ bypass the broker to obtain filesystem, network, credential, or runtime-global
 authority. Startup reports collisions, rejected manifests, missing capability
 grants, and degraded extensions. Teardown is deterministic. Resource mutation
 uses descriptor-provided keys, not argument-name guessing.
+
+#### R6.4 Public hooks, middleware join points, and finalization control
+
+GAPs: HOOK-001, HOOK-002, HOOK-003.
+
+The measured design evidence is carried by
+[#2832](https://github.com/mangowhoiscloud/geode/pull/2832), grounded against
+Hermes `36e41c09ed02bd783c1186564bf08cca5c8e821d`, OpenClaw
+`90a22b4f50226b13735e77dde81a92340ae724cf`, and Codex
+`578c1b2230288104041e880a86d0f7f3a5ca6e47`. This section remains the
+execution SOT. The public ABI contains exactly:
+
+```text
+UserPromptSubmit
+PreToolUse, PermissionRequest, PostToolUse
+PreCompact, PostCompact
+SessionStart, SessionEnd
+SubagentStart, SubagentStop
+PreVerify, PostVerify, Stop
+```
+
+The 56 current runtime signals remain internal and retain their stored values.
+Public hook dispatch, trusted request/execution middleware, internal
+RuntimeEvent observation/persistence, and stateful domain services are separate
+planes. Unknown public names fail closed; a versioned JSON-safe schema fixes
+each hook's input, result, authority, redaction, timeout, composition, and
+correlation behavior.
+
+The four middleware join points are roles, not enum-like extension kinds:
+
+- `tool_request`: immutable N→N+1 transformation before validation, policy,
+  and approval;
+- `tool_execution`: async onion around the accepted exactly-once executor only;
+- `llm_request`: immutable N→N+1 transformation of the assembled adapter
+  request while preserving prompt-cache invariants;
+- `llm_execution`: async onion around the actual provider call.
+
+Every parallel, sequential, MCP, recovered, deferred, subagent, and retry path
+uses the same terminal. Execution middleware cannot wrap or weaken hard policy
+and approval. It receives the effective accepted payload, may call its
+`next_call` at most once, and preserves downstream exception identity. Original
+and effective payload hashes plus extension provenance are observable without
+persisting secrets or unrestricted content.
+
+Verification and stopping are three checkpoints in one internal finalization
+state machine, not three competing dispatch pipelines. `PreVerify` can add
+requirements, the built-in verifier creates one immutable `VerifyResult`,
+`PostVerify` can accept, strengthen to revision, or escalate but cannot turn a
+failure into a pass, and `Stop` controls only final delivery versus bounded
+continuation. Continuation appends a correlated follow-up; it never rewinds or
+replays a successful side effect. Attempt and idempotency budgets close the
+loop.
+
+Acceptance:
+
+- generated schema and round-trip fixtures pin exactly 13 public names and
+  prove that adding an internal RuntimeEvent does not change the public ABI;
+- all public payloads are bounded and redacted, unknown names are rejected,
+  handler authority is type-specific, and compatibility fixtures cover the
+  previous `HookSystem` facade during its declared migration window;
+- request transforms prove N→N+1 order, immutable original input, invalid
+  output rejection, and original/effective trace correlation;
+- execution chains prove onion order, single-use async `next_call`,
+  short-circuit semantics, cancellation, timeout/failure policy, exception
+  identity, and exactly one accepted terminal call across every tool and LLM
+  path;
+- tool tests prove transformed final arguments are revalidated and approved,
+  hard denial cannot be weakened, blocked calls never emit execution-start,
+  and start/end/error outcomes have exact cardinality;
+- LLM tests prove request replacement reaches the adapter, retry correlation is
+  stable, and system prompt/history/tool cache prefixes cannot change without
+  an explicit capability and invalidation trace;
+- lifecycle fixtures distinguish durable session generation from turn and
+  step, pair runtime-owned compaction boundaries honestly, and preserve
+  SQLite-as-SOT/JSONL-as-projection behavior from R6.2;
+- finalization fixtures prove monotone verify composition, built-in
+  fail-to-pass rejection, bounded revise and Stop continuation, no side-effect
+  replay, timeout fallback, external evidence correlation, and final
+  persistence/delivery ordering.
 
 ### R7 — Closure, hardening, and release
 


### PR DESCRIPTION
## Summary
- Register one roadmap-only R6.4 closure package with two OPEN gaps: HOOK-001 for the 13-hook ABI plus verify/finalization, and HOOK-002 for four middleware join points.
- Fix the canonical naming to HookName/HookRegistry, MiddlewareRegistry, and RuntimeEvent/RuntimeEventBus.
- Add a value-preserving migration map and explicitly reject redundant plan-only abstractions.

## Why
The current 56-member HookEvent surface mixes public callbacks, interceptors, lifecycle facts, and internal telemetry. Tool request control is mixed with TOOL_EXEC_STARTED, tool/LLM execution has no typed async next_call seam, and VerifyResult cannot drive bounded external continuation before delivery.

This revision also prevents scope reduction from fragmenting names: finalization is part of the public hook contract instead of a third GAP, domain services remain owners rather than a fourth generic plane, and legacy HookEvent is never reused for public semantics.

## Changes
| File | Change |
|---|---|
| docs/architecture/extensibility-roadmap.md | Register two OPEN GAP rows, define the three authority surfaces, consolidate verify/finalization into HOOK-001, and add the compatibility migration map. |

## GAP Audit
| GAP | Audit | Current evidence | Exit direction |
|---|---|---|---|
| HOOK-001 | MISFIT | Internal HookEvent is exported wholesale; one registry mixes observer, transform, and control authority; verify is terminal-only. | Exactly 13 versioned hooks plus one monotone bounded PreVerify → verifier → PostVerify → Stop state machine. |
| HOOK-002 | PARTIAL | TOOL_EXEC_STARTED doubles as request interception; no four typed request/execution middleware join points exist. | One MiddlewareRegistry with sequential request transforms and single-use async execution chains across all paths. |

## Ledger invariants
| Invariant | Result |
|---|---|
| Existing canonical GAP IDs/order/statuses | Preserved |
| New IDs | HOOK-001/002 unique and appended |
| Package selection | Both selected exactly once by R6.4 |
| Dependency existence/acyclicity | Passed |
| Active claims | Unchanged; R6.4 remains unclaimed and OPEN |
| Status transition | None |

## Verification
- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request
- uv run pytest tests/scripts/test_check_architecture_roadmap.py -q (40 passed)
- uv run python scripts/architecture_baseline.py --check
- git diff --check
- commit-time pre-commit hooks for the changed roadmap
