### PR TITLE
docs: add v1.0.16 runtime memory handoff

### DIFF
--- a/docs/plans/2026-08-07-runtime-memory-authority-release-handoff.md
+++ b/docs/plans/2026-08-07-runtime-memory-authority-release-handoff.md
@@ -1,0 +1,129 @@
+# Handoff — runtime memory authority and behavior evidence
+
+> Date: 2026-08-07
+> Runtime release: `v1.0.16`
+> Status: implementation, release, roadmap closure, and branch synchronization complete
+
+Start with this document, then use
+[`2026-08-07-runtime-memory-trajectory-convergence.md`](2026-08-07-runtime-memory-trajectory-convergence.md)
+for the audit, migration map, and future trajectory-v2 design. The canonical
+delivery ledger remains
+[`extensibility-roadmap.md`](../architecture/extensibility-roadmap.md).
+
+## 1. Current state
+
+| Outcome | Evidence |
+|---|---|
+| Memory authority cleanup | [#2903](https://github.com/mangowhoiscloud/geode/pull/2903), develop merge `a7a59b69f18589bec82eb515b482355924ac9467` |
+| Main promotion | [#2906](https://github.com/mangowhoiscloud/geode/pull/2906), release source `c28d06910f8044beb96eadea241fcc31b88fc936` |
+| Public distribution | [v1.0.16](https://github.com/mangowhoiscloud/geode/releases/tag/v1.0.16), PyPI `geode-agent==1.0.16` |
+| `MEM-001` closure | [#2907](https://github.com/mangowhoiscloud/geode/pull/2907), main commit `32f94bd94481b1236c96f0905136879790a1ae0d` |
+| Main → develop sync | [#2908](https://github.com/mangowhoiscloud/geode/pull/2908), develop commit `41d0522b0b6299a3dcfc6345fb9fce8fad6ec477` |
+| Immutable behavior evidence | [eval-artifact #15](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/15), commit `4903c31abf983b7be076fd1e35775190fd6f4718` |
+
+The cleanup was deletion-first: 217 insertions and 353 deletions. The default
+prompt now reads the wired global/project user profile; the implicit
+`TURN_COMPLETED` turn-trace memory writer and caller-free checkpoint/journal
+write APIs are gone. Historical profile, session, and journal files were not
+rewritten or deleted, and no durable schema migration was introduced.
+
+## 2. Final control surface
+
+The public ABI is exactly 13 names. Internal `RuntimeEvent` growth does not
+expand it.
+
+| Group | Public hooks |
+|---|---|
+| Session | `SessionStart`, `SessionEnd` |
+| Input | `UserPromptSubmit` |
+| Tool | `PreToolUse`, `PermissionRequest`, `PostToolUse` |
+| Compaction | `PreCompact`, `PostCompact` |
+| Delegation | `SubagentStart`, `SubagentStop` |
+| Verification | `PreVerify`, `PostVerify`, `Stop` |
+
+Four trusted middleware seams remain separate from that public lifecycle:
+`tool_request`, `tool_execution`, `llm_request`, and `llm_execution`. Request
+middleware transforms immutable envelopes in order; execution middleware wraps
+the accepted terminal call with a single-use `next_call`.
+
+```mermaid
+flowchart TD
+    A["SessionStart"] --> B["UserPromptSubmit"]
+    B --> C["LLM request / execution middleware"]
+    C --> D["PreToolUse"]
+    D --> E["PermissionRequest when required"]
+    E --> F["Tool request / execution middleware"]
+    F --> G["PostToolUse"]
+    G --> C
+    C --> H["PreVerify"]
+    H --> I["Built-in verifier"]
+    I --> J["PostVerify: accept / revise / escalate"]
+    J --> K["Stop"]
+    K -->|"deliver"| L["SessionEnd"]
+    K -->|"bounded continuation"| M["dynamic verification hint"]
+    M --> N["verify-fail replan"]
+    N --> C
+```
+
+`PostVerify` cannot erase a built-in failure. Retryable failures revise and
+enter the existing replan path; non-retryable failures become pending external
+verification; invalid failure-plus-accept decisions escalate. Continuation is
+bounded to two attempts and does not replay completed tool side effects.
+
+## 3. Records, telemetry, and artifacts
+
+```mermaid
+flowchart LR
+    R["AgenticLoop"] --> M["sessions.db: messages\nmutable resume context"]
+    R --> S["sessions.db: session_events\nappend-only behavior"]
+    R --> H["sessions.db: hook_events\nbounded telemetry"]
+    S --> J["events.jsonl\nportable projection"]
+    H --> J
+    S --> T["trajectory.json\nimmutable evaluation view"]
+    H --> T
+    E["Evidence / native receipts\nexternal authority"] -->|"digest + typed ref"| T
+    T --> A["geode-eval-artifacts\nreviewed public release"]
+```
+
+`session_events` and `hook_events` are intentionally separate. The former says
+what behavior durably happened and survives for replay/evaluation; the latter
+records extension invocation, middleware timing, blocking, errors, and policy
+telemetry under shorter retention. Native Tau2/MCPMark receipts, SIL ledgers,
+and Crucible evidence stay byte-authoritative outside SQLite and join the
+trajectory by digest and stable reference. Copying them into SQLite would
+create a second promotion authority.
+
+The published Luna/max run produced 22 SQLite rows and the same 22 JSONL rows,
+then projected 27 normalized trajectory events. Scope completeness passed;
+replay completeness is deliberately false because private payloads were
+redacted. The release manifest is
+`aba8839af72cd4d96e7e22979affac98e04cbe027fff41e3b67732e75720103d`.
+
+## 4. Verification
+
+- Local non-live suite: 10,407 passed, 23 skipped, 1 deselected.
+- Full lint, format, mypy, import contracts, dependency, architecture, roadmap,
+  official-doc, package-content, and clean-wheel gates passed.
+- Live `gpt-5.6-luna`, effort `max`: all 13 public hooks, all four middleware
+  seams, deny/block/error/cancel/timeout/short-circuit/double-`next_call`
+  behavior, SQLite/JSONL parity, trajectory projection, and secret scan passed.
+- Public `uvx --no-cache --from geode-agent==1.0.16 geode version` returned
+  `GEODE v1.0.16`.
+- GitHub and PyPI wheel SHA-256:
+  `865d49d6c7838018e1cdc3687a3a389bc5f48864c6a84962497f0a42fb3cada6`.
+- GitHub and PyPI sdist SHA-256:
+  `00e15285a414ed3e06182b0f1e1bb0f47022bf96c0a2ede97726a7c022a00495`.
+
+## 5. Deliberately unfinished
+
+Do not reopen `MEM-001`. The remaining trajectory-v2 work is a separate future
+GAP: causal `parent_event_id` propagation, parent/child rollout edges,
+best-of-N group/rank metadata, call-linked usage metering, large-payload content
+references, and evidence-bound reward atoms. Add those only through the
+architecture roadmap; do not add a reward database, policy framework, or a
+second runtime writer in anticipation.
+
+Operational follow-ups are non-blocking: the public site dependency audit still
+reports five pre-existing lockfile advisories, GitHub Actions warns that two
+pinned actions target deprecated Node.js 20, and Hugging Face publication was
+intentionally skipped to avoid duplicating the canonical release artifacts.

--- a/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
+++ b/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
@@ -35,6 +35,14 @@ run covered all 13 public hooks and four trusted middleware seams, with 22
 SQLite rows matching 22 JSONL rows. The privacy-reviewed 27-event trajectory
 is pinned to
 [`geode-eval-artifacts@4903c31`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/4903c31abf983b7be076fd1e35775190fd6f4718).
+The slice reached `main` through
+[`#2906`](https://github.com/mangowhoiscloud/geode/pull/2906) at
+`c28d06910f8044beb96eadea241fcc31b88fc936`, shipped as
+[`v1.0.16`](https://github.com/mangowhoiscloud/geode/releases/tag/v1.0.16),
+closed `MEM-001` through
+[`#2907`](https://github.com/mangowhoiscloud/geode/pull/2907), and synchronized
+the closure back to `develop` through
+[`#2908`](https://github.com/mangowhoiscloud/geode/pull/2908).
 
 ## 1. Decision
 
@@ -687,25 +695,18 @@ stored reflection hint; a failed built-in result trips the existing
 otherwise passing result follows the explicit policy instruction without
 claiming that verification failed.
 
-Three implementation gaps remain:
+The three measured hook-control gaps were closed by
+[`#2892`](https://github.com/mangowhoiscloud/geode/pull/2892) and released in
+`v1.0.15`:
 
-1. **No production PostVerify policy is registered.** The registry has zero
-   non-test `PostVerify` handlers. With no decision, a retryable built-in
-   failure is currently deliverable; its replan signal is dormant until a
-   later unrelated run.
-2. **Trusted control is represented as user content.** The continuation is
-   inserted into provider history as
-   `[system:verification_continuation] ...` with role `user`. It must instead
-   enter the existing dynamic system-hint path while the original root request
-   remains the task input for preflight/decomposition and the semantic
-   timeline keeps the correlated continuation event.
-3. **Policy attribution is flattened.** Runtime hook telemetry preserves
-   extension status, duration, reason, and evidence correlation, but the
-   durable semantic record does not retain each PostVerify handler/action or a
-   stable candidate target. This is insufficient for process reward and
-   external-loop audit.
+1. **Production fallback.** An empty decision set now maps pass to `accept`, a
+   retryable failure to `revise`, and a non-retryable failure to `escalate`.
+2. **Typed continuation context.** Revision enters the bounded dynamic system
+   hint while the original root request remains the task input.
+3. **Policy attribution.** `verification.decided` retains the candidate digest
+   and bounded per-handler action, reason, and evidence references.
 
-The minimum repair reuses the existing registry, finalization state machine,
+The delivered repair reuses the existing registry, finalization state machine,
 runtime-hint injection, session timeline, and attempt budget:
 
 | Gap | Minimal behavior | Deliberate non-goal |
@@ -750,7 +751,7 @@ There are three distinct failure modes:
 3. **early aggregation**: only a winner, scalar, count, or summary survives,
    erasing alternative branches and process attribution.
 
-### 7.1 Confirmed flattened or dangling signals
+### 7.1 Confirmed flattened, dangling, or recently closed signals
 
 | Signal | Current failure | Minimum repair |
 |---|---|---|
@@ -758,7 +759,7 @@ There are three distinct failure modes:
 | LLM latency | loop emits `latency_ms`; lifecycle activity builder reads `duration_ms` | align the typed event contract once |
 | middleware mutation | original/effective request hashes are emitted, but typed durable details omit them | persist bounded hashes and middleware IDs |
 | cognitive reflection | rich `CognitiveState` changes do not survive the generic typed activity projection | persist before/after state digest and changed fields, not hidden reasoning |
-| verification | PostVerify has no production fallback policy; continuation is encoded as user content; handler decisions are aggregated | add deterministic fallback, dynamic system hint, and candidate-digest-bound per-handler decisions; assign transition ID only in trajectory projection |
+| verification | hot-path gap closed in #2892: deterministic fallback, dynamic system hint, and candidate-digest-bound per-handler decisions are durable | assign a transition ID only in trajectory v2 projection; do not add another runtime writer |
 | hook retention | trajectory stores a cohort digest/count while `hook_events` later expires | snapshot required normalized facts into immutable trajectory v2 |
 | large tool evidence | payload over 256 KiB becomes a hash/truncation marker with no content locator | add content-addressed artifact reference before bounding |
 | benchmark reward | Tau2 breakdown stays inside native evidence refs | normalize each component as a RewardAtom without replacing the receipt |


### PR DESCRIPTION
## Summary
- Add the final v1.0.16 runtime-memory and behavior-evidence handoff.
- Correct stale PostVerify status in the convergence plan now that #2892/v1.0.15 closed those measured gaps.

## Why
The implementation, release, MEM-001 closure, and main → develop synchronization are complete. The next session needs one code-grounded entry point with exact PRs, commits, hook/middleware surfaces, storage boundaries, artifact digests, and deliberately unfinished trajectory-v2 work.

## Changes
| File | Change |
|---|---|
| docs/plans/2026-08-07-runtime-memory-authority-release-handoff.md | Add the final state, diagrams, verification, public artifact digests, and bounded follow-ups. |
| docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md | Add release/closure lineage and replace stale pre-#2892 PostVerify gap wording with delivered status. |

## Verification
- `git diff --check` — RESULT: PASS
- `uv run python scripts/check_official_docs.py` — RESULT: PASS; internal links clean and all 237 static pages built
- pre-commit hooks — RESULT: PASS

Documentation-only; no runtime or persisted-schema change.