### PR TITLE
docs: publish v1.0.12 benchmark regression

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -31,6 +31,14 @@ with 51,985 canonical events and 3,964 exact tool pairs. This is a
 `geode_agent + geode_user` diagnostic, not the native Tau2 user-simulator
 headline; `promotion_authority=none`.
 
+The latest released-package regression is pinned to artifact commit
+[`04ff1c4`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd):
+GEODE `v1.0.12@f99cea63` with GPT-5.4 subscription / effort `high` scored
+MCPMark filesystem/easy **9/10**, Tau2 mock **0/1**, and Tau2 Telecom-small
+**0/1**. The twelve scope-complete/replay-incomplete trajectories preserve 416
+events and 72 exact tool pairs. These release smokes retain their failures and
+do not replace the 278-task Tau2 full-cycle authority.
+
 ## 채택 4종
 
 | 벤치 | Trust | 측정 | GEODE에서의 역할 | 문서 |
@@ -61,8 +69,8 @@ Telecom small run 이후로 둔다.
 
 | 순위 | 벤치 | 첫 목표 | 완료 기준 |
 |---:|---|---|---|
-| 1 | MCPMark Verified | 완료: available standard 64/74; v1.0.11 filesystem/easy 재측정 10/10 | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
-| 2 | τ²-bench | 완료: GPT-5.4 `geode_agent + geode_user` base full cycle 200/278; v1.0.11 smoke도 별도 보존 | 세 domain result와 51,985-event trajectory release를 보존하고, native-user headline과 분리해 public page에 명시 |
+| 1 | MCPMark Verified | 완료: available standard 64/74; v1.0.12 GPT-5.4 filesystem/easy release smoke 9/10 | GEODE adapter로 filesystem/postgres/github verifier-backed result 생성, MCPMark Verified와 `filesystem/easy`를 분리 기록 |
+| 2 | τ²-bench | 완료: GPT-5.4 `geode_agent + geode_user` base full cycle 200/278; v1.0.12 failure smokes도 별도 보존 | 세 domain result와 51,985-event trajectory release를 보존하고, native-user headline과 분리해 public page에 명시 |
 | 3 | BFCL V4 | Agentic subset first | native/prompt function-calling route와 aggregation을 고정한 뒤 result/score artifact 보존 |
 | 4 | HAL Reliability | tau-bench airline single-rerun smoke | τ² adapter 재사용 여부와 rerun consistency schema 확인 |
 | 5 | Terminal-Bench 2.0 | 1-task Docker/tmux smoke | post-run test artifact와 shell transcript 보존 |
@@ -143,6 +151,7 @@ Verified 다음에 τ²-bench를 둔다.
 
 | 일자 | 변경 |
 |---|---|
+| 2026-08-03 | 배포된 GEODE `v1.0.12@f99cea63` / GPT-5.4 subscription `high` post-release 검증: MCPMark filesystem/easy 9/10, Tau2 mock 0/1, Telecom-small 0/1. 실패를 재시도 없이 보존하고 416 events / 72 exact tool pairs, 두 stable manifests, 비식별 native receipts를 artifact commit `04ff1c4`에 게시한 뒤 원격 read-back 검증 |
 | 2026-08-03 | GEODE `22789ee2` / GPT-5.4 subscription `high`로 Tau2 base 278-task full cycle 완료: Airline 42/50, Retail 79/114, Telecom 79/114, aggregate 200/278. SQLite와 exact-join한 51,985 events / 3,964 tool pairs, 비식별 native receipts, retry-lineage 제한을 artifact commit `86dcbba`에 게시하고 원격 read-back 검증 |
 | 2026-07-31 | 배포된 GEODE `v1.0.11@686ff372` 재측정: MCPMark filesystem/easy 10/10, tau2 mock 0/1, Telecom-small 1-task 1/1. SQLite와 exact-join한 368 events / 87 tool pairs, stable manifests와 비식별 native receipts를 artifact commit `16a54f0`에 게시하고 원격 read-back 검증 |
 | 2026-07-31 | GEODE `edb74602b` / GPT-5.6 subscription `high` 측정: MCPMark filesystem/easy 9/10, tau2 mock 0/1, Telecom-small 1-task 0/1. Raw receipts와 12개 정규화 trajectory를 artifact commit `9c00ecf`에 게시 |

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -16,6 +16,36 @@ not JFrog Artifactory or an opaque object-store upload. The publication unit is
 an allowlisted directory, and GitHub read-back from the exact merge commit is
 part of the evidence.
 
