### PR TITLE
release: v1.0.12 — GPT-5.4 Tau2 full-cycle evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,20 @@ jobs:
       - name: Ratchet — minimum test count
         if: needs.changes.outputs.code == 'true'
         run: |
-          count=$(uv run pytest --co -q 2>/dev/null | tail -1 | grep -oE '[0-9]+' | head -1)
-          echo "Test count: $count"
-          if [ "$count" -lt 2900 ]; then
-            echo "::error::Test count $count < 2900 (ratchet). Do not delete tests without justification."
+          collection_output=$(uv run pytest --collect-only)
+          summary="${collection_output##*$'\n'}"
+          echo "$summary"
+          if [[ "$summary" =~ ^([0-9]+)/[0-9]+\ tests\ collected ]]; then
+            count="${BASH_REMATCH[1]}"
+          elif [[ "$summary" =~ ^([0-9]+)\ tests\ collected ]]; then
+            count="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Could not parse pytest collection summary."
+            exit 1
+          fi
+          echo "Selected non-live test count: $count"
+          if [ "$count" -lt 10451 ]; then
+            echo "::error::Test count $count < 10451 (ratchet). Do not delete tests without justification."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.12] - 2026-08-03
+
+> GPT-5.4 subscription routing, concurrent session durability, and failed-tool
+> evidence are validated by a reviewed 278-task Tau2 full cycle whose native
+> receipts and canonical trajectory are published immutably.
+
 ### Fixed
 
 - Serialized and bounded-retried first-use `session_events` schema bootstrap so
@@ -71,6 +77,9 @@ functional change.
 
 ### Infrastructure
 
+- Made the CI test-count ratchet fail closed on collection or summary-parse
+  errors and raised its measured floor from the stale 2,900-test threshold to
+  10,451 non-live tests.
 - Updated the static documentation site to Next.js and `eslint-config-next`
   16.2.12 and refreshed patched `brace-expansion` lock entries. The deployed
   GitHub Pages export uses unoptimized images and has zero advisories when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.11
+- **Version**: 1.0.12
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
 - **Modules**: 432 core + 110 plugins = 542
