### PR TITLE
fix(eval): honor dynamic tool schemas during dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark-owned dynamic tool schemas now take precedence over same-named
+  built-in schemas during execution validation, so MCPMark filesystem tools
+  accept their native `path` contract and τ² tools cannot be rejected by an
+  unrelated GEODE definition before reaching the benchmark environment.
+
 ## [1.0.9] - 2026-07-31
 
 > Public extension control is now a small, versioned hook ABI backed by

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -129,6 +129,7 @@ class ToolExecutor:
         hooks: HookSystem | None = None,
         hook_registry: HookRegistry | None = None,
         middleware_registry: MiddlewareRegistry | None = None,
+        tool_input_schemas: dict[str, dict[str, Any]] | None = None,
         # (tool_name, detail, safety_level[, approval_id]) -> decision char.
         # 4-arg callbacks receive the ApprovalRecord id for reply matching;
         # legacy 3-arg callbacks are detected and called without it.
@@ -160,6 +161,7 @@ class ToolExecutor:
             middleware_registry = _MiddlewareRegistry(events=hooks)
         self._hook_registry = hook_registry
         self._middleware_registry = middleware_registry
+        self._tool_input_schemas = dict(tool_input_schemas or {})
         self._approval_callback = approval_callback
         self._interactive_approval = interactive_approval
 
@@ -586,20 +588,21 @@ class ToolExecutor:
         except Exception:
             return HookCorrelation()
 
-    @staticmethod
-    def _validate_tool_input(tool_name: str, tool_input: dict[str, Any]) -> str:
-        """Validate known tool inputs; dynamic MCP schemas stay server-owned."""
-        try:
-            from jsonschema import Draft202012Validator
+    def _validate_tool_input(self, tool_name: str, tool_input: dict[str, Any]) -> str:
+        """Validate against a caller-owned schema before the built-in fallback."""
+        from jsonschema import Draft202012Validator
 
-            from core.tools.base import load_tool_definition
+        schema = self._tool_input_schemas.get(tool_name)
+        if schema is None:
+            try:
+                from core.tools.base import load_tool_definition
 
