### PR TITLE
docs(tau2): link runtime-faithful evidence

### DIFF
--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -655,6 +655,12 @@ the corrected runtime yields external proposals before those guards, and
 snapshot admission now rejects the captured scope-incomplete trajectory. A
 clean rerun is required before publishing a replacement headline.
 
+The privacy-reviewed diagnostic evidence is pinned to
+[`geode-eval-artifacts@40be847`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md).
+Its 12-file manifest SHA-256 is
+`40206ed181f69bd15bc4dd4b986ec99b921ba1afd9b15b14c2d9b64a637af317`.
+This is invalidation evidence, not a stable score release.
+
 ## 참고
 
 - [τ-bench paper (NeurIPS '24)](https://arxiv.org/pdf/2406.12045)

--- a/docs/plans/2026-08-04-runtime-faithful-tau2.md
+++ b/docs/plans/2026-08-04-runtime-faithful-tau2.md
@@ -2,9 +2,10 @@
 
 Date: 2026-08-04
 Source feedback: `lg-ai/presentation/wiki/geode-runtime-faithful-tau2-handoff-2026-08-04.md`
-Status: implemented; staged live verification complete; full-cycle attempt
-infrastructure-invalid after subscription quota exhaustion; admission hardening
-in progress
+Status: implemented and merged in `baf170d70`; staged live verification
+complete; full-cycle attempt infrastructure-invalid after subscription quota
+exhaustion; diagnostic evidence published at `geode-eval-artifacts@40be847`;
+clean rerun pending subscription capacity
 
 ## 1. Outcome
 
@@ -246,6 +247,13 @@ snapshot state and makes Crucible recompute normalized-trajectory integrity;
 the captured Airline and Retail artifacts admit, while the scope-incomplete
 Telecom artifact is rejected. A clean 278-task rerun remains required after
 subscription capacity returns.
+
+The privacy-reviewed diagnostic report is immutable at
+[`geode-eval-artifacts@40be847`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md),
+with the three-domain companions under
+[`runtime-faithful-20260804`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/40be847f7c12004b1e70673808fa95bfd8646b59/crucible/runs/trajectory-snapshots/runtime-faithful-20260804).
+The remote manifest SHA-256 is
+`40206ed181f69bd15bc4dd4b986ec99b921ba1afd9b15b14c2d9b64a637af317`.
 
 ## 10. Deliberate non-goals and remaining boundary
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3134,6 +3134,8 @@ native `results.json`은 계속 점수 정본입니다. 그 digest와 reward, ta
 
 2026-08-04 full-cycle 시도는 278개 task를 모두 스케줄했지만, subscription quota 소진으로 Airline 2개, Retail 16개, Telecom 81개 등 99개 행이 infrastructure contamination 상태가 됐습니다. 이 행들은 0점이 아니라 미실행 작업이므로 이 시도에는 aggregate score 권한이 없습니다. quota 소진 전 Telecom call 6개에서는 external-yield 순서 결함도 발견했습니다. 현재 runtime은 post-tool convergence guard보다 먼저 proposal을 반환하고, admission은 당시의 scope-incomplete trajectory를 거부합니다. 새 headline은 깨끗한 재실행 이후에만 게시합니다.
 
+개인정보 검토를 통과한 진단 보고서와 세 도메인 companion은 [`geode-eval-artifacts@40be847`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md)에 고정했습니다. 12개 파일 manifest SHA-256은 `40206ed1…317`이며, 이 묶음은 점수가 아닌 invalidation evidence입니다.
+
 ## 2026-08-03 GPT-5.4 subscription base full cycle
 
 GEODE `22789ee2`에서 Airline, Retail, Telecom base 278개 task를 모두 실행했습니다. agent와 `geode_user`는 모두 `gpt-5.4` subscription / effort `high`이며, 결과는 **200/278 = 0.7194**입니다.

--- a/site/src/app/docs/benchmarks/tau2/page.tsx
+++ b/site/src/app/docs/benchmarks/tau2/page.tsx
@@ -67,6 +67,15 @@ export default function Page() {
               scope-incomplete trajectory를 거부합니다. 새 headline은 깨끗한
               재실행 이후에만 게시합니다.
             </p>
+            <p>
+              개인정보 검토를 통과한 진단 보고서와 세 도메인 companion은{" "}
+              <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md">
+                <code>geode-eval-artifacts@40be847</code>
+              </a>
+              에 고정했습니다. 12개 파일 manifest SHA-256은{" "}
+              <code>40206ed1…317</code>이며, 이 묶음은 점수가 아닌 invalidation
+              evidence입니다.
+            </p>
 
             <h2>2026-08-03 GPT-5.4 subscription base full cycle</h2>
             <p>
@@ -304,6 +313,15 @@ export default function Page() {
               guards, and admission rejects the captured scope-incomplete
               trajectory. A clean rerun is required before a new headline is
               published.
+            </p>
+            <p>
+              The privacy-reviewed diagnostic report and three-domain companions
+              are pinned to{" "}
+              <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md">
+                <code>geode-eval-artifacts@40be847</code>
+              </a>
+              . The 12-file manifest SHA-256 is <code>40206ed1…317</code>; this
+              bundle is invalidation evidence, not a score release.
             </p>
 
             <h2>2026-08-03 GPT-5.4 Subscription Base Full Cycle</h2>


### PR DESCRIPTION
## Summary
- Pin the 2026-08-04 runtime-faithful Tau2 diagnostic to its immutable eval-artifacts commit.
- Publish the remote manifest digest and retain the no-score admission ruling in internal and public docs.
- Refresh the generated `llms-full.txt` twin.

## Why
The runtime fix and artifact bundle are now merged, so the official docs must point to immutable evidence instead of a local handoff or mutable branch.

## Changes
| File | Change |
|---|---|
| `docs/eval/tau2-bench.md` | Add pinned diagnostic report and manifest digest |
| `docs/plans/2026-08-04-runtime-faithful-tau2.md` | Mark implementation/evidence merged; keep clean rerun pending |
| Tau2 public page | Add Korean/English immutable evidence link |
| `site/public/llms-full.txt` | Refresh generated public-doc export |

## Verification
- `git diff --check`
- pre-commit hooks: passed
- site lint: 0 errors (45 pre-existing warnings)
- Next.js static build: 237 pages
- `npm run export-md`: 74 markdown twins, llms-full refreshed

## Evidence
- Artifact commit: `40be847f7c12004b1e70673808fa95bfd8646b59`
- Manifest SHA-256: `40206ed181f69bd15bc4dd4b986ec99b921ba1afd9b15b14c2d9b64a637af317`
- Admission: diagnostic invalidation evidence only; no aggregate score.