### PR TITLE
feat(tau2): attest runtime-faithful executions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ owns only the package version and sync date.
 The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
-The current snapshot records 542 production Python files,
+The current snapshot records 543 production Python files,
 682 test Python files,
 78 tool definitions, and
 57 `RuntimeEvent` members.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- Added a benchmark-safe Tau2 runtime profile and retry-attempt manifest. New
+  snapshot v4 records digest-bind the runtime revision, model routes, assembled
+  prompt/tool-schema identities, exercised hook and middleware surfaces, every
+  participant session, retry ancestry, and final native simulation selection.
+
+### Changed
+
+- Tau2 participants now share one process-owned runtime event bus, public hook
+  registry, and four-surface middleware registry. Native `results.json`
+  reward/termination evidence is joined to session timelines before SessionEnd,
+  while `tau2-native-user` and `geode-dual-runtime` measurements remain distinct profiles.
+- Crucible now observably disables legacy `cached-row.v1` reuse for Tau2
+  snapshot v4 runs because that cache predates the runtime-profile and attempt
+  companions; runs execute fresh rather than synthesize provenance.
+
+### Fixed
+
+- Tau2 tool projection ACKs no longer masquerade as completed environment
+  actions. The adapter defers all environment execution to Tau2 and records the
+  official result or error only when its original call ID returns; orphaned or
+  still-pending calls fail closed. Terminal-step results are reconciled from
+  the native receipt, diagnostic auto-resume rows remain explicitly
+  unattested, and exhausted post-run failures cannot remain marked complete.
+
 ## [1.0.12] - 2026-08-03
 
 > GPT-5.4 subscription routing, concurrent session durability, and failed-tool

--- a/core/agent/tool_executor/processor.py
+++ b/core/agent/tool_executor/processor.py
@@ -149,19 +149,26 @@ class ToolCallProcessor:
 
         # Immutable session history: tool call + result share the provider call id.
         if self._timeline is not None:
+            status = "error" if isinstance(result, dict) and result.get("error") else "ok"
             if record_call:
                 self._timeline.record_tool_call(tool_name, durable_input, call_id=tool_use_id)
