### PR TITLE
docs(eval): publish GPT-5.6 benchmark results

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -2,7 +2,7 @@
 
 > Action/tool-execution 4종 벤치마크. GEODE의 quality ratchet(P4)에 통합 예정.
 > 각 문서는 **사례 + 필요 인프라 + 4-Phase 진행 시나리오**를 담음.
-> 마지막 갱신: 2026-07-13
+> 마지막 갱신: 2026-07-31
 
 ## Raw artifact repository
 
@@ -19,6 +19,15 @@ The latest runtime-contract record is the immutable
 13/13 public hooks, 4/4 trusted middleware join points, and matching 22-row
 SQLite/JSONL extension projections. It is a release-validation probe, not a
 scored benchmark.
+
+The latest scored behavior record is pinned to artifact commit
+[`9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49):
+MCPMark filesystem/easy **9/10**, tau2 mock **0/1**, and one Telecom-small
+task **0/1** on GEODE `edb74602b` with `gpt-5.6-sol` subscription / effort
+`high`. The
+[run report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/9c00ecf4a3b5a68ee65db9afe185b2271da46b49/reports/e2e-validation/2026-07-31-gpt56-benchmark.md)
+links raw receipts and twelve normalized tool/dialogue trajectories. The two
+tau2 failures are behavioral evidence, not provider or adapter failures.
 
 ## 채택 4종
 
@@ -50,8 +59,8 @@ Telecom small run 이후로 둔다.
 
 | 순위 | 벤치 | 첫 목표 | 완료 기준 |
 |---:|---|---|---|
-| 1 | MCPMark Verified | available local standard services, then blocked services as infra follow-up | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
-| 2 | τ²-bench | `mock` smoke with `geode_agent` + `geode_user` over subscription, then Telecom small run; native tau2 `gpt-4.1` / `gpt-5.2` user-simulator runs are optional comparator tracks | tau2 result directory와 domain split을 보존하고, user route / trial 수를 public page에 명시 |
+| 1 | MCPMark Verified | 완료: available standard 64/74; 2026-07-31 filesystem/easy 재측정 9/10 | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
+| 2 | τ²-bench | 완료: `mock` 0/1 + Telecom small 1-task 0/1, `geode_agent` + `geode_user` subscription | tau2 result directory와 domain split을 보존하고, user route / trial 수를 public page에 명시 |
 | 3 | BFCL V4 | Agentic subset first | native/prompt function-calling route와 aggregation을 고정한 뒤 result/score artifact 보존 |
 | 4 | HAL Reliability | tau-bench airline single-rerun smoke | τ² adapter 재사용 여부와 rerun consistency schema 확인 |
 | 5 | Terminal-Bench 2.0 | 1-task Docker/tmux smoke | post-run test artifact와 shell transcript 보존 |
@@ -132,6 +141,7 @@ Verified 다음에 τ²-bench를 둔다.
 
 | 일자 | 변경 |
 |---|---|
+| 2026-07-31 | GEODE `edb74602b` / GPT-5.6 subscription `high` 측정: MCPMark filesystem/easy 9/10, tau2 mock 0/1, Telecom-small 1-task 0/1. Raw receipts와 12개 정규화 trajectory를 artifact commit `9c00ecf`에 게시 |
 | 2026-07-10 | MCPMark blocked 사례 해소: notion 세션 만료 원인 확정·재발급 후 easy smoke 1/1, github `GITHUB_EVAL_ORG` 영속화(State Duplication Error 6건 원인 제거), postgres 컨테이너 복구, `--agent geode` 커밋 런처 추가, playwright 실행 준비 확인. 잔여 blocked=`playwright_webarena`(WebArena 이미지 ~100GB, 로컬 디스크 초과). Agent-World 비교 런북 추가 |
 | 2026-07-03 | 남은 벤치마크 측정 큐를 추가하고 `tau2-bench`를 2순위로 승격 |
 | 2026-07-04 | MCPMark standard available-services run 추가: filesystem 25/30, postgres 20/21, github 19/23, measured total 64/74 |

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -34,6 +34,15 @@ runtime checkpoints, provider reasoning, SQLite/WAL, JSONL, usage, and
 diagnostic files remain withheld. Its manifest supersedes the first run
 without deleting or rewriting that append-only record.
 
+The 2026-07-31 GPT-5.6 benchmark publication is pinned to artifact commit
+[`9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49).
+It contains masked MCPMark and tau2 receipts plus twelve normalized
+dialogue/tool trajectories. Manifest directory digests are
+`b86f5071cbe0` (MCPMark) and `4ec1c13434d1` (tau2). Runtime homes, session
+SQLite, JSONL mirrors, hidden reasoning, and credential files remain
+withheld. Local usernames and synthetic telecom personal fields are redacted
+in the public copies.
+
 Still in the GEODE repository after the 2026-07-13 migration: the live
 `docs/audits/eval-logs/` manifest ledger (`core/audit/manifest.py` appends to
 it on every `geode audit --live`), the code-referenced

