### PR TITLE
release: v1.0.13 — runtime-faithful hooks and Tau2 admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.13] - 2026-08-05
+
+> Runtime-faithful Tau2 execution now exercises GEODE's public hooks and
+> trusted middleware while preserving Tau2's native environment and score
+> authority. Incomplete trajectories fail closed and remain diagnostic
+> evidence rather than becoming benchmark scores.
+
 ### Added
 
 - Added a benchmark-safe Tau2 runtime profile and retry-attempt manifest. New

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.12
+- **Version**: 1.0.13
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.12 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.13 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.12: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.13: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/plans/2026-08-05-runtime-faithful-hooks-release-handoff.md
+++ b/docs/plans/2026-08-05-runtime-faithful-hooks-release-handoff.md
@@ -1,0 +1,179 @@
+# Handoff — runtime-faithful hooks, trajectories, and v1.0.13
+
+Date: 2026-08-05
+
+Release authority: `v1.0.13`. When this document is read from that annotated
+tag, its target is the exact runtime source. If the tag, GitHub release, or
+public package is absent, release completion must not be inferred from this
+document or a merged PR.
+
+Read §1 for the result, §2 for the final hook/middleware surface, §3 for the
+record and artifact boundaries, §4 for Tau2 evidence, and §5 for remaining
+work.
+
+## 1. Result and evidence chain
+
+GEODE is not only a recording system. `AgenticLoop` already owns the
+plan/act/observe/verify/repair control cycle; this release makes the execution
+and evidence boundaries explicit enough for an external loop to inspect or
+intervene without taking over native verifier authority.
+
+| Scope | Authority |
+|---|---|
+| 13 public hooks, four trusted middleware seams, versioned session/trajectory contract | [GEODE #2868](https://github.com/mangowhoiscloud/geode/pull/2868), merge `f08e7d6f5c785f76881ea2f9dfc2983ced8556d8` |
+| external-tool yield ordering and fail-closed trajectory admission | [GEODE #2869](https://github.com/mangowhoiscloud/geode/pull/2869), merge `baf170d70e235419528ade3f07910ce862c87d2b` |
+| immutable artifact links in official docs | [GEODE #2870](https://github.com/mangowhoiscloud/geode/pull/2870), merge `3cca7d2e8d507c62f45e00e7af810dc245f784db` |
+| privacy-reviewed invalidation evidence | [`geode-eval-artifacts@40be847`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/40be847f7c12004b1e70673808fa95bfd8646b59) |
+| machine/human diagnostic report | [report](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/40be847f7c12004b1e70673808fa95bfd8646b59/reports/e2e-validation/2026-08-04-gpt54-runtime-faithful-tau2-diagnostic.md) |
+| public distribution | GitHub release and PyPI package `geode-agent==1.0.13` |
+
+The remote 12-file diagnostic manifest SHA-256 is
+`40206ed181f69bd15bc4dd4b986ec99b921ba1afd9b15b14c2d9b64a637af317`.
+The bundle is invalidation evidence, not a score release.
+
+## 2. Final extension surface
+
+### 2.1 Three planes
+
+| Plane | Stable surface | Role |
+|---|---|---|
+| public control | 13 `HookName` values, `geode.public-hook.v1` | bounded/redacted external decisions |
+| trusted execution | four typed middleware protocols | immutable request transforms and exactly-once execution wrappers |
+| runtime observation | 57 `RuntimeEvent` members | internal telemetry and lifecycle vocabulary, not public ABI |
+
+The public hooks are:
+
+```text
+UserPromptSubmit
+PreToolUse -> PermissionRequest -> PostToolUse
+PreCompact -> PostCompact
+SessionStart -> SessionEnd
+SubagentStart -> SubagentStop
+PreVerify -> PostVerify
+Stop
+```
+
+`PostVerify` accepts only the closed `accept`, `revise`, and `escalate`
+decisions. This gives SIL, Crucible, and other owning outer loops a stable seam
+to retain evidence, request a bounded revision, or pause for external judgment
+without replaying completed side effects. Tau2's native episode verdict is not
+silently converted into a PostVerify decision; it enters the durable record as
+typed `verification.evidence` and remains subject to Crucible admission.
+
+The trusted middleware seams are exactly:
+
+```text
+tool_request     # transform a cloned ToolCallRequest before approval
+tool_execution   # wrap the approved executor through next_call
+llm_request      # transform a cloned LlmCallRequest before dispatch
+llm_execution    # wrap provider execution through next_call
+```
+
+There is no `MiddlewareKind` enum. The four protocols and four registration
+methods are already the type-level vocabulary; adding a parallel enum would
+create a second registry without improving dispatch.
+
+### 2.2 Runtime ownership
+
+```mermaid
+flowchart LR
+    U["User / outer loop"] --> H["13 public hooks"]
+    H --> L["AgenticLoop<br/>plan · act · observe · verify · repair"]
+    M["4 trusted middleware seams"] --> L
+    L --> X["ToolExecutor / LLM adapter"]
+    X --> E["57 RuntimeEvents<br/>internal observation"]
+    L --> S[("sessions.db")]
+    E --> S
+```
+
+`HookRegistry`, `MiddlewareRegistry`, and `RuntimeEventBus` are process-owned
+and shared by a runtime. Tau2's benchmark-safe runtime now passes those exact
+instances to every participant loop and tool executor.
+
+## 3. Record, trajectory, and artifact boundaries
+
+```mermaid
+flowchart TD
+    C["Checkpoint<br/>mutable resume state"] --> DB[("sessions.db")]
+    DB --> SR["session_events<br/>append-only behavior history"]
+    DB --> HR["hook_events<br/>bounded runtime activity"]
+    SR --> J["events.jsonl<br/>portable run projection"]
+    SR --> T["geode.trajectory@1<br/>immutable normalized projection"]
+    N["native benchmark receipt"] --> V["evidence + digest admission"]
+    T --> V
+    V --> A["reviewed eval-artifact Git commit"]
+```
+
+| Data | Store | Authority |
+|---|---|---|
+| current session/messages | `sessions.db:sessions/messages` | resume and conversation reconstruction |
+| behavioral history | `sessions.db:session_events` | append-only execution record |
+| hook/middleware/runtime activity | `sessions.db:hook_events` | operational observation with retention |
+| portable run projection | run-local `events.jsonl` | rebuildable JSONL, never resume truth |
+| normalized trajectory | `geode.trajectory@1` | correlation/replay/evaluation sidecar |
+| native Tau2 result | upstream `results.json` | reward and native termination |
+| public evidence | `geode-eval-artifacts` commit + manifest | reviewed disclosure and immutable read-back |
+
+New runtime sessions do not create global transcript JSONL. The schema-backed
+`SessionTimeline`, `RunTimeline`, `session_events`, and `events.jsonl` are the
+new path. Deprecated transcript constructors and legacy filenames remain only
+as read/import compatibility; explicit `geode session migrate-records` imports
+old bytes idempotently without rewriting them.
+
+## 4. Runtime-faithful Tau2 cycle
+
+### 4.1 Frozen contract
+
+- GEODE runtime revision: `f08e7d6f5c785f76881ea2f9dfc2983ced8556d8`
+- Tau2 revision: `1901a301961cbbe3fd11f3e84a2a376530c759e3`
+  (`tau2==1.0.0`)
+- agent and user: GPT-5.4 subscription, effort `high`
+- profile: `geode-dual-runtime`
+- base tasks: Airline 50, Retail 114, Telecom 114; 278 scheduled
+- native environment executor: Tau2 only
+- promotion authority: none
+
+### 4.2 Admission result
+
+| Domain | Reward-bearing rows | Passed rows | Infrastructure rows | Trajectory |
+|---|---:|---:|---:|---|
+| Airline | 48 / 50 | 42 | 2 | admitted |
+| Retail | 98 / 114 | 76 | 16 | admitted |
+| Telecom | 33 / 114 | 30 | 81 | rejected: six orphan calls |
+| Total | 179 / 278 | 148 | 99 | no aggregate score authority |
+
+Subscription capacity exhausted in the tail. The 99 rows are missing work,
+not zero rewards, so no weighted score may be computed or compared with the
+earlier 200/278 diagnostic.
+
+Before quota exhaustion, six Telecom calls exposed an ordering defect:
+`AgenticLoop` applied local convergence/repetition guards after a deferred ACK
+but before returning the external proposal to Tau2. The adapter then emitted a
+terminal response, leaving calls without results. The fix yields immediately
+after the cognitive/tool round, before local guards. Crucible now verifies the
+normalized trajectory's schema, digests, run identity, and recomputed
+`scope_complete=true`; the captured Telecom artifact therefore fails closed.
+
+## 5. Remaining work and recovery order
+
+1. After subscription capacity resets, rerun the clean 278-task Tau2 contract
+   on the released `v1.0.13` tree. Publish a score only if every scheduled row
+   is native-receipt-bound and all three normalized trajectories are
+   scope-complete.
+2. Run MCPMark from the same released tree and account window. Keep its native
+   verifier/result authority and publish through the same privacy/digest gate.
+3. Remove the deprecated `SessionTranscript`/`RunTranscript` import aliases and
+   automatic legacy filename fallback in a dedicated compatibility-removal GAP.
+   Keep explicit archival migration; do not rewrite old artifacts.
+4. Tau2 currently records native verdicts as `verification.evidence`; it does
+   not consume `PostVerify`. Wire that only when an owning external loop must
+   resume the same episode after accept/revise/escalate.
+5. A general search-space graph and continuously learned reward policy remain
+   domain-owned rather than being invented in the core runtime. Add either only
+   when a second production loop proves a shared contract.
+
+Release recovery order is release PR to `develop`, CI-gated `develop -> main`,
+manual `release.yml` dispatch with `publish_stable=true`, then annotated tag,
+GitHub assets, PyPI files, checksums, clean install, public distribution
+verifier, Pages read-back, and finally task-owned worktree cleanup. Never move a
+published tag or replace PyPI bytes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.12"
+version = "1.0.13"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
     "count": 252,
-    "stamped": "1.0.12"
+    "stamped": "1.0.13"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.12"
+    "stamped": "1.0.13"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.12"
+    "stamped": "1.0.13"
   },
   "duplicated_signatures": {
     "count": 97,
-    "stamped": "1.0.12"
+    "stamped": "1.0.13"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.12. Last sync 2026-08-03. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.13. Last sync 2026-08-04. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 
@@ -5960,7 +5960,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1486 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1487 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.12. Last sync 2026-08-03. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.13. Last sync 2026-08-04. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-03
+ * Last sync: 2026-08-04
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Added\n\n- Added a benchmark-safe Tau2 runtime profile and retry-attempt manifest. New\n  snapshot v4 records digest-bind the runtime revision, model routes, assembled\n  prompt/tool-schema identities, exercised hook and middleware surfaces, every\n  participant session, retry ancestry, and final native simulation selection.\n\n### Changed\n\n- Tau2 participants now share one process-owned runtime event bus, public hook\n  registry, and four-surface middleware registry. Native `results.json`\n  reward/termination evidence is joined to session timelines before SessionEnd,\n  while `tau2-native-user` and `geode-dual-runtime` measurements remain distinct profiles.\n- Crucible now observably disables legacy `cached-row.v1` reuse for Tau2\n  snapshot v4 runs because that cache predates the runtime-profile and attempt\n  companions; runs execute fresh rather than synthesize provenance.\n\n### Fixed\n\n- Tau2 tool projection ACKs no longer masquerade as completed environment\n  actions. The adapter defers all environment execution to Tau2 and records the\n  official result or error only when its original call ID returns; orphaned or\n  still-pending calls fail closed. Terminal-step results are reconciled from\n  the native receipt, diagnostic auto-resume rows remain explicitly\n  unattested, and exhausted post-run failures cannot remain marked complete.\n- External half-duplex tool proposals now reach their orchestrator before\n  convergence guards can terminate the turn, and Crucible rejects snapshots\n  whose hash-bound GEODE trajectory is missing, corrupt, or scope-incomplete."
+    "body": ""
+  },
+  {
+    "version": "1.0.13",
+    "date": "2026-08-05",
+    "body": "> Runtime-faithful Tau2 execution now exercises GEODE's public hooks and\n> trusted middleware while preserving Tau2's native environment and score\n> authority. Incomplete trajectories fail closed and remain diagnostic\n> evidence rather than becoming benchmark scores.\n\n### Added\n\n- Added a benchmark-safe Tau2 runtime profile and retry-attempt manifest. New\n  snapshot v4 records digest-bind the runtime revision, model routes, assembled\n  prompt/tool-schema identities, exercised hook and middleware surfaces, every\n  participant session, retry ancestry, and final native simulation selection.\n\n### Changed\n\n- Tau2 participants now share one process-owned runtime event bus, public hook\n  registry, and four-surface middleware registry. Native `results.json`\n  reward/termination evidence is joined to session timelines before SessionEnd,\n  while `tau2-native-user` and `geode-dual-runtime` measurements remain distinct profiles.\n- Crucible now observably disables legacy `cached-row.v1` reuse for Tau2\n  snapshot v4 runs because that cache predates the runtime-profile and attempt\n  companions; runs execute fresh rather than synthesize provenance.\n\n### Fixed\n\n- Tau2 tool projection ACKs no longer masquerade as completed environment\n  actions. The adapter defers all environment execution to Tau2 and records the\n  official result or error only when its original call ID returns; orphaned or\n  still-pending calls fail closed. Terminal-step results are reconciled from\n  the native receipt, diagnostic auto-resume rows remain explicitly\n  unattested, and exhausted post-run failures cannot remain marked complete.\n- External half-duplex tool proposals now reach their orchestrator before\n  convergence guards can terminate the turn, and Crucible rejects snapshots\n  whose hash-bound GEODE trajectory is missing, corrupt, or scope-incomplete."
   },
   {
     "version": "1.0.12",
@@ -2458,4 +2463,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-08-03";
+export const CHANGELOG_SYNCED_AT = "2026-08-04";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-03
+ * Last sync: 2026-08-04
  */
 
 export const GEODE_SOT = {
-  version: "1.0.12",
-  syncedAt: "2026-08-03",
+  version: "1.0.13",
+  syncedAt: "2026-08-04",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Promote the runtime-faithful public-hook, trusted-middleware, and Tau2 snapshot-v4 contract as GEODE 1.0.13.
- Preserve the infrastructure-invalid 278-task attempt as diagnostic evidence, never an aggregate score.
- Add the final runtime/storage/artifact handoff and refresh every generated release surface.

## Why
GEODE now exposes the Hermes-shaped 13-hook control plane, four trusted execution seams, and 57-event observation plane while preserving Tau2 native environment and verifier authority. The release also includes the external-yield ordering fix and fail-closed trajectory admission found by the live full cycle.

## Changes
| Area | Change |
|---|---|
| Version | `pyproject.toml`, lockfile, README/CLAUDE surfaces -> 1.0.13 |
| CHANGELOG | Fold `[Unreleased]` into 1.0.13 with an empty new Unreleased section |
| Handoff | Final hook/middleware/storage diagram, Tau2 invalidation evidence, migration map, remaining gates |
| Generated docs | SOT, changelog data, llms indexes, slop ratchet |

## GAP audit
| GAP | State | Evidence |
|---|---|---|
| Public hook surface | Closed | 13 versioned hooks in #2868 |
| Trusted execution wrapping | Closed | four typed request/execution protocols in #2868 |
| External Tau2 proposal suppression | Closed | ordering fix in #2869 |
| Incomplete trajectory admission | Closed | digest-bound scope recomputation in #2869 |
| Clean 278-task score | Open/external | subscription quota exhausted; no score claimed |
| Transcript compatibility removal | Deferred | new writers already use schema-backed timeline; explicit removal GAP retained |

## Verification
- Full non-live pytest suite: exit 0
- ruff check and format: passed (1,269 files)
- mypy: passed (543 source files)
- import contracts: 4/4 kept
- official docs gate: passed; 237 pages, 74 markdown twins, no broken links
- architecture, llms-version, and slop ratchets: passed
- `uv build`, `twine check`, package-content gate: wheel 619 files / sdist 621 files
- `uv run geode version`: GEODE v1.0.13

## Immutable evidence
- Artifact commit: `40be847f7c12004b1e70673808fa95bfd8646b59`
- Manifest SHA-256: `40206ed181f69bd15bc4dd4b986ec99b921ba1afd9b15b14c2d9b64a637af317`
- Admission: diagnostic invalidation evidence only; a clean rerun remains required after quota reset.