### PR TITLE
docs(architecture): register durable collaboration control

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -494,6 +494,7 @@ as testable phases without replacing the loop with an opaque framework.
 | D-014 Compatibility windows start at publication | The v1.0.1 facade and preserved state roots remain publicly available for a final qualifying interval of at least 30 consecutive days measured from confirmed GitHub Release and PyPI publication; every release inside that interval retains them |
 | D-015 Facade retirement is removal-only | Retiring `core.self_improving` removes only forwarding imports and legacy source/module launchers after the publication gate; canonical product code, configuration, durable state, and unrelated APIs do not move in the same transaction |
 | D-016 State follows declared ownership | A feature-owned dataset manifest declares lifecycle, schema, path, writer, and migration policy; the code move does not relocate data, tracked SoT moves in R8.2 before facade retirement, and runtime cutovers remain additive, idempotent, and single-writer |
+| D-017 Collaboration control is not a second transcript | Mutable child-run state and bounded mailboxes live in the existing session database; child checkpoints, messages, and append-only session events remain the independent rollout history and sole replay source |
 
 ## 5. Master GAP ledger
 
@@ -553,6 +554,9 @@ and closure evidence are appended in §10.
 | STORE-003 | `MISFIT` | Self-improving datasets span tracked `core/self_improving/state`, runtime `~/.geode/self-improving`, actively written `~/.geode/autoresearch/handoff`, and isolated `GEODE_STATE_ROOT/autoresearch` roots without one dataset-level ownership manifest | A feature-owned manifest declares every dataset's lifecycle, schema/version, root, writer/readers, concurrency, retention/redaction, migration, rollback, and rebuild contract; tracked SoT leaves `core` with hash/history parity, while runtime/override/worker roots remain compatible or migrate additively with one writer | R8.2 | REL-002, STORE-001 | `OPEN` |
 | HOOK-001 | `MISFIT` | The 56-member internal `HookEvent` enum is exported at the package root, one registry mixes observer, result-transform, and control-interceptor authority without a stable public allowlist, and verification is emitted only inside terminal finalization | Exactly 13 versioned `HookName` contracts expose the Codex 11-event lifecycle plus `PreVerify`/`PostVerify`; typed authority, redaction, correlation, unknown-name rejection, and compatibility tests prevent internal RuntimeEvent growth from expanding the ABI, while one monotone bounded `PreVerify` → verifier → `PostVerify` → `Stop` state machine supports executable external continuation without erasing built-in failure or replaying side effects | R6.4 | — | `DONE` |
 | HOOK-002 | `PARTIAL` | Tool request interception is mixed with `TOOL_EXEC_STARTED`; no typed sequential tool/LLM request transform or async `next_call` chain wraps the accepted executor and provider call across every runtime path | `tool_request`, `tool_execution`, `llm_request`, and `llm_execution` are four typed join points with N→N+1 request composition, original/effective trace, single-use async `next_call`, exception identity, policy-before-execution ordering, and all-path parity tests | R6.4 | HOOK-001 | `DONE` |
+| COLLAB-001 | `MISFIT` | `delegate_task` tells callers that long-running work should not block, but awaits the complete fan-out and returns no stable handle for later control | Opt-in background delegation returns before completion and supports parent-scoped list, bounded wait, and interrupt while preserving the existing depth, session-cap, and Lane limits | R6.5 | HOOK-001 | `OPEN` |
+| COLLAB-002 | `MISFIT` | Subagent completion announcements live only in a five-minute process-memory queue, so parent inactivity or daemon restart can discard collaboration delivery | A bounded, redacted mailbox in the existing session database preserves ordered parent/child messages and completion delivery with transactional at-most-once consumption | R6.5 | COLLAB-001, STORE-002 | `OPEN` |
+| COLLAB-003 | `PARTIAL` | Child checkpoints and session history are durable, but every isolated worker invocation creates a fresh conversation and never restores the child checkpoint | Follow-up and resume reopen the same child session as a new generation, restore its checkpoint, accept queued mailbox input at a loop boundary, and preserve one independent rollout without replaying successful side effects | R6.5 | COLLAB-001, COLLAB-002 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -585,6 +589,12 @@ narrow compatibility-preserving package over the current measured call sites
 and sinks. It owns convergence of those call sites into its four middleware
 join points, but does not claim or bypass the broader owner replacements
 elsewhere in R2-R6.
