### PR TITLE
docs(eval): Agent-World 비교 계약 정의

### DIFF
--- a/.claude/skills/agent-world-benchmark/SKILL.md
+++ b/.claude/skills/agent-world-benchmark/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: agent-world-benchmark
+description: Align, run, audit, and publish GEODE benchmark comparisons against Agent-World arXiv 2604.18292v1 across MCP-Mark, BFCL V4, and tau2-bench. Use for Agent-World or AgentWorld comparison requests, cross-suite agent benchmark design, Tau2 comparator/profile diagnosis, paired thin-runtime-versus-GEODE experiments, mean-accuracy@8 replication, or benchmark comparability and artifact reviews.
+---
+
+# Agent-World Benchmark
+
+Build evidence that separates an external paper reference from a causal GEODE
+runtime comparison. Never reconstruct missing Agent-World implementation
+details from its score table.
+
+First disambiguate the target. This skill covers Dong et al.'s Agent-World
+(`arXiv:2604.18292`), not Qwen's later `Qwen-AgentWorld-35B-A3B` and
+`AgentWorldBench` (`arXiv:2606.24597`).
+
+## Read First
+
+Read these sources in order:
+
+1. `docs/eval/agent-world-comparison-contract.md` — canonical profile,
+   comparability classes, fields, and done definition.
+2. `docs/eval/agent-world-run-manifest.template.json` — machine-readable
+   preregistration scaffold; copy it per arm and replace every placeholder.
+3. `docs/eval/benchmark-publishing-cycle.md` — execution, artifact admission,
+   publication, and release workflow.
+4. The suite ledger for every selected suite:
+   `docs/eval/mcpmark-agentworld-comparison-runbook.md`,
+   `docs/eval/frontier-agentic-tool-use-benchmark-cases.md`, and
+   `docs/eval/tau2-bench.md`.
+5. Current upstream primary source and repository revision. Treat the dated
+   GEODE ledgers as evidence, not as a substitute for current source.
+
+## Select The Claim Before Running
+
+Choose exactly one claim class:
+
+| Claim | Meaning | Authority |
+|---|---|---|
+| `paper-reference` | Place a GEODE result beside Agent-World Table 1 | Directional only |
+| `paired-runtime` | Measure GEODE versus a thin upstream adapter with every non-runtime variable matched | Causal scaffold evidence |
+| `suite-headline` | Publish a score under the official suite's own current protocol | Suite-specific only |
+| `smoke` | Prove wiring, reset, scoring, and artifact flow | No performance claim |
+
+Do not promote one class into another after seeing results.
+
+## Freeze The Measurement Contract
+
+Record before any live run:
+
+- a shared comparison ID and a unique per-arm run ID;
+- GEODE and harness commits, package/server versions, task IDs/order/hash;
+- model label, provider, API/subscription route, and reasoning setting;
+- arm-specific runtime, adapter, prompt hash, and policy hash;
+- exact tool execution path and schema hash, timeout, step/error/retry budgets,
+  concurrency, and environment reset;
+- agent and simulated-user wall-clock, token, and round budgets;
+- user simulator implementation/model/route for tau2;
+- trial count, seed schedule, retry policy, score authority, and aggregation;
+- confidence coverage, estimator, sampling unit, paired method, resample count,
+  and uncertainty RNG seed;
+- artifact destination, redaction boundary, invalid-attempt rule, and promotion
+  authority.
+
+Copy `docs/eval/agent-world-run-manifest.template.json` for each arm. Give the
+pair one `comparison_id`; derive each unique `run_id` by adding arm role and
+runtime. Validate that each file parses as JSON, contains no `<...>`
+placeholders, has a non-empty ordered task list, and uses the required JSON
+number or `null` type for every limit. Literal template strings and inherited
+zero defaults whose semantics were not checked are invalid. If a runtime uses
+zero to mean unlimited rounds, record zero explicitly together with
+`zero_rounds_semantics=unlimited`.
+
+Apply claim-specific validation:
+
+- Agent-World-aligned results use `repetitions=8`, `mean_accuracy@8`, and
+  exactly eight ordered seeds;
+- smoke runs record their actual repetition count and `diagnostic`;
+- directional paper comparisons record the actual GEODE run count, statistic,
+  and one seed per repetition; paper-only rows do not use a run manifest;
+- `paired_task_trials=true` requires two matched arms;
+- tau2 requires `user_simulator.required=true` and non-`na` user identity and
+  wall/token/round budgets.
+
+For `paired-runtime`, allow only the runtime arm to differ. Use the same model
+route and decoding surface in both arms. Name the control `thin-upstream` or by
+its concrete adapter; do not call the Agent-World paper row `no-loop` or
+`vanilla`, because the paper says it used an undisclosed in-house evaluation
+framework.
+
+Diff paired preregistrations before running. Ignore only `run_id`, the complete
+`arm` object, and arm-specific evidence destinations; reject the pair if its
+comparison ID, ordered tasks, tool path/schema hash, model route/effective
+decoding, user simulator, budgets, retry rule, or scoring contract differs.
+
+## Apply The Agent-World V1 Surface
+
+Preserve the paper's public surface without inventing hidden settings:
+
+- suites: MCP-Mark, BFCL V4, tau2-bench;
+- MCP-Mark columns: File, GitHub, Notion, Play, Post, official aggregate;
+- BFCL V4 columns: WebSearch, Memory, Multi-Turn, Non-Live, Live,
+  Relevant, Irrelevant, official aggregate;
+- tau2 columns: Retail, Telecom, Airline, official aggregate;
+- evaluation decoding target: `temperature=1.0`, `top_p=1.0`;
+- eight complete repetitions and mean accuracy across repetitions.
+
+Call the statistic `mean_accuracy@8`, not `pass@8`, `pass^8`, or `avg@8`
+without definition. If a subscription route does not expose temperature or
+top-p, keep the target at 1.0 but record both effective values as `null`, note
+the protocol deviation, and keep the paper comparison directional.
+Never manually average displayed subcolumns; use each official harness's
+aggregate because the paper does not publish its aggregation implementation.
+
+## Execute In Gates
+
+1. Run a no-model preflight and state-reset test.
+2. Run one task per environment as a wiring smoke.
+3. Run one full repetition and reject infrastructure contamination.
+4. Run eight complete repetitions for an Agent-World-aligned measurement.
+5. Preserve every attempt; select only a valid final attempt according to the
+   preregistered retry rule.
+6. Report per-task rows, suite/domain rolls, mean, uncertainty, wall time,
+   tokens, failures, and paired flips where applicable.
+
+Live model, account, or remote-service calls require explicit user approval.
+Quota exhaustion, missing services, and harness faults are infrastructure
+invalidity, not zero reward and not a partial headline.
+
+## Preserve And Publish Evidence
+
+Keep these layers distinct:
+
+- upstream native result as score authority;
+- GEODE session/trajectory and exact tool call-result pairs as behavior
+  evidence;
+- verifier receipts and environment state diffs as judgement evidence;
+- immutable eval bundle and publication manifest as release evidence.
+
+Publish append-only artifacts to `geode-eval-artifacts`, pin its commit in the
+GEODE ledger, and keep local absolute paths, credentials, OAuth material, raw
+private prompts, and account identifiers out of public output.
+
+## Fail-Loud Rules
+
+- Reject a direct paper comparison when harness/task/user/scaffold identity is
+  unknown or mismatched.
+- Reject cross-suite composite scores unless a preregistered, named aggregate
+  is the claim; do not use them for promotion.
+- Keep Agent-World's version-unspecified MCP-Mark and MCPMark Verified in
+  separate columns.
+- Keep tau2 native-user and `geode_user` profiles separate.
+- Keep `max_errors`, `max_steps`, user simulator, route, and model changes out
+  of a single causal conclusion.
+- Reject empty ordered-task lists, duplicate paired run IDs, incomplete
+  agent/user budgets, and a task hash with no recorded preimage.
+- Reject tau2 without a user simulator, a seed-count/repetition mismatch, and
+  uncertainty recorded only as a confidence percentage without its estimator
+  and sampling unit.
+- Do not convert missing or infrastructure-invalid tasks to failures.
+- Do not describe normal protocol `Stop` as task success without verifier
+  evidence.
+
+## Report Contract
+
+Finish with the selected claim class, frozen/mismatched fields, suite-level
+scores, uncertainty, invalid attempts, artifact commit, comparability verdict,
+and the next smallest experiment that can isolate any unresolved variable.