+The 2026-08-03 GEODE v1.0.12 GPT-5.4 post-release publication is pinned to
+artifact commit
+[`04ff1c4`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd)
+from
+[`geode-eval-artifacts#12`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/12).
+MCPMark filesystem/easy scored **9/10**; the Tau2 mock and fixed
+Telecom-small tasks scored **0/1** and **0/1**, ending with `USER_STOP` and
+`MAX_STEPS`. All failures are retained as behavior evidence. They do not
+replace the earlier Tau2 **200/278** full cycle, and the MCPMark comparison to
+v1.0.11 is model-confounded by GPT-5.6 → GPT-5.4.
+
+The [MCPMark
+manifest](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/trajectories/mcpmark-geode-gpt54-v1.0.12-f99cea63-filesystem-easy-20260803T104819Z-9636b39c16fb/manifest.json)
+has SHA-256
+`9636b39c16fb494b5c7e97b8052451e521055ef08e17fddeb5a129b9e367d267`;
+the [Tau2
+manifest](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb/manifest.json)
+has SHA-256
+`fd524ce7a3cb1f1088f0e7a1531130d6302fb9f43d57a734303071bf6fd72288`.
+Together they preserve 12 scope-complete, replay-incomplete trajectories, 416
+canonical events, and 72 exact tool pairs. GitHub API read-back from the exact
+merge commit revalidated both manifest bytes, the MCPMark 9/10 summary, and
+the Tau2 `MAX_STEPS` receipt.
+
+Native/public publication ledgers separately bind all 35 restricted-source
+and public-copy byte counts and hashes. The public copies mask local home
+paths plus Tau2 synthetic phone/email values. An independent scan parsed 42
+JSON documents and found zero non-redacted home paths, email/phone values, or
+credential patterns in the staged release.
+
 The 2026-08-03 GPT-5.4 Tau2 base full-cycle publication is pinned to artifact
 commit
 [`86dcbba`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/86dcbba3d15f1979b71a501780bf66fea4b450b5)

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -530,6 +530,41 @@ was independently revalidated before merge; GitHub API read-back confirmed the
 manifest, reports, and all three public native receipt paths at the exact merge
 commit.
 