-            status = "error" if isinstance(result, dict) and result.get("error") else "ok"
-            summary = "personal account data omitted" if personal else ""
-            if isinstance(result, dict) and not personal:
-                summary = str(result.get("summary", result.get("error", "")))
-            self._timeline.record_tool_result(
-                tool_name,
-                status,
-                summary,
-                call_id=tool_use_id,
-                result=durable_result,
+            external_execution = (
+                result.get("external_execution") if isinstance(result, dict) else None
             )
+            # A benchmark transport ACK is a proposal, not the
+            # authoritative tool outcome. Its external ToolMessage will close
+            # this call later with the same provider call id.
+            if external_execution != "deferred":
+                summary = "personal account data omitted" if personal else ""
+                if isinstance(result, dict) and not personal:
+                    summary = str(result.get("summary", result.get("error", "")))
+                self._timeline.record_tool_result(
+                    tool_name,
+                    status,
+                    summary,
+                    call_id=tool_use_id,
+                    result=durable_result,
+                )
             if tool_name in {"computer", "computer_use"} and isinstance(result, dict):
                 payload = self._computer_gui_payload(tool_input, result, tool_use_id)
                 if payload:

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -283,11 +283,11 @@ machine-readable artifact is
 
 | Measure | Current tree |
 |---|---:|
-| Production Python files (`core/` + `plugins/`) | 542 |
+| Production Python files (`core/` + `plugins/`) | 543 |
 | Test Python files | 682 |
-| `core/` Python LOC | 138,904 |
-| `plugins/` Python LOC | 40,709 |
-| Test Python LOC | 178,281 |
+| `core/` Python LOC | 138,911 |
+| `plugins/` Python LOC | 41,820 |
+| Test Python LOC | 178,949 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -565,6 +565,81 @@ and two scope-complete/replay-incomplete trajectories. Manifest SHA-256
 `fd524ce7a3cb1f1088f0e7a1531130d6302fb9f43d57a734303071bf6fd72288`
 was recomputed from the remote bytes after the artifact PR merged.
 
+## 2026-08-04 runtime-faithful adapter contract
+
+The current adapter replaces the two limitations measured in the 2026-08-03
+artifacts: an isolated loop with no hook composition, and retry lineage inferred
+after the run. Those older artifacts remain immutable and their claims stay
+revision-scoped; they are not retroactively upgraded.
+
+One process-owned benchmark-safe runtime now supplies the same
+`RuntimeEventBus`, `HookRegistry`, and `MiddlewareRegistry` instances to every
+Tau2 `ToolExecutor` and `AgenticLoop`. All four trusted join points are wired.
+All 13 public hooks are registered, but conditional hooks are not manufactured:
+an unvisited hook is `not_exercised`, not `passed`. Plugin/MCP discovery,
+scheduler, gateway, and auto-learning remain explicitly disabled so benchmark
+trials cannot acquire production cross-session state.
+
+Tool projection now preserves the official environment boundary. A GEODE
+wrapper returns `external_execution=deferred`; this ACK creates `tool.called`
+but not `tool.completed`. The pinned Tau2 orchestrator executes the call, and
+its `ToolMessage.id` closes the original call with the native result/error.
+Unknown result IDs and sessions with pending calls fail closed. When Tau2
+terminates directly after an environment step, the binder joins the final
+native ToolMessage from the receipt before testing for pending calls.
+
+After Tau2 finalizes `results.json`, GEODE hashes the receipt and records typed
+`verification.evidence` on every selected participant session before
+`SessionEnd`. The evidence keeps reward/components, native and runtime
+termination, semantic/infrastructure validity, participant role, task/trial,
+attempt ID, and `promotion_authority=none`. A normal `USER_STOP` with reward 0
+therefore remains runtime-complete and task-failed at the same time.
+
+Every new snapshot uses `crucible_tau2_trajectory_snapshot.v4` and digest-binds
+two sibling companions:
+
+| Companion | Contents |
+|---|---|
+| `<run>.runtime-profile.json` | revision; route/profile; assembled prompt hash/block inventory; tool schema digest/allowlist; exercised hook/middleware/event surfaces; SQLite/native receipt references |
+| `<run>.attempt-manifest.json` | every task/trial attempt; retry predecessor/reason; participant session IDs; native simulation ID; selected final result |
+
+The verifier rejects companion path traversal, byte/schema/run-ID drift,
+runtime-revision or native-receipt mismatch, broken retry ancestry, and final
+selection coverage that differs from native simulations. `tau2-native-user` and
+`geode-dual-runtime` are separate serialized profiles and cannot be combined into one
+headline or used as each other's baseline.
+
+The legacy `crucible.cached-row.v1` cache stores native simulation rows but not
+these two companions. Snapshot v4 runs therefore disable it with an explicit
+state marker and execute fresh. Existing cache bytes are retained for a future
+schema migration; GEODE does not synthesize a runtime profile from them.
+
+Frozen contract runs do not permit auto-resume. A diagnostic resume can retain
+completed native rows from an earlier process, but labels them
+`resumed_native_unattested`; it does not claim that the current process
+observed their hook, middleware, prompt, or retry surfaces.
+
+```mermaid
+flowchart LR
+    A["GEODE proposal<br/>tool.called"] --> D["deferred ACK<br/>no completion"]
+    D --> T["Tau2 environment<br/>native execution"]
+    T --> O["ToolMessage result/error<br/>same call_id"]
+    O --> S["sessions.db<br/>canonical tool.completed"]
+    T --> R["results.json<br/>score authority"]
+    R --> V["verification.evidence<br/>before SessionEnd"]
+    V --> S
+    S --> G["geode.trajectory@1"]
+    P["runtime profile"] --> C["snapshot v4 admission"]
+    M["attempt manifest"] --> C
+    R --> C
+    G --> C
+```
+
+The executable design and migration ledger are in
+[`docs/plans/2026-08-04-runtime-faithful-tau2.md`](../plans/2026-08-04-runtime-faithful-tau2.md).
+Live measurements must proceed mock → one task per domain → paired failure pack;
+the 278-task cycle is justified only after the v4 contract itself is reviewable.
+
 ## 참고
 
 - [τ-bench paper (NeurIPS '24)](https://arxiv.org/pdf/2406.12045)

--- a/docs/plans/2026-08-04-runtime-faithful-tau2.md
+++ b/docs/plans/2026-08-04-runtime-faithful-tau2.md
@@ -1,0 +1,242 @@
+# Runtime-faithful Tau2 execution contract
+
+Date: 2026-08-04
+Source feedback: `lg-ai/presentation/wiki/geode-runtime-faithful-tau2-handoff-2026-08-04.md`
+Status: implemented; non-live verification complete; live rollout pending
+
+## 1. Outcome
+
+Tau2 continues to own its task, shared environment, tool execution, retry
+policy, native termination, and reward. GEODE now runs each Tau2 participant
+through the same process-owned hook/event/middleware composition used by
+production and binds the native outcome back to the append-only session record
+before the session closes.
+
+The benchmark-safe profile deliberately excludes MCP/plugin discovery,
+scheduler, gateway, and auto-learning. A disabled surface is serialized as
+`disabled` or `not_exercised`, never as `passed`.
+
+```mermaid
+flowchart LR
+    T["Frozen Tau2 task + user + environment"] --> L["GEODE AgenticLoop"]
+    H["One process-owned RuntimeEventBus<br/>HookRegistry + MiddlewareRegistry"] --> L
+    H --> X["ToolExecutor"]
+    L --> X
+    X --> P["Tool proposal<br/>call_id preserved"]
+    P --> O["Tau2 orchestrator<br/>only environment executor"]
+    O --> J["ToolMessage result/error<br/>same call_id"]
+    J --> S["sessions.db<br/>tool.completed canonical outcome"]
+    O --> R["results.json<br/>native score authority"]
+    R --> V["verification.evidence<br/>receipt digest + reward + validity"]
+    V --> S
+    V --> C["SessionEnd"]
+    S --> G["geode.trajectory@1<br/>portable projection"]
+    R --> A["snapshot v4 admission"]
+    M["runtime profile + attempt manifest"] --> A
+    G --> A
+```
+
+## 2. Authority and storage boundary
+
+| Record | Mutability | Store | Authority |
+|---|---|---|---|
+| Active checkpoint | mutable | session checkpoint store | resume only |
+| Session events | append-only | `sessions.db:session_events` plus local JSONL projection | GEODE execution history |
+| Runtime events / extension dispatch | append-only, retention-bounded | `sessions.db:hook_events` | operational observability |
+| Tau2 native receipt | immutable after finalization | upstream `results.json` plus copied trajectory receipt | task reward and native termination |
+| Runtime profile | immutable companion | `<run>.runtime-profile.json` | runtime revision, route, prompt/tool digests, exercised surfaces |
+| Attempt manifest | immutable companion | `<run>.attempt-manifest.json` | retry/session/final-selection lineage |
+| Normalized trajectory | immutable projection | `<run>.geode-trajectory.json` | replay/correlation sidecar; no score authority |
+| Snapshot v4 | immutable commit marker | `<run>.snapshot.json` | digest admission across the preceding artifacts |
+
+`results.json` is not copied into `tool.completed`, and GEODE's built-in
+`PostVerify` does not impersonate the episode-native Tau2 verifier. The native
+verdict enters the session as typed `verification.evidence` and retains
+`promotion_authority=none` until Crucible independently admits it.
+
+## 3. Runtime profile
+
+The runner creates one `Tau2RuntimeContract` per process and gives its exact
+`RuntimeEventBus`, `HookRegistry`, and `MiddlewareRegistry` instances to every
+Tau2 `ToolExecutor` and `AgenticLoop`.
+
+The four trusted middleware surfaces are concretely registered and observed:
+
+- `tool_request`
+- `tool_execution`
+- `llm_request`
+- `llm_execution`
+
+All 13 public hooks are registered without adding policy decisions. Hooks that
+the run never reaches remain `not_exercised`. The manifest stores only bounded
+contract facts: the assembled prompt SHA-256 and XML block inventory, canonical
+tool-schema SHA-256 and allowlist, route identity, counts, runtime revision,
+SQLite paths, and native receipt digest. It does not persist raw system prompts,
+credentials, hidden reasoning, or private tool bodies.
+
+Runtime profiles remain disjoint:
+
+| Serialized profile | Participant ownership | Permitted reading |
+|---|---|---|
+| `tau2-native-user` | GEODE agent + upstream fixed user simulator | external comparison/runtime regression |
+| `geode-dual-runtime` | GEODE agent + GEODE user simulator | two-sided runtime stress diagnostic |
+
+They may not be averaged, pooled into one headline, or used as each other's
+baseline.
+
+## 4. External tool correlation
+
+The former adapter executed read tools locally and returned a dry-run ACK for
+mutating tools. Both paths could be recorded as a completed GEODE tool before
+Tau2 applied the official environment transition.
+
+The current path is uniform:
+
+```text
+provider tool_use id
+  -> GEODE tool.called
+  -> deferred projection ACK (not tool.completed)
+  -> Tau2 ToolCall.id
+  -> Tau2 environment result/error
+  -> Tau2 ToolMessage.id
+  -> GEODE tool.completed with the original id
+```
+
+An unknown result ID fails the attempt as infrastructure contamination. A
+session with a still-pending call cannot be admitted or closed as successful.
+If Tau2 terminates on the environment step before invoking the participant
+again, the binder reconciles the final native `ToolMessage` from `results.json`
+before applying that pending-call check.
+No generic external transport abstraction was added; the join stays in the
+Tau2 adapter until a second harness proves the same seam is needed.
+
+## 5. Native verdict and close ordering
+
+Terminal tokens and simulation deadlines no longer close a participant
+immediately. After `run_domain()` finalizes `results.json`, the runner:
+
+1. reads and hashes the native receipt;
+2. joins each simulation to session IDs embedded in native messages;
+3. records task, trial, participant, attempt, reward components, native/runtime
+   termination and semantic/infrastructure validity as verification evidence;
+4. records retry-exclusion evidence for sessions absent from the final receipt;
+5. closes only selected receipt-bound sessions as completed and closes failed
+   attempts as error.
+
+`USER_STOP + reward=0` is therefore represented as a normal runtime completion
+with a failed native task score. Stop protocol success and evaluator success are
+not aliases.
+
+## 6. Attempt manifest
+
+The adapter temporarily observes the pinned Tau2 `run_with_retry` boundary; it
+does not change retry count, delay, exception policy, seed, or final selection.
+Every attempted task/trial records:
+
+- stable attempt ID and retry predecessor;
+- seed, status, bounded retry reason;
+- assistant/user participant session IDs;
+- native simulation ID;
+- selected-final flag and final selection outcome.
+
+This is a run-local JSON companion, not a new SQLite table. Session SQLite
+remains complete local history; the manifest makes exclusion and selection
+portable and machine-verifiable.
+
+Contract-backed score runs forbid `--auto-resume`. Diagnostic auto-resume may
+include native rows produced by an earlier process; those rows are retained as
+`resumed_native_unattested` rather than being attributed to the current
+runtime profile. They cannot satisfy snapshot-v4 promotion admission.
+
+## 7. Snapshot v3 to v4 migration
+
+| v3 field/behavior | v4 replacement | Compatibility rule |
+|---|---|---|
+| raw receipt digest only | raw receipt + runtime profile + attempt manifest digests | new score-bearing runs require v4 |
+| projection ACK paired as completion | deferred ACK plus native result join | no alias; historical v3 remains immutable |
+| retry sessions inferred from SQLite time scope | explicit retry/selection manifest | old runs remain diagnostic |
+| native receipt joined after SessionEnd | `verification.evidence` before SessionEnd | old events are not rewritten |
+| isolated loop without hook composition | shared benchmark-safe hook/middleware composition | historical claims remain revision-scoped |
+| one undifferentiated GEODE route label | `tau2-native-user` / `geode-dual-runtime` | cross-profile aggregation forbidden |
+
+The v4 verifier rejects missing companion references, sibling-path traversal,
+companion digest changes, schema/run-ID drift, runtime revision drift, native
+receipt digest drift, broken retry ancestry, and a final selection that does
+not exactly cover native simulations.
+
+`crucible.cached-row.v1` predates both companions. Crucible therefore leaves
+existing cache shards intact but refuses them observably with
+`row-cache-disabled.json`; it runs fresh rather than synthesize a false runtime
+profile. Row reuse can return only after a new cache schema digest-binds the
+source runtime profile and attempt fragment for every cached simulation.
+
+## 8. Acceptance ledger
+
+| Gate | Evidence | Status |
+|---|---|---|
+| Shared event bus/hook/middleware pair | loop/executor object-identity test | verified |
+| Prompt block/hash and tool schema/allowlist | LLM request capture + runtime profile | verified |
+| ACK is not completion | processor lifecycle test | verified |
+| Exact result/error join; orphan rejection | supervisor join tests | verified |
+| `USER_STOP + reward=0` split | before-close native evidence test | verified |
+| Receipt/companion digest admission | v4 verifier tamper tests | verified |
+| Retry lineage and final selection | retry wrapper manifest test | verified |
+| Disabled is not passed | typed runtime profile states | verified |
+| Native/dual profile separation | snapshot/verifier profile check | verified |
+
+## 9. Verification and rollout
+
+Non-live order:
+
+1. targeted Tau2 adapter, verifier, and tool lifecycle tests;
+2. ruff, mypy, import boundaries;
+3. complete non-live suite and repository hygiene;
+4. independent Codex review.
+
+Completed evidence on 2026-08-04:
+
+- targeted runtime-faithful Tau2 set: 120 passed;
+- complete non-live suite: 10,438 passed, 23 skipped, 1 deselected;
+- ruff check/format, mypy (543 source files), four import contracts, and
+  architecture-baseline check: passed;
+- public site lint (0 errors) and static build (237 pages): passed;
+- `uv build`: sdist and wheel built for GEODE 1.0.12.
+
+The independent GPT-5.6 Codex review found three source-level gaps that the
+initial suite missed: terminal-step ToolMessage reconciliation, explicit
+diagnostic auto-resume provenance, and the final exhausted post-run attempt
+state. All three were fixed and covered by the focused post-review suite.
+
+The full suite still emits pre-existing scheduler teardown logging noise and
+deprecation warnings; neither changed the zero exit status. Live evidence is
+not claimed by this ledger until the staged rollout below produces admitted
+snapshot-v4 artifacts.
+
+Live order after the implementation PR is reviewable:
+
+```text
+mock × 1
+-> Airline / Retail / Telecom × 1 each
+-> known-failure paired pack
+-> full 278 only because this change alters the runtime/artifact contract
+```
+
+The live report must publish the snapshot v4 commit marker and both companion
+manifests with the native receipt and normalized trajectory. A run lacking any
+required digest is infrastructure-invalid and cannot enter promotion.
+
+## 10. Deliberate non-goals and remaining boundary
+
+- The benchmark does not discover production plugins, skills, MCP servers,
+  scheduler jobs, gateways, or auto-learning state.
+- Conditional hooks are not artificially triggered to manufacture coverage.
+- Raw prompts, credentials, private bodies, and hidden reasoning remain absent;
+  `replay_complete=false` may therefore be the truthful public state.
+- Tau2 episode reward is not converted into a `PostVerify` decision. A future
+  explicit external-verification ingress requires evidence that a live outer
+  loop must resume the same episode after native judgment.
+- The Tau2-specific deferred-result join is promoted into core only after a
+  second external harness demonstrates the same ownership boundary.
+- Legacy `cached-row.v1` is retained for migration evidence but is not admitted
+  into snapshot v4 runs because it cannot prove prompt/tool/runtime or retry
+  lineage.

--- a/plugins/benchmark_harness/tau2_geode_agent.py
+++ b/plugins/benchmark_harness/tau2_geode_agent.py
@@ -9,7 +9,6 @@ Contract runs bind the user runtime outside the candidate mutation surface.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
 import os
 import re
@@ -21,12 +20,20 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from plugins.benchmark_harness.tau2_runtime_contract import (
+    Tau2RuntimeContract,
+    native_results_path,
+    runtime_companion_paths,
+    runtime_contract_from_args,
+    snapshot_contract_metadata,
+)
 from plugins.benchmark_harness.tau2_turn_supervisor import (
     GeodeTau2State,
     _agent_system_prompt,
-    _jsonish,
     _message_to_prompt,
     _pre_execution_retry_telemetry,
+    _record_tau2_tool_results,
+    _remember_tau2_tool_calls,
     _run_geode_turn,
     _tau2_terminal_token,
     _tau2_tool_calls,
@@ -36,15 +43,10 @@ from plugins.benchmark_harness.tau2_turn_supervisor import (
     _user_system_prompt,
 )
 from plugins.benchmark_harness.trajectory_artifacts import (
-    close_benchmark_session as _close_tau_session,
-)
-from plugins.benchmark_harness.trajectory_artifacts import (
     geode_session_trace,
     geode_trajectory_snapshot_path,
+    tau2_trajectory_snapshot_paths,
     write_tau2_trajectory_snapshot,
-)
-from plugins.benchmark_harness.trajectory_artifacts import (
-    tau2_trajectory_snapshot_paths as _trajectory_snapshot_paths,
 )
 from plugins.crucible.contract import (
     ContractError,
@@ -62,20 +64,7 @@ DEFAULT_HARNESS_DIR = REPO_ROOT / "artifacts" / "eval" / "harnesses" / "tau2-ben
 DEFAULT_TRAJECTORY_SNAPSHOT_DIR = (
     REPO_ROOT / "artifacts" / "eval" / "runs" / "crucible" / "trajectory-snapshots"
 )
-_ACTIVE_TAU_LOOPS: dict[str, Any] = {}
-
-
-def _register_tau_loop(loop: Any) -> None:
-    session_id = str(getattr(loop, "_session_id", "") or f"loop-{id(loop)}")
-    _ACTIVE_TAU_LOOPS[session_id] = loop
-
-
-def _close_all_tau_sessions(*, success: bool) -> None:
-    """Close participants even when tau2, not GEODE, owns the stop edge."""
-    loops = list(_ACTIVE_TAU_LOOPS.values())
-    _ACTIVE_TAU_LOOPS.clear()
-    for loop in loops:
-        _close_tau_session(loop, success=success)
+_trajectory_snapshot_paths = tau2_trajectory_snapshot_paths
 
 
 def _tau2_data_root(harness_dir: Path) -> Path:
@@ -210,16 +199,15 @@ class Tau2GeodeTool:
 
     async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
         kwargs.pop("_tool_context", None)
-        if self.mutates_state:
-            return {
-                "result": (
-                    f"Recorded {self.name} for tau2 orchestrator execution. "
-                    "The official tau2 environment will apply this tool call."
-                ),
-                "projected_to_tau2": True,
-            }
-        raw = await asyncio.to_thread(self.tau2_tool, **kwargs)
-        return {"result": _jsonish(raw)}
+        return {
+            "result": (
+                f"Recorded {self.name} for tau2 orchestrator execution. "
+                "The official tau2 environment will execute this tool call."
+            ),
+            "projected_to_tau2": True,
+            "external_execution": "deferred",
+            "mutates_state": self.mutates_state,
+        }
 
 
 def _build_loop(
@@ -233,6 +221,7 @@ def _build_loop(
     time_budget_s: float,
     max_tokens: int,
     max_rounds: int,
+    runtime_contract: Tau2RuntimeContract,
     allow_actionable_partial_on_empty: bool = False,
 ) -> Any:
     from core.agent.conversation import ConversationContext
@@ -251,6 +240,9 @@ def _build_loop(
         action_handlers=handlers,
         auto_approve=True,
         hitl_level=0,
+        hooks=runtime_contract.hooks,
+        hook_registry=runtime_contract.hook_registry,
+        middleware_registry=runtime_contract.middleware_registry,
         tool_input_schemas={
             name: registered.parameters
             for name in handlers
@@ -275,6 +267,7 @@ def _build_loop(
         enable_goal_decomposition=False,
         allow_actionable_partial_on_empty=allow_actionable_partial_on_empty,
         yield_after_tool_round=True,
+        hooks=runtime_contract.hooks,
     )
 
 
@@ -295,6 +288,7 @@ def register_geode_tau2_participants(
     user_max_tokens: int,
     user_max_rounds: int,
     simulation_timeout_s: float | None,
+    runtime_contract: Tau2RuntimeContract,
     fail_on_empty_geode_turn: bool = True,
 ) -> None:
     from core.llm.adapters.registry import bootstrap_builtins
@@ -317,6 +311,7 @@ def register_geode_tau2_participants(
                 time_budget_s=agent_time_budget_s,
                 max_tokens=agent_max_tokens,
                 max_rounds=agent_max_rounds,
+                runtime_contract=runtime_contract,
             )
             deadline_at = (
                 time.monotonic() + simulation_timeout_s
@@ -324,7 +319,7 @@ def register_geode_tau2_participants(
                 else None
             )
             state = GeodeTau2State(loop=loop, deadline_at=deadline_at)
-            _register_tau_loop(loop)
+            runtime_contract.register_loop(loop, participant_role="assistant")
             if message_history:
                 state.messages_seen = len(message_history)
             return state
@@ -333,11 +328,11 @@ def register_geode_tau2_participants(
             self, message: Any, state: GeodeTau2State
         ) -> tuple[Any, GeodeTau2State]:
             started = time.monotonic()
+            _record_tau2_tool_results(state, message)
             prompt = _message_to_prompt(message, recipient="assistant agent")
             try:
                 result = _run_geode_turn(state, prompt)
             except _Tau2TurnDeadlineError:
-                _close_tau_session(state.loop, success=False)
                 assistant = AssistantMessage.text(
                     "The configured tau2 simulation deadline elapsed.",
                     raw_data={
@@ -362,7 +357,6 @@ def register_geode_tau2_participants(
                     role="assistant agent",
                 )
             if terminal_token is not None:
-                _close_tau_session(state.loop, success=True)
                 assistant = AssistantMessage.text(
                     terminal_token,
                     usage=_usage_dict(result),
@@ -378,6 +372,7 @@ def register_geode_tau2_participants(
                 )
                 return assistant, state
             if tool_calls:
+                _remember_tau2_tool_calls(state, tool_calls)
                 assistant = AssistantMessage(
                     role="assistant",
                     tool_calls=tool_calls,
@@ -444,6 +439,7 @@ def register_geode_tau2_participants(
                 max_tokens=user_max_tokens,
                 max_rounds=user_max_rounds,
                 allow_actionable_partial_on_empty=self.allow_actionable_partial_on_empty,
+                runtime_contract=runtime_contract,
             )
             deadline_at = (
                 time.monotonic() + simulation_timeout_s
@@ -451,7 +447,7 @@ def register_geode_tau2_participants(
                 else None
             )
             state = GeodeTau2State(loop=loop, deadline_at=deadline_at)
-            _register_tau_loop(loop)
+            runtime_contract.register_loop(loop, participant_role="user_simulator")
             if message_history:
                 state.messages_seen = len(message_history)
             return state
@@ -460,11 +456,11 @@ def register_geode_tau2_participants(
             self, message: Any, state: GeodeTau2State
         ) -> tuple[Any, GeodeTau2State]:
             started = time.monotonic()
+            _record_tau2_tool_results(state, message)
             prompt = _message_to_prompt(message, recipient="simulated user")
             try:
                 result = _run_geode_turn(state, prompt)
             except _Tau2TurnDeadlineError:
-                _close_tau_session(state.loop, success=False)
                 user_message = UserMessage.text(
                     "The configured tau2 simulation deadline elapsed.",
                     raw_data={
@@ -490,7 +486,6 @@ def register_geode_tau2_participants(
                     role="simulated user",
                 )
             if terminal_token is not None:
-                _close_tau_session(state.loop, success=True)
                 user_message = UserMessage.text(
                     terminal_token,
                     usage=_usage_dict(result),
@@ -507,6 +502,7 @@ def register_geode_tau2_participants(
                 )
                 return user_message, state
             if tool_calls:
+                _remember_tau2_tool_calls(state, tool_calls)
                 user_message = UserMessage(
                     role="user",
                     tool_calls=tool_calls,
@@ -562,6 +558,7 @@ def _write_trajectory_snapshot(
     snapshot_dir: Path,
     run_id: str,
     metadata: dict[str, Any],
+    companion_artifacts: Mapping[str, Mapping[str, str]] | None = None,
 ) -> tuple[Path, Path] | None:
     results_path = _tau2_data_root(harness_dir) / "simulations" / run_id / "results.json"
     if not results_path.exists():
@@ -572,6 +569,7 @@ def _write_trajectory_snapshot(
         snapshot_dir=snapshot_dir,
         run_id=run_id,
         metadata=metadata,
+        companion_artifacts=companion_artifacts,
     )
     normalized_path = geode_trajectory_snapshot_path(snapshot_dir, run_id)
     snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
@@ -607,10 +605,17 @@ def _validate_contract_output_paths(
         raise ContractError("contract --save-to must be a simple, path-free run ID")
     trajectory_path, snapshot_path = _trajectory_snapshot_paths(snapshot_dir, run_id)
     normalized_path = geode_trajectory_snapshot_path(snapshot_dir, run_id)
+    companion_paths = runtime_companion_paths(snapshot_dir, run_id)
     raw_run_dir = _tau2_data_root(harness_dir) / "simulations" / run_id
     collisions = [
         path
-        for path in (raw_run_dir, trajectory_path, normalized_path, snapshot_path)
+        for path in (
+            raw_run_dir,
+            trajectory_path,
+            normalized_path,
+            *companion_paths,
+            snapshot_path,
+        )
         if path.exists()
     ]
     if collisions:
@@ -1020,6 +1025,8 @@ def main() -> int:
         _restore_tau2_data_root(previous_tau2_data_dir)
         raise SystemExit(f"invalid tau2 data root: {exc}") from exc
 
+    effective_run_id = args.save_to or (f"tau2-diagnostic-{int(time.time())}-{os.getpid()}")
+    runtime_contract = runtime_contract_from_args(args, effective_run_id, REPO_ROOT)
     register_geode_tau2_participants(
         agent_model=args.model,
         agent_provider=args.provider,
@@ -1036,6 +1043,7 @@ def main() -> int:
         user_max_tokens=args.user_max_tokens,
         user_max_rounds=args.user_max_rounds,
         simulation_timeout_s=args.timeout,
+        runtime_contract=runtime_contract,
         fail_on_empty_geode_turn=not args.allow_empty_geode_turn,
     )
 
@@ -1058,7 +1066,7 @@ def main() -> int:
         max_errors=args.max_errors,
         max_retries=args.max_retries,
         timeout=args.timeout,
-        save_to=args.save_to,
+        save_to=effective_run_id,
         log_level=args.log_level,
         auto_resume=args.auto_resume,
         verbose_logs=args.verbose_logs,
@@ -1089,13 +1097,15 @@ def main() -> int:
     if args.disable_tool_search_defer:
         object.__setattr__(settings, "tool_search_defer", False)
         object.__setattr__(settings, "tool_search_defer_codex", False)
-    run_error: BaseException | None = None
+    results_path = native_results_path(expected_tau2_data_dir, effective_run_id)
     try:
-        run_domain(config)
-    except BaseException as exc:
-        run_error = exc
+        run_error = runtime_contract.execute(
+            run_domain,
+            config,
+            results_path,
+            classify_termination=TAU2_ADAPTER.classify_termination,
+        )
     finally:
-        _close_all_tau_sessions(success=run_error is None)
         if previous_fail_empty_text is None:
             os.environ.pop("GEODE_CODEX_OAUTH_FAIL_EMPTY_TEXT", None)
         else:
@@ -1135,6 +1145,11 @@ def main() -> int:
             else:
                 failure_class = "run_error_and_route_contamination"
 
+    companion_artifacts = (
+        runtime_contract.companion_artifacts(args.trajectory_snapshot_dir.resolve())
+        if not args.no_trajectory_snapshot and args.save_to and final_error is None
+        else None
+    )
     if not args.no_trajectory_snapshot and args.save_to:
         if experiment_contract is None:
             arm = "diagnostic"
@@ -1142,21 +1157,7 @@ def main() -> int:
         else:
             arm = str(args.trajectory_arm)
             candidate_surface = "git_revision"
-        contract_metadata = (
-            {
-                "experiment_contract_id": experiment_contract.contract_id,
-                "baseline_sha": experiment_contract.baseline_sha,
-                "candidate_sha": experiment_contract.candidate_sha,
-                "evaluator_sha256": experiment_contract.evaluator_sha256,
-                "harness_sha256": experiment_contract.harness_sha256,
-                "task_pack_sha256": experiment_contract.task_pack_sha256,
-                "assay_config_sha256": experiment_contract.assay_config_sha256,
-                "contract_validation": "identity_preflight",
-                "promotion_authority": "none",
-            }
-            if experiment_contract is not None
-            else {"promotion_authority": "none"}
-        )
+        contract_metadata = snapshot_contract_metadata(experiment_contract)
         written = _write_trajectory_snapshot(
             harness_dir=args.harness_dir.resolve(),
             snapshot_dir=args.trajectory_snapshot_dir.resolve(),
@@ -1179,11 +1180,13 @@ def main() -> int:
                 "max_concurrency": args.max_concurrency,
                 "seed": args.seed,
                 "assay_config": assay_config,
+                "runtime_profile": runtime_contract.runtime_profile,
                 "execution_status": "complete" if final_error is None else "invalid",
                 "failure_class": failure_class,
                 "argv": sys.argv,
                 **contract_metadata,
             },
+            companion_artifacts=companion_artifacts,
         )
         if final_error is None:
             _require_contract_snapshot(experiment_contract, written)

--- a/plugins/benchmark_harness/tau2_runtime_contract.py
+++ b/plugins/benchmark_harness/tau2_runtime_contract.py
@@ -1,0 +1,858 @@
+"""Run-scoped GEODE runtime and evidence contract for tau2-bench.
+
+The benchmark keeps tau2's orchestrator, environment, retry loop, evaluator,
+and native ``results.json`` authoritative.  This module only supplies the
+production-shaped GEODE surfaces that the adapter used to omit and preserves
+the identities needed to join tau2 outcomes back to GEODE sessions.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import dataclasses
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import threading
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from core.hooks import (
+    HookDecision,
+    HookDispatch,
+    HookInvocation,
+    HookName,
+    HookRegistry,
+    HookSystem,
+    LlmCallRequest,
+    MiddlewareRegistry,
+    ToolCallRequest,
+)
+from core.hooks.middleware import LlmNextCall, ToolNextCall
+from core.llm.adapters.base import AdapterCallResult
+from core.memory.atomic_write import atomic_write_json
+from core.observability.event_store import HookEventStore
+from core.observability.hook_persistence import HookPersistenceSink
+
+RUNTIME_PROFILE_SCHEMA = "geode.tau2-runtime-profile.v1"
+ATTEMPT_MANIFEST_SCHEMA = "geode.tau2-attempt-manifest.v1"
+NATIVE_VERDICT_SCHEMA = "tau2.results@native"
+TAU2_NATIVE_USER_PROFILE = "tau2-native-user"
+GEODE_DUAL_RUNTIME_PROFILE = "geode-dual-runtime"
+
+_PROMPT_TAG = re.compile(r"<([A-Za-z][A-Za-z0-9_-]{0,63})(?:\s|>)")
+_REQUIRED_PUBLIC_HOOKS = frozenset(
+    {
+        HookName.USER_PROMPT_SUBMIT,
+        HookName.SESSION_START,
+        HookName.SESSION_END,
+        HookName.PRE_VERIFY,
+        HookName.POST_VERIFY,
+        HookName.STOP,
+    }
+)
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        _jsonable(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+    return _sha256_bytes(encoded)
+
+
+def _jsonable(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _jsonable(dataclasses.asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _runtime_revision(repo_root: Path) -> str:
+    git = shutil.which("git")
+    if git is None:
+        return "unknown"
+    result = subprocess.run(  # noqa: S603 -- executable resolved by shutil.which
+        [git, "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    revision = result.stdout.strip()
+    return revision if result.returncode == 0 and len(revision) == 40 else "unknown"
+
+
+def _tool_name(tool: Any) -> str:
+    if isinstance(tool, Mapping):
+        direct = tool.get("name")
+        if isinstance(direct, str):
+            return direct
+        function = tool.get("function")
+        if isinstance(function, Mapping) and isinstance(function.get("name"), str):
+            return str(function["name"])
+    return str(getattr(tool, "name", "") or "")
+
+
+@dataclass(slots=True)
+class _Attempt:
+    attempt_id: str
+    task_id: str
+    trial: int
+    attempt: int
+    seed: int
+    retry_of: str | None
+    status: str = "running"
+    retry_reason: str | None = None
+    selected_final: bool = False
+    simulation_id: str | None = None
+    sessions: list[dict[str, str]] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "attempt_id": self.attempt_id,
+            "task_id": self.task_id,
+            "trial": self.trial,
+            "attempt": self.attempt,
+            "seed": self.seed,
+            "retry_of": self.retry_of,
+            "status": self.status,
+            "retry_reason": self.retry_reason,
+            "selected_final": self.selected_final,
+            "simulation_id": self.simulation_id,
+            "sessions": list(self.sessions),
+        }
+
+
+_CURRENT_ATTEMPT: contextvars.ContextVar[_Attempt | None] = contextvars.ContextVar(
+    "geode_tau2_attempt",
+    default=None,
+)
+
+
+class Tau2AttemptTracker:
+    """Observe tau2's existing retry loop without changing its policy."""
+
+    def __init__(self, run_id: str) -> None:
+        self.run_id = run_id
+        self._lock = threading.Lock()
+        self._attempts: list[_Attempt] = []
+        self._final_results: list[dict[str, Any]] = []
+        self._resumed_results: list[dict[str, Any]] = []
+
+    def register_session(self, *, participant_role: str, session_id: str) -> None:
+        attempt = _CURRENT_ATTEMPT.get()
+        if attempt is None:
+            raise RuntimeError("tau2 participant was created outside a tracked attempt")
+        with self._lock:
+            attempt.sessions.append(
+                {"participant_role": participant_role, "session_id": session_id}
+            )
+
+    def attempt_for_session(self, session_id: str) -> _Attempt | None:
+        with self._lock:
+            return next(
+                (
+                    attempt
+                    for attempt in self._attempts
+                    if any(row["session_id"] == session_id for row in attempt.sessions)
+                ),
+                None,
+            )
+
+    def wrap(self, original: Callable[..., Any]) -> Callable[..., Any]:
+        def tracked(
+            run_fn: Callable[[], Any],
+            task: Any,
+            trial: int,
+            seed: int,
+            **kwargs: Any,
+        ) -> Any:
+            task_id = str(getattr(task, "id", "") or "unknown-task")
+            previous: _Attempt | None = None
+            attempt_number = 0
+
+            def tracked_run() -> Any:
+                nonlocal attempt_number, previous
+                if (
+                    previous is not None
+                    and previous.status == "complete"
+                    and not previous.selected_final
+                ):
+                    # tau2 can retry after run_fn returns when display or
+                    # checkpoint persistence fails inside run_with_retry.
+                    previous.status = "error"
+                    previous.retry_reason = "upstream post-run failure before selection"
+                attempt_number += 1
+                attempt = _Attempt(
+                    attempt_id=f"{self.run_id}:{task_id}:{trial}:{attempt_number}",
+                    task_id=task_id,
+                    trial=int(trial),
+                    attempt=attempt_number,
+                    seed=int(seed),
+                    retry_of=previous.attempt_id if previous is not None else None,
+                )
+                with self._lock:
+                    self._attempts.append(attempt)
+                token = _CURRENT_ATTEMPT.set(attempt)
+                try:
+                    simulation = run_fn()
+                except BaseException as exc:
+                    attempt.status = "error"
+                    attempt.retry_reason = f"{type(exc).__name__}: {str(exc)[:512]}"
+                    previous = attempt
+                    raise
+                finally:
+                    _CURRENT_ATTEMPT.reset(token)
+                attempt.status = "complete"
+                attempt.simulation_id = str(getattr(simulation, "id", "") or "") or None
+                previous = attempt
+                return simulation
+
+            result = original(tracked_run, task, trial, seed, **kwargs)
+            simulation_id = str(getattr(result, "id", "") or "") or None
+            with self._lock:
+                selected_attempt = next(
+                    (
+                        row
+                        for row in reversed(self._attempts)
+                        if row.task_id == task_id
+                        and row.trial == int(trial)
+                        and row.status == "complete"
+                        and row.simulation_id == simulation_id
+                    ),
+                    None,
+                )
+                if (
+                    selected_attempt is None
+                    and previous is not None
+                    and previous.status == "complete"
+                ):
+                    previous.status = "error"
+                    previous.retry_reason = "upstream post-run failure before selection"
+                if selected_attempt is not None:
+                    selected_attempt.selected_final = True
+                selected = selected_attempt.attempt_id if selected_attempt is not None else None
+                self._final_results.append(
+                    {
+                        "task_id": task_id,
+                        "trial": int(trial),
+                        "simulation_id": simulation_id,
+                        "selected_attempt_id": selected,
+                        "selection_status": "selected" if selected else "no_successful_attempt",
+                    }
+                )
+            return result
+
+        return tracked
+
+    def record_resumed_result(
+        self,
+        *,
+        task_id: str,
+        trial: int,
+        simulation_id: str,
+        session_ids: list[str],
+    ) -> None:
+        """Mark a native auto-resume row whose originating process is unavailable."""
+        with self._lock:
+            self._resumed_results.append(
+                {
+                    "task_id": task_id,
+                    "trial": trial,
+                    "simulation_id": simulation_id,
+                    "session_ids": session_ids,
+                    "selection_status": "resumed_native_unattested",
+                }
+            )
+
+    @contextlib.contextmanager
+    def patch_tau2_retry_runner(self) -> Iterator[None]:
+        """Temporarily instrument the pinned runner's imported retry function."""
+        from tau2.runner import batch
+
+        original = batch.run_with_retry
+        batch.run_with_retry = self.wrap(original)
+        try:
+            yield
+        finally:
+            batch.run_with_retry = original
+
+    def manifest(self) -> dict[str, Any]:
+        with self._lock:
+            attempts = [attempt.as_dict() for attempt in self._attempts]
+            final_results = [dict(row) for row in self._final_results]
+            resumed_results = [dict(row) for row in self._resumed_results]
+        return {
+            "schema": ATTEMPT_MANIFEST_SCHEMA,
+            "run_id": self.run_id,
+            "attempts": attempts,
+            "final_results": final_results,
+            "resumed_results": resumed_results,
+        }
+
+
+class Tau2RuntimeCapture:
+    """No-op production middleware that records only bounded contract facts."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._surface_counts = {
+            "tool_request": 0,
+            "tool_execution": 0,
+            "llm_request": 0,
+            "llm_execution": 0,
+        }
+        self._hook_counts = {hook.value: 0 for hook in HookName}
+        self._event_counts: dict[str, int] = {}
+        self._prompts: dict[str, dict[str, Any]] = {}
+
+    async def tool_request(self, request: ToolCallRequest) -> ToolCallRequest:
+        self._increment_surface("tool_request")
+        return request
+
+    async def tool_execution(
+        self,
+        request: ToolCallRequest,
+        next_call: ToolNextCall,
+    ) -> dict[str, Any]:
+        self._increment_surface("tool_execution")
+        return await next_call(request)
+
+    async def llm_request(self, request: LlmCallRequest) -> LlmCallRequest:
+        self._increment_surface("llm_request")
+        system_prompt = str(request.request.system_prompt or "")
+        tools = list(request.request.tools or [])
+        session_id = str(request.correlation.get("session_id") or "unbound")
+        prompt_sha256 = _sha256_bytes(system_prompt.encode("utf-8"))
+        tool_schema_sha256 = _canonical_sha256(tools)
+        tags: dict[str, int] = {}
+        for match in _PROMPT_TAG.finditer(system_prompt):
+            name = match.group(1)
+            tags[name] = tags.get(name, 0) + 1
+        record = {
+            "session_id": session_id,
+            "model": request.request.model,
+            "assembled_prompt_sha256": prompt_sha256,
+            "assembled_prompt_bytes": len(system_prompt.encode("utf-8")),
+            "prompt_block_inventory": {
+                "cache_boundary_present": "__GEODE_PROMPT_CACHE_BOUNDARY__" in system_prompt,
+                "xml_tags": [{"name": name, "count": tags[name]} for name in sorted(tags)[:64]],
+            },
+            "tool_schema_sha256": tool_schema_sha256,
+            "tool_allowlist": sorted(name for tool in tools if (name := _tool_name(tool))),
+            "observed_count": 1,
+        }
+        with self._lock:
+            key = f"{session_id}:{prompt_sha256}:{tool_schema_sha256}"
+            existing = self._prompts.get(key)
+            if existing is None:
+                self._prompts[key] = record
+            else:
+                existing["observed_count"] = int(existing["observed_count"]) + 1
+        return request
+
+    async def llm_execution(
+        self,
+        request: LlmCallRequest,
+        next_call: LlmNextCall,
+    ) -> AdapterCallResult:
+        self._increment_surface("llm_execution")
+        return await next_call(request)
+
+    def observe_hook(self, invocation: HookInvocation) -> HookDecision:
+        with self._lock:
+            self._hook_counts[invocation.name.value] += 1
+        return HookDecision()
+
+    def observe_event(self, dispatch: HookDispatch) -> None:
+        with self._lock:
+            name = dispatch.event.value
+            self._event_counts[name] = self._event_counts.get(name, 0) + 1
+
+    def _increment_surface(self, surface: str) -> None:
+        with self._lock:
+            self._surface_counts[surface] += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "middleware": dict(self._surface_counts),
+                "public_hooks": dict(self._hook_counts),
+                "runtime_events": dict(sorted(self._event_counts.items())),
+                "assembled_requests": [dict(self._prompts[key]) for key in sorted(self._prompts)],
+            }
+
+
+class Tau2RuntimeContract:
+    """One process-owned runtime surface shared by every tau2 participant."""
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        repo_root: Path,
+        agent_route: Mapping[str, Any],
+        user_route: Mapping[str, Any],
+        runtime_profile: str,
+        event_db_path: Path | None = None,
+        allow_resumed_native: bool = False,
+    ) -> None:
+        self.run_id = run_id
+        self.repo_root = repo_root
+        self.agent_route = dict(agent_route)
+        self.user_route = dict(user_route)
+        if runtime_profile not in {
+            TAU2_NATIVE_USER_PROFILE,
+            GEODE_DUAL_RUNTIME_PROFILE,
+        }:
+            raise ValueError(f"unsupported tau2 runtime profile: {runtime_profile!r}")
+        self.runtime_profile = runtime_profile
+        self.allow_resumed_native = allow_resumed_native
+        self.capture = Tau2RuntimeCapture()
+        self.hooks = HookSystem()
+        self.event_store = HookEventStore(event_db_path)
+        self.hooks.register_sink(
+            HookPersistenceSink(
+                self.event_store,
+                session_key=f"tau2:{run_id}",
+                run_id=run_id,
+            ),
+            name="hook_persistence",
+        )
+        self.hooks.register_sink(self.capture.observe_event, name="tau2_runtime_capture")
+        self.hook_registry = HookRegistry(events=self.hooks)
+        self.middleware_registry = MiddlewareRegistry(events=self.hooks)
+        for hook in HookName:
+            self.hook_registry.register(
+                hook,
+                self.capture.observe_hook,
+                name="tau2_runtime_capture",
+            )
+        self.middleware_registry.register_tool_request(self.capture, name="tau2_runtime_capture")
+        self.middleware_registry.register_tool_execution(self.capture, name="tau2_runtime_capture")
+        self.middleware_registry.register_llm_request(self.capture, name="tau2_runtime_capture")
+        self.middleware_registry.register_llm_execution(self.capture, name="tau2_runtime_capture")
+        self.attempts = Tau2AttemptTracker(run_id)
+        self._loops: dict[str, Any] = {}
+        self._roles: dict[str, str] = {}
+        self._native_receipt: dict[str, Any] | None = None
+        self._bound_sessions: set[str] = set()
+
+    def register_loop(self, loop: Any, *, participant_role: str) -> None:
+        session_id = str(getattr(loop, "_session_id", "") or f"loop-{id(loop)}")
+        self._loops[session_id] = loop
+        self._roles[session_id] = participant_role
+        self.attempts.register_session(
+            participant_role=participant_role,
+            session_id=session_id,
+        )
+
+    def execute(
+        self,
+        run_fn: Callable[[Any], Any],
+        config: Any,
+        results_path: Path,
+        *,
+        classify_termination: Callable[[str], str],
+    ) -> BaseException | None:
+        """Run Tau2, bind its receipt, and close every participant in order."""
+        run_error: BaseException | None = None
+        try:
+            with self.attempts.patch_tau2_retry_runner():
+                run_fn(config)
+        except BaseException as exc:
+            run_error = exc
+        try:
+            self.bind_native_results(
+                results_path,
+                classify_termination=classify_termination,
+            )
+        except BaseException as exc:
+            if run_error is None:
+                run_error = exc
+        try:
+            from plugins.benchmark_harness.trajectory_artifacts import (
+                close_benchmark_session,
+            )
+
+            for session_id, loop in self._loops.items():
+                close_benchmark_session(
+                    loop,
+                    success=run_error is None and self.session_completed(session_id),
+                )
+        finally:
+            self.close()
+        return run_error
+
+    def bind_native_results(
+        self,
+        results_path: Path,
+        *,
+        classify_termination: Callable[[str], str],
+    ) -> None:
+        """Join the authoritative receipt to live timelines before they close."""
+        raw = results_path.read_bytes()
+        digest = _sha256_bytes(raw)
+        parsed = json.loads(raw)
+        if not isinstance(parsed, Mapping):
+            raise RuntimeError("tau2 results receipt must be a JSON object")
+        simulations = parsed.get("simulations")
+        if not isinstance(simulations, list):
+            raise RuntimeError("tau2 results receipt must contain simulations")
+        bound_sessions: set[str] = set()
+        for simulation in simulations:
+            if not isinstance(simulation, Mapping):
+                continue
+            termination = str(simulation.get("termination_reason") or "")
+            termination_class = classify_termination(termination)
+            validity = "infrastructure" if termination_class == "infra" else "semantic"
+            reward_info = simulation.get("reward_info")
+            reward_row = reward_info if isinstance(reward_info, Mapping) else {}
+            reward = reward_row.get("reward")
+            simulation_id = str(simulation.get("id") or "")
+            task_id = str(simulation.get("task_id") or "")
+            trial = int(simulation.get("trial") or 0)
+            simulation_sessions = _simulation_sessions(simulation)
+            unknown_sessions = [
+                session_id
+                for session_id, _termination in simulation_sessions
+                if session_id not in self._loops
+            ]
+            if unknown_sessions:
+                if self.allow_resumed_native and len(unknown_sessions) == len(simulation_sessions):
+                    self.attempts.record_resumed_result(
+                        task_id=task_id,
+                        trial=trial,
+                        simulation_id=simulation_id,
+                        session_ids=unknown_sessions,
+                    )
+                    continue
+                raise RuntimeError(
+                    f"tau2 receipt references unknown GEODE session {unknown_sessions[0]!r}"
+                )
+            if validity == "semantic":
+                expected_roles = (
+                    {"assistant", "user_simulator"}
+                    if self.runtime_profile == GEODE_DUAL_RUNTIME_PROFILE
+                    else {"assistant"}
+                )
+                observed_roles = {
+                    self._roles.get(session_id, "unknown")
+                    for session_id, _runtime_termination in simulation_sessions
+                }
+                if observed_roles != expected_roles:
+                    raise RuntimeError(
+                        f"tau2 simulation {simulation_id!r} GEODE participant coverage "
+                        f"{sorted(observed_roles)!r} != {sorted(expected_roles)!r}"
+                    )
+            for session_id, runtime_termination in simulation_sessions:
+                loop = self._loops.get(session_id)
+                if loop is None:  # guarded by unknown_sessions above
+                    raise AssertionError("known tau2 session disappeared during native binding")
+                bound_sessions.add(session_id)
+                pending = getattr(loop, "_tau2_pending_tool_calls", {})
+                if pending:
+                    from plugins.benchmark_harness.tau2_turn_supervisor import (
+                        GeodeTau2State,
+                        _reconcile_tau2_terminal_results,
+                    )
+
+                    requestor = (
+                        "user" if self._roles.get(session_id) == "user_simulator" else "assistant"
+                    )
+                    _reconcile_tau2_terminal_results(
+                        GeodeTau2State(loop=loop, pending_tool_calls=pending),
+                        simulation.get("messages"),
+                        requestor=requestor,
+                    )
+                if pending:
+                    raise RuntimeError(
+                        f"tau2 session {session_id!r} closed with orphan tool calls: "
+                        + ", ".join(sorted(pending))
+                    )
+                attempt = self.attempts.attempt_for_session(session_id)
+                reference = {
+                    "kind": "native_receipt",
+                    "schema_id": NATIVE_VERDICT_SCHEMA,
+                    "authority": "tau2 native evaluator",
+                    "reference": digest,
+                    "raw_artifact_sha256": digest,
+                    "simulation_id": simulation_id,
+                    "task_id": task_id,
+                    "trial": trial,
+                    "participant_role": self._roles.get(session_id, "unknown"),
+                    "attempt_id": attempt.attempt_id if attempt is not None else None,
+                    "reward": reward,
+                    "reward_components": _reward_components(reward_row),
+                    "native_termination_reason": termination,
+                    "runtime_termination_reason": runtime_termination,
+                    "validity": validity,
+                    "promotion_authority": "none",
+                }
+                timeline = getattr(loop, "_timeline", None)
+                if timeline is None:
+                    raise RuntimeError(f"GEODE session {session_id!r} has no timeline")
+                timeline.record_verification_evidence(
+                    [reference],
+                    root_turn_id=str(getattr(loop, "_turn_id", "") or "tau2-native-verdict"),
+                    verify_attempt=0,
+                    policy_action="observe_native_verdict",
+                )
+
+        for session_id, loop in self._loops.items():
+            if session_id in bound_sessions:
+                continue
+            attempt = self.attempts.attempt_for_session(session_id)
+            timeline = getattr(loop, "_timeline", None)
+            if timeline is None:
+                continue
+            timeline.record_verification_evidence(
+                [
+                    {
+                        "kind": "native_receipt",
+                        "schema_id": "tau2.retry-exclusion.v1",
+                        "authority": "tau2 retry controller",
+                        "reference": attempt.attempt_id if attempt is not None else session_id,
+                        "raw_artifact_sha256": digest,
+                        "participant_role": self._roles.get(session_id, "unknown"),
+                        "attempt_id": attempt.attempt_id if attempt is not None else None,
+                        "retry_reason": attempt.retry_reason if attempt is not None else None,
+                        "validity": "infrastructure",
+                        "promotion_authority": "none",
+                    }
+                ],
+                root_turn_id=str(getattr(loop, "_turn_id", "") or "tau2-retry-exclusion"),
+                verify_attempt=0,
+                policy_action="exclude_failed_attempt",
+            )
+        self._native_receipt = {
+            "path": results_path.name,
+            "sha256": digest,
+            "simulation_count": len(simulations),
+        }
+        self._bound_sessions = bound_sessions
+
+    def session_completed(self, session_id: str) -> bool:
+        """Return whether the native receipt selected this session's attempt."""
+        attempt = self.attempts.attempt_for_session(session_id)
+        return (
+            session_id in self._bound_sessions
+            and attempt is not None
+            and attempt.status == "complete"
+            and attempt.selected_final
+        )
+
+    def write_companions(self, snapshot_dir: Path) -> tuple[Path, Path]:
+        if self._native_receipt is None:
+            raise RuntimeError("runtime profile requires a bound tau2 native receipt")
+        from core import __version__
+
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        slug = _slug(self.run_id)
+        profile_path = snapshot_dir / f"{slug}.runtime-profile.json"
+        attempts_path = snapshot_dir / f"{slug}.attempt-manifest.json"
+        capture = self.capture.snapshot()
+        session_dbs = sorted(
+            {
+                str(getattr(getattr(loop, "_timeline", None), "db_path", ""))
+                for loop in self._loops.values()
+                if getattr(getattr(loop, "_timeline", None), "db_path", None)
+            }
+        )
+        session_dbs = sorted({Path(path).name for path in session_dbs})
+        hook_rows = []
+        for hook in HookName:
+            count = int(capture["public_hooks"].get(hook.value, 0))
+            hook_rows.append(
+                {
+                    "name": hook.value,
+                    "expectation": "required" if hook in _REQUIRED_PUBLIC_HOOKS else "conditional",
+                    "observed_count": count,
+                    "status": "exercised" if count else "not_exercised",
+                }
+            )
+        profile = {
+            "schema": RUNTIME_PROFILE_SCHEMA,
+            "run_id": self.run_id,
+            "runtime_revision": _runtime_revision(self.repo_root),
+            "runtime_version": __version__,
+            "runtime_profile": self.runtime_profile,
+            "routes": {"agent": self.agent_route, "user": self.user_route},
+            "assembled_requests": capture["assembled_requests"],
+            "surfaces": {
+                "public_hooks": hook_rows,
+                "middleware": [
+                    {
+                        "name": name,
+                        "status": "exercised" if count else "not_exercised",
+                        "observed_count": count,
+                    }
+                    for name, count in sorted(capture["middleware"].items())
+                ],
+                "runtime_events": capture["runtime_events"],
+                "disabled": [
+                    {
+                        "name": name,
+                        "status": "disabled",
+                        "reason": "outside benchmark-safe runtime profile",
+                    }
+                    for name in (
+                        "auto_learning",
+                        "gateway",
+                        "mcp_discovery",
+                        "plugin_discovery",
+                        "scheduler",
+                    )
+                ],
+            },
+            "persistence": {
+                "session_event_dbs": session_dbs,
+                "hook_event_db": Path(self.event_store.db_path).name,
+                "native_receipt": dict(self._native_receipt),
+            },
+        }
+        atomic_write_json(profile_path, profile, indent=2)
+        atomic_write_json(attempts_path, self.attempts.manifest(), indent=2)
+        return profile_path, attempts_path
+
+    def companion_artifacts(self, snapshot_dir: Path) -> dict[str, dict[str, str]]:
+        profile_path, attempts_path = self.write_companions(snapshot_dir)
+        return {
+            "runtime_profile": artifact_reference(profile_path),
+            "attempt_manifest": artifact_reference(attempts_path),
+        }
+
+    def close(self) -> None:
+        self.hooks.close()
+        self.event_store.close()
+
+
+def _simulation_sessions(simulation: Mapping[str, Any]) -> list[tuple[str, str]]:
+    sessions: dict[str, str] = {}
+    messages = simulation.get("messages")
+    if not isinstance(messages, list):
+        return []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        raw_data = message.get("raw_data")
+        if not isinstance(raw_data, Mapping):
+            continue
+        session_id = str(raw_data.get("geode_session_id") or "")
+        if not session_id:
+            continue
+        termination = str(raw_data.get("geode_termination_reason") or "")
+        if termination or session_id not in sessions:
+            sessions[session_id] = termination
+    return list(sessions.items())
+
+
+def _reward_components(reward_info: Mapping[str, Any]) -> dict[str, Any]:
+    breakdown = reward_info.get("reward_breakdown")
+    return {
+        "reward_breakdown": dict(breakdown) if isinstance(breakdown, Mapping) else {},
+        "db_check_present": reward_info.get("db_check") is not None,
+        "env_assertion_count": len(reward_info.get("env_assertions") or []),
+        "action_check_count": len(reward_info.get("action_checks") or []),
+        "nl_assertion_count": len(reward_info.get("nl_assertions") or []),
+        "communicate_check_count": len(reward_info.get("communicate_checks") or []),
+    }
+
+
+def artifact_reference(path: Path) -> dict[str, str]:
+    return {"path": path.name, "sha256": _sha256_bytes(path.read_bytes())}
+
+
+def runtime_contract_from_args(
+    args: Any,
+    run_id: str,
+    repo_root: Path,
+) -> Tau2RuntimeContract:
+    profile = (
+        GEODE_DUAL_RUNTIME_PROFILE
+        if args.user in {"geode_user", "crucible_user"}
+        else TAU2_NATIVE_USER_PROFILE
+    )
+    return Tau2RuntimeContract(
+        run_id=run_id,
+        repo_root=repo_root,
+        agent_route={
+            "model": args.model,
+            "provider": args.provider,
+            "source": args.source,
+            "effort": args.effort,
+        },
+        user_route={
+            "implementation": args.user,
+            "model": args.user_llm,
+            "provider": args.user_provider,
+            "source": args.user_source,
+            "effort": args.user_effort,
+        },
+        runtime_profile=profile,
+        allow_resumed_native=bool(args.auto_resume),
+    )
+
+
+def runtime_companion_paths(snapshot_dir: Path, run_id: str) -> tuple[Path, Path]:
+    slug = _slug(run_id)
+    return (
+        snapshot_dir / f"{slug}.runtime-profile.json",
+        snapshot_dir / f"{slug}.attempt-manifest.json",
+    )
+
+
+def native_results_path(data_root: Path, run_id: str) -> Path:
+    return data_root / "simulations" / run_id / "results.json"
+
+
+def snapshot_contract_metadata(contract: Any | None) -> dict[str, Any]:
+    if contract is None:
+        return {"promotion_authority": "none"}
+    return {
+        "experiment_contract_id": contract.contract_id,
+        "baseline_sha": contract.baseline_sha,
+        "candidate_sha": contract.candidate_sha,
+        "evaluator_sha256": contract.evaluator_sha256,
+        "harness_sha256": contract.harness_sha256,
+        "task_pack_sha256": contract.task_pack_sha256,
+        "assay_config_sha256": contract.assay_config_sha256,
+        "contract_validation": "identity_preflight",
+        "promotion_authority": "none",
+    }
+
+
+def _slug(value: str) -> str:
+    return "".join(
+        character if character.isalnum() or character in "._-" else "-" for character in value
+    )
+
+
+__all__ = [
+    "ATTEMPT_MANIFEST_SCHEMA",
+    "GEODE_DUAL_RUNTIME_PROFILE",
+    "RUNTIME_PROFILE_SCHEMA",
+    "TAU2_NATIVE_USER_PROFILE",
+    "Tau2RuntimeContract",
+    "artifact_reference",
+    "native_results_path",
+    "runtime_companion_paths",
+    "runtime_contract_from_args",
+    "snapshot_contract_metadata",
+]

--- a/plugins/benchmark_harness/tau2_turn_supervisor.py
+++ b/plugins/benchmark_harness/tau2_turn_supervisor.py
@@ -25,6 +25,13 @@ class GeodeTau2State:
     loop: Any
     messages_seen: int = 0
     deadline_at: float | None = None
+    pending_tool_calls: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.pending_tool_calls is None:
+            self.pending_tool_calls = {}
+        # The run contract audits this shared map before closing the session.
+        self.loop._tau2_pending_tool_calls = self.pending_tool_calls
 
 
 class _Tau2TurnDeadlineError(RuntimeError):
@@ -51,7 +58,13 @@ def _message_to_prompt(message: Any, *, recipient: str) -> str:
     content = str(getattr(message, "content", "") or "").strip()
     if content:
         if role == "tool":
-            return f"Tool result to {recipient} from tau2 orchestrator:\n{content}"
+            single_payload = {
+                "id": getattr(message, "id", ""),
+                "requestor": getattr(message, "requestor", ""),
+                "content": content,
+                "error": getattr(message, "error", False),
+            }
+            return f"Tool result to {recipient} from tau2 orchestrator:\n{_jsonish(single_payload)}"
         return f"Message to {recipient} from {role}:\n{content}"
     tool_calls = getattr(message, "tool_calls", None)
     if tool_calls:
@@ -166,6 +179,95 @@ def _tau2_tool_calls(result: Any, *, requestor: str) -> list[Any]:
             )
         )
     return calls
+
+
+def _remember_tau2_tool_calls(state: GeodeTau2State, calls: list[Any]) -> None:
+    """Retain the exact provider call IDs until tau2 returns their outcomes."""
+    pending = state.pending_tool_calls
+    if pending is None:
+        raise RuntimeError("tau2 pending tool-call state is unavailable")
+    for call in calls:
+        call_id = str(getattr(call, "id", "") or "")
+        tool_name = str(getattr(call, "name", "") or "")
+        if not call_id or not tool_name:
+            raise RuntimeError("tau2 projection requires non-empty tool call id and name")
+        if call_id in pending:
+            raise RuntimeError(f"duplicate pending tau2 tool call id: {call_id}")
+        pending[call_id] = tool_name
+
+
+def _message_field(message: Any, name: str, default: Any = None) -> Any:
+    return (
+        message.get(name, default)
+        if isinstance(message, Mapping)
+        else getattr(message, name, default)
+    )
+
+
+def _tool_messages(message: Any) -> list[Any]:
+    nested = _message_field(message, "tool_messages")
+    if isinstance(nested, list):
+        return nested
+    raw_role = _message_field(message, "role", "")
+    role = str(getattr(raw_role, "value", raw_role) or "").lower()
+    return [message] if role.rsplit(".", 1)[-1] == "tool" else []
+
+
+def _record_tau2_tool_result(
+    state: GeodeTau2State,
+    tool_message: Any,
+    *,
+    allow_missing: bool = False,
+) -> bool:
+    pending = state.pending_tool_calls
+    if pending is None:
+        raise RuntimeError("tau2 pending tool-call state is unavailable")
+    call_id = str(_message_field(tool_message, "id", "") or "")
+    tool_name = pending.pop(call_id, None)
+    if tool_name is None:
+        if allow_missing:
+            return False
+        raise RuntimeError(f"orphan tau2 tool result id: {call_id or '[empty]'}")
+    timeline = getattr(state.loop, "_timeline", None)
+    if timeline is None:
+        raise RuntimeError("GEODE tau2 loop has no session timeline")
+    has_error = bool(_message_field(tool_message, "error", False))
+    content = str(_message_field(tool_message, "content", "") or "")
+    timeline.record_tool_result(
+        tool_name,
+        "error" if has_error else "ok",
+        "tau2 orchestrator result",
+        call_id=call_id,
+        result={
+            "content": content,
+            "error": has_error,
+            "source": "tau2_orchestrator",
+        },
+    )
+    return True
+
+
+def _record_tau2_tool_results(state: GeodeTau2State, message: Any) -> None:
+    """Join official tau2 ToolMessage outcomes to their original GEODE calls."""
+    for tool_message in _tool_messages(message):
+        _record_tau2_tool_result(state, tool_message)
+
+
+def _reconcile_tau2_terminal_results(
+    state: GeodeTau2State,
+    messages: Any,
+    *,
+    requestor: str,
+) -> None:
+    """Close native tool outcomes that terminate before the participant is called again."""
+    if not isinstance(messages, list):
+        return
+    for message in messages:
+        for tool_message in _tool_messages(message):
+            owner = str(_message_field(tool_message, "requestor", "") or "")
+            if owner and owner != requestor:
+                continue
+            _record_tau2_tool_result(state, tool_message, allow_missing=True)
 
 
 def _tau2_terminal_token(result: Any) -> str | None:

--- a/plugins/benchmark_harness/trajectory_artifacts.py
+++ b/plugins/benchmark_harness/trajectory_artifacts.py
@@ -84,6 +84,7 @@ def write_tau2_trajectory_snapshot(
     snapshot_dir: Path,
     run_id: str,
     metadata: Mapping[str, Any],
+    companion_artifacts: Mapping[str, Mapping[str, str]] | None = None,
 ) -> tuple[Path, Path]:
     """Atomically publish a tau2 receipt, GEODE view, and commit marker.
 
@@ -109,6 +110,7 @@ def write_tau2_trajectory_snapshot(
                 run_id=run_id,
                 raw_artifact_sha256=raw_artifact_sha256,
                 metadata=metadata,
+                companion_artifacts=companion_artifacts,
             )
             normalized_status = "written"
             normalized_error = None
@@ -118,13 +120,15 @@ def write_tau2_trajectory_snapshot(
             normalized_error = str(exc)
             normalized_sha256 = None
         snapshot = {
-            "schema": "crucible_tau2_trajectory_snapshot.v3",
+            "schema": "crucible_tau2_trajectory_snapshot.v4",
             "filename_convention": {
                 "run_id": (
                     "crucible-tau2-<stage>-<domain>-<arm>-"
                     "<agent_route>-<user_route>-n<tasks>k<trials>-<yyyymmdd>-<seq>"
                 ),
                 "trajectory": "<run-id>.trajectory.json",
+                "runtime_profile": "<run-id>.runtime-profile.json",
+                "attempt_manifest": "<run-id>.attempt-manifest.json",
                 "snapshot": "<run-id>.snapshot.json",
             },
             "run_id": run_id,
@@ -136,6 +140,12 @@ def write_tau2_trajectory_snapshot(
             "geode_trajectory_status": normalized_status,
             "geode_trajectory_error": normalized_error,
             "snapshot_metadata": str(snapshot_path),
+            "runtime_profile_artifact": dict(
+                (companion_artifacts or {}).get("runtime_profile", {})
+            ),
+            "attempt_manifest_artifact": dict(
+                (companion_artifacts or {}).get("attempt_manifest", {})
+            ),
             **metadata,
         }
         staged_snapshot.write_text(
@@ -159,6 +169,7 @@ def export_tau2_trajectory(
     run_id: str,
     raw_artifact_sha256: str,
     metadata: Mapping[str, Any],
+    companion_artifacts: Mapping[str, Mapping[str, str]] | None = None,
 ) -> Path:
     """Project a tau2 receipt through GEODE's shared trajectory validator."""
     from core.observability.trajectory import export_trajectory, trajectory_from_sessions
@@ -183,7 +194,7 @@ def export_tau2_trajectory(
         evidence_refs.append(
             {
                 "kind": "crucible_evidence",
-                "schema_id": "crucible_tau2_trajectory_snapshot.v3",
+                "schema_id": "crucible_tau2_trajectory_snapshot.v4",
                 "reference": contract_id,
                 "contract_id": contract_id,
                 "arm": metadata.get("arm"),
@@ -199,6 +210,12 @@ def export_tau2_trajectory(
             "run": run_id,
             "session": run_id,
             "parents": session_ids,
+            "runtime_profile_sha256": (companion_artifacts or {})
+            .get("runtime_profile", {})
+            .get("sha256"),
+            "attempt_manifest_sha256": (companion_artifacts or {})
+            .get("attempt_manifest", {})
+            .get("sha256"),
         },
         outcome={
             "execution_status": metadata.get("execution_status"),
@@ -219,10 +236,12 @@ def export_tau2_trajectory(
             "payloads": "redacted and bounded by SessionEventStore",
         },
         artifact_digests=[
-            {
-                "path": results_path.name,
-                "sha256": raw_artifact_sha256,
-            }
+            {"path": results_path.name, "sha256": raw_artifact_sha256},
+            *[
+                dict(reference)
+                for reference in (companion_artifacts or {}).values()
+                if reference.get("path") and reference.get("sha256")
+            ],
         ],
         evidence_refs=evidence_refs,
         content_policy="digest",

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -20,13 +20,25 @@
       "id": "file:plugins/benchmark_harness/tau2_geode_agent.py",
       "filePath": "plugins/benchmark_harness/tau2_geode_agent.py",
       "name": "Tau2 GEODE adapter",
-      "summary": "Builds GEODE participants, delegates half-duplex turn control, and persists per-turn pre-execution retry identity.",
+      "summary": "Builds GEODE participants on one process-owned hook and middleware runtime, delegates half-duplex turn control, and binds native results before session closure.",
       "tags": [
         "adapter",
         "benchmark",
         "tool-projection"
       ],
-      "contentSha256": "0224f4e1fc860d0d00b086e80f8f7cf4e0307f3ef5a50645d486d5ddfde1c9aa"
+      "contentSha256": "7c5b7ffd0a39680cf74764091ef1e7ea1049124330e637391ac70f84bf3f7f45"
+    },
+    {
+      "id": "file:plugins/benchmark_harness/tau2_runtime_contract.py",
+      "filePath": "plugins/benchmark_harness/tau2_runtime_contract.py",
+      "name": "Tau2 runtime contract",
+      "summary": "Owns shared hooks and middleware, captures the effective runtime profile, records retry lineage, and joins exact native Tau2 verdicts before session closure.",
+      "tags": [
+        "attempt-manifest",
+        "benchmark",
+        "runtime-profile"
+      ],
+      "contentSha256": "7035bb822d7558776ba67716c4e5edb45987059e90de10505f0f2a229f4542b5"
     },
     {
       "id": "file:plugins/benchmark_harness/trajectory_artifacts.py",
@@ -38,20 +50,20 @@
         "benchmark",
         "trajectory"
       ],
-      "contentSha256": "19d4814e23fba8e847a8bc4b2e52831637e01ba4eb2c7e978a73d8185af7f821"
+      "contentSha256": "103a272dcfef4ee7b858a7bb86635ef32846a5a6bb6abe293e180f5ea686f1cc"
     },
     {
       "id": "file:plugins/benchmark_harness/tau2_turn_supervisor.py",
       "filePath": "plugins/benchmark_harness/tau2_turn_supervisor.py",
       "name": "Tau2 turn supervisor",
-      "summary": "Owns the half-duplex deadline, stop mapping, and retry-telemetry projection while AgenticLoop yields after each completed tool batch.",
+      "summary": "Owns the half-duplex deadline, stop mapping, and exact ToolCall.id to ToolMessage.id result join while AgenticLoop yields after deferred external tool batches.",
       "tags": [
         "benchmark",
         "deadline",
         "external-loop",
         "tool-projection"
       ],
-      "contentSha256": "245d8f2ef53660e37cffcbfee125531503dc9375477feb0944a1f18d1e2dbc57"
+      "contentSha256": "0badf7ed4f176dc6adec79fdc976fb92b90235ff429708436e3671bc6980e370"
     },
     {
       "id": "file:core/agent/loop/agent_loop.py",
@@ -68,37 +80,25 @@
       "id": "file:core/agent/tool_executor/processor.py",
       "filePath": "core/agent/tool_executor/processor.py",
       "name": "Tool call processor",
-      "summary": "Executes one model response's tool calls and preserves input order while batching eligible calls.",
+      "summary": "Executes one model response's tool calls, preserves input order, and leaves deferred external acknowledgements open until their native result is joined.",
       "tags": [
         "runtime",
         "tools",
         "parallel"
       ],
-      "contentSha256": "b4ce924b4f53c59d457f91536e75930bb66371b5015164d1f97584d2151b1537"
+      "contentSha256": "2f8d6cbcdfffc7406dfe854dad0b6ef3c0f3b24264b5402371be040581ca2302"
     },
     {
       "id": "file:plugins/crucible/tau2_live.py",
       "filePath": "plugins/crucible/tau2_live.py",
       "name": "Paired tau2 evaluator",
-      "summary": "Derives frozen runner arguments, gives baseline and candidate one supervisor-anchored shared deadline, and emits receipts bound to exact arm artifacts and cache provenance. Screens unreachable train arms at zero candidate cost, projects structural failure codes, reuses identity-proven cached rows across relaunches, and stops the paid process group after finalized infrastructure contamination.",
+      "summary": "Derives frozen runner arguments, gives baseline and candidate one supervisor-anchored shared deadline, and emits receipts bound to exact arm artifacts. Screens unreachable train arms at zero candidate cost, disables legacy row reuse that lacks snapshot-v4 companions, projects structural failure codes, and stops the paid process group after finalized infrastructure contamination.",
       "tags": [
         "crucible",
         "evaluator",
         "paired"
       ],
-      "contentSha256": "4deee0c2a96fc3c208a4010a18c752beac0d6397288a149d037832ba459283ce"
-    },
-    {
-      "id": "file:plugins/crucible/row_cache.py",
-      "filePath": "plugins/crucible/row_cache.py",
-      "name": "Hash-bound row cache",
-      "summary": "Reuses only infrastructure-clean semantic tau2 rows whose full measurement identity and row/context payload hashes verify; placeholders and source-attested retry rows remain missing work.",
-      "tags": [
-        "cache",
-        "crucible",
-        "recovery"
-      ],
-      "contentSha256": "d82eb18f8c24eb7a694653ef09b63d84b299ebf3981a4e4012e84be42943beaa"
+      "contentSha256": "95f4d70b091cfbbb7614aa35db44ef194fa36d7c0d07cd5998153582e8223885"
     },
     {
       "id": "file:plugins/crucible/runtime_receipt.py",
@@ -195,6 +195,11 @@
     },
     {
       "source": "file:plugins/benchmark_harness/tau2_geode_agent.py",
+      "target": "file:plugins/benchmark_harness/tau2_runtime_contract.py",
+      "type": "depends_on"
+    },
+    {
+      "source": "file:plugins/benchmark_harness/tau2_geode_agent.py",
       "target": "file:plugins/benchmark_harness/tau2_turn_supervisor.py",
       "type": "delegates_to"
     },
@@ -217,11 +222,6 @@
       "source": "file:plugins/crucible/tau2_live.py",
       "target": "file:plugins/benchmark_harness/tau2_geode_agent.py",
       "type": "calls"
-    },
-    {
-      "source": "file:plugins/crucible/tau2_live.py",
-      "target": "file:plugins/crucible/row_cache.py",
-      "type": "depends_on"
     },
     {
       "source": "file:plugins/crucible/tau2_live.py",

--- a/plugins/crucible/tau2_live.py
+++ b/plugins/crucible/tau2_live.py
@@ -27,15 +27,6 @@ from .artifacts import load_json_object, write_exclusive_json
 from .contract import ContractError, ExperimentContract, load_contract, validate_test_parent
 from .evidence import EvidenceEnvelope, ResourceUsage, expected_pairs
 from .promotion import SCREENING_FAILURE, PromotionReachability, promotion_reachability
-from .row_cache import (
-    cached_context,
-    cached_rows,
-    harvest_arm_rows,
-    merge_results,
-    missing_task_ids,
-    selected_expected_rows,
-    synthesized_snapshot,
-)
 from .runtime_receipt import (
     MeasurementSource,
     SharedRuntimeDeadline,
@@ -388,28 +379,6 @@ def _git(checkout: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _harvest_partial(
-    cache_root: Path | None,
-    contract: ExperimentContract,
-    revision_sha: str,
-    harness_root: Path,
-    run_id: str,
-) -> None:
-    """Best-effort salvage of finalized simulations from an interrupted run."""
-    if cache_root is None:
-        return
-    source_raw = harness_root / "data" / "simulations" / run_id / "results.json"
-    if not source_raw.is_file():
-        return
-    try:
-        partial = load_json_object(
-            source_raw, f"tau2 partial {run_id}", max_bytes=512 * 1024 * 1024
-        )
-        harvest_arm_rows(cache_root, contract, revision_sha=revision_sha, raw_results=partial)
-    except (ContractError, OSError):
-        return
-
-
 def _terminate_process_group(process: subprocess.Popen[bytes]) -> int:
     """Stop one tau2 process tree and wait until no paid child is orphaned."""
 
@@ -552,7 +521,6 @@ def _run_arm(
             "TMPDIR": str(temp_root),
         }
     )
-    revision_sha = contract.baseline_sha if arm == "baseline" else contract.candidate_sha
     cache_root_value = os.environ.get("CRUCIBLE_ROW_CACHE_ROOT")
     if cache_root_value and contract.stage != "train":
         # Row reuse would freeze a past noise realisation into a sealed
@@ -570,127 +538,83 @@ def _run_arm(
             encoding="utf-8",
         )
         cache_root_value = None
-    cache_root = Path(cache_root_value).resolve() if cache_root_value else None
-    salvaged: dict[tuple[str, int], Mapping[str, Any]] = {}
-    salvage_context: Mapping[str, Any] | None = None
-    if cache_root is not None:
-        salvaged = selected_expected_rows(
-            contract,
-            cached_rows(cache_root, contract, revision_sha=revision_sha),
+    elif cache_root_value:
+        # cached-row.v1 preserves native simulations but not the runtime
+        # profile or attempt manifest required by Tau2 snapshot v4. Reusing
+        # those rows would manufacture an execution contract after the fact.
+        # Keep the cache on disk for migration, but run fresh until a future
+        # cache schema digest-binds both companions per row.
+        (state_root / "row-cache-disabled.json").write_text(
+            json.dumps(
+                {
+                    "schema": "crucible.row-cache-disabled.v1",
+                    "reason": "cached-row.v1 lacks snapshot-v4 runtime companions",
+                    "stage": contract.stage,
+                }
+            ),
+            encoding="utf-8",
         )
-        salvage_context = cached_context(cache_root, contract, revision_sha=revision_sha)
-    unfinished_ids = (
-        missing_task_ids(contract, salvaged)
-        if salvage_context is not None
-        else list(contract.task_ids)
-    )
+        cache_root_value = None
     raw_path = output_dir / f"{arm}.raw.json"
     elapsed = 0.0
     runner_returncode = 0
     marginal_usage = ResourceUsage(0.0, 0, 0, 0.0)
-    if salvage_context is not None and not unfinished_ids:
-        measurement_source: MeasurementSource = "full_cache"
-        # Every expected row is identity-proven in the cache: rebuild the
-        # results file without spending a single conversation.
-        raw = merge_results(salvage_context, salvaged)
-        write_exclusive_json(raw_path, raw)
-        snapshot = snapshot_dir / f"{run_id}.snapshot.json"
+    measurement_source: MeasurementSource = "fresh"
+    command = tau2_command(
+        contract,
+        arm=arm,
+        checkout=checkout,
+        harness_root=harness_root,
+        contract_path=contract_path,
+        snapshot_dir=snapshot_dir,
+        run_id=run_id,
+        parent_contract_path=parent_contract_path,
+    )
+    source_raw = harness_root / "data" / "simulations" / run_id / "results.json"
+    started = time.monotonic()
+    try:
+        completed, infrastructure_abort = _run_tau2_command(
+            command,
+            cwd=checkout,
+            env=environment,
+            timeout=timeout if absolute_deadline is None else None,
+            deadline_seconds=absolute_deadline,
+            results_path=source_raw,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if on_timeout is not None:
+            on_timeout()
+        raise TimeoutError(f"tau2 {arm} arm timed out") from exc
+    elapsed = time.monotonic() - started
+    runner_returncode = completed.returncode
+    snapshot = snapshot_dir / f"{run_id}.snapshot.json"
+    if not source_raw.is_file() or (not infrastructure_abort and not snapshot.is_file()):
+        if completed.returncode:
+            raise Tau2InfrastructureError(
+                f"tau2 {arm} arm exited with status {completed.returncode}"
+            )
+        raise Tau2InfrastructureError(
+            f"tau2 {arm} arm did not produce finalized raw and snapshot files"
+        )
+    fresh = load_json_object(source_raw, f"tau2 {arm} raw", max_bytes=512 * 1024 * 1024)
+    fresh_usage = tau2_resource_usage_floor(fresh)
+    marginal_usage = ResourceUsage(
+        wall_seconds=max(elapsed, fresh_usage.wall_seconds),
+        calls=fresh_usage.calls,
+        tokens=fresh_usage.tokens,
+        cost_usd=fresh_usage.cost_usd,
+    )
+    shutil.copyfile(source_raw, raw_path)
+    if infrastructure_abort:
+        snapshot = snapshot_dir / f"{run_id}.aborted.snapshot.json"
         write_exclusive_json(
             snapshot,
-            synthesized_snapshot(
-                contract, arm=arm, raw_sha256=_file_sha256(raw_path, f"{arm} rebuilt raw")
+            _infrastructure_abort_snapshot(
+                contract,
+                arm=arm,
+                raw_sha256=_file_sha256(raw_path, f"{arm} aborted raw"),
             ),
         )
-    else:
-        measurement_source = (
-            "partial_cache" if salvage_context is not None and salvaged else "fresh"
-        )
-        command = tau2_command(
-            contract,
-            arm=arm,
-            checkout=checkout,
-            harness_root=harness_root,
-            contract_path=contract_path,
-            snapshot_dir=snapshot_dir,
-            run_id=run_id,
-            parent_contract_path=parent_contract_path,
-            task_ids_override=(
-                unfinished_ids
-                if salvage_context is not None and len(unfinished_ids) < len(contract.task_ids)
-                else None
-            ),
-        )
-        source_raw = harness_root / "data" / "simulations" / run_id / "results.json"
-        started = time.monotonic()
-        try:
-            completed, infrastructure_abort = _run_tau2_command(
-                command,
-                cwd=checkout,
-                env=environment,
-                timeout=timeout if absolute_deadline is None else None,
-                deadline_seconds=absolute_deadline,
-                results_path=source_raw,
-            )
-        except subprocess.TimeoutExpired as exc:
-            if on_timeout is not None:
-                on_timeout()
-            _harvest_partial(cache_root, contract, revision_sha, harness_root, run_id)
-            raise TimeoutError(f"tau2 {arm} arm timed out") from exc
-        except BaseException:
-            _harvest_partial(cache_root, contract, revision_sha, harness_root, run_id)
-            raise
-        elapsed = time.monotonic() - started
-        runner_returncode = completed.returncode
-        snapshot = snapshot_dir / f"{run_id}.snapshot.json"
-        if not source_raw.is_file() or (not infrastructure_abort and not snapshot.is_file()):
-            # tau2 finalizes each simulation into results.json incrementally;
-            # an interrupted arm still donates its completed rows (r23: 18
-            # finished executions were discarded for want of this line).
-            _harvest_partial(cache_root, contract, revision_sha, harness_root, run_id)
-            if completed.returncode:
-                raise Tau2InfrastructureError(
-                    f"tau2 {arm} arm exited with status {completed.returncode}"
-                )
-            raise Tau2InfrastructureError(
-                f"tau2 {arm} arm did not produce finalized raw and snapshot files"
-            )
-        fresh = load_json_object(source_raw, f"tau2 {arm} raw", max_bytes=512 * 1024 * 1024)
-        fresh_usage = tau2_resource_usage_floor(fresh)
-        marginal_usage = ResourceUsage(
-            wall_seconds=max(elapsed, fresh_usage.wall_seconds),
-            calls=fresh_usage.calls,
-            tokens=fresh_usage.tokens,
-            cost_usd=fresh_usage.cost_usd,
-        )
-        if salvage_context is not None and salvaged:
-            fresh_rows = _index_simulations(fresh, f"tau2 {arm} partial-cache raw")
-            # A task with one missing trial must be re-run as a whole because
-            # tau2 accepts task IDs rather than individual pairs.  Preserve
-            # any identity-proven original trial instead of silently replacing
-            # it with the repeated realization.
-            raw = merge_results(salvage_context, {**fresh_rows, **salvaged})
-            write_exclusive_json(raw_path, raw)
-            snapshot = snapshot_dir / f"{run_id}.merged.snapshot.json"
-            write_exclusive_json(
-                snapshot,
-                synthesized_snapshot(
-                    contract, arm=arm, raw_sha256=_file_sha256(raw_path, f"{arm} rebuilt raw")
-                ),
-            )
-        else:
-            shutil.copyfile(source_raw, raw_path)
-        if infrastructure_abort:
-            snapshot = snapshot_dir / f"{run_id}.aborted.snapshot.json"
-            write_exclusive_json(
-                snapshot,
-                _infrastructure_abort_snapshot(
-                    contract,
-                    arm=arm,
-                    raw_sha256=_file_sha256(raw_path, f"{arm} aborted raw"),
-                ),
-            )
-        if cache_root is not None:
-            harvest_arm_rows(cache_root, contract, revision_sha=revision_sha, raw_results=fresh)
     raw = load_json_object(raw_path, f"tau2 {arm} raw", max_bytes=512 * 1024 * 1024)
     observed_usage = tau2_resource_usage_floor(raw)
     arm_usage = ResourceUsage(

--- a/plugins/crucible/verifiers/tau2.py
+++ b/plugins/crucible/verifiers/tau2.py
@@ -10,10 +10,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from plugins.benchmark_harness.tau2_runtime_contract import (
+    GEODE_DUAL_RUNTIME_PROFILE,
+    TAU2_NATIVE_USER_PROFILE,
+)
 from plugins.crucible.contract import ContractError, ExperimentContract, TaskUnit
 from plugins.crucible.evidence import EVIDENCE_SCHEMA, EvidenceEnvelope, ResourceUsage
 
-_SNAPSHOT_SCHEMA = "crucible_tau2_trajectory_snapshot.v3"
+_SNAPSHOT_SCHEMA = "crucible_tau2_trajectory_snapshot.v4"
 # Public alias: the row cache synthesizes snapshots the verifier must accept,
 # so both sides must share one schema constant rather than drifting literals.
 SNAPSHOT_SCHEMA = _SNAPSHOT_SCHEMA
@@ -26,6 +30,7 @@ class Tau2AssayAdapter:
     schema: str = "crucible.tau2-assay.v1"
     required_evaluator_paths: tuple[str, ...] = (
         "plugins/benchmark_harness/tau2_geode_agent.py",
+        "plugins/benchmark_harness/tau2_runtime_contract.py",
         "plugins/benchmark_harness/trajectory_artifacts.py",
         "plugins/crucible",
     )
@@ -395,6 +400,8 @@ def _verify_snapshot(
     arm: Literal["baseline", "candidate"],
     raw_sha256: str,
     snapshot: Mapping[str, Any],
+    snapshot_path: Path | None = None,
+    raw: Mapping[str, Any] | None = None,
 ) -> tuple[Literal["complete", "invalid"], str | None]:
     if snapshot.get("schema") != _SNAPSHOT_SCHEMA:
         raise ContractError(f"snapshot.schema must be {_SNAPSHOT_SCHEMA!r}")
@@ -427,7 +434,203 @@ def _verify_snapshot(
         return "invalid", failure
     if failure is not None:
         raise ContractError("complete snapshot cannot carry failure_class")
+    if snapshot_path is None or raw is None:
+        raise ContractError("complete snapshot verification requires companion artifact context")
+    expected_profile = (
+        GEODE_DUAL_RUNTIME_PROFILE
+        if _mapping(contract.assay_config.get("user"), "assay_config.user").get("implementation")
+        in {"geode_user", "crucible_user"}
+        else TAU2_NATIVE_USER_PROFILE
+    )
+    if snapshot.get("runtime_profile") != expected_profile:
+        raise ContractError("snapshot runtime_profile does not match the user implementation")
+    runtime_profile = _verify_companion(
+        snapshot,
+        snapshot_path=snapshot_path,
+        field="runtime_profile_artifact",
+        schema="geode.tau2-runtime-profile.v1",
+    )
+    if runtime_profile.get("runtime_revision") != expected_revision:
+        raise ContractError("runtime profile revision does not match the selected arm")
+    if runtime_profile.get("runtime_profile") != expected_profile:
+        raise ContractError("runtime profile mode does not match the snapshot")
+    native_receipt = _mapping(
+        _mapping(runtime_profile.get("persistence"), "runtime_profile.persistence").get(
+            "native_receipt"
+        ),
+        "runtime_profile.persistence.native_receipt",
+    )
+    if native_receipt.get("sha256") != raw_sha256:
+        raise ContractError("runtime profile native receipt digest does not match results")
+    attempt_manifest = _verify_companion(
+        snapshot,
+        snapshot_path=snapshot_path,
+        field="attempt_manifest_artifact",
+        schema="geode.tau2-attempt-manifest.v1",
+    )
+    _verify_attempt_manifest(attempt_manifest, raw)
     return "complete", None
+
+
+def _verify_companion(
+    snapshot: Mapping[str, Any],
+    *,
+    snapshot_path: Path,
+    field: str,
+    schema: str,
+) -> Mapping[str, Any]:
+    reference = _mapping(snapshot.get(field), f"snapshot.{field}")
+    filename = reference.get("path")
+    digest = reference.get("sha256")
+    if not isinstance(filename, str) or not filename:
+        raise ContractError(f"snapshot.{field}.path is required")
+    relative = Path(filename)
+    if relative.is_absolute() or len(relative.parts) != 1 or relative.name != filename:
+        raise ContractError(f"snapshot.{field}.path must be a sibling filename")
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise ContractError(f"snapshot.{field}.sha256 is required")
+    path = snapshot_path.parent / relative
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise ContractError(f"cannot read snapshot companion {filename!r}: {exc}") from exc
+    if hashlib.sha256(payload).hexdigest() != digest:
+        raise ContractError(f"snapshot.{field}.sha256 does not match companion bytes")
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ContractError(f"cannot parse snapshot companion {filename!r}: {exc}") from exc
+    row = _mapping(parsed, f"snapshot companion {filename}")
+    if row.get("schema") != schema:
+        raise ContractError(f"snapshot companion {filename!r} must use schema {schema!r}")
+    if row.get("run_id") != snapshot.get("run_id"):
+        raise ContractError(f"snapshot companion {filename!r} run_id does not match")
+    return row
+
+
+def _verify_attempt_manifest(
+    manifest: Mapping[str, Any],
+    raw: Mapping[str, Any],
+) -> None:
+    attempts = manifest.get("attempts")
+    final_results = manifest.get("final_results")
+    simulations = raw.get("simulations")
+    if not isinstance(attempts, list) or not isinstance(final_results, list):
+        raise ContractError("tau2 attempt manifest requires attempts and final_results lists")
+    if not isinstance(simulations, list):
+        raise ContractError("tau2 results simulations must be a list")
+    attempt_ids: set[str] = set()
+    selected_ids: set[str] = set()
+    selected_groups: set[tuple[str, int]] = set()
+    attempts_by_id: dict[str, Mapping[str, Any]] = {}
+    previous_by_run: dict[tuple[str, int], tuple[str, int, int]] = {}
+    for index, value in enumerate(attempts):
+        attempt = _mapping(value, f"attempt_manifest.attempts[{index}]")
+        attempt_id = str(attempt.get("attempt_id") or "")
+        if not attempt_id or attempt_id in attempt_ids:
+            raise ContractError("tau2 attempt manifest attempt ids must be unique")
+        attempt_ids.add(attempt_id)
+        attempts_by_id[attempt_id] = attempt
+        task_id = str(attempt.get("task_id") or "")
+        trial = _integer(attempt.get("trial"), "attempt_manifest attempt trial")
+        ordinal = _integer(attempt.get("attempt"), "attempt_manifest attempt ordinal")
+        seed = _integer(attempt.get("seed"), "attempt_manifest attempt seed")
+        if not task_id or trial < 0 or ordinal < 1:
+            raise ContractError("tau2 attempt requires task_id and non-negative trial/ordinal")
+        group = (task_id, trial)
+        previous = previous_by_run.get(group)
+        retry_of = attempt.get("retry_of")
+        if previous is None:
+            if ordinal != 1 or retry_of is not None:
+                raise ContractError("first tau2 attempt must have ordinal 1 and no retry_of")
+        else:
+            previous_id, previous_ordinal, previous_seed = previous
+            if ordinal != previous_ordinal + 1 or retry_of != previous_id:
+                raise ContractError("tau2 retry lineage must be consecutive within task/trial")
+            if seed != previous_seed:
+                raise ContractError("tau2 retry seed must remain stable within task/trial")
+        previous_by_run[group] = (attempt_id, ordinal, seed)
+        if attempt.get("status") not in {"complete", "error"}:
+            raise ContractError("final tau2 attempt status must be complete or error")
+        if not isinstance(attempt.get("selected_final"), bool):
+            raise ContractError("tau2 attempt selected_final must be boolean")
+        if attempt.get("selected_final") is True:
+            if attempt.get("status") != "complete" or not attempt.get("simulation_id"):
+                raise ContractError("selected tau2 attempt must be complete with simulation_id")
+            if group in selected_groups:
+                raise ContractError("tau2 task/trial may have only one selected attempt")
+            selected_groups.add(group)
+            selected_ids.add(attempt_id)
+    simulations_by_key = {
+        (
+            str(_mapping(value, "tau2 simulation").get("task_id") or ""),
+            _integer(_mapping(value, "tau2 simulation").get("trial"), "tau2 trial"),
+            str(_mapping(value, "tau2 simulation").get("id") or ""),
+        ): _mapping(value, "tau2 simulation")
+        for value in simulations
+    }
+    observed = set(simulations_by_key)
+    declared: set[tuple[str, int, str]] = set()
+    referenced_selected_ids: set[str] = set()
+    for index, value in enumerate(final_results):
+        result = _mapping(value, f"attempt_manifest.final_results[{index}]")
+        key = (
+            str(result.get("task_id") or ""),
+            _integer(result.get("trial"), "attempt_manifest final trial"),
+            str(result.get("simulation_id") or ""),
+        )
+        if key in declared:
+            raise ContractError("tau2 attempt manifest final results must be unique")
+        declared.add(key)
+        selected = result.get("selected_attempt_id")
+        if selected is not None and selected not in selected_ids:
+            raise ContractError("final tau2 selection references a non-selected attempt")
+        native_sessions = _native_session_ids(simulations_by_key.get(key, {}))
+        if selected is None:
+            if result.get("selection_status") != "no_successful_attempt":
+                raise ContractError("unselected tau2 result requires no_successful_attempt status")
+            if native_sessions:
+                raise ContractError("unselected tau2 result cannot reference GEODE sessions")
+            continue
+        if result.get("selection_status") != "selected":
+            raise ContractError("selected tau2 result requires selected status")
+        referenced_selected_ids.add(str(selected))
+        selected_attempt = attempts_by_id[str(selected)]
+        if (
+            str(selected_attempt.get("task_id") or ""),
+            _integer(selected_attempt.get("trial"), "selected tau2 attempt trial"),
+            str(selected_attempt.get("simulation_id") or ""),
+        ) != key:
+            raise ContractError("selected tau2 attempt identity does not match final result")
+        session_rows = selected_attempt.get("sessions")
+        if not isinstance(session_rows, list):
+            raise ContractError("selected tau2 attempt requires a sessions list")
+        declared_sessions = {
+            str(_mapping(row, "attempt session").get("session_id") or "") for row in session_rows
+        }
+        declared_sessions.discard("")
+        if declared_sessions != native_sessions:
+            raise ContractError("selected tau2 attempt sessions do not match native messages")
+    if declared != observed:
+        raise ContractError("tau2 attempt manifest final results do not match native results")
+    if referenced_selected_ids != selected_ids:
+        raise ContractError("selected tau2 attempts must be referenced exactly once")
+
+
+def _native_session_ids(simulation: Mapping[str, Any]) -> set[str]:
+    messages = simulation.get("messages")
+    if not isinstance(messages, list):
+        return set()
+    session_ids: set[str] = set()
+    for value in messages:
+        message = value if isinstance(value, Mapping) else {}
+        raw_data = message.get("raw_data")
+        if not isinstance(raw_data, Mapping):
+            continue
+        session_id = str(raw_data.get("geode_session_id") or "")
+        if session_id:
+            session_ids.add(session_id)
+    return session_ids
 
 
 def _verify_tau2_info(contract: ExperimentContract, raw: Mapping[str, Any]) -> None:
@@ -630,6 +833,8 @@ def normalize_tau2_results(
         arm=arm,
         raw_sha256=raw_sha256,
         snapshot=snapshot,
+        snapshot_path=snapshot_path,
+        raw=raw,
     )
     _verify_tau2_info(contract, raw)
     _verify_tau2_tasks(contract, raw)

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,6 +1,6 @@
 {
   "bypass_markers": {
-    "count": 251,
+    "count": 252,
     "stamped": "1.0.12"
   },
   "stale_todos": {

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3023,6 +3023,7 @@ SIL의 `events.jsonl` 실행 타임라인, mutation/attribution 원장, Inspect 
 | --- | --- | --- |
 | SIL Inspect `.eval` | `kind=sil_eval`, `schema_id=inspect_ai.eval@native`, source SHA-256 | scored archive를 digest로 연결; judge 결과를 대체하지 않음 |
 | tau2 `results.json` | `kind=native_receipt`, `schema_id=tau2.results@native` | native score receipt를 그대로 정본으로 유지 |
+| tau2 runtime profile / attempt manifest | `snapshot v4`의 sibling path + SHA-256, trajectory `artifact_digests` | 실행 표면과 retry 선택을 증명하며 native reward를 대체하지 않음 |
 | Crucible frozen contract | identity preflight가 끝난 경우에만 `kind=crucible_evidence` | verdict나 promotion authority를 얻지 않음 |
 
 로컬 export를 privacy-reviewed public candidate로 승격하고 append-only artifact PR로 게시하는 절차는 [trajectory 게시 가이드](https://mangowhoiscloud.github.io/geode/docs/guides/publish-trajectory.md)를 따릅니다.
@@ -3124,6 +3125,12 @@ URL: https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2
 Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2.md
 
 tau2-bench는 대화형 tool-use 벤치마크입니다. 에이전트가 시뮬레이션된 사용자와 대화하며 airline, retail, telecom 도메인의 DB 액션을 수행하고, verifier가 필수 액션 충족 여부로 reward를 매깁니다. GEODE는`plugins/benchmark_harness`의 공개 어댑터로 참가하며, 점수는 그 점수를 만든 harness revision, model route, effort에 고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
+
+## 2026-08-04 runtime-faithful 실행 계약
+
+현재 어댑터는 process-owned `RuntimeEventBus`, 13개 공개 hook registry, 4개 trusted middleware join point를 Tau2의 모든`ToolExecutor`와 `AgenticLoop`에 공유합니다. Tau2가 실제 환경 tool을 실행하며, GEODE의 projection ACK는`deferred`로 남습니다. 이후 native `ToolMessage.id`가 원래 call ID의 유일한 completion/error를 닫습니다. 환경 단계에서 즉시 종료된 경우에는 native receipt의 마지막 ToolMessage를 결합합니다.
+
+native `results.json`은 계속 점수 정본입니다. 그 digest와 reward, task/trial, native/runtime termination은`verification.evidence`로 SessionEnd 전에 기록됩니다. 새`snapshot v4`는 runtime revision, assembled prompt/tool schema digest, 실제로 exercise된 surface를 담은 runtime profile과 모든 retry/session/final selection을 담은 attempt manifest를 함께 검증합니다.`tau2-native-user`와 `geode-dual-runtime` profile은 합산하지 않습니다. 진단 auto-resume의 이전 process 행은`resumed_native_unattested`로 표시합니다.
 
 ## 2026-08-03 GPT-5.4 subscription base full cycle
 
@@ -5949,7 +5956,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1485 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1486 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -6109,7 +6116,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 
 | 측정값 | 현재 트리 |
 | --- | --- |
-| 프로덕션 Python 파일 | 542 |
+| 프로덕션 Python 파일 | 543 |
 | 테스트 Python 파일 | 682 |
 | 도구 정의 / 실행 등록 / 유효 스키마 | 78 / 81 / 78 |
 | RuntimeEvent 멤버 | 57 |

--- a/site/src/app/docs/benchmarks/tau2/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/page.tsx
@@ -32,6 +32,28 @@ export default function Page() {
               고정해서만 게시합니다. 같은 조건의 재실행과만 비교할 수 있습니다.
             </p>
 
+            <h2>2026-08-04 runtime-faithful 실행 계약</h2>
+            <p>
+              현재 어댑터는 process-owned <code>RuntimeEventBus</code>, 13개 공개
+              hook registry, 4개 trusted middleware join point를 Tau2의 모든
+              <code>ToolExecutor</code>와 <code>AgenticLoop</code>에 공유합니다. Tau2가
+              실제 환경 tool을 실행하며, GEODE의 projection ACK는
+              <code>deferred</code>로 남습니다. 이후 native <code>ToolMessage.id</code>가
+              원래 call ID의 유일한 completion/error를 닫습니다. 환경 단계에서 즉시
+              종료된 경우에는 native receipt의 마지막 ToolMessage를 결합합니다.
+            </p>
+            <p>
+              native <code>results.json</code>은 계속 점수 정본입니다. 그 digest와
+              reward, task/trial, native/runtime termination은
+              <code>verification.evidence</code>로 SessionEnd 전에 기록됩니다. 새
+              <code>snapshot v4</code>는 runtime revision, assembled prompt/tool schema
+              digest, 실제로 exercise된 surface를 담은 runtime profile과 모든
+              retry/session/final selection을 담은 attempt manifest를 함께 검증합니다.
+              <code>tau2-native-user</code>와 <code>geode-dual-runtime</code> profile은 합산하지
+              않습니다. 진단 auto-resume의 이전 process 행은
+              <code>resumed_native_unattested</code>로 표시합니다.
+            </p>
+
             <h2>2026-08-03 GPT-5.4 subscription base full cycle</h2>
             <p>
               GEODE <code>22789ee2</code>에서 Airline, Retail, Telecom base
@@ -231,6 +253,29 @@ export default function Page() {
               published number is pinned to the harness revision, model route, and
               effort that produced it. Compare only against reruns with the same
               settings.
+            </p>
+
+            <h2>2026-08-04 Runtime-Faithful Execution Contract</h2>
+            <p>
+              The current adapter shares one process-owned{" "}
+              <code>RuntimeEventBus</code>, all 13 public hook registrations, and
+              all four trusted middleware join points across every Tau2{" "}
+              <code>ToolExecutor</code> and <code>AgenticLoop</code>. Tau2 remains
+              the only environment-tool executor. GEODE&apos;s projection ACK stays{" "}
+              <code>deferred</code>, and the native <code>ToolMessage.id</code>
+              later closes the original call ID with its sole completion or error,
+              including a terminal-step result recovered from the native receipt.
+            </p>
+            <p>
+              Native <code>results.json</code> remains score authority. Its digest,
+              reward, task/trial, and native/runtime termination are recorded as{" "}
+              <code>verification.evidence</code> before SessionEnd. New{" "}
+              <code>snapshot v4</code> admission also verifies a runtime profile
+              containing revision, assembled prompt/tool-schema digests and actually
+              exercised surfaces, plus an attempt manifest covering every retry,
+              participant session, and final selection. <code>tau2-native-user</code> and{" "}
+              <code>geode-dual-runtime</code> profiles are never pooled. A diagnostic
+              auto-resume labels prior-process rows as <code>resumed_native_unattested</code>.
             </p>
 
             <h2>2026-08-03 GPT-5.4 Subscription Base Full Cycle</h2>

--- a/site/src/app/docs/verification/observability/page.tsx
+++ b/site/src/app/docs/verification/observability/page.tsx
@@ -114,6 +114,7 @@ export default function Page() {
               <tbody>
                 <tr><td>SIL Inspect <code>.eval</code></td><td><code>kind=sil_eval</code>, <code>schema_id=inspect_ai.eval@native</code>, source SHA-256</td><td>scored archive를 digest로 연결; judge 결과를 대체하지 않음</td></tr>
                 <tr><td>tau2 <code>results.json</code></td><td><code>kind=native_receipt</code>, <code>schema_id=tau2.results@native</code></td><td>native score receipt를 그대로 정본으로 유지</td></tr>
+                <tr><td>tau2 runtime profile / attempt manifest</td><td><code>snapshot v4</code>의 sibling path + SHA-256, trajectory <code>artifact_digests</code></td><td>실행 표면과 retry 선택을 증명하며 native reward를 대체하지 않음</td></tr>
                 <tr><td>Crucible frozen contract</td><td>identity preflight가 끝난 경우에만 <code>kind=crucible_evidence</code></td><td>verdict나 promotion authority를 얻지 않음</td></tr>
               </tbody>
             </table>
@@ -245,6 +246,7 @@ export default function Page() {
               <tbody>
                 <tr><td>SIL Inspect <code>.eval</code></td><td><code>kind=sil_eval</code>, <code>schema_id=inspect_ai.eval@native</code>, source SHA-256</td><td>Digest-join the scored archive; never replace its judgment</td></tr>
                 <tr><td>tau2 <code>results.json</code></td><td><code>kind=native_receipt</code>, <code>schema_id=tau2.results@native</code></td><td>Keep the native score receipt authoritative</td></tr>
+                <tr><td>tau2 runtime profile / attempt manifest</td><td>Sibling path + SHA-256 in <code>snapshot v4</code>, plus trajectory <code>artifact_digests</code></td><td>Prove execution surfaces and retry selection without replacing native reward</td></tr>
                 <tr><td>Crucible frozen contract</td><td><code>kind=crucible_evidence</code> only after identity preflight</td><td>Gain neither verdict nor promotion authority</td></tr>
               </tbody>
             </table>

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,15 +528,15 @@
   "packages": {
     "core": {
       "python_files": 432,
-      "python_loc": 138904
+      "python_loc": 138911
     },
     "plugins": {
-      "python_files": 110,
-      "python_loc": 40709
+      "python_files": 111,
+      "python_loc": 41820
     },
     "tests": {
       "python_files": 682,
-      "python_loc": 178281
+      "python_loc": 178949
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Added\n\n- Added a benchmark-safe Tau2 runtime profile and retry-attempt manifest. New\n  snapshot v4 records digest-bind the runtime revision, model routes, assembled\n  prompt/tool-schema identities, exercised hook and middleware surfaces, every\n  participant session, retry ancestry, and final native simulation selection.\n\n### Changed\n\n- Tau2 participants now share one process-owned runtime event bus, public hook\n  registry, and four-surface middleware registry. Native `results.json`\n  reward/termination evidence is joined to session timelines before SessionEnd,\n  while `tau2-native-user` and `geode-dual-runtime` measurements remain distinct profiles.\n- Crucible now observably disables legacy `cached-row.v1` reuse for Tau2\n  snapshot v4 runs because that cache predates the runtime-profile and attempt\n  companions; runs execute fresh rather than synthesize provenance.\n\n### Fixed\n\n- Tau2 tool projection ACKs no longer masquerade as completed environment\n  actions. The adapter defers all environment execution to Tau2 and records the\n  official result or error only when its original call ID returns; orphaned or\n  still-pending calls fail closed. Terminal-step results are reconciled from\n  the native receipt, diagnostic auto-resume rows remain explicitly\n  unattested, and exhausted post-run failures cannot remain marked complete."
   },
   {
     "version": "1.0.12",

--- a/tests/core/agent/test_tool_processor_lifecycle.py
+++ b/tests/core/agent/test_tool_processor_lifecycle.py
@@ -180,6 +180,41 @@ def test_session_tool_start_is_durable_before_handler_execution() -> None:
     assert order == ["tool.called", "handler", "tool.completed"]
 
 
+def test_external_execution_ack_does_not_claim_tool_completion() -> None:
+    order: list[str] = []
+
+    class Timeline:
+        def record_tool_call(
+            self,
+            _name: str,
+            _arguments: dict,
+            *,
+            call_id: str,
+        ) -> None:
+            assert call_id == "tool-1"
+            order.append("tool.called")
+
+        def record_tool_result(self, *_args: object, **_kwargs: object) -> None:
+            order.append("tool.completed")
+
+    async def handler(**_kwargs: object) -> dict[str, object]:
+        return {"external_execution": "deferred", "projected_to_tau2": True}
+
+    executor = ToolExecutor(action_handlers={"read_file": handler})
+    op_logger = MagicMock()
+    op_logger.log_tool_call.return_value = True
+    processor = ToolCallProcessor(
+        executor=executor,
+        op_logger=op_logger,
+        error_recovery=MagicMock(),
+        timeline=Timeline(),
+    )
+
+    asyncio.run(processor._execute_single(_block()))
+
+    assert order == ["tool.called"]
+
+
 def test_personal_failure_is_omitted_from_hooks_logs_and_event_store(tmp_path, caplog) -> None:
     from core.memory.episodic import EpisodicStore, get_episodic_store, set_episodic_store
     from core.tools.personal_data import PERSONAL_DATA_ERROR_OMITTED

--- a/tests/plugins/benchmark_harness/test_tau2_adapter.py
+++ b/tests/plugins/benchmark_harness/test_tau2_adapter.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 import os
 import sys
@@ -6,7 +8,9 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 from plugins.benchmark_harness.tau2_geode_agent import (
+    Tau2GeodeTool,
     _assert_tau2_route_ready,
+    _build_loop,
     _codex_empty_text_dumps,
     _pin_tau2_data_root,
     _raise_on_new_codex_empty_text_dumps,
@@ -21,10 +25,16 @@ from plugins.benchmark_harness.tau2_geode_agent import (
     _validate_tau2_task_order,
     _write_trajectory_snapshot,
 )
+from plugins.benchmark_harness.tau2_runtime_contract import (
+    Tau2AttemptTracker,
+    Tau2RuntimeContract,
+)
 from plugins.benchmark_harness.tau2_turn_supervisor import (
     GeodeTau2State,
     _agent_system_prompt,
     _message_to_prompt,
+    _record_tau2_tool_results,
+    _remember_tau2_tool_calls,
     _run_geode_turn,
     _tau2_terminal_token,
     _tau2_tool_calls,
@@ -50,6 +60,386 @@ def test_tau2_agent_prompt_blocks_inferred_optional_tool_args() -> None:
     assert "Policy body" in prompt
 
 
+def test_tau2_loop_reuses_one_process_owned_hook_and_middleware_registry(
+    tmp_path: Path,
+) -> None:
+    from core.llm.adapters.registry import bootstrap_builtins
+
+    bootstrap_builtins()
+    runtime = Tau2RuntimeContract(
+        run_id="shared-runtime",
+        repo_root=Path.cwd(),
+        agent_route={},
+        user_route={},
+        runtime_profile="tau2-native-user",
+        event_db_path=tmp_path / "events.db",
+    )
+    try:
+        loop = _build_loop(
+            tools=[],
+            system_prompt="Agent: runtime contract test",
+            model="gpt-5.5",
+            provider="openai",
+            source="subscription",
+            effort="high",
+            time_budget_s=1.0,
+            max_tokens=32,
+            max_rounds=0,
+            runtime_contract=runtime,
+        )
+
+        assert loop._hook_registry is runtime.hook_registry
+        assert loop._middleware_registry is runtime.middleware_registry
+        assert loop.executor.hook_registry is runtime.hook_registry
+        assert loop.executor.middleware_registry is runtime.middleware_registry
+    finally:
+        runtime.close()
+
+
+def test_tau2_attempt_tracker_preserves_retry_lineage_and_final_selection() -> None:
+    tracker = Tau2AttemptTracker("retry-run")
+    calls = 0
+
+    def run_fn() -> SimpleNamespace:
+        nonlocal calls
+        calls += 1
+        tracker.register_session(
+            participant_role="assistant",
+            session_id=f"session-{calls}",
+        )
+        if calls == 1:
+            raise RuntimeError("first attempt failed")
+        return SimpleNamespace(id="simulation-final")
+
+    def retry_once(fn, _task, _trial, _seed, **_kwargs):
+        with contextlib.suppress(RuntimeError):
+            fn()
+        return fn()
+
+    result = tracker.wrap(retry_once)(
+        run_fn,
+        SimpleNamespace(id="task-1"),
+        0,
+        300,
+    )
+    manifest = tracker.manifest()
+
+    assert result.id == "simulation-final"
+    assert [row["status"] for row in manifest["attempts"]] == ["error", "complete"]
+    assert manifest["attempts"][1]["retry_of"] == manifest["attempts"][0]["attempt_id"]
+    assert manifest["attempts"][1]["selected_final"] is True
+    assert manifest["final_results"] == [
+        {
+            "task_id": "task-1",
+            "trial": 0,
+            "simulation_id": "simulation-final",
+            "selected_attempt_id": manifest["attempts"][1]["attempt_id"],
+            "selection_status": "selected",
+        }
+    ]
+
+
+def test_tau2_attempt_tracker_selects_only_after_upstream_accepts_result() -> None:
+    tracker = Tau2AttemptTracker("post-run-retry")
+    calls = 0
+
+    def run_fn() -> SimpleNamespace:
+        nonlocal calls
+        calls += 1
+        tracker.register_session(
+            participant_role="assistant",
+            session_id=f"post-run-session-{calls}",
+        )
+        return SimpleNamespace(id=f"simulation-{calls}")
+
+    def retry_after_checkpoint_failure(fn, _task, _trial, _seed, **_kwargs):
+        fn()
+        return fn()
+
+    tracker.wrap(retry_after_checkpoint_failure)(
+        run_fn,
+        SimpleNamespace(id="task-1"),
+        0,
+        300,
+    )
+    attempts = tracker.manifest()["attempts"]
+
+    assert attempts[0]["status"] == "error"
+    assert attempts[0]["selected_final"] is False
+    assert attempts[0]["retry_reason"] == "upstream post-run failure before selection"
+    assert attempts[1]["retry_of"] == attempts[0]["attempt_id"]
+    assert attempts[1]["selected_final"] is True
+
+
+def test_tau2_attempt_tracker_downgrades_final_post_run_failure() -> None:
+    tracker = Tau2AttemptTracker("final-post-run-failure")
+
+    def run_fn() -> SimpleNamespace:
+        tracker.register_session(participant_role="assistant", session_id="session-1")
+        return SimpleNamespace(id="simulation-real")
+
+    def exhausted_after_checkpoint_failure(fn, _task, _trial, _seed, **_kwargs):
+        fn()
+        return SimpleNamespace(id="simulation-infrastructure-placeholder")
+
+    tracker.wrap(exhausted_after_checkpoint_failure)(
+        run_fn,
+        SimpleNamespace(id="task-1"),
+        0,
+        300,
+    )
+    manifest = tracker.manifest()
+
+    assert manifest["attempts"][0]["status"] == "error"
+    assert manifest["attempts"][0]["retry_reason"] == ("upstream post-run failure before selection")
+    assert manifest["final_results"][0]["selection_status"] == "no_successful_attempt"
+
+
+def test_tau2_native_verdict_is_recorded_before_session_close(tmp_path: Path) -> None:
+    from core.hooks import LlmCallRequest
+    from core.llm.adapters.base import AdapterCallRequest, ToolSpec
+
+    evidence: list[dict[str, object]] = []
+
+    class Timeline:
+        db_path = tmp_path / "sessions.db"
+
+        def record_verification_evidence(
+            self,
+            references: list[dict[str, object]],
+            *,
+            root_turn_id: str,
+            verify_attempt: int,
+            policy_action: str,
+        ) -> None:
+            evidence.append(
+                {
+                    "references": references,
+                    "root_turn_id": root_turn_id,
+                    "verify_attempt": verify_attempt,
+                    "policy_action": policy_action,
+                }
+            )
+
+    runtime = Tau2RuntimeContract(
+        run_id="native-verdict-run",
+        repo_root=Path.cwd(),
+        agent_route={},
+        user_route={},
+        runtime_profile="tau2-native-user",
+        event_db_path=tmp_path / "events.db",
+    )
+    loop = SimpleNamespace(
+        _session_id="session-agent",
+        _timeline=Timeline(),
+        _turn_id="turn-final",
+        _tau2_pending_tool_calls={},
+    )
+
+    def execute() -> SimpleNamespace:
+        runtime.register_loop(loop, participant_role="assistant")
+        return SimpleNamespace(id="simulation-1")
+
+    def no_retry(fn, _task, _trial, _seed, **_kwargs):
+        return fn()
+
+    runtime.attempts.wrap(no_retry)(
+        execute,
+        SimpleNamespace(id="task-1"),
+        0,
+        300,
+    )
+    results = tmp_path / "results.json"
+    results.write_text(
+        json.dumps(
+            {
+                "simulations": [
+                    {
+                        "id": "simulation-1",
+                        "task_id": "task-1",
+                        "trial": 0,
+                        "termination_reason": "user_stop",
+                        "reward_info": {"reward": 0.0},
+                        "messages": [
+                            {
+                                "raw_data": {
+                                    "geode_session_id": "session-agent",
+                                    "geode_termination_reason": "completed",
+                                }
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        runtime.bind_native_results(results, classify_termination=lambda _reason: "semantic")
+        asyncio.run(
+            runtime.capture.llm_request(
+                LlmCallRequest(
+                    adapter=SimpleNamespace(),
+                    request=AdapterCallRequest(
+                        model="gpt-5.4",
+                        messages=(),
+                        system_prompt=(
+                            "Agent: test\n__GEODE_PROMPT_CACHE_BOUNDARY__\n"
+                            "<dynamic_context><policy>bounded</policy></dynamic_context>"
+                        ),
+                        tools=(
+                            ToolSpec(
+                                name="lookup_account",
+                                description="lookup",
+                                input_schema={"type": "object"},
+                            ),
+                        ),
+                    ),
+                    correlation={"session_id": "session-agent"},
+                )
+            )
+        )
+        profile_path, manifest_path = runtime.write_companions(tmp_path / "snapshots")
+
+        reference = evidence[0]["references"][0]
+        assert reference["reward"] == 0.0
+        assert reference["validity"] == "semantic"
+        assert reference["native_termination_reason"] == "user_stop"
+        assert reference["runtime_termination_reason"] == "completed"
+        assert evidence[0]["policy_action"] == "observe_native_verdict"
+        profile = json.loads(profile_path.read_text())
+        request = profile["assembled_requests"][0]
+        assert request["assembled_prompt_sha256"]
+        assert request["prompt_block_inventory"]["cache_boundary_present"] is True
+        assert {row["name"] for row in request["prompt_block_inventory"]["xml_tags"]} == {
+            "dynamic_context",
+            "policy",
+        }
+        assert request["tool_schema_sha256"]
+        assert request["tool_allowlist"] == ["lookup_account"]
+        assert all(row["status"] != "passed" for row in profile["surfaces"]["public_hooks"])
+        assert json.loads(manifest_path.read_text())["final_results"][0]["selected_attempt_id"]
+    finally:
+        runtime.close()
+
+
+def test_tau2_native_verdict_reconciles_terminal_tool_result(tmp_path: Path) -> None:
+    recorded: list[dict[str, object]] = []
+
+    class Timeline:
+        db_path = tmp_path / "sessions.db"
+
+        def record_tool_result(self, *args: object, **kwargs: object) -> None:
+            recorded.append({"args": args, "kwargs": kwargs})
+
+        def record_verification_evidence(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    runtime = Tau2RuntimeContract(
+        run_id="terminal-tool-run",
+        repo_root=Path.cwd(),
+        agent_route={},
+        user_route={},
+        runtime_profile="tau2-native-user",
+        event_db_path=tmp_path / "events.db",
+    )
+    loop = SimpleNamespace(
+        _session_id="session-agent",
+        _timeline=Timeline(),
+        _turn_id="turn-final",
+        _tau2_pending_tool_calls={"call-final": "lookup_account"},
+    )
+
+    def execute() -> SimpleNamespace:
+        runtime.register_loop(loop, participant_role="assistant")
+        return SimpleNamespace(id="simulation-1")
+
+    runtime.attempts.wrap(lambda fn, *_args, **_kwargs: fn())(
+        execute,
+        SimpleNamespace(id="task-1"),
+        0,
+        300,
+    )
+    results = tmp_path / "terminal-results.json"
+    results.write_text(
+        json.dumps(
+            {
+                "simulations": [
+                    {
+                        "id": "simulation-1",
+                        "task_id": "task-1",
+                        "trial": 0,
+                        "termination_reason": "too_many_errors",
+                        "messages": [
+                            {"raw_data": {"geode_session_id": "session-agent"}},
+                            {
+                                "role": "tool",
+                                "id": "call-final",
+                                "requestor": "assistant",
+                                "content": "failed",
+                                "error": True,
+                            },
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        runtime.bind_native_results(results, classify_termination=lambda _reason: "semantic")
+    finally:
+        runtime.close()
+
+    assert loop._tau2_pending_tool_calls == {}
+    assert recorded[0]["kwargs"]["call_id"] == "call-final"
+    assert recorded[0]["args"][:2] == ("lookup_account", "error")
+
+
+def test_tau2_auto_resume_marks_prior_native_rows_unattested(tmp_path: Path) -> None:
+    runtime = Tau2RuntimeContract(
+        run_id="resume-run",
+        repo_root=Path.cwd(),
+        agent_route={},
+        user_route={},
+        runtime_profile="tau2-native-user",
+        event_db_path=tmp_path / "events.db",
+        allow_resumed_native=True,
+    )
+    results = tmp_path / "resumed-results.json"
+    results.write_text(
+        json.dumps(
+            {
+                "simulations": [
+                    {
+                        "id": "simulation-old",
+                        "task_id": "task-old",
+                        "trial": 0,
+                        "termination_reason": "user_stop",
+                        "messages": [{"raw_data": {"geode_session_id": "prior-process-session"}}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        runtime.bind_native_results(results, classify_termination=lambda _reason: "semantic")
+        manifest = runtime.attempts.manifest()
+    finally:
+        runtime.close()
+
+    assert manifest["resumed_results"] == [
+        {
+            "task_id": "task-old",
+            "trial": 0,
+            "simulation_id": "simulation-old",
+            "session_ids": ["prior-process-session"],
+            "selection_status": "resumed_native_unattested",
+        }
+    ]
+
+
 def test_tau2_message_prompt_normalizes_enum_like_roles() -> None:
     message = SimpleNamespace(
         role=SimpleNamespace(value="tool"),
@@ -58,9 +448,15 @@ def test_tau2_message_prompt_normalizes_enum_like_roles() -> None:
         tool_calls=None,
     )
 
-    assert _message_to_prompt(message, recipient="assistant") == (
-        "Tool result to assistant from tau2 orchestrator:\ntool output"
-    )
+    rendered = _message_to_prompt(message, recipient="assistant")
+
+    assert rendered.startswith("Tool result to assistant from tau2 orchestrator:\n")
+    assert json.loads(rendered.split("\n", 1)[1]) == {
+        "id": "",
+        "requestor": "",
+        "content": "tool output",
+        "error": False,
+    }
 
 
 def test_tau2_explicit_task_pack_runs_every_task_by_default() -> None:
@@ -200,6 +596,19 @@ def test_tau2_tool_mutability_uses_upstream_marker_and_fails_safe() -> None:
     assert _tool_mutates_state(SimpleNamespace(name="get_unknown")) is True
 
 
+def test_tau2_tool_wrapper_returns_a_deferred_ack_without_local_execution() -> None:
+    class NativeTool:
+        name = "lookup_account"
+
+        def __call__(self, **_kwargs: object) -> object:
+            raise AssertionError("tau2 must remain the only environment executor")
+
+    result = asyncio.run(Tau2GeodeTool(NativeTool(), mutates_state=False).aexecute(id="A"))
+
+    assert result["external_execution"] == "deferred"
+    assert result["projected_to_tau2"] is True
+
+
 @pytest.mark.parametrize("tool_name", ["modify_user_address", "future_required_empty"])
 def test_tau2_tool_calls_preserves_explicit_empty_arguments(
     monkeypatch: pytest.MonkeyPatch,
@@ -264,6 +673,80 @@ def test_tau2_tool_projection_is_scoped_to_each_agentic_run(
 
     assert [call.id for call in first_calls] == ["call_1"]
     assert [call.id for call in second_calls] == ["call_2"]
+
+
+def test_tau2_external_result_closes_the_original_provider_call_id() -> None:
+    recorded: list[dict[str, object]] = []
+
+    class Timeline:
+        def record_tool_result(
+            self,
+            tool: str,
+            status: str,
+            summary: str,
+            *,
+            call_id: str,
+            result: object,
+        ) -> None:
+            recorded.append(
+                {
+                    "tool": tool,
+                    "status": status,
+                    "summary": summary,
+                    "call_id": call_id,
+                    "result": result,
+                }
+            )
+
+    state = GeodeTau2State(loop=SimpleNamespace(_timeline=Timeline()))
+    _remember_tau2_tool_calls(
+        state,
+        [SimpleNamespace(id="call_exact", name="update_address")],
+    )
+
+    _record_tau2_tool_results(
+        state,
+        SimpleNamespace(
+            role="tool",
+            id="call_exact",
+            requestor="assistant",
+            content='{"ok": true}',
+            error=False,
+            tool_messages=None,
+        ),
+    )
+
+    assert recorded == [
+        {
+            "tool": "update_address",
+            "status": "ok",
+            "summary": "tau2 orchestrator result",
+            "call_id": "call_exact",
+            "result": {
+                "content": '{"ok": true}',
+                "error": False,
+                "source": "tau2_orchestrator",
+            },
+        }
+    ]
+    assert state.pending_tool_calls == {}
+
+
+def test_tau2_external_result_rejects_an_orphan_call_id() -> None:
+    state = GeodeTau2State(loop=SimpleNamespace(_timeline=SimpleNamespace()))
+
+    with pytest.raises(RuntimeError, match="orphan tau2 tool result id"):
+        _record_tau2_tool_results(
+            state,
+            SimpleNamespace(
+                role="tool",
+                id="unknown",
+                requestor="assistant",
+                content="not joined",
+                error=False,
+                tool_messages=None,
+            ),
+        )
 
 
 def test_tau2_tool_projection_preserves_failed_execution_for_official_accounting(

--- a/tests/plugins/crucible/test_row_cache.py
+++ b/tests/plugins/crucible/test_row_cache.py
@@ -3,6 +3,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+from plugins.crucible.contract import ContractError
 from plugins.crucible.row_cache import (
     cached_context,
     cached_rows,
@@ -282,7 +284,7 @@ def test_merge_rebuilds_full_results_in_stable_order(tmp_path: Path) -> None:
     )
 
 
-def test_synthesized_snapshot_matches_the_verifier_contract_fields() -> None:
+def test_legacy_cached_row_snapshot_is_not_admitted_without_v4_companions() -> None:
     from tests.plugins.crucible.test_tau2_live import _contract
 
     contract = _contract()
@@ -290,10 +292,10 @@ def test_synthesized_snapshot_matches_the_verifier_contract_fields() -> None:
     snapshot = synthesized_snapshot(contract, arm="candidate", raw_sha256=raw_sha)
     from plugins.crucible.verifiers.tau2 import _verify_snapshot
 
-    status, failure_class = _verify_snapshot(
-        contract,
-        arm="candidate",
-        raw_sha256=raw_sha,
-        snapshot=snapshot,
-    )
-    assert status == "complete" and failure_class is None
+    with pytest.raises(ContractError, match="companion artifact context"):
+        _verify_snapshot(
+            contract,
+            arm="candidate",
+            raw_sha256=raw_sha,
+            snapshot=snapshot,
+        )

--- a/tests/plugins/crucible/test_tau2_live.py
+++ b/tests/plugins/crucible/test_tau2_live.py
@@ -252,7 +252,7 @@ def test_timeout_receipt_is_persisted_before_outer_checkout_cleanup(
     assert receipt["observation"]["status"] == "right_censored"
 
 
-def test_timeout_receipt_is_written_before_partial_cache_salvage(
+def test_timeout_receipt_is_written_before_arm_returns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -269,11 +269,6 @@ def test_timeout_receipt_is_written_before_partial_cache_salvage(
             subprocess.TimeoutExpired(cmd=["tau2-fixture"], timeout=1.0)
         ),
     )
-
-    def harvest(*args: object, **kwargs: object) -> None:
-        assert receipt_path.is_file(), "right-censored receipt must precede cache salvage"
-
-    monkeypatch.setattr("plugins.crucible.tau2_live._harvest_partial", harvest)
 
     with pytest.raises(TimeoutError, match="arm timed out"):
         _run_arm_with_deadline(
@@ -443,7 +438,10 @@ def test_unreachable_candidate_is_a_zero_call_screening_reject(tmp_path: Path) -
     assert raw["schema"] == "crucible.screened-arm.v1"
     assert raw["reason"] == SCREENING_FAILURE
     assert candidate.usage == ResourceUsage(0.0, 0, 0, 0.0)
-    assert marginal_usage == ResourceUsage(0.0, 0, 0, 0.0)
+    assert marginal_usage.calls == 0
+    assert marginal_usage.tokens == 0
+    assert marginal_usage.cost_usd == 0.0
+    assert marginal_usage.wall_seconds >= 0.0
     assert verdict.verdict == "REJECT"
     assert verdict.reasons == (SCREENING_FAILURE,)
     assert verdict.pair_count == 0
@@ -795,7 +793,7 @@ def test_run_arm_rejects_nonzero_exit_with_complete_evidence(
         )
 
 
-def test_run_arm_partial_cache_reruns_missing_task_and_keeps_original_trial(
+def test_run_arm_disables_legacy_partial_cache_without_v4_companions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -891,28 +889,23 @@ def test_run_arm_partial_cache_reruns_missing_task_and_keeps_original_trial(
 
     command = commands[0]
     task_slice = command[command.index("--task-ids") + 1 : command.index("--num-tasks")]
-    assert task_slice == ["task-1"]
-    assert measurement_source == "partial_cache"
+    assert task_slice == list(contract.task_ids)
+    assert measurement_source == "fresh"
     merged = json.loads(merged_path.read_text(encoding="utf-8"))
     rewards = {
         (row["task_id"], row["trial"]): row["reward_info"]["reward"]
         for row in merged["simulations"]
     }
-    assert rewards == {
-        ("task-1", 0): 1.0,
-        ("task-1", 1): 1.0,
-        ("task-2", 0): 1.0,
-        ("task-2", 1): 1.0,
-    }
-    merged_snapshot = output / "snapshots" / f"{run_id}.merged.snapshot.json"
-    assert json.loads(merged_snapshot.read_text())["row_cache"]["synthesized"] is True
+    assert rewards == {("task-1", 0): 0.0, ("task-1", 1): 1.0}
+    marker = json.loads((output / "state" / "baseline" / "row-cache-disabled.json").read_text())
+    assert marker["reason"] == "cached-row.v1 lacks snapshot-v4 runtime companions"
     assert marginal_usage.calls == 0
     assert marginal_usage.tokens == 0
     assert marginal_usage.cost_usd == 0.0
     assert marginal_usage.wall_seconds >= 0.0
 
 
-def test_run_arm_full_cache_spends_zero_marginal_usage(
+def test_run_arm_disables_legacy_full_cache_and_executes_fresh(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -944,6 +937,10 @@ def test_run_arm_full_cache_spends_zero_marginal_usage(
         revision_sha=contract.baseline_sha,
         raw_results=raw,
     )
+    run_id = "full-cache-run"
+    source_raw = harness / "data" / "simulations" / run_id / "results.json"
+    source_raw.parent.mkdir(parents=True)
+    source_raw.write_text(json.dumps(raw), encoding="utf-8")
     evidence = _arm_evidence(
         contract,
         arm="baseline",
@@ -951,13 +948,19 @@ def test_run_arm_full_cache_spends_zero_marginal_usage(
         raw_hash="a" * 64,
     )
     monkeypatch.setenv("CRUCIBLE_ROW_CACHE_ROOT", str(cache))
-    monkeypatch.setattr(
-        "plugins.crucible.tau2_live._run_tau2_command",
-        lambda *args, **kwargs: pytest.fail("a full-cache arm must not launch tau2"),
-    )
+    commands: list[list[str]] = []
+
+    def run(command: list[str], **kwargs: object) -> tuple[subprocess.CompletedProcess[str], bool]:
+        commands.append(command)
+        snapshot_dir = Path(command[command.index("--trajectory-snapshot-dir") + 1])
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / f"{run_id}.snapshot.json").write_text("{}\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args=command, returncode=0), False
+
+    monkeypatch.setattr("plugins.crucible.tau2_live._run_tau2_command", run)
     monkeypatch.setattr(
         "plugins.crucible.tau2_live.tau2_resource_usage_floor",
-        lambda _raw: ResourceUsage(900.0, 152, 1_238_603, 1.24225),
+        lambda _raw: ResourceUsage(0.0, 0, 0, 0.0),
     )
     monkeypatch.setattr("plugins.crucible.tau2_live.tau2_trace_checks", lambda _raw: {})
     monkeypatch.setattr(
@@ -972,12 +975,18 @@ def test_run_arm_full_cache_spends_zero_marginal_usage(
         harness_root=harness,
         contract_path=tmp_path / "contract.json",
         output_dir=output,
-        run_id="full-cache-run",
+        run_id=run_id,
         timeout=10.0,
     )
 
-    assert marginal_usage == ResourceUsage(0.0, 0, 0, 0.0)
-    assert measurement_source == "full_cache"
+    assert marginal_usage.calls == 0
+    assert marginal_usage.tokens == 0
+    assert marginal_usage.cost_usd == 0.0
+    assert marginal_usage.wall_seconds >= 0.0
+    assert measurement_source == "fresh"
+    assert len(commands) == 1
+    marker = json.loads((output / "state" / "baseline" / "row-cache-disabled.json").read_text())
+    assert marker["reason"] == "cached-row.v1 lacks snapshot-v4 runtime companions"
 
 
 def test_run_arm_ignores_row_cache_outside_train_stage(

--- a/tests/plugins/crucible/test_tau2_verifier.py
+++ b/tests/plugins/crucible/test_tau2_verifier.py
@@ -13,6 +13,7 @@ from plugins.crucible.evidence import ResourceUsage
 from plugins.crucible.verifiers.tau2 import (
     TAU2_ADAPTER,
     _canonical_task_sha256,
+    _verify_attempt_manifest,
     normalize_tau2_results,
     tau2_has_infrastructure_contamination,
     tau2_resource_usage_floor,
@@ -307,9 +308,65 @@ def _write_artifacts(
     results = tmp_path / "results.json"
     results.write_text(json.dumps(raw), encoding="utf-8")
     raw_sha = hashlib.sha256(results.read_bytes()).hexdigest()
+    run_id = "tau2-verifier-test"
+    runtime_profile = tmp_path / "runtime-profile.json"
+    runtime_profile_payload = {
+        "schema": "geode.tau2-runtime-profile.v1",
+        "run_id": run_id,
+        "runtime_revision": contract.candidate_sha,
+        "runtime_profile": "tau2-native-user",
+        "persistence": {
+            "native_receipt": {"path": str(results), "sha256": raw_sha},
+        },
+    }
+    runtime_profile.write_text(json.dumps(runtime_profile_payload), encoding="utf-8")
+    attempts = []
+    final_results = []
+    simulations = raw.get("simulations")
+    assert isinstance(simulations, list)
+    for index, value in enumerate(simulations, start=1):
+        assert isinstance(value, dict)
+        attempt_id = f"attempt-{index}"
+        attempts.append(
+            {
+                "attempt_id": attempt_id,
+                "task_id": value["task_id"],
+                "trial": value["trial"],
+                "attempt": 1,
+                "seed": 300,
+                "retry_of": None,
+                "status": "complete",
+                "retry_reason": None,
+                "selected_final": True,
+                "simulation_id": value["id"],
+                "sessions": [],
+            }
+        )
+        final_results.append(
+            {
+                "task_id": value["task_id"],
+                "trial": value["trial"],
+                "simulation_id": value["id"],
+                "selected_attempt_id": attempt_id,
+                "selection_status": "selected",
+            }
+        )
+    attempt_manifest = tmp_path / "attempt-manifest.json"
+    attempt_manifest.write_text(
+        json.dumps(
+            {
+                "schema": "geode.tau2-attempt-manifest.v1",
+                "run_id": run_id,
+                "attempts": attempts,
+                "final_results": final_results,
+            }
+        ),
+        encoding="utf-8",
+    )
     snapshot = tmp_path / "snapshot.json"
     payload: dict[str, object] = {
-        "schema": "crucible_tau2_trajectory_snapshot.v3",
+        "schema": "crucible_tau2_trajectory_snapshot.v4",
+        "run_id": run_id,
         "experiment_contract_id": contract.contract_id,
         "baseline_sha": contract.baseline_sha,
         "candidate_sha": contract.candidate_sha,
@@ -320,6 +377,15 @@ def _write_artifacts(
         "assay_config": contract.assay_config,
         "arm": "candidate",
         "raw_artifact_sha256": raw_sha,
+        "runtime_profile": "tau2-native-user",
+        "runtime_profile_artifact": {
+            "path": runtime_profile.name,
+            "sha256": hashlib.sha256(runtime_profile.read_bytes()).hexdigest(),
+        },
+        "attempt_manifest_artifact": {
+            "path": attempt_manifest.name,
+            "sha256": hashlib.sha256(attempt_manifest.read_bytes()).hexdigest(),
+        },
         "execution_status": status,
         "failure_class": None,
     }
@@ -522,6 +588,79 @@ def test_tau2_adapter_rejects_raw_tampering_and_missing_checks(tmp_path: Path) -
             usage=_usage(),
             checks_by_pair={("1", 0): {"safety": True}},
         )
+
+
+def test_tau2_adapter_rejects_runtime_profile_digest_tampering(tmp_path: Path) -> None:
+    contract = _contract()
+    results, snapshot = _write_artifacts(tmp_path, contract, raw=_raw_results())
+    snapshot_payload = json.loads(snapshot.read_text())
+    profile_ref = snapshot_payload["runtime_profile_artifact"]
+    profile_path = snapshot.parent / profile_ref["path"]
+    profile_path.write_text('{"tampered": true}', encoding="utf-8")
+
+    with pytest.raises(ContractError, match=r"runtime_profile_artifact\.sha256"):
+        normalize_tau2_results(
+            contract,
+            arm="candidate",
+            results_path=results,
+            snapshot_path=snapshot,
+            usage=_usage(),
+            checks_by_pair=_checks(),
+        )
+
+
+def test_tau2_attempt_manifest_rejects_broken_retry_lineage() -> None:
+    raw = {
+        "simulations": [
+            {
+                "id": "simulation-final",
+                "task_id": "task-1",
+                "trial": 0,
+                "messages": [{"raw_data": {"geode_session_id": "session-final"}}],
+            }
+        ]
+    }
+    attempts = [
+        {
+            "attempt_id": "attempt-1",
+            "task_id": "task-1",
+            "trial": 0,
+            "attempt": 1,
+            "seed": 300,
+            "retry_of": None,
+            "status": "error",
+            "selected_final": False,
+            "simulation_id": None,
+            "sessions": [{"session_id": "session-retried"}],
+        },
+        {
+            "attempt_id": "attempt-2",
+            "task_id": "task-1",
+            "trial": 0,
+            "attempt": 2,
+            "seed": 300,
+            "retry_of": "not-the-previous-attempt",
+            "status": "complete",
+            "selected_final": True,
+            "simulation_id": "simulation-final",
+            "sessions": [{"session_id": "session-final"}],
+        },
+    ]
+    manifest = {
+        "attempts": attempts,
+        "final_results": [
+            {
+                "task_id": "task-1",
+                "trial": 0,
+                "simulation_id": "simulation-final",
+                "selected_attempt_id": "attempt-2",
+                "selection_status": "selected",
+            }
+        ],
+    }
+
+    with pytest.raises(ContractError, match="retry lineage"):
+        _verify_attempt_manifest(manifest, raw)
 
 
 def test_tau2_adapter_requires_frozen_task_order_and_content(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Make Tau2 score-bearing runs runtime-faithful: native tool execution remains owned by the pinned Tau2 orchestrator, while GEODE records exact requests, native results, lifecycle hooks, middleware, sessions, and verifier evidence.
- Add snapshot v4 with a run-scoped runtime profile and retry/selection attempt manifest.
- Harden Crucible admission so only complete, digest-linked, runtime-attributed runs can be promoted.

## Why
The prior adapter projected Tau2 tool calls into GEODE but could not prove that the recorded completion came from the native executor. It also inferred retries from session timing and did not carry a bounded runtime identity into the eval artifact. That was sufficient for diagnostics, not for score-bearing external-loop evidence.

## Changes
| Area | Change |
|---|---|
| Tau2 adapter | Defers tool execution to Tau2 and joins the exact native ToolMessage by call ID |
| Runtime contract | One shared HookSystem and middleware registry, all 13 public hooks, four middleware surfaces, bounded profile schema |
| Attempt lineage | Explicit attempt IDs, retry predecessor, selected-final outcome, resumed-native labeling |
| Session evidence | Native results bound before SessionEnd; deferred ACK is no longer a completed session tool |
| Artifacts | Snapshot v4 references native receipt, runtime profile, and attempt manifest by sibling path and SHA-256 |
| Crucible | Verifies schema, run/revision identity, digests, retry ancestry, session coverage, and final selection |
| Docs | Canonical Tau2 contract, migration map, storage diagram, admission rules, public benchmark/observability docs |

## GAP Audit
| Gap | Before | Closure |
|---|---|---|
| Native tool completion | Projection ACK could appear completed | Deferred ACK plus exact native ToolMessage join |
| Hook and middleware parity | Isolated loop did not prove composition | Shared run-scoped registries and bounded counts |
| Runtime identity | No portable execution profile | geode.tau2-runtime-profile.v1 |
| Retry provenance | Inferred from SQLite time scope | geode.tau2-attempt-manifest.v1 |
| Resume attribution | Older process rows could be ambiguous | resumed_native_unattested and no v4 promotion |
| Final admission | Receipt digest alone | Snapshot v4 companion and lineage verification |

## Verification
- Full non-live suite before the final review fixes: 10,438 passed, 23 skipped, 1 deselected.
- Post-review focused Tau2, lifecycle, Crucible, cache, and harness boundary tests passed.
- Ruff check and format check passed.
- Mypy passed across 543 source files.
- Import contracts passed.
- Architecture baseline check passed.
- Site lint passed with 45 pre-existing warnings and zero errors.
- Next static export built 237 pages.
- Python sdist and wheel built successfully.
- Pre-commit passed on the amended commit.
- Independent GPT subscription review found three edge cases; all were fixed and the follow-up review returned no remaining actionable findings.

## Live gate
The contract intentionally does not claim a new score yet. Live promotion proceeds after merge through mock, one task per domain, the known-failure paired pack, then the frozen 278-task full cycle.