### PR TITLE
docs(eval): promote v1.0.11 behavior evidence to main

### DIFF
--- a/docs/architecture/event-persistence.md
+++ b/docs/architecture/event-persistence.md
@@ -189,9 +189,12 @@ Historical artifact-repository releases using dated identifiers such as
   and executable checks remain promotion authority. The GEODE trajectory is a
   replay sidecar with the raw artifact SHA-256 and Crucible snapshot/contract
   reference. It cannot convert an invalid arm into scored evidence.
-- **MCPMark / tau2**: native receipts stay byte-identical. The shared benchmark
-  bridge emits a normalized SQLite-backed trajectory beside them and keeps
-  publication machinery outside Crucible's bounded candidate surface.
+- **MCPMark / tau2**: authoritative native receipts stay byte-identical in the
+  private run store. The shared benchmark bridge emits a normalized
+  SQLite-backed trajectory beside them. A public receipt copy may apply a
+  reviewed path/identity redaction and therefore receives its own digest; the
+  manifest records both the raw source digest and public disclosure digest.
+  Publication machinery stays outside Crucible's bounded candidate surface.
 
 ## Migration and rollback
 
@@ -225,5 +228,8 @@ geode session prune-records --retention-days 180
 
 MCPMark, tau2-bench, and the hook behavior E2E export through the same
 trajectory builder and JSON-schema validator. Benchmark-native raw artifacts
