### PR TITLE
docs: promote Stanford test-time compute grounding skill

### DIFF
--- a/.claude/skills/stanford-test-time-compute/SKILL.md
+++ b/.claude/skills/stanford-test-time-compute/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: stanford-test-time-compute
+description: Ground GEODE design and evaluation work in Stanford CS329A Test-Time Compute Scaling Part 2. Use for test-time or inference-time compute, best-of-N, parallel candidate width, sequential repair depth, measurement replication, verifier/evaluator versus promotion authority, verifier-aware scheduling, Archon or inference-program search, and GEODE/Eco²/SIL/Crucible comparisons.
+---
+
+# Stanford Test-Time Compute Grounding
+
+Keep lecture evidence, project interpretation, measurement, and change authority
+separate while applying test-time compute concepts to GEODE.
+
+## Workflow
+
+1. Read `references/lecture-analysis.md` completely before making a claim or
+   design decision. The full read is deliberate: this user-designated SOT owns
+   both the 63-minute lecture analysis and its project-mapping caveats.
+2. Classify the request using the decision planes below.
+3. Read only the matching project references from
+   `references/project-application-index.md`.
+4. Inspect current GEODE code and tests for every implementation claim.
+   Historical presentation snapshots are context, never current code authority.
+5. If exact timing, wording, or a slide is material, follow
+   `references/source-manifest.md` and verify against the original source.
+6. Report lecture evidence and GEODE application as separate claims.
+
+## Decision planes
+
+| Plane | Question | Do not confuse with |
+|---|---|---|
+| Parallel candidate width | How many alternatives solve the same task? | workflow fan-out or repeated benchmark trials |
+| Sequential repair depth | How many feedback-conditioned revisions occur? | long chain-of-thought without observations |
+| Inference-program search | Which bounded operator composition should run? | online self-modification or product promotion |
+| Measurement replication | How uncertain is one policy's measured result? | best-of-N candidate selection |
+| Promotion authority | Which evidence may change named state or release state? | verifier score or candidate ranking |
+
+## Claim discipline
+
+- Preserve the source labels `[직접근거]`, `[외부연구]`, and `[해석]`.
+- State the search object, budget unit, verifier, measurement unit, and write
+  authority for every proposed compute policy.
+- Distinguish oracle coverage from delivered correctness.
+- Treat a trajectory as a training-data candidate only after identity, privacy,
+  duplication, reward quality, and evaluator-leakage checks.
+- Call GEODE's current capability a direct implementation only when the input,
+  output, decision object, and authority match the cited operator contract.
+
+## Guardrails
+
+- Do not call concurrent subagents parallel sampling unless they produce
+  comparable candidates for the same task.
+- Do not call K repeated evaluations best-of-K.
+- Do not call a gate a ranker merely because it chooses keep or revert.
+- Do not claim GEODE implements Archon or compute-optimal scheduling without
+  current code and executable evidence.
+- Do not infer performance scaling from observed trajectory length; run a
+  controlled budget intervention first.
+- Keep completed state-changing trajectories out of answer fusion. Consider
+  fusion only before side effects, over plan or text candidates.
+
+## Output contract
+
+For a design, audit, or report, include:
+
+1. the decision plane and search object;
+2. lecture evidence versus project interpretation;
+3. current GEODE code/test grounding;
+4. verifier and promotion-authority boundaries;
+5. measured GAPs, non-goals, and the smallest justified next experiment.

