### PR TITLE
chore(release): v1.0.15 릴리스 준비

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.15] - 2026-08-07
+
+> PostVerify control release: deterministic default decisions now feed the
+> bounded revise/replan path, while decision provenance remains replayable in
+> the semantic session timeline.
+
 ### Changed
 
 - **PostVerify now controls delivery by default.** With no external handler,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.14
+- **Version**: 1.0.15
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)
-- **Modules**: 432 core + 110 plugins = 542
-- **Tests**: 10451 (+1 live)
+- **Modules**: 431 core + 111 plugins = 542
+- **Tests**: 10447 (+1 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.14 — A Self-improving Autonomous Execution Agent
+# GEODE v1.0.15 — A Self-improving Autonomous Execution Agent
 
 자기 자신이 올라탄 scaffold 를 스스로 고쳐쓰는 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 짧은 프롬프트도, 장시간 세션도 동일하게. 그 아래에서는 outer loop 가 작업을 수행하는 시스템 자체를 계속 다듬습니다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.14: A Self-improving Autonomous Execution Agent
+# GEODE v1.0.15: A Self-improving Autonomous Execution Agent
 
 A general-purpose autonomous agent that also rewrites the scaffolding it runs on. You ask in plain language; GEODE plans, calls tools, and reports, for one prompt or a long-running session. Underneath, an outer loop keeps tuning the system that runs your tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.14"
+version = "1.0.15"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
-    "count": 252,
-    "stamped": "1.0.14"
+    "count": 251,
+    "stamped": "1.0.15"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.14"
+    "stamped": "1.0.15"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.14"
+    "stamped": "1.0.15"
   },
   "duplicated_signatures": {
     "count": 97,
-    "stamped": "1.0.14"
+    "stamped": "1.0.15"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.14. Last sync 2026-08-05. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.15. Last sync 2026-08-07. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is a self-evolving autonomous execution agent: an inner agentic loop runs tasks (research, analysis, automation, scheduling) and an outer self-improving loop (Petri audit -> fitness gate) tunes the system that runs them.
 
-Version v1.0.14. Last sync 2026-08-05. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.15. Last sync 2026-08-07. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-05
+ * Last sync: 2026-08-07
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Changed\n\n- **PostVerify now controls delivery by default.** With no external handler,\n  passing candidates are accepted, retryable failures enter the existing\n  bounded revise/replan path, and non-retryable failures pause for external\n  verification. Revision instructions now use the dynamic system context\n  instead of user-role history, and candidate-digest-bound handler decisions\n  persist in the semantic session timeline for trajectory reconstruction."
+    "body": ""
+  },
+  {
+    "version": "1.0.15",
+    "date": "2026-08-07",
+    "body": "> PostVerify control release: deterministic default decisions now feed the\n> bounded revise/replan path, while decision provenance remains replayable in\n> the semantic session timeline.\n\n### Changed\n\n- **PostVerify now controls delivery by default.** With no external handler,\n  passing candidates are accepted, retryable failures enter the existing\n  bounded revise/replan path, and non-retryable failures pause for external\n  verification. Revision instructions now use the dynamic system context\n  instead of user-role history, and candidate-digest-bound handler decisions\n  persist in the semantic session timeline for trajectory reconstruction."
   },
   {
     "version": "1.0.14",
@@ -2468,4 +2473,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-08-05";
+export const CHANGELOG_SYNCED_AT = "2026-08-07";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-05
+ * Last sync: 2026-08-07
  */
 
 export const GEODE_SOT = {
-  version: "1.0.14",
-  syncedAt: "2026-08-05",
+  version: "1.0.15",
+  syncedAt: "2026-08-07",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- PostVerify 전달 제어 변경을 `v1.0.15` 릴리스로 묶습니다.
- 패키지·README·scaffold·공개 문서 생성물의 버전 표면을 함께 갱신합니다.

## Why
PR #2892로 병합된 PostVerify 기본 판정과 revise/replan 제어 경로를 main에 올리기 전에 단일 릴리스 계약으로 고정해야 합니다.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | `v1.0.15` 릴리스 절과 PostVerify 제어 요약 추가 |
| `pyproject.toml`, `uv.lock` | 패키지 버전 `1.0.15`로 갱신 |
| `README*.md`, `CLAUDE.md` | 버전과 실측 모듈·테스트 수 정렬 |
| `scripts/slop_ratchet_baseline.json` | 우회 마커 감소분(252→251)을 새 기준선으로 고정 |
| `site/**` 생성물 | 공개 버전·CHANGELOG·llms 문서 재생성 |

## GAP Audit
| 항목 | 병합 전 | 이 PR |
|------|---------|-------|
| 패키지 버전 | `1.0.14` | `1.0.15` |
| 공개 문서 버전 | `1.0.14` | `1.0.15` |
| 모듈 계측 | `432 core + 110 plugins` | `431 core + 111 plugins` |
| non-live 수집 수 | 문서 `10,451` | 실측 `10,447` |

## Verification
- `uv run ruff check core/ tests/ plugins/ scripts/`
- `uv run ruff format --check core/ tests/ plugins/ scripts/`
- `uv run mypy core/ plugins/`
- `uv run lint-imports`
- `uv run python scripts/check_slop_ratchet.py`
- `uv run python scripts/architecture_baseline.py --check`
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- `uv run pytest tests/ -m "not live"` — 10,424 passed, 23 skipped, 1 deselected
- `npm run build`
- `npm run export-md`
- `uv build && uv run twine check dist/*`
- `uv run geode version` — `GEODE v1.0.15`