-remain byte-identical inputs and are bound to normalized trajectories by
-SHA-256 rather than embedded or replaced.
+remain byte-identical authoritative inputs and are bound to normalized
+trajectories by SHA-256 rather than embedded or replaced. The `v1.0.11`
+benchmark publication at artifact commit `16a54f08450d` was downloaded from
+GitHub after merge and passed anchored manifest verification for 12
+trajectories, 368 events, and 87 exact tool call/result pairs.

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -15,19 +15,21 @@ those claims. See [External Evaluation Artifact Repository](external-artifact-re
 for path mappings, disclosure rules, and the publication manifest scaffold.
 
 The latest runtime-contract record is the immutable
-[2026-07-31 hook/middleware behavior trajectory](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/3e5b35f4505a4a2dc76d595b24862e8e73e668ff/trajectories/geode-agenticloop-hook-middleware-behavior-e2e-20260731T001640Z-1326e99cb447):
+[2026-07-31 stable hook/middleware behavior trajectory](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/b979268d7e64c99ca27b51c025a2cd25022cc1a5/trajectories/geode-agenticloop-hook-middleware-behavior-e2e-20260731T091808Z-d418e55ff8aa):
 13/13 public hooks, 4/4 trusted middleware join points, and matching 22-row
 SQLite/JSONL extension projections. It is a release-validation probe, not a
 scored benchmark.
 
 The latest scored behavior record is pinned to artifact commit
-[`9c00ecf`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/9c00ecf4a3b5a68ee65db9afe185b2271da46b49):
-MCPMark filesystem/easy **9/10**, tau2 mock **0/1**, and one Telecom-small
-task **0/1** on GEODE `edb74602b` with `gpt-5.6-sol` subscription / effort
+[`16a54f0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/16a54f08450db771c02e30c73bdc3867f6282f83):
+MCPMark filesystem/easy **10/10**, tau2 mock **0/1**, and one Telecom-small
+task **1/1** on released GEODE `v1.0.11` (`686ff372`) with
+`gpt-5.6-sol` subscription / effort
 `high`. The
-[run report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/9c00ecf4a3b5a68ee65db9afe185b2271da46b49/reports/e2e-validation/2026-07-31-gpt56-benchmark.md)
-links raw receipts and twelve normalized tool/dialogue trajectories. The two
-tau2 failures are behavioral evidence, not provider or adapter failures.
+[run report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/16a54f08450db771c02e30c73bdc3867f6282f83/reports/e2e-validation/2026-07-31-gpt56-v1011-benchmark.md)
+links privacy-reviewed native receipt copies and twelve stable trajectories.
+The retained mock failure is behavioral evidence, not a provider or adapter
+failure.
 
 ## 채택 4종
 
@@ -59,8 +61,8 @@ Telecom small run 이후로 둔다.
 
 | 순위 | 벤치 | 첫 목표 | 완료 기준 |
 |---:|---|---|---|
-| 1 | MCPMark Verified | 완료: available standard 64/74; 2026-07-31 filesystem/easy 재측정 9/10 | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
-| 2 | τ²-bench | 완료: `mock` 0/1 + Telecom small 1-task 0/1, `geode_agent` + `geode_user` subscription | tau2 result directory와 domain split을 보존하고, user route / trial 수를 public page에 명시 |
+| 1 | MCPMark Verified | 완료: available standard 64/74; v1.0.11 filesystem/easy 재측정 10/10 | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
+| 2 | τ²-bench | 완료: v1.0.11 `mock` 0/1 + Telecom small 1-task 1/1, `geode_agent` + `geode_user` subscription | tau2 result directory와 domain split을 보존하고, user route / trial 수를 public page에 명시 |
 | 3 | BFCL V4 | Agentic subset first | native/prompt function-calling route와 aggregation을 고정한 뒤 result/score artifact 보존 |
 | 4 | HAL Reliability | tau-bench airline single-rerun smoke | τ² adapter 재사용 여부와 rerun consistency schema 확인 |
 | 5 | Terminal-Bench 2.0 | 1-task Docker/tmux smoke | post-run test artifact와 shell transcript 보존 |
@@ -141,6 +143,7 @@ Verified 다음에 τ²-bench를 둔다.
 
 | 일자 | 변경 |
 |---|---|
+| 2026-07-31 | 배포된 GEODE `v1.0.11@686ff372` 재측정: MCPMark filesystem/easy 10/10, tau2 mock 0/1, Telecom-small 1-task 1/1. SQLite와 exact-join한 368 events / 87 tool pairs, stable manifests와 비식별 native receipts를 artifact commit `16a54f0`에 게시하고 원격 read-back 검증 |
 | 2026-07-31 | GEODE `edb74602b` / GPT-5.6 subscription `high` 측정: MCPMark filesystem/easy 9/10, tau2 mock 0/1, Telecom-small 1-task 0/1. Raw receipts와 12개 정규화 trajectory를 artifact commit `9c00ecf`에 게시 |
 | 2026-07-10 | MCPMark blocked 사례 해소: notion 세션 만료 원인 확정·재발급 후 easy smoke 1/1, github `GITHUB_EVAL_ORG` 영속화(State Duplication Error 6건 원인 제거), postgres 컨테이너 복구, `--agent geode` 커밋 런처 추가, playwright 실행 준비 확인. 잔여 blocked=`playwright_webarena`(WebArena 이미지 ~100GB, 로컬 디스크 초과). Agent-World 비교 런북 추가 |
 | 2026-07-03 | 남은 벤치마크 측정 큐를 추가하고 `tau2-bench`를 2순위로 승격 |

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -1,6 +1,6 @@
 # External Evaluation Artifact Repository
 
-GEODE's canonical public raw-artifact store is
+GEODE's canonical public evaluation-artifact store is
 [`mangowhoiscloud/geode-eval-artifacts`](https://github.com/mangowhoiscloud/geode-eval-artifacts).
 The GEODE repository keeps code, interpretation, comparability boundaries, and
 digest pointers; the artifact repository keeps large verifier outputs and
@@ -10,6 +10,11 @@ This split is deliberate. `artifacts/` remains gitignored in GEODE, while the
 external repository is an append-only evidence store. A published result is
 durable only when its GEODE ledger names both the artifact path and the exact
 artifact-repository commit.
+
+“Artifact repository” here means a reviewed Git branch/PR and immutable commit,
+not JFrog Artifactory or an opaque object-store upload. The publication unit is
+an allowlisted directory, and GitHub read-back from the exact merge commit is
+part of the evidence.
 
 ## Path mapping
 
@@ -58,6 +63,39 @@ dialogue/tool trajectories. Manifest directory digests are
 SQLite, JSONL mirrors, hidden reasoning, and credential files remain
 withheld. Local usernames and synthetic telecom personal fields are redacted
 in the public copies.
+
+The post-release `v1.0.11` behavior regression is pinned to
+[`16a54f0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/16a54f08450db771c02e30c73bdc3867f6282f83)
+from
+[`geode-eval-artifacts#9`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/9).
+It preserves the native MCPMark 10/10 receipt and tau2 mock 0/1 plus
+Telecom-small 1/1 receipts, and publishes two stable trajectory releases:
+
+- [MCPMark release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/trajectories/mcpmark-geode-gpt56-v1.0.11-686ff372-filesystem-easy-20260731T105713Z-82fe94b01a25):
+  10 trajectories, 226 events, 78 exact tool pairs, manifest SHA-256
+  `82fe94b01a25e7e9f8c504d511f018129cb058ad532dbcbc315de9c6819db0fb`.
+- [Tau2 release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c):
+  2 trajectories, 142 events, 9 exact tool pairs, manifest SHA-256
+  `a71155f7006c8dd412af8d1471e7d2380e5f072cc8f0495924fa86f26d69a9a2`.
+
+Both releases are scope-complete and deliberately replay-incomplete because
+non-public message/tool bodies are represented by digests. Every trajectory
+matched its isolated canonical SQLite event set exactly. Secret, identity,
+credential, path, duplicate-ID, missing-correlation, and orphan-pair findings
+were all zero. An independent GitHub API read-back of the exact merge commit
+revalidated both releases rather than trusting the staging worktree.
+
+Raw native evidence and public disclosure bytes have separate identities.
+MCPMark's public receipt set contains 31 files / 554,366 bytes with path-set
+digest `3ffcdeebc39be91f5d957b66f1a5e48bd1408645f83120e84346bba7beef6417`.
+Tau2's contains 4 files / 114,004 bytes with path-set digest
+`a5d2a2f6b8dd719f22f050e16afe4ad8bf65345c35a65552e5467745b3eeda5f`.
+For the Telecom result specifically, the authoritative raw receipt digest is
+`eda3cdbdb9cd0c2f993db3f9fe2e813cdbc06fe9cf112e23ba60c7ea9d98a45b`;
+the public, synthetic-phone/email-redacted copy is separately hashed as
+`506f906cfa1d6e8e4320ba284be1aa0f7ec26ea2fc47b43e7b36f69e3643a9d4`.
+This preserves Crucible's native evidence authority without leaking reviewed
+fields or falsely claiming transformed bytes are identical.
 
 Those historical releases use the dated
 `geode.trajectory@2026-07-29`/`@2026-07-31` envelope and stay immutable. New

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -6,7 +6,7 @@ Multi-turn tool-agent-user 시뮬레이션 벤치. 에이전트와 LLM 시뮬 �
 
 - **Repo**: [sierra-research/tau2-bench](https://github.com/sierra-research/tau2-bench) — 1.1k★
 - **마지막 commit**: 2026-05-05 (live submissions PR, 매주 갱신)
-- **라이센스**: 확인 필요 (Apache-2.0 추정)
+- **라이센스**: MIT (`LICENSE`, grounded at harness revision `1901a30`)
 - **버전 히스토리**: v1 NeurIPS '24 → v² 2025 (telecom dual-control) → v0.2.0 2025-10-06 (web leaderboard) → v0.2.1 2025-11 (RL support). τ³(banking+voice)은 paper만, 코드 미공개
 - **Frontier 인용**: GPT-5.5 system card (**telecom 98.0%**), Anthropic 인용
 
@@ -323,6 +323,59 @@ The failed `--task-set-name telecom_small` preflight exposed a compatibility
 GAP: that upstream loader does not accept the generic `task_split_name`
 keyword used by GEODE's ordered-task preflight. It produced no scored run and
 is not included in the two results above.
+
+## 2026-07-31 v1.0.11 release regression
+
+These runs use the public `geode-agent==1.0.11` wheel at GEODE revision
+`686ff37257fc7dd655025049dccee7a10d6ef340`, not an editable checkout. A
+preflight rejected the harness environment's stale editable `1.0.9` install
+before measurement. Both the agent and simulated user used `gpt-5.6-sol`,
+OpenAI subscription, effort `high`, and tau2-bench
+`1901a301961cbbe3fd11f3e84a2a376530c759e3` (`tau2==1.0.0`).
+
+| Scope | Reward / pass^1 | Duration | Termination | Reading |
+|---|---:|---:|---|---|
+| `mock/create_task_1` | 0.0 / 0.000 | 9.03s | `user_stop` | Genuine repeat failure: `description=""` was not requested, so the native exact action and DB comparators rejected the write |
+| Telecom `small`, first task | 1.0 / 1.000 | 78.52s | `user_stop` | DB, `toggle_roaming`, mobile-data state, and excellent-speed assertions all passed |
+
+The stable trajectory join was checked against an isolated `sessions.db` for
+each run:
+
+| Scope | Events | Exact tool pairs | Missing IDs / orphan pairs |
+|---|---:|---:|---:|
+| mock | 25 | 1 | 0 / 0 |
+| Telecom | 117 | 8 | 0 / 0 |
+
+Tau2 `results.json` remains the scoring authority. The associated
+`crucible_tau2_trajectory_snapshot.v3` records are diagnostic with
+`promotion_authority=none` and `candidate_surface=unfrozen_git`; the
+`geode.trajectory@1` files are replay/correlation sidecars, not a way to
+promote an unfrozen arm.
+
+The authoritative raw native receipt SHA-256 values are:
+
+- mock:
+  `eb0e8eea5516b2cbb6b95385846bb8b6cbcdae42a4fb48e1fa447939d2d0e369`;
+- Telecom:
+  `eda3cdbdb9cd0c2f993db3f9fe2e813cdbc06fe9cf112e23ba60c7ea9d98a45b`.
+
+The public Telecom copy removes synthetic phone/email fields and therefore has
+the distinct digest
+`506f906cfa1d6e8e4320ba284be1aa0f7ec26ea2fc47b43e7b36f69e3643a9d4`.
+That transformation is explicit; it is not presented as the raw Crucible
+receipt.
+
+Artifacts are immutable at
+[`geode-eval-artifacts@16a54f0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/16a54f08450db771c02e30c73bdc3867f6282f83):
+
+- [native receipt copies](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/tau2/simulations);
+- [stable trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c);
+- [validation report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/16a54f08450db771c02e30c73bdc3867f6282f83/reports/e2e-validation/2026-07-31-gpt56-v1011-benchmark.md).
+
+Manifest SHA-256
+`a71155f7006c8dd412af8d1471e7d2380e5f072cc8f0495924fa86f26d69a9a2`
+was independently revalidated after downloading the exact merge commit from
+GitHub.
 
 ## 참고
 

--- a/docs/plans/2026-07-31-hook-session-record-release-handoff.md
+++ b/docs/plans/2026-07-31-hook-session-record-release-handoff.md
@@ -1,0 +1,362 @@
+# Handoff — public hooks, session records, and evaluation artifacts
+
+Date: 2026-07-31
+
+Runtime release: GEODE `v1.0.11`
+
+Runtime commit: `686ff37257fc7dd655025049dccee7a10d6ef340`
+
+Artifact commit: `16a54f08450db771c02e30c73bdc3867f6282f83`
+
+Read §1 for the shipped state, §2 for the final hook surface, §3 for storage
+and Artifactory publication, and §4 for SIL/Crucible compatibility. Later
+sections contain verification and follow-up details.
+
+## 1. Shipped state
+
+The hook/middleware and session-record work is released, not merely planned:
+
+| Change | Evidence |
+|---|---|
+| implementation into `develop` | [`GEODE #2850`](https://github.com/mangowhoiscloud/geode/pull/2850), squash `dc8b9175525db50ff23d8460e4c89316b16767cf` |
+| release metadata into `develop` | [`GEODE #2851`](https://github.com/mangowhoiscloud/geode/pull/2851), squash `7b988ffd944f2080efb53c0023f5596e4c6c3a39` |
+| `develop` into `main` | [`GEODE #2852`](https://github.com/mangowhoiscloud/geode/pull/2852), merge `686ff37257fc7dd655025049dccee7a10d6ef340` |
+| package | [`v1.0.11`](https://github.com/mangowhoiscloud/geode/releases/tag/v1.0.11), PyPI `geode-agent==1.0.11` |
+| public hook behavior | [`geode-eval-artifacts #8`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/8), commit `b979268d7e64c99ca27b51c025a2cd25022cc1a5` |
+| post-release benchmarks | [`geode-eval-artifacts #9`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/9), commit `16a54f08450db771c02e30c73bdc3867f6282f83` |
+
+The package wheel SHA-256 is
+`63c4811cf992c0c797bff25abb6faea57dbc1467c73cf370827585e759e369b9`;
+the sdist SHA-256 is
+`d5f02a15d52e963a03930dd8546a6f8b4d8895dd9c44316e28dd9153cb6af88f`.
+GitHub and PyPI served the same wheel bytes.
+
+## 2. Final hook and middleware surface
+
+### 2.1 Exposure levels
+
+GEODE no longer presents one flat vocabulary as if every internal event were a
+stable extension point:
+
+| Level | Surface | Stability / authority |
+|---|---|---|
+| public control hooks | 13 `HookName` values | versioned, redacted, bounded payloads; closed actions |
+| trusted execution middleware | 4 named join points | in-process immutable transforms or exactly-once async wrappers |
+| runtime events | 57-member internal `RuntimeEvent` vocabulary | observability and wiring; not a public compatibility promise |
+
+This avoids exposing every telemetry detail while still retaining internal
+diagnostic resolution. `MiddlewareKind` was not introduced: one
+`MiddlewareRegistry` already has four type-specific registration and execution
+methods, so a second enum would duplicate the type system and fragment naming.
+
+### 2.2 Public hook contract
+
+| Hook | Allowed decisions | Control point |
+|---|---|---|
+| `UserPromptSubmit` | `continue`, `rewrite`, `block` | before the submitted prompt enters the loop |
+| `PreToolUse` | `continue`, `rewrite`, `block`, `request_permission` | after request middleware, before policy/permission/execution |
+| `PermissionRequest` | `allow`, `deny`, `ask` | explicit tool permission decision |
+| `PostToolUse` | `continue`, `add_context`, `block` | after the executor returns |
+| `PreCompact` | `continue`, `rewrite`, `defer` | before compaction |
+| `PostCompact` | `continue` | after compaction persistence |
+| `SessionStart` | `continue` | new/resumed session boundary |
+| `SessionEnd` | `continue` | terminal session boundary |
+| `SubagentStart` | `continue` | child execution starts |
+| `SubagentStop` | `continue` | child execution ends |
+| `PreVerify` | `continue`, `strengthen` | before the executable verifier |
+| `PostVerify` | `accept`, `revise`, `escalate` | after verifier evidence exists, before delivery |
+| `Stop` | `finalize`, `continue` | final delivery/continuation gate |
+
+`PostVerify.revise` requires an instruction. `PostVerify.escalate` withholds
+ordinary delivery and terminates with
+`external_verification_required`; it does not silently turn the run into a
+success or automatic retry.
+
+### 2.3 Trusted middleware contract
+
+| Join point | Shape | What it controls |
+|---|---|---|
+| `tool_request` | `ToolCallRequest -> ToolCallRequest` | effective tool arguments before public hook, guardrail, permission, and execution |
+| `tool_execution` | `(ToolCallRequest, next_call) -> result` | actual executor call as an async onion |
+| `llm_request` | `LlmCallRequest -> LlmCallRequest` | assembled provider-agnostic adapter request |
+| `llm_execution` | `(LlmCallRequest, next_call) -> result` | actual provider call as an async onion |
+
+Inputs are cloned/immutable, middleware names are unique per join point,
+priority ordering is deterministic, and execution wrappers may call
+`next_call` exactly once. Tool and LLM execution have independent timeouts.
+This closes the former partial `tool_request`/`TOOL_EXEC_STARTED` overlap and
+the missing executor/provider wrapper seams.
+
+### 2.4 Why `PostVerify` is public
+
+An external loop normally needs a decision after executable checks, not only a
+notification that generation stopped. `PostVerify` exposes that exact
+boundary:
+
+- `accept` releases a verifier-backed candidate;
+- `revise` returns a bounded instruction to the agent loop;
+- `escalate` pauses delivery for an operator, SIL policy, Crucible gate, or
+  another external authority;
+- typed `evidence_refs` preserve who judged what, under which schema, without
+  copying the judge payload into agent dialogue.
+
+This makes an outside loop able to control delivery without becoming coupled
+to GEODE's internal `RuntimeEvent` taxonomy. The hook controls flow; it does
+not inherit SIL or Crucible promotion authority.
+
+## 3. Storage and Artifactory publication
+
+### 3.1 Plane separation
+
+```mermaid
+flowchart LR
+    U[User / external loop] --> H[13 public hooks]
+    H --> M[4 trusted middleware seams]
+    M --> L[AgenticLoop + tools + provider]
+    L --> V[Executable verifier]
+    V --> PV[PostVerify]
+    PV -->|accept / revise / escalate| U
+
+    H -. diagnostic .-> RE[RuntimeEvent]
+    M -. diagnostic .-> RE
+    L -. lifecycle .-> SE[SessionEvent]
+    V -. evidence / pending .-> SE
+
+    RE --> HE[(sessions.db<br/>hook_events)]
+    SE --> DB[(sessions.db<br/>session_events)]
+    DB --> RJ[run events.jsonl<br/>bounded projection]
+    DB --> T[geode.trajectory@1<br/>immutable derived view]
+    RJ -. portable lifecycle .-> SIL[SIL run ledger]
+    T --> RM[geode.trajectory-release@1<br/>digest manifest]
+    RM --> AR[geode-eval-artifacts<br/>Git PR + immutable commit]
+
+    SIL -->|Inspect .eval + mutation/attribution| ER[typed evidence_refs]
+    C[Crucible v3 + frozen contract<br/>native receipt + verifier] --> ER
+    ER --> T
+```
+
+| Plane | Stored elements | Role |
+|---|---|---|
+| checkpoint | SQLite `sessions`, `messages` | mutable model-visible resume state |
+| lifecycle record | SQLite `session_events`, `geode.session-event@1` | append-only reconstruction across session/turn/call |
+| telemetry | SQLite `hook_events`, `geode.observer.v1` | bounded hook/middleware/runtime diagnostics |
+| run projection | co-located `events.jsonl`, `geode.run-event@1` | bounded, rebuildable tail/copy/exchange view |
+| evaluation | `trajectory.json`, `geode.trajectory@1` | immutable behavior projection with quality and evidence joins |
+| publication | trajectory plus `geode.trajectory-release@1` manifest | allowlisted, privacy-reviewed public evidence |
+
+The telemetry/lifecycle boundary is therefore explicit. A middleware timing or
+hook dispatch observation remains telemetry. A user message, tool call/result,
+verification evidence, pending external decision, or terminal session state is
+lifecycle. Telemetry is not required to reconstruct the conversation.
+
+The old `SessionTranscript` and `RunTranscript` names remain deprecated
+compatibility shims over `SessionTimeline` and `RunTimeline`. New runtime
+history does not create a competing global transcript store. Legacy
+`transcript.jsonl` and `dialogue.jsonl` are accepted as read-only fallback
+inputs; `events.jsonl` is the new run projection.
+
+### 3.2 What is in one trajectory
+
+Each `geode.trajectory@1` carries:
+
+- schema, trajectory, source, and coverage identity;
+- ordered event IDs and ordinals;
+- session, generation, turn, and call correlation keys;
+- dialogue/tool projections and runtime-event references;
+- typed evidence/verifier references;
+- payload digests and declared redaction/omission state;
+- recomputed integrity quality, not a trusted producer assertion.
+
+The validator recomputes unique IDs, contiguous ordinals, required correlation,
+tool call/result counts, exact pairs, orphan calls/results, missing call IDs,
+truncation, corruption, and omitted content. Missing correlation or an orphan
+sets `scope_complete=false`; lossy payloads set `replay_complete=false`.
+
+### 3.3 How it “goes to Artifactory”
+
+There is no JFrog Artifactory upload. GEODE uses the append-only public Git
+repository
+[`mangowhoiscloud/geode-eval-artifacts`](https://github.com/mangowhoiscloud/geode-eval-artifacts):
+
+1. preserve authoritative native run bytes in the private ignored
+   `artifacts/` tree;
+2. validate the trajectory schema and recompute quality;
+3. resolve and SHA-256-check every native `artifact_digests` reference;
+4. require a structured privacy review and scan the exact public bytes for
+   paths, identity, email, bearer credentials, GitHub/OpenAI tokens, duplicate
+   IDs, and undeclared files;
+5. stage a content-addressed, non-overwriting release directory containing only
+   trajectories and a manifest;
+6. copy allowlisted native receipt views and stable releases into a fresh
+   artifact-repository branch/worktree;
+7. merge by PR;
+8. download the exact merge commit from GitHub and verify manifest SHA-256,
+   file bytes, counts, trajectory IDs, source digests, and scans again;
+9. pin the artifact commit and immutable paths in GEODE docs.
+
+The stable release itself excludes `sessions.db`, WAL files, general
+`events.jsonl`, checkpoints, hidden reasoning, provider diagnostics, and
+credentials.
+
+### 3.4 Data-quality result
+
+The post-release publication at artifact commit `16a54f08450d` raised the
+evidence bar from “a transcript file exists” to an independently recomputed and
+remotely read-back contract:
+
+| Release | Trajectories | Events | Exact tool pairs | Missing correlation / orphans | Manifest SHA-256 |
+|---|---:|---:|---:|---:|---|
+| MCPMark v1.0.11 filesystem/easy | 10 | 226 | 78 | 0 / 0 | `82fe94b01a25e7e9f8c504d511f018129cb058ad532dbcbc315de9c6819db0fb` |
+| Tau2 v1.0.11 mock + Telecom | 2 | 142 | 9 | 0 / 0 | `a71155f7006c8dd412af8d1471e7d2380e5f072cc8f0495924fa86f26d69a9a2` |
+
+All 368 events matched the isolated canonical SQLite event sets by event ID,
+session, turn, call, and kind. Both releases are scope-complete and explicitly
+replay-incomplete because non-public bodies are digested rather than leaked.
+All configured secret/identity/credential/path scan classes returned zero.
+
+Native authority and public disclosure identity are kept separate:
+
+- MCPMark public receipt set: 31 files, 554,366 bytes, path-set digest
+  `3ffcdeebc39be91f5d957b66f1a5e48bd1408645f83120e84346bba7beef6417`;
+- Tau2 public receipt set: 4 files, 114,004 bytes, path-set digest
+  `a5d2a2f6b8dd719f22f050e16afe4ad8bf65345c35a65552e5467745b3eeda5f`;
+- Telecom raw native receipt:
+  `eda3cdbdb9cd0c2f993db3f9fe2e813cdbc06fe9cf112e23ba60c7ea9d98a45b`;
+- Telecom public redacted copy:
+  `506f906cfa1d6e8e4320ba284be1aa0f7ec26ea2fc47b43e7b36f69e3643a9d4`.
+
+The different Telecom digests are intentional and disclosed: synthetic
+phone/email fields were removed from the public copy.
+
+## 4. Frontier and external-loop alignment
+
+The comparison was rerun on locally pulled exact source heads:
+
+| System | Exact head and grounded source | GEODE alignment |
+|---|---|---|
+| Hermes | `98105f31f46d`; `docs/middleware/README.md`, `docs/observability/README.md`, `state.db` session paths | same four middleware seams and SQLite-centric interactive state; GEODE adds immutable request contracts and exactly-once async `next_call` |
+| OpenClaw | `49b4841081c6`; `src/config/sessions/session-accessor.sqlite-transcript-store.ts`, `trajectory_runtime_events` schema/tests | separate durable transcript/lifecycle and bounded runtime telemetry; exported/serialized artifacts are not another hot-path truth |
+| Codex | `f0c30e528a54`; hook names in `codex-rs/analytics/src/events.rs` and hook runtime/config | same 11 public lifecycle/tool hooks, with GEODE's deliberate `PreVerify`/`PostVerify` extension |
+
+The result is not a union of every frontier event. It is:
+
+```text
+Codex public 11
++ GEODE PreVerify / PostVerify
++ Hermes four middleware seams
++ Hermes/OpenClaw SQLite state ownership
++ Codex correlation and replay rigor
+```
+
+### SIL
+
+SIL keeps three authorities separate:
+
+- `RunTimeline/events.jsonl` for portable run lifecycle;
+- mutation and attribution ledgers for the self-improvement process;
+- Inspect `.eval` for scored Petri assays.
+
+`geode session export-trajectory --sil-eval <archive.eval>` creates a typed
+`inspect_ai.eval@native` evidence reference and checks its source digest. This
+is an explicit promotion action, not automatic SIL finalization. SIL may
+discard a campaign without publishing a GEODE trajectory.
+
+### Crucible
+
+Crucible keeps `crucible.evidence.v3`, the frozen experiment contract, native
+tau2 result, verifier, and promotion state as authority. GEODE contributes
+stable session/turn/call correlation and a replay sidecar. It cannot make an
+invalid or unfrozen arm valid.
+
+The current tau2 snapshots are intentionally marked
+`promotion_authority=none` and `candidate_surface=unfrozen_git`. The public
+copy can be privacy-transformed, while the raw receipt digest remains the
+Crucible join key. This is compatible with a future frozen Crucible campaign
+without changing the trajectory schema.
+
+## 5. Behavior E2E and benchmarks
+
+### Hook behavior
+
+The GPT subscription behavior E2E used `gpt-5.6-sol`, effort `high`:
+
+- all 13 public hooks executed;
+- middleware counts were `tool_request=1`, `tool_execution=1`,
+  `llm_request=3`, `llm_execution=3`;
+- SQLite and JSONL each contained all 22 hook/middleware extension rows;
+- the public trajectory contained 27 events and one exact tool pair;
+- scope was complete, replay was deliberately incomplete, and secret scans
+  returned zero.
+
+Artifact:
+[`d418e55ff8aa`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/b979268d7e64c99ca27b51c025a2cd25022cc1a5/trajectories/geode-agenticloop-hook-middleware-behavior-e2e-20260731T091808Z-d418e55ff8aa).
+
+### MCPMark
+
+Released `v1.0.11`, `filesystem/easy`, `gpt-5.6-sol` subscription/high:
+
+- official verifier: 10/10;
+- 596.580 seconds, 56 turns;
+- 700,719 input, 12,164 output, 206,848 cache-read tokens;
+- recorded cost estimate $2.937699, not subscription billing;
+- 226 events and 78 exact tool pairs.
+
+The earlier uppercase failure now passes.
+
+### Tau2
+
+Released `v1.0.11`, agent and user both `gpt-5.6-sol`
+subscription/high:
+
+- mock `create_task_1`: 0/1; genuine exact-comparator failure because the model
+  supplied unrequested `description=""`;
+- first Telecom-small task: 1/1; DB, `toggle_roaming`, mobile-data, and speed
+  assertions all passed;
+- no provider, quota, or adapter exception in either run.
+
+Report:
+[`2026-07-31-gpt56-v1011-benchmark.md`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/16a54f08450db771c02e30c73bdc3867f6282f83/reports/e2e-validation/2026-07-31-gpt56-v1011-benchmark.md).
+
+## 6. Quality gates and anti-deception findings
+
+Release gates passed:
+
+- ruff check and format;
+- mypy over 542 source files;
+- four import contracts over 430 files / 1,537 dependencies;
+- architecture, llms index, and slop ratchets;
+- 10,434 non-live tests;
+- 236-page static site build;
+- source distribution and wheel build;
+- installed-wheel smoke from outside the source tree;
+- main CI, smoke, Pages, GitHub release, and PyPI verification.
+
+Four apparently green paths were rejected before becoming evidence:
+
+1. a wheel smoke run from the repository inherited source-tree imports; it was
+   rerun from `/tmp` against site-packages;
+2. the first PyPI verification observed a Simple API propagation race after
+   upload; failed jobs were rerun idempotently and verified published bytes;
+3. an MCPMark command initially shadowed the release source with the harness
+   checkout; exact release-tree import preflight corrected it;
+4. the tau2 environment had a stale editable GEODE `1.0.9`; it was replaced by
+   the public `1.0.11` package before scoring.
+
+These are evidence-quality improvements: environment identity and remote bytes
+are now proven rather than inferred from a successful process exit.
+
+## 7. Deliberate non-expansions and remaining work
+
+The implementation avoided the following fragmentation:
+
+- no public exposure of all 57 internal runtime events;
+- no `MiddlewareKind` enum beside four typed methods;
+- no second canonical transcript beside SQLite;
+- no K3-specific or benchmark-specific canonical trajectory schema;
+- no embedded SIL/Crucible verdict that could steal outer-loop authority;
+- no automatic copy of the whole private artifact tree.
+
+One genuine behavior gap remains: tau2 mock can fail when the model supplies an
+empty optional `description`. The result was retained as 0/1. Fixing it should
+be evaluated as tool-schema/action-normalization behavior, not hidden in the
+artifact bridge or relabeled as infrastructure failure.

--- a/docs/plans/2026-07-31-session-record-contract.md
+++ b/docs/plans/2026-07-31-session-record-contract.md
@@ -5,7 +5,10 @@
 > [`extensibility-roadmap.md`](../architecture/extensibility-roadmap.md).
 
 Date: 2026-07-31  
-Implementation branch: `feature/codex-session-record-contract`  
+Implementation: released as GEODE `v1.0.11` at `686ff372` through
+[`#2850`](https://github.com/mangowhoiscloud/geode/pull/2850),
+[`#2851`](https://github.com/mangowhoiscloud/geode/pull/2851), and
+[`#2852`](https://github.com/mangowhoiscloud/geode/pull/2852)
 Diagram: [`session-record-contract.html`](../diagrams/session-record-contract.html)
 
 ## 1. Outcome
@@ -55,10 +58,10 @@ The comparison uses the locally updated source trees and exact heads:
 
 | Runtime | Grounded storage shape | Applied lesson |
 |---|---|---|
-| Hermes `36e41c09e` | `state.db` schema v23 owns sessions and messages; optional JSON snapshots are off by default; message rows retain active/compacted state; batch/RL trajectories stay separate | SQLite owns resumable conversation truth; offline artifacts do not become a second hot-path truth |
-| OpenClaw `90a22b4f5` | SQLite `transcript_events` and separate bounded `trajectory_runtime_events`; versioned `openclaw-trajectory` envelope; export produces a bundle; legacy JSONL is archive/import input | distinguish durable transcript, runtime telemetry, and exported trajectory; give every event a schema, sequence, lineage, and retention rule |
-| Codex `578c1b223` | rollout JSONL remains durable history; SQLite `thread_turns/items` is an ordinal and byte-cursor projection; diagnostic rollout-trace bundles preserve raw payload references and compaction checkpoints | carry session → turn → call identity, contiguous ordinals, partial-line recovery, and explicit compaction boundaries |
-| GEODE eval artifacts `9c00ecf4a3b5` | append-only public Git repository; historical dated trajectory envelopes; per-file byte/count/SHA-256 manifest; privacy/license review; remote read-back; runtime SQLite and general session dumps excluded | keep the producer schema stable, separate its release manifest, publish only allowlisted normalized views, and bind native evidence by digest |
+| Hermes `98105f31f46d` | `state.db` owns sessions and messages; optional JSON snapshots are off by default; message rows retain active/compacted state; batch/RL trajectories stay separate | SQLite owns resumable conversation truth; offline artifacts do not become a second hot-path truth |
+| OpenClaw `49b4841081c6` | SQLite `transcript_events` and separate bounded `trajectory_runtime_events`; versioned trajectory envelope; export produces a bundle; JSONL remains a serialization/archive boundary | distinguish durable transcript, runtime telemetry, and exported trajectory; give every event a schema, sequence, lineage, and retention rule |
+| Codex `f0c30e528a54` | rollout JSONL remains durable history; SQLite thread projections carry ordinal and byte-cursor state; diagnostic rollout-trace bundles preserve raw payload references and compaction checkpoints | carry session → turn → call identity, contiguous ordinals, partial-line recovery, and explicit compaction boundaries |
+| GEODE eval artifacts `16a54f08450d` | append-only public Git/PR repository; stable producer and release schemas; per-file byte/count/SHA-256 manifest; privacy/license review; remote read-back; runtime SQLite and general session dumps excluded | keep the producer schema stable, separate its release manifest, publish only allowlisted normalized views, and bind native evidence by digest |
 
 There is no universal “SQLite always wins” frontier rule. Codex deliberately
 keeps rollout JSONL canonical. Hermes and OpenClaw deliberately moved
@@ -66,13 +69,11 @@ interactive transcript truth into SQLite. GEODE is closer to Hermes in runtime
 identity and already fixed project `sessions.db` as the queryable state SOT, so
 this work keeps that decision and adopts Codex's correlation/replay rigor.
 
-The artifact repository's checked-in `TRAJECTORIES.md` still describes the
-historical dated envelope and `events[].sequence`. Before the first `@1`
-publication merges there, its policy must add the stable
-`geode.trajectory@1` + `events[].ordinal` producer contract while retaining the
-dated files as immutable legacy inputs. GEODE's in-memory adapter already
-implements that compatibility direction; an artifact-repository PR closes the
-policy half.
+The artifact repository's `TRAJECTORIES.md` now recognizes
+`geode.trajectory@1` + `events[].ordinal` and the separate
+`geode.trajectory-release@1` manifest. Historical dated envelopes and
+`events[].sequence` remain immutable legacy inputs and normalize only in
+memory.
 
 ## 4. Target event contract
 
@@ -204,8 +205,11 @@ SIL and Crucible keep their own promotion authority:
 - `crucible.evidence.v3`, the frozen experiment contract, native tau2 receipt,
   and executable verifier remain Crucible's SOT. The GEODE trajectory is a
   replay sidecar and cannot promote an invalid arm.
-- MCPMark and tau2 native receipts remain byte-identical and are joined through
-  `artifact_digests`; publication code stays outside Crucible's candidate
+- MCPMark and tau2 native receipts remain byte-identical in their authoritative
+  local run stores and are joined through `artifact_digests`. A separately
+  hashed public copy may redact local paths or synthetic personal fields; its
+  disclosure transform and digest are recorded rather than presented as the
+  raw native digest. Publication code stays outside Crucible's candidate
   mutation boundary.
 
 ## 5. Naming and migration map
@@ -299,8 +303,9 @@ uv build
 npm run build  # site/
 ```
 
-The wheel was installed into a fresh temporary environment. `geode version`
-reported `1.0.10`, and all four packaged Draft 2020-12 schemas loaded through
+The released wheel was installed into a fresh temporary environment from
+outside the source tree. `geode version` reported `1.0.11`, and all four
+packaged Draft 2020-12 schemas loaded through
 `importlib.resources`. The site generated all 236 static pages. The Next.js
 build still reports the pre-existing broad seed-directory tracing warnings;
 the Python suite still exposes pre-existing scheduler threads attempting to
@@ -332,6 +337,24 @@ An independent checkout of that exact remote commit passed anchored read-back
 with manifest SHA-256
 `d418e55ff8aa4cae22db9e6c59ac0ecbe060be78ffcc46c900da1e23a6f7b994`:
 27 events, one scope-complete trajectory, zero scope-incomplete trajectories,
-and zero findings in all configured secret-scan classes. Post-release
-MCPMark/tau2 runs remain sequenced after package deployment so their native
-receipts name the released GEODE revision.
+and zero findings in all configured secret-scan classes.
+
+Post-release behavior runs used the published `v1.0.11` package and GEODE
+revision `686ff372`. MCPMark `filesystem/easy` passed 10/10 in 596.580 seconds:
+its ten trajectories carry 226 events, 78 exact tool call/result pairs, zero
+missing required turn IDs, and exact event joins to the isolated SQLite stores.
+Tau2 retained the genuine `mock/create_task_1` failure (0/1 because the action
+included an unrequested `description=""`) and passed the first Telecom-small
+case (1/1); their two trajectories carry 142 events and nine exact tool pairs.
+
+Artifact PR
+[`geode-eval-artifacts#9`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/9)
+merged as
+[`16a54f0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/16a54f08450db771c02e30c73bdc3867f6282f83).
+The stable release manifest digests are
+`82fe94b01a25e7e9f8c504d511f018129cb058ad532dbcbc315de9c6819db0fb`
+for MCPMark and
+`a71155f7006c8dd412af8d1471e7d2380e5f072cc8f0495924fa86f26d69a9a2`
+for tau2. An independent GitHub read-back of the exact merge commit downloaded
+and revalidated both manifests, all trajectories, source digests, file counts,
+and privacy-scan results.

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3052,13 +3052,15 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2.md
 
 tau2-bench는 대화형 tool-use 벤치마크입니다. 에이전트가 시뮬레이션된 사용자와 대화하며 airline, retail, telecom 도메인의 DB 액션을 수행하고, verifier가 필수 액션 충족 여부로 reward를 매깁니다. GEODE는`plugins/benchmark_harness`의 공개 어댑터로 참가하며, 점수는 그 점수를 만든 harness revision, model route, effort에 고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
 
-## 2026-07-31 subscription 진단
+## 2026-07-31 v1.0.11 release 진단
 
-GEODE `edb74602b`에서 agent와 simulated user를 모두 `gpt-5.6-sol` subscription / effort `high`로 실행했습니다. `mock/create_task_1`과 Telecom-small 첫 task는 각각 **0/1**이었습니다. 둘 다 정상 `USER_STOP`이며 provider, quota, adapter exception은 없었습니다.
+배포된 GEODE `v1.0.11` (`686ff372`)에서 agent와 simulated user를 모두 `gpt-5.6-sol` subscription / effort `high`로 실행했습니다. `mock/create_task_1`은 **0/1**, Telecom-small 첫 task는 **1/1**입니다. 둘 다 정상 `USER_STOP`이며 provider, quota, adapter exception은 없었습니다.
 
--   Mock: `create_task`는 실행됐지만 요청에 없던 optional `description=""`를 추가해 exact action/DB comparator가 실패했습니다.
--   Telecom: 계정·회선·로밍·사용량 조회는 맞았지만 사용자 측 device workflow를 안내하지 않고 human transfer해 `toggle_roaming`과 환경 assertion을 놓쳤습니다.
--   [`geode-eval-artifacts/trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1): redaction과 call/result pairing을 검증한 두 dialogue/tool trajectory.
+-   Mock: 이전과 동일하게 `create_task`가 요청에 없던 optional `description=""`를 추가해 exact action/DB comparator가 실패했습니다.
+-   Telecom: 이전의 premature human transfer가 사라졌습니다. `toggle_roaming`, DB match, mobile-data 상태, excellent-speed assertion이 모두 1.0입니다.
+-   [`geode-eval-artifacts/trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c): 142개 이벤트와 9개 exact tool pair를 담은 두 `geode.trajectory@1`.
+
+점수 정본은 여전히 tau2 `results.json`입니다. Crucible snapshot은 두 run을 diagnostic / `promotion_authority=none`으로 유지하며, GEODE trajectory는 digest-joined replay sidecar입니다.
 
 ## Headline: native user-simulator 트랙
 
@@ -3092,6 +3094,80 @@ GEODE `edb74602b`에서 agent와 simulated user를 모두 `gpt-5.6-sol` subscrip
 -   This weighted aggregate is for internal Agent-World-style comparison only.
 -   The run spec differs from OpenAI's official GPT-5.2 Tau2 headline, which used an internal research setup and excludes Airline.
 -   The run spec differs from the earlier GEODE geode\_user smoke matrix.
+
+**Telecom small first-task GPT-5.6 v1.0.11 diagnostic** · 2026-07-31 KST · gpt-5.6-sol · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.11@686ff372</code></td></tr><tr><td>Reward / pass^1</td><td><strong>1.0 / 1.000 (1 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/tau2/simulations/geode-gpt56-sol-high-v1011-686ff372-geode-user-telecom-small-01-20260731/results.json</code></td></tr></tbody></table>
+
+-   DB check 1.0
+-   toggle\_roaming write action 1.0
+-   Mobile-data and excellent-speed assertions 1.0
+-   Termination user\_stop
+-   Duration 78.52s / 117 canonical events / 8 exact tool pairs
+
+```
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain telecom \
+  --task-split-name small \
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 50 \
+  --timeout 1800 \
+  --model gpt-5.6-sol \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --time-budget-s 300 \
+  --user geode_user \
+  --user-llm gpt-5.6-sol \
+  --user-source subscription \
+  --user-effort high \
+  --user-time-budget-s 180 \
+  --save-to geode-gpt56-sol-high-v1011-686ff372-geode-user-telecom-small-01-20260731
+```
+
+-   The earlier premature human-transfer failure is closed for this fixed case.
+-   Tau2 native DB/action/assertion checks remain the score authority; the GEODE trajectory is a digest-joined replay sidecar.
+-   The Crucible v3 snapshot remains diagnostic with promotion\_authority=none because no frozen experiment contract was supplied.
+
+**mock/create\_task\_1 GPT-5.6 v1.0.11 diagnostic** · 2026-07-31 KST · gpt-5.6-sol · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>mock / create_task_1</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.11@686ff372</code></td></tr><tr><td>Reward / pass^1</td><td><strong>0.0 / 0.000 (0 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/tau2/simulations/geode-gpt56-sol-high-v1011-686ff372-geode-user-mock-smoke-20260731/results.json</code></td></tr></tbody></table>
+
+-   Communication check 1.0 / DB check 0.0
+-   create\_task action check 0.0
+-   Termination user\_stop
+-   Duration 9.03s
+-   25 canonical events / 1 exactly paired tool call and result
+
+```
+python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain mock \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 8 \
+  --timeout 900 \
+  --model gpt-5.6-sol \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --time-budget-s 180 \
+  --user geode_user \
+  --user-llm gpt-5.6-sol \
+  --user-source subscription \
+  --user-effort high \
+  --user-time-budget-s 120 \
+  --save-to geode-gpt56-sol-high-v1011-686ff372-geode-user-mock-smoke-20260731
+```
+
+-   The failure reproduces the earlier behavior: create\_task includes unrequested description="" and the native exact comparator rejects it.
+-   The run completed normally and is retained without retry or relabeling.
+-   This diagnostic has promotion\_authority=none and is not a native user\_simulator leaderboard row.
 
 **Telecom small first-task GPT-5.6 subscription diagnostic** · 2026-07-31 KST · gpt-5.6-sol · subscription · agent high / user high
 
@@ -3336,12 +3412,14 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark.md
 
 MCPMark는 실제 MCP 서버(filesystem, Postgres, GitHub, Notion, Playwright 등)를 대상으로 한 tool-use 벤치마크입니다. 태스크마다 독립 검증 스크립트가 결과 상태를 확인합니다. GEODE는 `plugins/benchmark_harness`의 `BaseMCPAgent` 어댑터로 참가하고 upstream `pipeline.py`는 패치하지 않습니다. 점수는 harness commit, 서비스 집합, model route, timeout에 고정해서만 게시합니다.
 
-## 2026-07-31 GPT-5.6 subscription run
+## 2026-07-31 v1.0.11 release regression
 
-GEODE `edb74602b`, `gpt-5.6-sol`, effort `high`로 `filesystem/easy` 10건을 다시 측정했습니다. 공식 verifier 결과는 **9/10 (90.0%)**, 총 799.4초와 54 turns입니다. 유일한 실패는 `file_context/uppercase`가 다섯 파일을 만들고도 `file_01.txt`를 완전히 대문자로 바꾸지 못한 행동 실패입니다. schema 충돌이나 429 실패는 없었습니다.
+배포된 GEODE `v1.0.11` (`686ff372`)과 `gpt-5.6-sol` subscription / effort `high`로 `filesystem/easy` 10건을 재측정했습니다. 공식 verifier는 **10/10 (100.0%)**, 총 596.6초와 56 turns입니다. 이전 `edb74602b` run의 유일한 실패였던 `file_context/uppercase`도 통과했습니다.
 
--   [`geode-eval-artifacts/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy): 마스킹된 verifier receipt와 ordered MCP execution logs.
--   [`geode-eval-artifacts/trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0): task별 10개 content-addressed tool trajectory.
+10개 stable trajectory의 226개 이벤트는 canonical SQLite 행과 ID·session·turn·call·kind까지 일치합니다. 78개 tool call/result가 모두 정확히 pairing됐고 필수 turn ID 누락은 0건입니다.
+
+-   [`geode-eval-artifacts/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy): 마스킹된 verifier receipt와 ordered MCP execution logs.
+-   [`geode-eval-artifacts/trajectories/mcpmark-geode-gpt56-v1.0.11-686ff372-filesystem-easy-20260731T105713Z-82fe94b01a25`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/16a54f08450db771c02e30c73bdc3867f6282f83/trajectories/mcpmark-geode-gpt56-v1.0.11-686ff372-filesystem-easy-20260731T105713Z-82fe94b01a25): privacy review와 source digest 검증을 통과한 10개 `geode.trajectory@1`.
 
 ## Headline: Verified available-services 트랙
 
@@ -3402,6 +3480,37 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   The OpenAI model route was the GEODE Codex subscription route, not MCPMark's native LiteLLM OpenAI API route.
 -   GitHub fixture repositories were made public during execution so the Docker GitHub MCP server could use normal public-repo semantics; all transient repos were deleted by cleanup.
 -   The filesystem score counts papers/author\_folders as a failed no-result transport run after two attempts without meta output.
+
+**filesystem/easy GPT-5.6 v1.0.11 release regression** · 2026-07-31 KST · gpt-5.6-sol · subscription · high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>filesystem/easy</code></td></tr><tr><td>Model</td><td><code>gpt-5.6-sol</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>high</code></td></tr><tr><td>Route</td><td>GEODE AgenticLoop MCPMark adapter</td></tr><tr><td>Harness</td><td><code>eval-sys/mcpmark@cd45b7f, GEODE v1.0.11@686ff372</code></td></tr><tr><td>Accuracy</td><td><strong>100.0% (10 / 10)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy</code></td></tr></tbody></table>
+
+-   Total task execution time 596.580s / average 59.658s
+-   56 GEODE turns total / 5.6 average
+-   700,719 input / 12,164 output / 206,848 cache-read tokens
+-   Recorded estimate $2.937699; not subscription billing
+-   226 canonical events / 78 exactly paired tool calls and results / 0 missing required turn IDs
+
+```
+cd artifacts/eval/harnesses/mcpmark
+GEODE_HOME=<isolated-v1011-runtime-home> \
+PYTHONPATH=<geode-v1.0.11-release-tree> \
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark \
+  --mcp filesystem \
+  --task-suite easy \
+  --models gpt-5.6-sol \
+  --agent geode \
+  --reasoning-effort high \
+  --k 1 \
+  --timeout 1200 \
+  --exp-name geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy \
+  --output-dir ./results-geode-v1011
+```
+
+-   The earlier file\_context/uppercase failure now passes; all ten official filesystem/easy verifiers are green.
+-   This remains directly comparable only to filesystem/easy, not to the MCPMark Verified standard aggregate.
+-   The stable geode.trajectory@1 release is scope-complete but intentionally replay-incomplete because dialogue and tool bodies are digested.
+-   Native receipts and stable trajectories are pinned to geode-eval-artifacts commit 16a54f0.
 
 **filesystem/easy GPT-5.6 subscription rerun** · 2026-07-31 KST · gpt-5.6-sol · subscription · high
 

--- a/site/src/app/docs/benchmarks/mcpmark/page.tsx
+++ b/site/src/app/docs/benchmarks/mcpmark/page.tsx
@@ -85,24 +85,35 @@ export default function Page() {
               고정해서만 게시합니다.
             </p>
 
-            <h2>2026-07-31 GPT-5.6 subscription run</h2>
+            <h2>2026-07-31 v1.0.11 release regression</h2>
             <p>
-              GEODE <code>edb74602b</code>, <code>gpt-5.6-sol</code>, effort{" "}
-              <code>high</code>로 <code>filesystem/easy</code> 10건을 다시
-              측정했습니다. 공식 verifier 결과는 <strong>9/10 (90.0%)</strong>,
-              총 799.4초와 54 turns입니다. 유일한 실패는{" "}
-              <code>file_context/uppercase</code>가 다섯 파일을 만들고도{" "}
-              <code>file_01.txt</code>를 완전히 대문자로 바꾸지 못한 행동
-              실패입니다. schema 충돌이나 429 실패는 없었습니다.
+              배포된 GEODE <code>v1.0.11</code> (<code>686ff372</code>)과{" "}
+              <code>gpt-5.6-sol</code> subscription / effort <code>high</code>로{" "}
+              <code>filesystem/easy</code> 10건을 재측정했습니다. 공식 verifier는{" "}
+              <strong>10/10 (100.0%)</strong>, 총 596.6초와 56 turns입니다.
+              이전 <code>edb74602b</code> run의 유일한 실패였던{" "}
+              <code>file_context/uppercase</code>도 통과했습니다.
+            </p>
+            <p>
+              10개 stable trajectory의 226개 이벤트는 canonical SQLite 행과
+              ID·session·turn·call·kind까지 일치합니다. 78개 tool call/result가
+              모두 정확히 pairing됐고 필수 turn ID 누락은 0건입니다.
             </p>
             <ul>
               <li>
-                <RunLogLink path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy" />:
+                <RunLogLink
+                  path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
                 마스킹된 verifier receipt와 ordered MCP execution logs.
               </li>
               <li>
-                <RunLogLink path="trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0" />:
-                task별 10개 content-addressed tool trajectory.
+                <RunLogLink
+                  path="trajectories/mcpmark-geode-gpt56-v1.0.11-686ff372-filesystem-easy-20260731T105713Z-82fe94b01a25"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
+                privacy review와 source digest 검증을 통과한 10개{" "}
+                <code>geode.trajectory@1</code>.
               </li>
             </ul>
 
@@ -165,25 +176,35 @@ export default function Page() {
               settings.
             </p>
 
-            <h2>2026-07-31 GPT-5.6 Subscription Run</h2>
+            <h2>2026-07-31 v1.0.11 Release Regression</h2>
             <p>
-              We reran the ten <code>filesystem/easy</code> tasks on GEODE{" "}
-              <code>edb74602b</code> with <code>gpt-5.6-sol</code> at effort{" "}
-              <code>high</code>. The official verifier scored{" "}
-              <strong>9/10 (90.0%)</strong> over 799.4 seconds and 54 turns. The
-              only failure was behavioral: <code>file_context/uppercase</code>{" "}
-              created all five files but did not fully uppercase{" "}
-              <code>file_01.txt</code>. No schema collision or 429 failure
-              occurred.
+              We reran the ten <code>filesystem/easy</code> tasks with the
+              released GEODE <code>v1.0.11</code> (<code>686ff372</code>) and{" "}
+              <code>gpt-5.6-sol</code> subscription at effort <code>high</code>.
+              The official verifier scored <strong>10/10 (100.0%)</strong> over
+              596.6 seconds and 56 turns. The earlier{" "}
+              <code>file_context/uppercase</code> failure now passes.
+            </p>
+            <p>
+              All 226 events in the ten stable trajectories join their canonical
+              SQLite rows on ID, session, turn, call, and kind. All 78 tool
+              calls have exactly one result, with zero missing required turn IDs.
             </p>
             <ul>
               <li>
-                <RunLogLink path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-edb74602b-20260731-mcpmark-filesystem-easy" />:
+                <RunLogLink
+                  path="mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
                 redacted verifier receipts and ordered MCP execution logs.
               </li>
               <li>
-                <RunLogLink path="trajectories/mcpmark-geode-gpt56-edb74602b-filesystem-easy-20260731T034305Z-b86f5071cbe0" />:
-                ten content-addressed per-task tool trajectories.
+                <RunLogLink
+                  path="trajectories/mcpmark-geode-gpt56-v1.0.11-686ff372-filesystem-easy-20260731T105713Z-82fe94b01a25"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
+                ten privacy-reviewed, source-digest-verified{" "}
+                <code>geode.trajectory@1</code> artifacts.
               </li>
             </ul>
 

--- a/site/src/app/docs/benchmarks/tau2/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/page.tsx
@@ -32,32 +32,41 @@ export default function Page() {
               고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
             </p>
 
-            <h2>2026-07-31 subscription 진단</h2>
+            <h2>2026-07-31 v1.0.11 release 진단</h2>
             <p>
-              GEODE <code>edb74602b</code>에서 agent와 simulated user를 모두{" "}
-              <code>gpt-5.6-sol</code> subscription / effort <code>high</code>로
-              실행했습니다. <code>mock/create_task_1</code>과 Telecom-small 첫
-              task는 각각 <strong>0/1</strong>이었습니다. 둘 다 정상{" "}
+              배포된 GEODE <code>v1.0.11</code> (<code>686ff372</code>)에서
+              agent와 simulated user를 모두 <code>gpt-5.6-sol</code>{" "}
+              subscription / effort <code>high</code>로 실행했습니다.{" "}
+              <code>mock/create_task_1</code>은 <strong>0/1</strong>,
+              Telecom-small 첫 task는 <strong>1/1</strong>입니다. 둘 다 정상{" "}
               <code>USER_STOP</code>이며 provider, quota, adapter exception은
               없었습니다.
             </p>
             <ul>
               <li>
-                Mock: <code>create_task</code>는 실행됐지만 요청에 없던 optional{" "}
+                Mock: 이전과 동일하게 <code>create_task</code>가 요청에 없던 optional{" "}
                 <code>description=&quot;&quot;</code>를 추가해 exact action/DB
                 comparator가 실패했습니다.
               </li>
               <li>
-                Telecom: 계정·회선·로밍·사용량 조회는 맞았지만 사용자 측 device
-                workflow를 안내하지 않고 human transfer해{" "}
-                <code>toggle_roaming</code>과 환경 assertion을 놓쳤습니다.
+                Telecom: 이전의 premature human transfer가 사라졌습니다.{" "}
+                <code>toggle_roaming</code>, DB match, mobile-data 상태,
+                excellent-speed assertion이 모두 1.0입니다.
               </li>
               <li>
-                <RunLogLink path="trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1" />:
-                redaction과 call/result pairing을 검증한 두 dialogue/tool
-                trajectory.
+                <RunLogLink
+                  path="trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
+                142개 이벤트와 9개 exact tool pair를 담은 두{" "}
+                <code>geode.trajectory@1</code>.
               </li>
             </ul>
+            <p>
+              점수 정본은 여전히 tau2 <code>results.json</code>입니다. Crucible
+              snapshot은 두 run을 diagnostic / <code>promotion_authority=none</code>으로
+              유지하며, GEODE trajectory는 digest-joined replay sidecar입니다.
+            </p>
 
             <h2>Headline: native user-simulator 트랙</h2>
             <p>
@@ -114,33 +123,42 @@ export default function Page() {
               settings.
             </p>
 
-            <h2>2026-07-31 Subscription Diagnostics</h2>
+            <h2>2026-07-31 v1.0.11 Release Diagnostics</h2>
             <p>
-              On GEODE <code>edb74602b</code>, both the agent and simulated user
-              ran through <code>gpt-5.6-sol</code> subscription at effort{" "}
-              <code>high</code>. <code>mock/create_task_1</code> and the first
-              Telecom-small task each scored <strong>0/1</strong>. Both ended
-              normally with <code>USER_STOP</code>; neither hit a provider,
-              quota, or adapter exception.
+              With the released GEODE <code>v1.0.11</code> (<code>686ff372</code>),
+              both the agent and simulated user ran through{" "}
+              <code>gpt-5.6-sol</code> subscription at effort <code>high</code>.{" "}
+              <code>mock/create_task_1</code> scored <strong>0/1</strong>; the
+              first Telecom-small task scored <strong>1/1</strong>. Both ended
+              normally with <code>USER_STOP</code>, with no provider, quota, or
+              adapter exception.
             </p>
             <ul>
               <li>
-                Mock: <code>create_task</code> executed, but the model added the
-                unrequested optional <code>description=&quot;&quot;</code>, so the
-                exact action and DB comparators failed.
+                Mock: as before, <code>create_task</code> added the unrequested
+                optional <code>description=&quot;&quot;</code>, so the native exact
+                action and DB comparators failed.
               </li>
               <li>
-                Telecom: account, line, roaming, and usage lookup were correct,
-                but the agent transferred to a human instead of guiding the
-                user-side device workflow, missing <code>toggle_roaming</code>{" "}
-                and the environment assertions.
+                Telecom: the earlier premature human transfer is gone.{" "}
+                <code>toggle_roaming</code>, DB match, mobile-data status, and
+                excellent-speed assertions all scored 1.0.
               </li>
               <li>
-                <RunLogLink path="trajectories/tau2-geode-gpt56-edb74602b-mock-telecom-small-20260731T034305Z-4ec1c13434d1" />:
-                two redaction- and call/result-validated dialogue/tool
-                trajectories.
+                <RunLogLink
+                  path="trajectories/tau2-geode-gpt56-v1.0.11-686ff372-mock-telecom-small-20260731T105713Z-a71155f7006c"
+                  revision="16a54f08450db771c02e30c73bdc3867f6282f83"
+                />:
+                two <code>geode.trajectory@1</code> artifacts with 142 events and
+                nine exact tool pairs.
               </li>
             </ul>
+            <p>
+              Tau2 <code>results.json</code> remains the score authority. The
+              Crucible snapshots keep both runs diagnostic with{" "}
+              <code>promotion_authority=none</code>; the GEODE trajectory is a
+              digest-joined replay sidecar.
+            </p>
 
             <h2>Headline: Native User-Simulator Track</h2>
             <p>

--- a/site/src/components/geode-docs/benchmark-run-ledger.tsx
+++ b/site/src/components/geode-docs/benchmark-run-ledger.tsx
@@ -67,9 +67,17 @@ export function BenchmarkRunList({ group }: { group: BenchmarkGroup }) {
   );
 }
 
-export function RunLogLink({ path, label }: { path: string; label?: string }) {
+export function RunLogLink({
+  path,
+  label,
+  revision = "main",
+}: {
+  path: string;
+  label?: string;
+  revision?: string;
+}) {
   return (
-    <a href={`${EVAL_ARTIFACTS_REPO}/tree/main/${path}`}>
+    <a href={`${EVAL_ARTIFACTS_REPO}/tree/${revision}/${path}`}>
       <code>{label ?? `geode-eval-artifacts/${path}`}</code>
     </a>
   );

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -127,6 +127,51 @@ OPENAI_API_KEY=dummy \\
   ],
 };
 
+const mcpmarkFilesystemEasyGpt56V1011: BenchmarkMeasurement = {
+  id: "mcpmark-filesystem-easy-20260731-gpt56-high-v1011",
+  group: "mcpmark",
+  title: "filesystem/easy GPT-5.6 v1.0.11 release regression",
+  measuredAt: "2026-07-31 KST",
+  suite: "filesystem/easy",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai",
+  source: "subscription",
+  effort: "high",
+  route: "GEODE AgenticLoop MCPMark adapter",
+  harness: "eval-sys/mcpmark@cd45b7f, GEODE v1.0.11@686ff372",
+  artifact:
+    "geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/mcpmark/results-geode-agentworld/geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy",
+  scoreLabel: "Accuracy",
+  scoreValue: "100.0% (10 / 10)",
+  secondary: [
+    "Total task execution time 596.580s / average 59.658s",
+    "56 GEODE turns total / 5.6 average",
+    "700,719 input / 12,164 output / 206,848 cache-read tokens",
+    "Recorded estimate $2.937699; not subscription billing",
+    "226 canonical events / 78 exactly paired tool calls and results / 0 missing required turn IDs",
+  ],
+  command: `cd artifacts/eval/harnesses/mcpmark
+GEODE_HOME=<isolated-v1011-runtime-home> \\
+PYTHONPATH=<geode-v1.0.11-release-tree> \\
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark \\
+  --mcp filesystem \\
+  --task-suite easy \\
+  --models gpt-5.6-sol \\
+  --agent geode \\
+  --reasoning-effort high \\
+  --k 1 \\
+  --timeout 1200 \\
+  --exp-name geode-gpt56-sol-high-v1011-686ff372-20260731-mcpmark-filesystem-easy \\
+  --output-dir ./results-geode-v1011`,
+  notes: [
+    "The earlier file_context/uppercase failure now passes; all ten official filesystem/easy verifiers are green.",
+    "This remains directly comparable only to filesystem/easy, not to the MCPMark Verified standard aggregate.",
+    "The stable geode.trajectory@1 release is scope-complete but intentionally replay-incomplete because dialogue and tool bodies are digested.",
+    "Native receipts and stable trajectories are pinned to geode-eval-artifacts commit 16a54f0.",
+  ],
+};
+
 const mcpmarkFilesystemEasyParallel: BenchmarkMeasurement = {
   id: "mcpmark-filesystem-easy-parallel-20260703-gpt55-xhigh",
   group: "mcpmark",
@@ -578,6 +623,109 @@ const tau2TelecomSmallGpt56: BenchmarkMeasurement = {
   ],
 };
 
+const tau2MockGpt56V1011: BenchmarkMeasurement = {
+  id: "tau2-mock-20260731-gpt56-high-geode-user-v1011",
+  group: "tau2",
+  title: "mock/create_task_1 GPT-5.6 v1.0.11 diagnostic",
+  measuredAt: "2026-07-31 KST",
+  suite: "mock / create_task_1",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness: "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.11@686ff372",
+  artifact:
+    "geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/tau2/simulations/geode-gpt56-sol-high-v1011-686ff372-geode-user-mock-smoke-20260731/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "0.0 / 0.000 (0 / 1)",
+  secondary: [
+    "Communication check 1.0 / DB check 0.0",
+    "create_task action check 0.0",
+    "Termination user_stop",
+    "Duration 9.03s",
+    "25 canonical events / 1 exactly paired tool call and result",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain mock \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 8 \\
+  --timeout 900 \\
+  --model gpt-5.6-sol \\
+  --provider openai \\
+  --source subscription \\
+  --effort high \\
+  --time-budget-s 180 \\
+  --user geode_user \\
+  --user-llm gpt-5.6-sol \\
+  --user-source subscription \\
+  --user-effort high \\
+  --user-time-budget-s 120 \\
+  --save-to geode-gpt56-sol-high-v1011-686ff372-geode-user-mock-smoke-20260731`,
+  notes: [
+    "The failure reproduces the earlier behavior: create_task includes unrequested description=\"\" and the native exact comparator rejects it.",
+    "The run completed normally and is retained without retry or relabeling.",
+    "This diagnostic has promotion_authority=none and is not a native user_simulator leaderboard row.",
+  ],
+};
+
+const tau2TelecomSmallGpt56V1011: BenchmarkMeasurement = {
+  id: "tau2-telecom-small-20260731-gpt56-high-geode-user-v1011",
+  group: "tau2",
+  title: "Telecom small first-task GPT-5.6 v1.0.11 diagnostic",
+  measuredAt: "2026-07-31 KST",
+  suite:
+    "telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]",
+  status: "complete",
+  model: "gpt-5.6-sol",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness: "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.11@686ff372",
+  artifact:
+    "geode-eval-artifacts@16a54f08450db771c02e30c73bdc3867f6282f83/tau2/simulations/geode-gpt56-sol-high-v1011-686ff372-geode-user-telecom-small-01-20260731/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "1.0 / 1.000 (1 / 1)",
+  secondary: [
+    "DB check 1.0",
+    "toggle_roaming write action 1.0",
+    "Mobile-data and excellent-speed assertions 1.0",
+    "Termination user_stop",
+    "Duration 78.52s / 117 canonical events / 8 exact tool pairs",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \\
+  --harness-dir artifacts/eval/harnesses/tau2-bench \\
+  --domain telecom \\
+  --task-split-name small \\
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \\
+  --num-tasks 1 \\
+  --num-trials 1 \\
+  --max-concurrency 1 \\
+  --max-steps 50 \\
+  --timeout 1800 \\
+  --model gpt-5.6-sol \\
+  --provider openai \\
+  --source subscription \\
+  --effort high \\
+  --time-budget-s 300 \\
+  --user geode_user \\
+  --user-llm gpt-5.6-sol \\
+  --user-source subscription \\
+  --user-effort high \\
+  --user-time-budget-s 180 \\
+  --save-to geode-gpt56-sol-high-v1011-686ff372-geode-user-telecom-small-01-20260731`,
+  notes: [
+    "The earlier premature human-transfer failure is closed for this fixed case.",
+    "Tau2 native DB/action/assertion checks remain the score authority; the GEODE trajectory is a digest-joined replay sidecar.",
+    "The Crucible v3 snapshot remains diagnostic with promotion_authority=none because no frozen experiment contract was supplied.",
+  ],
+};
+
 const tau2NativeAirlineBase: BenchmarkMeasurement = {
   id: "tau2-airline-base-20260703-geode-099269-gpt52-high-payg",
   group: "tau2",
@@ -822,6 +970,7 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       mcpmarkVerifiedAvailable,
+      mcpmarkFilesystemEasyGpt56V1011,
       mcpmarkFilesystemEasyGpt56,
       mcpmarkVerifiedGithub,
       mcpmarkVerifiedPostgres,
@@ -875,6 +1024,8 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       tau2NativeAggregate,
+      tau2TelecomSmallGpt56V1011,
+      tau2MockGpt56V1011,
       tau2TelecomSmallGpt56,
       tau2MockGpt56,
       tau2NativeTelecomBase,


### PR DESCRIPTION
## Summary
- Promote the reviewed v1.0.11 hook/session-record handoff and post-release benchmark evidence from `develop` to `main`.
- Publish immutable MCPMark/tau2 artifact links and regenerated `llms-full.txt`.

## Why
The runtime package and eval artifacts are already public. This sync makes the canonical site and main-branch documentation describe the same released state.

## Changes
| Area | Change |
|---|---|
| Hooks/storage | Final 13-hook, 4-middleware, SQLite/JSONL/trajectory contract and diagram |
| External loops | Explicit SIL and Crucible authority/digest compatibility |
| Benchmarks | MCPMark 10/10, tau2 mock 0/1, Telecom-small 1/1 |
| Public docs | Commit-pinned artifact links and current generated llms-full index |

## Verification
- Feature PR #2853: all CI, Pages build, link, and dual-OS install checks passed
- Local site build: 236 static pages
- Artifact commit `16a54f08450db771c02e30c73bdc3867f6282f83`: anchored remote read-back passed