### PR TITLE
feat(hooks): make PostVerify delivery control effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PostVerify now controls delivery by default.** With no external handler,
+  passing candidates are accepted, retryable failures enter the existing
+  bounded revise/replan path, and non-retryable failures pause for external
+  verification. Revision instructions now use the dynamic system context
+  instead of user-role history, and candidate-digest-bound handler decisions
+  persist in the semantic session timeline for trajectory reconstruction.
+
 ## [1.0.14] - 2026-08-05
 
 > Cleanup release: retire the orphaned unary DPO precursor and the unreachable

--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -9,6 +9,7 @@ thin one-line delegators.
 from __future__ import annotations
 
 import logging
+from html import escape
 from typing import TYPE_CHECKING, Any
 
 from core.agent.system_prompt import build_system_prompt as _build_system_prompt
@@ -144,3 +145,11 @@ def inject_runtime_hints(system_prompt: str, *hints: str | None) -> str:
     if idx >= 0 and not system_prompt[idx + len(closing) :].strip():
         return system_prompt[:idx] + payload + "\n\n" + system_prompt[idx:]
     return system_prompt + "\n\n" + payload
+
+
+def render_verification_continuation_hint(instruction: str) -> str:
+    """Render trusted revision control inside the dynamic system envelope."""
+    text = instruction.strip()
+    if not text:
+        return ""
+    return f"<verification_continuation>\n{escape(text, quote=False)}\n</verification_continuation>"

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import warnings
 from dataclasses import replace
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from core.hooks import (
@@ -642,20 +643,39 @@ async def _run_public_finalization_async(
         )
     )
     actions = {decision.action for decision in post.decisions}
+    fallback_action = ""
+    fallback_instruction = ""
     invalid_accept = not vr.passed and HookAction.ACCEPT in actions
     escalated = HookAction.ESCALATE in actions or invalid_accept
     follow_up = ""