--- a/.claude/skills/stanford-test-time-compute/references/eco2-runtime.md
+++ b/.claude/skills/stanford-test-time-compute/references/eco2-runtime.md
@@ -1,0 +1,352 @@
+# Eco² — LG AI 1차 면접 PT 사실 카드 (검증 완료)
+
+> 수집일: 2026-07-28. 검증 등급: `[실측]` 파일/커밋에서 직접 확인, `[문서주장]` 레포 문서상 주장(코드 미확인), `[미검증]` 근거 없음.
+> 로컬 SoT: `${HOME}/workspace/SeSACTHON/backend` (main, HEAD
+> 4c3eebb3). [Eco² 포트폴리오](https://mangowhoiscloud.github.io/portfolio/eco2/)
+
+검증 표기: `[직접근거]`는 코드·Git·artifact 실측, `[외부연구]`는 공식
+외부 문서, `[해석]`은 두 근거를 발표 직무 맥락에 정렬한 판단이다.
+
+---
+
+## ① 한 줄 개요
+
+폐기물 분리배출 도우미 **production-level AI Agent 서비스** — LangGraph Multi-Agent 챗봇(10 intent) + Vision LLM 폐기물 분류 파이프라인을 Self-managed Kubernetes(Istio/ArgoCD/KEDA) 위에서 운영. **2025 서울시 새싹(SeSAC) 해커톤 우수상** `[실측: frontend/README.md:17-19 "2025 새싹 해커톤 … 🏆 우수상 수상 🏆" + 수상 사진]`. 수상 배경 "본선 32팀 중 Top 4, 총 181팀 지원" `[문서주장: 포트폴리오 페이지]`.
+
+---
+
+## ② 문제 → 접근 → 아키텍처 (에이전트 워크플로우 중심)
+
+### 이력서 주장 1 — Intent 분류 + Send API 병렬 fan-out: **전부 [실측]**
+
+- **10개 intent enum**: `WASTE, CHARACTER, LOCATION, BULK_WASTE, RECYCLABLE_PRICE, COLLECTION_POINT, WEATHER, IMAGE_GENERATION, WEB_SEARCH, GENERAL` `[실측: backend/apps/chat_worker/domain/enums/intent.py + routing/dynamic_router.py:162-173 INTENT_TO_NODE 정확히 10개]`
+- **Intent 분류 앞단**: LLM Structured Output(`generate_structured`) 기반 분류 + Chain-of-Intent(`previous_intents`) + multi-intent 감지/분해 `[실측: application/commands/classify_intent_command.py:49,225,307,330]`
+- **LangGraph Send API fan-out**: `dynamic_router`가 `list[Send]` 반환 — ① 주 intent 노드 ② `additional_intents` 병렬 Send(multi-intent fanout) ③ 규칙 기반 enrichment ④ 조건부 enrichment `[실측: routing/dynamic_router.py:203-317, from langgraph.types import Send :31]`
+- **general fallback**: `INTENT_TO_NODE.get(primary_intent, "general")` — 미매핑 intent는 general로 폴백 `[실측: dynamic_router.py:226]`. 추가로 general+확신도<0.75면 web_search 자동 보강 `[실측: dynamic_router.py:141-158]`
+- **weather enrichment 자동 합류**: `waste`/`bulk_waste` intent → `weather` 노드 자동 추가 `[실측: dynamic_router.py:78-90 ENRICHMENT_RULES]`, `user_location` 존재 시 조건부 weather 추가 `[실측: :131-140]`. 병렬 결과는 `aggregator` 노드에서 합류 `[실측: nodes/aggregator_node.py 존재; README.md:225-238 그래프 edge]`. Fail-Open 정책(보조 컨텍스트 누락 시 진행)은 `[문서주장: README.md:336]`
+- **후단**: aggregator → 토큰 임계값(4K) 초과 시 summarize(OpenCode 스타일 압축) → answer(토큰 스트리밍) `[실측: 그래프 구조 README.md:189-242 (draw_mermaid 산출) + summarization.py 존재; 4K 수치는 문서주장 README.md:337]`
+- **주의**: "질문이 10개 intent로 갈라진다는 **관찰**"(데이터 분석으로 10개를 도출했다는 서사)의 근거 데이터/문서는 레포에서 발견 못함 → 관찰 과정 자체는 `[미검증]`. 10개 분류 체계의 존재는 [실측].
+
+### Tool Calling / 서브에이전트 구성
+
+- Tool Calling 자산 6종: weather(기상청), bulk_waste(자치구), recyclable_price(시세), location·collection_point(Kakao Local), web_search(OpenAI web_search / Gemini Google Search native). 단, 현재 factory는 `*_agent_node.py`의 반복형 multi-tool loop가 아니라 대부분 `generate_function_call()` 1회로 인자를 추출한 뒤 application command를 실행하는 node를 연결한다. 따라서 현재 runtime을 "6개 ReAct subagent"라고 부르면 과장이다. `[실측: factory.py imports/wiring + nodes/*_node.py와 *_agent_node.py 대조]`
+- OpenAI adapter의 Structured Output·web search 경로는 Agents SDK(primary) + Responses API(fallback)를 실제 사용한다. 일반 answer/stream 경로는 Chat Completions다. SDK 사용 범위와 전체 graph의 agent 성격을 구분해야 한다. `[실측: infrastructure/llm/clients/openai_client.py]`
+- 이미지 생성: `dynamic_router`의 동급 branch로
+  `image_generation_node → GenerateImageCommand →
+  GeminiNativeImageGenerator → ImageStoragePort(gRPC) → Images API →
+  CDN URL → aggregator`가 배선된다. 현재 generator는
+  `gemini-3-pro-image-preview`로 고정되고, node policy는 timeout 30초,
+  retry 1회, `FAIL_OPEN`이다. `[직접근거:
+  factory.py:474-521,600-650; image_generation_node.py;
+  generate_image_command.py; setup/dependencies.py:442-518;
+  policies/node_policy.py:146-152]`
+- Tool calling·Agents SDK 계보: `ecd59c7d`의 반복형 function-calling
+  agent 자산 뒤 `174959d9`가 production API node를 one-shot argument
+  extraction + deterministic command로 제한했다. `64a4e65b`·`b7316337`은
+  Agents SDK primary를 추가했지만, 현재 factory는 반복형
+  `*_agent_node.py`가 아니라 `*_node.py`를 연결한다. Agents SDK는
+  structured output과 native web search에서 실제 사용된다.
+  `[직접근거: Git + factory.py imports + openai_client.py]`
+- LangGraph 노드 총 23개 = main 17 + eval subgraph 6 `[문서주장: backend/portfolio/eco2/architecture-facts.md:13,28-31 — "코드에서 직접 추출" 명시된 자체 실측 문서]`
+
+### 시스템 아키텍처 (5-Layer)
+
+- Edge(ALB+Istio Ingress) / Service(8 도메인 API) / Integration(Event Bus + Worker) / Persistence(PostgreSQL, Redis 용도별 분리) / Platform(ArgoCD, KEDA, Prometheus/Grafana, Jaeger, LangSmith, EFK) `[문서주장: README.md:26-49; apps/ 디렉토리 18개 서비스·워커는 실측]`
+- Scan 파이프라인: Celery Chain 4단계 Vision(GPT Vision)→Rule(Lite RAG)→Answer→Reward, RabbitMQ + KEDA 오토스케일링 `[실측: apps/scan_worker 존재 + README.md:133-140]`
+- Checkpoint: Redis Primary(~1ms) + PostgreSQL Async Sync(5s batch) — Worker PG 연결 192→8 (96% 감소) `[문서주장: README.md:353-399; checkpointer.py, sync/ 디렉토리는 실측]`
+
+---
+
+## ③ 내 역할 / 참여도 / 타임라인 (이력서 주장 4)
+
+### git 실측 수치
+
+- **Backend(인프라 포함 모노레포)**: 발표 검증 핀 `4c3eebb3afc3`의 HEAD는 2,277커밋. 본인 동일 이메일의 두 저자명(mangowhoiscloud 1,526 + mango 654 = **2,180**) / 다른 팀원 9 / 자동화 계정 88이다. `[실측: git rev-list --count HEAD; git shortlog -sne HEAD]` 모든 ref 기준 2,429와 섞지 않는다. 커밋 수는 활동 범위의 보조 증거이며 코드 품질·성과의 대리 지표가 아니다. terraform/, ansible/, clusters/, workloads/(K8s manifests) 모두 이 레포에 포함 → 인프라 전담 근거.
+- **Backend 월별(본인)**: 2025-10: 64 / 11: 904 / 12: 721 / 2026-01: 477 / 02: 11 / 03: 3 `[실측: git log --author]`
+- **Frontend**: 팀 공동 — 본인 208(133+75), suji8073 99, ChaeHyun-Kim 계열 119+, Suji Chae 33 `[실측: git shortlog @ frontend]`
+- **Frontend 월별(본인)**: 2025-12: 7 → **2026-01: 157** — 타 FE 팀원 커밋은 2025-12에서 종료, **1월부터 FE 단독 인수** `[실측: git log 월별 분포; frontend 마지막 커밋 2026-01-25]`
+
+### 타임라인
+
+- 레포 시작: frontend 2025-10-27, backend 첫 본인 커밋 2025-10-30 `[실측: git log --reverse]`
+- 포트폴리오 주장 기간: 2025-10-31 ~ 2026-01-28 (91일) `[문서주장: 포트폴리오 페이지]` — git 실측으론 backend 활동이 2026-03-08까지 이어짐(eval 파이프라인 등 후속 작업 2월).
+- **정직한 서사**: ① 해커톤 기간(10월 말~11월, MVP): 5인 팀(BE/Infra 1 = 본인, AI 1, FE 2, 디자인 1 `[문서주장: 포트폴리오 페이지]`)에서 백엔드·인프라 전담 ② 수상 후(12월~3월): BE·Infra 계속 전담 + 12월 FE 참여 시작, **1월부터 FE·BE·Infra·Agent(LLM) 단독** 확장. → 이력서의 "1개월 MVP + 3개월 단독 확장"은 git 분포와 **대체로 정합**. 단 "단독 확장" 중 12월은 FE 팀원 잔여 커밋(suji 32, chaehyun 26)이 있으므로 "12월부터 완전 단독"이라고 말하면 과장됨.
+
+### 팀 구성
+
+- 5인: Backend/Infra 1(본인), AI Researcher 1, Frontend 2, UI/UX 1 `[문서주장: 포트폴리오 페이지]`. AI Researcher(taemin-steve 추정) backend 기여 8커밋(2025-11) `[실측]`.
+
+---
+
+## ④ 핵심 수치 (근거 병기)
+
+### 이력서 주장 3 — SSE 재설계 + k6: **핵심 수치 [실측], 전사(前史) [문서주장]**
+
+| 항목 | 값 | 근거 |
+|---|---|---|
+| 구조 개편 전 병목 | **50 VU**에서 SSE 성능 붕괴: SSE 1개당 RabbitMQ 연결 21개(Celery Events blocking 수신), RabbitMQ 연결 341개, scan-api 메모리 676Mi > 512Mi limit → readiness 실패 → 503 | `[문서주장: docs/blogs/redis-streams-sse/00-architecture-migration.md (2025-12-26)]` |
+| 재설계 | Redis Streams(내구) + Pub/Sub(실시간) + State KV(복구) 3-tier Event Bus, Event Router(XREADGROUP/XCLAIM) + SSE Gateway 분리, 연결 곱폭발 O(client×conn) → 상수화 | `[실측: apps/event_router/, apps/sse_gateway/ 존재]` + `[문서주장: 위 블로그 + README.md:141-149]` |
+| k6 스윕 | VU 500/600/700/800/900/1000 단계별 JSON 결과 파일 12개가 레포 루트에 실존 (2026-01-27) | `[실측: backend/k6-scan-polling-vu{500..1000}-*.json]` |
+| **VU 1000 최종** | submitted 1,518 / completed 1,469 / failed 33 → **success_rate "97.8%"**, throughput 373.4 req/m, **e2e_p95 173.3s**, e2e_avg 121.3s | `[실측: k6-scan-polling-vu1000-2026-01-27T20-06-38-794Z.json]` |
+| VU 900 (권장 한계) | 1,540 submitted, **99.7%**, 405.5 req/m, e2e_p95 149.6s | `[실측: k6-scan-polling-vu900-…json]` |
+| 300s 타임아웃 | `POLL_TIMEOUT = 300000` (5분) 내 완료를 성공으로 판정 | `[실측: e2e-tests/performance/k6-scan-polling-test.js:51]` |
+| 스윕의 실체 | 같은 날 보존된 VU1000 6회는 파일 timestamp 순 **92.5% → 96.6% → 0.0% → 0.0% → 0.0% → 97.8%**다. 선형 개선이 아니라 중간 회귀 뒤 복구한 기록이다. | `[실측: vu1000 JSON 6개 비교]` |
+| 튜닝 내용 | Pub/Sub 채널 job_id 해시 4-shard 샤딩(Hot Key 분산), KEDA minReplicas 1→2/max 3→5(Cold Start), 병목=Celery Probe I/O-bound, OpenAI Tier 4 TPM 61% | `[문서주장: README.md:738-742,796-799]` |
+
+**측정 방법론 주의(면접 대비)**: VU1000 "완료율 97.8%"는 **k6 폴링 방식**(평균 46.4 polls/task, 총 70,432 poll 요청 `[실측: 동일 JSON polling 섹션]`)으로 E2E 완료를 측정한 것. SSE 스트리밍 자체의 부하 스크립트는 별도 존재(`e2e-tests/performance/k6-sse-e2e.js, k6-sse-test.js, locustfile_sse.py` `[실측]`). "동기 SSE 포화 → 이벤트 기반 재설계"는 아키텍처 사실이고, 97.8%는 그 파이프라인의 E2E 처리 완료율.
+
+### 이벤트 버스 발전 계보 — 블로그·포트폴리오·Git 대조
+
+기준 revision은 Eco² backend `4c3eebb3afc3`이다. 블로그는 당시의 문제
+인식과 선택 근거, 포트폴리오는 특정 시점의 요약, Git과 현재 코드는
+실제 착지 상태로 구분해 읽는다.
+
+| 시점 | 관찰한 압력 | 구조 변화 | 증거와 해석 |
+|---|---|---|---|
+| 2025-12-26 | 50 VU에서 활성 SSE 16개가 RabbitMQ 연결 341개를 만들고 scan-api 메모리가 676Mi로 512Mi limit을 초과 | SSE마다 Celery Events receiver를 여는 구조의 연결 증폭을 병목으로 판정 | `docs/blogs/async/23-*`, `redis-streams-sse/00-*`; 1:21은 당시 관측치 |
+| 2025-12-26 | 작업 실행과 진행 이벤트가 같은 RabbitMQ 연결 수명에 결합 | RabbitMQ는 Celery task queue로 남기고, worker 진행 이벤트를 Redis Streams로 이동 | “RabbitMQ 제거”가 아니라 task plane과 event plane 분리 |
+| 2025-12-27~28 | API가 client connection과 event consumption을 함께 소유하면 수평 확장·복구가 어려움 | SSE Gateway 분리, Event Router의 `XREADGROUP → State KV → Pub/Sub → XACK`, Streams catch-up, KEDA·metrics 추가 | `eb407926`, `1fd68f34`, `087f25c4`; Event Bus v1.0.7 |
+| 2026-01-20 | 포트폴리오가 Event Relay 3-tier와 VU 50→300, 포화점 VU 80→500을 기록 | Redis Streams + Pub/Sub + State KV 구조가 중간 성과로 정리됨 | `${HOME}/Downloads/portfolio_류지환.pdf`; 최종 shard·VU1000 이전 snapshot |
+| 2026-01-21~25 | duplicate, publish 실패 뒤 ACK, reconnect gap, stale Pub/Sub, replica 간 Pub/Sub 비복제, hot channel이 드러남 | `stream_id` dedupe, 실패 시 ACK 보류와 `XAUTOCLAIM`, `Last-Event-ID`, master-only Pub/Sub service, job hash 4-shard 도입 | `35268e39`, `a2ef9ae3`, `90604d39`, `97c0a00f`, `9c3297ec` |
+| 2026-01-27~28 | 연결 병목을 제거한 뒤 worker·queue·외부 API가 새 처리 한계가 됨 | queue·pending·connection 신호별 KEDA 조정과 단계별 k6 sweep | VU1000 최종 97.8%는 300초 polling E2E completion이며 SSE throughput이 아님 |
+
+이 계보의 핵심은 브로커 교체가 아니다. **작업 실행, 재생 가능한 이벤트,
+실시간 전달, 복구 상태, client connection의 수명과 확장 신호를
+분리한 것**이다.
+
+### 현재 클러스터의 이벤트 버스 구조
+
+| 평면 | 실제 흐름 | 상태·복구 계약 | 확장 신호 |
+|---|---|---|---|
+| Task | API → RabbitMQ queue → scan/chat worker | RabbitMQ는 작업 오케스트레이션만 소유 | scan worker는 `scan.vision/answer/rule` queue length, 현재 manifest 2–4 pods |
+| Event log | Worker → `scan:events:{0..3}` / `chat:events:{0..3}` | Redis Streams consumer group과 event sequence | Streams Redis exporter |
+| Distribution | Event Router `XREADGROUP` → non-token은 Lua state/idempotency, token은 publish-only → `sse:events:{0..3}` → 성공 시 `XACK` | publish 실패 시 ACK하지 않고 5분 idle 뒤 `XAUTOCLAIM`; state TTL 1h, marker TTL 2h | pending ≥100, Event Router 1–2 pods |
+| Realtime | master-only Redis Pub/Sub → SSE Gateway process-local subscriber queue → client | 초기·재접속 시 State KV와 Streams catch-up, `Last-Event-ID` dedupe | active SSE 100/pod, Gateway 1–3 pods |
+| Control | ArgoCD sync wave 27 Redis Operator → 28 Redis CR → 29–32 RabbitMQ → 35 KEDA → 42 Gateway → 43 Router | `prune/selfHeal`; KEDA가 소유하는 `/spec/replicas`는 ArgoCD diff에서 제외 | desired state와 autoscaling authority 분리 |
+| Observe | Prometheus ServiceMonitor → Grafana Event Bus dashboard, OTEL → Jaeger | connection, lag, batch, publish error, reclaim, queue drop, TTFB 관측 | 관측만 수행하며 실행 권한 없음 |
+
+발표 정확성 경계:
+
+- “3-tier Event Bus”는 **논리적 역할 분리**다. State KV는 별도 세 번째
+  Redis가 아니라 Streams Redis에 함께 있다.
+- Streams Redis는 Pub/Sub보다 재생·consumer recovery가 가능하지만
+  현재 manifest가 `emptyDir`, AOF/RDB off이므로 장기 durable storage로
+  부르지 않는다.
+- README의 scan-worker 2–5 pods보다 현재 ScaledObject의 2–4 pods를
+  우선한다.
+- 일부 config docstring은 `sse:events:{job_id}`로 남았지만 실제
+  `EventProcessor`와 Gateway는 MD5 job hash 기반 4개 shard channel을
+  사용한다.
+
+### Observability를 에이전트의 feedback surface로 만든 외부 루프
+
+2026-01-20 포트폴리오는 GitOps와 동기화된 코드베이스를 사람과
+에이전트가 공유하는 SoT로 두고, 터미널·CLI·Observability로 실제
+클러스터 상태를 읽으며 Foundations·Plans·Reports를 프로젝트 기억으로
+사용했다고 기록한다. 이는 당시 작업 방식의 snapshot이다.
+
+현재 revision의 매니페스트와 애플리케이션 코드는 이 서술이 기대는
+관측면을 다음처럼 구체화한다.
+
+| 관측면 | 현재 코드에 배선된 구성 | 외부 루프에 제공한 신호 | 정확성 경계 |
+|---|---|---|---|
+| Metrics | `kube-prometheus-stack` Prometheus 15일 보존, Grafana, API·RabbitMQ·Redis·Event Router·SSE Gateway exporter와 ServiceMonitor | request/error/latency, RabbitMQ connection·queue, Streams pending·lag, Router process/publish/reclaim, SSE CCU·TTFB·write·queue drop, pod/node resource | Router·Gateway ServiceMonitor scrape 주기는 15초다. dashboard query와 exporter 이름을 맞춘 수정 이력이 있다. |
+| Logs | Fluent Bit DaemonSet → Elasticsearch 8.11 → Kibana | pod·namespace·container가 붙은 구조화 로그, 재시작 전 로그와 event sequence 대조 | 현재 Elasticsearch CR은 **1 node**, 50Gi PVC다. 기존 “3-node EFK” 표현은 사용하지 않는다. |
+| Traces | 애플리케이션 OTEL + Istio → Jaeger, Kiali에서 service graph와 Prometheus·Grafana·trace 연결 | API→MQ→Worker→Event Router→Gateway 구간과 외부 호출의 시간 분해 | 현재 Jaeger는 all-in-one, memory storage, 최대 15,000 traces다. 장기 trace archive로 부르지 않는다. Router·Gateway 기본 sampling은 0.1이다. |
+| Agent trace | chat-worker의 LangSmith tracing과 node·token·cost metadata, optional OTEL export | intent·node·LLM 호출 단위 실행 분석 | Chat Agent에 한정된 application trace다. 클러스터 전체의 운영 메트릭을 대체하지 않는다. |
+| Alert | Pod·node·resource·Redis·ArgoCD·API latency/error PrometheusRule, Slack용 AlertmanagerConfig와 ExternalSecret | 사람이 루프를 시작해야 하는 threshold signal | 코드에는 `configExistingSecret: alertmanager-config`와 `AlertmanagerConfig/slack-alerts`가 함께 있으나 해당 Secret은 저장소에서 확인되지 않는다. Slack 전달이 실제 운영됐다고 단정하지 않는다. |
+
+포트폴리오의 스택 나열보다 발표에서 중요한 것은 **신호가 변경으로
+이어진 절차**다.
+
+```text
+k6 workload / alert
+        ↓
+metric + log + trace + cluster event
+        ↓
+coding agent가 code·manifest·project skill·의사결정 문서를 함께 대조
+        ↓
+병목 가설과 가장 작은 source / manifest diff
+        ↓
+lint·test·CI → Git desired state → ArgoCD reconcile
+        ↓
+같은 workload와 같은 signal family로 재측정
+        ↓
+사람이 keep / revise / revert
+```
+
+에이전트가 읽을 수 있었던 인터페이스도 코드베이스에 남아 있다.
+`.claude/skills/k8s-debugging/SKILL.md`는 원격 클러스터의 node·pod·container
+state, current/previous logs, Kubernetes events, CI job, ArgoCD refresh,
+rollout, image digest를 확인하는 절차를 `Claude Code용`으로 명시한다.
+`docs/blogs/tooling/01-cursor-to-claude-code-migration.md`는 51개 이상의
+로컬 문서와 83개 이상의 블로그를 trigger 기반 skill과 `CLAUDE.md`로
+재구성해 새 세션에도 architecture history를 공급한 과정을 기록한다.
+
+#### 외부 루프가 병목을 이동시킨 두 사례
+
+| 압력과 관측 | 가설 | 변경 | 재측정에서 알게 된 것 |
+|---|---|---|---|
+| 50 VU에서 SSE 16, RabbitMQ connection 341, scan-api 676Mi > 512Mi, readiness 503 | client connection마다 Celery Events receiver를 열어 task transport와 progress delivery 수명이 결합됨 | RabbitMQ는 task queue로 유지하고 progress는 Streams→Router→Pub/Sub→Gateway로 분리 | 연결 곱폭발을 제거한 뒤 queue·worker·외부 API가 다음 병목 후보로 이동 |
+| 단계별 VU sweep에서 queue wait·worker state·probe restart와 OpenAI usage를 함께 대조 | CPU·memory나 OpenAI rate limit보다 I/O-bound Celery worker의 inspect-based probe가 in-flight task를 잃게 함 | KEDA min replica 조정과 probe 병목 진단, Pub/Sub 4-shard 등 부하 표면별 수정 | VU1000 polling E2E completion 97.8%; 100%가 아닌 이유를 33개 probe-timeout failure로 분리 |
+
+첫 사례의 수치는 당시 Prometheus 분석 문서
+`docs/blogs/async/23-sse-bottleneck-analysis-50vu.md`에 남아 있다. 둘째
+사례의 최종 수치는 k6 JSON에서 직접 확인되지만, probe 원인과 OpenAI
+TPM 61% 해석은 `docs/blogs/tests/2026-01-27-scan-load-test-vu1000-final.md`
+및 README의 문서 주장이다.
+
+Git 계보도 이 루프의 순서를 뒷받침한다.
+
+- 2025-12-24~25: RabbitMQ·SSE metric을 세분화하고 병목 분석용 dashboard와
+  HPA를 먼저 추가했다.
+- 2025-12-26~27: Redis Streams, SSE Gateway, Event Router를 도입했다.
+- 2025-12-27~28: Router/Gateway 자체 metric과 ServiceMonitor를 추가하고,
+  dashboard query와 KEDA trigger를 **실제 exporter 이름에 맞게**
+  수정했다.
+- 2026-01-21~25: 중복·ACK·reconnect·Pub/Sub master·channel hot spot을
+  관측한 뒤 recovery와 4-shard 구조를 보강했다.
+- 2026-01-27: VU500–1000 sweep으로 새 포화 지점을 다시 찾았다.
+
+따라서 정확한 발표 문장은 다음과 같다.
+
+> 모니터링을 대시보드 설치로 끝내지 않았습니다. metric·log·trace와
+> 클러스터 event를 코딩 에이전트가 읽을 수 있는 feedback surface로,
+> Git desired state를 검증 가능한 action surface로 만들었습니다.
+> 부하를 재현하고 가장 작은 변경을 반영한 뒤 같은 신호로 다시
+> 측정했으며, 최종 채택 권한은 사람에게 남겼습니다.
+
+이것은 production runtime이 스스로 source를 고치는 자율 self-improvement가
+아니다. **사람과 coding agent가 함께 수행한 외부 engineering loop**다.
+Eco²에서 관측값과 변경 이력은 문서·commit·k6 result로 흩어져 있었고,
+GEODE에서는 이 한계를 trajectory, revision-bound eval artifact,
+keep/revert gate로 구조화한다.
+
+### 시스템의 발전을 제한하고 보호한 guardrail
+
+Eco²의 guardrail은 하나의 승인 버튼이 아니다. 변경, 배포, 실행,
+메시지 정합성, 부하, 관측의 각 층에서 **누가 무엇을 소유하는지**를
+나눈 계약이다.
+
+| 층 | 막으려 한 실패 | 실제 guardrail | 발전 과정과 한계 |
+|---|---|---|---|
+| Change boundary | 에이전트나 운영자가 live cluster만 고쳐 Git과 실제 상태가 갈라짐 | Git branch를 desired state로 두고 ArgoCD `prune/selfHeal`로 reconcile | drift는 복구하지만 manifest 자체의 오류까지 올바르게 만들지는 않는다. dev/prod가 immutable SHA가 아니라 branch를 추적한다는 한계가 있다. |
+| Build boundary | 생성 코드의 문법·형식·단위 회귀, 잘못 렌더링된 manifest | 경로별 CI에서 Black·Ruff·Pytest, infra CI에서 Helm render·chart test·Kustomize build·Kubeconform·render parity | Radon은 설정과 수동 분석 자산이지 현재 blocking CI gate로 확인되지는 않는다. 테스트 통과를 production correctness와 동일시하지 않는다. |
+| Rollout boundary | 검증되지 않은 revision이 stable traffic 전체에 즉시 노출 | stable/canary deployment와 `X-Canary: true` header routing, 별도 canary image tag | 여러 API·worker에 배선됐지만 label·tag 표기가 완전히 균일하지 않다. “전 서비스 자동 promotion”으로 과장하지 않는다. |
+| Runtime boundary | runaway resource, 비정상 process가 계속 traffic을 받음, 불필요한 권한 | request/limit, readiness/liveness, non-root·read-only filesystem, NetworkPolicy | probe는 보호 장치지만 I/O-bound Celery worker에서는 오탐 재시작과 in-flight loss를 만들었다. guardrail 자체도 관측·수정 대상이 됐다. |
+| Scaling boundary | CPU만 보고 늦게 확장하거나 metric 장애 때 0으로 수렴, scale flap | queue/pending/connection 기반 KEDA, min/max replica, metric failure 3회 뒤 fallback 2 replicas, 300초 scale-down stabilization | replica 필드는 KEDA가 소유하고 ArgoCD가 무시한다. desired-state controller와 autoscaler의 권한 충돌을 계약으로 제거했다. |
+| Message integrity | 중복, out-of-order, publish 실패 뒤 ACK로 영구 유실, 재연결 gap | Lua state+published marker, publish 성공 시에만 `XACK`, 5분 idle `XAUTOCLAIM`, `stream_id` dedupe, Last-Event-ID catch-up | at-least-once delivery의 중복을 idempotency로 흡수한다. Streams 저장소가 `emptyDir`라 장기 durability를 보장하지는 않는다. |
+| Detection boundary | 장애가 사용자 503으로 드러날 때까지 원인을 모름 | exporter·ServiceMonitor·Grafana, PrometheusRule, logs, traces, cluster events | threshold와 dashboard는 진단을 시작하게 할 뿐 변경을 승인하지 않는다. Slack alert delivery는 현재 코드만으로 검증되지 않는다. |
+| Release boundary | coding agent가 자신이 만든 가설과 변경을 스스로 승인 | scoped diff → lint/test/CI → Git/ArgoCD → 동일 workload 재측정 → human keep/revise/revert | Eco²에는 GEODE Crucible 같은 formal promotion verdict가 없다. 최종 판정은 사람과 Git history에 남았다. |
+
+가드레일은 장애를 겪으며 다음 순서로 두꺼워졌다.
+
+```text
+desired state / reconcile
+    → runtime health와 resource boundary
+    → task plane과 event plane 분리
+    → idempotency·ACK·reclaim·replay
+    → workload-specific scaling threshold와 fallback
+    → observability를 읽는 agent-assisted outer loop
+```
+
+이 발전사의 핵심은 “안전 장치를 많이 붙였다”가 아니다.
+
+1. **권한 충돌을 줄였다.** Git/ArgoCD는 선언 상태, KEDA는 replica,
+   Event Router는 ACK, 사람은 release를 소유한다.
+2. **실패를 국소화했다.** task 실행, event delivery, recovery,
+   client connection을 분리해 한 영역의 포화가 전체 수명으로
+   증폭되지 않게 했다.
+3. **guardrail의 실패도 관측했다.** VU1000에서 CPU·memory보다 probe
+   오탐이 실패를 만든 사실은 보호 장치도 workload에 맞춰 검증해야
+   한다는 근거가 됐다.
+4. **결정론으로 막을 수 있는 것은 모델에게 맡기지 않았다.** format,
+   unit test, manifest schema, resource ceiling, idempotency, ACK 조건은
+   코드와 controller가 판정했다.
+
+발표에서는 다음 한 문장으로 압축한다.
+
+> 시스템은 에이전트가 자유롭게 고쳐서 발전한 것이 아닙니다. Git,
+> CI, controller, runtime invariant, message contract가 변경 범위를
+> 제한했고, Observability가 그 가드레일의 부작용까지 다시 드러냈습니다.
+> 에이전트는 그 경계 안에서 가설과 작은 변경을 만들고, 사람은 같은
+> workload의 재측정 결과로 채택을 결정했습니다.
+
+### 기타 규모 수치
+
+- 마이크로서비스 19(9 API + 9 Worker + ext-authz), EC2 20노드(vCPU 28/RAM 90GB), RabbitMQ 큐 12/익스체인지 7, NetworkPolicy 21, KEDA ScaledObject 4, ArgoCD sync-wave 16단계(00~63), CI/CD 워크플로 9 `[문서주장: portfolio/eco2/architecture-facts.md — "codebase verified" 자체 명시, apps/ 18개 디렉토리는 실측]`
+- Chat Worker 43,832+ LOC `[문서주장: architecture-facts.md:12]`
+- ext-authz 성능: VU 2500, RPS 1200, p99 200-300ms (Grafana snapshot 링크) `[문서주장: README.md:876]`; RPS 42→1,200 (28×), 캐시 히트 >99% `[문서주장: 포트폴리오 페이지]`
+- README 표기 "24-Nodes"와 architecture-facts "20 EC2" 불일치 존재 — 발표 시 하나로 통일 필요(EC2 20대가 실측 문서 쪽) `[실측: 두 문서 대조]`
+
+---
+
+## ⑤ Agent Workflow 운영 증거 + Data Governance 관점
+
+### 이력서 주장 2 — 평가 파이프라인(Swiss Cheese 3-Tier): **구현 [실측], 운영 상태에 중요한 단서 있음**
+
+- **L1 Code Grader (결정론, 무비용)**: 6개 직교 슬라이스 — format_compliance / length_check / language_consistency(한국어 비율≥0.80) / hallucination_keywords / citation_presence / intent_answer_alignment, 가중치 합 1.0, 목표 지연 <50ms, 외부 의존성 없음 `[실측: apps/chat_worker/application/services/eval/code_grader.py:1-49]`
+  - hallucination blocklist 12항목("100% 안전", "제 생각에는" 등), citation 패턴(환경부/출처:/※ 등) `[실측: code_grader.py:52-90]`
+- **L2 LLM Judge (BARS 루브릭)**: 5축 BARS — faithfulness 0.30 / relevance 0.25 / completeness 0.20 / safety 0.15 / communication 0.10 `[실측: domain/services/eval_scoring.py:27-34]`
+  - **위험물 intent 시 safety 0.15→0.25 동적 부스트** `[실측: eval_scoring.py:36-42 HAZARDOUS_WEIGHTS]`
+  - positional bias 완화를 위한 축 순서 셔플, Structured Output retry-with-repair 최대 2회 `[실측: infrastructure/llm/evaluators/bars_evaluator.py:100-102, :37]`
+  - BARS 2·4의 경계 축은 3회 추가 평가 뒤 중앙값 채택 `[실측: application/services/eval/llm_grader.py:28-29, 144-188]`
+  - 평가 모델 기본값 `gpt-4o-mini`, LLM 점수 부재 시 code-only degraded mode `[실측: application/dto/eval_config.py:43, score_aggregator.py:_aggregate_code_only]`
+  - 등급: S[90,100] / A[75,90) / B[55,75) / C[0,55) `[실측: domain/enums/eval_grade.py:15-31]`; C등급 재생성은 `eval_regeneration_enabled` 플래그(기본 False) `[실측: eval_config.py:42]`
+- **L3 Calibration Monitor (judge 자체 점검)**: CUSUM 양방향 누적합, slack k=0.5, CRITICAL h=4.0(~3σ), WARNING 2.4(~2σ), 기대평균 3.0, 최근 N=50 표본, 축별 독립 감시 `[실측: application/services/eval/calibration_monitor.py:34-74]`
+  - **Calibration set**: JSON 수동 큐레이션(`calibration_set.json` v1.0-2026-02-10) — 샘플 **8개**, 필드 query/intent/context/reference_answer/**human_scores**/**annotator_agreement**, `min_kappa` 포함, 포함 기준 Cohen's kappa ≥ 0.6 `[실측: git show d344a9ea:…/calibration_set.json + docs/plans/chat-eval-pipeline-plan.md:453]`
+- **eval subgraph**: eval_entry → Send API 병렬(code_grader ∥ llm_grader ∥ calibration_check) → eval_aggregator → eval_decision `[실측: infrastructure/orchestration/langgraph/eval_graph_factory.py:8-21 + factory.py:109-111 main graph 배선]`
+- **점수의 정확한 의미**: full mode의 0–100은 L2 BARS 가중합이다. L1은 독립 진단과 개선 hint로 보존되고 L2 점수가 없을 때만 code-only 점수로 대체된다. L3는 각 답변의 세 번째 점수가 아니라 judge drift 신호다. 따라서 세 layer를 단일 점수의 직렬 합산으로 설명하지 않는다. `[실측: score_aggregator.py:80-136, eval_graph_factory.py:420-462]`
+- **품질 게이트 프로세스**: 설계 리뷰 5라운드 69.4 → 89.2 → 95.4 → 98.8 → **99.8/100** (2026-02-09), 구현 리뷰 97.1, 테스트 165개(단위 148+통합 17) 전수 통과, PR #545/#546 merge `[문서주장: docs/plans/chat-eval-pipeline-review.md:9-15, docs/reports/chat-eval-pipeline-implementation-report.md; PR #546 merge 커밋 1a5463a7은 실측]`
+
+### ⚠ 정직성 단서 (발표에서 과장 금지)
+
+1. eval 기본값이 서로 충돌한다. DTO의 `enable_eval_pipeline`은 `False`지만 runtime `Settings`는 `True`이고, dependency 조립부는 후자를 DTO에 전달한다. 배포 manifest에서 명시적 override는 발견되지 않았다. 따라서 "기본 비활성(opt-in)"으로 단정할 수 없으며, "현재 main의 활성 경로는 아래 조립 불일치 때문에 운영 가능 상태가 아니다"가 정확하다. `[실측: application/dto/eval_config.py:38, setup/config.py:125, setup/dependencies.py:912-955]`
+2. `recalibrate()`는 **stub** — HITL 재교정 인프라 미구축(경고 로그만) `[실측+문서주장: impl report "recalibrate() stub — HITL 인프라 미구축", calibration_monitor.py 주석 "재교정 시 사용 (현재 미구현)"]`
+3. persistence adapter 5종 + calibration_set.json을 추가한 커밋 **922a9e74, d344a9ea는 feat/chat-eval-pipeline 브랜치에만 있고 main 미머지**다. 더구나 `get_chat_graph()`는 현재 `create_chat_graph()` 시그니처에 없는 `eval_counter`를 넘기며, 내부 subgraph 호출에도 counter를 전달하지 않는다. runtime 기본값이 True인 상태에서 ModuleNotFoundError 또는 TypeError가 날 수 있으므로 eval은 "응답 평가 계약 구현·부분 통합"으로만 소개한다. `[실측: git branch --contains + git ls-tree main + setup/dependencies.py:1222 + factory.py:196-238, 659-666]`
+4. calibration 8샘플은 CUSUM N=50 요구 대비 통계적으로 얇음 — "초기 시드셋" 프레임이 정직.
+5. eval 파이프라인은 **2026-02 작업**(수상 이후 확장기 산출물). 해커톤 수상 기능으로 소개하면 안 됨.
+6. Krippendorff α≥0.75, Expert Review "99.8/100" 등 포트폴리오 페이지 수치 일부는 로컬 근거 문서와 지표 이름이 다름(plan은 Cohen's kappa ≥0.6) — 발표에는 레포 실측치만 사용 권장.
+
+### 데이터 자산·로그 (Data Engineer 직무 연결 소재)
+
+- **도메인 데이터 taxonomy**: `item_class_list.yaml` **86개 품목**(재활용/종이/종이팩… 계층형) `[실측: apps/chat_worker/infrastructure/assets/data/item_class_list.yaml, grep 카운트 86]`, `situation_tags.yaml`(80개 상황 `[문서주장: README.md:138]`), 분리배출 규정 JSON **18종**(대형폐기물/음식물/재활용_플라스틱류 등) `[실측: apps/scan_worker/infrastructure/assets/data/source/ 18파일]` — scan_worker/chat/chat_worker 3곳에 동일 자산 복제 배포 `[실측: find 결과]`
+- **평가 이력 영속화**: V005 migration으로 eval schema DDL, EvalResult에 model_version / prompt_version(**루브릭 git SHA**) / eval_duration_ms / eval_cost_usd / calibration_status 기록 `[실측: d344a9ea --stat + score_aggregator.py aggregate() 시그니처]`
+- **로그 파이프라인**: Fluent Bit(DaemonSet) → Elasticsearch(현재 CR 1-node, 50Gi PVC) → Kibana, JSON 구조화 로그와 K8s 메타데이터 `[실측: workloads/logging/base/{fluent-bit,elasticsearch,kibana}.yaml]`
+- **트레이싱**: LangSmith(LangGraph 트레이스) + OpenTelemetry E2E + Jaeger, aio-pika/OpenAI/Gemini instrumentation `[문서주장: README.md:343,446-451]`
+- **멱등성/유실 방지**: Event Router Lua script 멱등 마킹(TTL 7200s), ACK 정책 수정(실패 시 XACK 스킵→Reclaimer 재처리), P0 데이터 유실 버그 자체 발견·수정 리포트 `[문서주장: docs/reports/event-router-improvement-report.md — P0: consumer.py:216-223 process_event 실패에도 ACK→영구 유실]`
+
+---
+
+## ⑥ 시각 자산 후보
+
+| 자산 | 위치 | 용도 |
+|---|---|---|
+| LangGraph StateGraph mermaid (draw_mermaid 산출, intent→router→10노드→aggregator→answer) | backend/README.md:189-242 | **주장 1의 핵심 다이어그램** — 그대로 재작도 |
+| Eval subgraph 구조 (Send API 병렬 3-grader) | eval_graph_factory.py:8-21 docstring | 주장 2 다이어그램 |
+| SSE 포화→재설계 before/after (연결 곱폭발 1:21 → Event Bus) | docs/blogs/redis-streams-sse/00-architecture-migration.md | 주장 3 문제-해결 서사 |
+| Token Streaming Event Bus mermaid (XADD→XREADGROUP→PUBLISH→SSE) | README.md:248-304 | 주장 3 아키텍처 |
+| Scan E2E flow mermaid (Celery Chain 4단계) | README.md:61-131 | 파이프라인 소개 |
+| Checkpoint 아키텍처 mermaid (Redis Primary + PG Sync, 192→8 conn) | README.md:357-391 | 심화 질문 대비 |
+| k6 스윕 결과 표 + 원본 JSON 12개 | README.md:155-162 + backend 루트 k6-*.json | 수치 신뢰성 증빙(원자료 보유 어필) |
+| 서비스 아키텍처 전경 이미지 / GitOps 이미지 | README.md:23, :720 (github user-attachments) | 오프닝 슬라이드 |
+| 수상 사진 | frontend/README.md:21 | 도입부 |
+| 데모 영상 | [Eco² 서비스 시연](https://youtu.be/aFtb-oPv2Bo) | 서비스 시연 |
+| 기존 발표덱 PPTX | backend/portfolio/eco2/eco2-portfolio-html.pptx (+build_pptx.py) | 재활용 소스 |
+| 실측 팩트 시트 | backend/portfolio/eco2/architecture-facts.md | 수치 SoT |
+| Grafana ext-authz snapshot | README.md:876 링크 | 성능 스크린샷 |
+
+---
+
+## ⑦ 예상 질문 소재 (약점 포함)
+
+1. **"팀 프로젝트인데 단독 확장이 무슨 뜻?"** → git으로 답: backend HEAD 2,277개 중 후보자 별칭 2,180개, 다른 팀원 9개, 자동화 88개. FE는 1월부터 인수(본인 12월 7→1월 157커밋, 타 FE 팀원 12월 종료). "12월까지는 FE 팀원 활동이 있었고, 1월부터 4개 영역 단독"이 정확한 표현. `[실측]`
+2. **"평가 파이프라인 실제로 돌고 있나?"** → 정직 답변 필수: PR #546으로 grader·subgraph·DI 중심부는 main에 병합됐지만 runtime 설정 기본값과 DTO가 충돌하고, persistence adapter·calibration asset은 branch에만 있으며 `eval_counter` 인자가 graph factory 경계에서 끊긴다. async fire-and-forget도 feature branch에만 있고 recalibrate는 HITL 미구축 stub이다. "운영 상시 활성"이나 "main에서 즉시 실행 가능"이라고 답하면 코드로 반박당함.
+3. **"97.8%는 뭘 어떻게 잰 수치인가?"** → k6 폴링 기반 E2E 완료율(300s 타임아웃, VU1000, 1,469/1,518), SSE 스트리밍 별도 스크립트 존재. 같은 날의 시간순 보존본은 92.5%→96.6%→0%×3→97.8%이며, 선형 튜닝 성공이 아니라 회귀 탐지와 복구 증거로만 사용한다.
+4. **"LLM judge를 어떻게 믿나?"** → L1 결정론 게이트 + BARS 루브릭 + 축 셔플(편향 완화) + CUSUM 드리프트 감시 + human_scores 기반 calibration set. 약점: 샘플 8개, kappa 실측 기록 없음 → "시드셋 단계, 확장 설계 완료"로 방어.
+5. **"intent 10개는 어떻게 정했나?"** → 도출 과정의 데이터 근거는 레포에 없음[미검증]. 서비스 도메인 분석 + 외부 API 단위로 설계했다는 서사로 답하고, "관찰"을 정량 주장으로 만들지 말 것.
+6. **"위험물 안전은?"** → HAZARDOUS_WEIGHTS(safety 0.25 부스트) + hallucination blocklist가 준비된 답변. `[실측]`
+7. **"데이터 품질 관리(직무 연결)"** → 86품목 taxonomy + 18종 규정 JSON의 버전/출처 관리, 3개 앱에 자산 복제 배포(동기화 리스크) — 스스로 한계 언급하면 governance 감수성 어필.
+8. **"격리 실행 환경 경험은?"(직무 요구)** → Eco²에 코드 샌드박스는 없음. K8s taint 기반 노드 격리(worker-ai/worker-storage NoSchedule `[문서주장: README.md:707-709]`) + NetworkPolicy 21종으로 실행 격리 개념 연결 가능.
+9. **수치 불일치 리스크**: README "24-Nodes" vs architecture-facts "20 EC2"; 포트폴리오 페이지 "9 intent/11 subagent" vs 코드 10 intent — 발표 자료는 **코드 실측치(10 intent, EC2 20)**로 통일할 것.
+10. **비용/생산성 수치**(Cursor 76일, 10.66B tokens, $7,473; 커밋 10.2K 등)는 포트폴리오 페이지 주장으로 로컬 근거 미확인 `[미검증]` — PT에서 쓰려면 원자료 확보 후 사용.

--- a/.claude/skills/stanford-test-time-compute/references/lecture-analysis.md
+++ b/.claude/skills/stanford-test-time-compute/references/lecture-analysis.md
@@ -1,0 +1,846 @@
+# Stanford CS329A Test-Time Compute Scaling Part 2
+
+| 항목 | 값 |
+|---|---|
+| 수집·검증일 | 2026-08-05 |
+| 원본 | [Stanford CS329A Self-Improving AI Agents · Part 2](https://www.youtube.com/watch?v=-Ggc37xLj_Y) |
+| 강의 시점 | 2025-09-26, Stanford CS329A Lecture 2 |
+| 공개 시점 | 2026-08-03, Stanford Online |
+| 강연자 | Azalia Mirhoseini |
+| 길이 | 63분 20초 |
+
+## 한 문장 결론
+
+`[해석]` Test-time compute는 모델에게 단순히 더 긴 추론을 허용하는 기법이
+아니다. 같은 문제를 넓게 탐색하는 `candidate width`, 한 후보를 연속 수정하는
+`revision depth`, 후보를 가르는 `verification`, 연산자 조합 자체를 찾는
+`inference-program search`를 과제 난도·비용·검증 가능성에 맞춰 배분하는
+실행 정책이다.
+
+강의의 핵심 경고는 더 짧다.
+
+> 후보가 늘면 oracle coverage는 상승한다. 그러나 verifier가 희소한 정답을
+> 식별하지 못하면 delivered correctness는 포화한다.
+
+## 조사 방법과 증거 경계
+
+이번 문서는 1시간 전체를 다음 자료로 교차 확인했다.
+
+- 로컬 MP4 전 구간 재생과 60초 간격 contact sheet 6장
+- YouTube 자동 영문 자막 4,120행 전체
+- Stanford CS329A 공식 syllabus와 Lecture 2 지정 논문 4편
+- 논문 최신 arXiv abstract와 강의에서 제시된 도식·수치의 버전 차이
+
+자동 자막은 시간 탐색과 논리 전개 복원에만 사용했다. 수식·수치·논문 결론은
+가능한 범위에서 원문으로 재검증했다. 질문 구간의 청중 발언, 화면의 작은 수치,
+자동 자막이 불명확한 표현은 정량 claim으로 승격하지 않았다.
+
+`[직접근거]` 자동 자막의 단순 단어 수는 8,496개로 약 134 WPM이다. 강의는
+10–15분의 논증 뒤 2–7분 질문 구간으로 호흡을 낮추며, 문제 제기→메커니즘
+도식→실험 그래프→한계→다음 추상화 순서를 반복한다.
+
+AI-assisted source review를 사용했으며, 아래 `[직접근거]`, `[외부연구]`,
+`[해석]` 표시는 강의 관찰, 논문 근거, 프로젝트 적용 판단을 구분한다.
+
+## 로컬 보존
+
+- 영상: `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.mp4`
+- 자동 자막: `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.en-j3PyPqV-e1s.vtt`
+- 메타데이터: `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.info.json`
+- 리듬 manifest: `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/rhythm-manifest.json`
+- contact sheet: `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/`
+
+| 파일 | SHA-256 |
+|---|---|
+| 영상 | `98b756b08dd5dd18fa9b067126ce7e4b33abb50e1315b4455b91b0b6be734833` |
+| 자동 자막 | `06aac8e835910d682836c4ccde52e57ab06fb0cd30dac160c567173a35734639` |
+| 리듬 manifest | `10665f685c4fb3eb22bdbe8a57745539b002e84902c59eccc87c75354043fbff` |
+
+## 63분 전체 전개 지도
+
+| 시간 | 전개 | 전달된 판단 |
+|---:|---|---|
+| 00:00–01:11 | pre-training·fine-tuning·inference 구분 | weight update 없이 inference budget으로 utility를 높이는 세 번째 scaling 축을 연다. |
+| 01:11–04:39 | Large Language Monkeys | 같은 문제의 반복 샘플이 최소 한 번 성공할 확률, 즉 coverage를 키운다. |
+| 04:44–11:20 | inference scaling law | task별 지수 감소와 전체 benchmark의 power law가 heavy-tailed 난도 분포로 함께 설명된다. |
+| 11:20–12:17 | compute paradigm shift | inference는 더 이상 무시 가능한 단일 호출 비용이 아니며, long-running·offline agent의 계산 축이 된다. |
+| 12:20–19:22 | generation–verification gap | 자동 검증이 없으면 majority vote와 reward model selection이 oracle coverage를 회수하지 못한다. |
+| 19:24–26:55 | verifier 연구 공간 | simulation, negative filtering, ensemble, tool grounding은 verifier를 보강하지만 비용·gaming·불완전성도 만든다. |
+| 26:55–31:22 | parallel 대 sequential | 독립 후보의 폭과 이전 결과를 조건으로 한 수정 깊이는 다른 search operator다. |
+| 31:22–35:57 | ORM·PRM·beam search | 최종 답 점수와 중간 reasoning step 점수를 구분하고 process verifier로 분기를 잘라낸다. |
+| 36:00–42:59 | compute-optimal allocation | task difficulty에 따라 폭·깊이·선택기를 바꾸는 adaptive allocation이 고정 best-of-N보다 효율적이다. |
+| 43:00–45:47 | pretraining 대 inference | base policy가 답의 지지집합을 갖는 영역에서 test-time compute가 유효하며, 가장 어려운 문제에는 큰 모델이 남는다. |
+| 45:47–48:53 | Archon 문제 정의 | 모델·연산자·예산·benchmark가 주어질 때 inference architecture 자체를 최적화한다. |
+| 48:53–54:18 | operator catalog | generate·rank·critic·fuse·verify·unit-test 연산자를 prompt-based module로 구성한다. |
+| 54:18–60:01 | layered architecture | top-k filtering, fusion, coding-specific test path, deeper composition의 task별 효과를 비교한다. |
+| 60:01–63:15 | ITAS와 결과 | 제약된 탐색공간을 Bayesian optimization으로 탐색하며 general-purpose와 task-specific architecture를 분리한다. |
+
+## 1. Repeated sampling은 정답 생성 확률을 확장한다
+
+### Coverage와 delivered accuracy를 먼저 갈라야 한다
+
+`[외부연구]` Large Language Monkeys가 측정한 `coverage`는 주어진 문제에 대해
+생성한 후보 중 하나라도 정답인 비율이다. 이는 사용자가 실제로 받는 정답률과
+같지 않다. 정답 후보가 존재해도 selector가 그것을 고르지 못할 수 있기 때문이다.
+
+문제 `i`의 독립 1회 성공 확률을 `p_i`, 샘플 수를 `k`라고 두면 oracle이 보는
+성공 확률은 다음과 같다.
+
+```text
+P_i(pass@k) = 1 - (1 - p_i)^k
+```
+
+따라서 `p_i > 0`인 문제는 같은 분포에서 독립 시도를 늘릴수록 실패 확률이
+지수적으로 감소한다. 이 식은 세 가지 가정을 포함한다.
+
+1. 샘플 간 상관이 낮다.
+2. 정답이 base policy의 proposal support 안에 있다.
+3. oracle 또는 충분히 강한 verifier가 정답을 식별할 수 있다.
+
+`[외부연구]` SWE-bench Lite에서는 DeepSeek-Coder-V2-Instruct가 1회 표본의
+15.9%에서 250회 표본의 56% coverage로 상승했다. 자동 검증 가능한 coding과
+formal proof에서는 이 coverage를 실제 성능으로 회수할 수 있다.
+
+`[해석]` 반복 호출은 모델을 학습시키지 않는다. 같은 policy의 확률 질량을 더
+많이 탐색할 뿐이다. `p_i ≈ 0`이면 샘플 수만 늘려도 답이 나오지 않으며,
+retrieval·tool·prompt·model·fine-tuning 중 proposal distribution을 바꾸는 조치가
+필요하다.
+
+### 왜 benchmark 전체에서는 power law처럼 보이는가
+
+`[외부연구]` 개별 문제의 실패는 지수적으로 줄지만 benchmark 평균은
+power law처럼 보일 수 있다. `How Do Large Language Monkeys Get Their Power
+(Laws)?`는 single-attempt success probability가 heavy-tailed일 때 극소수의 매우
+어려운 문제가 aggregate curve를 지배한다고 설명한다.
+
+```text
+per task:        failure_i(k) = (1 - p_i)^k
+task mixture:    many moderate p_i + a long tail of near-zero p_i
+aggregate:       slow power-law-like decay
+```
+
+이 관점은 평균 점수만 보는 대신 `p_i` 분포의 꼬리를 보게 한다. 쉬운 문제는
+소수 샘플로 포화하고, 어려운 문제는 수백·수천 회에서도 희소한 정답 하나만
+만들 수 있다. 논문은 이 분포를 이용하면 scaling exponent 예측에 필요한
+inference compute를 크게 줄일 수 있다고 보고한다.
+
+## 2. Verification이 compute를 capability로 바꾼다
+
+### 자동 검증이 강한 도메인
+
+강의는 다음 과제를 verifier가 강한 예로 든다.
+
+| 도메인 | 외부 신호 | 주의점 |
+|---|---|---|
+| formal proof | proof checker | formalization 범위 밖의 의미 오류는 잡지 못한다. |
+| code generation | executable unit tests | coverage가 불완전하면 overfit·gaming이 가능하다. |
+| program translation | semantic·behavioral equivalence | 관측되지 않은 동작과 환경 차이를 분리해야 한다. |
+| GPU kernel generation | reference output·correctness test | 수치 허용오차와 성능 목표를 별도 계약으로 둬야 한다. |
+
+`[해석]` verifier의 본질은 자연어 비평이 아니라 후보와 환경 사이의 외부
+상태 차이를 측정하는 데 있다. GEODE의 tool result·final state·native receipt가
+text critique보다 중요한 이유와 같다.
+
+### Generation–verification gap
+
+`[외부연구]` 자동 verifier가 약한 수학·자연어 과제에서는 majority voting과
+reward-model ranking이 수백 개 이후 포화한다. 어려운 문제의 정답이 1,000개
+중 1–3개뿐이면 majority는 오답 군집을 선택한다. Reward model 역시 학습 분포와
+다른 희소 정답을 낮게 평가할 수 있다.
+
+```text
+generated set ── oracle ──> coverage
+       │
+       └── weak selector ──> delivered accuracy < coverage
+```
+
+이 차이가 generation–verification gap이다. 후보를 더 생성하는 것은 상단 선을
+올리지만, verifier가 고르지 못하면 하단 선은 움직이지 않는다.
+
+### 강의가 열어 둔 verifier 연구 공간
+
+19–27분 질문 구간은 다음 가능성과 한계를 함께 다룬다.
+
+- retrieval·knowledge graph로 candidate quality와 검증 근거를 보강한다.
+- 잘못됐음을 증명하기 쉬운 후보를 먼저 제거하는 negative filtering을 쓴다.
+- simulator·compiler·database·domain tool을 결과 verifier로 쓴다.
+- 서로 다른 약한 judge를 ensemble해 편향을 낮춘다.
+- unit test를 늘리되 test coverage와 generated-test gaming을 별도 위험으로 본다.
+- 모델이 답하기 전 자료를 탐색하거나 self-study하게 해 proposal support를 바꾼다.
+
+`[해석]` 이 구간은 verifier 문제가 해결됐다는 보고가 아니다. 다음 강의가
+`Robust Verification`으로 편성된 이유처럼, test-time scaling이 verifier에
+의존한다는 병목을 노출한다.
+
+## 3. Compute budget은 폭과 깊이에 다르게 쓰인다
+
+### Parallel width
+
+같은 입력에서 독립 또는 다양화된 후보를 여러 개 생성한다.
+
+```text
+x ─┬─> y1
+   ├─> y2 ──> selector ──> y*
+   ├─> y3
+   └─> yN
+```
+
+- 장점: 서로 다른 해법을 탐색하고 rare success coverage를 높인다.
+- 조건: 후보 다양성과 강한 verifier가 필요하다.
+- 비용: N에 비례한 호출·token·latency·selection 비용이 든다.
+- 실패: 상관된 후보, 약한 verifier, 답이 proposal support 밖에 있는 경우다.
+
+Best-of-N은 후보를 N개 만든 뒤 가장 높은 점수 하나를 선택한다. `pass@N`은
+oracle coverage 지표이고, `best-of-N accuracy`는 실제 selector를 거친 지표다.
+둘은 같은 수치가 아니다.
+
+### Sequential depth
+
+이전 응답과 feedback을 다음 생성의 조건으로 넣어 proposal distribution을
+업데이트한다.
+
+```text
+y0 ── feedback ──> y1 ── feedback ──> y2 ──> stop
+```
+
+- 장점: 부분적으로 맞는 답을 국소 수정하고 일관성을 유지한다.
+- 조건: 오류 위치를 알려주는 process signal 또는 외부 observation이 필요하다.
+- 비용: 단계가 직렬이므로 wall-clock latency가 누적된다.
+- 실패: 잘못된 초안에 고착되거나 verifier 편향을 반복 강화할 수 있다.
+
+`[해석]` 긴 CoT는 feedback 없이 token만 늘릴 수 있다. Sequential revision의
+핵심은 길이가 아니라 `이전 action → 외부 observation → 다음 proposal`의
+조건부 상태 전이다.
+
+### ORM과 PRM
+
+| 구분 | 평가 단위 | 쓰임 | 한계 |
+|---|---|---|---|
+| Outcome Reward Model | 최종 응답 | best-of-N의 최종 선택 | 어느 중간 단계에서 틀렸는지 알려주지 않는다. |
+| Process Reward Model | reasoning step | beam 확장·가지치기 | step annotation과 domain transfer가 어렵다. |
+
+PRM-guided beam search는 각 단계에서 자식 후보를 만들고 PRM 점수로 상위 분기를
+남긴다. 이는 parallel과 sequential이 합쳐진 구조다. 동일 budget에서도 beam
+width, branch factor, depth를 어떻게 배분하느냐에 따라 성능이 달라진다.
+
+## 4. Compute-optimal scaling은 task-conditioned scheduling이다
+
+`[외부연구]` Snell et al.은 고정된 non-trivial inference budget에서 다음 두
+방식을 분석한다.
+
+1. dense process-based verifier를 이용한 search
+2. 이전 응답에 따라 response distribution을 갱신하는 adaptive revision
+
+핵심 결과는 단일 연산자가 항상 우월하지 않다는 것이다. 효과는 prompt
+difficulty에 따라 바뀌며, 난도별로 compute를 배분하는 전략은 best-of-N보다
+4배 이상 효율적일 수 있다. 작은 모델이 이미 non-trivial success rate를 갖는
+문제에서는 FLOP을 맞췄을 때 14배 큰 모델을 넘는 경우도 보고한다.
+
+강의의 실험 전개는 다음과 같다.
+
+- MATH 문제를 pass@1 추정치로 5개 난도 bin에 나눈다.
+- parallel sampling, sequential revision, 두 방식의 혼합을 비교한다.
+- 같은 target accuracy에 필요한 generation budget을 비교한다.
+- 쉬운 문제와 어려운 문제에서 최적 allocation이 달라짐을 확인한다.
+- 같은 FLOP에서 더 큰 모델과 작은 모델+test-time compute를 비교한다.
+
+`[해석]` 실서비스의 compute policy는 `N` 하나가 아니라 다음 조건부 결정이다.
+
+```text
+π_B(x) = choose(width, depth, selector, stop)
+         subject to budget, latency, risk, verifier confidence
+```
+
+이는 강의 수식의 재현이 아니라 시스템 설계용 요약이다. 입력 난도와 verifier
+confidence를 추정하고, 조기 종료·수정·병렬 탐색·handoff 중 하나를 선택한다.
+
+### 실무 의사결정 표
+
+| 관측 상태 | 우선 compute policy | 종료 조건 |
+|---|---|---|
+| 쉬운 과제, verifier confidence 높음 | single pass 또는 early exit | 계약 통과 |
+| 부분 정답, 수정 위치 관측 가능 | sequential repair | improvement 정체 또는 pass |
+| 해법 다양성 큼, deterministic verifier 존재 | parallel sampling·beam | marginal coverage 감소 |
+| 후보가 상보적이고 ranker가 강함 | rank top-k 후 fuse | fusion gain 소멸 |
+| base success가 거의 0 | model·retrieval·tool 변경 | sampling 확대 금지 |
+| verifier 약함, side effect 위험 높음 | 행동 축소·human handoff | authority 확인 |
+
+### Pretraining과 test-time compute는 대체재가 아니다
+
+`[외부연구]` 쉬운·중간 문제에서는 작은 모델에 inference compute를 더 쓰는 편이
+효율적일 수 있다. 가장 어려운 문제에서는 큰 모델의 proposal distribution이
+필요하다. 또한 pretraining compute는 여러 요청에 amortize되지만 test-time
+compute는 각 요청마다 다시 지불한다.
+
+따라서 비교에는 최소한 다음 네 항목이 필요하다.
+
+- task distribution과 호출 빈도
+- token·FLOP·API 비용
+- latency와 병렬 실행 capacity
+- verifier·selection 비용과 실패 위험
+
+## 5. Archon은 inference operator의 조합을 탐색한다
+
+### 입력과 출력
+
+`[외부연구]` Archon은 다음 조건에서 inference architecture를 찾는다.
+
+```text
+target benchmark + available LLMs + call/token budget + operator catalog
+                              │
+                              ▼
+             inference-time architecture search
+                              │
+                              ▼
+             layered inference program on a Pareto frontier
+```
+
+Search 결과는 새로운 model weight가 아니라, 어떤 모델과 연산자를 어떤 순서와
+폭으로 호출할지 정한 inference program이다.
+
+### 연산자 카탈로그
+
+| 연산자 | 입력→출력 | 역할 |
+|---|---|---|
+| Generator | prompt→candidate set | 반복 샘플링과 모델 다양성 |
+| Critic | candidate→strengths·weaknesses | 후속 수정·융합 근거 생성 |
+| Ranker | candidates→ordered top-k | selector budget 축소 |
+| Fuser | top-k candidates→synthesized answer | 여러 후보의 상보 정보 결합 |
+| Verifier | answer→validity signal | reasoning·instruction 후보 판정 |
+| Unit Test Generator | coding task→tests | coding-specific evaluation surface 생성 |
+| Unit Test Evaluator | candidate+tests→score | 후보가 test를 통과하는지 평가 |
+
+이 모듈은 대부분 prompt-based component다. 별도 weight training을 전제하지 않고
+기존 LLM을 호출해 역할을 수행한다.
+
+### 49분 표를 프로젝트에 적용하는 판정 규칙
+
+`[외부연구]` 이 일곱 이름은 모두 한 instruction에 대한 candidate response를
+만들고, 비평하고, 정렬하고, 합성하거나 판정하는 inference-time contract다.
+컴포넌트 이름이 비슷하다는 이유만으로 다른 제어 평면에 같은 이름을 붙이지 않는다.
+
+| 판정 | 기준 |
+|---|---|
+| 직접 구현 | 입력·출력과 결정 대상이 Part 2 operator와 같은 candidate-response 평면이다. |
+| 기능 대응 | 유사한 판단을 하지만 scenario·runtime state·revision 등 다른 대상을 다룬다. |
+| 의도적 부재 | 독립 operator가 없거나, side effect·권한 경계 때문에 두지 않았다. |
+
+따라서 context block을 순서대로 조립하는 `ContextAssembler`는 Fuser가 아니고,
+baseline과 candidate 중 named state를 정하는 gate는 Ranker가 아니다. Tau²·Petri·
+MCPMark처럼 환경을 실행한 evaluator도 Archon의 model-judged Unit Test Evaluator와
+기능은 닮았지만 같은 연산 계약은 아니다.
+
+### 왜 select가 아니라 fuse까지 필요한가
+
+Ranker는 기존 후보 하나를 고르므로 oracle candidate ceiling을 넘을 수 없다.
+Fuser는 서로 다른 후보의 부분 정보를 새 답으로 합칠 수 있어 그 ceiling을 넘을
+수 있다. 강의는 모든 후보를 한 번에 fuse하기보다 ranker로 top-k를 줄인 뒤
+fuse하는 편이 유리한 결과를 보여준다.
+
+`[외부연구]` 최신 arXiv v6 abstract는 instruction following·reasoning·coding에서
+Archon이 지정 baseline보다 평균 15.1% 향상했다고 적는다. 강의 화면·발화의
+14.1%와 차이가 있으므로 발표에서 수치를 사용할 때는 논문 버전을 함께 표기해야
+한다.
+
+### ITAS의 search contract
+
+Archon은 조합 폭발을 그대로 탐색하지 않는다. 강의에서 제시된 제약은 다음과
+같다.
+
+- 첫 layer는 generator다.
+- 한 layer에는 한 operation type을 둔다.
+- critic은 ranker·fuser보다 앞선다.
+- unit-test generator 뒤에는 evaluator가 온다.
+- 허용 model, layer, call budget을 미리 제한한다.
+
+그 위에서 Bayesian optimization으로 architecture 후보를 고른다. Greedy와
+random search보다 적은 평가로 좋은 조합을 찾는 것이 목적이다. Task-specific
+architecture와 여러 benchmark를 평균한 general-purpose architecture를 별도로
+다룬다.
+
+### Archon 결과를 읽을 때 남겨야 할 한계
+
+- benchmark에서 고른 architecture가 production distribution에도 최적이라는
+  보장은 없다.
+- 많은 layer와 endpoint는 token cost뿐 아니라 5배 이상의 latency를 만들 수
+  있다.
+- 7B급 모델 조합은 70B+ 조합보다 약한 결과를 보였다.
+- model-generated unit-test evaluation은 실제 test execution과 같지 않다.
+- train·held-out benchmark split은 architecture selection의 과적합을 줄이는
+  장치이며, SIL의 mutation-hidden set과 동일한 계약이 아니다.
+- Archon은 offline inference-program search다. 온라인 self-modification이나
+  DGM으로 부르면 안 된다.
+
+## 6. 강의를 하나의 시스템 모델로 합치면
+
+강의의 네 층은 중첩되지만 같은 축이 아니다.
+
+```text
+Layer A · within trajectory
+  sequential revision / repair depth
+
+Layer B · across candidates
+  parallel sampling / beam width / rank / fuse
+
+Layer C · across inference programs
+  offline search over operator composition
+
+Orthogonal · measurement
+  repeated trials for variance and confidence
+
+Outside lecture · authority
+  which evidence may change runtime, scaffold, release state
+```
+
+`[해석]` 모델 능력으로 전환되는 test-time compute는 다음 곱에 가깝다.
+
+```text
+usable capability
+≈ proposal support × search allocation × verifier quality × task fit
+```
+
+어느 항 하나가 0에 가까우면 호출 수만 늘려도 실효 성능은 오르지 않는다. 특히
+verifier가 약하면 compute가 reward hacking과 selection error까지 확대할 수 있다.
+
+## 7. Eco²·GEODE runtime·Seed·SIL·Crucible의 operation map
+
+### 먼저 한눈에 보는 분류
+
+`[직접근거]` 현재 GEODE v1.0.13 코드 기준의 분류다. `Seed`는 SIL이 사용하는
+평가 scenario를 만드는 별도 pipeline이며 SIL core와 합치지 않는다.
+
+| Part 2 operation | GEODE runtime | Seed Scenario Generation | SIL | Crucible |
+|---|---|---|---|---|
+| Generator | 직접: 기본 응답·ToolCall 생성, opt-in same-task `best_of=2..4` | 직접: 독립 seed draft 생성 | 대응: cycle당 JSON mutation 1개 | 대응: producer가 committed mutation 1개 생성 |
+| Fuser | 의도적 부재 | 부재 | 부재 | 부재 |
+| Critic | 대응: post-tool reflection이 trajectory state를 비평 | 직접: seed별 strengths·weaknesses | 독립 operator 부재 | 대응: closed failure-code projection |
+| Ranker | 직접: structured judge의 top-1 선택 | 직접: panel·pilot signal로 top-K survivor 선택 | 부재: keep/revert gate는 ranker가 아님 | 부재: paired verdict는 ranker가 아님 |
+| Verifier | 직접: turn candidate 검사, 단 기본 권한은 제한 | 대응: Petri Pilot이 scenario discrimination 측정 | 대응: Petri audit와 promotion gate | 대응: trusted evaluator와 paired gate |
+| Unit Test Generator | 부재 | 대응: adversarial scenario 생성 | upstream Seed에서만 제공 | 부재: task pack은 in-loop 생성하지 않고 고정 |
+| Unit Test Evaluator | 대응: opt-in verifier subagent+`run_bash`, built-in test operator는 부재 | 대응: Petri Pilot | 대응: Petri audit | 대응: Tau²·MCPMark executable assay |
+
+이 표의 `대응`은 우열이 아니라 제어 평면의 차이다. Archon은 answer delivery를
+고르고, Seed는 evaluation distribution을 만들며, SIL·Crucible은 다음 revision에
+쓸 named state를 고른다.
+
+### Eco²
+
+| 구현 | 강의의 축 | 판정 |
+|---|---|---|
+| Intent Router | task routing | test-time search가 아니라 입력별 graph path 선택이다. |
+| LangGraph node | fixed inference operator | operator catalog의 초기 형태로 볼 수 있으나 architecture search는 아니다. |
+| Send API 병렬 활성화 | task decomposition concurrency | 동일 문제 후보를 비교하지 않으므로 best-of-N이 아니다. |
+| BARS judge 반복 | measurement replication | 후보 탐색이 아니라 judge 불확실성 추정이다. |
+
+`[해석]` Eco²는 graph-owned workflow를 고정하고 입력별 경로와 병렬 실행을
+선택했다. compute scaling보다 workflow routing·concurrency·observability의
+초기 단계로 서술하는 편이 정확하다.
+
+### GEODE runtime
+
+`[직접근거]` Runtime의 직접적인 candidate path는 아래 하나다.
+
+```text
+delegate_task(best_of=2..4)
+→ diversity lens를 붙인 same-task Generator N개
+→ 격리된 SubResult N개
+→ structured judge Ranker
+→ selected top-1 SubResult
+```
+
+- `core/agent/candidate_sampling.py:53-89,161-255`가 최대 4개 lens와 structured
+  winner schema를 정의한다.
+- `core/agent/tool_executor/executor.py:951-988,1141-1206`가 single-task에서만
+  `best_of`를 확장하고 성공 후보 중 하나를 반환한다.
+- 선택 결과에는 후보와 judge failure가 남지만, 여러 결과를 새 답으로 합치는
+  Fuser는 없다.
+
+기본 `AgenticLoop`의 adapter call도 instruction·context에서 응답 또는 ToolCall을
+만드는 Generator다 (`core/agent/loop/agent_loop.py:2042-2189,2643-2809`).
+`best_of`는 이 Generator를 항상 확장하는 scheduler가 아니라 모델이 명시적으로
+요청할 때만 동작하는 single-task option이다. 최대 4개로 clamp되고 batch form에는
+적용되지 않는다.
+
+`[직접근거]` Post-tool reflection은 observation을 압축해 hypothesis, confidence,
+next-action hint를 갱신하고 낮은 confidence에서 replan pressure를 만든다
+(`core/agent/loop/agent_loop.py:782-900`; `core/agent/loop/_reflection.py:304-440`).
+이는 candidate별 strengths·weaknesses를 만드는 Critic이 아니라 trajectory-state
+Critic에 해당하는 기능 대응이다.
+
+`[직접근거]` Turn finalization의 `PreVerify → verifier → PostVerify → Stop`은
+candidate delivery를 accept·revise·escalate하는 Verifier 대응 경로다
+(`core/agent/loop/_lifecycle.py:609-742`). 다만 Archon의 2-call reasoning verifier와
+달리 GEODE는 rule-based 또는 LLM judge를 선택한다. `PostVerify/Stop` 정책이
+`revise` 또는 `escalate`를 반환하면 bounded continuation이나 candidate withholding이
+발생하지만, built-in verify 실패만으로 항상 hard delivery gate가 되지는 않는다.
+발표에서는 `검사 지점`과 `전달 차단 권한`을 분리해야 한다.
+
+`[직접근거]` Unit Test Evaluator의 기능 대응은 `role="verifier"` subagent다. 이
+role은 `run_bash`로 test·lint·smoke를 실행하고 typed `passed/checks` 결과를 돌려줄
+수 있지만, runtime이 candidate마다 test를 자동 생성·실행하는 built-in operator는
+아니다 (`core/agent/subagent_roles.py:101-113,172-179`;
+`core/agent/sub_agent.py:825-851,1237-1264`).
+
+`[해석]` 실행이 파일·프로세스·승인·외부 상태를 바꾸므로 completed trajectory를
+Fuser로 합치는 것은 의미가 없다. Fusion을 검토한다면 side effect 이전의 plan이나
+text candidate에만 둘 수 있다. Planning, tool action, permission, observation,
+compaction, termination/handoff, trajectory persistence는 Part 2의 일곱 operation
+밖에 있는 agent-runtime operator다.
+
+### GEODE가 추가한 environment-runtime operation
+
+| Operation family | 바꾸거나 남기는 객체 | 대표 구현 |
+|---|---|---|
+| Plan / Replan | action search path | goal decomposition, low-confidence replan |
+| Act / Observe | environment state와 observation | tool batch, result, error, state update |
+| Admit / Permit | effective request와 실행 권한 | schema·middleware·approval·dispatch |
+| Isolate / Delegate | child session과 capability | depth·session cap, role allowlist, typed `SubResult` |
+| Compact / Recover | model-visible working set | pair-safe compaction, overflow recovery |
+| Stop / Handoff | terminal control ownership | bounded continuation, candidate withholding, paused session |
+| Persist / Project | checkpoint·event·trajectory·evidence | mutable resume state와 immutable eval view 분리 |
+
+이 표는 Stanford operator의 추가 구현 목록이 아니다. Candidate response가 아니라
+환경 상태, 권한, context, session과 evidence를 다루기 때문에 별도 runtime taxonomy로
+유지한다.
+
+### Seed Scenario Generation
+
+`[직접근거]` Seed pipeline은 Stanford 표와 가장 닮았지만, 답변이 아니라 평가
+scenario를 탐색한다.
+
+```text
+Generator
+→ Proximity Dedup
+→ Critic
+→ Petri Pilot
+→ Ranker / Top-K
+→ Evolver
+→ Meta Reviewer
+```
+
+- 전체 phase order는 `plugins/seed_generation/orchestrator.py:210-251`에 고정된다.
+- `Generator`는 독립 candidate를 병렬 생성한다
+  (`plugins/seed_generation/agents/generator.py:85-224`).
+- `Critic`은 각 seed의 strengths·weaknesses와 discrimination risk를 구조화한다
+  (`plugins/seed_generation/agents/critic.py:93-203`).
+- `Pilot`은 Petri를 직접 호출해 dimension mean과 uncertainty를 보존한다
+  (`plugins/seed_generation/agents/pilot.py:125-260`).
+- `Ranker`는 panel vote와 pilot evidence를 결합해 survivor를 고른다
+  (`plugins/seed_generation/agents/ranker.py:172-465`).
+
+Proximity와 Meta Reviewer는 Archon 표 밖의 dataset-quality operator다. Evolver도
+여러 후보를 한 답으로 합치지 않고 survivor를 개별 수정하므로 Fuser로 부르지
+않는다. Unit Test Generator/Evaluator의 가장 가까운 대응은 adversarial scenario와
+Petri Pilot이지만, generated code test가 아니라 safety-evaluation scenario다.
+
+### SIL
+
+`[직접근거]` SIL core의 한 cycle은 candidate pool을 만들지 않는다.
+
+```text
+failure evidence + bounded JSON contract
+→ one scaffold mutation
+→ Petri measurement
+→ hard veto + targeted/full fitness gate
+→ keep | revert
+```
+
+- Mutation contract는 한 cycle에 policy section 하나만 바꾼다
+  (`core/self_improving/loop/mutate/runner.py:451-545,1581-1660`).
+- Gate는 hard contract, critical veto, margin과 targeted dimension을 확인한다
+  (`core/self_improving/gate.py:353-514`).
+- Reject는 SoT를 직전 상태로 되돌린다
+  (`core/self_improving/gate.py:789-945`).
+
+따라서 mutation LLM은 experiment-plane Generator에 대응하지만, `(1+1)` keep/revert는
+Ranker가 아니라 state promotion gate다. Petri는 external Verifier/Evaluator 대응이다.
+K=3은 같은 candidate의 measurement replication이고, mutation policy에 노출하지
+않는 held-out은 generalization monitor다. `15→Top-5` 탐색은 SIL core가 아니라
+upstream Seed Scenario Generation에 귀속한다.
+
+### Crucible
+
+`[직접근거]` Crucible은 one-candidate experiment protocol이다.
+
+```text
+failure codes + bounded surface + knowledge graph
+→ CommandProducer / one committed mutation
+→ frozen contract + trusted CommandEvaluator
+→ baseline:candidate paired evidence
+→ PromotionVerdict KEEP | REJECT | INVALID
+→ private search-head update
+```
+
+- Contract는 mutation, task pack, measurement hash와 budget을 동결한다
+  (`plugins/crucible/contract.py:1-29`).
+- Producer와 evaluator는 별도 process command다
+  (`plugins/crucible/supervisor.py:1164-1272`).
+- Supervisor가 bounded loop와 private ref를 소유한다
+  (`plugins/crucible/supervisor.py:1318-1510`).
+- `PromotionVerdict`와 paired decision은 release 권한 없이 KEEP·REJECT·INVALID만
+  반환한다 (`plugins/crucible/promotion.py:195-246,342-520`).
+
+Candidate producer는 experiment-plane Generator에 대응한다. Trusted evaluator는
+Unit Test Evaluator보다 executable assay에 가깝고, paired promotion decision은
+Ranker가 아니다. Fuser·top-K pool·in-loop test generator는 없다. Task pack을 미리
+고정하고 opaque test를 producer에서 숨기는 이유는 candidate가 평가 기준까지
+바꾸는 오염을 막기 위해서다 (`plugins/crucible/program.md:98-101,158`). 다음
+cycle에 돌려주는 closed failure code는 Critic과 유사한 진단 신호지만, candidate의
+장단점을 자유문으로 노출하지 않으므로 별도 feedback-projection operation으로 둔다.
+
+## 8. Agent Workflow에 적용할 범위
+
+### 범위 A · Runtime compute controller
+
+Trajectory에서 difficulty, verifier confidence, tool error, latency, cost를 읽고
+다음 action budget을 선택한다.
+
+```text
+task admission
+→ single pass
+→ verify
+→ early exit | sequential repair | parallel branch | handoff
+```
+
+필요 계약은 `compute_budget`, `branch_id`, `parent_action_id`, `verifier_id`,
+`selection_reason`, `stop_reason`이다. 이 값이 없으면 최종 점수가 같아도 어떤
+compute policy가 효과적이었는지 재구성할 수 없다.
+
+### 범위 B · Verifier-aware scheduler
+
+Verifier confidence가 낮은 과제에서는 width를 늘리지 않는다. Deterministic
+tool·state assertion이 있는 과제만 best-of-N·beam을 허용하고, 자연어 judge만
+있는 고위험 mutation은 human handoff 또는 제한된 action surface로 보낸다.
+
+### 범위 C · Offline inference-program search
+
+Archon의 문법을 그대로 구현할 필요는 없다. GEODE가 이미 가진 generator,
+delegate, verifier, replan, tool, skill, model route를 제한된 catalog로 정의하고,
+task pack에서 `fixed budget → measure → select`를 수행할 수 있다. Runtime source
+자유 수정이 아니라 선언형 policy/scaffold만 후보로 두는 현재 방향과 맞는다.
+
+### 범위 D · Evidence와 policy learning
+
+```text
+trajectory
+→ difficulty / failure cluster
+→ compute-policy candidate
+→ paired replay
+→ verifier + held-out
+→ keep / revert / handoff
+```
+
+이때 trajectory는 곧바로 training data가 아니다. Action identity, reward 품질,
+privacy, duplication, evaluator leakage를 검사한 뒤에야 supervised·preference·RL
+데이터 후보가 된다.
+
+### 범위 E · 비용과 권한을 함께 최적화
+
+Enterprise agent의 objective는 accuracy 하나가 아니다.
+
+```text
+maximize task utility
+subject to cost + latency + risk + authority + auditability
+```
+
+검색 폭이 커질수록 tool side effect와 승인 요청도 늘어난다. 따라서 compute
+controller는 model 호출 수뿐 아니라 action budget, read/write capability,
+approval boundary, terminal handoff를 함께 관리해야 한다.
+
+## 9. 현재 덱 반영 후보
+
+이번 operator map은 새 장을 추가하기보다 기존 화면 30을 교체하는 데 사용한다.
+화면 16의 subagent admission과 화면 31–34의 SIL·Crucible 상세를 반복하지 않고,
+서로 다른 decision plane만 한 장에서 고정한다.
+
+| 우선순위 | 화면 | 적용 |
+|---:|---:|---|
+| P0 | 09 | observe→verify→replan을 `sequential repair depth`로 명명하고 feedback 없는 long CoT와 구분한다. |
+| P0 | 21 | oracle coverage와 delivered correctness 사이의 verifier gap을 한 그래프로 표현한다. |
+| P0 | 30 | candidate-response inference, scenario search, revision promotion을 세 개 lane으로 분리한다. |
+| P1 | 31 | Seed 15→Top-5를 exploration width, SIL mutation을 cross-run scaffold search로 분리한다. |
+| P1 | 32–33 | held-out을 mutation policy에 비노출된 monitor로 두고 selection set과 권한을 분리한다. |
+| P1 | 37 | Agent Workflow 기여를 `task-conditioned compute + evidence-preserving runtime`으로 압축한다. |
+
+화면 30의 head message 후보는 다음이다.
+
+> **후보는 고르고, 실행은 검증하며, revision은 gate만 바꿨습니다**
+
+본문 계약은 다음 한 문장으로 닫는다.
+
+> Runtime은 응답과 action trajectory를, Seed·SIL은 scenario와 JSON scaffold를,
+> Crucible은 Git revision을 다룹니다. 같은 Generate·Evaluate·Select라도 객체와
+> 피드백 가시성, write authority가 다르므로 서로 다른 operation contract로
+> 분리했습니다.
+
+시각화는 같은 폭의 세 horizontal lane으로 고정한다.
+
+```text
+RUNTIME          Generate → Act/Observe → Reflect → Verify → Replan/Stop
+                 └ best_of N=2..4 → Rank top-1 ─┘          answer delivery
+
+SEED + SIL       Seed Generate → Dedup → Critic/Pilot → Rank top-K → scenario bank
+                 one JSON mutation → Petri → Gate → keep/revert SoT
+
+CRUCIBLE         failure projection → one Git revision → paired τ² → Normalize
+                 → KEEP/REJECT/INVALID → private search ref
+```
+
+각 lane 왼쪽에는 `search object`, 오른쪽에는 `authority`를 고정하고 중앙에 operation만
+놓는다. 첫 lane에는 `FUSER 없음 · completed side effects는 합성하지 않음`을 작은
+경계 주석으로 둔다. Fusion을 추가한다면 plan-before-act 단계라는 위치만 표시하고
+구현 claim은 하지 않는다. Tool permission·compaction·hook·persistence의 상세는
+화면 9–19에서 설명하므로 화면 30에는 operation family 이름만 둔다.
+
+### 결과 그래프의 발표 문법
+
+`[외부연구]` 강의의 결과 장은 그래프를 먼저 놓고 제목에 해석을 적는 구성이 아니다.
+제목이 먼저 한 개의 비교 판정을 내리고, 두 패널은 같은 종속변수와 비교군을 유지한
+채 자원 축만 바꾼다. 고정 모델 성능은 옅은 수평선으로 두고, 발표는 random control
+→selector→fuser→composition 순으로 곡선의 교차·포화·한계효용을 읽는다. 따라서
+선은 시간의 흐름을 꾸미는 장식이 아니라 각 x 조건에서 실제로 측정된 결과여야 한다.
+
+`[해석]` GEODE 아티팩트에도 같은 시각 문법을 적용할 수 있지만, 현재 full-cycle은
+budget intervention 실험이 아니다. 관측된 실행 길이를 hard budget 아래의 재실행
+성능처럼 부르면 안 된다. 지금 만들 수 있는 것은 `compute-scaling curve`가 아니라
+`observed completion-cost profile`이다.
+
+### 현재 데이터에서 채택할 주제
+
+> **Retail과 Telecom은 모두 79/114였지만, 성공 경로의 shared-world
+> interaction p90은 11회와 38회였습니다**
+
+`[직접근거]` `geode-eval-artifacts`의 GPT-5.4 subscription/high Tau2 full-cycle
+`results.json`을 successful trajectory만 대상으로 nearest-rank p90으로 다시
+집계했다. 두 도메인은 각각 114개 중 79개를 완료했다. 후보 agent가 요청한 tool
+action p90은 Retail 11회, Telecom 12회로 비슷했다. 반면 user simulator의 tool
+action까지 포함한 shared-world tool event p90은 11회와 38회, wall time p90은
+143.8초와 542.3초였다. 이는 Telecom의 dual-control interaction이 더 길었다는
+관측이지, GEODE policy가 3.5배 비효율적이라는 판정이 아니다.
+
+근거 파일은 다음 두 native receipt다.
+
+- `tau2/simulations/geode-gpt54-high-22789ee2-geode-user-retail-base-full-transport-retry1-20260803/results.json`
+- `tau2/simulations/geode-gpt54-high-22789ee2-geode-user-telecom-base-full-transport-retry1-20260803/results.json`
+
+이 장은 현재 Tau2 full-cycle 결과 장 직후에 둔다. 두 패널은 같은 y축
+`114개 중 관측된 누적 성공 비율`과 같은 Retail·Telecom series를 쓴다.
+
+```text
+LEFT · AGENT ACTION PROFILE          RIGHT · SHARED-WORLD INTERACTION PROFILE
+y: cumulative successful tasks      y: cumulative successful tasks
+x: assistant-owned tool actions     x: all tool events
+
+Retail p90 11 ─ Telecom p90 12      Retail p90 11 ─ Telecom p90 38
+                                     wall time 144 s ─ 542 s
+```
+
+최대 y는 두 곡선 모두 `79/114 = 0.693`으로 닫는다. 왼쪽 곡선은 거의 겹치고,
+오른쪽 Telecom 곡선만 오른쪽으로 이동해야 한다. 범례 대신 선 끝에 도메인을 직접
+표기하고 p90 두 점만 강조한다. 하단에는 다음 한계를 고정한다.
+
+> `Observed final-attempt profile · not pass@budget · no hard-cap rerun`
+
+`[해석]` 이 장이 지지하는 결정은 `더 많은 compute`가 아니다. Aggregate task
+success가 같아도 environment ownership과 interaction depth가 다르므로, runtime
+budget·termination·handoff를 task-conditioned policy로 관리하고 score와 함께
+action ownership을 보존해야 한다는 것이다. 이 결론이 다음 External Loop 장의
+`native outcome + canonical behavior` 결속으로 이어진다.
+
+### 보류할 주제
+
+| 후보 | 판정 | 이유 |
+|---|---|---|
+| Telecom success/failure tail | Q&A 또는 후속 장 | 실패 p90과 `MAX_STEPS`는 조기 handoff 가설을 만들지만, 종료 정책을 바꾼 대조실험은 아니다. |
+| SIL selection 대 held-out | 후속 실험 | cycle별 동일 ruler와 완전한 candidate lineage를 먼저 고정해야 한다. |
+| Crucible 42 attempts→verdict | 기존 gate 장의 수치 보강 | funnel·verdict composition에 적합하며 sample-scaling line에는 맞지 않는다. |
+| Petri 13-scenario matrix | 기존 heatmap 유지 | dimension·scenario가 달라 누적 sample curve로 연결하면 IID 반복처럼 오인된다. |
+| 과거 버전 점수 연결 | 금지 | model route·runtime revision·assay가 달라 하나의 발전 곡선이 아니다. |
+
+실제 Stanford식 intervention curve가 필요하면 같은 task stratum·model·revision·
+evaluator를 고정하고 action budget 또는 candidate width만 바꿔 다시 실행한다. 현재
+아티팩트만으로 그 실험을 수행한 것처럼 보이는 선은 만들지 않는다.
+
+### 현재 덱에서 빠진 서술
+
+1. 화면 16과 30 모두 `best_of`가 Generator와 top-1 Ranker의 조합이라는 이름이 없다.
+2. 화면 30은 `delegate_task`와 Seed Top-K를 한 candidate policy에 넣어 answer 선택과
+   evaluation-distribution 정제를 혼동한다.
+3. SIL·Crucible gate를 Ranker나 Verifier로 오해하지 않게 `named-state authority`를
+   입력·출력과 함께 보여주지 않는다.
+4. model-judged verification과 Petri·Tau²·MCPMark의 executable/environment evidence
+   차이가 한눈에 드러나지 않는다.
+5. Fuser 부재와 이유가 없다. 이미 실행된 trajectory는 결합할 수 없고, fusion은
+   side effect 이전 plan/text candidate에만 허용할 수 있다.
+6. 호출 수, candidate 수, wall-time, action budget 중 어떤 budget을 썼는지 operator별
+   비용 단위가 빠져 있다.
+7. 현재 Verifier를 hard gate로 읽을 위험이 있다. Built-in verify와
+   `PostVerify/Stop`이 가진 revise·escalate authority를 분리해 말해야 한다.
+8. `best_of`가 opt-in·single-task·최대 4개이고, 네 고정 lens가 통계적 독립성을
+   보장하지 않는다는 구현 한계가 대본에 없다.
+
+별도 장은 만들지 않는다. 이 여덟 누락은 화면 30의 lane label·boundary note와 발표
+대본으로 설명할 수 있고, 새 장을 추가하면 화면 16·31–34와 중복된다.
+
+## 10. 발표에서 지켜야 할 용어
+
+### 사용할 표현
+
+- parallel candidate width
+- sequential repair depth
+- test-time compute allocation
+- verifier-aware scheduling
+- generation–verification gap
+- inference-program search
+- measurement replication
+- external promotion authority
+
+### 사용하지 않을 표현
+
+- 긴 CoT 전체를 test-time scaling이라고 부르지 않는다.
+- Send API 동시 실행을 parallel sampling이라고 부르지 않는다.
+- K=3 반복 측정을 best-of-3이라고 부르지 않는다.
+- inference compute가 pretraining을 대체한다고 말하지 않는다.
+- Archon을 self-improving runtime 또는 DGM이라고 부르지 않는다.
+- generated unit-test evaluation을 deterministic test execution이라고 부르지 않는다.
+- 강의의 held-out을 SIL held-out과 같은 계약이라고 말하지 않는다.
+- GEODE가 Archon을 구현했다고 말하지 않는다.
+
+## 11. 발표용 90초 해설 초안
+
+> Test-time compute를 처음에는 호출 수의 문제로 봤습니다. Stanford 강의는 이
+> 관점을 네 층으로 가릅니다. 같은 문제의 후보를 넓히는 parallel width, 외부
+> feedback으로 한 후보를 고치는 sequential depth, 후보를 실제 성능으로 바꾸는
+> verifier, 그리고 이 연산자의 조합 자체를 찾는 inference-program search입니다.
+>
+> 중요한 건 compute가 아니라 변환 조건입니다. 정답 후보가 한 번이라도 생성되는
+> coverage는 샘플 수와 함께 오르지만, verifier가 희소한 정답을 찾지 못하면 실제
+> 전달 성능은 포화합니다. 그래서 GEODE에서는 긴 추론보다 observe, verify,
+> replan을 연결했고, SIL에서는 seed 탐색 폭과 K=3 반복 측정, held-out monitor,
+> 승격 권한을 서로 다른 평면으로 분리했습니다.
+>
+> 다음 단계는 더 많은 호출이 아닙니다. 과제 난도, verifier confidence, 비용,
+> side-effect risk를 trajectory에서 읽고 single pass, repair, parallel search,
+> handoff를 선택하는 compute policy입니다. 그 정책과 결과를 같은 evidence contract로
+> 남겨야 새 모델과 새 workflow도 동일 기준으로 비교하고 승격할 수 있습니다.
+
+## 12. 미해결 연구 질문
+
+- Runtime에서 task difficulty를 leakage 없이 어떻게 추정할 것인가.
+- Branch 간 상관을 측정해 nominal N과 effective sample size를 어떻게 구분할 것인가.
+- Verifier confidence와 false-positive cost를 action risk에 따라 어떻게 보정할 것인가.
+- Sequential repair의 improvement plateau를 어떤 terminal event로 판정할 것인가.
+- Offline architecture search가 benchmark-specific overfit이 되지 않게 어떤
+  held-out·sealed protocol을 둘 것인가.
+- Text candidate가 아닌 state-changing tool trajectory를 fuse하거나 rank할 때
+  side effect를 어떻게 격리할 것인가.
+- Compute policy provenance를 session·trajectory·eval artifact에 어떤 identity로
+  결속할 것인가.
+
+## 1차 원문
+
+- [Stanford CS329A Self-Improving AI Agents](https://cs329a.stanford.edu/)
+- [Large Language Monkeys: Scaling Inference Compute with Repeated Sampling](https://arxiv.org/abs/2407.21787)
+- [How Do Large Language Monkeys Get Their Power (Laws)?](https://arxiv.org/abs/2502.17578)
+- [Scaling LLM Test-Time Compute Optimally can be More Effective than Scaling Model Parameters](https://arxiv.org/abs/2408.03314)
+- [Archon: An Architecture Search Framework for Inference-Time Techniques](https://arxiv.org/abs/2409.15254)

--- a/.claude/skills/stanford-test-time-compute/references/presentation-index-snapshot.md
+++ b/.claude/skills/stanford-test-time-compute/references/presentation-index-snapshot.md
@@ -1,0 +1,499 @@
+# LG AI Research 1차 기술 면접 PT — 작업 SoT
+
+작성 시작: 2026-07-28. 상위 `../README.md`(공고 SoT)와 함께 읽을 것.
+
+## 면접 스펙 (2026-07-28 면접 안내 메일 요약 기준)
+
+- **전형**: 1차 기술 면접 = 개인 PT 발표 (WEBEX 화상)
+- **구성**: PT 20분 + 질의응답 40분 (총 1시간)
+- **장수**: 본편 37장. Q&A 부록은 근거가 확정된 뒤 별도 설계
+- **면접관**: Data Governance Team 리더 외 1명
+- **자료**: 자유 양식, 참여도 높은 핵심 프로젝트 2~3개
+- **제출 기한**: 면접 하루 전까지 (일정 확정 메일에서 구체화 예정)
+- **직무 맥락**: AI Data Engineer Internship의 **Agent Workflow 공고** — 사내 AI 업무 도우미, workflow 개선·테스트, tool calling·agent skill·prompt 검증, 상태 관리, 격리 실행, 로그·실패·평가 분석 (`../README.md` §1 및 [공식 채용 공고](https://www.lgresearch.ai/careers/view?seq=187))
+
+## 발표 구성 (사용자 확정)
+
+1. **Meta harness** — 제작 조건·검증·revision의 change authority
+2. **Application runtime** — prompt-only→fixed DAG→loop runtime,
+   prompt·state·hook·context·tool·skill·MCP·subagent
+3. **Observe / Evaluation / Verify** — Eco² service observability→GEODE
+   session/trajectory→Eco² Swiss Cheese Eval→GEODE Verify/Replan
+4. **Simulator / Benchmark** — Petri interaction audit와
+   τ²·MCPMark의 environment completion contract
+5. **External experiment loop** — SIL의 bounded scaffold search와
+   Crucible의 독립 promotion control
+6. **Transfer** — REODE migration과 EXAONE application vertical slice
+
+## 디렉토리
+
+```text
+presentation/
+  README.md      ← 이 파일 (SoT)
+  progress-audit.md ← 현재 완성도·누락·내러티브 v2
+  talk-script-20min.md ← 11개월 작업법 헤드라인·37장 타임코드·발표 대본
+  wiki/          ← 역할 조사 + 프로젝트별 실측 수집 (LLM wiki)
+  design.md      ← 디자인 진입점·기존 초안 상태
+  design/        ← 공식 자산 실측 기반 시각 시스템
+  strategy.md    ← 20분 콘텐츠 풀 + Agent Workflow 예상 질문
+  slides/        ← 37장 활성 HTML 슬라이드
+  assets/        ← (예정) 로고, 다이어그램
+```
+
+## 수집 절차 (wiki 규약)
+
+- 역할 SoT: `wiki/role-agent-workflow.md`
+- 연구개발 문제의식: `wiki/exaone-agent-rd.md`
+- ChatEXAONE Enterprise Agent 심층:
+  `wiki/chatexaone-enterprise-agent.md`
+- Frontier Agent 원문 비교: `wiki/frontier-agent-engineering-2026.md`
+- K-EXAONE 2.0·Solar Open 2·한중 모델 비교:
+  `wiki/k-exaone-2.0-solar-open-2-comparison-2026.md`,
+  `wiki/k-exaone-2.0-agent-workflow-opportunity-2026-07-31.md`
+  (K‑EXAONE 2.0 이후 application control plane의 기회, GEODE current
+  main 교정, 31장 call-up/reduce 결정)
+- Kimi K2.5 Agent Swarm·PARL:
+  `wiki/kimi-k2.5-agent-swarm.md`
+- seq=636 이후 공개 추적: `wiki/lg-research-after-seq636.md`
+- 프로젝트당 1파일: `wiki/eco2.md`, `wiki/geode.md`, `wiki/reode.md`, `wiki/kiki.md`, `wiki/assets-pipeline.md`
+- 축 보강 (2026-07-29): `wiki/skills-geode.md`(GEODE 자체 skill 시스템),
+  `wiki/geode-codebase-atlas.md`(PDF 88쪽→현재 코드·test·artifact→발표의
+  G0~G9 추적 지도),
+  `wiki/skills-eco2.md`(메타하네스 — 클러스터 배포 조정 skill),
+  `wiki/evolution-eco2-agent.md`(블로그 104개 인덱스·코드·Git 대조),
+  `wiki/geode-context-engineering.md`(PDF 24~33쪽·실행 wiring·Git 대조),
+  `wiki/runtime-context-assembly-terminology.md`(GEODE prompt 분기 순서,
+  OpenAI·LangChain·Google ADK·Anthropic의 dynamic instruction/context
+  용어 대조, turn-scoped assembly 표현),
+  `wiki/geode-trajectory-judgment.md`(Eval·Observe·Diagnose와
+  feedback/evolution 폐루프·autoresearch/AlphaEvolve/GRPO 게이트 계보·
+  Crucible/SIL 판정),
+  `wiki/eval-artifact-lineage.md`(Eco² Chat Agent→GEODE Petri의 인과,
+  2026-05-11 내부 archive→2026-07-13 공개 저장소, artifact 기반
+  승격 판정 프로토콜),
+  `wiki/agent-workflow-codebase-map.md`(Understand-Anything knowledge
+  graph로 GEODE·Eco²의 runtime·tool·state·evaluation·infra 구조를
+  같은 taxonomy에 연결하고 seq=187 어필 포인트를 우선순위화),
+  `wiki/evaluation-guided-scaffold-search.md`(Hold-out·nested CV·
+  adaptive holdout의 원전 계보, agent scaffold/workflow 탐색 용어와
+  GEODE 평가 권한 정렬),
+  `wiki/narrative-evaluation-guided-geode.md`(원전→GEODE→
+  ChatEXAONE 기여 방향의 사용자 검토용 6단락·90초 내러티브),
+  `wiki/deck-restructure-2026-07-30.md`(Eco² desired state→Agent
+  활용면/runtime→GEODE meta/runtime harness→eval-artifact
+  promotion→REODE→EXAONE application으로 이어지는 15장 발표 SOT),
+  `wiki/bounded-harness-control-2607.25415.md`(frozen LLM 주변의
+  6개 bounded harness lever·control/bandit/REINFORCE 이론, 공개 코드의
+  nominal 729↔effective surface 감사, GEODE 7개 behavior SoT 및
+  SIL→Crucible 시간선 정렬),
+  `wiki/hyperagents-2603.19461.md`(HyperAgents 원문·Meta 공식 페이지·
+  commit-pinned 코드 검증, editable task+meta program과 fixed outer
+  evaluator의 경계, Paul 2607.25415의 비판적 해석 교정, Red Queen
+  Gödel Machine 원문의 독립 교차 인용),
+  `wiki/creator-persona-narrative-audit-2026-07-30.md`(Eco²·GEODE·SIL·
+  Crucible의 evidence-derived 제작자 의도 페르소나, 100점 정합성
+  scorecard, 오탐·누락·순서 교정, Petri·τ² 결과 경계),
+  `wiki/deck-restructure-2026-07-31.md`(38장 구조의 이전 SOT),
+  `wiki/k-exaone-2.0-agent-workflow-opportunity-2026-07-31.md`
+  (현재 31장 활성 순서와 claim boundary),
+  `wiki/eval-gate-visual-grammar-2026-07-31.md`(외부 Eval·실험 발표에서
+  추출한 identity→evidence→validity→decision→authority 시각 문법과
+  GEODE 화면별 적용),
+  `wiki/project-signal-audit-2026-07-31.md`(Eco²·GEODE·Petri·SIL·
+  Crucible·REODE·Kiki·EXAONE 본편 누락 신호와 P0/P1/P2 편집 우선순위),
+  `wiki/geode-v1.0.10-motivation-control-boundaries-2026-07-31.md`
+  (v1.0.10 runtime·hook·benchmark schema 근거와
+  Motivation→계약→구현→검증/backlog 발표 문법),
+  `wiki/meta-harness-and-prompt-assembly-2026-07-31.md`
+  (Eco² research→CI→image/manifest→ArgoCD reconcile, GEODE
+  GAP→preflight/CI→protected release, 실제 system prompt XML 조립 순서와
+  local dump·구조 테스트),
+  `wiki/geode-v1.0.11-documentation-reinforcement-strategy-2026-08-01.md`
+  (v1.0.10 기록 구조 감사→v1.0.11 session record·trajectory release 구현→
+  공식 Pages·LLM wiki·13/18/27/29/30장 보강 순서와 acceptance gate),
+  `wiki/sil-held-out-and-petri-rubric-2026-08-02.md`
+  (2026-06-04 SIL 영상·현재 code·공개 eval-artifact 대조, Petri 22-dim
+  rubric 구성, selection 10과 held-out 10의 서로 다른 판정 권한, 24·31장
+  call-up/reduce 결정),
+  `wiki/deck-role-evaluation-loop-2026-08-03.md`
+  (면접 메일·seq=187 직무·최신 공식 자료를 기준으로 37장 활성 덱을
+  채점한 100점 루브릭, 전수 판정, P0/P1 수정 queue와 승격 gate),
+  `wiki/geode-v1.0.12-full-cycle-deck-callup-2026-08-04.md`
+  (v1.0.12 Tau2 278-task full cycle의 score·behavior·trajectory·release
+  권한 경계, 12·13·18·21·22·27·28·34–35장 call-up/keep 판단),
+  `wiki/geode-runtime-faithful-tau2-handoff-2026-08-04.md`
+  (Tau2 adapter의 production wiring·deferred tool result·native verdict·
+  retry lineage 결손과 benchmark-safe runtime profile, acceptance gate),
+  `wiki/evolution-kiki.md`·`wiki/evolution-reode.md`(발전사 + 피드백→개선 축)
+- 채점·루브릭 학술 계보: `wiki/eval-rubric-lineage.md` (BARS/CUSUM/McNemar → HealthBench/RaR/Petri 정합)
+- Petri 심층: `wiki/petri-judge-reliability.md` (루브릭 제작·시뮬레이션→평가 연결·judge 신뢰성 — Anthropic/Inspect 1차 자료)
+- 면접 메일 원문: `source/2026-07-28-interview-notice-mail.md`
+- 발표 호흡 근거: `wiki/reference-talk-rhythm.md`
+- Stanford CS329A Course Overview의 Agent Workflow 공개 baseline, 42–52분
+  구간의 workflow/agent·generator/verifier 경계, Eco²→GEODE→SIL/Crucible
+  투사와 7·8·28·30장 반영 결정:
+  `wiki/stanford-cs329a-agent-workflow-baseline-2026-08-05.md`
+- Stanford CS329A Test-Time Compute Scaling Part 2의 63분 전문·자동 자막·
+  contact sheet 보존, repeated-sampling power law·generation-verification
+  gap·compute-optimal allocation·Archon inference-program search의 전체
+  전개와 Eco²·GEODE·SIL·Crucible 적용 경계:
+  `wiki/stanford-cs329a-test-time-compute-part2-2026-08-05.md`
+- Stanford CS329A 공개 플레이리스트 9부작의 전체 자동 자막·60초 contact
+  sheet·metadata 보존, verification→feedback→planning→RL→search→long-horizon
+  evaluation→open-ended loop의 강의별 상세 해설과 재사용 스킬:
+  `wiki/stanford-cs329a-self-improving-agents-course-2026-08-05.md`,
+  `.agents/skills/apply-self-improving-agent-systems/SKILL.md`
+- Eco²의 graph-owned routing에서 GEODE의 model proposal·runtime admission·
+  verify·promotion policy 분리로 이어지는 코드 기반 재프레이밍, 기존
+  `session_events`→trajectory projection의 정당성, v1.0.13 worktree 판정과
+  policy provenance 최소 보강 순서:
+  `wiki/policy-trajectory-reframing-2026-08-05.md`
+- Palantir의 2026-08-03 AI sovereignty 스탠스, Q2 주주서한 인용 교정,
+  model·Ontology/Action·permission·observability·eval·post-training
+  control stack과 GEODE runtime/evidence plane의 정렬·과장 경계:
+  `wiki/palantir-ai-sovereignty-runtime-control-2026-08-05.md`
+- 한국 기업 AI 발표 문법과 시각화 선택표:
+  `wiki/korean-enterprise-ai-presentation-grammar.md`
+- 기술 보고서·한국 기업 발표·프런티어 엔지니어링 자료의
+  evidence-led 제목 문법과 1·22장 적용:
+  `wiki/evidence-led-head-message-grammar-2026-07-31.md`
+- 프런티어 시스템 보고서·LG AI Research·EXAONE 표지의 시각 문법 대조와
+  v26 표지 결정:
+  `wiki/cover-visual-alignment-2026-08-01.md`
+- 35장 전수 렌더에서 확인한 제목 낱말 절단·label/connector·label/border·
+  image/region 충돌 사례와 이를 차단하는 실행형 시각 회귀 게이트:
+  `wiki/deck-visual-slop-regression-2026-08-01.md`
+- 두 개발 영상과 2025-12~2026-03 `잡담` intent ledger에서 추출한
+  개발 동기·작업 원칙, 35장 head-message 결정표와 편집 규칙:
+  `wiki/deck-motivation-philosophy-revision-plan-2026-07-31.md`
+- 로컬 제목 교정 스킬:
+  `.agents/skills/write-evidence-head-messages/SKILL.md`
+- observe→verify→failure contract 작업 규율:
+  `.agents/skills/practice-observe-verify-engineering/SKILL.md`
+- **모든 수치·주장에 근거 병기**: 파일 경로 / 커밋 / URL. 근거 없으면 싣지 않는다
+- **검증 등급 태그**: `[실측]`(직접 확인) / `[문서주장]`(레포 문서상 주장, 미재현) / `[미검증]`
+- GEODE 정직성 패스 준수: 죽은 주장(G1-G4, Cross-LLM α≥0.67, Expert Panel 등) 금지. confidence는 관찰용
+- 수집 관점: 발표의 주축은 **Agent Workflow 직무 적합성**이다. Data Governance는 면접관 관점의 보조 축으로 quality·audit·lineage·access 근거에만 반영한다
+
+## LLM wiki 검증
+
+새로운 외부 조사를 반영할 때는 다음 순서를 지킨다.
+
+1. 회사 방향은 공식 페이지·공식 저장소·기술 보고서에서 확인한다.
+2. 업계 맥락은 논문·공식 기술 문서 등 1차 자료로 교차 검증한다.
+3. 문장마다 `[직접근거]`, `[외부연구]`, `[해석]`의 경계를 표시한다.
+4. 링크와 로컬 문서 참조를 확인한 뒤 Markdown render lint를 실행한다.
+
+```bash
+python3 ~/.codex/skills/lg-agent-workflow-assessment/scripts/audit_research_wiki.py \
+  presentation/wiki/exaone-agent-rd.md \
+  presentation/wiki/frontier-agent-engineering-2026.md \
+  presentation/wiki/lg-research-after-seq636.md \
+  presentation/wiki/kimi-k2.5-agent-swarm.md \
+  presentation/wiki/evaluation-guided-scaffold-search.md \
+  presentation/wiki/bounded-harness-control-2607.25415.md \
+  presentation/wiki/hyperagents-2603.19461.md \
+  presentation/wiki/narrative-evaluation-guided-geode.md \
+  presentation/wiki/agentic-engineering-influences-and-geode-origin-talk.md \
+  presentation/wiki/creator-persona-narrative-audit-2026-07-30.md \
+  presentation/wiki/deck-visual-narrative-audit-2026-07-30.md \
+  presentation/wiki/deck-restructure-2026-07-30.md \
+  presentation/wiki/deck-restructure-2026-07-31.md \
+  presentation/wiki/k-exaone-2.0-solar-open-2-comparison-2026.md \
+  presentation/wiki/k-exaone-2.0-agent-workflow-opportunity-2026-07-31.md \
+  presentation/wiki/geode-v1.0.10-motivation-control-boundaries-2026-07-31.md \
+  presentation/wiki/geode-v1.0.11-documentation-reinforcement-strategy-2026-08-01.md \
+  presentation/wiki/evidence-led-head-message-grammar-2026-07-31.md \
+  presentation/wiki/deck-motivation-philosophy-revision-plan-2026-07-31.md \
+  presentation/wiki/cover-visual-alignment-2026-08-01.md \
+  presentation/wiki/palantir-ai-sovereignty-runtime-control-2026-08-05.md \
+  presentation/wiki/stanford-cs329a-self-improving-agents-course-2026-08-05.md
+
+${HOME}/workspace/geode/.venv/bin/pymarkdown \
+  -c presentation/.pymarkdown.json scan \
+  presentation/*.md presentation/design/*.md presentation/wiki/*.md
+```
+
+## 현재 덱 작업 핸드오프
+
+다른 세션은 이 절을 읽고 시작한다. 현재 편집 SoT는
+`slides/slides-v3.js`와 `slides/styles.css`다. 화면 번호와 렌더 순서는
+`slideData` 전체가 아니라 파일 하단 `presentationOrder`의 37개 ID를
+기준으로 확인한다.
+
+### 현재 v34 활성 구조
+
+- 본편: 37장
+- 편집 게이트: 문장형 head message + 직접 연결된 근거 도식,
+  narrative body 12pt 이상, `ink·gray·LG magenta` 3색 계열
+- 서술 게이트: `.agents/skills/writer-flow/SKILL.md`를 진입점으로
+  page job→pressure→mechanism→consequence를 정렬하고, title·thesis·figure가
+  같은 판단 기준을 공유하는지 검사
+- 도식 게이트: label–border·label–connector 8px 안전 간격,
+  node 아래에서 사라지는 connector와 text를 관통하는 edge 금지
+- 활성 순서: `slides/slides-v3.js::presentationOrder`
+- 01: 넓은 action search space를 observation·state transition·trajectory로
+  축적하고, evaluator가 keep/revert와 다음 탐색 경계를 판정하는 표지
+- 02: 11개월 프로젝트 timeline
+- 03: 2025-12~2026-07 intent ledger에서 추출한
+  code/action supply와 verification·root-cause capacity의 정성적 격차
+- 04: 작은 action→external observation→artifact→replay→verdict와
+  failure→contract→Git revision의 observe–verify ratchet
+- 05: Eco² research→ADR→CI/image→ArgoCD와
+  GEODE GAP→contract→preflight→protected release의 meta-harness 비교
+- 06: `UserPromptSubmit`→effective `ToolCallRequest`→`VerifyResult`의
+  input·action·output contract와 cross-cutting safety authority
+- 07: Eco² `list[Send]` fan-out→typed reducer→required-context join,
+  구현 metric·structured log·measurement backlog의 경계
+- 08: Eco² graph-owned path에서 GEODE의 model proposal→runtime admission→
+  verifier decision→gate promotion으로 확장된 policy ownership
+- 09: `ACT→OBSERVE→VERIFY/TERMINATE→REPLAN`의 실행 폐루프. Sequence
+  connector는 actor lifeline 또는 activation boundary에 직접 결속
+- 09: RUN 섹션 시작. action→observation→bounded replan과 closed terminal
+- 10–11: 고정 system prompt prefix와 turn-resolved XML assembly,
+  provider·surface·memory·verify·plan 조건부 삽입
+- 13–20: context·capability·subagent·observability·finalization에서
+  `failure signal→contract→verification/backlog`
+- 20–21: Eco² Swiss Cheese Eval에서 GEODE Verify/Replan·finalization
+  control로 넓어진 Evaluation / Verify 경계
+- 18: v1.0.13의 session·turn·call identity로 canonical behavior와 operational
+  telemetry를 분리하고, resolved policy snapshot은 남은 계약으로 표시
+- 22: v1.0.12 full-cycle resolved assay config, native `200/278`,
+  51,985 `session_events`, 3,964 internal call/ACK pairing을 manifest에
+  결속하고 score·behavior·policy·replay claim authority를 분리하는 Evidence Admission
+- 23–27: Petri interaction audit와 τ²·MCPMark environment completion을
+  분리한 Simulator / Benchmark 경계와 실측
+- 27: GPT-5.4 subscription/high의 `geode_agent + geode_user`, base 278개,
+  `k=1` diagnostic profile. Airline 42/50, Retail 79/114, Telecom 79/114이며
+  official leaderboard로 표현하지 않는다.
+- 28: native score는 evaluator, canonical behavior는 runtime, named-state
+  변경은 gate가 소유하는 External Loop authority boundary
+- 29–35: bounded scaffold surface→계산 연산자와 write authority 분리→
+  artifact handoff→수치 gate→SIL/Crucible
+- 30: same-task best-of-N과 반복 측정은 결과·ledger에만 쓰고,
+  named state는 `(1+1)`·sealed gate만 바꾸는 Goodhart control
+- 31: 실패 trajectory를 15개 adversarial draft로 변형해 미탐색 failure
+  branch와 audit headroom을 넓히고, Elo·Petri pilot·proximity dedup으로
+  Top-5를 선별한 뒤 한 JSON section만 수정 후보로 노출
+- 32: 22개 raw 측정값을 보존한 채 full aggregate의 신호 희석을
+  targeted ICC sub-fitness로 교정하고 full-surface veto를 유지한 baseline 발전
+- 33: mutation LLM에 숨긴 held-out 10개를 ledger-only monitor로 쓰되,
+  반복 노출·nonfatal·runtime overlap guard 부재 때문에 일반화 보증이나
+  sealed test로 부르지 않는다.
+- 35: Crucible r14의 train `0.500→0.833` KEEP이 disjoint one-shot sealed에서
+  REJECT된 관측 사례. Crucible은 Goodhart 알고리즘이 아니라
+  train proxy와 release authority를 분리한 통제 구조다.
+- 37: 특정 모델 연계를 전제하지 않고 model·prompt·visible tools·runtime/verify
+  policy identity를 request→isolated run→trajectory→verifier→gate→Human
+  release 경로에 결속하는 기여 가설
+- 대본: `talk-script-20min.md`
+- Claim/편집 SOT:
+  `wiki/geode-v1.0.10-motivation-control-boundaries-2026-07-31.md`
+- 섹션 반전: 05 BUILD · 09 RUN · 17 OBSERVE · 20 EVALUATE · 23 SIMULATE / BENCHMARK ·
+  28 EVOLVE · 36 TRANSFER의 첫 화면에만 dark field를 적용
+- 본문 흐름: OPEN 01–04 → BUILD 05–16 → OBSERVE 17–19 →
+  EVALUATE / VERIFY 20–21 → EVIDENCE ADMISSION 22 →
+  SIMULATE / BENCHMARK 23–27 → EVOLVE 28–35 → TRANSFER 36–37
+- 렌더: `slides/.render-check-v34/`
+- 최근 검증: 37장, viewport·header/visual/footer·SVG text·label/connector 충돌 0
+
+### 이전 v14 핸드오프 (폐기·근거 추적용)
+
+- 화면 27 제목:
+  `ReAct의 실행 환경이 전산 상태였기에 τ²를 택했습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-25"`
+- 스타일: `styles.css`의 `.v12-tau2*`
+- 근거:
+  `source/research/tau2-bench-2506.07982.pdf`,
+  `wiki/geode-context-engineering.md` §12.2,
+  GEODE `plugins/benchmark_harness/tau2_geode_agent.py`와
+  `tau2_turn_supervisor.py`
+- 시각 문법: 왼쪽은 single-control→dual-control의 측정 대상 변화,
+  오른쪽은 τ² evaluator와 GEODE candidate의 ownership boundary다.
+  Telecom만 새 dual-control domain이며 Airline/Retail에 같은 구조를
+  소급하지 않는다. K‑EXAONE·EXAONE 4.5 표기는 동일 구현 주장이 아니라
+  공개 Agentic Tool Use 평가 방향의 정렬만 뜻한다.
+- 화면 30 제목:
+  `하네스 전체가 아니라 7개 조정면만 실험 대상으로 열었습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-28"`
+- 스타일: `styles.css`의 `.v12-levers*`
+- 근거:
+  `wiki/bounded-harness-control-2607.25415.md`의
+  `GEODE의 일곱 변경 표면과 대응`,
+  GEODE `core/self_improving/loop/mutate/policies.py::TARGET_KINDS`
+- 시각 문법: 외부 연구 3개는 압축한 experiment grammar에만 연결하고,
+  오른쪽은 frozen execution plane 안의 7개 JSON behavior key를
+  editable surface로 표시한다. `hyperparam`, `retrieval`, runtime
+  source는 닫힌 표면으로 남긴다.
+- 화면 08 제목:
+  `긴 추론 대신 행동과 관측을 짧게 닫았습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-07"`
+- 스타일: `styles.css`의 `.v6-sequence*`, `.v11-sequence*`
+- 렌더 확인: `slides/.render-check-v14/slide-08.png`
+- 화면 09 제목:
+  `한 바이트가 달라지면, 캐시는 그 뒤를 재사용하지 못합니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-08"`
+- 스타일: `styles.css`의 `.v16-cache-prefix*`
+- 렌더 확인: `slides/.render-check-v14/slide-09.png`
+- 화면 10 제목:
+  `고정 prefix 뒤에서, 실행 상태가 모델이 볼 문맥을 결정합니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-08-materialized"`
+- 스타일: `styles.css`의 `.v15-prompt-instance*`
+- 렌더 확인: `slides/.render-check-v14/slide-10.png`
+- 근거:
+  `wiki/geode-context-engineering.md` §5,
+  GEODE `core/agent/system_prompt.py`, `core/agent/loop/_context.py`,
+  `core/agent/prompt_dump.py`, `core/llm/adapters/registry.py`
+- 실측: local `main@440bd3e7`에서 `gpt-5.5 / cli` dump는 18,588자,
+  추정 4,647 token, duplicate tag 0건이다. Registry는 adapter provider
+  3개, concrete source 3개와 built-in adapter 8개를 등록한다.
+- 시각 문법: 화면 09는 세 요청에서 글자·공백·순서까지 같은 prefix와
+  달라지는 tail을 겹쳐 보여준다. Anthropic `cache_control=1h`, OpenAI
+  `prompt_cache_key=hash(prefix)`, artifact의 cache read 관측을 함께
+  표기하되 이 split 단독의 hit-rate 상승률로 읽히지 않게 한다. 화면
+  10은 `MODEL ID/INTERACTION CONTRACT/SURFACE`로 고정한 XML instance와
+  provider·verify·plan 분기만 맡는다. 검은 코드 패널 대신 밝은 XML
+  syntax rail을 사용하고, 우측 조건은 `SIGNAL/STATE/OUTPUT` 고정 열로
+  맞춘다. `current_date`는 OpenAI 계열에서 생략되고 Anthropic·GLM에는
+  주입된다.
+- 화면 21 제목:
+  `실패를 규약으로 내리고 Git revision으로 고정했습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-19"`
+- 스타일: `styles.css`의 `.v12-failure-contract*`
+- 렌더 확인: `slides/.render-check-v14/slide-21.png`
+- 근거: `wiki/geode-codebase-atlas.md`의 G1.1·G1.2
+- 시각 문법: deterministic failure는 minimum contract→source+test→
+  revision ratchet으로, 의미가 열린 failure는 simulation/Judge lane으로
+  분리한다. Test 실패는 baseline·SoT·ref를 전진시키지 않는다.
+- 화면 23 제목:
+  `행동 차단과 제품 승격을 같은 평가 권한으로 두지 않았습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-21"`
+- 스타일: `styles.css`의 `.v12-eval-scope*`
+- 렌더 확인: `slides/.render-check-v14/slide-23.png`
+- 근거:
+  GEODE `ToolExecutor._gate_async`, `VerifyResult`,
+  `wiki/geode-trajectory-judgment.md`의 SIL·Crucible·Human 권한 경계
+- 시각 문법: tool call→turn→run→revision pair→product로 evidence
+  scope를 확대하되, automated authority는 release cut 앞에서 끝낸다.
+- 화면 24 제목:
+  `Agent 평가도 무엇을 환경으로 삼는지가 다릅니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-22"`
+- 스타일: `styles.css`의 `.v13-sim-systems*`
+- 렌더 확인: `slides/.render-check-v14/slide-24.png`
+- 근거:
+  [Petri 공식 리포트](https://alignment.anthropic.com/2025/petri/),
+  `source/research/tau2-bench-2506.07982.pdf`,
+  [MCPMark arXiv:2509.24002](https://arxiv.org/abs/2509.24002)
+- 시각 문법: Petri의 seed→adaptive auditor loop→transcript→Judge,
+  τ²의 user·agent→shared world→task verifier, MCPMark의 curated
+  initial state→MCP tool loop→final state→programmatic verifier를
+  같은 execution→artifact→verdict 좌표에 놓되 점수를 합산하지 않는다.
+- 화면 31 제목:
+  `판정에는 trajectory 전체가 아니라 검증된 수치 투영만 넣었습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-29"`
+- 스타일: `styles.css`의 `.v14-sil-projection*`
+- 렌더 확인: `slides/.render-check-v14/slide-31.png`
+- 화면 32 제목:
+  `같은 실험 문법을 서로 다른 비교군과 쓰기 권한으로 통제했습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-30"`
+- 스타일: `styles.css`의 `.v14-experiment-compare*`
+- 화면 33 제목:
+  `판정은 통과 조건과 바뀔 수 있는 상태를 함께 고정했습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-31"`
+- 스타일: `styles.css`의 `.v14-verdict-grid*`
+- 렌더 확인: `slides/.render-check-v14/slide-33.png`
+- 화면 34 제목:
+  `Failure artifact로 한 JSON section 후보만 만들었습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-32"`
+- 스타일: `styles.css`의 `.v14-artifact-montage*`
+- 렌더 확인: `slides/.render-check-v14/slide-34.png`
+- 화면 37 제목:
+  `업무 Agent가 결과와 실행 증거를 함께 남기게 하고, 그 trajectory로 다음 workflow와 모델을 더 빨리 검증하겠습니다`
+- 소스: `slides/slides-v3.js`의 `id: "slide-36"`
+- 스타일: `styles.css`의 `.v11-authority-frontier*`
+- 렌더 확인: `slides/.render-check-v14/slide-38.png`
+- 근거:
+  `wiki/hyperagents-2603.19461.md`의 claim ledger와 수정 표면 비교
+- 시각 문법: 31은 artifact boundary, 32는 공통 전이 kernel과 대조
+  설계, 33은 함수 순서와 상태 전이, 34는 세 하위 시스템 사이의
+  artifact handoff를 맡는다. 37은 K‑EXAONE 2.0의 공개 capability 신호를
+  JD의 내부 Agent application vertical과 연결하고, 실행 trajectory를
+  regression/eval·후속 학습 후보로 정제하는 확장 경로를 그린다. 직무와
+  특정 EXAONE 모델의 직접 연결은 확정하지 않는다.
+- 권한 경계: Crucible `KEEP`은 private search ref만 바꾸며 sealed
+  `ELIGIBLE`에도 제품 release 권한이 없다. SIL과 Crucible 사이에 자동
+  candidate handoff가 있다는 뜻이 아니다.
+
+### 슬라이드 31–33 직접 근거
+
+검증 revision은 GEODE
+`cabff1adb7bcae94a3a0cb06fe43aaf618cfff89`, 공개 eval artifact
+`e9ce94dd33c5c1a05ac4d9263d74816846fe5851`이다.
+
+| 표시 내용 | 코드·artifact 근거 |
+|---|---|
+| Petri 22 rubric → 18 fitness taxonomy → 15 weighted + stability | `plugins/petri_audit/judge_dims/geode_judge_subset.yaml`, `core/self_improving/fitness.py` |
+| `targeted_dims`는 weighted 15의 부분집합이며 ICC reshape한 sub-fitness | `core/self_improving/ledger.py`, `core/self_improving/fitness.py`, `core/self_improving/gate.py` |
+| 17→20→targeted→18 발전사 | GEODE `59feb756`, `17e410a29`, `b22969dcd`, `a0ee62a77`; eval artifact 2026-05-12·15·19 reports |
+| SIL `.eval`의 mean·stderr·sample row와 hard veto | `core/audit/dim_extractor.py`, `core/self_improving/fitness.py`, `core/self_improving/gate.py` |
+| `RunTranscript`는 lifecycle·재현·진단 원장이고 gate의 수치 입력이 아님 | `core/self_improving/loop/observe/run_transcript.py`, `core/self_improving/measure.py`, `core/self_improving/gate.py` |
+| `promote` 뒤 baseline 갱신, `reject` 뒤 `previous_value` 복원 | `core/self_improving/train.py`, `core/self_improving/gate.py` |
+| 공통 controlled-transition 표기와 SIL async-first control의 실제 경계 | `core/self_improving/campaign.py`, `core/self_improving/train.py`, `plugins/crucible/evidence.py`, `plugins/crucible/promotion.py` |
+| Crucible raw trajectory의 identity·coverage·safety·paired effect | `plugins/crucible/tau2_live.py`, `plugins/crucible/verifiers/tau2.py`, `plugins/crucible/promotion.py` |
+| `KEEP`만 private search ref 전진, `REJECT/INVALID`는 유지 | `plugins/crucible/supervisor.py`, `plugins/crucible/ref_journal.py` |
+| sealed `ELIGIBLE`에도 release authority 없음 | `plugins/crucible/sealed.py`, `plugins/crucible/program.md` |
+| Proximity는 cluster를 만들고 survivor dedup은 Ranker 뒤 Elo·Pilot로 수행 | `plugins/seed_generation/orchestrator.py`, `plugins/seed_generation/dedup.py` |
+| Seed pool→Petri→SIL은 단일 함수 체인이 아니라 file pointer와 eval artifact handoff | `plugins/seed_generation/orchestrator.py`, `core/self_improving/train.py`, `core/self_improving/measure.py` |
+
+해설과 claim boundary는
+`wiki/geode-trajectory-judgment.md`의 **Baseline은 어떻게 추출되고
+gate는 무엇을 비교하는가**와 **판정 뒤에는 무엇이 실제로 바뀌는가**를
+우선한다. 현재 코드·테스트·commit-pinned artifact가 이 위키와
+포트폴리오 PDF보다 우선한다. 포트폴리오 44쪽의 “18개 dim이 fitness
+가중”은 현재 코드 기준 `18개 taxonomy / 15개 weighted / 3개 info`로
+교정한다.
+
+### 재검증
+
+```bash
+python3 presentation/slides/validate.py
+
+NODE_PATH=${HOME}/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules \
+  ${HOME}/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node \
+  presentation/slides/render-check.cjs
+
+${HOME}/workspace/geode/.venv/bin/pymarkdown \
+  -c presentation/.pymarkdown.json scan \
+  presentation/*.md presentation/design/*.md presentation/wiki/*.md
+```
+
+## 진행 상태
+
+- [x] 스캐폴드 생성
+- [x] wiki 수집 완료 (2026-07-29, 역할 조사 + 프로젝트 5종)
+- [x] EXAONE 공개 구현·LG 기술 보고서·Agent Workflow 원문 17건 로컬 보존 및 출처 대장 갱신
+- [x] strategy.md — 슬라이드 맵 16장 + 수치 발화표 + 지뢰 15종 + Q&A 뱅크 + 면접 전 액션
+- [x] `design/lg-ai-research-visual-system.md` — 화이트페이퍼 기반,
+      `#513FF3` 기술 강조 + `#EC297B` 제한적 브랜드 큐. `design.md`의
+      다크 안은 폐기된 이력 초안으로만 보존
+- [x] `design/paper-diagram-visualization-taxonomy.md` — 논문형 구조·과정·
+      정량·평가·실험 시각화 분류와 16장 슬라이드별 권장 문법
+- [x] progress-audit.md — 자료 보존 상태·누락·HEAD 수치 규약·12장 내러티브 v2
+- [x] 축 보강 수집 (2026-07-29): skill 2종 + 발전사 3종 +
+      reode.md Q&A 근거 복원 + 메일 원문 보존
+- [x] GEODE context engineering: PDF v1.0.0과 현재 v1.0.3의
+      prompt·budget·state·resume wiring, trajectory 기반 prompt 조립 대조
+- [ ] GEODE 코드베이스 G0~G9 전수 감사:
+      `wiki/geode-codebase-atlas.md`에서 PDF 88쪽과 current code·test·
+      eval artifact를 교차 추적
+- [x] seq=636 이후 공개 연구·제품·채용 신호 추적 및 출처 대장
+- [x] 공식 웹·기술 보고서 실측 기반 LG AI Research 시각 시스템
+- [x] 본편 23장 연속 내러티브 HTML 구조와 렌더 검사
+- [ ] 면접 전 액션 아이템 (strategy.md §6 — Slack 스크린샷, 로고 확보)
+- [x] OpenClaw·autoresearch·Anthropic 영향 계보 → 두 하네스 → Eco² →
+      GEODE 순의 본편 23장 구조 확정
+- [ ] 발표용 핵심 자산 수집 및 출처 고정
+- [x] Eco² workflow→GEODE runtime→Petri→eval artifact→승격 권한의
+      검증된 콘텐츠·도표 주입
+- [ ] PPTX 빌드 → 게이트 4종 검증 → 제출본
+- [ ] 20분 리허설 2회 + 40분 Q&A 방어 점검

--- a/.claude/skills/stanford-test-time-compute/references/project-application-index.md
+++ b/.claude/skills/stanford-test-time-compute/references/project-application-index.md
@@ -1,0 +1,19 @@
+# Project application index
+
+Read `lecture-analysis.md` first. Then load only the row needed for the current
+request. These files are 2026-08-05 presentation snapshots; current GEODE code,
+tests, schemas, and release documents take precedence.
+
+| Need | Reference | Current GEODE grounding |
+|---|---|---|
+| Full presentation knowledge-base routing | `presentation-index-snapshot.md` | Use only to locate a relevant historical source |
+| Eco² graph policy, concurrency, observability, and feedback lineage | `eco2-runtime.md` | Compare objects and authority; do not relabel Send fan-out as candidate width |
+| SIL/Crucible trajectory judgement, evidence, and promotion | no additional snapshot required | `core/self_improving/`, `plugins/crucible/`, `docs/architecture/crucible-*.md` |
+| Frozen-model scaffold levers and bounded search | route through `presentation-index-snapshot.md` only when historical framing is needed | `core/self_improving/loop/mutate/`, `plugins/crucible/contract.py` |
+| Policy stack and trajectory provenance | no additional snapshot required | `core/agent/`, `core/observability/trajectory.py`, `core/agent/evidence_ledger.py` |
+| Runtime verification and public hooks | no presentation snapshot required | `core/agent/verify.py`, `core/agent/loop/_lifecycle.py`, `core/hooks/public.py`, `docs/architecture/hook-system.md` |
+| Tau2 executable evidence | no presentation snapshot required | `plugins/benchmark_harness/`, `docs/eval/tau2-bench.md`, `docs/plans/2026-08-04-runtime-faithful-tau2.md` |
+
+When a snapshot names an old version or revision, preserve it as historical
+evidence and re-run the corresponding current-code check before reusing its
+claim.

--- a/.claude/skills/stanford-test-time-compute/references/source-manifest.md
+++ b/.claude/skills/stanford-test-time-compute/references/source-manifest.md
@@ -1,0 +1,37 @@
+# Stanford CS329A Part 2 source manifest
+
+The tracked skill contains analysis and selected project snapshots. It does not
+duplicate the 37 MB lecture video, the full automatic-caption file, or extracted
+frames. This keeps copyrighted raw media and generated derivatives out of the
+GEODE source distribution while retaining a reproducible source boundary.
+
+## Public source
+
+- Lecture: [Stanford CS329A Self-Improving AI Agents · Part 2](https://www.youtube.com/watch?v=-Ggc37xLj_Y)
+- Course: [Stanford CS329A](https://cs329a.stanford.edu/)
+
+## Optional local evidence workspace
+
+Resolve `${HOME}` at runtime; do not hardcode a user name.
+
+| Evidence | Local path | SHA-256 |
+|---|---|---|
+| Source analysis | `${HOME}/workspace/lg-ai/presentation/wiki/stanford-cs329a-test-time-compute-part2-2026-08-05.md` | `909914e79dd9068263e439ec3e689357a18b7917ba15b819f5d8ea24add30c7d` |
+| Presentation index | `${HOME}/workspace/lg-ai/presentation/README.md` | `f0ad61f14c3db23398727381788de7d214cbebb75adfa761ea30f0b31b36a701` |
+| Video | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.mp4` | `98b756b08dd5dd18fa9b067126ce7e4b33abb50e1315b4455b91b0b6be734833` |
+| Automatic captions | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.en-j3PyPqV-e1s.vtt` | `06aac8e835910d682836c4ccde52e57ab06fb0cd30dac160c567173a35734639` |
+| Video metadata | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/-Ggc37xLj_Y.info.json` | `141ab786f0b3530bb8b2f16a11cfa78174f23dbb6e42318173530d92d2db3072` |
+| Rhythm manifest | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/rhythm-manifest.json` | `10665f685c4fb3eb22bdbe8a57745539b002e84902c59eccc87c75354043fbff` |
+| Contact sheet 01 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-01.jpg` | `c7ea308c09b917a87db4d0860d7023691218da01506807428549327d118b26a2` |
+| Contact sheet 02 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-02.jpg` | `48cbb8d9b2f1eac3b68b0b853f6747f20dd7a3e4524734aa3910313407c8110b` |
+| Contact sheet 03 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-03.jpg` | `3455dd31f645fdf06c032038a8bc2e5fd9839bd1ca5564bd9402c9a1b7edfaf6` |
+| Contact sheet 04 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-04.jpg` | `26963d63e31fd255ca8d4497ef20c12c4972d100101b50b1aa4b12c513e0d660` |
+| Contact sheet 05 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-05.jpg` | `649cabe8b2daeb03b7e4b41198ee911c71f8c01efd03863d7a546e8b331bde45` |
+| Contact sheet 06 | `${HOME}/workspace/lg-ai/presentation/source/video/-Ggc37xLj_Y/contact-sheets/sheet-06.jpg` | `68e0e48a108b90728dcb61370df47a7807d7421ad55a9f7d24c6bcf96b4afd8d` |
+
+The tracked `lecture-analysis.md` normalizes only its five local evidence paths
+to `${HOME}`. The source-analysis hash above identifies the original file.
+
+Use captions for timestamp navigation, not as final authority for equations,
+numbers, or paper conclusions. Verify material claims against the lecture frame
+and cited primary paper.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ Use `docs/workflow.md` as the canonical workflow summary and
 scaffold. It is shared with Claude Code and supersedes the older issue-first
 workflow.
 
+For test-time compute, best-of-N, verifier-aware scheduling, inference-program
+search, or GEODE/Eco²/SIL/Crucible comparisons, use
+`.claude/skills/stanford-test-time-compute/`. Read its lecture analysis before
+mapping the concepts to current code, and keep candidate width, repair depth,
+measurement replication, and promotion authority separate.
+
 ## Module map
 
 Read the module you are about to change. If a section says "read this first",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ uv run geode "schedule daily standup reminder at 9am"
 |----------|------|---------|
 | Agent Identity | `GEODE.md` | Identity, Voice & Conduct, runtime architecture, LLM models |
 | Operational Workflow | `docs/workflow.md` + `.claude/skills/geode-workflow/` | Evidence-first execution scaffold shared by Claude Code, Codex, and contributors |
+| Test-Time Compute Grounding | `.claude/skills/stanford-test-time-compute/` | Stanford CS329A Part 2 evidence and GEODE/Eco²/SIL/Crucible application boundaries |
 | Architecture/Extensibility Program | `docs/architecture/extensibility-roadmap.md` | Single execution SOT for GAP IDs, merge order, status, acceptance, and closure evidence |
 | Hook System | `docs/architecture/hook-system.md` | HookSystem 56 events |
 | Scaffold | `CLAUDE.md` | Development workflow, quality gates, CANNOT/CAN (this file) |

--- a/docs/scaffold-skills.md
+++ b/docs/scaffold-skills.md
@@ -7,6 +7,7 @@ Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate f
 | Skill | Triggers | Content |
 |-------|----------|---------|
 | `geode-workflow` | workflow, scaffold, feature work, provider/model changes, GUI/computer-use, observability, verification | Evidence-first execution scaffold with progressive-disclosure references |
+| `stanford-test-time-compute` | test-time compute, inference-time scaling, best-of-N, parallel width, sequential repair, measurement replication, verifier/evaluator, promotion authority, Archon | Stanford CS329A Part 2 grounding with GEODE/Eco²/SIL/Crucible decision-plane and authority boundaries |
 | `prompt-writing` | prompt, system prompt, model-facing text, identity, You are, Fable | GEODE prompt-writing standard: metadata/behavioral clauses, no direct identity assertions |
 | `geode-distribution` | homebrew, brew, formula, tap, uvx, 배포 | Coordinated GitHub Release + PyPI + Homebrew stable promotion |
 | `geode-gitflow` | branch, git, pr, merge, commit | Gitflow strategy, PR templates, CI fix loops |


### PR DESCRIPTION
## Summary
- Promote the Stanford CS329A Part 2 grounding skill from develop to main.
- Make the evidence and decision-plane guide available to default GEODE workspaces.

## Why
PR #2881 is merged and the complete main-to-develop tree diff contains only this documentation and scaffold skill. No runtime or release metadata changes are included.

## Changes
| Surface | Change |
|---|---|
| Scaffold skill | Full lecture SOT, selective references, portable source manifest |
| Agent entry points | AGENTS.md, CLAUDE.md, and scaffold catalog wiring |

## Verification
- Feature PR #2881 CI: all checks passed
- Skill package validator: passed
- Markdown lint and repository hygiene: passed
- Independent Codex review: no actionable regression
- main versus develop diff audited: exactly 9 skill and scaffold documentation files