### PR TITLE
release: v1.0.10 — benchmark tool schema dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.10] - 2026-07-31
+
+> Benchmark-owned tool contracts now pass through GEODE's trusted execution
+> boundary without being replaced by same-named built-in schemas.
+
 ### Fixed
 
 - Benchmark-owned dynamic tool schemas now take precedence over same-named

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.9
+- **Version**: 1.0.10
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.9 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.10 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.9: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.10: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.9"
+version = "1.0.10"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.9. Last sync 2026-07-30. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.10. Last sync 2026-07-31. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5420,7 +5420,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1479 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1480 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.9. Last sync 2026-07-30. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.10. Last sync 2026-07-31. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-30
+ * Last sync: 2026-07-31
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- Benchmark-owned dynamic tool schemas now take precedence over same-named\n  built-in schemas during execution validation, so MCPMark filesystem tools\n  accept their native `path` contract and τ² tools cannot be rejected by an\n  unrelated GEODE definition before reaching the benchmark environment."
+    "body": ""
+  },
+  {
+    "version": "1.0.10",
+    "date": "2026-07-31",
+    "body": "> Benchmark-owned tool contracts now pass through GEODE's trusted execution\n> boundary without being replaced by same-named built-in schemas.\n\n### Fixed\n\n- Benchmark-owned dynamic tool schemas now take precedence over same-named\n  built-in schemas during execution validation, so MCPMark filesystem tools\n  accept their native `path` contract and τ² tools cannot be rejected by an\n  unrelated GEODE definition before reaching the benchmark environment."
   },
   {
     "version": "1.0.9",
@@ -2443,4 +2448,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-30";
+export const CHANGELOG_SYNCED_AT = "2026-07-31";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-30
+ * Last sync: 2026-07-31
  */
 
 export const GEODE_SOT = {
-  version: "1.0.9",
-  syncedAt: "2026-07-30",
+  version: "1.0.10",
+  syncedAt: "2026-07-31",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Promote the validated dynamic benchmark-tool schema dispatch fix to GEODE v1.0.10.
- Keep a fresh empty `[Unreleased]` section while aligning package, scaffold, README, lockfile, and generated site release surfaces.

## Why
MCPMark live E2E exposed that a benchmark-owned `write_file(path=...)` schema could be replaced by GEODE's same-named built-in `write_file(file_path=...)` contract at execution time. PR #2844 fixed the trusted dispatch boundary, PR #2845 published the exact GPT-5.6 benchmark evidence and handoff, and this patch train makes that validated source publicly installable.

## Included changes
- #2844 `fix(eval): honor dynamic tool schemas during dispatch`
- #2845 `docs(eval): publish GPT-5.6 benchmark results`
- `geode-eval-artifacts` #7: masked raw receipts plus normalized MCPMark/Tau2 behavior trajectories

## GAP audit
| Surface | Before | v1.0.10 |
|---|---|---|
| Dynamic benchmark tool validation | Same-named built-in schema could win | Caller-owned schema reaches the benchmark executor |
| Release metadata | v1.0.9 with fix under `[Unreleased]` | v1.0.10 with a fresh empty `[Unreleased]` |
| Public benchmark evidence | Prior benchmark tracks only | Exact merged-source GPT-5.6 MCPMark/Tau2 receipts and trajectories linked |

## Changes
| File group | Change |
|---|---|
| `pyproject.toml`, `uv.lock` | Package version 1.0.9 → 1.0.10 |
| `CLAUDE.md`, `README.md`, `README.ko.md` | Scaffold and public version stamp 1.0.10 |
| `CHANGELOG.md` | Promote the dynamic-schema fix to `[1.0.10] - 2026-07-31`; retain empty `[Unreleased]` |
| Generated site surfaces | Regenerate `sot.ts`, `changelog.ts`, `llms.txt`, and `llms-full.txt` at v1.0.10 |

## Scope
- Runtime code change in this PR: none; the green runtime fix is already on `origin/develop` via #2844.
- Dependencies: none added or removed.
- Release diff: 10 files, +24/-14.

## Verification
- [x] `uv run pytest tests/ -m "not live"` — 10,348 passed, 23 skipped, 1 deselected
- [x] `scripts/preflight.sh --fast` — all enabled static/type/security/ratchet gates passed
- [x] `uv build` — wheel and sdist built
- [x] `uv run twine check dist/*` — both artifacts passed
- [x] `uv run python scripts/check_package_artifacts.py` — wheel 607 files, sdist 609 files, both passed
- [x] clean wheel install smoke — `GEODE v1.0.10`
- [x] `npm run build` — 236/236 static pages
- [x] `npm run export-md` — 73 Markdown twins
- [x] committed public-doc generators rerun with no diff
- [x] `uv run python scripts/check_llms_version.py` — clean
- [x] `uv run python scripts/architecture_baseline.py --check` — pass
- [x] #2844 and #2845 full CI Gate green