-    policy_action = "escalate" if escalated else ("accept" if vr.passed else "built_in_fail")
-    if HookAction.REVISE in actions and not escalated:
-        policy_action = "revise"
-        follow_up = next(
-            (
-                decision.instruction
-                for decision in post.decisions
-                if decision.action is HookAction.REVISE and decision.instruction
-            ),
-            "",
-        )
+    if not post.decisions:
+        if vr.passed:
+            fallback_action = policy_action = "accept"
+        elif vr.should_retry:
+            fallback_action = policy_action = "revise"
+            miss_summary = ", ".join(vr.rubric_misses[:8]) or "unspecified"
+            follow_up = (
+                "Verification: retry required.\n"
+                f"Rubric misses: {miss_summary}.\n"
+                "Required action: repair the candidate, re-check relevant evidence, "
+                "and return a corrected result."
+            )
+            fallback_instruction = follow_up
+        else:
+            fallback_action = policy_action = "escalate"
+            escalated = True
+    else:
+        policy_action = "escalate" if escalated else ("accept" if vr.passed else "built_in_fail")
+        if HookAction.REVISE in actions and not escalated:
+            policy_action = "revise"
+            follow_up = next(
+                (
+                    decision.instruction
+                    for decision in post.decisions
+                    if decision.action is HookAction.REVISE and decision.instruction
+                ),
+                "",
+            )
 
     stop = await loop._hook_registry.invoke(
         HookName.STOP,
@@ -700,6 +720,46 @@ async def _run_public_finalization_async(
         escalated = True
         policy_action = "escalate_budget_exhausted"
 
+    decision_records: list[dict[str, Any]] = []
+    if fallback_action:
+        instruction_bytes = fallback_instruction.encode("utf-8")
+        decision_records.append(
+            {
+                "surface": HookName.POST_VERIFY.value,
+                "handler": "runtime_default",
+                "action": fallback_action,
+                "reason": "empty_post_verify_decision_set",
+                "instruction_sha256": (
+                    sha256(instruction_bytes).hexdigest() if instruction_bytes else ""
+                ),
+                "instruction_bytes": len(instruction_bytes),
+                "evidence_refs": [],
+            }
+        )
+    for surface, outcome in (
+        (HookName.POST_VERIFY.value, post),
+        (HookName.STOP.value, stop),
+    ):
+        for source, decision in zip(
+            outcome.decision_sources,
+            outcome.decisions,
+            strict=True,
+        ):
+            instruction_bytes = decision.instruction.encode("utf-8")
+            decision_records.append(
+                {
+                    "surface": surface,
+                    "handler": source,
+                    "action": decision.action.value,
+                    "reason": decision.reason,
+                    "instruction_sha256": (
+                        sha256(instruction_bytes).hexdigest() if instruction_bytes else ""
+                    ),
+                    "instruction_bytes": len(instruction_bytes),
+                    "evidence_refs": [ref.as_dict() for ref in decision.evidence_refs],
+                }
+            )
+
     ledger = getattr(loop, "_evidence_ledger", None)
     if ledger is not None and (post.decisions or stop.decisions or evidence_refs):
         try:
@@ -719,6 +779,18 @@ async def _run_public_finalization_async(
         except Exception:
             log.debug("Verification policy evidence row failed", exc_info=True)
     timeline = getattr(loop, "_timeline", None)
+    if timeline is not None:
+        try:
+            timeline.record_verification_decision(
+                candidate=result.text or "",
+                root_turn_id=correlation.turn_id,
+                verify_attempt=correlation.verify_attempt,
+                built_in_passed=vr.passed,
+                policy_action=policy_action,
+                decisions=decision_records,
+            )
+        except Exception:
+            log.debug("Verification decision timeline row failed", exc_info=True)
     if timeline is not None and evidence_refs:
         try:
             timeline.record_verification_evidence(
@@ -784,7 +856,8 @@ async def _close_verify_attempt(
                 and is_successful_task_termination(getattr(result, "termination_reason", "")),
                 verify=verify_payload,
             )
-    loop._save_checkpoint(user_input, round_idx=round_idx)
+    root_input = getattr(loop, "_verify_root_user_input", "") or user_input
+    loop._save_checkpoint(root_input, round_idx=round_idx)
     if loop._hooks:
         _session_ended, turn_completed, reasoning_metrics = _final_hook_payloads(
             loop,

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1010,13 +1010,14 @@ class AgenticLoop:
         self,
         system_prompt: str,
         reflection_hint: str | None = None,
+        verification_hint: str | None = None,
     ) -> str:
         """Sync model drift + rebuild the system prompt.
 
         Rebuilds when the model drifted (``settings.model`` changed) or
         ``_prompt_dirty`` is set (direct ``update_model_async``). On
-        rebuild, re-applies the preflight / reflection / plan hints inside
-        the dynamic envelope so a mid-arun drift doesn't drop them (the
+        rebuild, re-applies the preflight / reflection / verification / plan
+        hints inside the dynamic envelope so a mid-arun drift doesn't drop them (the
         preflight hint was silently lost here before 2026-07-29). Returns
         the (possibly-rebuilt) prompt; clears ``_prompt_dirty``.
         """
@@ -1031,6 +1032,7 @@ class AgenticLoop:
                 self._build_system_prompt(),
                 getattr(self, "_preflight_hint", ""),
                 reflection_hint,
+                verification_hint,
                 plan_hint if isinstance(plan_hint, str) else "",
             )
             self._prompt_dirty = False
@@ -1198,14 +1200,14 @@ class AgenticLoop:
     ) -> AgenticResult | None:
         """Publish legacy start signals, then the durable public boundary."""
         if verification_continuation:
-            self.context.add_system_event("verification_continuation", user_input)
             if self._timeline is not None:
                 self._timeline.record_verification_continuation(
                     user_input,
                     root_turn_id=self._verify_root_turn_id,
                     verify_attempt=self._verify_attempt,
                 )
-            self._save_checkpoint(user_input, round_idx=0)
+            root_input = self._verify_root_user_input or user_input
+            self._save_checkpoint(root_input, round_idx=0)
             return None
         intercepted = await self._emit_session_start_signals(user_input)
         if intercepted is not None:
@@ -2061,7 +2063,16 @@ class AgenticLoop:
         if intercept_result is not None:
             return intercept_result
 
-        preflight_hint = self._prepare_task_preflight(user_input)
+        verification_continuation = _verify_continuation is not None
+        task_input = (
+            self._verify_root_user_input or user_input if verification_continuation else user_input
+        )
+        verification_hint = (
+            _context.render_verification_continuation_hint(user_input)
+            if verification_continuation
+            else ""
+        )
+        preflight_hint = self._prepare_task_preflight(task_input)
         # Retained on self so mid-arun prompt rebuilds re-apply it.
         self._preflight_hint = preflight_hint
 
@@ -2070,7 +2081,10 @@ class AgenticLoop:
         # rendered via ``_consume_plan_hint`` — the hint return was removed
         # as dead plumbing, it had been None-only since the Plan migration).
         try:
-            await self._try_decompose(user_input)
+            await self._try_decompose(
+                user_input,
+                enabled=not verification_continuation,
+            )
         except BillingError as exc:
             self._emit_quota_panel(exc)
             return await self._afinalize_and_return(
@@ -2095,6 +2109,7 @@ class AgenticLoop:
             self._build_system_prompt(),
             preflight_hint,
             reflection_hint,
+            verification_hint,
             self._consume_plan_hint(),
         )
 
@@ -2127,7 +2142,9 @@ class AgenticLoop:
             await self._maybe_replan_async(round_idx)
 
             system_prompt = await self._sync_model_and_rebuild_prompt(
-                system_prompt, reflection_hint=reflection_hint
+                system_prompt,
+                reflection_hint=reflection_hint,
+                verification_hint=verification_hint,
             )
 
             # Poll for sub-agent announced results (OpenClaw Spawn+Announce)
@@ -2611,12 +2628,14 @@ class AgenticLoop:
     # Goal decomposition — delegate to ``_planner_dispatch``
     # ------------------------------------------------------------------
 
-    async def _try_decompose(self, user_input: str) -> str | None:
+    async def _try_decompose(self, user_input: str, *, enabled: bool = True) -> str | None:
         """Delegates to :func:`_planner_dispatch.try_decompose`.
 
         Async because the planner path awaits ``loop._call_llm`` — single
         async LLM dispatch, no thread-pool hop.
         """
+        if not enabled:
+            return None
         return await _planner_dispatch.try_decompose(self, user_input)
 
     # ------------------------------------------------------------------

--- a/core/hooks/public.py
+++ b/core/hooks/public.py
@@ -458,6 +458,7 @@ class HookOutcome:
     invocation: HookInvocation
     decisions: tuple[HookDecision, ...] = ()
     handler_errors: tuple[str, ...] = ()
+    decision_sources: tuple[str, ...] = ()
 
     @property
     def blocked(self) -> bool:
@@ -552,6 +553,7 @@ class HookRegistry:
             handlers = tuple(self._handlers.get(resolved, ()))
 
         decisions: list[HookDecision] = []
+        decision_sources: list[str] = []
         errors: list[str] = []
         for handler in handlers:
             started = time.monotonic()
@@ -580,6 +582,7 @@ class HookRegistry:
                     self._validate_payload(resolved, updated_invocation.payload)
                     invocation = updated_invocation
                 decisions.append(decision)
+                decision_sources.append(handler.name)
                 reason = decision.reason
                 if decision.action in {HookAction.BLOCK, HookAction.DENY}:
                     outcome = decision.action.value
@@ -597,7 +600,12 @@ class HookRegistry:
                     duration_ms=(time.monotonic() - started) * 1_000,
                     correlation=invocation.correlation,
                 )
-        return HookOutcome(invocation, tuple(decisions), tuple(errors))
+        return HookOutcome(
+            invocation=invocation,
+            decisions=tuple(decisions),
+            handler_errors=tuple(errors),
+            decision_sources=tuple(decision_sources),
+        )
 
     @staticmethod
     async def _call(handler: _RegisteredHook, invocation: HookInvocation) -> HookDecision | None:

--- a/core/observability/record_paths.py
+++ b/core/observability/record_paths.py
@@ -19,6 +19,7 @@ EVENT_STREAM_FILENAMES = (EVENTS_FILENAME, *LEGACY_EVENT_FILENAMES)
 _SESSION_KIND_TO_LEGACY = {
     "session.started": "session_start",
     "session.ended": "session_end",
+    "verification.decided": "verification_decided",
     "verification.continued": "verification_continued",
     "verification.evidence": "verification_evidence",
     "verification.pending": "verification_pending",

--- a/core/observability/session_timeline.py
+++ b/core/observability/session_timeline.py
@@ -69,6 +69,7 @@ class SessionEventKind(StrEnum):
     SESSION_STARTED = "session.started"
     SESSION_ENDED = "session.ended"
     TURN_COMPLETED = "turn.completed"
+    VERIFICATION_DECIDED = "verification.decided"
     VERIFICATION_CONTINUED = "verification.continued"
     VERIFICATION_EVIDENCE = "verification.evidence"
     VERIFICATION_PENDING = "verification.pending"
@@ -816,6 +817,33 @@ class SessionTimeline:
                 "root_turn_id": root_turn_id,
                 "verify_attempt": max(0, int(verify_attempt)),
                 "source": "post_verify_or_stop",
+            },
+        )
+
+    def record_verification_decision(
+        self,
+        *,
+        candidate: str,
+        root_turn_id: str,
+        verify_attempt: int,
+        built_in_passed: bool,
+        policy_action: str,
+        decisions: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Persist bounded delivery-control decisions against one candidate."""
+        candidate_bytes = candidate.encode("utf-8")
+        self._record(
+            SessionEventKind.VERIFICATION_DECIDED,
+            role="policy",
+            status=policy_action,
+            payload={
+                "candidate_sha256": sha256(candidate_bytes).hexdigest(),
+                "candidate_bytes": len(candidate_bytes),
+                "root_turn_id": root_turn_id,
+                "verify_attempt": max(0, int(verify_attempt)),
+                "built_in_passed": bool(built_in_passed),
+                "policy_action": policy_action,
+                "decisions": [dict(decision) for decision in decisions],
             },
         )
 

--- a/core/observability/trajectory.py
+++ b/core/observability/trajectory.py
@@ -80,6 +80,7 @@ _TURN_SCOPED_KINDS = {
     *_TOOL_CALL_KINDS,
     *_TOOL_RESULT_KINDS,
     "turn.completed",
+    "verification.decided",
     "verification.continued",
     "verification.evidence",
     "verification.pending",

--- a/docs/architecture/event-persistence.md
+++ b/docs/architecture/event-persistence.md
@@ -69,7 +69,8 @@ The closed session history vocabulary is:
 ```text
 session.started      session.ended
 turn.completed
-verification.continued verification.evidence verification.pending
+verification.decided verification.continued
+verification.evidence verification.pending
 message.user         message.assistant
 tool.called          tool.completed
 subagent.started     subagent.stopped

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -286,16 +286,16 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 542 |
 | Test Python files | 680 |
-| `core/` Python LOC | 138,647 |
+| `core/` Python LOC | 138,786 |
 | `plugins/` Python LOC | 41,879 |
-| Test Python LOC | 178,706 |
+| Test Python LOC | 178,877 |
 | Tool definitions / executable registrations / valid schemas | 78 / 81 / 78 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |
 | Module-level `ContextVar` declarations under `core/` | 30 |
 | `core` → `plugins` import sites | 31 across 14 files |
 | Import-linter contracts / ignored edges | 4 / 24 |
-| `AgenticLoop` file LOC / methods / constructor args | 2,968 / 74 / 27 |
+| `AgenticLoop` file LOC / methods / constructor args | 2,987 / 74 / 27 |
 | `SubAgentManager` file LOC / methods / constructor args | 1,370 / 17 / 16 |
 | `RuntimeCoreConfig` fields | 19 |
 | Global Ruff ratchets | complexity 52; args 23; branches 51; returns 18; statements 212 |

--- a/docs/architecture/hook-system.ko.md
+++ b/docs/architecture/hook-system.ko.md
@@ -75,7 +75,13 @@ revision, 외부 판단 escalation을 선택한다.
 hook은 built-in 실패를 성공으로 뒤집을 수 없다. revision 횟수는 고정되어
 있고 이미 끝난 tool side effect를 재생하지 않은 채 follow-up turn을 시작한다.
 따라서 evaluator, CI, human-review 같은 외부 loop가 `PostVerify`를 안전하게
-사용하면서도 GEODE verifier의 단조 권위를 보존한다. escalation은 telemetry
+사용하면서도 GEODE verifier의 단조 권위를 보존한다. 외부 `PostVerify`
+handler가 결정을 반환하지 않으면 runtime은 같은 단조 기본 정책을 적용한다.
+pass는 accept, 재시도 가능한 실패는 revise, 재시도 불가능한 실패는
+escalate한다. revision 지시는 dynamic system context에 한 번만 들어가며 user
+message나 task decomposition으로 전달되지 않는다. `verification.decided`는
+후보 본문을 복제하지 않고 최종 정책과 handler별 결정을 후보 SHA-256 digest,
+root turn, verify attempt에 결합한다. escalation은 telemetry
 표식이 아니라 delivery gate다. GEODE는 세션을
 `external_verification_required`로 pause하고 후보를
 `AgenticResult.pending_text`로 외부 소유자에게만 돌려주며 terminal

--- a/docs/architecture/hook-system.md
+++ b/docs/architecture/hook-system.md
@@ -83,6 +83,13 @@ A hook cannot turn a built-in failure into a pass. Revision has a fixed
 continuation budget and starts a follow-up turn without replaying completed
 tool side effects. This makes `PostVerify` useful to evaluator, CI, or
 human-review loops while preserving GEODE's verifier as the monotone authority.
+When no external `PostVerify` handler returns a decision, the runtime applies
+the same monotone default: pass → accept, retryable failure → revise, and
+non-retryable failure → escalate. The revision instruction is injected once in
+the dynamic system context; it is never represented as a user message or sent
+through task decomposition. `verification.decided` binds the final policy and
+each attributed handler decision to the candidate SHA-256 digest, root turn,
+and verify attempt without copying candidate text.
 Escalation is a delivery gate: GEODE parks the session with
 `external_verification_required`, returns the withheld candidate as
 `AgenticResult.pending_text` to the owning external loop, and does not create

--- a/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
+++ b/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
@@ -1,0 +1,1020 @@
+# Runtime memory · session record · trajectory convergence
+
+> Date: 2026-08-07  
+> Status: code-grounded research and implementation plan; no runtime behavior changed  
+> GEODE baseline: `origin/develop@bd9d8ccfea63dfc35b3fd1e1da30cbe7f2e89aae`  
+> Comparison baselines: Codex `main@0bdce9f424eb9b39d7b3a8811742d10b6fbf8d54`,
+> Hermes `main@eb8421ba9864cd58b0cf246cdffc6d45f6949372`
+
+This document persists the 2026-08-07 audit of memory admission, duplicate
+storage, session records, trajectories, and reward-ready execution signals. It
+also incorporates the follow-up review performed against `main@03ef7999`, then
+re-grounded against the newer `origin/develop` baseline named above. It is
+design evidence, not a competing delivery ledger. Implementation must first
+register any untracked architecture GAP through
+[`extensibility-roadmap.md`](../architecture/extensibility-roadmap.md) and
+follow that ledger's claim protocol.
+
+## 1. Decision
+
+The attached assessments are directionally correct. The architectural problem
+is best stated as three unresolved authorities, not as “too many stores”:
+
+| Authority | Question | Current split |
+|---|---|---|
+| **Read authority** | What exactly reaches the model? | the live `system_prompt.py` path reads stores directly while the richer `ContextAssembler` is bypassed |
+| **Activation authority** | Which observation may change future behavior, and when? | explicit, heuristic, LLM-derived, and dream paths have different quality but no shared admission contract |
+| **Resume authority** | Which state reconstructs the loop after interruption? | SQLite messages, JSON metadata/tool caches, and SQLite projections are committed independently |
+
+Three corrections follow from that framing.
+
+1. Do not choose the current `ContextAssembler` or `system_prompt.py` as a
+   monolithic winner. Split collection from formatting: a typed snapshot
+   builder owns storage reads; a pure prompt renderer owns cache layout and XML.
+2. The four `TURN_COMPLETED` handlers do not write identical bytes, and their
+   outputs must not share one default gate. Explicit user intent, executable
+   evidence, heuristic/LLM inference, and dream synthesis need source-specific
+   admission.
+3. `session_events`, `hook_events`, native receipts, and evaluation
+   trajectories should not be collapsed. They have different retention and
+   authority. They need complete correlation and immutable export, not one
+   giant database.
+4. A checkpoint is mutable resume state, not a replay of session events. Its
+   field-complete authority should converge on one SQLite transaction; JSON
+   files become temporary projections and migration inputs.
+
+The convergence rule is:
+
+> Preserve canonical facts once; derive caches and evaluation views from those
+> facts; let only explicit writes or promoted candidates change model-visible
+> memory.
+
+The smallest target that satisfies that rule is:
+
+- one read authority: a frozen `ContextSnapshot` built from wired adapters;
+- one pure renderer: `core.agent.system_prompt.build_system_prompt(snapshot=...)`
+  performs no filesystem or database access;
+- one accepted project-memory file: `.geode/memory/PROJECT.md`;
+- one injected `FileBasedUserProfile` instance per runtime;
+- explicit user intent may activate directly after scope, permission, and
+  capacity checks; executable facts, inferences, and dream artifacts follow
+  distinct admission rules;
+- SQLite atomically keeps field-complete resumable state and messages, while
+  semantic/runtime events remain separate tables with separate retention;
+- JSONL remains only where portability, billing, or an external domain ledger
+  requires it;
+- trajectory v2 performs the causal and reward joins without creating another
+  hot runtime store.
+
+### 1.1 Follow-up feedback disposition
+
+| Feedback | Decision | Reason |
+|---|---|---|
+| typed context snapshot plus pure renderer | **accept** | fixes both profile-scope drift and hidden storage reads without injecting the current assembler's journal/vault/dream bundle |
+| source-specific memory admission | **accept** | explicit user intent should not wait for three-session repetition; model inference must not activate directly |
+| SQLite transactional checkpoint | **accept** | current save order spans independent commits and cannot prove an all-or-nothing resume generation |
+| all ProjectJournal data as a projection | **reject as stated** | run/cost/error may be read models; learned/accepted memory is domain state, never an execution projection |
+| `memory-decisions.jsonl` plus `MemoryPromoter` class | **simplify** | reuse `context_artifacts` for immutable candidate and decision records; one `apply_memory_admission()` function is enough until multiple backends appear |
+| rename `preferences.toml` to `tool-policy.toml` | **correct to `permissions.toml`** | GEODE already has a distinct self-improving `tool-policy.json`; reusing the name would preserve ambiguity |
+
+## 2. Current system: the measured divergence
+
+```mermaid
+%%{init: {'theme':'default','themeVariables':{'fontSize':'13px','fontFamily':'arial','lineColor':'#6366F1','primaryColor':'#dbeafe','primaryBorderColor':'#3b82f6','primaryTextColor':'#1e293b','clusterBkg':'#f8fafc','clusterBorder':'#cbd5e1'}}}%%
+graph TD
+    TURN["TURN_COMPLETED"]:::startNode
+
+    subgraph WRITERS ["FOUR MEMORY WRITERS"]
+        AM["turn_auto_memory<br/>turn trace"]:::axisRed
+        AL["turn_auto_learn<br/>heuristic preference"]:::axisYellow
+        LE["LLM extraction<br/>model-derived preference"]:::axisYellow
+        DR["dreaming<br/>long-context synthesis"]:::axisPurple
+    end
+
+    PM[".geode/memory/PROJECT.md<br/>active immediately"]:::axisRed
+    UP["user_profile/learned.md<br/>active immediately"]:::axisRed
+    CA["sessions.db:context_artifacts<br/>offline synthesis"]:::axisBlue
+
+    subgraph READERS ["TWO CONTEXT READERS"]
+        SP["system_prompt.py<br/>actual AgenticLoop path"]:::axisGreen
+        AS["ContextAssembler<br/>rich dict, no production caller"]:::axisRed
+    end
+
+    MODEL["MODEL REQUEST"]:::finalNode
+
+    TURN --> AM --> PM --> SP
+    TURN --> AL --> UP --> SP
+    TURN --> LE --> UP
+    TURN --> DR --> CA --> AS
+    AS -. "not wired" .-> MODEL
+    SP --> MODEL
+
+    classDef startNode fill:#1e293b,stroke:#1e293b,color:#fff,font-weight:bold
+    classDef finalNode fill:#1e293b,stroke:#1e293b,color:#fff,font-weight:bold,stroke-width:3px
+    classDef axisBlue fill:#dbeafe,stroke:#2563eb,color:#1e293b,stroke-width:2px
+    classDef axisGreen fill:#dcfce7,stroke:#16a34a,color:#1e293b,stroke-width:2px
+    classDef axisPurple fill:#ede9fe,stroke:#7c3aed,color:#1e293b,stroke-width:2px
+    classDef axisRed fill:#fee2e2,stroke:#dc2626,color:#1e293b,stroke-width:2px
+    classDef axisYellow fill:#fef3c7,stroke:#d97706,color:#1e293b,stroke-width:2px
+```
+
+### 2.1 The default loop bypasses `ContextAssembler`
+
+| Fact | Code evidence |
+|---|---|
+| The loop builds its prompt through the loop helper and `core.agent.system_prompt` | `core/agent/loop/_context.py:74-100`, `core/agent/system_prompt.py:241-375` |
+| The actual prompt path reads `.geode/MEMORY.md`, learned profile rows, `.geode/memory/PROJECT.md`, rules, and user context directly | `core/agent/system_prompt.py:348-361`, `635-761` |
+| `ContextAssembler` can additionally read journal, vault, run history, dream, and compaction artifacts | `core/memory/context.py:32-300` |
+| The sole production-looking wrapper is `GeodeRuntime.assemble_context()` | `core/runtime.py:388-394` |
+| An exhaustive production caller search found no caller of that wrapper or of `ContextAssembler.assemble()` | `rg "assemble_context\\(|context_assembler\\.assemble\\(" core plugins` |
+
+Therefore the published statement that every LLM request is assembled through
+the five-tier `ContextAssembler` is false on the default runtime path. Routing
+the loop through that rich dictionary is not the fix: it would automatically
+inject low-quality journal, vault, and dream material. Keeping storage access
+inside `system_prompt.py` is also not the fix. Reuse the wired dependencies and
+only the measured useful collection logic to replace the loose assembler with
+a typed `ContextSnapshotBuilder`; then reduce the existing system-prompt path
+to a pure renderer. The current `ContextAssembler.assemble() -> dict` API and
+its unconditional journal/vault/dream injectors still retire.
+
+### 2.2 The same prompt can read two user-profile scopes
+
+`build_memory()` constructs one profile with the configured global directory
+and project overlay, then injects it through `profile_tools`
+(`core/wiring/bootstrap.py:734-831`). `_build_learning_context()` uses that
+instance (`core/agent/system_prompt.py:690-723`). `_build_user_context()` instead
+constructs a fresh `FileBasedUserProfile()` (`:526-575`), dropping configured
+and project-local scope.
+
+This is a concrete defect, not an architectural preference. Both builders must
+use `get_user_profile()`.
+
+### 2.3 Four turn-completion handlers cross one admission boundary
+
+`core/wiring/bootstrap.py:414-482` registers:
+
+| Handler | Writes | Current quality control | Correct target |
+|---|---|---|---|
+| `turn_auto_memory` | `.geode/memory/PROJECT.md` | handler length check plus generic insight gate; still stores `[turn] input → tools` | delete; the canonical session record already owns this trace |
+| `turn_auto_learn` | `user_profile/learned.md` | pattern heuristic, cooldown, local dedup | candidate unless the detector proves explicit quoted user intent |
+| `turn_llm_extract` | the same `learned.md` | every-N-turn gate, model parse, local dedup; excludes explicit memory-tool turns | candidate only |
+| `turn_dreaming` | `context_artifacts(kind="dream")` | source range, content hash, background generation | derived retrieval artifact only; never direct active memory |
+
+The heuristic and LLM writers do not coordinate with each other. Their local
+dedup is substring/input based, not a shared provenance or promotion contract.
+Dreaming is launched after every completed turn with at least one round
+(`core/memory/dreaming.py:310-329`), although its output is available only to
+artifact search, the unused assembler, and the project-memory lifecycle.
+
+The corrected admission statement is therefore not “all four become
+`memory_candidate`.” `turn_auto_memory` stops; dream remains a dream; and the
+two learning paths first classify whether they are replaying explicit intent
+or inferring a preference.
+
+### 2.4 Project memory has a deprecated reader that is still live
+
+- `.geode/MEMORY.md` is called a deprecated meta-index in the architecture
+  documentation, but `_build_geode_memory_context()` still injects it.
+- `.geode/memory/PROJECT.md` is the active `ProjectMemory` store and is also
+  injected by `_build_project_memory_context()`.
+- `.geode/journal/learned.md` has an API and an unused assembler reader, but no
+  production writer.
+
+The convergence target is not a rename carousel. Finish the already-declared
+migration: `.geode/memory/PROJECT.md` remains the sole accepted project-memory
+file, `.geode/MEMORY.md` gets a lossless compatibility migration and then loses
+its prompt reader, and journal `learned.md` is removed.
+
+## 3. Storage authority audit
+
+### 3.1 Current authority matrix
+
+| Plane | Current destination | What it really owns | Verdict |
+|---|---|---|---|
+| Resume conversation | `sessions.db:messages` | full model-visible message history | **keep canonical** |
+| Resume machine metadata | `<session>/state.json` | status, round, model/provider, guards, pending verification | **current required fragment; migrate to SQLite checkpoint** |
+| Session query index | `sessions.db:sessions` | list/search projection plus verify/handoff columns | **keep, declare projection vs owned columns** |
+| Message compatibility | `<session>/messages.json` | full duplicate of SQLite messages plus legacy fallback | **retire after global parity migration** |
+| Tool-log compatibility | `<session>/tools.json` | last 50 processor log rows | **retire; resume never restores it into the processor** |
+| Active pointer | `sessions/active.json` | latest session pointer | **retire after latest-resumable SQLite query parity** |
+| Session state transitions | `sessions/transitions.jsonl` | legal, reopen, implicit, and refused edges | **migrate into canonical semantic events, then retire** |
+| Semantic execution | `sessions.db:session_events` | append-only user/assistant/tool/subagent/verify history | **keep canonical** |
+| Runtime/policy telemetry | `sessions.db:hook_events` | bounded hook, middleware, lifecycle, correlation and latency | **keep separate** |
+| Portable run view | run-local `events.jsonl` | bounded rebuildable projection | **keep projection only** |
+| Evaluation | immutable `trajectory.json` | reviewed/replayable derived view | **keep immutable** |
+| Judgment | `~/.geode/evidence/*.jsonl` and native receipts | claims, verifier decisions, external authority | **keep external; bind by digest and stable key** |
+| Billing | `~/.geode/usage/YYYY-MM.jsonl` | portable monthly cost ledger | **keep only if it remains billing authority** |
+| Project run journal | `.geode/journal/runs.jsonl` | subagent start/stop/failure summary | **retire after parity; do not silently relabel as fully rebuildable** |
+| Project journal cost/error/learned | `.geode/journal/{costs,errors}.jsonl`, `learned.md` | APIs with no production callers | **remove APIs; preserve old files as user data** |
+| Ephemeral session dictionary | `InMemorySessionStore` | current runtime/tool context | **keep** |
+| Duplicate checkpoint API | `InMemorySessionStore.save_checkpoint/load_checkpoint` | no production callers | **remove** |
+
+`state.json` and `sessions.db:sessions` currently call themselves “both SoTs”
+in `SessionCheckpoint._write_status()` (`core/memory/session_checkpoint.py:430-457`).
+That phrase should disappear. More importantly, `SessionCheckpoint.save()`
+currently writes status JSON, cognitive state, messages, compatibility JSON,
+the active pointer, and session metadata through separate atomic writes or
+SQLite commits (`:136-221`, `:573-644`). This means the current implementation
+has field-level authorities but no atomic checkpoint generation.
+
+The target is a typed `session_checkpoints` row plus ordered `messages`, written
+in one SQLite transaction. `state.json`, `messages.json`, `tools.json`, and
+`active.json` then become compatibility projections or one-time migration
+inputs—not independent recovery requirements.
+
+### 3.2 Local storage measurement
+
+A metadata-only scan of the complete local `~/.geode` tree on 2026-08-07 read
+file sizes and SQLite row counts, not message or memory content.
+
+| Surface | Files / databases | Bytes | Rows where applicable |
+|---|---:|---:|---:|
+| `sessions.db` | 479 | 911,618,048 | `sessions`: 21,414 across 474 DBs |
+| `messages.json` | 21,415 | 523,302,337 | — |
+| `tools.json` | 5,453 | 273,801,641 | — |
+| `state.json` | 21,416 | 38,019,313 | — |
+| SQLite `messages` | 409 DBs | included above | 170,122 |
+| SQLite `session_events` | 15 DBs | included above | 58,330 |
+| SQLite `hook_events` | 67 DBs | included above | 13,146 |
+| SQLite `context_artifacts` | 95 DBs | included above | 72 |
+| journal `runs.jsonl` | 423 | 838,294 | — |
+
+Interpretation:
+
+- `messages.json` is almost one-for-one with the 21,414 indexed sessions and
+  occupies about 499 MiB. `tools.json` adds about 261 MiB. This is a material
+  compatibility tax, not theoretical duplication.
+- The 479 databases span historical projects/worktrees and schema generations.
+  Only databases opened by newer runtimes necessarily have every additive
+  table. The table-count difference is migration coverage, not proof of data
+  corruption.
+- Deleting the caches now would be unsafe: 70 databases do not yet expose a
+  `messages` table. A global, idempotent backfill and parity report must precede
+  cache deletion.
+- ProjectJournal's disk cost is small; its removal is justified by duplicate
+  authority and dead code, not storage savings.
+
+`session_events` currently deletes terminal-session history after 180 days
+(`core/observability/session_timeline.py:39,491-532`). Therefore any future
+project-wide run view kept longer than 180 days is an independently retained
+materialized history, not a perpetually rebuildable projection. The default
+plan is still to remove the unconsumed ProjectJournal rather than create that
+view. If a measured external consumer requires it, each row must carry its
+source event ID and projection watermark.
+
+### 3.3 Current policy boundary
+
+GEODE already has effect policy; it does not yet have memory-admission policy.
+
+| Policy | Current owner | Semantics |
+|---|---|---|
+| tool exposure/effects | `core/tools/policy.py` | six-layer allow/deny chain; every applicable rule must pass |
+| public hook decision | `core/hooks/public.py` | permission/block/revise decisions at declared lifecycle seams |
+| verification continuation | PostVerify + pending verification checkpoint | accept, revise/replan, or hold external delivery |
+| benchmark promotion | SIL/Crucible/native contract | evidence and non-exchangeable vetoes; GEODE trajectory has no promotion authority |
+| memory admission | none shared | heuristic and model-derived writes can currently become active directly |
+| personalization | `user_profile/preferences.json` | model-visible language/output preferences |
+| tool permission | `user_profile/preferences.toml` | external effect authorization; despite the filename, not personalization |
+
+The missing contract should stay narrow: it decides only whether a derived
+memory is candidate or accepted. It must not become a second general
+`PolicyChain`, and reward weights must never override an effect denial,
+PostVerify hold, executable-check failure, or Crucible veto.
+
+The two preference filenames also need semantic separation. Rename the effect
+authorization file to `permissions.toml`, not `tool-policy.toml`: the latter
+would collide with GEODE's existing self-improving `tool-policy.json` mutation
+surface (`core/agent/tool_policy.py`).
+
+## 4. What is duplication and what is not
+
+### Delete or migrate
+
+1. `turn_auto_memory`: it promotes a low-information trace already represented
+   by user/tool/session events.
+2. `ContextAssembler.assemble() -> dict` plus `GeodeRuntime.assemble_context()`:
+   dead model-input API. Reuse only required wired reads in the typed snapshot
+   builder; delete unconditional journal/vault/dream injection.
+3. `ProjectJournal` learned/cost/error APIs: no production callers.
+4. ProjectJournal subagent hooks and `runs.jsonl`: duplicate subagent lifecycle
+   after parity with `session_events` is proven.
+5. `InMemorySessionStore.save_checkpoint/load_checkpoint` and the matching
+   protocol methods: dead competing checkpoint vocabulary.
+6. `tools.json`: loaded into `SessionState.tool_log`, but no resume path restores
+   it into `ToolProcessor`; no replacement store is needed.
+7. `messages.json`: remove writer after global SQLite parity; retain one
+   read-only compatibility window, then remove reader and reclaim files.
+8. `.geode/MEMORY.md` prompt reader: finish migration into
+   `.geode/memory/PROJECT.md`.
+9. `preferences.toml` permission filename: migrate to `permissions.toml` so it
+   is not confused with personalization `preferences.json` or the existing
+   self-improving `tool-policy.json`.
+10. `transitions.jsonl`: first import transition/refusal facts into an explicit
+    session-event kind, then stop the JSONL writer.
+11. field-fragmented JSON resume authority: migrate to one versioned SQLite
+    checkpoint transaction, then retire the JSON writers by parity gate.
+
+### Keep separate
+
+1. `session_events` and `hook_events`. The former is durable behavioral
+   history; the latter is bounded operational/policy telemetry.
+2. checkpoint state and messages. They have different schemas but must share
+   one resume generation and commit boundary; co-location is not conflation.
+3. native receipts/evidence and trajectories. A receipt is promotion authority;
+   a trajectory is a normalized view. Copying raw receipts into SQLite would
+   create a second authority and inflate the hot store.
+4. accepted memory and session search. Always-on curated context and on-demand
+   historical recall solve different problems.
+5. `personalization.json` (migrated from `preferences.json`) and
+   `permissions.toml` (migrated from `preferences.toml`). One personalizes
+   output; the other authorizes effects. The existing `tool-policy.json` is a
+   third, self-improving tool-surface policy and remains separately named.
+6. JSONL usage ledger if billing/export consumes it independently. If no such
+   consumer remains, it should be reclassified and removed in a separate
+   measured change.
+
+Accepted memory and learning candidates are never ProjectJournal projections.
+If a run/cost/error read model survives because an external consumer is found,
+it is explicitly marked with its source event, watermark, and independent
+retention; otherwise deletion is smaller and safer.
+
+## 5. Frontier comparison
+
+### 5.1 Hermes: few active memories, one prompt reader
+
+At `eb8421b`, Hermes has two bounded active files:
+
+- `MEMORY.md`, default 2,200 characters;
+- `USER.md`, default 1,375 characters.
+
+`MemoryStore` loads and deduplicates them once, scans prompt-bound content for
+threat patterns, and freezes the system-prompt snapshot while keeping live
+tool state separate (`tools/memory_tool.py:148-240`). One prompt builder reads
+that snapshot (`agent/system_prompt.py:515-524`). Writes use file locks, refuse
+unreadable/drifted files, reject duplicates and overflow, and may be staged by
+the documented memory-write approval gate. Full message history and FTS search
+live in SQLite; compaction soft-archives old rows instead of deleting them
+(`hermes_state.py:7144-7216`). Batch/RL trajectories remain separate from the
+interactive session database.
+
+Applied lesson: GEODE does not need Hermes's exact two filenames, but it needs
+the same properties—bounded accepted memory, one reader, a stable snapshot
+boundary, explicit write authority, and on-demand history outside the prompt.
+
+### 5.2 Codex: raw rollout, candidate memory, and promoted memory are distinct
+
+At `0bdce9f`, Codex separates the memory read and write crates. The write path
+has two explicit stages:
+
+1. eligible idle root rollouts are leased, filtered, redacted, and extracted
+   into `raw_memory` plus `rollout_summary`;
+2. a globally locked consolidation selects a bounded, usage/recency-ranked set,
+   materializes a Git-diffable workspace, and lets a network-disabled,
+   non-recursive subagent update consolidated memory.
+
+External-context use can mark a thread's memory mode `polluted`, excluding it
+from memory generation (`codex-rs/core/src/stream_events_utils.rs:141-157`).
+Memory citations update per-source usage (`:174-185`). Current Codex also uses
+six physically separate runtime SQLite files—including state, logs, goals,
+memories, queue, and thread history—rather than forcing all state into one DB
+(`codex-rs/state/src/sqlite.rs:29-106`). Migration 0035 removes memory tables
+from the state DB and `memory_migrations/0001_memories.sql` recreates them under
+the memory DB.
+
+Applied lesson: physical consolidation is not maturity. Explicit ownership,
+eligibility, leases, pollution state, selection, promotion, and migration are.
+GEODE can obtain the relevant benefit with existing `context_artifacts` and
+memory-lifecycle; it does not need Codex's full two-agent consolidation system.
+
+### 5.3 Comparison matrix
+
+| Concern | Hermes | Codex | GEODE now | GEODE target |
+|---|---|---|---|---|
+| Active memory | two bounded files | consolidated memory workspace | multiple prompt files + auto writers | one project memory + one user-profile owner |
+| Prompt read/render | frozen store snapshot + one builder | read crate/instruction injection | system prompt performs I/O + unused assembler | typed snapshot builder + pure renderer |
+| Automatic extraction | optional gated memory writes | leased phase 1 candidates | heuristic/LLM direct activation | `context_artifacts` candidates |
+| Promotion | explicit tool/approval | bounded phase 2 consolidation | partial cross-session proposal for dreams | existing lifecycle + HITL/explicit write |
+| Resume/history | SQLite messages + FTS | rollout JSONL + SQLite projection | SQLite messages/events + required JSON fragments | transactional SQLite checkpoint/messages; events remain append-only history |
+| Pollution | scan + refuse unsafe memory | thread `memory_mode=polluted` | sanitizers but no common admission | provenance/scope/pollution metadata on candidates |
+| RL/eval | separate batch/RL systems | rollout is replay source | immutable trajectory v1 | trajectory v2 reward projection |
+
+## 6. Target architecture
+
+```mermaid
+%%{init: {'theme':'default','themeVariables':{'fontSize':'13px','fontFamily':'arial','lineColor':'#6366F1','primaryColor':'#dbeafe','primaryBorderColor':'#3b82f6','primaryTextColor':'#1e293b','clusterBkg':'#f8fafc','clusterBorder':'#cbd5e1'}}}%%
+graph TD
+    subgraph ACT ["ACTIVATION AUTHORITY"]
+        EX["explicit user intent<br/>or approved memory tool"]:::axisGreen
+        VF["executable verified fact"]:::axisBlue
+        INF["heuristic or LLM inference"]:::axisYellow
+        DRM["dream or compaction"]:::axisPurple
+        CAND["context_artifacts<br/>immutable candidate"]:::axisPurple
+        DEC["context_artifacts<br/>immutable admission decision"]:::axisBlue
+        APPLY["apply_memory_admission()<br/>one mutation boundary"]:::axisGreen
+        ACTIVE["accepted memory<br/>PROJECT.md + user profile"]:::axisGreen
+
+        EX --> DEC
+        VF --> CAND
+        INF --> CAND
+        DRM -->|"retrieval artifact only"| CAND
+        CAND --> DEC --> APPLY --> ACTIVE
+    end
+
+    subgraph READ ["READ AUTHORITY"]
+        ADAPT["wired adapters<br/>identity · profile · project · retrieval"]:::codeNode
+        BUILD["ContextSnapshotBuilder<br/>storage reads + budgets"]:::axisBlue
+        SNAP["immutable ContextSnapshot<br/>content + provenance + omissions"]:::axisPurple
+        RENDER["PromptRenderer<br/>cache · model · skills · XML<br/>NO I/O"]:::axisGreen
+        MODEL["MODEL REQUEST"]:::finalNode
+
+        ACTIVE --> ADAPT
+        ADAPT --> BUILD --> SNAP --> RENDER --> MODEL
+    end
+
+    subgraph RESUME ["RESUME AUTHORITY"]
+        LOOP["AgenticLoop state<br/>messages + guards + pending verify"]:::codeNode
+        TX["one SQLite transaction"]:::axisGreen
+        CP["session_checkpoints<br/>typed state + generation + hash"]:::axisBlue
+        MSG["messages<br/>ordered conversation"]:::axisBlue
+        CACHE["legacy JSON projections<br/>migration window only"]:::axisRed
+
+        LOOP --> TX
+        TX --> CP
+        TX --> MSG
+        CP -. "compatibility" .-> CACHE
+        MSG -. "compatibility" .-> CACHE
+    end
+
+    subgraph HISTORY ["HISTORY AND OFFLINE LEARNING"]
+        SE["session_events<br/>semantic history"]:::axisBlue
+        HE["hook_events<br/>bounded telemetry"]:::axisPurple
+        REC["native receipts<br/>external authority"]:::axisYellow
+        JOIN["trajectory v2 join<br/>episode · transition · agent edge"]:::axisBlue
+        ATOM["RewardAtom[]<br/>raw typed signals"]:::axisPurple
+        VIEW["versioned RewardView<br/>no safety scalarization"]:::axisYellow
+        SIM["replay · hill-climbing<br/>DPO/GRPO/PRM export"]:::axisGreen
+
+        LOOP --> SE
+        LOOP --> HE
+        LOOP --> REC
+        SE --> JOIN
+        HE --> JOIN
+        REC --> JOIN
+        JOIN --> ATOM --> VIEW --> SIM
+    end
+
+    SNAP -->|"snapshot ID + digest"| SE
+
+    classDef codeNode fill:#f1f5f9,stroke:#64748b,color:#1e293b,stroke-width:2px
+    classDef finalNode fill:#1e293b,stroke:#1e293b,color:#fff,font-weight:bold,stroke-width:3px
+    classDef axisBlue fill:#dbeafe,stroke:#2563eb,color:#1e293b,stroke-width:2px
+    classDef axisGreen fill:#dcfce7,stroke:#16a34a,color:#1e293b,stroke-width:2px
+    classDef axisPurple fill:#ede9fe,stroke:#7c3aed,color:#1e293b,stroke-width:2px
+    classDef axisYellow fill:#fef3c7,stroke:#d97706,color:#1e293b,stroke-width:2px
+    classDef axisRed fill:#fee2e2,stroke:#dc2626,color:#1e293b,stroke-width:2px
+```
+
+### 6.1 Context snapshot and rendering contract
+
+The current `ContextAssembler` class is not promoted as-is. Replace its loose
+dictionary API in `core/memory/context.py` with the smallest typed contract:
+
+```text
+ContextSection
+  name, content, source_refs, content_hash, scope,
+  trust_class, admission_class, freshness,
+  retrieval_reason, omitted_reason
+
+ContextSnapshot
+  schema_version, snapshot_id, memory_generation,
+  token_budget, sections[]
+```
+
+`ContextSnapshotBuilder` is constructed from the already wired organization,
+profile, project-memory, session, and artifact adapters. It collects only
+declared sections. Journal, vault inventory, dream, compaction, and historical
+sessions are absent unless an explicit retrieval decision supplies a reason
+and budget. Missing, stale, rejected, or over-budget sources are represented by
+bounded omission metadata rather than silently disappearing.
+
+`PromptRenderer` keeps the valuable parts of `system_prompt.py`: cache
+boundary, model card, provider/surface guidance, skills, audit/persona gates,
+and XML layout. It receives no path or storage object and performs no I/O.
+Determinism is defined over both inputs:
+
+```text
+ContextSnapshot
++ RenderConfig(model, surface, audit mode, skill digest, renderer version)
+→ identical prompt hash
+```
+
+Snapshots are immutable per LLM request and keyed by an accepted-memory
+generation. An explicit admitted write advances that generation and appears in
+the next request. Background heuristic, LLM, and dream work cannot advance it.
+The snapshot ID and section digests are recorded in session history so an eval
+can prove what the model saw without storing the full prompt twice.
+
+### 6.2 Memory admission contract
+
+No new memory framework or table is required initially.
+
+| Source | Admission | Activation |
+|---|---|---|
+| exact user preference/correction with source span | sanitize, scope, conflict, sensitivity, capacity; emit accepted decision | next request |
+| approved `memory_save` / `profile_learn` | existing permission plus the same admission function and durable receipt | next request |
+| executable-tool-verified project fact | candidate by default; TTL auto-admit only for an allowlisted claim class with immutable evidence | decision-dependent |
+| regex inference | candidate; repeated evidence or confirmation required | never direct |
+| LLM extraction | candidate with model/provider/prompt hash and `derived=true` | never direct |
+| dream/compaction | keep its own artifact kind and source range | retrieval only; never direct |
+| `turn_auto_memory` trace | semantic turn/tool event | not memory |
+| project rule or runtime policy | explicit human approval and effect-policy check | accepted rule generation |
+
+Candidate payload and decision are separate immutable rows in the existing
+`context_artifacts` table:
+
+```text
+memory_candidate
+  claim_type, scope, producer, source_event_refs, evidence_refs,
+  confidence, sensitivity, expires_at, conflicts_with, supersedes
+
+memory_admission_decision
+  candidate_id, verdict, reason, reviewer/source, target_digest, decided_at
+```
+
+The semantic session event records the transition for timeline joins. Accepted
+memory frontmatter retains the candidate and decision IDs so its provenance
+survives the 180-day session-event retention. There is no new JSONL ledger and
+no `MemoryPromoter` class. A single `apply_memory_admission()` function routes
+accepted decisions through the existing `ProjectMemory` or
+`FileBasedUserProfile` writer and increments the memory generation. Explicit
+tools call the same function with an explicit-source decision; background
+producers can only write candidates.
+
+The existing cross-session memory lifecycle remains useful for repeated
+project insight, not as a universal gate. Dream scheduling moves from every
+completed turn to session end, idle, compaction, explicit request, or measured
+token/context-pressure thresholds. Generation cost, later retrieval,
+proposal-use, and acceptance are counted before adding any smarter scheduler.
+
+### 6.3 Transactional checkpoint contract
+
+Do not derive resume from `session_events`. Add one versioned mutable table to
+the existing `sessions.db`, not a new database:
+
+```text
+session_checkpoints
+  session_id PRIMARY KEY
+  generation
+  schema_version
+  state_json
+  state_hash
+  message_count
+  messages_hash
+  updated_at
+```
+
+`state_json` is validated by the existing typed `SessionState` serializer and
+contains round/model/provider/status, loop guards, pending verification,
+cognitive state, and only tool state proven necessary for resumption. One
+`BEGIN IMMEDIATE` transaction replaces ordered `messages` and upserts the next
+checkpoint generation plus its hashes. The query-oriented `sessions` row may
+be updated in that same transaction, but remains an index/read model rather
+than the resume contract.
+
+Required invariants after migration:
+
+```text
+delete state.json     → resume succeeds from SQLite
+delete messages.json  → resume succeeds from SQLite
+delete tools.json     → resume succeeds or the unused tool_log field is gone
+delete active.json    → latest resumable session query recovers the pointer
+hash/count mismatch   → load fails loud; it never mixes in a JSON fallback
+```
+
+Legacy JSON is a digest-backed, idempotent migration input. It is not an
+indefinite read fallback. This transaction changes resume authority only;
+`session_events` continues to answer what happened, and `hook_events`
+continues to answer how runtime/policy middleware behaved.
+
+### 6.4 Evidence and receipts
+
+Native Tau2/MCPMark receipts, SIL ledgers, Crucible evidence, screenshots, and
+large tool outputs should **not** be copied into SQLite. SQLite should persist
+the stable locator, digest, media type, producer schema, and correlation key.
+The immutable trajectory/export must snapshot every reward-relevant normalized
+fact before bounded hook telemetry expires. Raw receipt authority remains with
+the native store.
+
+This produces one-way ownership:
+
+```text
+native receipt bytes --SHA-256/reference--> trajectory evidence_ref
+                                    |
+                                    +--> RewardAtom(normalized fact)
+```
+
+The reverse direction is forbidden: a trajectory score cannot rewrite or
+upgrade a native receipt.
+
+### 6.5 Public hook loop and PostVerify control contract
+
+The public ABI is already the intended finite surface. Production call-site
+census confirms all 13 names are wired:
+
+```text
+UserPromptSubmit
+PreToolUse, PermissionRequest, PostToolUse
+PreCompact, PostCompact
+SessionStart, SessionEnd
+SubagentStart, SubagentStop
+PreVerify, PostVerify, Stop
+```
+
+The finalization path is one monotone control chain rather than independent
+hook pipelines:
+
+```mermaid
+flowchart TD
+    A["candidate answer"] --> B["PreVerify: add requirements only"]
+    B --> C["built-in verifier: immutable VerifyResult"]
+    C --> D["PostVerify: ACCEPT / REVISE / ESCALATE"]
+    D --> E["Stop: deliver or bounded continuation"]
+    E -->|"deliver"| F["SessionEnd / response delivery"]
+    E -->|"continue, max 2"| G["close attempt without SessionEnd"]
+    G --> H["next turn: reflection hint + verify-fail replan"]
+    H --> A
+    D -->|"escalate"| I["pending verification checkpoint"]
+    I --> J["external resume"]
+```
+
+`PreVerify` can only strengthen the built-in result. `PostVerify` cannot turn a
+failed verifier result into a pass: `ESCALATE` wins, an invalid `ACCEPT` on a
+failure becomes escalation, and the first priority-ordered `REVISE` supplies
+the continuation instruction. `Stop` runs last and may request continuation
+only when verification has not escalated. The shared continuation budget is
+two attempts, so the state machine cannot loop indefinitely or replay a
+completed tool side effect.
+
+The retry path is real, including replan. A revision closes the current verify
+attempt, persists its candidate and completion event, checkpoints, and starts
+a correlated `arun()` without emitting `SessionEnd`. The next run consumes the
+stored reflection hint; a failed built-in result trips the existing
+`verify_fail` replan gate before the next provider call. A revision of an
+otherwise passing result follows the explicit policy instruction without
+claiming that verification failed.
+
+Three implementation gaps remain:
+
+1. **No production PostVerify policy is registered.** The registry has zero
+   non-test `PostVerify` handlers. With no decision, a retryable built-in
+   failure is currently deliverable; its replan signal is dormant until a
+   later unrelated run.
+2. **Trusted control is represented as user content.** The continuation is
+   inserted into provider history as
+   `[system:verification_continuation] ...` with role `user`. It must instead
+   enter the existing dynamic system-hint path while the original root request
+   remains the task input for preflight/decomposition and the semantic
+   timeline keeps the correlated continuation event.
+3. **Policy attribution is flattened.** Runtime hook telemetry preserves
+   extension status, duration, reason, and evidence correlation, but the
+   durable semantic record does not retain each PostVerify handler/action or a
+   stable candidate target. This is insufficient for process reward and
+   external-loop audit.
+
+The minimum repair reuses the existing registry, finalization state machine,
+runtime-hint injection, session timeline, and attempt budget:
+
+| Gap | Minimal behavior | Deliberate non-goal |
+|---|---|---|
+| empty PostVerify decision set | deterministic fallback: pass → accept, retryable fail → revise, non-retryable fail → escalate | no new policy engine or fourth hook plane |
+| continuation role spoofing | one-shot typed verification hint in the dynamic system block; do not re-submit it through user history or task decomposition | no new prompt template or conversation-message role |
+| flattened policy evidence | bounded `verification.decided` semantic event with root turn, attempt, candidate digest, handler, action, reason, and evidence refs | no raw candidate duplication or mutable reward table |
+
+The candidate digest is the current stable target. Trajectory v2 may assign a
+`transition_id` while projecting it, but the runtime must not invent a dangling
+transition identifier before that projection exists. Optional hook failures
+remain observable and fail open. A fail-closed `required` handler flag is
+deferred until a real SIL/Crucible deployment needs mixed optional and
+authoritative handlers; otherwise one timeout branch would add a general
+extension-policy framework without a measured consumer.
+
+Required control E2E:
+
+```text
+pass                  -> accept -> deliver once
+retryable failure     -> revise -> system hint -> verify_fail replan -> retry
+non-retryable failure -> pending external verification -> resume
+invalid fail+accept   -> escalation
+third continuation    -> budget exhaustion, no side-effect replay
+```
+
+## 7. Signal preservation and reward readiness
+
+GEODE already records many useful signals, but it does not yet guarantee the
+join:
+
+```text
+state -> action -> observation -> judgement -> reward
+```
+
+There are three distinct failure modes:
+
+1. **actual loss**: a value is emitted but dropped or renamed before durable
+   storage;
+2. **distributed isolation**: values survive in separate stores but lack a
+   stable join key;
+3. **early aggregation**: only a winner, scalar, count, or summary survives,
+   erasing alternative branches and process attribution.
+
+### 7.1 Confirmed flattened or dangling signals
+
+| Signal | Current failure | Minimum repair |
+|---|---|---|
+| event causality | `session_events.parent_event_id` exists, but `SessionTimeline._record()` cannot accept it | wire parent ID through the one shared recorder |
+| LLM latency | loop emits `latency_ms`; lifecycle activity builder reads `duration_ms` | align the typed event contract once |
+| middleware mutation | original/effective request hashes are emitted, but typed durable details omit them | persist bounded hashes and middleware IDs |
+| cognitive reflection | rich `CognitiveState` changes do not survive the generic typed activity projection | persist before/after state digest and changed fields, not hidden reasoning |
+| verification | PostVerify has no production fallback policy; continuation is encoded as user content; handler decisions are aggregated | add deterministic fallback, dynamic system hint, and candidate-digest-bound per-handler decisions; assign transition ID only in trajectory projection |
+| hook retention | trajectory stores a cohort digest/count while `hook_events` later expires | snapshot required normalized facts into immutable trajectory v2 |
+| large tool evidence | payload over 256 KiB becomes a hash/truncation marker with no content locator | add content-addressed artifact reference before bounding |
+| benchmark reward | Tau2 breakdown stays inside native evidence refs | normalize each component as a RewardAtom without replacing the receipt |
+| child causality | control DB knows parent/generation, but trajectory needs manually supplied session IDs | emit parent/child/branch edge in canonical history |
+| best-of-N | all `SubResult`s and winner survive, but no group, branch, rank, criterion, or judge confidence | add sampling-group and selection metadata |
+| usage | usage rows are not reliably call-linked; `0` conflates actual zero and unmetered | require call/attempt ID and metering status |
+| session transitions | refusal/reopen facts remain isolated in `transitions.jsonl` | migrate to a semantic event and trajectory transition edge |
+
+`action_family()` is not a loss: the original action remains and the family is
+an additive taxonomy. The loss happens only if a downstream view retains the
+family and discards the original action.
+
+### 7.2 Trajectory v2 projection
+
+Trajectory v2 is an immutable projection, not a new writer on the hot path.
+It adds four normalized objects:
+
+| Object | Required identity | Purpose |
+|---|---|---|
+| `Episode` | episode/session/root-task ID, environment and contract digests | reproducible initial conditions |
+| `AgentEdge` | parent agent/session, child agent/session, generation, branch/group | hierarchical rollout causality |
+| `Transition` | transition ID, state digest, action, observation/evidence refs, terminal state | step-level replay and process attribution |
+| `RewardAtom` | atom ID, target episode/transition, source, type, value/status, evidence digest | lossless reward inputs before weighting |
+
+A `RewardView` is a versioned offline configuration over atoms. Hard
+permission, safety, verifier, and promotion contracts remain vetoes; they are
+not converted into a compensable scalar. This supports:
+
+- hill-climbing: compare artifact-bound candidate runs under the same contract;
+- DPO: export controlled chosen/rejected trajectory pairs;
+- GRPO: export same-initial-state sampling groups and relative rewards;
+- process reward modeling: target atoms to `transition_id` rather than only the
+  final response;
+- outcome reward: retain Tau2/MCPMark/Crucible terminal checks independently.
+
+Weight-level RL remains an external trainer concern. Subscription models are
+not updateable policies; GEODE supplies reproducible rollouts, typed feedback,
+and promotion decisions.
+
+## 8. Migration map
+
+| Current surface | Target | Compatibility and deletion gate |
+|---|---|---|
+| `_build_user_context(): FileBasedUserProfile()` | injected `get_user_profile()` | direct bug fix; no data migration |
+| `ContextAssembler.assemble() -> dict` and `GeodeRuntime.assemble_context()` | typed `ContextSnapshotBuilder` in the existing memory context module | shadow parity first; retain only declared wired sources; remove loose API after exhaustive non-test caller census |
+| storage reads inside `system_prompt.py` | pure `PromptRenderer(snapshot, render_config)` | shadow-render prompt sections, token count, and hash before cutover; enforce no storage imports/I/O |
+| `.geode/MEMORY.md` | `.geode/memory/PROJECT.md` | if only old exists, lossless import; if both exist, warn and require explicit merge; stop reader one release later |
+| `turn_auto_memory` | canonical session/tool events | delete handler; do not migrate low-quality turn strings into memory |
+| heuristic/LLM direct `learned.md` writes | `context_artifacts(memory_candidate)` | exact explicit intent may use fast admission; inference never writes active memory |
+| candidate decision state | `context_artifacts(memory_admission_decision)` + accepted-file provenance | immutable row, semantic event, and target digest must agree; no new JSONL ledger |
+| ProjectJournal `runs.jsonl` | deletion by default | prove start/stop/failure/status parity, preserve historical file; add an independently retained materialized view only for a measured external consumer |
+| ProjectJournal learned/cost/error APIs | none | remove code; never delete historical user files automatically |
+| `SessionStorePort` checkpoint methods | `SessionCheckpoint` | remove dead protocol/class methods and tests |
+| independent checkpoint/metadata writes | SQLite `session_checkpoints` + messages in one transaction | typed schema, generation, state/message hashes, crash-injection tests |
+| `messages.json` writer | SQLite messages | global backfill, per-session count/hash parity, stop writer; legacy file is one-time migration input, then cleanup |
+| `tools.json` | none; canonical events for diagnostics | prove no non-test consumer and resume parity; stop writer/reader and remove `SessionState.tool_log` if unused |
+| `state.json` + SQLite status “both SoTs” | SQLite checkpoint authority | transactional cutover, projection parity, then remove JSON read requirement |
+| `active.json` | latest-resumable SQLite query | prove deterministic selection and compatibility pointer parity |
+| `transitions.jsonl` | semantic session transition event | import with digest/idempotency, then stop writer |
+| `preferences.json` | `personalization.json` | read new first, migrate exact JSON, warn on old, one release fallback |
+| `preferences.toml` | `permissions.toml` | read new first, migrate exact TOML, warn on old, one release fallback; do not touch self-improving `tool-policy.json` |
+| trajectory v1 runtime refs | trajectory v2 normalized joins | v1 remains immutable/readable; v2 exporter is additive |
+
+No migration deletes source data in the same release that flips authority.
+Every destructive cleanup is a separate, count/hash-verified step with a dry
+run and byte-reclamation report.
+
+## 9. Implementation sequence
+
+### Phase 0 — authority matrix, ledger registration, and frozen baseline
+
+- Register the newly measured memory/read-authority, cache-retirement, and
+  causal-reward residuals through the roadmap protocol. `STORE-001/002` are
+  already `DONE`; silently reopening them would falsify the ledger.
+- Record one owner for model-visible context, active user/project memory,
+  candidates/decisions, tool permission, resume state/messages, execution
+  events, usage, and evaluation evidence.
+- Freeze current file/table counts, compatibility consumers, and sample
+  trajectory quality metrics.
+- Add no feature code in the registration PR.
+
+### Phase 1 — repair concrete defects and dead competitors
+
+- fix `_build_user_context()` to use the wired profile;
+- delete `turn_auto_memory`;
+- remove dead `SessionStorePort` checkpoint methods;
+- remove dead ProjectJournal learned/cost/error methods;
+- correct documentation that claims every LLM call uses `ContextAssembler`;
+- keep the current live prompt path unchanged beyond the profile bug so the
+  next shadow comparison has a stable baseline.
+
+Acceptance: one profile scope appears in both prompt blocks; no automatic turn
+trace enters accepted memory; caller census is zero for removed APIs.
+
+### Phase 2 — Context Snapshot shadow mode
+
+- replace the loose assembler output with typed `ContextSection` and
+  `ContextSnapshot` values built from wired adapters;
+- build the old live prompt and the new snapshot/render result side by side,
+  while sending only the old prompt to the model;
+- compare source inclusion/omission, project overlay, token count, section
+  digests, cache boundary, and prompt hash;
+- add no journal, vault, dream, or history section without a declared retrieval
+  reason and budget.
+
+Acceptance: the shadow report explains every mismatch; identical snapshot and
+render config reproduce the same prompt hash; project-local profile scope is
+the same in every user/learning section.
+
+### Phase 3 — read cutover and source-specific admission
+
+- make `system_prompt.py` a pure renderer of snapshot plus render config and
+  enforce that it imports no memory/storage adapter;
+- write heuristic and LLM extractions as context artifacts with provenance;
+- write admission decisions as separate immutable context artifacts and route
+  active writes through one `apply_memory_admission()` function;
+- keep dream as a synthesis artifact and gate it by idle/context pressure rather
+  than every successful turn;
+- extend the existing lifecycle just enough to consume candidates and create a
+  review proposal;
+- retire the loose `ContextAssembler` API, its runtime wrapper, ProjectJournal
+  injection, and the deprecated `.geode/MEMORY.md` reader after migration;
+- migrate `preferences.json` to `personalization.json` and
+  `preferences.toml` to `permissions.toml`, leaving self-improving
+  `tool-policy.json` untouched.
+
+Acceptance: a background extraction cannot change the active prompt; an
+explicit approved preference appears in the next request; regex/LLM inference
+requires evidence or reviewer decision; dream never becomes a user preference;
+accepted files cite immutable candidate/decision IDs.
+
+### Phase 4 — transactional checkpoint and duplicate-ledger pruning
+
+- add the versioned SQLite checkpoint row and atomic checkpoint/messages save;
+- run global v4 backfill over every project DB and emit count/hash parity;
+- migrate legacy JSON once by digest, then stop `state.json`, `messages.json`,
+  `tools.json`, and `active.json` runtime dependence in that order;
+- remove `tools.json` after consumer/resume tests;
+- fail loud on checkpoint/message hash mismatch; an interrupted transaction
+  rolls back and therefore leaves the prior generation intact;
+- migrate transition facts and subagent journal facts before retiring their
+  JSONL writers;
+- remove ProjectJournal by default; if an external long-retention consumer is
+  measured, give its read model source IDs and a projection watermark rather
+  than calling it fully rebuildable.
+
+Acceptance: resume, gateway continuation, pending verification, follow-up,
+session listing, search, and subagent restart pass with compatibility files
+absent. Cleanup dry-run reports eligible file count and bytes; apply mode never
+touches a file whose SQLite parity is unproven. Crash injection at every write
+boundary yields either the previous or next complete generation, never a mix.
+
+### Phase 5 — causal trajectory and reward atoms
+
+- close PostVerify control first: deterministic fallback, system-level
+  continuation hint, and bounded candidate-digest-bound decision records;
+- fix parent-event, LLM duration, middleware hash, reflection digest, subagent
+  edge, best-of group, and usage-metering contracts;
+- emit trajectory v2 from canonical sessions plus bounded telemetry/native
+  evidence joins;
+- normalize Tau2 reward components first, then MCPMark and SIL/Crucible
+  promotion evidence;
+- add DPO pair, GRPO group, and transition-reward exports only after the shared
+  trajectory objects are exercised by real E2E runs.
+
+Acceptance: one E2E parent/child run reconstructs every transition and tool
+pair; no required runtime reference dangles after hook retention; every reward
+atom resolves to immutable evidence; hard-contract failures cannot be outweighed
+by positive scalar atoms.
+
+### Phase 6 — release and storage cleanup
+
+- update architecture, context, memory, observability, trajectory publication,
+  and external-loop documentation;
+- build the package and public site;
+- run non-live CI, then explicitly approved subscription E2E;
+- publish a privacy-reviewed eval-artifact trajectory and verify remote digest;
+- perform compatibility cleanup only in the subsequent release.
+
+## 10. Required E2E scenarios
+
+| Scenario | What must be observed |
+|---|---|
+| context read parity | project preference appears identically in learning and user context, from the same source digest |
+| snapshot determinism | same snapshot plus render config produces the same section order and prompt hash |
+| renderer no-I/O | renderer has no memory/storage import and succeeds from an in-memory snapshot with filesystem access denied |
+| project override scope | project-local profile overrides every applicable global section consistently |
+| unadmitted-memory isolation | heuristic/LLM candidate is durable/searchable but current snapshot generation and prompt are unchanged |
+| explicit preference fast path | exact user preference or approved tool write produces a decision/receipt and appears in the next request |
+| verified fact policy | evidence-bound fact follows its declared candidate/TTL policy; an unallowlisted fact never auto-activates |
+| single mutation boundary | production caller census shows all accepted project/profile/rule writes cross `apply_memory_admission()` |
+| policy separation | personalization changes cannot expand permissions; permissions cannot become model-visible prose |
+| polluted external context | candidate is marked polluted/excluded from promotion |
+| dream value accounting | generation cost, later retrieval, proposal use, and accepted-memory count remain separately observable |
+| checkpoint without each JSON projection | deleting state/messages/tools/active JSON independently still restores CLI/gateway/pending verification from SQLite |
+| checkpoint crash matrix | interruption before/after message and checkpoint writes yields one complete generation and detects all digest mismatches |
+| legacy backfill | old `messages.json` imports once, digest matches, rerun is idempotent |
+| subagent hierarchy | parent, child, generation, follow-up, interrupt, terminal result, and independent rollout all join |
+| best-of-N | all candidates, group ID, winner, rank, criteria, evidence, cost, and latency survive |
+| PostVerify accept/revise/escalate | fallback policy is deterministic; revise enters the dynamic system context and reaches `verify_fail` replan; candidate digest, decision, next plan edge, and bounded-attempt outcome are reconstructable |
+| Tau2 full cycle | native reward breakdown becomes evidence-bound atoms without modifying receipt bytes |
+| retention simulation | delete an expired hook cohort; exported trajectory remains self-contained for normalized facts |
+| hard-policy veto | high scalar outcome cannot promote a run that violated permission or verifier contract |
+
+## 11. Over-engineering guard
+
+Do not add:
+
+- a new memory database or generic event bus;
+- a `MemoryPromoter` interface/class or separate `memory-decisions.jsonl`;
+- embeddings before FTS/candidate selection is measured insufficient;
+- a universal `Policy`/`MemoryKind` framework for four concrete sources;
+- a snapshot section for every available store merely because it exists;
+- mutable reward tables on the runtime hot path;
+- automatic scalarization of safety, permission, correctness, or promotion;
+- hidden chain-of-thought capture;
+- raw receipt/blob duplication in SQLite;
+- DPO/GRPO training orchestration before controlled pairs/groups exist.
+
+Use existing components:
+
+- `core/memory/context.py` for the replacement typed snapshot builder rather
+  than adding a parallel context package;
+- `context_artifacts` for content-addressed candidate, synthesis, and immutable
+  admission-decision records;
+- memory-lifecycle for evidence clustering and review proposals;
+- one function over existing project/profile writers for accepted mutations;
+- existing `sessions.db` and one checkpoint table/transaction, not a new DB;
+- `session_events` for semantic facts;
+- `hook_events` for bounded operational detail;
+- content-addressed external references for large/native evidence;
+- trajectory export for reward normalization.
+
+Deletion is the primary implementation outcome: one read contract, one
+renderer, fewer direct writers, fewer compatibility files, and fewer unowned
+JSONL ledgers.
+
+## 12. Documentation correction scope
+
+The following documents currently overstate `ContextAssembler` or retain old
+storage claims and must be corrected with the implementation:
+
+- `docs/architecture/context-lifecycle.md` and `.ko.md`;
+- `site/src/app/docs/runtime/context/page.tsx`;
+- `site/src/app/docs/runtime/memory/5-tier/page.tsx`;
+- `site/src/app/docs/architecture/system-index/page.tsx`;
+- `site/src/app/docs/explanation/self-hosting/page.tsx`;
+- `docs/scaffold-architecture.md`;
+- `docs/architecture/storage-hierarchy.md`;
+- `docs/architecture/event-persistence.md`;
+- `docs/architecture/session-state-machine.md`;
+- public/user-profile and tool-permission references that currently overload
+  the two `preferences.*` names;
+- `docs/plans/2026-07-31-session-record-contract.md` only through a dated
+  supersession note; do not rewrite its historical release evidence.
+
+Until implementation lands, the accurate public sentence is:
+
+> Session restore, search, and memory extraction are each wired. The remaining
+> convergence is to make model-visible context, automatic-memory activation,
+> and field-complete resume state explicit through a Context Snapshot Contract,
+> Memory Admission Contract, and Checkpoint Authority Contract.
+
+## 13. Primary sources
+
+### Frontier runtimes
+
+- [Hermes memory guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory/)
+- [Codex memory pipeline at the audited commit](https://github.com/openai/codex/blob/0bdce9f424eb9b39d7b3a8811742d10b6fbf8d54/codex-rs/memories/README.md)
+- [Codex memory runtime at the audited commit](https://github.com/openai/codex/blob/0bdce9f424eb9b39d7b3a8811742d10b6fbf8d54/codex-rs/state/src/runtime/memories.rs)
+
+### Learning and process supervision
+
+- [Direct Preference Optimization](https://arxiv.org/abs/2305.18290)
+- [DeepSeekMath / GRPO](https://arxiv.org/abs/2402.03300)
+- [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050)
+- [Agent Lightning](https://arxiv.org/abs/2508.03680)
+- [WebAgent-R1](https://arxiv.org/abs/2505.16421)
+
+These papers motivate offline preference/group/process projections. They do not
+justify adding training infrastructure to GEODE before its causal execution
+contract is complete.

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -74,7 +74,7 @@
         "runtime",
         "while-tool-use"
       ],
-      "contentSha256": "b676b675e041ed36f0f99b6783be38502ac3bcf0e8221bc76e8487e153da9eaf"
+      "contentSha256": "8e1df9fe07c485fa59ab60f0d5f97b0ff0acab4fc591e5f0ad853325735c9331"
     },
     {
       "id": "file:core/agent/tool_executor/processor.py",

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -1123,6 +1123,8 @@ print(schema["properties"]["decision"])
 
 `PostVerify`는 이미 실행된 부수 효과를 재생하지 않고, 완성된 후보와 내장 검증 결과를 외부 평가기·CI 정책·오케스트레이터가 판정하게 합니다. revise는 구체적인 후속 지시가 있어야 하며 최대 2회 연속 시도로 제한됩니다. 최종 결과에는 모든 시도의 rounds, tool calls, usage가 합산된 뒤 증거와 체크포인트가 저장됩니다. escalate는 단순 telemetry가 아니라 delivery gate입니다. 세션을 pause하고 후보를 외부 소유자에게만 pending\_text로 반환하며 terminal`session.ended`를 만들지 않습니다.
 
+외부 handler 결정이 없으면 pass는 accept, 재시도 가능한 실패는 revise, 그 밖의 실패는 escalate하는 기본 정책이 동작합니다. revision 지시는 user message가 아니라 dynamic system context에 한 번 주입되고,`verification.decided`는 후보 본문 대신 SHA-256 digest와 handler별 결정을 session timeline에 남깁니다.
+
 ## 신뢰 미들웨어 4개 결합점
 
 | 결합점 | 계약 |
@@ -5960,7 +5962,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1488 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1489 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/app/docs/harness/hooks/page.tsx
+++ b/site/src/app/docs/harness/hooks/page.tsx
@@ -108,6 +108,13 @@ export default function Page() {
               외부 소유자에게만 pending_text로 반환하며 terminal
               <code>session.ended</code>를 만들지 않습니다.
             </p>
+            <p>
+              외부 handler 결정이 없으면 pass는 accept, 재시도 가능한 실패는
+              revise, 그 밖의 실패는 escalate하는 기본 정책이 동작합니다. revision
+              지시는 user message가 아니라 dynamic system context에 한 번 주입되고,
+              <code>verification.decided</code>는 후보 본문 대신 SHA-256 digest와
+              handler별 결정을 session timeline에 남깁니다.
+            </p>
 
             <h2>신뢰 미들웨어 4개 결합점</h2>
             <table>
@@ -234,6 +241,14 @@ export default function Page() {
               telemetry: it pauses the session, exposes the withheld candidate
               only to the owning loop as pending_text, and does not create a
               terminal <code>session.ended</code> record.
+            </p>
+            <p>
+              Without an external handler decision, the default policy accepts a
+              pass, revises a retryable failure, and escalates any other failure.
+              Revision control enters the dynamic system context once rather than
+              user history, while <code>verification.decided</code> stores the
+              candidate SHA-256 digest and attributed handler decisions in the
+              session timeline.
             </p>
 
             <h2>Four trusted middleware join points</h2>

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -237,7 +237,7 @@
   "coordinators": {
     "AgenticLoop": {
       "constructor_arg_count": 27,
-      "file_loc": 2968,
+      "file_loc": 2987,
       "method_count": 74,
       "path": "core/agent/loop/agent_loop.py"
     },
@@ -528,7 +528,7 @@
   "packages": {
     "core": {
       "python_files": 431,
-      "python_loc": 138647
+      "python_loc": 138786
     },
     "plugins": {
       "python_files": 111,
@@ -536,7 +536,7 @@
     },
     "tests": {
       "python_files": 680,
-      "python_loc": 178706
+      "python_loc": 178877
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Changed\n\n- **PostVerify now controls delivery by default.** With no external handler,\n  passing candidates are accepted, retryable failures enter the existing\n  bounded revise/replan path, and non-retryable failures pause for external\n  verification. Revision instructions now use the dynamic system context\n  instead of user-role history, and candidate-digest-bound handler decisions\n  persist in the semantic session timeline for trajectory reconstruction."
   },
   {
     "version": "1.0.14",

--- a/tests/core/agent/test_arun_model_drift_sync.py
+++ b/tests/core/agent/test_arun_model_drift_sync.py
@@ -35,6 +35,7 @@ def test_helper_method_exists() -> None:
     # 2026-07-29: decomposition_hint plumbing deleted (None-only since the
     # Plan migration); reflection_hint remains.
     assert "reflection_hint" in sig.parameters
+    assert "verification_hint" in sig.parameters
     # Returns str — caller rebinds the local.
     assert "str" in str(sig.return_annotation)
 
@@ -77,9 +78,14 @@ class _StubLoop:
         return self._rebuilt_prompt
 
 
-def _call_helper(stub: _StubLoop, system_prompt: str, hint: str | None) -> str:
+def _call_helper(
+    stub: _StubLoop,
+    system_prompt: str,
+    hint: str | None,
+    verification_hint: str | None = None,
+) -> str:
     bound = AgenticLoop._sync_model_and_rebuild_prompt.__get__(stub, _StubLoop)
-    return asyncio.run(bound(system_prompt, hint))
+    return asyncio.run(bound(system_prompt, hint, verification_hint))
 
 
 def test_no_drift_no_dirty_returns_input_unchanged() -> None:
@@ -159,6 +165,17 @@ def test_reflection_hint_none_not_applied() -> None:
     result = _call_helper(stub, "ORIGINAL", None)
     assert result == "REBUILT_PROMPT"
     assert "None" not in result
+
+
+def test_verification_hint_survives_prompt_rebuild() -> None:
+    stub = _StubLoop(sync_returns_drifted=True)
+    result = _call_helper(
+        stub,
+        "ORIGINAL",
+        None,
+        "<verification_continuation>retry</verification_continuation>",
+    )
+    assert result.endswith("<verification_continuation>retry</verification_continuation>")
 
 
 def test_reflection_hint_ignored_when_not_rebuilding() -> None:

--- a/tests/core/agent/test_arun_session_start_extraction.py
+++ b/tests/core/agent/test_arun_session_start_extraction.py
@@ -111,6 +111,8 @@ def test_arun_calls_session_start_helper() -> None:
     assert "intercept_result = await self._open_turn(" in src
     assert "verification_continuation=_verify_continuation is not None" in src
     assert "await self._emit_session_start_signals(user_input)" in open_src
+    assert 'context.add_system_event("verification_continuation"' not in open_src
+    assert "enabled=not verification_continuation" in src
 
 
 def test_arun_surfaces_intercept_result_verbatim() -> None:

--- a/tests/core/agent/test_autonomous_safety.py
+++ b/tests/core/agent/test_autonomous_safety.py
@@ -152,7 +152,7 @@ class TestCostBudgetAutoStop:
         loop = AgenticLoop(context, executor, cost_budget=0.0)
         assert loop._cost_budget == 0.0
 
-        response = _make_text_response("Hello")
+        response = _make_text_response("Hello world")
         with (
             patch.object(loop, "_call_llm", return_value=response),
             patch.object(loop, "_track_usage"),
@@ -222,7 +222,7 @@ class TestCostBudgetAutoStop:
         mock_tracker = MagicMock()
         mock_tracker.accumulator.total_cost_usd = 0.50
 
-        response = _make_text_response("Hello")
+        response = _make_text_response("Hello world")
 
         with (
             patch.object(loop, "_call_llm", return_value=response),

--- a/tests/core/agent/test_runtime_hint_envelope.py
+++ b/tests/core/agent/test_runtime_hint_envelope.py
@@ -7,7 +7,10 @@ closed envelope, and the mid-run rebuild dropped the preflight hint.
 
 from __future__ import annotations
 
-from core.agent.loop._context import inject_runtime_hints
+from core.agent.loop._context import (
+    inject_runtime_hints,
+    render_verification_continuation_hint,
+)
 
 
 def test_hints_inserted_inside_envelope() -> None:
@@ -27,6 +30,15 @@ def test_no_envelope_appends_plainly() -> None:
 def test_empty_and_non_str_hints_are_dropped() -> None:
     prompt = "S\n\n<dynamic_context>\n\nd\n\n</dynamic_context>"
     assert inject_runtime_hints(prompt, "", None) == prompt
+
+
+def test_verification_continuation_is_a_bounded_system_hint() -> None:
+    hint = render_verification_continuation_hint("Repair <unsafe> & retry.")
+    assert hint == (
+        "<verification_continuation>\n"
+        "Repair &lt;unsafe&gt; &amp; retry.\n"
+        "</verification_continuation>"
+    )
 
 
 def test_reflection_str_payload_parsed() -> None:

--- a/tests/core/agent/test_verify.py
+++ b/tests/core/agent/test_verify.py
@@ -18,6 +18,7 @@ import asyncio
 import inspect
 import os
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from core.agent.loop.models import AgenticResult
@@ -416,12 +417,14 @@ def test_lifecycle_finalize_records_verify(monkeypatch: pytest.MonkeyPatch) -> N
         _evidence_ledger=None,
     )
     with session_metrics_scope(session_id="t-finalize"):
-        payload, _follow_up, _escalated, _correlation = asyncio.run(
+        payload, follow_up, escalated, _correlation = asyncio.run(
             _lifecycle._run_public_finalization_async(loop, result)
         )
         assert payload is not None
         assert payload["passed"] is False
         assert "empty_turn" in payload["rubric_misses"]
+        assert "empty_turn" in follow_up
+        assert escalated is False
         m = current_session_metrics()
         assert m.verify_fail_count == 1
         assert m.last_verify_reflection_hint.startswith("<reflection>")
@@ -506,6 +509,43 @@ def test_post_verify_failure_cannot_be_accepted(
     assert follow_up == ""
 
 
+def test_empty_post_verify_policy_escalates_non_retryable_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.agent.loop import _lifecycle
+
+    loop = SimpleNamespace(
+        _hook_registry=HookRegistry(),
+        _session_id="",
+        _turn_id="t-1",
+        _verify_root_turn_id="t-1",
+        _verify_attempt=0,
+        _verify_continuation_budget=2,
+        _session_generation=1,
+        _evidence_ledger=None,
+    )
+
+    async def hard_failure(*args: object, **kwargs: object) -> VerifyResult:
+        return VerifyResult(
+            passed=False,
+            mode=VerifyMode.RULE_BASED,
+            rubric_misses=("operator_action_required",),
+            should_retry=False,
+        )
+
+    monkeypatch.setattr("core.agent.verify.verify_turn_async", hard_failure)
+    with session_metrics_scope(session_id="post-hard-fail"):
+        _payload, follow_up, escalated, _correlation = asyncio.run(
+            _lifecycle._run_public_finalization_async(
+                loop,
+                _make_result(text="candidate"),
+            )
+        )
+
+    assert follow_up == ""
+    assert escalated is True
+
+
 def test_post_verify_escalation_withholds_candidate_before_persistence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -561,7 +601,9 @@ def test_post_verify_revision_returns_bounded_follow_up(
             action=HookAction.REVISE,
             instruction="Run the missing validation, then answer again.",
         ),
+        name="reviewer",
     )
+    recorded_decisions: list[dict[str, object]] = []
     loop = SimpleNamespace(
         _hook_registry=registry,
         _session_id="",
@@ -571,6 +613,9 @@ def test_post_verify_revision_returns_bounded_follow_up(
         _verify_continuation_budget=2,
         _session_generation=1,
         _evidence_ledger=None,
+        _timeline=SimpleNamespace(
+            record_verification_decision=lambda **kwargs: recorded_decisions.append(kwargs)
+        ),
     )
 
     async def passed_verify(*args: object, **kwargs: object) -> VerifyResult:
@@ -589,6 +634,10 @@ def test_post_verify_revision_returns_bounded_follow_up(
     assert follow_up == "Run the missing validation, then answer again."
     assert correlation.turn_id == "t-1"
     assert correlation.verify_attempt == 0
+    assert recorded_decisions[0]["policy_action"] == "revise"
+    decisions = recorded_decisions[0]["decisions"]
+    assert isinstance(decisions, list)
+    assert decisions[0]["handler"] == "reviewer"
 
 
 def test_verify_continuation_does_not_emit_or_persist_session_end(
@@ -632,6 +681,40 @@ def test_verify_continuation_does_not_emit_or_persist_session_end(
     assert recorded == ["candidate"]
     assert RuntimeEvent.SESSION_ENDED not in emitted
     assert emitted == [RuntimeEvent.TURN_COMPLETED, RuntimeEvent.REASONING_METRICS]
+
+
+def test_verify_continuation_stays_out_of_user_history_and_checkpoint() -> None:
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    context = SimpleNamespace(
+        add_system_event=lambda *_args: pytest.fail("policy entered user history")
+    )
+    recorded: list[str] = []
+    checkpoint_inputs: list[str] = []
+    loop = SimpleNamespace(
+        context=context,
+        _timeline=SimpleNamespace(
+            record_verification_continuation=lambda instruction, **_kwargs: recorded.append(
+                instruction
+            )
+        ),
+        _verify_root_turn_id="root-turn",
+        _verify_root_user_input="original task",
+        _verify_attempt=1,
+        _save_checkpoint=lambda user_input, **_kwargs: checkpoint_inputs.append(user_input),
+    )
+
+    result = asyncio.run(
+        AgenticLoop._open_turn(
+            cast(AgenticLoop, loop),
+            "repair instruction",
+            verification_continuation=True,
+        )
+    )
+
+    assert result is None
+    assert recorded == ["repair instruction"]
+    assert checkpoint_inputs == ["original task"]
 
 
 def test_post_verify_timeout_preserves_the_builtin_result(

--- a/tests/core/hooks/test_public_hooks.py
+++ b/tests/core/hooks/test_public_hooks.py
@@ -55,6 +55,30 @@ def test_unknown_hook_name_is_rejected() -> None:
         registry.register(cast(HookName, "LLMCallStart"), lambda _invocation: None)
 
 
+@_async_test
+async def test_outcome_attributes_each_decision_to_its_handler() -> None:
+    registry = HookRegistry()
+    registry.register(
+        HookName.USER_PROMPT_SUBMIT,
+        lambda _invocation: HookDecision(action=HookAction.CONTINUE),
+        name="first",
+        priority=10,
+    )
+    registry.register(
+        HookName.USER_PROMPT_SUBMIT,
+        lambda _invocation: HookDecision(action=HookAction.CONTINUE),
+        name="second",
+        priority=20,
+    )
+
+    outcome = await registry.invoke(
+        HookName.USER_PROMPT_SUBMIT,
+        payload={"user_input": "hello"},
+    )
+
+    assert outcome.decision_sources == ("first", "second")
+
+
 def test_all_public_hook_schemas_are_generated_and_json_round_trip() -> None:
     schemas = {hook.value: public_hook_schema(hook) for hook in HookName}
 

--- a/tests/core/observability/test_session_timeline.py
+++ b/tests/core/observability/test_session_timeline.py
@@ -79,6 +79,39 @@ def test_session_start_is_once_per_generation(tmp_path: Path) -> None:
     assert [row.turn_id for row in rows] == ["t-1", "t-3"]
 
 
+def test_verification_decision_targets_candidate_without_copying_it(tmp_path: Path) -> None:
+    timeline = SessionTimeline("s-verify", db_path=tmp_path / "sessions.db")
+    timeline.bind_turn("attempt-turn")
+    timeline.record_verification_decision(
+        candidate="private candidate",
+        root_turn_id="root-turn",
+        verify_attempt=1,
+        built_in_passed=False,
+        policy_action="revise",
+        decisions=[
+            {
+                "surface": "PostVerify",
+                "handler": "runtime_default",
+                "action": "revise",
+                "reason": "empty_post_verify_decision_set",
+                "instruction_sha256": "abc",
+                "instruction_bytes": 3,
+                "evidence_refs": [],
+            }
+        ],
+    )
+
+    [row] = SessionEventStore(timeline.db_path).read(
+        "s-verify", kinds=[SessionEventKind.VERIFICATION_DECIDED]
+    )
+    assert row.kind == "verification.decided"
+    assert row.payload["root_turn_id"] == "root-turn"
+    assert row.payload["verify_attempt"] == 1
+    assert row.payload["policy_action"] == "revise"
+    assert row.payload["candidate_bytes"] == len(b"private candidate")
+    assert "private candidate" not in json.dumps(row.payload)
+
+
 def test_read_combines_turn_kind_cursor_and_limit_filters(tmp_path: Path) -> None:
     store = SessionEventStore(tmp_path / "sessions.db")
     for turn_id, kind in (


### PR DESCRIPTION
## Summary\n- Make the existing PostVerify boundary an effective delivery controller when no external handler decides.\n- Keep revision control out of user-role history and preserve it across prompt rebuilds.\n- Persist candidate-digest-bound verification decisions in the semantic session timeline for trajectory reconstruction.\n- Add the runtime-memory-trajectory convergence plan and synchronize internal/public hook documentation.\n\n## Why\nThe 13 public hooks were already present, but PostVerify had three production gaps: an empty decision set did not select a delivery action, revision text was represented as synthetic conversation context, and aggregated decisions lost handler attribution in durable history. HOOK-003 closes those gaps without adding another hook plane, policy engine, database, or raw candidate copy.\n\n## Changes\n| Area | Change |\n|---|---|\n| PostVerify control | Deterministic default: pass to accept, retryable failure to revise, non-retryable failure to escalate |\n| Continuation | Inject escaped revision control once in the dynamic system envelope; skip task decomposition and retain the original root task in checkpoints |\n| Hook outcome | Preserve the handler name for every returned decision |\n| Session timeline | Add verification.decided with candidate digest/size, root turn, attempt, final policy, handler decisions, and evidence references |\n| Trajectory | Treat verification.decided as turn-scoped and retain legacy projection compatibility |\n| Docs | Add the full convergence plan, hook contract updates, event vocabulary, public site copy, changelog, and generated architecture baseline |\n| Attestation | Refresh the Crucible AgenticLoop content digest |\n\n## GAP Audit\n| GAP | Before | Closure evidence |\n|---|---|---|\n| HOOK-003-A | Empty PostVerify outcome left retryable verifier failure without a delivery decision | Default monotone policy plus retryable/non-retryable tests |\n| HOOK-003-B | Revision instruction entered synthetic conversation history | Dynamic system hint, decomposition bypass, root-input checkpoint tests |\n| HOOK-003-C | Durable history flattened handler decisions | Handler attribution and verification.decided persistence tests |\n| Scope guard | Risk of a second policy/storage subsystem | Reused HookRegistry, AgenticLoop continuation, SessionTimeline, and existing SQLite event store |\n\n## Verification\n- uv run pytest tests/ -m "not live" — 10424 passed, 23 skipped, 1 deselected\n- uv run pytest tests/core/agent tests/core/hooks tests/core/observability -q — passed\n- uv run ruff check core/ tests/ plugins/ scripts/\n- uv run ruff format --check core/ tests/ plugins/ scripts/\n- uv run mypy core/ plugins/\n- uv run lint-imports\n- uv run python scripts/architecture_baseline.py --check\n- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request\n- npm run build in site — passed; existing broad Petri seed glob warnings remain\n- uv run geode version — GEODE v1.0.14\n- pre-commit hooks including Bandit and deptry — passed\n\nLive/provider tests were not run.