### PR TITLE
docs(architecture): 중단된 R1.1 claim 해제

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,7 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
-| R1.1 | BND-001 | `session=codex-2026-07-18 task=architecture-package-classification` | `feature/architecture-package-classification` | R1.1 readiness reconciled by [#2776](https://github.com/mangowhoiscloud/geode/pull/2776); claim PR [#2790](https://github.com/mangowhoiscloud/geode/pull/2790); current `develop` re-audit confirms delivered GOV-002 and the measurable §7 classification/migration-map contract | 2026-07-18T09:15:41Z |
+| _none yet_ | — | — | — | — | — |
 
 ## 1. Program objective
 
@@ -513,7 +513,7 @@ and closure evidence are appended in §10.
 | GOV-002 | `PARTIAL` | Hand-audited counts disagree with `AGENTS.md` (78 tools/56 hooks vs 67/65 prose) | One generated architecture baseline and a drift check own the counts | R0.2 | GOV-001 | `DONE` |
 | GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `DONE` |
 | GOV-004 | `PARTIAL` | 24 import ignores and very high global Ruff ceilings lack uniform owner/expiry metadata | Every exception is removed or recorded per symbol/edge with owner, rationale, expiry, and ratchet | R0.3 | GOV-002 | `DONE` |
-| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `IN_PROGRESS` |
+| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `READY` |
 | BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `OPEN` |
 | BND-003 | `ABSENT` | One-off core-only probe fails at `core.cli`; CI does not test an installed kernel without features | Isolated wheel/package test boots and runs kernel tests without bundled/third-party modules | R1.3 | BND-001, BND-002, BND-006 | `OPEN` |
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
@@ -1887,9 +1887,12 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-After this claim merges, allocate `feature/architecture-package-classification`
-from the updated `origin/develop` tip and verify that its branch and owner match
-the canonical R1.1 active claim. R1.1 delivers only the package-classification
+R1.1 is `READY` and unclaimed. Its 2026-07-18 implementation attempt was
+abandoned after opening no implementation PR, so the stale branch is not
+delivery evidence and must not be merged wholesale. Before resuming, re-audit
+its useful decisions against current `origin/develop`, merge a fresh claim that
+names the new owner and branch, and allocate that branch from the resulting
+canonical tip. R1.1 delivers only the package-classification
 ADR and product-shell migration map; it does not move implementation modules.
 R1.4 (`BND-005`) and R1.2 (`BND-002`) remain `OPEN` until R1.1 supplies that
 classification contract. R1.5 (`BND-006`) then waits for both the neutral seams


### PR DESCRIPTION
## Summary
- 2026-07-18 이후 구현 PR 없이 남은 R1.1/BND-001 활성 claim을 규정된 abandonment reconciliation으로 해제합니다.
- BND-001을 `READY`로 되돌리고, stale 구현 브랜치를 delivery evidence로 간주하지 않도록 다음 진입 절차를 명시합니다.

## Why
Canonical roadmap의 `IN_PROGRESS` claim이 실제 구현·PR 없이 후속 아키텍처 패키지를 장기간 잠그고 있었습니다. 브랜치 존재만으로 소유권이나 전달 증거를 주장할 수 없으므로 §0.3의 중단 reconciliation 절차를 적용합니다.

## Changes
| File | Change |
|------|--------|
| `docs/architecture/extensibility-roadmap.md` | R1.1 active claim 제거, BND-001 `IN_PROGRESS` → `READY`, fresh claim/re-audit 재진입 절차 기록 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| R1.1 / BND-001 stale claim | Released | 구현 PR이 없으므로 delivery evidence 없음 |
| 기존 branch 코드 | Preserved, not accepted | 현 `origin/develop` 기준 선택적 재감사 전 wholesale merge 금지 |

## Verification
- [x] `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- [x] `git diff --check`
- [x] Documentation-only reconciliation; CHANGELOG not required

🤖 Generated with [Codex](https://Codex.com/Codex)