### PR TITLE
release: 운영 부채 해소 변경을 main에 승격

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
 The current snapshot records 541 production Python files,
-678 test Python files,
+679 test Python files,
 84 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Made lifecycle restarts and runtime tests honor their real ownership
+  boundaries.** Detached `geode serve` restarts now allow the documented
+  30-second readiness window instead of terminating healthy MCP-heavy boots at
+  ten seconds; timed-out child termination escalates from terminate to kill,
+  and an unreaped child is reported explicitly. Runtime construction rolls
+  back scheduler threads on staged
+  failures; wiring tests use isolated scheduler stores and close every returned
+  runtime, preventing operator jobs and threads from leaking into later tests
+  after pytest capture has closed. Non-live tests also discard inherited
+  provider credentials, and the credentialed web-search E2E is now explicitly
+  marked `live`, preventing accidental billable calls during local CI.
+
 ## [1.0.17] - 2026-08-08
 
 > Runtime hygiene release: execution-correlated feedback, retired compatibility

--- a/core/cli/commands/lifecycle.py
+++ b/core/cli/commands/lifecycle.py
@@ -42,6 +42,9 @@ from core.paths import (
 )
 from core.ui.console import console
 
+SERVE_STARTUP_TIMEOUT_S = 30.0
+SERVE_TERMINATION_TIMEOUT_S = 5.0
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -707,7 +710,7 @@ def _start_serve_background(
     *,
     dry_run: bool = False,
     executable: str = "geode",
-    timeout: float = 10.0,
+    timeout: float = SERVE_STARTUP_TIMEOUT_S,
 ) -> bool:
     """Start ``geode serve`` detached and verify socket readiness."""
     if dry_run:
@@ -736,6 +739,17 @@ def _start_serve_background(
 
     with contextlib.suppress(OSError):
         process.terminate()
+    try:
+        process.wait(timeout=SERVE_TERMINATION_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(OSError):
+            process.kill()
+        try:
+            process.wait(timeout=SERVE_TERMINATION_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            console.print(
+                "  [error]Timed-out serve process could not be reaped after kill.[/error]"
+            )
     console.print("  [warning]Updated, but restarted serve did not become ready.[/warning]")
     return False
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -255,10 +255,14 @@ class GeodeRuntime:
             organization_memory=memory["organization_memory"],
             context_assembler=memory["context_assembler"],
         )
-        instance = cls(core_config, scheduling_config, memory_config)
-        instance.run_id = run_id
-        instance.task_graph = memory["task_graph"]
-        return instance
+        try:
+            instance = cls(core_config, scheduling_config, memory_config)
+            instance.run_id = run_id
+            instance.task_graph = memory["task_graph"]
+            return instance
+        except BaseException:
+            cls._stop_staged_scheduling(scheduling)
+            raise
 
     @staticmethod
     def _build_core(
@@ -359,7 +363,11 @@ class GeodeRuntime:
 
         scheduling = scheduling_wiring.build_scheduling(hooks=hooks)
 
-        task_graph = bootstrap.build_task_graph()
+        try:
+            task_graph = bootstrap.build_task_graph()
+        except BaseException:
+            GeodeRuntime._stop_staged_scheduling(scheduling)
+            raise
 
         memory = {
             "project_memory": project_memory,
@@ -368,6 +376,22 @@ class GeodeRuntime:
             "task_graph": task_graph,
         }
         return memory, scheduling
+
+    @staticmethod
+    def _stop_staged_scheduling(scheduling: dict[str, Any]) -> None:
+        """Roll back scheduler threads when staged runtime assembly fails."""
+        scheduler_service = scheduling.get("scheduler_service")
+        if scheduler_service is not None:
+            try:
+                scheduler_service.stop()
+            except Exception:
+                log.warning("Staged scheduler rollback failed", exc_info=True)
+        trigger_manager = scheduling.get("trigger_manager")
+        if trigger_manager is not None:
+            try:
+                trigger_manager.stop_scheduler()
+            except Exception:
+                log.warning("Staged trigger rollback failed", exc_info=True)
 
     # ------------------------------------------------------------------
     # Instance methods

--- a/core/wiring/scheduling.py
+++ b/core/wiring/scheduling.py
@@ -11,6 +11,7 @@ remains is the live scheduler stack.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import Any
 
@@ -32,72 +33,81 @@ def build_scheduling(*, hooks: HookSystem) -> dict[str, Any]:
         scheduler_interval_s=settings.trigger_scheduler_interval_s,
         hooks=hooks,
     )
-    trigger_manager.start_scheduler()
-
-    # Advanced scheduler service (3-type: AT/EVERY/CRON + active hours)
-    from core.scheduler import create_scheduler
-
-    scheduler_service = create_scheduler(
-        trigger_manager=trigger_manager,
-        hooks=hooks,
-        enable_jitter=settings.scheduler_jitter_enabled,
-        max_jitter_ms=settings.scheduler_max_jitter_ms,
-    )
-    scheduler_service.load()
-
-    # Predefined automations are package-specific templates.
-    # They require a wired callback to be useful. Without callback/action,
-    # they fire as empty jobs consuming resources.
-    # Registration is skipped — users can enable predefined templates
-    # via /schedule enable <template_id> when an external package provides
-    # the callback wiring.
-
-    # PR-MEMORY-LIFECYCLE (2026-07-03) — first-party read-only engineering
-    # report jobs (callback path: pure-python collectors, budget_usd=0.0,
-    # no tool loop). Registered DISABLED by default; operators opt in via
-    # /schedule enable <job_id> or run once via /schedule run <job_id>.
+    scheduler_service: Any | None = None
     try:
-        from core.scheduler.engineering_reports import register_engineering_report_jobs
+        trigger_manager.start_scheduler()
 
-        register_engineering_report_jobs(scheduler_service)
-    except Exception:
-        log.exception("engineering report job wiring failed; scheduler continues without them")
+        # Advanced scheduler service (3-type: AT/EVERY/CRON + active hours)
+        from core.scheduler import create_scheduler
 
-    if settings.scheduler_auto_start:
-        scheduler_service.start(
-            interval_s=settings.scheduler_interval_s,
-        )
-
-    # OL-A1 (2026-05-22) — self-improving-loop auto-trigger. Opt-in:
-    # only fires when [self_improving_loop.scheduler] enabled=true in
-    # ~/.geode/config.toml. Default off → register_auto_trigger no-ops.
-    try:
-        from core.config.self_improving import load_self_improving_loop_config
-        from core.self_improving.loop.auto_trigger import register_auto_trigger
-
-        sil_cfg = load_self_improving_loop_config()
-        register_auto_trigger(
-            trigger_manager,
-            enabled=sil_cfg.scheduler.enabled,
-            cron=sil_cfg.scheduler.cron,
-            min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
-            # PR-MAX-GEN (2026-05-26) — production wiring for the
-            # generation cap. ``0`` (config default) preserves legacy
-            # unbounded behaviour. Operators set a non-zero cap in
-            # ~/.geode/config.toml under [self_improving_loop.scheduler]
-            # max_generation = N.
-            max_generation=sil_cfg.scheduler.max_generation,
+        scheduler_service = create_scheduler(
+            trigger_manager=trigger_manager,
             hooks=hooks,
+            enable_jitter=settings.scheduler_jitter_enabled,
+            max_jitter_ms=settings.scheduler_max_jitter_ms,
         )
-    except Exception:
-        log.exception("auto_trigger wiring failed; scheduler continues without it")
+        scheduler_service.load()
 
-    _register_trigger_logger(hooks)
+        # Predefined automations are package-specific templates.
+        # They require a wired callback to be useful. Without callback/action,
+        # they fire as empty jobs consuming resources.
+        # Registration is skipped — users can enable predefined templates
+        # via /schedule enable <template_id> when an external package provides
+        # the callback wiring.
 
-    return {
-        "trigger_manager": trigger_manager,
-        "scheduler_service": scheduler_service,
-    }
+        # PR-MEMORY-LIFECYCLE (2026-07-03) — first-party read-only engineering
+        # report jobs (callback path: pure-python collectors, budget_usd=0.0,
+        # no tool loop). Registered DISABLED by default; operators opt in via
+        # /schedule enable <job_id> or run once via /schedule run <job_id>.
+        try:
+            from core.scheduler.engineering_reports import register_engineering_report_jobs
+
+            register_engineering_report_jobs(scheduler_service)
+        except Exception:
+            log.exception("engineering report job wiring failed; scheduler continues without them")
+
+        if settings.scheduler_auto_start:
+            scheduler_service.start(
+                interval_s=settings.scheduler_interval_s,
+            )
+
+        # OL-A1 (2026-05-22) — self-improving-loop auto-trigger. Opt-in:
+        # only fires when [self_improving_loop.scheduler] enabled=true in
+        # ~/.geode/config.toml. Default off → register_auto_trigger no-ops.
+        try:
+            from core.config.self_improving import load_self_improving_loop_config
+            from core.self_improving.loop.auto_trigger import register_auto_trigger
+
+            sil_cfg = load_self_improving_loop_config()
+            register_auto_trigger(
+                trigger_manager,
+                enabled=sil_cfg.scheduler.enabled,
+                cron=sil_cfg.scheduler.cron,
+                min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
+                # PR-MAX-GEN (2026-05-26) — production wiring for the
+                # generation cap. ``0`` (config default) preserves legacy
+                # unbounded behaviour. Operators set a non-zero cap in
+                # ~/.geode/config.toml under [self_improving_loop.scheduler]
+                # max_generation = N.
+                max_generation=sil_cfg.scheduler.max_generation,
+                hooks=hooks,
+            )
+        except Exception:
+            log.exception("auto_trigger wiring failed; scheduler continues without it")
+
+        _register_trigger_logger(hooks)
+
+        return {
+            "trigger_manager": trigger_manager,
+            "scheduler_service": scheduler_service,
+        }
+    except BaseException:
+        if scheduler_service is not None:
+            with contextlib.suppress(Exception):
+                scheduler_service.stop()
+        with contextlib.suppress(Exception):
+            trigger_manager.stop_scheduler()
+        raise
 
 
 def _register_trigger_logger(hooks: HookSystem) -> None:

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,7 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
-| R1.1 | BND-001 | `session=codex-2026-07-18 task=architecture-package-classification` | `feature/architecture-package-classification` | R1.1 readiness reconciled by [#2776](https://github.com/mangowhoiscloud/geode/pull/2776); claim PR [#2790](https://github.com/mangowhoiscloud/geode/pull/2790); current `develop` re-audit confirms delivered GOV-002 and the measurable §7 classification/migration-map contract | 2026-07-18T09:15:41Z |
+| _none yet_ | — | — | — | — | — |
 
 ## 1. Program objective
 
@@ -513,7 +513,7 @@ and closure evidence are appended in §10.
 | GOV-002 | `PARTIAL` | Hand-audited counts disagree with `AGENTS.md` (78 tools/56 hooks vs 67/65 prose) | One generated architecture baseline and a drift check own the counts | R0.2 | GOV-001 | `DONE` |
 | GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `DONE` |
 | GOV-004 | `PARTIAL` | 24 import ignores and very high global Ruff ceilings lack uniform owner/expiry metadata | Every exception is removed or recorded per symbol/edge with owner, rationale, expiry, and ratchet | R0.3 | GOV-002 | `DONE` |
-| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `IN_PROGRESS` |
+| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `READY` |
 | BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `OPEN` |
 | BND-003 | `ABSENT` | One-off core-only probe fails at `core.cli`; CI does not test an installed kernel without features | Isolated wheel/package test boots and runs kernel tests without bundled/third-party modules | R1.3 | BND-001, BND-002, BND-006 | `OPEN` |
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
@@ -1887,9 +1887,12 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-After this claim merges, allocate `feature/architecture-package-classification`
-from the updated `origin/develop` tip and verify that its branch and owner match
-the canonical R1.1 active claim. R1.1 delivers only the package-classification
+R1.1 is `READY` and unclaimed. Its 2026-07-18 implementation attempt was
+abandoned after opening no implementation PR, so the stale branch is not
+delivery evidence and must not be merged wholesale. Before resuming, re-audit
+its useful decisions against current `origin/develop`, merge a fresh claim that
+names the new owner and branch, and allocate that branch from the resulting
+canonical tip. R1.1 delivers only the package-classification
 ADR and product-shell migration map; it does not move implementation modules.
 R1.4 (`BND-005`) and R1.2 (`BND-002`) remain `OPEN` until R1.1 supplies that
 classification contract. R1.5 (`BND-006`) then waits for both the neutral seams

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -283,10 +283,10 @@ machine-readable artifact is
 | Measure | Current tree |
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 541 |
-| Test Python files | 678 |
-| `core/` Python LOC | 138,101 |
+| Test Python files | 679 |
+| `core/` Python LOC | 138,149 |
 | `plugins/` Python LOC | 41,831 |
-| Test Python LOC | 178,149 |
+| Test Python LOC | 178,312 |
 | Tool definitions / executable registrations / valid schemas | 84 / 87 / 84 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/docs/plans/2026-08-08-operational-debt-disposition.md
+++ b/docs/plans/2026-08-08-operational-debt-disposition.md
@@ -1,0 +1,82 @@
+# Operational debt disposition — 2026-08-08
+
+> Evidence note, not a competing status ledger. Runtime implementation status
+> remains in code and `CHANGELOG.md`; architecture package status remains in
+> `docs/architecture/extensibility-roadmap.md`.
+
+## Decision summary
+
+| Item | Measured state | Decision |
+|---|---|---|
+| Detached serve readiness | Default helper window was 10 seconds; the local 13-MCP boot reached readiness in about 21 seconds | Raise the existing window to the documented 30 seconds; do not add another configuration surface |
+| Full-suite scheduler logging | Runtime wiring tests loaded project/legacy scheduler state and leaked owned threads beyond test teardown | Isolate scheduler paths and close every test-created `GeodeRuntime` |
+| Non-live credential leakage | Test collection loaded operator `.env` files globally, allowing an unmarked agent path to issue a real PAYG reflection call | Strip provider credentials before imports; load credentials only inside explicitly `live` tests |
+| R1.1 / BND-001 claim | Active since 2026-07-18, with no implementation PR | Release through the roadmap's abandonment reconciliation; require a fresh claim and re-audit before resumption |
+| `feature/crucible-reentry-hardening` | No PR; 37 branch-only commits on a base hundreds of commits behind current `develop` | Drop the stale branch after recording the salvage audit below |
+| Reward-memory convergence plan | One documentation commit in an owner-protected worktree | Preserve; do not copy or delete another session's work |
+| Four untracked telecom calibration files | No caller, command registration, or documentation; two tests only pin the orphan scripts | Do not promote them into the product; move them to the operator Trash for recoverable cleanup |
+
+## Scheduler root cause and contract
+
+`GeodeRuntime.create()` owns both `TriggerManager` and `SchedulerService`.
+Two wiring-test modules constructed runtimes repeatedly without calling
+`shutdown()`. Because the scheduler defaults are module-level project and
+legacy paths, those tests also loaded real `.geode/scheduled_tasks.json` rows.
+Two enabled operator jobs then aged out and fired from leaked daemon threads
+later in the suite. Pytest had already closed the originating capture stream,
+so ordinary scheduler and hook logging raised:
+
+```text
+ValueError: I/O operation on closed file
+core/scheduler/service.py::_loop -> check_due_jobs
+core/wiring/scheduling.py::_trigger_logger
+```
+
+The correction belongs at the test ownership boundary:
+
+1. Replace scheduler store, log, and legacy-migration paths with one per-test
+   temporary root before constructing a runtime.
+2. Track each runtime constructed by those modules.
+3. Call `runtime.shutdown()` during fixture teardown while pytest capture is
+   still valid.
+4. Preserve the `classmethod` factory contract and roll back scheduler threads
+   if staged construction fails before a runtime can be returned.
+
+Suppressing logging or catching `ValueError` would hide an actual lifecycle
+leak and leave operator jobs executable inside tests, so those options are
+rejected.
+
+The same isolation rule applies to credentials: `-m "not live"` must be a
+spend boundary, not merely a naming convention. Unit tests inject synthetic
+keys locally and bootstrap without daemon dotenv promotion; live tests resolve
+operator credentials only after pytest has selected the explicit `live`
+marker.
+
+## Crucible branch salvage audit
+
+The stale branch changed 53 Python files relative to its merge base. An AST
+census found only six files with top-level symbols absent by name on current
+`origin/develop`:
+
+- Tau2 trajectory path construction is now delegated to
+  `plugins.benchmark_harness.trajectory_artifacts` and retained as a local
+  compatibility alias.
+- Window preflight functions moved from the CLI script into
+  `plugins.crucible.preflight`, giving the CLI and campaign preparation one
+  implementation.
+- The old `_harvest_partial` helper depended on `cached-row.v1`. Current
+  execution intentionally refuses that cache because it cannot bind the
+  runtime profile and attempt manifest required by Tau2 snapshot v4. Restoring
+  the helper would weaken evidence identity.
+- Remaining missing names are stale tests for those retired shapes.
+
+The branch therefore has no independently salvageable production primitive.
+Its historical commits may still be inspected through local recovery until
+the explicit branch cleanup, but it must not be rebased or merged wholesale.
+
+## Deferred, not silently absorbed
+
+The reward-memory convergence plan remains under a different `.owner` marker.
+This pass reads it as evidence only. A future session may re-ground its phases
+against #2903, #2915, and later runtime changes, but this work does not steal
+the checkout, rewrite the commit, or claim that the plan has shipped.

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5974,7 +5974,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1496 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1497 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -6135,7 +6135,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 | 측정값 | 현재 트리 |
 | --- | --- |
 | 프로덕션 Python 파일 | 541 |
-| 테스트 Python 파일 | 678 |
+| 테스트 Python 파일 | 679 |
 | 도구 정의 / 실행 등록 / 유효 스키마 | 84 / 87 / 84 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 8 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,15 +528,15 @@
   "packages": {
     "core": {
       "python_files": 430,
-      "python_loc": 138101
+      "python_loc": 138149
     },
     "plugins": {
       "python_files": 111,
       "python_loc": 41831
     },
     "tests": {
-      "python_files": 678,
-      "python_loc": 178149
+      "python_files": 679,
+      "python_loc": 178312
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Fixed\n\n- **Made lifecycle restarts and runtime tests honor their real ownership\n  boundaries.** Detached `geode serve` restarts now allow the documented\n  30-second readiness window instead of terminating healthy MCP-heavy boots at\n  ten seconds; timed-out child termination escalates from terminate to kill,\n  and an unreaped child is reported explicitly. Runtime construction rolls\n  back scheduler threads on staged\n  failures; wiring tests use isolated scheduler stores and close every returned\n  runtime, preventing operator jobs and threads from leaking into later tests\n  after pytest capture has closed. Non-live tests also discard inherited\n  provider credentials, and the credentialed web-search E2E is now explicitly\n  marked `live`, preventing accidental billable calls during local CI."
   },
   {
     "version": "1.0.17",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""pytest configuration — load .env before any module imports.
+"""pytest configuration — isolate operator state before test imports.
 
 Hook-based observability (SQLite events + LLM_CALL_START/END) needs no
 special test-time setup; the hook system is wired only when an
@@ -8,10 +8,21 @@ HookSystem instance is present.
 import contextlib
 import os
 import tempfile
+from collections.abc import Iterator
 
-from dotenv import load_dotenv
-
-load_dotenv()  # Must run before test module imports
+# A non-live test run must never inherit billable provider credentials from the
+# operator shell or a repository ``.env``. Tests that exercise credential
+# discovery set synthetic values with ``monkeypatch``; explicitly live tests
+# resolve their own credentials inside the marked test body.
+for _credential_var in (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "ZHIPUAI_API_KEY",
+    "ZAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+):
+    os.environ.pop(_credential_var, None)
 
 # Redirect SessionCheckpoint to a temp directory during tests to prevent
 # production data contamination.
@@ -33,6 +44,56 @@ import pytest  # noqa: E402
 
 _test_auth_toml = os.path.join(tempfile.gettempdir(), "geode_test_auth.toml")
 os.environ.setdefault("GEODE_AUTH_TOML", _test_auth_toml)
+
+
+@pytest.fixture
+def managed_geode_runtimes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Isolate scheduler state and close every runtime created by a test.
+
+    ``GeodeRuntime.create`` owns two scheduler threads. Tests that only inspect
+    wiring used to leave those threads alive and could import real project or
+    legacy scheduler jobs. The leaked jobs then ran later in the suite after
+    pytest had closed its capture stream.
+    """
+    from core import runtime as runtime_module
+    from core.scheduler import service as scheduler_service
+
+    scheduler_root = tmp_path / "scheduler"
+    monkeypatch.setattr(
+        scheduler_service,
+        "DEFAULT_STORE_PATH",
+        scheduler_root / "scheduled_tasks.json",
+    )
+    monkeypatch.setattr(
+        scheduler_service,
+        "DEFAULT_LOG_DIR",
+        scheduler_root / "logs",
+    )
+    monkeypatch.setattr(
+        scheduler_service,
+        "_LEGACY_STORE_PATH",
+        scheduler_root / "legacy_jobs.json",
+    )
+
+    runtimes: list[runtime_module.GeodeRuntime] = []
+    original_create = runtime_module.GeodeRuntime.create.__func__
+
+    def _create(
+        cls: type[runtime_module.GeodeRuntime],
+        *args: object,
+        **kwargs: object,
+    ) -> runtime_module.GeodeRuntime:
+        runtime = original_create(cls, *args, **kwargs)
+        runtimes.append(runtime)
+        return runtime
+
+    monkeypatch.setattr(runtime_module.GeodeRuntime, "create", classmethod(_create))
+    yield
+    for runtime in reversed(runtimes):
+        runtime.shutdown()
 
 
 # CSP-7 (2026-05-22) — Pipeline.run() writes cross-run state to

--- a/tests/core/cli/test_cli_bootstrap.py
+++ b/tests/core/cli/test_cli_bootstrap.py
@@ -139,16 +139,15 @@ class TestBootstrapGeode:
             boot = bootstrap_geode(load_env=False)
             assert boot is not None
 
-    def test_load_env_true_calls_dotenv(self) -> None:
-        """When load_env=True, dotenv loading is attempted."""
+    def test_load_env_true_calls_daemon_env_loader(self) -> None:
+        """When load_env=True, daemon env loading is attempted without real IO."""
         with (
             patch("core.cli.bootstrap.log"),
-            patch("dotenv.load_dotenv") as _mock_dotenv,
+            patch("core.cli.bootstrap.load_daemon_env") as load_daemon_env,
         ):
             boot = bootstrap_geode(load_env=True)
             assert boot is not None
-            # load_dotenv may or may not be called depending on file existence
-            # but the code path should not crash
+            load_daemon_env.assert_called_once_with()
 
 
 class TestBootstrapIdempotent:

--- a/tests/core/cli/test_lifecycle_commands.py
+++ b/tests/core/cli/test_lifecycle_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import signal
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -177,6 +178,20 @@ class TestStop:
 
 
 class TestStartServe:
+    def test_default_timeout_allows_twenty_second_boot(self, tmp_path: Path) -> None:
+        executable = str(tmp_path / "bin" / "geode")
+        with (
+            patch("core.cli.commands.lifecycle.subprocess.Popen") as popen,
+            patch("core.cli.ipc_client.is_serve_running", return_value=True),
+            patch(
+                "core.cli.commands.lifecycle.time.monotonic",
+                side_effect=[0.0, 20.0],
+            ),
+        ):
+            assert _start_serve_background(executable=executable)
+
+        popen.assert_called_once()
+
     def test_waits_for_socket_readiness(self, tmp_path: Path) -> None:
         executable = str(tmp_path / "bin" / "geode")
         with (
@@ -192,6 +207,38 @@ class TestStartServe:
         popen.assert_called_once()
         assert popen.call_args.args[0] == [executable, "serve"]
         assert running.call_count == 2
+
+    def test_timeout_escalates_and_reaps_process(self, tmp_path: Path) -> None:
+        executable = str(tmp_path / "bin" / "geode")
+        with (
+            patch("core.cli.commands.lifecycle.subprocess.Popen") as popen,
+            patch("core.cli.ipc_client.is_serve_running", return_value=False),
+            patch("core.cli.commands.lifecycle.time.monotonic", return_value=0.0),
+        ):
+            process = popen.return_value
+            process.wait.side_effect = [subprocess.TimeoutExpired(executable, 5.0), 0]
+            assert not _start_serve_background(executable=executable, timeout=0.0)
+
+        process.terminate.assert_called_once()
+        process.kill.assert_called_once()
+        assert process.wait.call_count == 2
+
+    def test_timeout_reports_unreaped_process(
+        self,
+        tmp_path: Path,
+        capfd: pytest.CaptureFixture[str],
+    ) -> None:
+        executable = str(tmp_path / "bin" / "geode")
+        with (
+            patch("core.cli.commands.lifecycle.subprocess.Popen") as popen,
+            patch("core.cli.ipc_client.is_serve_running", return_value=False),
+            patch("core.cli.commands.lifecycle.time.monotonic", return_value=0.0),
+        ):
+            process = popen.return_value
+            process.wait.side_effect = subprocess.TimeoutExpired(executable, 5.0)
+            assert not _start_serve_background(executable=executable, timeout=0.0)
+
+        assert "could not be reaped" in capfd.readouterr().out
 
 
 class TestCleanStaleArtifacts:

--- a/tests/core/cli/test_serve_e2e.py
+++ b/tests/core/cli/test_serve_e2e.py
@@ -9,9 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from dotenv import load_dotenv
-
-load_dotenv(str(Path.home() / ".geode" / ".env"), override=False)
 
 
 def _run_executor(executor: Any, tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any]:
@@ -24,7 +21,7 @@ class TestServeToolExecution:
     def test_bootstrap_handlers_count(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         assert len(boot.tool_handlers) >= 44
         assert "calculate" in boot.tool_handlers
         assert "web_fetch" in boot.tool_handlers
@@ -36,7 +33,7 @@ class TestServeToolExecution:
     def test_web_fetch_http(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         # PR-LOOP-POLLUTION-FIX (2026-06-12) — delegated handlers are async now.
         result = asyncio.run(
             boot.tool_handlers["web_fetch"](url="http://example.com", max_chars=200)
@@ -47,18 +44,21 @@ class TestServeToolExecution:
     def test_web_fetch_https_ssl_fallback(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         result = asyncio.run(
             boot.tool_handlers["web_fetch"](url="https://example.com", max_chars=200)
         )
         # Should succeed via SSL fallback
         assert "result" in result
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY"),
-        reason="Requires ANTHROPIC_API_KEY",
-    )
+    @pytest.mark.live
     def test_general_web_search(self) -> None:
+        from dotenv import load_dotenv
+
+        load_dotenv(str(Path.home() / ".geode" / ".env"), override=False)
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            pytest.skip("Requires ANTHROPIC_API_KEY")
+
         from core.cli.bootstrap import bootstrap_geode
 
         boot = bootstrap_geode(load_env=True)
@@ -69,7 +69,7 @@ class TestServeToolExecution:
         from core.agent.tool_executor import ToolExecutor
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,
             mcp_manager=boot.mcp_manager,
@@ -84,7 +84,7 @@ class TestServeToolExecution:
         from core.agent.tool_executor import ToolExecutor
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,
             mcp_manager=boot.mcp_manager,
@@ -99,7 +99,7 @@ class TestServeToolExecution:
         from core.agent.tool_executor import ToolExecutor
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,
             mcp_manager=boot.mcp_manager,
@@ -115,7 +115,7 @@ class TestServeToolExecution:
         from core.agent.tool_executor import ToolExecutor
         from core.cli.bootstrap import bootstrap_geode
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,
             mcp_manager=boot.mcp_manager,
@@ -144,7 +144,7 @@ class TestServeToolExecution:
         from core.cli.bootstrap import bootstrap_geode
         from core.tools.base import load_all_tool_definitions
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         handlers = set(boot.tool_handlers)
         exposed = {tool["name"] for tool in load_all_tool_definitions()}
         missing = sorted(exposed - handlers - SPECIAL_EXECUTION_BINDINGS)
@@ -155,7 +155,7 @@ class TestServeToolExecution:
         from core.cli.bootstrap import bootstrap_geode
         from core.cli.tool_handlers import _build_tool_handlers
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         result = {}
 
         def daemon_work():
@@ -183,7 +183,7 @@ class TestServeToolExecution:
         from core.cli.bootstrap import bootstrap_geode
         from core.cli.tool_handlers import _build_tool_handlers
 
-        boot = bootstrap_geode(load_env=True)
+        boot = bootstrap_geode()
         result = {}
 
         def daemon_work():

--- a/tests/core/test_runtime.py
+++ b/tests/core/test_runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import pytest
 from core.hooks import HookEvent, HookSystem
 from core.hooks.catalog import event_persistence_spec
 from core.memory.session import InMemorySessionStore
@@ -25,12 +27,17 @@ from core.wiring.container import (
     build_default_registry as _build_default_registry,
 )
 
+pytestmark = pytest.mark.usefixtures("managed_geode_runtimes")
+
 
 class TestGeodeRuntimeCreate:
     def test_create_basic(self, tmp_path: Path):
         runtime = GeodeRuntime.create("demo", log_dir=tmp_path)
         assert runtime.subject_id == "demo"
         assert runtime.session_key == "subject:demo:analysis"
+        assert runtime.scheduler_service._store_path == (
+            tmp_path / "scheduler" / "scheduled_tasks.json"
+        )
         assert isinstance(runtime.hooks, HookSystem)
         assert isinstance(runtime.session_store, InMemorySessionStore)
         assert isinstance(runtime.policy_chain, PolicyChain)
@@ -40,6 +47,33 @@ class TestGeodeRuntimeCreate:
     def test_create_custom_phase(self, tmp_path: Path):
         runtime = GeodeRuntime.create("Demo Subject", phase="scoring", log_dir=tmp_path)
         assert runtime.session_key == "subject:demo_subject:scoring"
+
+    def test_staged_scheduling_is_stopped_when_task_graph_creation_fails(self) -> None:
+        bootstrap = MagicMock()
+        bootstrap.build_memory.return_value = (MagicMock(), MagicMock(), MagicMock(), None)
+        bootstrap.build_task_graph.side_effect = RuntimeError("task graph failed")
+        scheduler_service = MagicMock()
+        trigger_manager = MagicMock()
+        scheduling = {
+            "scheduler_service": scheduler_service,
+            "trigger_manager": trigger_manager,
+        }
+
+        with (
+            patch("core.wiring.scheduling.build_scheduling", return_value=scheduling),
+            pytest.raises(RuntimeError, match="task graph failed"),
+        ):
+            GeodeRuntime._build_memory_and_scheduling(
+                bootstrap,
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                session_key="subject:demo:analysis",
+                subject_id="demo",
+            )
+
+        scheduler_service.stop.assert_called_once()
+        trigger_manager.stop_scheduler.assert_called_once()
 
 
 class TestRuntimeHookEvents:

--- a/tests/core/wiring/test_full_tool_registration.py
+++ b/tests/core/wiring/test_full_tool_registration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from core.runtime import GeodeRuntime
 from core.wiring.container import (
     build_default_policies as _build_default_policies,
@@ -11,6 +12,8 @@ from core.wiring.container import (
 from core.wiring.container import (
     build_default_registry as _build_default_registry,
 )
+
+pytestmark = pytest.mark.usefixtures("managed_geode_runtimes")
 
 ALL_TOOL_NAMES = {
     # Analysis (1)

--- a/tests/core/wiring/test_scheduling.py
+++ b/tests/core/wiring/test_scheduling.py
@@ -1,0 +1,19 @@
+"""Failure-atomicity tests for scheduler wiring."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.wiring.scheduling import build_scheduling
+
+
+def test_build_scheduling_stops_trigger_thread_when_service_creation_fails() -> None:
+    trigger_manager = MagicMock()
+    with (
+        patch("core.wiring.scheduling.TriggerManager", return_value=trigger_manager),
+        patch("core.scheduler.create_scheduler", side_effect=RuntimeError("service failed")),
+        pytest.raises(RuntimeError, match="service failed"),
+    ):
+        build_scheduling(hooks=MagicMock())
+
+    trigger_manager.start_scheduler.assert_called_once()
+    trigger_manager.stop_scheduler.assert_called_once()


### PR DESCRIPTION
## Summary
- 로드맵의 방치된 R1.1/BND-001 claim을 해제해 새 소유자가 재감사 후 진행할 수 있게 합니다.
- serve readiness, scheduler 소유권, staged rollback, 비라이브 credential 격리를 main에 승격합니다.
- public docs generator 산출물과 architecture baseline을 동기화합니다.

## Included PRs
- #2918 — abandoned R1.1 claim reconciliation
- #2919 — runtime lifecycle and non-live isolation hardening

## Verification
- Feature PR #2919: Gate, full Test, lint/format, type, security, Pages build, macOS/Ubuntu install smoke 모두 통과
- 로컬 full non-live suite: 100%, exit 0
- package sdist/wheel build 통과
- public site 237 pages + 74 markdown twins 생성 및 committed-generator diff 통과
- Codex independent diff review: final `No findings`

## Merge policy
- `develop -> main` merge commit으로 승격합니다.
- 패키지 버전은 기존 `1.0.17`을 유지하며 별도 배포 릴리스는 만들지 않습니다.