-            schema = load_tool_definition(tool_name).get("input_schema", {})
-        except KeyError:
-            return ""
-        except Exception as exc:
-            log.warning("Tool schema lookup failed for %s: %s", tool_name, exc)
-            return ""
+                schema = load_tool_definition(tool_name).get("input_schema", {})
+            except KeyError:
+                return ""
+            except Exception as exc:
+                log.warning("Tool schema lookup failed for %s: %s", tool_name, exc)
+                return ""
         errors = sorted(
             Draft202012Validator(schema).iter_errors(tool_input),
             key=lambda error: tuple(str(part) for part in error.path),

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -284,9 +284,9 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 535 |
 | Test Python files | 678 |
-| `core/` Python LOC | 134,481 |
-| `plugins/` Python LOC | 40,265 |
-| Test Python LOC | 176,177 |
+| `core/` Python LOC | 134,484 |
+| `plugins/` Python LOC | 40,302 |
+| Test Python LOC | 176,239 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/plugins/benchmark_harness/mcpmark_geode_agent.py
+++ b/plugins/benchmark_harness/mcpmark_geode_agent.py
@@ -14,7 +14,10 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.hooks.middleware import ToolCallRequest
 
 
 def _jsonish(value: Any) -> str:
@@ -73,6 +76,18 @@ class MCPMarkGeodeTool:
         return {"result": _jsonish(result)}
 
 
+@dataclass
+class _MCPMarkArgumentNormalizer:
+    schemas: dict[str, dict[str, Any]]
+
+    async def tool_request(self, request: ToolCallRequest) -> ToolCallRequest:
+        schema = self.schemas.get(request.tool_name)
+        if schema is None:
+            return request
+        arguments = _normalize_tool_arguments(schema, dict(request.arguments))
+        return request.with_arguments(arguments)
+
+
 def _build_loop(
     *,
     tools: list[MCPMarkGeodeTool],
@@ -86,6 +101,7 @@ def _build_loop(
     from core.agent.conversation import ConversationContext
     from core.agent.loop import AgenticLoop
     from core.agent.tool_executor import ToolExecutor
+    from core.hooks.middleware import MiddlewareRegistry
     from core.llm.adapters.registry import bootstrap_builtins
     from core.tools.registry import ToolRegistry
 
@@ -97,7 +113,19 @@ def _build_loop(
         registry.register(tool)
         handlers[tool.name] = tool.aexecute
 
-    executor = ToolExecutor(action_handlers=handlers, auto_approve=True, hitl_level=0)
+    schemas = {tool.name: tool.schema for tool in tools}
+    middleware = MiddlewareRegistry()
+    middleware.register_tool_request(
+        _MCPMarkArgumentNormalizer(schemas),
+        name="mcpmark-argument-normalizer",
+    )
+    executor = ToolExecutor(
+        action_handlers=handlers,
+        auto_approve=True,
+        hitl_level=0,
+        middleware_registry=middleware,
+        tool_input_schemas={tool.name: tool.parameters for tool in tools},
+    )
     return AgenticLoop(
         ConversationContext(max_turns=200),
         executor,

--- a/plugins/benchmark_harness/tau2_geode_agent.py
+++ b/plugins/benchmark_harness/tau2_geode_agent.py
@@ -224,7 +224,16 @@ def _build_loop(
         tool_registry.register(wrapped)
         handlers[wrapped.name] = wrapped.aexecute
 
-    executor = ToolExecutor(action_handlers=handlers, auto_approve=True, hitl_level=0)
+    executor = ToolExecutor(
+        action_handlers=handlers,
+        auto_approve=True,
+        hitl_level=0,
+        tool_input_schemas={
+            name: registered.parameters
+            for name in handlers
+            if (registered := tool_registry.get(name)) is not None
+        },
+    )
     allowed_tool_names = set(handlers)
     return AgenticLoop(
         ConversationContext(max_turns=200),

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -26,7 +26,7 @@
         "benchmark",
         "tool-projection"
       ],
-      "contentSha256": "0ad48f845a2eb6de47d7214e4f232f3e123a3b9037bd6ea7f07984ec74e3e9d2"
+      "contentSha256": "3921da35f3d45931a55a55ff9b6b716ec5fbcb8b7d4e22c5f88acb631fc2a12a"
     },
     {
       "id": "file:plugins/benchmark_harness/tau2_turn_supervisor.py",

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -514,15 +514,15 @@
   "packages": {
     "core": {
       "python_files": 426,
-      "python_loc": 134481
+      "python_loc": 134484
     },
     "plugins": {
       "python_files": 109,
-      "python_loc": 40265
+      "python_loc": 40302
     },
     "tests": {
       "python_files": 678,
-      "python_loc": 176177
+      "python_loc": 176239
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Fixed\n\n- Benchmark-owned dynamic tool schemas now take precedence over same-named\n  built-in schemas during execution validation, so MCPMark filesystem tools\n  accept their native `path` contract and τ² tools cannot be rejected by an\n  unrelated GEODE definition before reaching the benchmark environment."
   },
   {
     "version": "1.0.9",

--- a/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
+++ b/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
@@ -1,14 +1,76 @@
+import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 from plugins.benchmark_harness.mcpmark_geode_agent import (
+    MCPMarkGeodeTool,
+    _build_loop,
     _github_repo_visibility,
     _normalize_tool_arguments,
     _patch_mcpmark_github_visibility,
     _route_from_model,
     register_mcpmark_agent,
 )
+
+
+def test_mcpmark_loop_validates_colliding_tool_with_mcp_schema() -> None:
+    class MCPServer:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call_tool(self, name: str, arguments: dict[str, object]) -> str:
+            self.calls.append((name, arguments))
+            return "ok"
+
+    server = MCPServer()
+    tool = MCPMarkGeodeTool(
+        mcp_server=server,
+        schema={
+            "name": "write_file",
+            "description": "MCP filesystem writer",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    )
+    loop = _build_loop(
+        tools=[tool],
+        instruction="write the answer",
+        model="gpt-5.6-sol",
+        provider="openai",
+        source="subscription",
+        effort="high",
+        timeout=30,
+    )
+
+    result = asyncio.run(
+        loop.executor.aexecute(
+            "write_file",
+            {"path": "fixture/answer.txt", "content": "answer"},
+        )
+    )
+    compatibility_result = asyncio.run(
+        loop.executor.aexecute(
+            "write_file",
+            {"file_path": "fixture/compatibility.txt", "content": "compatibility"},
+        )
+    )
+
+    assert result == {"result": "ok"}
+    assert compatibility_result == {"result": "ok"}
+    assert server.calls == [
+        ("write_file", {"path": "fixture/answer.txt", "content": "answer"}),
+        (
+            "write_file",
+            {"path": "fixture/compatibility.txt", "content": "compatibility"},
+        ),
+    ]
 
 
 def test_route_from_geode_model_label() -> None:


### PR DESCRIPTION
## Summary

- Validate benchmark-owned dynamic tools against the same JSON Schema exposed to the model.
- Preserve MCPMark compatibility normalization before validation through the trusted `tool_request` boundary.
- Wire both MCPMark and τ² adapters without changing built-in tool validation or safety gates.

## Why

The post-v1.0.9 MCPMark filesystem smoke found the correct answer but could not
write `answer.txt`: the model-visible MCP schema required `path`, while
`ToolExecutor` reloaded GEODE's same-named built-in `write_file` schema and
required `file_path`. This was infrastructure contamination, not a benchmark
score.

## GAP Audit

| Surface | Before | Resolution |
|---|---|---|
| Model-visible dynamic schema | Existing | Reused unchanged |
| Executor validation for unknown dynamic names | Existing | Unchanged server-owned fallback |
| Executor validation for same-named dynamic tools | Partial | Explicit caller-owned schema wins |
| MCPMark `file_path` / empty cursor compatibility | Existing but ordered too late | Normalize at `tool_request`, then validate |
| τ² same-name collision protection | Partial | Pass wrapper schemas to the executor |

## Changes

| File | Change |
|---|---|
| `core/agent/tool_executor/executor.py` | Accept optional per-tool input schemas with built-in fallback |
| `plugins/benchmark_harness/mcpmark_geode_agent.py` | Normalize requests before dynamic validation and pass MCP schemas |
| `plugins/benchmark_harness/tau2_geode_agent.py` | Pass τ² wrapper schemas |
| `tests/plugins/benchmark_harness/test_mcpmark_adapter.py` | Cover both native `path` and compatibility `file_path` through dispatch |
| Generated consumers | Refresh source attestation, architecture inventory, and public changelog data |

## Verification

- MCPMark and τ² adapter tests: pass.
- Tool executor, agent loop, forced-tool-policy, benchmark harness, source
  attestation, and architecture snapshot tests: pass.
- Ruff lint/format, mypy, import contracts, repo hygiene, architecture baseline,
  and `git diff --check`: pass.
- Full non-live suite initially identified the two generated-consumer drifts now
  fixed. Its remaining doctor assertion was caused by running through another
  checkout's virtualenv; the same assertion passes in this worktree's own
  environment and in the clean v1.0.9 worktree.
- Independent GPT-5.6 review found one P1 ordering regression. Fixed by moving
  compatibility normalization to `tool_request`; focused re-review: no findings.
- Subscription-backed MCPMark filesystem smoke on the fixed source: official
  verifier **1/1**, 81.2 s, 5 turns, 32,527 input tokens, 1,743 output tokens,
  8,704 cache-read tokens, recorded cost $0.175757.

The measured MCPMark and τ² benchmark runs follow on the merged source after CI.