--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -520,6 +520,40 @@ Interpretation:
 - Token usage averages 26,678 tokens per task. The run is suitable as a
   smoke/regression baseline, but not as a cost-efficient CI gate.
 
+### Live GEODE MCPMark Filesystem Easy — GPT-5.6
+
+Run date: 2026-07-31. Revision:
+`edb74602bb2e1e4d627cb6aa1f0b94072a57da62`; harness:
+`eval-sys/mcpmark@cd45b7f`.
+
+| Field | Value |
+|---|---|
+| Suite | `MCPMark filesystem/easy` |
+| Model route | GEODE `gpt-5.6-sol`, provider `openai-codex`, source `subscription` |
+| Reasoning effort | `high` |
+| Passed | 9 / 10 |
+| Success rate | 90.0% |
+| Total / average task time | 799.435s / 79.943s |
+| Turns | 54 total / 5.4 average |
+| Usage | 799,679 input / 10,976 output / 97,792 cache-read |
+| Recorded estimate | $3.887611; not subscription billing |
+
+The sole failure was `file_context__uppercase`: all five output files existed,
+but `file_01.txt` was not completely uppercased. It is an official verifier
+failure, not a schema, quota, or adapter failure. A response stream disconnected
+once after `file_splitting` had produced its output; that task passed all
+official integrity checks. No 429 occurred.
+
+The upstream `summary.json` reports `total_tokens=0` and
+`total_reasoning_tokens=0` despite populated input/output usage. Those two
+aggregate fields are treated as an upstream accounting mismatch and are not
+used.
+
+Raw receipts and ten normalized tool trajectories are pinned at
+[`geode-eval-artifacts@9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49),
+including the content-addressed
+[`b86f5071cbe0` trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/9c00ecf4a3b5a68ee65db9afe185b2271da46b49/trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0).
+
 ### Live GEODE MCPMark Verified Available Services
 
 Run date: 2026-07-04.

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -188,8 +188,9 @@ Adapter calibration notes:
 - r3 projected GEODE internal tool logs back to tau2 `ToolCall` messages.
 - r4 made mutating tools dry-run inside GEODE so tau2 orchestrator applies the
   official state mutation exactly once.
-- r5 stripped empty optional arguments before projection, matching tau2's
-  action comparator exactly.
+- r5 strips absent (`None`) arguments before projection. Explicit empty values
+  remain because some tau2 tools require them; the agent policy therefore
+  forbids inventing optional descriptions or metadata.
 
 Comparability:
 
@@ -264,6 +265,64 @@ uv run python scripts/eval/tau2_geode_agent.py \
   --save-to geode-gpt-5-5-xhigh-geode-user-gpt-5-2-payg-telecom-mobile-data-20260703-max200 \
   --log-level INFO
 ```
+
+## 2026-07-31 GPT-5.6 subscription diagnostics
+
+These are scored behavior diagnostics on GEODE
+`edb74602bb2e1e4d627cb6aa1f0b94072a57da62`, not native-user leaderboard
+rows. Both the agent and simulated user used `gpt-5.6-sol`, OpenAI
+subscription, effort `high`. Harness:
+`sierra-research/tau2-bench@1901a301961cbbe3fd11f3e84a2a376530c759e3`
+(`tau2==1.0.0`).
+
+| Scope | Reward / pass^1 | Duration | Termination | Failure |
+|---|---:|---:|---|---|
+| `mock/create_task_1` | 0.0 / 0.000 | 14.58s | `user_stop` | `create_task` executed with inferred optional `description=""`; exact action and DB checks failed |
+| Telecom `small`, first task | 0.0 / 0.000 | 51.91s | `user_stop` | customer/line diagnostics passed, then the agent transferred to a human instead of guiding the user-side roaming/device workflow |
+
+Neither run contained a provider, quota, or adapter exception. The mock
+trajectory proves that the dynamic `create_task` schema reached execution; its
+failure is the model's extra argument. The Telecom trajectory contains five
+correct assistant-side reads before the premature transfer, but no required
+user-side `toggle_roaming` action or environment assertion.
+
+The measured Telecom command must use the official split name rather than the
+`telecom_small` task-set alias:
+
+```bash
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain telecom \
+  --task-split-name small \
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 50 \
+  --timeout 1800 \
+  --model gpt-5.6-sol \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --user geode_user \
+  --user-llm gpt-5.6-sol \
+  --user-source subscription \
+  --user-effort high \
+  --save-to geode-gpt56-sol-high-edb74602b-geode-user-telecom-small-01-20260731
+```
+
+Artifacts are immutable at
+[`geode-eval-artifacts@9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49):
+
+- raw public copies:
+  [`tau2/simulations`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/9c00ecf4a3b5a68ee65db9afe185b2271da46b49/tau2/simulations);
+- normalized paired dialogue/tool trajectories:
+  [`4ec1c13434d1`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/9c00ecf4a3b5a68ee65db9afe185b2271da46b49/trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1).
+
+The failed `--task-set-name telecom_small` preflight exposed a compatibility
+GAP: that upstream loader does not accept the generic `task_split_name`
+keyword used by GEODE's ordered-task preflight. It produced no scored run and
+is not included in the two results above.
 
 ## 참고
 

--- a/docs/plans/2026-07-31-hook-middleware-handoff.md
+++ b/docs/plans/2026-07-31-hook-middleware-handoff.md
@@ -133,3 +133,45 @@ canonical public names end at `HookName`, `HookRegistry`,
 - A Codex read-only review found four release-gate defects in the first
   harness; all were fixed and the live run repeated. The follow-up review
   returned no actionable findings.
+
+## Post-release benchmark follow-up
+
+GEODE `edb74602b` fixed a same-name dynamic-tool validation defect discovered
+by the first MCPMark smoke: the model saw MCPMark's `write_file(path=...)`
+schema while `ToolExecutor` had reloaded GEODE's unrelated built-in
+`write_file(file_path=...)` schema. Benchmark-owned schemas now win for their
+registered names; built-in validation and approval behavior are unchanged.
+PR #2844 passed all CI and merged to `develop`.
+
+Measured on that exact tree with `gpt-5.6-sol`, subscription, effort `high`:
+
+| Benchmark | Result | Reading |
+|---|---:|---|
+| MCPMark filesystem/easy | **9/10** | one real uppercase-content failure; no schema or 429 contamination |
+| tau2 mock | **0/1** | inferred optional `description=""` broke exact action/DB matching |
+| tau2 Telecom small, first task | **0/1** | correct account diagnostics followed by premature human transfer |
+
+The full MCPMark run created ten isolated sessions. Runtime persistence was:
+
+| Store | Records |
+|---|---:|
+| evidence JSONL | 10 files / 60 rows |
+| run transcript JSONL | 10 files / 174 rows |
+| usage JSONL | 1 file / 54 rows |
+| session SQLite | 10 sessions / 108 messages |
+| session-transition JSONL | 10 rows |
+| `sessions.db:hook_events` | 0 rows |
+
+This does not contradict the hook release probe's 22-row SQLite/JSONL parity.
+The generic MCPMark adapter activated conversation, evidence, usage, and
+session persistence but did not install the hook-persistence bridge used by
+the owning-runtime E2E. Table creation is schema availability, not proof of
+event recording. Lifecycle authority remains in the session/compaction
+owners; telemetry sinks remain optional projections.
+
+The public-safe receipts and twelve normalized trajectories are immutable at
+artifact commit
+[`9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49).
+The MCPMark manifest digest is `b86f5071cbe0`; the tau2 manifest digest is
+`4ec1c13434d1`. Runtime homes, SQLite, JSONL, provider reasoning, and
+credentials were not published.

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3039,6 +3039,14 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2.md
 
 tau2-bench는 대화형 tool-use 벤치마크입니다. 에이전트가 시뮬레이션된 사용자와 대화하며 airline, retail, telecom 도메인의 DB 액션을 수행하고, verifier가 필수 액션 충족 여부로 reward를 매깁니다. GEODE는`plugins/benchmark_harness`의 공개 어댑터로 참가하며, 점수는 그 점수를 만든 harness revision, model route, effort에 고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
 
+## 2026-07-31 subscription 진단
+
+GEODE `edb74602b`에서 agent와 simulated user를 모두 `gpt-5.6-sol` subscription / effort `high`로 실행했습니다. `mock/create_task_1`과 Telecom-small 첫 task는 각각 **0/1**이었습니다. 둘 다 정상 `USER_STOP`이며 provider, quota, adapter exception은 없었습니다.
+
+-   Mock: `create_task`는 실행됐지만 요청에 없던 optional `description=""`를 추가해 exact action/DB comparator가 실패했습니다.
+-   Telecom: 계정·회선·로밍·사용량 조회는 맞았지만 사용자 측 device workflow를 안내하지 않고 human transfer해 `toggle_roaming`과 환경 assertion을 놓쳤습니다.
+-   [`geode-eval-artifacts/trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1): redaction과 call/result pairing을 검증한 두 dialogue/tool trajectory.
+
 ## Headline: native user-simulator 트랙
 
 2026-07-03/04 run, GEODE v0.99.269, `sierra-research/tau2-bench@1901a30` (`tau2==1.0.0`), agent `gpt-5.2` PAYG effort `high`, native `user_simulator` `gpt-4.1-2025-04-14` effort `medium`, `max_steps=200`.
@@ -3071,6 +3079,74 @@ tau2-bench는 대화형 tool-use 벤치마크입니다. 에이전트가 시뮬�
 -   This weighted aggregate is for internal Agent-World-style comparison only.
 -   The run spec differs from OpenAI's official GPT-5.2 Tau2 headline, which used an internal research setup and excludes Airline.
 -   The run spec differs from the earlier GEODE geode\_user smoke matrix.
+
+**Telecom small first-task GPT-5.6 subscription diagnostic** · 2026-07-31 KST · gpt-5.6-sol · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE@edb74602b</code></td></tr><tr><td>Reward / pass^1</td><td><strong>0.0 / 0.000 (0 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@9c00ecf/tau2/simulations/geode-gpt56-sol-high-edb74602b-geode-user-telecom-small-01-20260731/results.json</code></td></tr></tbody></table>
+
+-   Required user toggle\_roaming action 0.0
+-   Mobile-data and excellent-speed assertions 0.0
+-   Termination user\_stop after human transfer
+-   Duration 51.91s
+
+```
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain telecom \
+  --task-split-name small \
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 50 \
+  --timeout 1800 \
+  --model gpt-5.6-sol \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --user geode_user \
+  --user-llm gpt-5.6-sol \
+  --user-source subscription \
+  --user-effort high \
+  --save-to geode-gpt56-sol-high-edb74602b-geode-user-telecom-small-01-20260731
+```
+
+-   The agent correctly identified the customer, line, roaming state, and data usage.
+-   It then declared device tools unavailable and transferred to a human instead of guiding the user-side roaming/device workflow.
+-   No provider, quota, or adapter exception occurred; the failure is retained as behavior evidence.
+
+**mock/create\_task\_1 GPT-5.6 subscription diagnostic** · 2026-07-31 KST · gpt-5.6-sol · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>mock / create_task_1</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE@edb74602b</code></td></tr><tr><td>Reward / pass^1</td><td><strong>0.0 / 0.000 (0 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@9c00ecf/tau2/simulations/geode-gpt56-sol-high-edb74602b-geode-user-mock-smoke-20260731/results.json</code></td></tr></tbody></table>
+
+-   Communication check 1.0 / DB check 0.0
+-   create\_task action check 0.0
+-   Termination user\_stop
+-   Duration 14.58s
+
+```
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain mock \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 8 \
+  --timeout 900 \
+  --model gpt-5.6-sol \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --user geode_user \
+  --user-llm gpt-5.6-sol \
+  --user-source subscription \
+  --user-effort high \
+  --save-to geode-gpt56-sol-high-edb74602b-geode-user-mock-smoke-20260731
+```
+
+-   The create\_task tool executed, but the model supplied an unrequested optional description="".
+-   Tau2's exact action and DB comparators rejected the extra argument; this is retained as a behavioral failure.
+-   This GEODE-owned user route is not comparable to the native tau2 user\_simulator headline.
 
 **telecom/base native user\_simulator** · 2026-07-04 03:45 KST · gpt-5.2 · payg · agent high / user medium
 
@@ -3232,7 +3308,7 @@ uv run python scripts/eval/tau2_geode_agent.py \
 
 ## Run 로그
 
-원본 simulation JSON(태스크별 reward, 액션 체크, 전체 대화 transcript)은 [geode-eval-artifacts](https://github.com/mangowhoiscloud/geode-eval-artifacts) 레포에 무수정 보존됩니다.
+원본 simulation JSON(태스크별 reward, 액션 체크, 전체 대화 transcript)은 [geode-eval-artifacts](https://github.com/mangowhoiscloud/geode-eval-artifacts) 레포에 로컬 경로와 합성 개인정보를 마스킹한 공개 copy로 보존됩니다.
 
 -   [`geode-eval-artifacts/tau2/simulations`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/tau2/simulations): GEODE 소유 run의 simulation JSON. headline run은 `geode-gpt-5-2-high-native-user-*-base-20260703/results.json` 패턴입니다.
 
@@ -3246,6 +3322,13 @@ URL: https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark
 Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark.md
 
 MCPMark는 실제 MCP 서버(filesystem, Postgres, GitHub, Notion, Playwright 등)를 대상으로 한 tool-use 벤치마크입니다. 태스크마다 독립 검증 스크립트가 결과 상태를 확인합니다. GEODE는 `plugins/benchmark_harness`의 `BaseMCPAgent` 어댑터로 참가하고 upstream `pipeline.py`는 패치하지 않습니다. 점수는 harness commit, 서비스 집합, model route, timeout에 고정해서만 게시합니다.
+
+## 2026-07-31 GPT-5.6 subscription run
+
+GEODE `edb74602b`, `gpt-5.6-sol`, effort `high`로 `filesystem/easy` 10건을 다시 측정했습니다. 공식 verifier 결과는 **9/10 (90.0%)**, 총 799.4초와 54 turns입니다. 유일한 실패는 `file_context/uppercase`가 다섯 파일을 만들고도 `file_01.txt`를 완전히 대문자로 바꾸지 못한 행동 실패입니다. schema 충돌이나 429 실패는 없었습니다.
+
+-   [`geode-eval-artifacts/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy): 마스킹된 verifier receipt와 ordered MCP execution logs.
+-   [`geode-eval-artifacts/trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0): task별 10개 content-addressed tool trajectory.
 
 ## Headline: Verified available-services 트랙
 
@@ -3306,6 +3389,38 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   The OpenAI model route was the GEODE Codex subscription route, not MCPMark's native LiteLLM OpenAI API route.
 -   GitHub fixture repositories were made public during execution so the Docker GitHub MCP server could use normal public-repo semantics; all transient repos were deleted by cleanup.
 -   The filesystem score counts papers/author\_folders as a failed no-result transport run after two attempts without meta output.
+
+**filesystem/easy GPT-5.6 subscription rerun** · 2026-07-31 KST · gpt-5.6-sol · subscription · high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>filesystem/easy</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai-codex</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>high</code></td></tr><tr><td>Route</td><td>GEODE local MCPMark adapter</td></tr><tr><td>Harness</td><td><code>eval-sys/mcpmark@cd45b7f, GEODE@edb74602b</code></td></tr><tr><td>Accuracy</td><td><strong>90.0% (9 / 10)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@9c00ecf/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy</code></td></tr></tbody></table>
+
+-   Total task execution time 799.435s / average 79.943s
+-   54 GEODE turns total / 5.4 average
+-   799,679 input / 10,976 output / 97,792 cache-read tokens
+-   Recorded estimate $3.887611; not subscription billing
+-   Failure: file\_context/uppercase left file\_01.txt incompletely uppercased
+
+```
+cd artifacts/eval/harnesses/mcpmark
+GEODE_HOME=<isolated-runtime-home> \
+PYTHONPATH=<geode-edb74602b-worktree> \
+OPENAI_API_KEY=dummy \
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark \
+  --mcp filesystem \
+  --task-suite easy \
+  --models geode-gpt-5.6-sol \
+  --agent geode \
+  --reasoning-effort high \
+  --k 1 \
+  --timeout 1200 \
+  --exp-name geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy \
+  --output-dir ./results-geode-edb74602b
+```
+
+-   This is directly comparable to filesystem/easy only, not to the MCPMark Verified standard aggregate.
+-   The upstream total\_tokens and total\_reasoning\_tokens summary fields were zero despite populated input/output fields; they are not used.
+-   One response stream disconnected after the first task had already produced its files; that task passed every official integrity check and no 429 occurred.
+-   Raw receipts and ten normalized tool trajectories are pinned to geode-eval-artifacts commit 9c00ecf.
 
 **Verified github standard slice** · 2026-07-04 KST · gpt-5.5 · subscription · xhigh
 

--- a/site/src/app/docs/benchmarks/mcpmark/page.tsx
+++ b/site/src/app/docs/benchmarks/mcpmark/page.tsx
@@ -85,6 +85,27 @@ export default function Page() {
               고정해서만 게시합니다.
             </p>
 
+            <h2>2026-07-31 GPT-5.6 subscription run</h2>
+            <p>
+              GEODE <code>edb74602b</code>, <code>gpt-5.6-sol</code>, effort{" "}
+              <code>high</code>로 <code>filesystem/easy</code> 10건을 다시
+              측정했습니다. 공식 verifier 결과는 <strong>9/10 (90.0%)</strong>,
+              총 799.4초와 54 turns입니다. 유일한 실패는{" "}
+              <code>file_context/uppercase</code>가 다섯 파일을 만들고도{" "}
+              <code>file_01.txt</code>를 완전히 대문자로 바꾸지 못한 행동
+              실패입니다. schema 충돌이나 429 실패는 없었습니다.
+            </p>
+            <ul>
+              <li>
+                <RunLogLink path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy" />:
+                마스킹된 verifier receipt와 ordered MCP execution logs.
+              </li>
+              <li>
+                <RunLogLink path="trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0" />:
+                task별 10개 content-addressed tool trajectory.
+              </li>
+            </ul>
+
             <h2>Headline: Verified available-services 트랙</h2>
             <p>
               2026-07-04 run, GEODE v0.99.269 계열, <code>eval-sys/mcpmark@cd45b7f</code>,{" "}
@@ -143,6 +164,28 @@ export default function Page() {
               pinned to the harness commit, service set, model route, and timeout
               settings.
             </p>
+
+            <h2>2026-07-31 GPT-5.6 Subscription Run</h2>
+            <p>
+              We reran the ten <code>filesystem/easy</code> tasks on GEODE{" "}
+              <code>edb74602b</code> with <code>gpt-5.6-sol</code> at effort{" "}
+              <code>high</code>. The official verifier scored{" "}
+              <strong>9/10 (90.0%)</strong> over 799.4 seconds and 54 turns. The
+              only failure was behavioral: <code>file_context/uppercase</code>{" "}
+              created all five files but did not fully uppercase{" "}
+              <code>file_01.txt</code>. No schema collision or 429 failure
+              occurred.
+            </p>
+            <ul>
+              <li>
+                <RunLogLink path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy" />:
+                redacted verifier receipts and ordered MCP execution logs.
+              </li>
+              <li>
+                <RunLogLink path="trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0" />:
+                ten content-addressed per-task tool trajectories.
+              </li>
+            </ul>
 
             <h2>Headline: Verified Available-Services Track</h2>
             <p>

--- a/site/src/app/docs/benchmarks/tau2/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/page.tsx
@@ -32,6 +32,33 @@ export default function Page() {
               고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
             </p>
 
+            <h2>2026-07-31 subscription 진단</h2>
+            <p>
+              GEODE <code>edb74602b</code>에서 agent와 simulated user를 모두{" "}
+              <code>gpt-5.6-sol</code> subscription / effort <code>high</code>로
+              실행했습니다. <code>mock/create_task_1</code>과 Telecom-small 첫
+              task는 각각 <strong>0/1</strong>이었습니다. 둘 다 정상{" "}
+              <code>USER_STOP</code>이며 provider, quota, adapter exception은
+              없었습니다.
+            </p>
+            <ul>
+              <li>
+                Mock: <code>create_task</code>는 실행됐지만 요청에 없던 optional{" "}
+                <code>description=&quot;&quot;</code>를 추가해 exact action/DB
+                comparator가 실패했습니다.
+              </li>
+              <li>
+                Telecom: 계정·회선·로밍·사용량 조회는 맞았지만 사용자 측 device
+                workflow를 안내하지 않고 human transfer해{" "}
+                <code>toggle_roaming</code>과 환경 assertion을 놓쳤습니다.
+              </li>
+              <li>
+                <RunLogLink path="trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1" />:
+                redaction과 call/result pairing을 검증한 두 dialogue/tool
+                trajectory.
+              </li>
+            </ul>
+
             <h2>Headline: native user-simulator 트랙</h2>
             <p>
               2026-07-03/04 run, GEODE v0.99.269, <code>sierra-research/tau2-bench@1901a30</code>{" "}
@@ -58,7 +85,8 @@ export default function Page() {
             <h2>Run 로그</h2>
             <p>
               원본 simulation JSON(태스크별 reward, 액션 체크, 전체 대화 transcript)은{" "}
-              <EvalArtifactsRepoLink /> 레포에 무수정 보존됩니다.
+              <EvalArtifactsRepoLink /> 레포에 로컬 경로와 합성 개인정보를
+              마스킹한 공개 copy로 보존됩니다.
             </p>
             <ul>
               <li>
@@ -85,6 +113,34 @@ export default function Page() {
               effort that produced it. Compare only against reruns with the same
               settings.
             </p>
+
+            <h2>2026-07-31 Subscription Diagnostics</h2>
+            <p>
+              On GEODE <code>edb74602b</code>, both the agent and simulated user
+              ran through <code>gpt-5.6-sol</code> subscription at effort{" "}
+              <code>high</code>. <code>mock/create_task_1</code> and the first
+              Telecom-small task each scored <strong>0/1</strong>. Both ended
+              normally with <code>USER_STOP</code>; neither hit a provider,
+              quota, or adapter exception.
+            </p>
+            <ul>
+              <li>
+                Mock: <code>create_task</code> executed, but the model added the
+                unrequested optional <code>description=&quot;&quot;</code>, so the
+                exact action and DB comparators failed.
+              </li>
+              <li>
+                Telecom: account, line, roaming, and usage lookup were correct,
+                but the agent transferred to a human instead of guiding the
+                user-side device workflow, missing <code>toggle_roaming</code>{" "}
+                and the environment assertions.
+              </li>
+              <li>
+                <RunLogLink path="trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1" />:
+                two redaction- and call/result-validated dialogue/tool
+                trajectories.
+              </li>
+            </ul>
 
             <h2>Headline: Native User-Simulator Track</h2>
             <p>
@@ -113,7 +169,8 @@ export default function Page() {
             <h2>Run Logs</h2>
             <p>
               The raw simulation JSONs (per-task rewards, action checks, and full
-              conversation transcripts) are preserved unmodified in the{" "}
+              conversation transcripts) are preserved as public copies with local
+              paths and synthetic personal fields redacted in the{" "}
               <EvalArtifactsRepoLink /> repository.
             </p>
             <ul>

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -81,6 +81,52 @@ OPENAI_API_KEY=dummy \\
   ],
 };
 
+const mcpmarkFilesystemEasyGpt56: BenchmarkMeasurement = {
+  id: "mcpmark-filesystem-easy-20260731-gpt56-high",
+  group: "mcpmark",
+  title: "filesystem/easy GPT-5.6 subscription rerun",
+  measuredAt: "2026-07-31 KST",
+  suite: "filesystem/easy",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai-codex",
+  source: "subscription",
+  effort: "high",
+  route: "GEODE local MCPMark adapter",
+  harness: "eval-sys/mcpmark@cd45b7f, GEODE@edb74602b",
+  artifact:
+    "geode-eval-artifacts@9c00ecf/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy",
+  scoreLabel: "Accuracy",
+  scoreValue: "90.0% (9 / 10)",
+  secondary: [
+    "Total task execution time 799.435s / average 79.943s",
+    "54 GEODE turns total / 5.4 average",
+    "799,679 input / 10,976 output / 97,792 cache-read tokens",
+    "Recorded estimate $3.887611; not subscription billing",
+    "Failure: file_context/uppercase left file_01.txt incompletely uppercased",
+  ],
+  command: `cd artifacts/eval/harnesses/mcpmark
+GEODE_HOME=<isolated-runtime-home> \\
+PYTHONPATH=<geode-edb74602b-worktree> \\
+OPENAI_API_KEY=dummy \\
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark \\
+  --mcp filesystem \\
+  --task-suite easy \\
+  --models geode-gpt-5.6-sol \\
+  --agent geode \\
+  --reasoning-effort high \\
+  --k 1 \\
+  --timeout 1200 \\
+  --exp-name geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy \\
+  --output-dir ./results-geode-edb74602b`,
+  notes: [
+    "This is directly comparable to filesystem/easy only, not to the MCPMark Verified standard aggregate.",
+    "The upstream total_tokens and total_reasoning_tokens summary fields were zero despite populated input/output fields; they are not used.",
+    "One response stream disconnected after the first task had already produced its files; that task passed every official integrity check and no 429 occurred.",
+    "Raw receipts and ten normalized tool trajectories are pinned to geode-eval-artifacts commit 9c00ecf.",
+  ],
+};
+
 const mcpmarkFilesystemEasyParallel: BenchmarkMeasurement = {
   id: "mcpmark-filesystem-easy-parallel-20260703-gpt55-xhigh",
   group: "mcpmark",
@@ -435,6 +481,103 @@ const tau2MockSmoke: BenchmarkMeasurement = {
   ],
 };
 
+const tau2MockGpt56: BenchmarkMeasurement = {
+  id: "tau2-mock-20260731-gpt56-high-geode-user",
+  group: "tau2",
+  title: "mock/create_task_1 GPT-5.6 subscription diagnostic",
+  measuredAt: "2026-07-31 KST",
+  suite: "mock / create_task_1",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness: "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE@edb74602b",
+  artifact:
+    "geode-eval-artifacts@9c00ecf/tau2/simulations/geode-gpt56-sol-high-edb74602b-geode-user-mock-smoke-20260731/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "0.0 / 0.000 (0 / 1)",
+  secondary: [
+    "Communication check 1.0 / DB check 0.0",
+    "create_task action check 0.0",
+    "Termination user_stop",
+    "Duration 14.58s",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain mock \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 8 \\
+  --timeout 900 \\
+  --model gpt-5.6-sol \\
+  --provider openai \\
+  --source subscription \\
+  --effort high \\
+  --user geode_user \\
+  --user-llm gpt-5.6-sol \\
+  --user-source subscription \\
+  --user-effort high \\
+  --save-to geode-gpt56-sol-high-edb74602b-geode-user-mock-smoke-20260731`,
+  notes: [
+    "The create_task tool executed, but the model supplied an unrequested optional description=\"\".",
+    "Tau2's exact action and DB comparators rejected the extra argument; this is retained as a behavioral failure.",
+    "This GEODE-owned user route is not comparable to the native tau2 user_simulator headline.",
+  ],
+};
+
+const tau2TelecomSmallGpt56: BenchmarkMeasurement = {
+  id: "tau2-telecom-small-20260731-gpt56-high-geode-user",
+  group: "tau2",
+  title: "Telecom small first-task GPT-5.6 subscription diagnostic",
+  measuredAt: "2026-07-31 KST",
+  suite:
+    "telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness: "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE@edb74602b",
+  artifact:
+    "geode-eval-artifacts@9c00ecf/tau2/simulations/geode-gpt56-sol-high-edb74602b-geode-user-telecom-small-01-20260731/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "0.0 / 0.000 (0 / 1)",
+  secondary: [
+    "Required user toggle_roaming action 0.0",
+    "Mobile-data and excellent-speed assertions 0.0",
+    "Termination user_stop after human transfer",
+    "Duration 51.91s",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain telecom \\
+  --task-split-name small \\
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 50 \\
+  --timeout 1800 \\
+  --model gpt-5.6-sol \\
+  --provider openai \\
+  --source subscription \\
+  --effort high \\
+  --user geode_user \\
+  --user-llm gpt-5.6-sol \\
+  --user-source subscription \\
+  --user-effort high \\
+  --save-to geode-gpt56-sol-high-edb74602b-geode-user-telecom-small-01-20260731`,
+  notes: [
+    "The agent correctly identified the customer, line, roaming state, and data usage.",
+    "It then declared device tools unavailable and transferred to a human instead of guiding the user-side roaming/device workflow.",
+    "No provider, quota, or adapter exception occurred; the failure is retained as behavior evidence.",
+  ],
+};
+
 const tau2NativeAirlineBase: BenchmarkMeasurement = {
   id: "tau2-airline-base-20260703-geode-099269-gpt52-high-payg",
   group: "tau2",
@@ -679,6 +822,7 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       mcpmarkVerifiedAvailable,
+      mcpmarkFilesystemEasyGpt56,
       mcpmarkVerifiedGithub,
       mcpmarkVerifiedPostgres,
       mcpmarkVerifiedFilesystem,
@@ -731,6 +875,8 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       tau2NativeAggregate,
+      tau2TelecomSmallGpt56,
+      tau2MockGpt56,
       tau2NativeTelecomBase,
       tau2NativeRetailBase,
       tau2NativeAirlineBase,


### PR DESCRIPTION
## Summary

- Publish the GPT-5.6 subscription MCPMark and tau2 results in the internal and public docs.
- Pin raw receipts and twelve normalized trajectories to eval-artifact commit `9c00ecf`.
- Record the lifecycle/telemetry persistence boundary observed during the ten-session MCPMark run.
- Regenerate the public `llms-full.txt` document.

## Why

PR #2844 removed benchmark schema contamination and enabled a valid measured
run. The resulting verifier scores, behavioral failures, persistence evidence,
and public artifact digests now need one canonical record before release.

## Results

| Benchmark | Result |
|---|---:|
| MCPMark filesystem/easy | 9/10 (90.0%) |
| tau2 mock | 0/1 |
| tau2 Telecom small, first task | 0/1 |

The tau2 failures were normal scored behavior failures, not provider, quota,
or adapter exceptions.

## Changes

| Surface | Change |
|---|---|
| Eval ledgers | Add exact run commands, metrics, failure readings, and artifact links |
| Public benchmark pages | Add GPT-5.6 run records in Korean and English |
| Handoff | Add benchmark outcome and measured JSONL/SQLite persistence counts |
| Generated docs | Refresh `llms-full.txt` from the static export |

## Verification

- `scripts/check_docs_links.py`: 645 links, no broken internal links.
- Site ESLint: 0 errors (pre-existing warnings only).
- Next static build: 236/236 pages.
- Markdown export: 73 twins; `llms-full.txt` regenerated.
- Pre-commit: all applicable hooks passed.
- `git diff --check`: pass.