--- a/.claude/skills/agent-world-benchmark/agents/openai.yaml
+++ b/.claude/skills/agent-world-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent-World Benchmark"
+  short_description: "Align GEODE runs with Agent-World's public benchmark profile"
+  default_prompt: "Use $agent-world-benchmark to design or audit an Agent-World-aligned GEODE benchmark run."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ search, or GEODE/Eco²/SIL/Crucible comparisons, use
 mapping the concepts to current code, and keep candidate width, repair depth,
 measurement replication, and promotion authority separate.
 
+For Agent-World comparisons, three-suite MCP-Mark/BFCL V4/tau2 profiles,
+paired thin-runtime controls, or `mean_accuracy@8` publication, use
+`.claude/skills/agent-world-benchmark/` and treat
+`docs/eval/agent-world-comparison-contract.md` as the canonical comparison
+contract. Never label the paper's undisclosed in-house wrapper as `no loop`.
+
 ## Module map
 
 Read the module you are about to change. If a section says "read this first",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ uv run geode "schedule daily standup reminder at 9am"
 | Agent Identity | `GEODE.md` | Identity, Voice & Conduct, runtime architecture, LLM models |
 | Operational Workflow | `docs/workflow.md` + `.claude/skills/geode-workflow/` | Evidence-first execution scaffold shared by Claude Code, Codex, and contributors |
 | Test-Time Compute Grounding | `.claude/skills/stanford-test-time-compute/` | Stanford CS329A Part 2 evidence and GEODE/Eco²/SIL/Crucible application boundaries |
+| Agent-World Benchmark | `docs/eval/agent-world-comparison-contract.md` + `.claude/skills/agent-world-benchmark/` | Three-suite comparison profile, paired runtime control, replication, and artifact contract |
 | Architecture/Extensibility Program | `docs/architecture/extensibility-roadmap.md` | Single execution SOT for GAP IDs, merge order, status, acceptance, and closure evidence |
 | Hook System | `docs/architecture/hook-system.md` | HookSystem 56 events |
 | Scaffold | `CLAUDE.md` | Development workflow, quality gates, CANNOT/CAN (this file) |

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -55,9 +55,12 @@ do not replace the 278-task Tau2 full-cycle authority.
 | GUI Trajectory Eval | observation coverage, classified failures, coordinate sanity, final screenshot availability | `computer`/`computer_use` trajectory rows를 모델 prose와 분리해 사후 평가 |
 | Capability/Evidence Preflight | provider/source/tool support, required evidence classes | 작업 시작 전 route mismatch를 드러내고 evidence ledger에 남김 |
 | Frontier agentic tool-use benchmark cases | MCPMark/BFCL V4/tau2 공개 사례와 GEODE 측정 계약 | GPT-5.5 subscription 결과를 공개 baseline과 섞기 전 비교 가능성 분리 |
