### PR TITLE
release: v1.0.14 — prune unreachable learning and finalizer paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.14] - 2026-08-05
+
+> Cleanup release: retire the orphaned unary DPO precursor and the unreachable
+> synchronous AgenticLoop finalizer while preserving historical timelines,
+> public verification APIs, hook order, and SQLite action-family queries.
+
 ### Removed
 
 - **Removed the unreachable synchronous AgenticLoop finalizer chain.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.13
+- **Version**: 1.0.14
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.13 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.14 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.13: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.14: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/docs/plans/2026-08-05-action-family-finalizer-release-handoff.md
+++ b/docs/plans/2026-08-05-action-family-finalizer-release-handoff.md
@@ -1,0 +1,84 @@
+# Handoff — action-family query contract and finalizer cleanup
+
+Date: 2026-08-05
+
+Release authority: `v1.0.14`. The tag, GitHub release, and public
+`geode-agent==1.0.14` package must exist before distribution is considered
+complete. The full hook, middleware, trajectory, and Tau2 handoff remains
+[`2026-08-05-runtime-faithful-hooks-release-handoff.md`](2026-08-05-runtime-faithful-hooks-release-handoff.md).
+
+## 1. What landed
+
+- PR [#2877](https://github.com/mangowhoiscloud/geode/pull/2877) removed the
+  orphaned unary `eval_response_recorded` DPO precursor. Historical RunTimeline
+  JSONL remains readable; no migration is required.
+- PR [#2878](https://github.com/mangowhoiscloud/geode/pull/2878) removed the
+  unreachable synchronous AgenticLoop finalizer chain. The exported synchronous
+  `verify_turn()` library API remains available.
+- Production finalization remains one asynchronous path with the monotonic
+  public-hook sequence `PreVerify -> PostVerify -> Stop`.
+
+## 2. `action_family` means analytics, not public hooks
+
+`core.hooks.catalog.action_family(action)` takes the first segment of an
+internal `RuntimeEvent.action` string and maps legacy heads into one of 13
+query families:
+
+```text
+cognitive  context  cost  improve  llm  mcp  memory
+mutation   policy   session  subagent  tool  turn
+```
+
+Compatibility folds are:
+
+```text
+adapter | prompt | model | reasoning        -> llm
+user | execution | result | post            -> turn
+shutdown | handoff                           -> session
+rule | config | extension | program          -> policy
+trigger | self | baseline                    -> improve
+```
+
+The raw `action` value is never rewritten. `HookEventStore.read(
+family_filter=...)` expands the same alias table in SQLite, so old and canonical
+rows remain query-compatible. A previous report that this policy lacked
+production wiring was incorrect; no new projector or migration was added.
+
+## 3. Final hook surface
+
+The public ABI remains exactly 13 hooks:
+
+```text
+UserPromptSubmit
+PreToolUse -> PermissionRequest -> PostToolUse
+PreCompact -> PostCompact
+SessionStart -> SessionEnd
+SubagentStart -> SubagentStop
+PreVerify -> PostVerify
+Stop
+```
+
+These are separate from the 57-member internal `RuntimeEvent` vocabulary and
+the 13 action families used to query that vocabulary. No public hook or runtime
+event was added or removed in v1.0.14.
+
+```mermaid
+flowchart LR
+    H["13 public hooks<br/>bounded control ABI"] --> L["AgenticLoop<br/>single async finalizer"]
+    L --> R["57 RuntimeEvents<br/>raw actions preserved"]
+    R --> DB[("sessions.db / hook_events")]
+    DB --> F["13 action families<br/>query-time fold"]
+```
+
+## 4. Verification and next work
+
+The feature branch passed the full non-live suite (`10,418 passed`, `23
+skipped`, `1 deselected`), Ruff, mypy, import contracts, architecture baseline,
+site build, package install checks, and an independent GPT subscription review
+with no actionable finding.
+
+No new policy/search/reward abstraction was added. Trajectory preference and
+agentic-RL export remain a future outer-loop concern; add them only when a real
+training consumer defines the pair and credit-assignment contract. The next
+operational work is the quota-reset Tau2 full cycle and MCPMark run described in
+the v1.0.13 handoff, not another hook taxonomy change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.13"
+version = "1.0.14"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
     "count": 252,
-    "stamped": "1.0.13"
+    "stamped": "1.0.14"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.13"
+    "stamped": "1.0.14"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.13"
+    "stamped": "1.0.14"
   },
   "duplicated_signatures": {
     "count": 97,
-    "stamped": "1.0.13"
+    "stamped": "1.0.14"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.13. Last sync 2026-08-04. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.14. Last sync 2026-08-05. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.13. Last sync 2026-08-04. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.14. Last sync 2026-08-05. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-04
+ * Last sync: 2026-08-05
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Removed\n\n- **Removed the unreachable synchronous AgenticLoop finalizer chain.** The\n  runtime has one async entrypoint and all terminal branches already converge\n  on the public-hook-aware async finalizer. Its sync-only delegator, verify\n  wrappers, and persistence duplicate had no production callers; the public\n  sync `verify_turn()` library API remains available.\n- **Retired the orphaned `eval_response_recorded` DPO precursor.** The deleted\n  M4.x pair builder had no reader for these unary autoresearch audit summaries,\n  whose synthetic prompts and rollback-derived labels were not valid\n  preference pairs. Promoted audits continue to feed the existing in-context\n  few-shot pool, and historical RunTimeline JSONL remains readable without\n  migration. The removal lowers the global `PLR0915` ceiling from 223 to 212;\n  the pre-existing 217-statement serve composer is now an explicit,\n  roadmap-owned exception instead of hidden below the old ceiling. The two\n  deleted producer-only files contributed 25 collected cases; the selected-test\n  ratchet moves from 10,451 to the measured 10,441 after consuming its prior\n  15-case safety margin."
+    "body": ""
+  },
+  {
+    "version": "1.0.14",
+    "date": "2026-08-05",
+    "body": "> Cleanup release: retire the orphaned unary DPO precursor and the unreachable\n> synchronous AgenticLoop finalizer while preserving historical timelines,\n> public verification APIs, hook order, and SQLite action-family queries.\n\n### Removed\n\n- **Removed the unreachable synchronous AgenticLoop finalizer chain.** The\n  runtime has one async entrypoint and all terminal branches already converge\n  on the public-hook-aware async finalizer. Its sync-only delegator, verify\n  wrappers, and persistence duplicate had no production callers; the public\n  sync `verify_turn()` library API remains available.\n- **Retired the orphaned `eval_response_recorded` DPO precursor.** The deleted\n  M4.x pair builder had no reader for these unary autoresearch audit summaries,\n  whose synthetic prompts and rollback-derived labels were not valid\n  preference pairs. Promoted audits continue to feed the existing in-context\n  few-shot pool, and historical RunTimeline JSONL remains readable without\n  migration. The removal lowers the global `PLR0915` ceiling from 223 to 212;\n  the pre-existing 217-statement serve composer is now an explicit,\n  roadmap-owned exception instead of hidden below the old ceiling. The two\n  deleted producer-only files contributed 25 collected cases; the selected-test\n  ratchet moves from 10,451 to the measured 10,441 after consuming its prior\n  15-case safety margin."
   },
   {
     "version": "1.0.13",
@@ -2463,4 +2468,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-08-04";
+export const CHANGELOG_SYNCED_AT = "2026-08-05";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-04
+ * Last sync: 2026-08-05
  */
 
 export const GEODE_SOT = {
-  version: "1.0.13",
-  syncedAt: "2026-08-04",
+  version: "1.0.14",
+  syncedAt: "2026-08-05",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Stamp v1.0.14 for the two reviewed dead-path removals already landed on `develop`.
- Rotate `[Unreleased]`, refresh all generated version surfaces, and build verified wheel/sdist artifacts.
- Add a concise handoff that distinguishes 13 public hooks, 57 internal runtime events, and 13 query-time action families.

## Why
The v1.0.14 train removes two producer/control paths with no valid consumer: the unary DPO precursor and the synchronous AgenticLoop finalizer chain. The release preserves historical timeline readability, the public `verify_turn()` API, `PreVerify → PostVerify → Stop`, and SQLite legacy-family queries.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | Promote the two removals into v1.0.14 and create a fresh `[Unreleased]`. |
| `pyproject.toml`, `uv.lock`, `CLAUDE.md`, READMEs | Stamp v1.0.14. |
| site SoT and llms files | Regenerate versioned public metadata and changelog projection. |
| slop ratchet | Rotate baseline version without changing measured counts. |
| release handoff | Record action-family semantics, hook/runtime counts, preserved contracts, and remaining operational work. |

## GAP Audit
| Contract | Release state |
|----------|---------------|
| Public hooks | 13, unchanged |
| Runtime events | 57, unchanged |
| Action families | 13 query families; raw action rows remain intact |
| DPO data | Invalid unary precursor removed; historical JSONL remains readable |
| Finalization | Async-only production path; sync `verify_turn()` API retained |
| New abstraction | None |

## Verification
- `uv run ruff check core/ tests/ plugins/ scripts/`
- `uv run ruff format --check core/ tests/ plugins/ scripts/`
- `uv run mypy core/ plugins/` — 542 source files
- `uv run lint-imports` — 4 contracts kept
- `uv run python scripts/architecture_baseline.py --check`
- `uv run python scripts/check_llms_version.py` — v1.0.14 clean
- `uv run geode version` — v1.0.14
- `uv build` — v1.0.14 wheel and sdist built and inspected
- `npm run lint` — 0 errors (45 existing warnings)
- `npm run build` — 237 pages
- `npm run export-md` — 74 Markdown twins
- Feature CI: full non-live suite and install matrices passed on #2877 and #2878