+
+R6.5 is a narrow collaboration-control package over the delivered public-hook
+and storage contracts. It makes the existing depth-one subagent runtime
+durable and controllable without introducing a general thread manager, a
+planner, or a second transcript, and it does not claim the broader R3.4
+`SubAgentManager` responsibility split.
 
 ### 6.1 v1.0.1 boundary-release train
 
@@ -1311,6 +1321,44 @@ Acceptance:
   fail-to-pass rejection, bounded revise and Stop continuation, no side-effect
   replay, timeout fallback, external evidence correlation, and final
   persistence/delivery ordering.
+
+#### R6.5 Durable child collaboration control
+
+GAPs: COLLAB-001, COLLAB-002, COLLAB-003.
+
+This package extends the existing `delegate_task` surface rather than creating
+a general-purpose thread subsystem. Background delegation returns a stable
+child handle; one parent-scoped control surface provides list, bounded wait,
+interrupt, message, follow-up, and resume operations. Children remain depth
+one, retain the current session cap and global Lane limit, and cannot control
+siblings or create descendants.
+
+Mutable run status and bounded mailbox delivery use additive tables in the
+existing `sessions.db`. They are control projections, not replay history. The
+child's checkpoint, messages, hook/runtime events, and projected trajectory
+remain its independent rollout. A resumed child increments a generation and
+restores that same checkpoint; it never replays a previously successful tool
+side effect. A daemon restart may mark an uncertain in-flight process
+interrupted, but does not automatically restart it.
+
+Acceptance:
+
+- foreground `delegate_task` behavior remains compatible, while background
+  mode returns before child completion and exposes one stable child handle;
+- list, bounded wait, and interrupt are scoped to the owning parent, preserve
+  terminal status, and emit exactly one terminal transition per generation;
+- messages and completion notices are bounded, redacted, ordered, durable
+  across parent inactivity and daemon restart, and consumed at most once;
+- a running child consumes mailbox input only at an agent-loop boundary;
+  follow-up/resume on a terminal or interrupted child restores the same child
+  checkpoint as a new generation without replaying completed side effects;
+- depth, per-session task cap, Lane concurrency, approval/policy, hooks,
+  checkpoint, session-event, and trajectory contracts remain executable in
+  foreground, background, interrupted, resumed, failed, and timed-out tests;
+- architecture and migration documentation distinguish mutable collaboration
+  control state from the independent append-only child rollout, and document
+  the deliberate absence of nesting, a residency cache, and automatic crash
+  restart.
 
 ### R7 — Closure, hardening, and release
 


### PR DESCRIPTION
## Summary
- Register R6.5 as the durable child-collaboration control package.
- Add COLLAB-001 through COLLAB-003 for background delegation/control, a durable mailbox, and checkpoint-backed child resume.
- Fix the storage boundary: mutable control state is not a second transcript; the child session remains the independent rollout.

## Why
GEODE already preserves child sessions and checkpoints, but `delegate_task` blocks until completion, announcements are process-memory only, and isolated workers never restore an existing child checkpoint. The new package records that measured gap without broadening R3.4 or introducing a general thread manager.

## GAP Audit
| GAP | Audit | Current evidence |
|---|---|---|
| COLLAB-001 | MISFIT | Long-running delegation still awaits full fan-out and returns no stable handle. |
| COLLAB-002 | MISFIT | Completion delivery is a five-minute in-memory queue. |
| COLLAB-003 | PARTIAL | Durable child checkpoints exist, but worker invocations always start a fresh conversation. |

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | Add D-017, the R6.5 GAP rows, dependency note, and measurable acceptance contract. |

## Verification
- `git diff --check`
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