+## 2026-08-03 v1.0.12 GPT-5.4 post-release smoke
+
+After the public `v1.0.12` distribution was independently verified, the fixed
+mock and Telecom-small diagnostic tasks ran against release commit
+`f99cea63dd39eb3f49fb00ac36e2e2804518c100` with GPT-5.4 subscription /
+effort `high` for both `geode_agent` and `geode_user`.
+
+| Scope | Result | Duration | Termination | Measured behavior |
+|---|---:|---:|---|---|
+| `mock/create_task_1` | **0/1** | 13.75s | `USER_STOP` | Communication 1.0; DB and required action 0.0 |
+| Telecom-small roaming task | **0/1** | 236.73s | `MAX_STEPS` | 50 steps and 14 paired tool calls; native component scoring skipped after premature termination |
+
+The Telecom trace repeats customer, line, network, usage, restriction, and VPN
+diagnostics. This is model behavior, not a missing event or transport defect:
+all 16 calls across both runs have exactly one result. No authentication,
+quota, provider-adapter, or harness exception occurred, and neither failure was
+retried.
+
+This pair is a post-release route smoke, not a second full cycle. It neither
+invalidates nor replaces the 278-task **200/278** diagnostic above. It instead
+shows why an external loop needs `PostVerify`: a normal protocol stop and a
+scope-complete trajectory can still fail an executable task verifier.
+
+Artifacts are immutable at
+[`geode-eval-artifacts@04ff1c4`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd):
+
+- [native result copies](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/tau2/simulations);
+- [stable two-task trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb);
+- [post-release report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/reports/e2e-validation/2026-08-03-gpt54-v1012-post-release-benchmark.md).
+
+The release contains 234 canonical events, 16 exact tool pairs, zero orphans,
+and two scope-complete/replay-incomplete trajectories. Manifest SHA-256
+`fd524ce7a3cb1f1088f0e7a1531130d6302fb9f43d57a734303071bf6fd72288`
+was recomputed from the remote bytes after the artifact PR merged.
+
 ## 참고
 
 - [τ-bench paper (NeurIPS '24)](https://arxiv.org/pdf/2406.12045)

--- a/docs/plans/2026-08-03-gpt54-tau2-release-handoff.md
+++ b/docs/plans/2026-08-03-gpt54-tau2-release-handoff.md
@@ -20,8 +20,10 @@ The implementation and evidence are split across reviewable merge vehicles:
 | concurrent `session_events` bootstrap | [GEODE #2858](https://github.com/mangowhoiscloud/geode/pull/2858) |
 | failed Tau2 tool-call projection | [GEODE #2859](https://github.com/mangowhoiscloud/geode/pull/2859) |
 | full-cycle official documentation | [GEODE #2860](https://github.com/mangowhoiscloud/geode/pull/2860) |
+| v1.0.12 promotion to `main` | [GEODE #2863](https://github.com/mangowhoiscloud/geode/pull/2863), merge `f99cea63dd39eb3f49fb00ac36e2e2804518c100` |
 | immutable full-cycle evidence | [`geode-eval-artifacts@86dcbba`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/86dcbba3d15f1979b71a501780bf66fea4b450b5) |
 | stable trajectory manifest | [`manifest.json`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/86dcbba3d15f1979b71a501780bf66fea4b450b5/trajectories/tau2-geode-gpt54-22789ee2-geode-user-airline-retail-telecom-base-full-20260803T091257Z-13162f7bcff9/manifest.json) |
+| v1.0.12 post-release behavior evidence | [`geode-eval-artifacts#12`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/12), merge [`04ff1c4`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd) |
 | public distribution | GitHub release and PyPI package `geode-agent==1.0.12` |
 
 The manifest SHA-256 is
@@ -29,6 +31,34 @@ The manifest SHA-256 is
 The artifact repository was read back at the exact commit after merge; the
 manifest, machine report, human report, and all three public native receipts
 matched the reviewed publication.
+
+### 1.1 Post-release closure
+
+The annotated `v1.0.12` tag, GitHub release assets, PyPI files, checksum
+ledger, clean `uvx --no-cache --from geode-agent==1.0.12 geode version`, and
+public distribution verifier all resolve to `f99cea63`. The release workflow
+completed successfully; the package is not merely PR-complete.
+
+The exact released tree then ran GPT-5.4 subscription / effort `high` through
+MCPMark filesystem/easy and two Tau2 diagnostics:
+
+| Scope | Result | Behavior evidence |
+|---|---:|---|
+| MCPMark filesystem/easy | **9/10** | `file_context/uppercase` created all files but did not fully uppercase `file_01.txt` |
+| Tau2 mock | **0/1** | `USER_STOP`; communication 1.0, DB/action 0.0 |
+| Tau2 Telecom-small | **0/1** | `MAX_STEPS`; 14 paired calls repeated diagnostics before verifier scoring |
+
+No failure was retried or relabeled. The two stable release manifests retain
+416 events and 72 exact tool pairs across 12 scope-complete,
+replay-incomplete trajectories. Their independently anchored hashes are
+`9636b39c16fb494b5c7e97b8052451e521055ef08e17fddeb5a129b9e367d267`
+(MCPMark) and
+`fd524ce7a3cb1f1088f0e7a1531130d6302fb9f43d57a734303071bf6fd72288`
+(Tau2); both were recomputed from GitHub bytes at artifact commit `04ff1c4`.
+
+These release smokes do not replace the 278-task full cycle. MCPMark's
+v1.0.11-to-v1.0.12 comparison is model-confounded, and the two Tau2 tasks are
+diagnostic samples rather than a new aggregate.
 
 ## 2. Final runtime surfaces
 
@@ -194,6 +224,16 @@ and evidence reference instead of being copied into `sessions.db` as verdicts.
    pytest-summary parser. The repository's GitHub workflow is fixed in this
    release and the current direct gates pass; update the separately installed
    local mirror before treating `geode-ci --fast` as authoritative again.
+8. **Tau2 does not yet consume `PostVerify`.** The public hook and middleware
+   E2E proves the contract, while the benchmark intentionally constructs an
+   isolated loop without a hook registry. The retained `USER_STOP` and
+   `MAX_STEPS` failures demonstrate the integration value, but a future
+   adapter change must explicitly wire verifier output into `PostVerify`
+   before claiming an executable outer-loop revise/escalate cycle.
+9. **The release smoke is not a causal regression study.** MCPMark changes
+   both release and model, and each Tau2 row has k=1. Use a frozen model,
+   harness, task set, and repeated trial contract before promoting these
+   deltas into a release gate.
 
 ## 6. Release and recovery checklist
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3136,6 +3136,16 @@ GEODE `22789ee2`에서 Airline, Retail, Telecom base 278개 task를 모두 실�
 
 이 행은 native `user_simulator` headline이 아닙니다. Tau2 `results.json`이 점수 정본이고 trajectory는 외부 루프용 진단 sidecar입니다. 7회 transport retry가 만든 14개 추가 SQLite session은 final trajectory parent 밖에 있으며, 공개 release는 이 lineage와 bounded payload 때문에 `replay_complete=false`입니다. 또한 Tau2 격리 loop는 `HookSystem` 없이 구성되어 public `hook_events`가 0입니다. hook dispatch의 정본은 별도 13-hook / 4-middleware E2E입니다.
 
+## 2026-08-03 v1.0.12 post-release smoke
+
+공개 배포된 GEODE `v1.0.12` (`f99cea63`)에서 같은 GPT-5.4 subscription / effort `high` route로 mock과 Telecom-small 고정 task를 다시 실행했습니다. 결과는 각각 **0/1**이며, 실패를 retry하거나 삭제하지 않았습니다.
+
+-   Mock은 13.75초 뒤 `USER_STOP`했습니다. communication은 1.0이지만 DB와 required action은 0.0입니다.
+-   Telecom은 236.73초와 50 steps 뒤 `MAX_STEPS`에 도달했습니다. 반복 진단을 포함한 14개 tool call/result가 모두 pairing됐지만 native component scoring 전에 종료됐습니다.
+-   [`geode-eval-artifacts/trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb): 234개 event, 16개 exact tool pair, manifest SHA-256 `fd524ce7a3cb…2288`.
+
+이 두 건은 배포 경로 회귀 smoke이며 278-task full cycle의 재실행이나 대체 결과가 아닙니다. route/인증/provider adapter 오류는 없었고, 실패는 외부 루프가 `Stop`과 trajectory 완결성을 task success로 오인하지 않게 하는 `PostVerify` 입력 증거입니다.
+
 ## 2026-08-02 GPT-5.4 subscription cycle
 
 GEODE `afaab52b`에서 agent와 `geode_user`를 모두 `gpt-5.4` subscription / effort `high`로 실행했습니다. `mock/create_task_1`은 **0/1**, Telecom-small 첫 task는 **1/1**이며, 두 run 모두 route, provider, adapter, quota exception 없이 정상 `USER_STOP`으로 끝났습니다.
@@ -3213,6 +3223,40 @@ python scripts/eval/tau2_geode_agent.py \
 -   Seven Telecom transport retries created 14 extra SQLite sessions outside the final trajectory parents; no behavior-score failure was retried.
 -   The released trajectories are scope-complete for final task attempts and replay-incomplete for bounded bodies and retry-attempt lineage.
 -   The isolated Tau2 AgenticLoop records no public hook\_events; the separate hook behavior E2E remains hook authority.
+
+**Telecom small first-task GPT-5.4 v1.0.12 post-release diagnostic** · 2026-08-03 KST · gpt-5.4 · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]</code></td></tr><tr><td>Model</td><td><code>gpt-5.4</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.12@f99cea63</code></td></tr><tr><td>Reward / pass^1</td><td><strong>0.0 / 0.000 (0 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/tau2/simulations/geode-gpt54-high-v1.0.12-f99cea63-geode-user-telecom-small-01-20260803/results.json</code></td></tr></tbody></table>
+
+-   Termination max\_steps before native component scoring
+-   Duration 236.73s
+-   203 canonical events / 14 exact tool pairs
+-   Repeated customer, line, network, usage, restriction, and VPN diagnostics
+
+```
+python scripts/eval/tau2_geode_agent.py   --harness-dir artifacts/eval/harnesses/tau2-bench   --domain telecom   --task-split-name small   --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]'   --num-tasks 1   --num-trials 1   --max-concurrency 1   --max-steps 50   --timeout 1800   --model gpt-5.4   --provider openai   --source subscription   --effort high   --time-budget-s 300   --user geode_user   --user-llm gpt-5.4   --user-provider openai   --user-source subscription   --user-effort high   --user-time-budget-s 180   --trajectory-stage benchmark   --save-to geode-gpt54-high-v1.0.12-f99cea63-geode-user-telecom-small-01-20260803
+```
+
+-   The run reached 50 steps before native DB/action scoring; repeated diagnostics are preserved as behavior evidence.
+-   All fourteen tool calls have exactly one result, with no route, authentication, quota, or adapter failure.
+-   This two-task release smoke does not invalidate or replace the 200/278 full-cycle diagnostic.
+
+**mock/create\_task\_1 GPT-5.4 v1.0.12 post-release diagnostic** · 2026-08-03 KST · gpt-5.4 · subscription · agent high / user high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>mock / create_task_1</code></td></tr><tr><td>Model</td><td><code>gpt-5.4</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>agent high / user high</code></td></tr><tr><td>Route</td><td>geode_agent + geode_user</td></tr><tr><td>Harness</td><td><code>sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.12@f99cea63</code></td></tr><tr><td>Reward / pass^1</td><td><strong>0.0 / 0.000 (0 / 1)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/tau2/simulations/geode-gpt54-high-v1.0.12-f99cea63-geode-user-mock-smoke-20260803/results.json</code></td></tr></tbody></table>
+
+-   Communication check 1.0 / DB check 0.0
+-   create\_task action check 0.0
+-   Termination user\_stop
+-   Duration 13.75s / 31 canonical events / 2 exact tool pairs
+
+```
+python scripts/eval/tau2_geode_agent.py   --harness-dir artifacts/eval/harnesses/tau2-bench   --domain mock   --task-ids create_task_1   --num-tasks 1   --num-trials 1   --max-concurrency 1   --max-steps 8   --timeout 900   --model gpt-5.4   --provider openai   --source subscription   --effort high   --time-budget-s 180   --user geode_user   --user-llm gpt-5.4   --user-provider openai   --user-source subscription   --user-effort high   --user-time-budget-s 120   --trajectory-stage benchmark   --save-to geode-gpt54-high-v1.0.12-f99cea63-geode-user-mock-smoke-20260803
+```
+
+-   The simulated user stopped before a verifier-compatible state change; DB and action checks are zero while communication is one.
+-   The run has no authentication, quota, provider-adapter, or harness exception and is retained without retry.
+-   This release smoke is not a rerun or replacement of the 278-task full cycle and is not a native user\_simulator leaderboard row.
 
 **Telecom small first-task GPT-5.4 subscription diagnostic** · 2026-08-02 KST · gpt-5.4 · subscription · agent high / user high
 
@@ -3629,6 +3673,15 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark.md
 
 MCPMark는 실제 MCP 서버(filesystem, Postgres, GitHub, Notion, Playwright 등)를 대상으로 한 tool-use 벤치마크입니다. 태스크마다 독립 검증 스크립트가 결과 상태를 확인합니다. GEODE는 `plugins/benchmark_harness`의 `BaseMCPAgent` 어댑터로 참가하고 upstream `pipeline.py`는 패치하지 않습니다. 점수는 harness commit, 서비스 집합, model route, timeout에 고정해서만 게시합니다.
 
+## 2026-08-03 v1.0.12 post-release regression
+
+공개 배포된 GEODE `v1.0.12` (`f99cea63`)과 `gpt-5.4` subscription / effort `high`로 `filesystem/easy` 10건을 실행했습니다. 공식 verifier는 **9/10 (90.0%)**, 총 802.2초와 53 turns입니다. 실패한 `file_context/uppercase`는 다섯 파일을 모두 만들었지만 `file_01.txt`를 완전히 대문자로 바꾸지 못했습니다.
+
+인증·quota·provider adapter·MCP transport 오류는 없었습니다. 10개 trajectory는 182개 canonical event와 56개 exact tool pair를 보존하며 `scope_complete=true`, `replay_complete=false`입니다. v1.0.11의 GPT-5.6 10/10과 비교할 때 모델까지 바뀌었으므로 release 회귀로 단정하지 않습니다.
+
+-   [`geode-eval-artifacts/mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy): verifier receipt, redacted execution logs, raw/public digest ledger.
+-   [`geode-eval-artifacts/trajectories/mcpmark-geode-gpt54-v1.0.12-f99cea63-filesystem-easy-20260803T104819Z-9636b39c16fb`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/trajectories/mcpmark-geode-gpt54-v1.0.12-f99cea63-filesystem-easy-20260803T104819Z-9636b39c16fb): manifest SHA-256 `9636b39c16fb…d267`로 원격 read-back된 stable release.
+
 ## 2026-07-31 v1.0.11 release regression
 
 배포된 GEODE `v1.0.11` (`686ff372`)과 `gpt-5.6-sol` subscription / effort `high`로 `filesystem/easy` 10건을 재측정했습니다. 공식 verifier는 **10/10 (100.0%)**, 총 596.6초와 56 turns입니다. 이전 `edb74602b` run의 유일한 실패였던 `file_context/uppercase`도 통과했습니다.
@@ -3697,6 +3750,26 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   The OpenAI model route was the GEODE Codex subscription route, not MCPMark's native LiteLLM OpenAI API route.
 -   GitHub fixture repositories were made public during execution so the Docker GitHub MCP server could use normal public-repo semantics; all transient repos were deleted by cleanup.
 -   The filesystem score counts papers/author\_folders as a failed no-result transport run after two attempts without meta output.
+
+**filesystem/easy GPT-5.4 v1.0.12 post-release regression** · 2026-08-03 KST · gpt-5.4 · subscription · high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>filesystem/easy</code></td></tr><tr><td>Model</td><td><code>gpt-5.4</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>high</code></td></tr><tr><td>Route</td><td>GEODE AgenticLoop MCPMark adapter</td></tr><tr><td>Harness</td><td><code>eval-sys/mcpmark@cd45b7f, GEODE v1.0.12@f99cea63</code></td></tr><tr><td>Accuracy</td><td><strong>90.0% (9 / 10)</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy</code></td></tr></tbody></table>
+
+-   Total task execution time 802.182s / average 80.218s
+-   53 GEODE turns total / 5.3 average
+-   302,984 input / 30,238 output tokens
+-   182 canonical events / 56 exactly paired tool calls and results
+-   Failure: file\_context/uppercase left file\_01.txt incompletely uppercased
+
+```
+cd artifacts/eval/harnesses/mcpmark
+PYTHONPATH=<geode-v1.0.12-release-tree> .venv/bin/python -m plugins.benchmark_harness.run_mcpmark   --mcp filesystem   --task-suite easy   --models geode-gpt-5.4   --agent geode   --reasoning-effort high   --k 1   --timeout 1200   --exp-name geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy   --output-dir ./results-geode-v1012
+```
+
+-   The official verifier found all five output files, but file\_01.txt was not fully uppercased; the failure is retained without retry.
+-   No authentication, quota, provider-adapter, MCP transport, or harness exception occurred.
+-   The v1.0.11 GPT-5.6 10/10 comparison is model-confounded and cannot be attributed to the runtime release alone.
+-   All ten trajectories are scope-complete and intentionally replay-incomplete; manifest and native receipts are pinned to artifact commit 04ff1c4.
 
 **filesystem/easy GPT-5.6 v1.0.11 release regression** · 2026-07-31 KST · gpt-5.6-sol · subscription · high
 

--- a/site/src/app/docs/benchmarks/mcpmark/page.tsx
+++ b/site/src/app/docs/benchmarks/mcpmark/page.tsx
@@ -85,6 +85,41 @@ export default function Page() {
               고정해서만 게시합니다.
             </p>
 
+            <h2>2026-08-03 v1.0.12 post-release regression</h2>
+            <p>
+              공개 배포된 GEODE <code>v1.0.12</code> (<code>f99cea63</code>)과{" "}
+              <code>gpt-5.4</code> subscription / effort <code>high</code>로{" "}
+              <code>filesystem/easy</code> 10건을 실행했습니다. 공식 verifier는{" "}
+              <strong>9/10 (90.0%)</strong>, 총 802.2초와 53 turns입니다.
+              실패한 <code>file_context/uppercase</code>는 다섯 파일을 모두
+              만들었지만 <code>file_01.txt</code>를 완전히 대문자로 바꾸지
+              못했습니다.
+            </p>
+            <p>
+              인증·quota·provider adapter·MCP transport 오류는 없었습니다. 10개
+              trajectory는 182개 canonical event와 56개 exact tool pair를
+              보존하며 <code>scope_complete=true</code>,{" "}
+              <code>replay_complete=false</code>입니다. v1.0.11의 GPT-5.6 10/10과
+              비교할 때 모델까지 바뀌었으므로 release 회귀로 단정하지 않습니다.
+            </p>
+            <ul>
+              <li>
+                <RunLogLink
+                  path="mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                verifier receipt, redacted execution logs, raw/public digest ledger.
+              </li>
+              <li>
+                <RunLogLink
+                  path="trajectories/mcpmark-geode-gpt54-v1.0.12-f99cea63-filesystem-easy-20260803T104819Z-9636b39c16fb"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                manifest SHA-256 <code>9636b39c16fb…d267</code>로 원격
+                read-back된 stable release.
+              </li>
+            </ul>
+
             <h2>2026-07-31 v1.0.11 release regression</h2>
             <p>
               배포된 GEODE <code>v1.0.11</code> (<code>686ff372</code>)과{" "}
@@ -175,6 +210,44 @@ export default function Page() {
               pinned to the harness commit, service set, model route, and timeout
               settings.
             </p>
+
+            <h2>2026-08-03 v1.0.12 Post-Release Regression</h2>
+            <p>
+              We ran the ten <code>filesystem/easy</code> tasks against the
+              public GEODE <code>v1.0.12</code> release (<code>f99cea63</code>)
+              with <code>gpt-5.4</code> subscription at effort <code>high</code>.
+              The official verifier scored <strong>9/10 (90.0%)</strong> over
+              802.2 seconds and 53 turns. The failed{" "}
+              <code>file_context/uppercase</code> task created all five files but
+              did not fully uppercase <code>file_01.txt</code>.
+            </p>
+            <p>
+              There was no authentication, quota, provider-adapter, or MCP
+              transport failure. The ten trajectories retain 182 canonical
+              events and 56 exact tool pairs with{" "}
+              <code>scope_complete=true</code> and{" "}
+              <code>replay_complete=false</code>. The v1.0.11 GPT-5.6 score was
+              10/10, but the model changed too, so this is not attributed to the
+              release alone.
+            </p>
+            <ul>
+              <li>
+                <RunLogLink
+                  path="mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                verifier receipts, redacted execution logs, and raw/public
+                digest ledger.
+              </li>
+              <li>
+                <RunLogLink
+                  path="trajectories/mcpmark-geode-gpt54-v1.0.12-f99cea63-filesystem-easy-20260803T104819Z-9636b39c16fb"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                stable release remotely read back at manifest SHA-256{" "}
+                <code>9636b39c16fb…d267</code>.
+              </li>
+            </ul>
 
             <h2>2026-07-31 v1.0.11 Release Regression</h2>
             <p>

--- a/site/src/app/docs/benchmarks/tau2/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/page.tsx
@@ -72,6 +72,39 @@ export default function Page() {
               별도 13-hook / 4-middleware E2E입니다.
             </p>
 
+            <h2>2026-08-03 v1.0.12 post-release smoke</h2>
+            <p>
+              공개 배포된 GEODE <code>v1.0.12</code> (<code>f99cea63</code>)에서
+              같은 GPT-5.4 subscription / effort <code>high</code> route로 mock과
+              Telecom-small 고정 task를 다시 실행했습니다. 결과는 각각{" "}
+              <strong>0/1</strong>이며, 실패를 retry하거나 삭제하지 않았습니다.
+            </p>
+            <ul>
+              <li>
+                Mock은 13.75초 뒤 <code>USER_STOP</code>했습니다. communication은
+                1.0이지만 DB와 required action은 0.0입니다.
+              </li>
+              <li>
+                Telecom은 236.73초와 50 steps 뒤 <code>MAX_STEPS</code>에
+                도달했습니다. 반복 진단을 포함한 14개 tool call/result가 모두
+                pairing됐지만 native component scoring 전에 종료됐습니다.
+              </li>
+              <li>
+                <RunLogLink
+                  path="trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                234개 event, 16개 exact tool pair, manifest SHA-256{" "}
+                <code>fd524ce7a3cb…2288</code>.
+              </li>
+            </ul>
+            <p>
+              이 두 건은 배포 경로 회귀 smoke이며 278-task full cycle의 재실행이나
+              대체 결과가 아닙니다. route/인증/provider adapter 오류는 없었고,
+              실패는 외부 루프가 <code>Stop</code>과 trajectory 완결성을 task
+              success로 오인하지 않게 하는 <code>PostVerify</code> 입력 증거입니다.
+            </p>
+
             <h2>2026-08-02 GPT-5.4 subscription cycle</h2>
             <p>
               GEODE <code>afaab52b</code>에서 agent와 <code>geode_user</code>를
@@ -242,6 +275,42 @@ export default function Page() {
               loop also runs without a <code>HookSystem</code> and records zero
               public <code>hook_events</code>; the separate 13-hook /
               four-middleware E2E remains hook-dispatch authority.
+            </p>
+
+            <h2>2026-08-03 v1.0.12 Post-Release Smoke</h2>
+            <p>
+              We reran the fixed mock and Telecom-small tasks against the
+              public GEODE <code>v1.0.12</code> release (<code>f99cea63</code>)
+              through the same GPT-5.4 subscription route at effort{" "}
+              <code>high</code>. Both scored <strong>0/1</strong>; neither failure
+              was retried or removed.
+            </p>
+            <ul>
+              <li>
+                Mock ended with <code>USER_STOP</code> after 13.75 seconds.
+                Communication scored 1.0, while the DB and required action
+                scored 0.0.
+              </li>
+              <li>
+                Telecom reached <code>MAX_STEPS</code> after 236.73 seconds and
+                50 steps. All 14 repeated diagnostic tool calls have one result,
+                but the run ended before native component scoring.
+              </li>
+              <li>
+                <RunLogLink
+                  path="trajectories/tau2-geode-gpt54-v1.0.12-f99cea63-geode-user-mock-telecom-small-20260803T104819Z-fd524ce7a3cb"
+                  revision="04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd"
+                />:
+                234 events, 16 exact tool pairs, manifest SHA-256{" "}
+                <code>fd524ce7a3cb…2288</code>.
+              </li>
+            </ul>
+            <p>
+              These are post-release route smokes, not a rerun or replacement
+              of the 278-task full cycle. There was no route, authentication, or
+              provider-adapter failure. The retained failures are direct
+              <code>PostVerify</code> evidence that a normal stop or complete
+              trajectory is not the same as task success.
             </p>
 
             <h2>2026-08-02 GPT-5.4 Subscription Cycle</h2>

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -172,6 +172,50 @@ PYTHONPATH=<geode-v1.0.11-release-tree> \\
   ],
 };
 
+const mcpmarkFilesystemEasyGpt54V1012: BenchmarkMeasurement = {
+  id: "mcpmark-filesystem-easy-20260803-gpt54-high-v1012",
+  group: "mcpmark",
+  title: "filesystem/easy GPT-5.4 v1.0.12 post-release regression",
+  measuredAt: "2026-08-03 KST",
+  suite: "filesystem/easy",
+  status: "complete",
+  model: "gpt-5.4",
+  provider: "openai",
+  source: "subscription",
+  effort: "high",
+  route: "GEODE AgenticLoop MCPMark adapter",
+  harness: "eval-sys/mcpmark@cd45b7f, GEODE v1.0.12@f99cea63",
+  artifact:
+    "geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/mcpmark/results-geode-agentworld/geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy",
+  scoreLabel: "Accuracy",
+  scoreValue: "90.0% (9 / 10)",
+  secondary: [
+    "Total task execution time 802.182s / average 80.218s",
+    "53 GEODE turns total / 5.3 average",
+    "302,984 input / 30,238 output tokens",
+    "182 canonical events / 56 exactly paired tool calls and results",
+    "Failure: file_context/uppercase left file_01.txt incompletely uppercased",
+  ],
+  command: `cd artifacts/eval/harnesses/mcpmark
+PYTHONPATH=<geode-v1.0.12-release-tree> \
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark \
+  --mcp filesystem \
+  --task-suite easy \
+  --models geode-gpt-5.4 \
+  --agent geode \
+  --reasoning-effort high \
+  --k 1 \
+  --timeout 1200 \
+  --exp-name geode-gpt54-high-v1.0.12-f99cea63-20260803-mcpmark-filesystem-easy \
+  --output-dir ./results-geode-v1012`,
+  notes: [
+    "The official verifier found all five output files, but file_01.txt was not fully uppercased; the failure is retained without retry.",
+    "No authentication, quota, provider-adapter, MCP transport, or harness exception occurred.",
+    "The v1.0.11 GPT-5.6 10/10 comparison is model-confounded and cannot be attributed to the runtime release alone.",
+    "All ten trajectories are scope-complete and intentionally replay-incomplete; manifest and native receipts are pinned to artifact commit 04ff1c4.",
+  ],
+};
+
 const mcpmarkFilesystemEasyParallel: BenchmarkMeasurement = {
   id: "mcpmark-filesystem-easy-parallel-20260703-gpt55-xhigh",
   group: "mcpmark",
@@ -693,6 +737,114 @@ python scripts/eval/tau2_geode_agent.py \\
   ],
 };
 
+const tau2MockGpt54V1012: BenchmarkMeasurement = {
+  id: "tau2-mock-20260803-gpt54-high-geode-user-v1012",
+  group: "tau2",
+  title: "mock/create_task_1 GPT-5.4 v1.0.12 post-release diagnostic",
+  measuredAt: "2026-08-03 KST",
+  suite: "mock / create_task_1",
+  status: "complete",
+  model: "gpt-5.4",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness:
+    "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.12@f99cea63",
+  artifact:
+    "geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/tau2/simulations/geode-gpt54-high-v1.0.12-f99cea63-geode-user-mock-smoke-20260803/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "0.0 / 0.000 (0 / 1)",
+  secondary: [
+    "Communication check 1.0 / DB check 0.0",
+    "create_task action check 0.0",
+    "Termination user_stop",
+    "Duration 13.75s / 31 canonical events / 2 exact tool pairs",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain mock \
+  --task-ids create_task_1 \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 8 \
+  --timeout 900 \
+  --model gpt-5.4 \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --time-budget-s 180 \
+  --user geode_user \
+  --user-llm gpt-5.4 \
+  --user-provider openai \
+  --user-source subscription \
+  --user-effort high \
+  --user-time-budget-s 120 \
+  --trajectory-stage benchmark \
+  --save-to geode-gpt54-high-v1.0.12-f99cea63-geode-user-mock-smoke-20260803`,
+  notes: [
+    "The simulated user stopped before a verifier-compatible state change; DB and action checks are zero while communication is one.",
+    "The run has no authentication, quota, provider-adapter, or harness exception and is retained without retry.",
+    "This release smoke is not a rerun or replacement of the 278-task full cycle and is not a native user_simulator leaderboard row.",
+  ],
+};
+
+const tau2TelecomSmallGpt54V1012: BenchmarkMeasurement = {
+  id: "tau2-telecom-small-20260803-gpt54-high-geode-user-v1012",
+  group: "tau2",
+  title: "Telecom small first-task GPT-5.4 v1.0.12 post-release diagnostic",
+  measuredAt: "2026-08-03 KST",
+  suite:
+    "telecom / small / [mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]",
+  status: "complete",
+  model: "gpt-5.4",
+  provider: "openai",
+  source: "subscription",
+  effort: "agent high / user high",
+  route: "geode_agent + geode_user",
+  harness:
+    "sierra-research/tau2-bench@1901a30, tau2==1.0.0, GEODE v1.0.12@f99cea63",
+  artifact:
+    "geode-eval-artifacts@04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd/tau2/simulations/geode-gpt54-high-v1.0.12-f99cea63-geode-user-telecom-small-01-20260803/results.json",
+  scoreLabel: "Reward / pass^1",
+  scoreValue: "0.0 / 0.000 (0 / 1)",
+  secondary: [
+    "Termination max_steps before native component scoring",
+    "Duration 236.73s",
+    "203 canonical events / 14 exact tool pairs",
+    "Repeated customer, line, network, usage, restriction, and VPN diagnostics",
+  ],
+  command: `python scripts/eval/tau2_geode_agent.py \
+  --harness-dir artifacts/eval/harnesses/tau2-bench \
+  --domain telecom \
+  --task-split-name small \
+  --task-ids '[mobile_data_issue]user_abroad_roaming_enabled_off[PERSONA:None]' \
+  --num-tasks 1 \
+  --num-trials 1 \
+  --max-concurrency 1 \
+  --max-steps 50 \
+  --timeout 1800 \
+  --model gpt-5.4 \
+  --provider openai \
+  --source subscription \
+  --effort high \
+  --time-budget-s 300 \
+  --user geode_user \
+  --user-llm gpt-5.4 \
+  --user-provider openai \
+  --user-source subscription \
+  --user-effort high \
+  --user-time-budget-s 180 \
+  --trajectory-stage benchmark \
+  --save-to geode-gpt54-high-v1.0.12-f99cea63-geode-user-telecom-small-01-20260803`,
+  notes: [
+    "The run reached 50 steps before native DB/action scoring; repeated diagnostics are preserved as behavior evidence.",
+    "All fourteen tool calls have exactly one result, with no route, authentication, quota, or adapter failure.",
+    "This two-task release smoke does not invalidate or replace the 200/278 full-cycle diagnostic.",
+  ],
+};
+
 const tau2MockGpt56: BenchmarkMeasurement = {
   id: "tau2-mock-20260731-gpt56-high-geode-user",
   group: "tau2",
@@ -1137,6 +1289,7 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       mcpmarkVerifiedAvailable,
+      mcpmarkFilesystemEasyGpt54V1012,
       mcpmarkFilesystemEasyGpt56V1011,
       mcpmarkFilesystemEasyGpt56,
       mcpmarkVerifiedGithub,
@@ -1191,6 +1344,8 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       tau2BaseFullGpt54,
+      tau2TelecomSmallGpt54V1012,
+      tau2MockGpt54V1012,
       tau2TelecomSmallGpt54,
       tau2MockGpt54,
       tau2NativeAggregate,


### PR DESCRIPTION
## Summary
- Publish the released-package GPT-5.4 MCPMark and Tau2 regression in the official measurement SoT, Korean/English benchmark pages, and generated LLM index.
- Pin all claims to `geode-eval-artifacts@04ff1c4` and both independently read-back manifest hashes.
- Update the release handoff with post-release closure and remaining integration/causality GAPs.

## Why
GEODE v1.0.12 is released and its native receipts are merged, but official docs must distinguish the authoritative 278-task Tau2 cycle from the post-release failure smokes. External loops also need an explicit boundary between scope-complete behavior evidence and executable verifier success.

## Changes
| File/area | Change |
|---|---|
| Benchmark measurement SoT | Add MCPMark 9/10, Tau2 mock 0/1, and Tau2 Telecom-small 0/1 with exact commands and comparison caveats |
| Public benchmark pages | Add matched Korean/English release-regression sections and immutable artifact links |
| Eval docs | Pin artifact PR #12, native/public digest boundary, remote readback, and PostVerify interpretation |
| Handoff | Record released distribution, post-release evidence, Tau2 PostVerify integration GAP, and causal-study boundary |
| Generated docs | Refresh `llms-full.txt` from the 74-page export |

## Verification
- `npm run lint` — 0 errors (45 pre-existing warnings).
- `uv run pytest tests/integration/test_check_official_docs.py -q` — 4 passed.
- `uv run python scripts/check_official_docs.py` — passed: architecture baseline, 659-link audit, render lint, Next.js TypeScript/static build (237 pages), 74 Markdown twins, generated-doc diff gate.
- `git diff --check` and pre-commit hooks — passed.

## GAP audit
| GAP | Disposition |
|---|---|
| Released evidence absent from official ledger | Closed |
| Full-cycle vs release-smoke authority ambiguous | Closed; 200/278 remains authoritative |
| Tau2 `PostVerify` consumption | Open; the isolated benchmark loop still has no hook registry |
| Release-delta causality | Open; MCPMark changes model and release, Tau2 rows are k=1 |