-- **Tests**: 10434 (+1 live)
+- **Tests**: 10451 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.11 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.12 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.11: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.12: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/plans/2026-08-03-gpt54-tau2-release-handoff.md
+++ b/docs/plans/2026-08-03-gpt54-tau2-release-handoff.md
@@ -1,0 +1,219 @@
+# Handoff — GPT-5.4, Tau2 full cycle, and v1.0.12
+
+Date: 2026-08-03
+
+Release authority: `v1.0.12`. When this document is read from that annotated
+tag, the tag target is the exact runtime source. If the tag or public package
+does not exist, the release is incomplete regardless of local or PR state.
+
+Read §1 for the outcome, §2 for the final runtime surfaces, §3 for the Tau2
+evidence, §4 for storage and artifact ownership, and §5 for the remaining
+GAPs. §6 is the recovery checklist.
+
+## 1. Outcome and evidence chain
+
+The implementation and evidence are split across reviewable merge vehicles:
+
+| Scope | Authority |
+|---|---|
+| GPT-5.4/Luna model surface and diagnostic Tau2 path | [GEODE #2857](https://github.com/mangowhoiscloud/geode/pull/2857) |
+| concurrent `session_events` bootstrap | [GEODE #2858](https://github.com/mangowhoiscloud/geode/pull/2858) |
+| failed Tau2 tool-call projection | [GEODE #2859](https://github.com/mangowhoiscloud/geode/pull/2859) |
+| full-cycle official documentation | [GEODE #2860](https://github.com/mangowhoiscloud/geode/pull/2860) |
+| immutable full-cycle evidence | [`geode-eval-artifacts@86dcbba`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/86dcbba3d15f1979b71a501780bf66fea4b450b5) |
+| stable trajectory manifest | [`manifest.json`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/86dcbba3d15f1979b71a501780bf66fea4b450b5/trajectories/tau2-geode-gpt54-22789ee2-geode-user-airline-retail-telecom-base-full-20260803T091257Z-13162f7bcff9/manifest.json) |
+| public distribution | GitHub release and PyPI package `geode-agent==1.0.12` |
+
+The manifest SHA-256 is
+`13162f7bcff9ade1194f41af06549f0b0f239847f59630d5223386e2ca6362b3`.
+The artifact repository was read back at the exact commit after merge; the
+manifest, machine report, human report, and all three public native receipts
+matched the reviewed publication.
+
+## 2. Final runtime surfaces
+
+### 2.1 OpenAI model surface
+
+The curated picker order is:
+
+1. `gpt-5.6-sol` — subscription and PAYG; effort `none` through `max`
+2. `gpt-5.6-terra` — subscription and PAYG; effort `none` through `max`
+3. `gpt-5.6-luna` — subscription and PAYG; effort `none` through `max`
+4. `gpt-5.5` — subscription; effort `none` through `xhigh`
+5. `gpt-5.4` — subscription and PAYG; effort `none` through `xhigh`
+6. `gpt-5.4-mini` — subscription and PAYG; effort `none` through `xhigh`
+7. `gpt-5.3-codex` — legacy management row for persisted installations
+
+The provider remains `openai`. Credential-source inference selects the Codex
+subscription backend for OAuth and the PAYG backend for API-key profiles.
+Off-catalog configured defaults and active role selections appear once as
+`Configured` rows; this preserves operator control without claiming that the
+model is part of the curated catalog. Picker effort values come from the
+adapter's `OpenAIModelSpec`, not a second CLI enum.
+
+### 2.2 Hook, middleware, and runtime-event planes
+
+| Plane | Surface | Authority |
+|---|---|---|
+| public control | 13 `HookName` values | versioned ABI; bounded/redacted payloads and closed decisions |
+| trusted execution | 4 middleware join points | immutable request transforms or exactly-once async wrappers |
+| internal observation | 57 `RuntimeEvent` members | telemetry/wiring vocabulary, not a public compatibility promise |
+
+The public hooks are `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`,
+`PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SessionEnd`,
+`SubagentStart`, `SubagentStop`, `PreVerify`, `PostVerify`, and `Stop`.
+
+The trusted join points are `tool_request`, `tool_execution`, `llm_request`,
+and `llm_execution`. `MiddlewareKind` was deliberately not added: the registry
+already exposes four type-specific protocols and registration/execution
+methods, so an enum would duplicate the type system and fragment naming.
+
+`PostVerify` lets an owning outer loop accept, revise, or escalate a candidate
+after executable verification. Revision is monotone and bounded; it does not
+replay completed tool side effects. Escalation withholds the candidate and
+parks the session as `external_verification_required`, which is the useful
+boundary for SIL, Crucible, and other external loops.
+
+## 3. Tau2 full-cycle evidence
+
+### 3.1 Contract
+
+- runtime revision: `22789ee28e87ba03580beec3db6e919f5cef5178`
+- upstream harness: `1901a301961cbbe3fd11f3e84a2a376530c759e3`
+  (`tau2==1.0.0`)
+- agent and user: `gpt-5.4`, subscription, effort `high`
+- agent/user pair: `geode_agent + geode_user`
+- domains: Airline 50, Retail 114, Telecom 114; 278 tasks total
+- concurrency: 2; one final trial; maximum 200 steps
+- task transport retries: Airline 0, Retail/Telecom at most 1
+- promotion authority: none
+
+`geode_user` is a GEODE external-loop diagnostic route, not Tau2's native user
+simulator. The aggregate must not replace the native-user headline or be
+presented as a leaderboard result.
+
+### 3.2 Result
+
+| Domain | Passed | Score |
+|---|---:|---:|
+| Airline | 42 / 50 | 0.8400 |
+| Retail | 79 / 114 | 0.6930 |
+| Telecom | 79 / 114 | 0.6930 |
+| **Weighted total** | **200 / 278** | **0.7194** |
+
+The final attempts comprise 556 parent sessions (agent plus user), 51,985
+canonical `session_events`, 9,148 SQLite messages, and 3,964 exact tool
+call/result pairs. Event IDs are unique, per-session ordinals are contiguous,
+and there are no orphan calls or results. All three release scopes are
+complete and all three source digests match.
+
+The three native-result source SHA-256 digests are:
+
+- Airline: `f15dc8b6798009161e0b14fbd2a86ededf82f08980a1447475aab5ecd43c7f51`
+- Retail: `4cbd04b3e847aabb0f96c5cf5b50318cb36d6e35c65c230cc7f044bbdbe0d97f`
+- Telecom: `6ac4f16c4954705dc87b17cae520f9ac882f7fafd4085a54c700716bfeaea9df`
+
+The public copies are separately hashed after the reviewed synthetic
+phone/email/home-address disclosure transform. They are not represented as
+byte-identical raw receipts.
+
+### 3.3 What the cycle does and does not prove
+
+```mermaid
+flowchart LR
+    T["278 Tau2 tasks"] --> P["556 final parent sessions"]
+    P --> S[("SQLite session_events")]
+    P --> M[("SQLite messages")]
+    S --> J["exact call/result join"]
+    M --> J
+    J --> R["geode.trajectory@1"]
+    R --> G{"release gates"}
+    G -->|"scope + digest + privacy pass"| A["immutable artifact commit"]
+    G -->|"replay incomplete"| X["disclosed limitation"]
+```
+
+This cycle validates provider routing, agent behavior, durable lifecycle
+history, failed tool-call projection, exact tool pairing, privacy review, and
+artifact publication. It does not validate public hook dispatch: the Tau2
+adapter intentionally constructs an isolated `AgenticLoop` without a
+`HookRegistry`, so `hook_events == 0` is expected. The separate subscription
+hook behavior E2E at artifact commit
+[`b979268`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/b979268d7e64c99ca27b51c025a2cd25022cc1a5)
+is the authority for all 13 hooks and four middleware seams.
+
+## 4. Persistence and artifact ownership
+
+| Concern | Canonical store | Role |
+|---|---|---|
+| resumable current state | `sessions.db:sessions/messages` | mutable checkpoint and conversation reconstruction |
+| behavioral history | `sessions.db:session_events` | append-only, versioned lifecycle/tool/message evidence |
+| runtime telemetry | `sessions.db:hook_events` | bounded hook/middleware/runtime diagnostics |
+| portable run projection | run-local `events.jsonl` | bounded, rebuildable serialization; not resume truth |
+| reviewed trajectory | `geode.trajectory@1` | immutable normalized evaluation projection |
+| public evidence | `geode-eval-artifacts` Git commit + release manifest | reviewed disclosure, digests, and remote read-back |
+| verifier authority | SIL / Crucible native evidence | independent promotion decision; never overwritten by GEODE |
+
+New runtime sessions do not create global transcript JSONL. `SessionTranscript`,
+`RunTranscript`, the `run_transcript` re-export, and automatic legacy filename
+fallbacks were deprecated in v1.0.11. v1.0.12 is the single post-deprecation
+grace release: new integrations use `SessionTimeline`, `RunTimeline`, and
+`events.jsonl`; old files should be migrated explicitly with
+`geode session migrate-records`.
+
+The external repository is a Git-backed evidence Artifactory, not a second hot
+runtime database. Publication is append-only and reviewed by PR. Native Tau2,
+SIL, and Crucible artifacts keep their own authority and are joined by digest
+and evidence reference instead of being copied into `sessions.db` as verdicts.
+
+## 5. Remaining GAPs
+
+1. **Retry-attempt lineage is not normalized.** Seven Telecom task-level
+   provider transport retries created fourteen extra SQLite sessions (agent and
+   user) outside the 556 final parents. Final-attempt evidence is complete, but
+   the retry graph is reconstructed from the bounded time window rather than a
+   general trajectory lineage table. Existing `run_lineage` is seed-generation
+   specific and correctly has zero Tau2 rows; do not overload it silently.
+2. **Replay is not complete.** The release reports `scope_complete=true` for
+   all three domains and `replay_complete=false` for all three. It is valid for
+   behavioral review and exact tool pairing, not deterministic environment
+   replay.
+3. **Hook authority is separate.** Tau2's isolated loop has no public hook
+   registry. Do not infer 13-hook coverage from the 51,985-event trajectory.
+4. **Comparator boundary remains.** `geode_user` is useful for the outer-loop
+   system but cannot be mixed into the native-user benchmark headline.
+5. **Transcript grace must close.** Before the release after v1.0.12, register
+   the compatibility-removal GAP, migrate remaining tests/callers, remove the
+   deprecated constructors and re-export module, and retain only an explicit
+   historical import path where archival migration requires it.
+6. **Optional `sharp` advisories remain upstream-bound.** The full npm install
+   reports two high advisories through optional `sharp<0.35.0`; the deployed
+   static export omits optional native tooling and `npm audit --omit=optional`
+   is clean. Do not describe the full dependency graph as advisory-free.
+7. **The user-local `geode-ci` mirror is stale.** Its current script still
+   passes the removed `autoresearch/` path to ruff and mypy and retains the old
+   pytest-summary parser. The repository's GitHub workflow is fixed in this
+   release and the current direct gates pass; update the separately installed
+   local mirror before treating `geode-ci --fast` as authoritative again.
+
+## 6. Release and recovery checklist
+
+The normal path is:
+
+1. release PR into `develop`, all CI green;
+2. `develop -> main` PR, merge commit, all CI green;
+3. dispatch `release.yml` from `main` with `version=1.0.12`,
+   `publish_stable=true`, and no hand-created tag;
+4. require the annotated tag, GitHub assets, PyPI files, checksums, clean
+   `uvx`, and public distribution verifier to agree on one main SHA;
+5. verify Pages and official Tau2 links by public read-back;
+6. remove only task-owned worktrees, harness copies, build directories, and
+   local Tau2 databases after every immutable remote receipt is verified.
+
+If the release workflow partially succeeds, rerun the same version against the
+unchanged tag target. Never delete or move a published tag, overwrite a PyPI
+file, or create a replacement release with different bytes.
+
+Do not rerun 278 paid tasks merely to reconstruct state. The immutable artifact
+commit, native source hashes, manifest, privacy review, and anchored remote
+read-back are the completion evidence. A new full cycle is warranted only for
+a runtime/provider/harness change or an explicitly versioned regression study.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.11"
+version = "1.0.12"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
     "count": 251,
-    "stamped": "1.0.11"
+    "stamped": "1.0.12"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.11"
+    "stamped": "1.0.12"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.11"
+    "stamped": "1.0.12"
   },
   "duplicated_signatures": {
     "count": 97,
-    "stamped": "1.0.11"
+    "stamped": "1.0.12"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.11. Last sync 2026-07-31. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.12. Last sync 2026-08-03. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -3005,7 +3005,7 @@ geode session prune-records --retention-days 180
 -   `prune-records`는 보존 기간보다 오래된 명시적 terminal session만 삭제하고 active/stale session은 남깁니다.
 -   삭제한 canonical row는 run projection에서 복구한다고 가정하지 마세요. 보존할 실행은 prune 전에 export합니다.
 
-`SessionTranscript`/`RunTranscript`와`transcript.jsonl`/`dialogue.jsonl` reader는 v1.0.11에서 compatibility adapter로만 남아 있습니다. 새 연동은`SessionTimeline`, `RunTimeline`,`events.jsonl`을 사용합니다. 제거는 이 릴리스 범위가 아니며 이후 CHANGELOG에서 별도로 공지해야 합니다.
+`SessionTranscript`/`RunTranscript`와`transcript.jsonl`/`dialogue.jsonl` reader는 v1.0.11에서 deprecated되었고 v1.0.12 grace release에는 compatibility adapter로만 남아 있습니다. 새 연동은`SessionTimeline`, `RunTimeline`,`events.jsonl`을 사용합니다. 제거는 이 릴리스 범위가 아니며 이후 CHANGELOG에서 별도로 공지해야 합니다.
 
 ## Trajectory 품질과 외부 루프
 
@@ -5876,7 +5876,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1484 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1485 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.11. Last sync 2026-07-31. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.12. Last sync 2026-08-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/app/docs/verification/observability/page.tsx
+++ b/site/src/app/docs/verification/observability/page.tsx
@@ -76,7 +76,8 @@ export default function Page() {
             <p>
               <code>SessionTranscript</code>/<code>RunTranscript</code>와
               <code>transcript.jsonl</code>/<code>dialogue.jsonl</code> reader는
-              v1.0.11에서 compatibility adapter로만 남아 있습니다. 새 연동은
+              v1.0.11에서 deprecated되었고 v1.0.12 grace release에는 compatibility
+              adapter로만 남아 있습니다. 새 연동은
               <code>SessionTimeline</code>, <code>RunTimeline</code>,
               <code>events.jsonl</code>을 사용합니다. 제거는 이 릴리스 범위가
               아니며 이후 CHANGELOG에서 별도로 공지해야 합니다.
@@ -204,8 +205,9 @@ export default function Page() {
             </ul>
             <p>
               <code>SessionTranscript</code>/<code>RunTranscript</code> and the
-              <code>transcript.jsonl</code>/<code>dialogue.jsonl</code> readers remain
-              only as compatibility adapters in v1.0.11. New integrations use
+              <code>transcript.jsonl</code>/<code>dialogue.jsonl</code> readers were
+              deprecated in v1.0.11 and remain only as compatibility adapters for
+              the v1.0.12 grace release. New integrations use
               <code>SessionTimeline</code>, <code>RunTimeline</code>, and
               <code>events.jsonl</code>. Removal is outside this release and must be
               announced separately in a later CHANGELOG.

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-31
+ * Last sync: 2026-08-03
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- Serialized and bounded-retried first-use `session_events` schema bootstrap so\n  concurrent agent loops and processes cannot lose their durable timeline while\n  the shared project database enters WAL mode. The component ownership row is\n  now created atomically.\n- Preserved failed GEODE tool calls when projecting Tau2 turns so invalid model\n  arguments become official Tau2 `ToolMessage(error=True)` evidence governed by\n  `max_errors`, instead of being misclassified as an empty-route infrastructure\n  failure.\n\n### Changed\n\n- Aligned the OpenAI model picker and `/login use` routing hints with the current Codex surface: GPT-5.6 Sol/Terra/Luna lead the list, GPT-5.4 remains available through both subscription and PAYG routes, deprecated GPT-5.3 Codex stays as a legacy management row for persisted installations, operator defaults and active role selections outside the curated surface remain manageable through deduplicated `Configured` rows, and picker reasoning-effort values now reuse the adapter's per-model contract while preserving a persisted legacy `minimal` value on a no-op confirmation.\n- Recorded a GPT-5.4 subscription-route Tau2 regression and three-domain base\n  full cycle against the pinned upstream harness. The full diagnostic scores\n  Airline 42/50, Retail 79/114, and Telecom 79/114 (200/278 weighted), with\n  51,985 reviewed canonical events and 3,964 exact tool pairs in the immutable\n  external artifact repository. The GEODE-user route remains separate from\n  the native-user headline and carries no promotion authority; retry-only\n  sessions and replay incompleteness are explicitly disclosed.\n\n### Infrastructure\n\n- Updated the static documentation site to Next.js and `eslint-config-next`\n  16.2.12 and refreshed patched `brace-expansion` lock entries. The deployed\n  GitHub Pages export uses unoptimized images and has zero advisories when\n  optional native image tooling is omitted; the full install still reports\n  upstream optional `sharp<0.35.0`, which the latest supported Next.js release\n  continues to constrain to `^0.34.5`."
+    "body": ""
+  },
+  {
+    "version": "1.0.12",
+    "date": "2026-08-03",
+    "body": "> GPT-5.4 subscription routing, concurrent session durability, and failed-tool\n> evidence are validated by a reviewed 278-task Tau2 full cycle whose native\n> receipts and canonical trajectory are published immutably.\n\n### Fixed\n\n- Serialized and bounded-retried first-use `session_events` schema bootstrap so\n  concurrent agent loops and processes cannot lose their durable timeline while\n  the shared project database enters WAL mode. The component ownership row is\n  now created atomically.\n- Preserved failed GEODE tool calls when projecting Tau2 turns so invalid model\n  arguments become official Tau2 `ToolMessage(error=True)` evidence governed by\n  `max_errors`, instead of being misclassified as an empty-route infrastructure\n  failure.\n\n### Changed\n\n- Aligned the OpenAI model picker and `/login use` routing hints with the current Codex surface: GPT-5.6 Sol/Terra/Luna lead the list, GPT-5.4 remains available through both subscription and PAYG routes, deprecated GPT-5.3 Codex stays as a legacy management row for persisted installations, operator defaults and active role selections outside the curated surface remain manageable through deduplicated `Configured` rows, and picker reasoning-effort values now reuse the adapter's per-model contract while preserving a persisted legacy `minimal` value on a no-op confirmation.\n- Recorded a GPT-5.4 subscription-route Tau2 regression and three-domain base\n  full cycle against the pinned upstream harness. The full diagnostic scores\n  Airline 42/50, Retail 79/114, and Telecom 79/114 (200/278 weighted), with\n  51,985 reviewed canonical events and 3,964 exact tool pairs in the immutable\n  external artifact repository. The GEODE-user route remains separate from\n  the native-user headline and carries no promotion authority; retry-only\n  sessions and replay incompleteness are explicitly disclosed.\n\n### Infrastructure\n\n- Made the CI test-count ratchet fail closed on collection or summary-parse\n  errors and raised its measured floor from the stale 2,900-test threshold to\n  10,451 non-live tests.\n- Updated the static documentation site to Next.js and `eslint-config-next`\n  16.2.12 and refreshed patched `brace-expansion` lock entries. The deployed\n  GitHub Pages export uses unoptimized images and has zero advisories when\n  optional native image tooling is omitted; the full install still reports\n  upstream optional `sharp<0.35.0`, which the latest supported Next.js release\n  continues to constrain to `^0.34.5`."
   },
   {
     "version": "1.0.11",
@@ -2453,4 +2458,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-07-31";
+export const CHANGELOG_SYNCED_AT = "2026-08-03";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-07-31
+ * Last sync: 2026-08-03
  */
 
 export const GEODE_SOT = {
-  version: "1.0.11",
-  syncedAt: "2026-07-31",
+  version: "1.0.12",
+  syncedAt: "2026-08-03",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Stamp GEODE v1.0.12 and promote the accumulated GPT-5.4 model-surface, SQLite durability, and Tau2 projection fixes.
- Ship the reviewed 278-task Tau2 full-cycle documentation and operational handoff.
- Make the CI test-count ratchet fail closed and raise its measured floor from 2,900 to 10,451 non-live tests.

## Why
The runtime changes and immutable evaluation artifact are already merged, but they are not a stable distribution until the release metadata, package, official docs, and promotion gates agree on one version. During release verification, the current CI log also exposed a false-green risk: pytest collection parsing returned an empty count and the shell comparison warning did not fail the job.

## Changes
| File | Change |
|------|--------|
| `pyproject.toml`, `uv.lock`, README, CLAUDE | Stamp v1.0.12 and measured 10,451 + 1 live test inventory. |
| `CHANGELOG.md` | Promote Unreleased into v1.0.12 with an English release summary. |
| `.github/workflows/ci.yml` | Fail on pytest collection/parse failure and enforce the current non-live floor. |
| `docs/plans/2026-08-03-gpt54-tau2-release-handoff.md` | Record final model/hook/storage surfaces, Tau2 evidence, limits, and recovery path. |
| observability public docs | Mark v1.0.12 as the single post-deprecation transcript grace release. |
| generated site/version files | Synchronize SOT, changelog, llms indexes, and slop stamp. |

## GAP Audit
| GAP | Before | Resolution / status |
|-----|--------|---------------------|
| stable distribution | Runtime fixes and evidence existed only on `develop` and the artifact repo. | v1.0.12 metadata and release train prepared. |
| CI test ratchet | Stale 2,900 floor; empty parser result emitted a warning and passed. | Fail-closed parser validated against `10451/10452 tests collected (1 deselected)`. |
| transcript compatibility | Public page described the compatibility adapter only in v1.0.11. | v1.0.12 grace boundary made explicit; constructor/re-export removal remains the next registered compatibility GAP. |
| retry/replay evidence | Final attempts were complete, but retry lineage and deterministic replay were not. | Disclosed explicitly; no false promotion or replay claim. |

## Verification
- `uv run ruff check core/ tests/ plugins/ scripts/`
- `uv run ruff format --check core/ tests/ plugins/ scripts/`
- `uv run mypy core/ plugins/ scripts/` — 586 source files
- `uv run lint-imports`
- architecture, slop, repo hygiene, prompt-integrity ratchets
- fail-closed Bash collection parser — 10,451 selected / 10,452 total
- `uv run python scripts/check_official_docs.py` — 659 links, 237 static pages, 74 markdown twins
- `npm run lint` — 0 errors, 45 existing warnings
- `npm audit --omit=optional` — 0 advisories; full install retains two disclosed optional `sharp` advisories
- `uv build`, `twine check`, package content gate — 618 wheel / 620 sdist files
- clean isolated wheel install — `GEODE v1.0.12`
- full Python CI on the exact runtime base in #2860 — 10,423 passed, 28 skipped, 80.28% coverage
- GPT-5.4 subscription Tau2 full cycle — Airline 42/50, Retail 79/114, Telecom 79/114; 200/278 aggregate; 51,985 canonical events and 3,964 exact tool pairs