+| Agent-World comparison contract | Agent-World v1 공개 열 + `mean_accuracy@8` + matched runtime control | paper reference와 GEODE scaffold 인과 비교를 분리 |
 | Benchmark Publishing Cycle | live benchmark run -> internal ledger -> official docs -> PR -> Pages deploy | 실측과 공식문서 배포를 하나의 반복 가능한 사이클로 고정 |
 
 참고: [frontier-agentic-tool-use-benchmark-cases.md](frontier-agentic-tool-use-benchmark-cases.md)
+Agent-World 비교 정본: [agent-world-comparison-contract.md](agent-world-comparison-contract.md),
+[agent-world-run-manifest.template.json](agent-world-run-manifest.template.json)
 운영 스캐폴드: [benchmark-publishing-cycle.md](benchmark-publishing-cycle.md),
 [benchmark-run-record.template.md](benchmark-run-record.template.md)
 

--- a/docs/eval/agent-world-comparison-contract.md
+++ b/docs/eval/agent-world-comparison-contract.md
@@ -1,0 +1,249 @@
+# Agent-World Comparison Contract
+
+Status: canonical GEODE comparison specification, 2026-08-08.
+
+This contract defines how GEODE may compare agentic tool-use results with
+Agent-World v1. It does not claim to reproduce Agent-World's private evaluation
+runtime or training system.
+
+Scope is Dong et al.'s Agent-World (`arXiv:2604.18292`), not Qwen's distinct
+[Qwen-AgentWorld-35B-A3B](https://huggingface.co/Qwen/Qwen-AgentWorld-35B-A3B)
+world-model project and `AgentWorldBench` (`arXiv:2606.24597`).
+
+Primary sources:
+
+- [Agent-World arXiv 2604.18292v1](https://arxiv.org/abs/2604.18292v1),
+  submitted 2026-04-20
+- [Agent-World Table 1 and experimental settings](https://arxiv.org/html/2604.18292v1#S4.T1)
+- [Agent-World project page](https://agent-tars-world.github.io/-/)
+
+As checked on 2026-08-08, the paper labels itself work in progress, says all
+baselines were evaluated in an in-house framework with results aligned to
+official scores, and publishes no code link on its project page. The exact
+harness revisions, prompts, frontier-model route, task selections, seeds,
+budgets, tau2 user simulator, and environment reset implementation are not
+public. Every Agent-World Table 1 comparison is therefore directional.
+
+## 1. What The Benchmark Measures
+
+Agent-World Table 1 supplies a useful three-suite capability surface:
+
+```mermaid
+flowchart LR
+    P["Agent-World v1 paper<br/>public score matrix"] --> D["Directional reference<br/>implementation undisclosed"]
+    C["Thin upstream adapter<br/>matched control"] --> M["Same model · route · tasks<br/>seed · evaluator · budgets"]
+    G["GEODE AgenticLoop<br/>treatment"] --> M
+    M --> E["Paired runtime effect<br/>causal scaffold evidence"]
+    S["Official suite profile"] --> H["MCPMark / BFCL / tau2<br/>separate headline"]
+```
+
+The paper reference and paired runtime experiment answer different questions:
+
+| Track | Question | Promotion authority |
+|---|---|---|
+| `agent-world-v1-paper-reference` | Is GEODE in the same broad capability band as published Agent-World rows? | None; directional only |
+| `geode-paired-runtime-v1` | What changes when the GEODE runtime replaces a named thin upstream adapter? | Eligible when every non-runtime field matches |
+| suite-native headline | What score does GEODE obtain under the suite's own frozen protocol? | Owned by that suite only |
+| smoke/diagnostic | Does wiring, state reset, scoring, and artifact flow work? | None |
+
+The Agent-World GPT-5.2 High row is not a demonstrated "no-loop" baseline.
+The paper says it used an in-house evaluation framework but does not disclose
+the wrapper. Existing GEODE copy that called it `vanilla · no loop` is retired.
+
+## 2. Public Agent-World V1 Surface
+
+Agent-World reports accuracy across these columns:
+
+| Suite | Required columns | Paper reference rows |
+|---|---|---|
+| MCP-Mark | File, GitHub, Notion, Play, Post, official Avg. | GPT-5.2 High 53.1; Agent-World-8B 8.9; Agent-World-14B 13.3 |
+| BFCL V4 | WebSearch, Memory, Multi-Turn, Non-Live, Live, Relevant, Irrelevant, official Avg. | GPT-5.2 High 62.9; Agent-World-8B 51.4; Agent-World-14B 55.8 |
+| tau2-bench | Retail, Telecom, Airline, official Avg. | GPT-5.2 High 80.2; Agent-World-8B 61.8; Agent-World-14B 65.4 |
+
+The experimental settings state `temperature=1.0`, `top_p=1.0`, eight
+repetitions, and average accuracy. GEODE names this statistic
+`mean_accuracy@8`. It is not `pass@8` or `pass^8`.
+
+Do not reconstruct the suite aggregate by averaging displayed rounded
+subcolumns. Use the official harness aggregate for a GEODE run and preserve the
+paper's published aggregate as an opaque reference value.
+
+## 3. Frozen GEODE Profile
+
+Every run manifest uses schema `geode.agent-world-comparison-profile.v1` and
+binds the following fields before any live execution:
+
+Start from
+[`agent-world-run-manifest.template.json`](agent-world-run-manifest.template.json)
+and use one manifest per arm. The template is a preregistration scaffold, not a
+published run until every placeholder is replaced and artifact references are
+resolved.
+
+One paired experiment has a shared `comparison_id` and two unique `run_id`
+values. Build the shared ID from suite, profile, model, route, reasoning, and a
+UTC timestamp; append arm role and runtime to obtain each run ID. This prevents
+same-day arms or reasoning variants from overwriting the same artifact path.
+
+| Boundary | Required fields |
+|---|---|
+| Reference | Agent-World arXiv version, table/figure, retrieval date |
+| GEODE | commit, branch, dirty state |
+| Harness | repository, commit/package, task suite, ordered task IDs plus their canonical hash, task-pack hash, image versions |
+| Model | exact label, provider, API/subscription/local route, reasoning setting, decoding surface |
+| Runtime | arm-specific adapter/prompt/policy identity; exact shared tool execution path, tool-schema artifact/hash, server versions, timeout, step/error/retry budgets, concurrency |
+| Environment | initial-state identity, reset strategy and receipt, external-service account isolation |
+| tau2 user | implementation, model, provider/route, reasoning, prompt hash, wall/token/round budgets |
+| Sampling | actual repetition count, stable task/trial identities, seed schedule; eight repetitions for Agent-World alignment |
+| Retry | retryable classes, stable seed rule, attempt lineage, final-attempt selection |
+| Scoring | native score authority, suite aggregation, paired statistics, invalid-attempt handling |
+| Evidence | raw results, trajectories, tool pairs, verifier receipts, state diffs, checksums, publication manifest |
+
+### 3.1 Suite versions
+
+Agent-World v1 does not disclose enough version information for exact
+reproduction. GEODE must therefore use a dated named profile rather than claim
+identity:
+
+- MCPMark: pin the selected upstream revision and state the exact task-set
+  generation, including `Verified` where applicable. Never place MCPMark
+  Verified in the paper's version-unspecified column without a qualifier.
+- BFCL V4: pin the official code/data checkpoint and native-function-calling
+  versus prompt-based mode. Preserve the official weighted aggregate.
+- tau2-bench: pin harness commit, domain split, native user implementation,
+  user model, `max_steps`, `max_errors`, timeout, task order, and trial count.
+  Keep native-user and GEODE-owned `geode_user` results in separate profiles.
+
+### 3.2 Decoding and product routes
+
+The Agent-World-aligned target is `temperature=1.0`, `top_p=1.0`. Keep that
+target separate from the effective route values. When a subscription product
+does not expose these parameters, record both effective values as `null`, set
+their source to `unavailable`, and classify the paper comparison as
+directional. Do not write the target values into the effective fields. A paired
+runtime experiment remains useful only if both arms use the same
+unavailable/default product surface.
+
+## 4. Paired Runtime Control
+
+The paired control must be an inspectable, named implementation such as
+`thin-upstream`, not the Agent-World score row. Treatment and control share:
+
+```text
+model + provider route + reasoning/decoding surface
+task objects/order/hash + initial states + seeds
+tool execution path + schemas/servers + evaluator + user simulator
+simulation timeout + max steps/errors/retries + concurrency
+agent/user wall-clock + token + round budgets
+```
+
+Only the agent runtime/scaffold may differ:
+
+```text
+thin upstream adapter  ↔  GEODE AgenticLoop
+```
+
+Before execution, diff the two manifests after ignoring only `run_id`, the
+whole `arm` object, and arm-specific evidence destinations. Adapter,
+prompt/policy hashes, and runtime commit belong inside `arm` because they are
+the intended treatment. `comparison_id`, ordered task list, tool-surface hash,
+model/route/decoding surface, every budget, and every scoring field must be
+byte-for-byte equal. The task-list hash is an integrity check, not a substitute
+for the ordered IDs: retain the IDs inline and optionally mirror them in an
+artifact when the list is large.
+
+If the upstream suite itself requires a loop, preserve that minimal loop and
+name its exact behavior. `No loop` is not a meaningful tool-agent control.
+
+For each suite report:
+
+- mean accuracy across eight complete repetitions and a 95% confidence
+  interval using a preregistered estimator and sampling unit;
+- per-domain/category accuracy and raw numerator/denominator;
+- paired task-level wins, losses, and ties under matched trials;
+- infrastructure-invalid attempts separately from semantic failures;
+- time, tokens, tool calls, retries, and termination distribution.
+
+Do not create one promotion score by averaging MCPMark, BFCL, and tau2. A
+visual cross-suite profile is allowed, but each suite retains its own ruler and
+promotion decision.
+
+Sampling is claim-specific. An Agent-World-aligned measurement requires eight
+seeds and `mean_accuracy@8`; a smoke records its actual smaller repetition
+count and `diagnostic`; a directional paper comparison records the actual GEODE
+run count and statistic rather than copying the paper's eight repetitions.
+`paired_task_trials=true` is valid only when matched arms exist. The seed
+schedule length must equal `repetitions`. A paper row without a GEODE execution
+belongs in the reference catalog, not in a run manifest. For tau2, a user
+simulator is always required and its identity plus wall/token/round budgets
+cannot be `na`.
+
+Freeze uncertainty before execution. At minimum record coverage, exact
+estimator, sampling unit, and any paired method, resample count, and RNG seed.
+Both arms use the identical uncertainty block; `95%` alone is not an
+estimator.
+
+## 5. Attempt And Artifact Contract
+
+An attempt is infrastructure-invalid when quota exhaustion, authentication,
+missing services, corrupted/reset state, harness faults, transport exhaustion,
+or incomplete coverage prevents semantic scoring. Invalid work is neither a
+zero nor a partial headline. Retry only preregistered infrastructure classes,
+keep the task/trial seed stable, and preserve the full attempt lineage.
+
+The evidence flow is:
+
+```text
+native harness result (score authority)
+    + GEODE session/trajectory (behavior evidence)
+    + verifier receipt/state diff (judgement evidence)
+    -> immutable eval bundle + publication manifest
+    -> geode-eval-artifacts commit
+```
+
+The immutable bundle must include profile and task-pack hashes, environment
+reset receipts, every attempt, selected final attempts, raw native results,
+exact tool call-result pairing, terminal reasons, verifier outputs, aggregate
+derivation, redaction report, and checksums. Missing trajectory detail does not
+change a native score but blocks behavioral or training-data claims.
+
+## 6. Execution Gates
+
+1. Validate sources and freeze a manifest without model calls.
+2. Run a no-model state-reset and verifier test.
+3. Run one task per environment as a wiring smoke.
+4. Run one complete repetition and reject infrastructure contamination.
+5. Run eight complete repetitions for an Agent-World-aligned result.
+6. Publish raw public artifacts append-only, then pin their repository commit
+   in the GEODE ledger and public page.
+
+Live model/account/service calls still require explicit user approval. A smoke
+or interrupted run may be published as a diagnostic but never promoted into
+the paper-reference table.
+
+## 7. Current GAPs
+
+| GAP | Current state | Closure evidence |
+|---|---|---|
+| AW-COMP-01 Paper implementation identity | Agent-World harness code and exact suite configs are not public | Upstream release or author-provided manifest |
+| AW-COMP-02 Paired thin control | GEODE has MCPMark and tau2 adapters, no BFCL adapter, and no frozen three-suite thin-control arm | Same manifest accepted by both arms; only runtime identity differs |
+| AW-COMP-03 Eight-repetition cluster | Existing GEODE rows are mostly `k=1` or partial-service runs | Eight complete valid repetitions per suite |
+| AW-COMP-04 BFCL execution | Evidence ledger exists; current cross-suite full-cycle artifact is absent | Pinned BFCL V4 run with native aggregate and immutable bundle |
+| AW-COMP-05 MCP version parity | GEODE's strongest run is MCPMark Verified while Agent-World reports version-unspecified MCP-Mark | Explicit versioned lanes or an upstream mapping |
+| AW-COMP-06 Tau2 causal isolation | Recent runs changed model, user simulator, error budget, and runtime together | Paired matrix isolating model, user simulator, and `max_errors` |
+
+AW-COMP-01 is not locally solvable and does not block directional comparison.
+AW-COMP-02 through AW-COMP-06 block causal or headline claims until closed.
+
+## 8. Migration Map
+
+| Retired label | Replacement |
+|---|---|
+| `Agent-World vanilla` | `Agent-World v1 paper reference` |
+| `no loop` for the paper row | `in-house evaluation wrapper undisclosed` |
+| `avg@8` | `mean_accuracy@8` |
+| mixed version-unspecified MCP-Mark/Verified average | versioned suite lanes |
+| tau2 `geode_user` compared as native | separate `geode-dual-runtime` diagnostic |
+| incomplete quota run divided by scheduled tasks | infrastructure-invalid attempt, no headline |
+
+Use `.claude/skills/agent-world-benchmark/` for future design, execution,
+audit, and publication work under this contract.

--- a/docs/eval/agent-world-run-manifest.template.json
+++ b/docs/eval/agent-world-run-manifest.template.json
@@ -1,0 +1,131 @@
+{
+  "schema": "geode.agent-world-comparison-profile.v1",
+  "comparison_id": "<suite>-<profile>-<model>-<route>-<reasoning>-<yyyymmddThhmmssZ>",
+  "run_id": "<comparison-id>-<control-or-treatment>-<runtime>",
+  "claim_class": "<paper-reference|paired-runtime|suite-headline|smoke>",
+  "reference": {
+    "agent_world_arxiv": "2604.18292v1",
+    "surface": "Table 1",
+    "score_authority": "published-paper",
+    "retrieved_at": "<YYYY-MM-DD>"
+  },
+  "geode": {
+    "commit": "<full-sha>",
+    "branch": "<branch>",
+    "dirty": false
+  },
+  "suite": {
+    "name": "<mcpmark|bfcl-v4|tau2-bench>",
+    "profile": "<versioned-profile-id>",
+    "harness_repository": "<url>",
+    "harness_commit": "<full-sha>",
+    "package_version": "<version-or-null>",
+    "task_suite": "<suite-or-split>",
+    "ordered_task_ids": ["<task-id-in-execution-order>"],
+    "ordered_task_ids_artifact": "<artifact-relative-path-or-na>",
+    "task_ids_sha256": "<sha256-of-canonical-ordered-task-ids>",
+    "task_pack_sha256": "<sha256>",
+    "container_images": {}
+  },
+  "arm": {
+    "role": "<control|treatment>",
+    "runtime": "<thin-upstream|geode-agentic-loop|named-adapter>",
+    "runtime_commit": "<full-sha-or-null>",
+    "adapter": "<adapter-id>",
+    "prompt_sha256": "<sha256>",
+    "policy_sha256": "<sha256>"
+  },
+  "tool_surface": {
+    "execution_path": "<exact-provider-native|mcp|suite-python|geode-function-path>",
+    "schema_artifact": "<artifact-relative-path>",
+    "schema_sha256": "<sha256>",
+    "server_versions": {}
+  },
+  "model": {
+    "label": "<exact-model-label>",
+    "provider": "<provider>",
+    "route": "<subscription|api|local>",
+    "reasoning": "<exact-setting>"
+  },
+  "decoding": {
+    "agent_world_target": {
+      "temperature": 1.0,
+      "top_p": 1.0
+    },
+    "effective": {
+      "temperature": "<number-or-null>",
+      "top_p": "<number-or-null>",
+      "source": "<explicit-request|provider-confirmed|unavailable>"
+    },
+    "deviation": "<none-or-explanation>"
+  },
+  "limits": {
+    "simulation_timeout_seconds": "<positive-number-or-null>",
+    "max_steps": "<positive-integer-or-null>",
+    "max_errors": "<nonnegative-integer-or-null>",
+    "max_retries": "<nonnegative-integer>",
+    "max_concurrency": "<positive-integer>",
+    "agent": {
+      "time_budget_seconds": "<positive-number-or-null>",
+      "max_tokens": "<positive-integer-or-null>",
+      "max_rounds": "<nonnegative-integer-or-null>",
+      "zero_rounds_semantics": "<unlimited-or-na>"
+    },
+    "user": {
+      "time_budget_seconds": "<positive-number-or-null>",
+      "max_tokens": "<positive-integer-or-null>",
+      "max_rounds": "<nonnegative-integer-or-null>",
+      "zero_rounds_semantics": "<unlimited-or-na>"
+    }
+  },
+  "environment": {
+    "initial_state_sha256": "<sha256>",
+    "reset_strategy": "<strategy>",
+    "reset_receipt": "<artifact-relative-path>",
+    "account_isolation": "<strategy-or-na>"
+  },
+  "user_simulator": {
+    "required": "<boolean-true-for-tau2>",
+    "implementation": "<native|geode_user|na>",
+    "model": "<exact-model-or-na>",
+    "provider": "<provider-or-na>",
+    "route": "<route-or-na>",
+    "reasoning": "<setting-or-na>",
+    "prompt_sha256": "<sha256-or-na>"
+  },
+  "sampling": {
+    "repetitions": "<positive-integer>",
+    "statistic": "<mean_accuracy@8|suite-native|diagnostic>",
+    "seed_schedule": ["<seed-per-repetition-in-order>"],
+    "paired_task_trials": "<boolean>"
+  },
+  "retry": {
+    "retryable_classes": [],
+    "preserve_seed": true,
+    "preserve_attempt_lineage": true,
+    "selection_rule": "<preregistered-rule>"
+  },
+  "scoring": {
+    "authority": "native-harness",
+    "aggregate": "<official-suite-aggregate>",
+    "uncertainty": {
+      "coverage": "<number-between-zero-and-one-or-null>",
+      "estimator": "<exact-estimator-or-none>",
+      "sampling_unit": "<repetition|task-trial|paired-task-trial|na>",
+      "paired_method": "<exact-method-or-na>",
+      "resamples": "<positive-integer-or-null>",
+      "seed": "<integer-or-null>"
+    },
+    "infrastructure_invalid_excluded": true,
+    "cross_suite_promotion_aggregate": false
+  },
+  "evidence": {
+    "native_results": "<artifact-relative-path>",
+    "trajectory_bundle": "<artifact-relative-path>",
+    "verifier_receipts": "<artifact-relative-path>",
+    "attempt_manifest": "<artifact-relative-path>",
+    "redaction_report": "<artifact-relative-path>",
+    "publication_manifest": "<artifact-relative-path>"
+  },
+  "promotion_authority": "<none|paired-runtime|suite-native>"
+}

--- a/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
+++ b/docs/eval/frontier-agentic-tool-use-benchmark-cases.md
@@ -9,6 +9,11 @@ harness smoke was run to validate setup and verification. Live GEODE runs were
 also completed for one MCPMark filesystem easy smoke task and the 10-task
 MCPMark filesystem easy suite with `gpt-5.5` / `xhigh`.
 
+The canonical comparison and replication rules now live in
+[`agent-world-comparison-contract.md`](agent-world-comparison-contract.md).
+This dated source ledger supplies cases and values; it does not establish
+exact reproduction of Agent-World's undisclosed in-house evaluation wrapper.
+
 Target benchmark cluster:
 
 - MCPMark / MCPMark Verified

--- a/docs/eval/mcpmark-agentworld-comparison-runbook.md
+++ b/docs/eval/mcpmark-agentworld-comparison-runbook.md
@@ -5,12 +5,17 @@ Agent-World Table 1 (arXiv `2604.18292v1`)의 MCP-Mark subdomain(File / Github /
 Play / Post)과 비교 가능한 상태를 만든다. 2026-07-04 실측에서 blocked였던 사례를
 다시 실행 가능하게 만드는 환경 조치를 이 문서에 고정한다.
 
+이 문서는 당시 MCPMark 환경 복구 기록이다. 현재 비교 가능성·반복·명명·증거
+계약의 정본은 [`agent-world-comparison-contract.md`](agent-world-comparison-contract.md)다.
+Agent-World의 in-house wrapper와 정확한 harness/task spec은 공개되지 않았으므로,
+아래 실행은 버전 라벨을 붙인 directional comparator이지 exact reproduction이 아니다.
+
 ## Agent-World 측 프로토콜 (논문 명시 사실만)
 
 | 항목 | Agent-World | GEODE 측 대응 |
 |---|---|---|
 | 서비스 | MCP-Mark 5종: File, Github, Notion, Play, Post | 동일 5종 (upstream `eval-sys/mcpmark@cd45b7f`, Verified/standard 127 tasks) |
-| 반복 | 8회 반복 평균 (avg@8) | `--k`로 동일 구성 가능. 1차 unblock 검증은 `k=1`, 헤드라인 비교는 `k` 명시 후 별도 라벨 |
+| 반복 | 8회 반복 평균 (`mean_accuracy@8`) | `--k`로 동일 구성 가능. 1차 unblock 검증은 `k=1`, 헤드라인 비교는 8개 완결 반복 후 별도 라벨 |
 | 디코딩 | temperature=1.0, top_p=1.0 | subscription/Codex 루트는 디코딩 파라미터 노출 없음. **directional 비교**로 라벨 |
 | 하네스 | in-house framework, "aligned to official scores" | official `pipeline.py` + GEODE `BaseMCPAgent` adapter |
 | 모델 | GPT-5.2 High 등 (GPT-5.5 없음) | `gpt-5.5`, provider `openai-codex`, source `subscription`, effort `xhigh` |

--- a/docs/scaffold-skills.md
+++ b/docs/scaffold-skills.md
@@ -8,6 +8,7 @@ Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate f
 |-------|----------|---------|
 | `geode-workflow` | workflow, scaffold, feature work, provider/model changes, GUI/computer-use, observability, verification | Evidence-first execution scaffold with progressive-disclosure references |
 | `stanford-test-time-compute` | test-time compute, inference-time scaling, best-of-N, parallel width, sequential repair, measurement replication, verifier/evaluator, promotion authority, Archon | Stanford CS329A Part 2 grounding with GEODE/Eco²/SIL/Crucible decision-plane and authority boundaries |
+| `agent-world-benchmark` | Agent-World, AgentWorld, MCP-Mark, BFCL V4, tau2 comparator, paired runtime, mean_accuracy@8 | Agent-World v1 directional reference plus matched thin-runtime control, replication, comparability, and artifact workflow |
 | `prompt-writing` | prompt, system prompt, model-facing text, identity, You are, Fable | GEODE prompt-writing standard: metadata/behavioral clauses, no direct identity assertions |
 | `geode-distribution` | homebrew, brew, formula, tap, uvx, 배포 | Coordinated GitHub Release + PyPI + Homebrew stable promotion |
 | `geode-gitflow` | branch, git, pr, merge, commit | Gitflow strategy, PR templates, CI fix loops |

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -733,10 +733,10 @@ function PerceiveBanner() {
 
 /**
  * Tau2 numbers over a measurement slip that separates what is being
- * measured (the agentic harness: GEODE's loop wrapped around a vanilla
- * model) from the ruler (the tau2-bench eval harness), closing on the
- * control and verdict. Values from benchmark-measurements.ts and the
- * externally preserved tau2 run artifacts.
+ * measured (the agentic harness: GEODE's loop wrapped around a model) from
+ * the ruler (the tau2-bench eval harness), closing on the external paper
+ * reference and comparability verdict. Values from benchmark-measurements.ts
+ * and the externally preserved tau2 run artifacts.
  */
 function MeasureBanner() {
   const tau2 = BENCHMARK_GROUPS.find((group) => group.id === "tau2");
@@ -747,8 +747,8 @@ function MeasureBanner() {
     { key: "bench", value: "tau2 @ 1901a30 · 2026-07-03", section: "eval harness · the ruler" },
     { key: "user-sim", value: "gpt-4.1 · pass^1 k=1" },
     { key: "airline", value: "trend-reference" },
-    { key: "control", value: "gpt-5.2 vanilla · no loop · 0.802", section: "agent-world reference" },
-    { key: "verdict", value: "same band · ±8pt limit", verdict: true },
+    { key: "reference", value: "gpt-5.2 · wrapper undisclosed · 0.802", section: "agent-world paper" },
+    { key: "verdict", value: "directional · not scaffold control", verdict: true },
   ];
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-3.5 px-6">
@@ -988,8 +988,8 @@ const features: {
     index: "#9 measure",
     headKo: "정직하게 잽니다",
     headEn: "KEEPS HONEST SCORE",
-    ko: "재는 것은 GEODE 루프를 씌운 gpt-5.2, 재는 자는 tau2-bench. 비교군은 루프 없는 같은 모델(Agent-World 바닐라)이고, pass^1 검출 한계 안에서 같은 밴드입니다.",
-    en: "Measured: gpt-5.2 wrapped in the GEODE loop. Ruler: tau2-bench. The control is the same model without the loop (Agent-World vanilla); within the pass^1 detection limit the bands match.",
+    ko: "재는 것은 GEODE 루프를 씌운 gpt-5.2, 재는 자는 tau2-bench입니다. Agent-World의 같은 모델 행은 in-house wrapper가 공개되지 않은 방향성 기준이며, GEODE 루프 효과를 재는 대조군은 아닙니다.",
+    en: "Measured: gpt-5.2 wrapped in the GEODE loop. Ruler: tau2-bench. Agent-World's same-model row is a directional reference with an undisclosed in-house wrapper, not a control for the GEODE loop effect.",
     banner: <MeasureBanner />,
   },
 ];


### PR DESCRIPTION
## Summary
- Agent-World v1의 MCP-Mark·BFCL V4·tau2-bench 공개 표면을 GEODE 비교 계약으로 고정합니다.
- 논문 행과 GEODE runtime 효과를 분리하고, matched `thin-upstream ↔ GEODE` paired 실험을 위한 manifest와 재사용 스킬을 추가합니다.
- 기존 포트폴리오의 근거 없는 `vanilla · no loop` 표현을 `wrapper 비공개 방향성 기준`으로 교정합니다.

## Why
Agent-World는 유용한 3-suite 점수표를 공개했지만 평가 wrapper, harness revision, task pack, seed, budget, Tau2 user simulator를 공개하지 않았습니다. 이 상태에서 논문 점수를 GEODE의 no-loop control처럼 사용하면 runtime 효과를 잘못 귀속하게 됩니다. 반복 live run에 비용을 쓰기 전에 방향성 비교, 인과 paired 비교, suite-native headline, smoke의 권한을 분리할 계약이 필요합니다.

## Changes

### Core Changes (Code)
- `site/src/app/portfolio/page.tsx`: Agent-World GPT-5.2 행을 no-loop 대조군으로 표현하던 문구를 wrapper 비공개 방향성 기준으로 수정했습니다.
  - 근거: 논문은 in-house evaluation framework를 명시하지만 scaffold 구현을 공개하지 않습니다.

### Secondary Changes (Code)
- 없음.

### Documentation/Config Changes
- `docs/eval/agent-world-comparison-contract.md`: 비교 등급, 3-suite 표면, paired control, 반복·불확실성·artifact 계약, GAP 원장을 정의했습니다.
- `docs/eval/agent-world-run-manifest.template.json`: 공유 comparison ID, arm별 run ID, ordered task IDs, tool schema identity, agent/user budget, target/effective decoding, CI estimator 필드를 추가했습니다.
- `.claude/skills/agent-world-benchmark/SKILL.md`: 설계·실행·감사·게시를 재사용할 수 있는 fail-loud workflow를 추가했습니다.
- `.claude/skills/agent-world-benchmark/agents/openai.yaml`: Codex 스킬 표시와 기본 prompt를 등록했습니다.
- `AGENTS.md`: Agent-World 비교 작업의 정본·스킬 진입점을 추가했습니다.
- `CLAUDE.md`: SOT 표에 Agent-World benchmark 계약을 연결했습니다.
- `docs/eval/README.md`: 평가 문서 인덱스에 계약과 manifest를 추가했습니다.
- `docs/eval/frontier-agentic-tool-use-benchmark-cases.md`: 현재 정본 계약으로 라우팅했습니다.
- `docs/eval/mcpmark-agentworld-comparison-runbook.md`: dated runbook의 방향성 한계와 `mean_accuracy@8` 명명을 반영했습니다.
- `docs/scaffold-skills.md`: 신규 스킬을 scaffold catalog에 등록했습니다.
- `CHANGELOG.md`: 문서·표현·스캐폴드 전용 변경이라 생략했습니다.

## Impact Scope
- **영향 범위**: 평가 계약, benchmark 운영 scaffold, 공개 포트폴리오 설명
- **하위 호환성**: 유지. runtime·adapter 실행 코드는 변경하지 않습니다.
- **테스트 변경**: 추가 0 / 수정 0 / 삭제 0
- **Live 비용**: 모델·계정·외부 서비스 호출 없음

## Design Decisions
- Agent-World 논문 행은 `paper-reference`로만 사용하고 promotion authority를 부여하지 않습니다.
- GEODE runtime 효과는 모델·route·task/order·seed·tool schema·evaluator·user simulator·budget이 같은 paired arms에서만 주장합니다.
- 8회 평균은 `mean_accuracy@8`로 명명해 `pass@8`·`pass^8`과 구분합니다.
- subscription 경로의 비노출 temperature/top-p는 target 1.0과 분리해 effective `null`로 기록합니다.
- MCP-Mark, BFCL V4, Tau2는 각자의 native aggregate와 promotion ruler를 유지하며 임의 cross-suite 합산을 금지합니다.

## GAP Audit
| GAP | 상태 | 폐쇄 조건 |
|---|---|---|
| Agent-World wrapper/config identity | upstream 미공개 | upstream manifest 또는 코드 공개 |
| Matched thin-runtime control | 계약 완료·구현 대기 | 두 arm의 비-runtime 필드 완전 일치 |
| 8회 반복 3-suite 측정 | 실행 대기 | suite별 8개 유효 repetition |
| BFCL V4 adapter | 누락 | pinned native aggregate와 immutable bundle |
| MCP-Mark version parity | 버전 불일치 | versioned lane 또는 upstream mapping |
| Tau2 causal isolation | 변수 혼합 | model/user/budget 분리 paired matrix |

## Verification
- [x] Skill quick validation — 통과
- [x] Manifest JSON parse — 통과
- [x] Internal docs link audit — broken link 0건, 기존 dynamic/relative unresolved 4건
- [x] Repository hygiene — 통과
- [x] `pytest tests/test_workflow_scaffold.py -q` — 6 passed
- [x] Portfolio ESLint — 통과
- [x] Next.js production build — 237 static pages 생성
- [x] 독립 Codex review 2회 — 발견 사항 전부 반영
- [x] GitHub CI — 10 successful, 1 intentional skip, 0 failure

## Reference
- Agent-World v1: https://arxiv.org/abs/2604.18292v1
- Agent-World project: https://agent-tars-world.github.io/-/

🤖 Generated with Codex
