### PR TITLE
fix(runtime): harden Goal budgets and packaged identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hardened explicit Goal budgets and packaged identity.** A model-supplied
+  numeric `create_goal.token_budget` now crosses the existing
+  `PermissionRequest` boundary before persistence, while the OpenAI-compatible
+  schema represents the unbounded default as required `null` instead of a
+  best-effort optional integer. This prevents an unsolicited minimum value
+  from immediately budget-limiting a Goal. Distribution artifacts now include
+  the Tier-0 `GEODE.md` identity used by source checkouts instead of silently
+  running installed wheels with an empty soul.
+
 ## [1.0.19] - 2026-08-10
 
 > Durable explicit Goals, serve-owned continuation, and truthful sub-agent

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -406,19 +406,32 @@ class ToolExecutor:
                 "error": f"Tool '{tool_name}' is not available in this session.",
                 "denied": True,
             }
+        budget_permission = (
+            tool_name == "create_goal" and tool_input.get("token_budget") is not None
+        )
+        force_permission = force_permission or budget_permission
         if force_permission:
+            detail = (
+                f"token_budget={tool_input['token_budget']}" if budget_permission else tool_name
+            )
             permission = await self._approval.prompt_with_always_async(
-                "Allow?",
-                tool_name,
-                safety_level="hook_requested",
+                "Allow token-limited Goal?" if budget_permission else "Allow?",
+                detail,
+                safety_level="goal_budget" if budget_permission else "hook_requested",
                 tool_name=tool_name,
                 allow_always=False,
                 allow_human_prompt=self._interactive_approval,
             )
             if permission != "y":
                 return {
-                    "error": f"Permission denied for '{tool_name}'",
+                    "error": (
+                        "token_budget requires explicit PermissionRequest approval; "
+                        "retry create_goal without token_budget when no budget was requested"
+                        if budget_permission
+                        else f"Permission denied for '{tool_name}'"
+                    ),
                     "denied": True,
+                    "recoverable": budget_permission,
                 }
 
         # Fleet view Stage 1.5 — the single per-tool dispatch boundary. A no-op

--- a/core/memory/organization.py
+++ b/core/memory/organization.py
@@ -15,8 +15,11 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
-# GEODE.md lives at project root (Karpathy P7: program.md = agent identity)
-DEFAULT_SOUL_PATH = Path(__file__).parent.parent.parent / "GEODE.md"
+# Source checkouts keep GEODE.md at the project root. Wheels install the same
+# file as package data under ``core/`` so the Tier-0 identity survives install.
+_SOURCE_SOUL_PATH = Path(__file__).parent.parent.parent / "GEODE.md"
+_PACKAGED_SOUL_PATH = Path(__file__).parent.parent / "GEODE.md"
+DEFAULT_SOUL_PATH = _SOURCE_SOUL_PATH if _SOURCE_SOUL_PATH.is_file() else _PACKAGED_SOUL_PATH
 
 
 class MonoLakeOrganizationMemory:

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -786,13 +786,17 @@
           "description": "The concrete end state to persist across turns."
         },
         "token_budget": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 1,
-          "description": "Optional positive completed-turn token budget; omit unless explicitly requested. The last turn can overshoot before subsequent continuation is stopped."
+          "description": "Positive completed-turn token budget only when explicitly requested; otherwise null. The last turn can overshoot before subsequent continuation is stopped."
         }
       },
       "required": [
-        "objective"
+        "objective",
+        "token_budget"
       ],
       "additionalProperties": false
     }

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -283,9 +283,9 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 546 |
 | Test Python files | 683 |
-| `core/` Python LOC | 139,121 |
+| `core/` Python LOC | 139,137 |
 | `plugins/` Python LOC | 41,831 |
-| Test Python LOC | 179,382 |
+| Test Python LOC | 179,457 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ packages = ["core", "plugins"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "scripts/macos" = "scripts/macos"
+"GEODE.md" = "core/GEODE.md"
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -197,6 +198,7 @@ include = [
     "/CHANGELOG.md",
     "/LICENSE",
     "/NOTICE",
+    "/GEODE.md",
     "/core",
     "/plugins",
     "/scripts/macos",

--- a/scripts/check_package_artifacts.py
+++ b/scripts/check_package_artifacts.py
@@ -18,6 +18,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED_WHEEL_PATHS = {
+    "core/GEODE.md",
     "core/tools/definitions.json",
     "core/tools/mcp_tools.json",
     "core/config/routing.toml",
@@ -33,6 +34,7 @@ REQUIRED_WHEEL_PATHS = {
 }
 
 REQUIRED_SDIST_PATHS = {
+    "GEODE.md",
     "pyproject.toml",
     "README.md",
     "README.ko.md",

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,7 +528,7 @@
   "packages": {
     "core": {
       "python_files": 435,
-      "python_loc": 139121
+      "python_loc": 139137
     },
     "plugins": {
       "python_files": 111,
@@ -536,7 +536,7 @@
     },
     "tests": {
       "python_files": 683,
-      "python_loc": 179382
+      "python_loc": 179457
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Fixed\n\n- **Hardened explicit Goal budgets and packaged identity.** A model-supplied\n  numeric `create_goal.token_budget` now crosses the existing\n  `PermissionRequest` boundary before persistence, while the OpenAI-compatible\n  schema represents the unbounded default as required `null` instead of a\n  best-effort optional integer. This prevents an unsolicited minimum value\n  from immediately budget-limiting a Goal. Distribution artifacts now include\n  the Tier-0 `GEODE.md` identity used by source checkouts instead of silently\n  running installed wheels with an empty soul."
   },
   {
     "version": "1.0.19",

--- a/tests/core/hooks/test_public_hook_wiring.py
+++ b/tests/core/hooks/test_public_hook_wiring.py
@@ -306,6 +306,82 @@ def test_headless_hook_permission_request_fails_closed_without_console() -> None
     handler.assert_not_called()
 
 
+def test_goal_token_budget_fails_closed_without_explicit_permission() -> None:
+    handler = MagicMock(return_value={"ok": True})
+    executor = ToolExecutor(
+        action_handlers={"create_goal": handler},
+        interactive_approval=False,
+    )
+
+    result = asyncio.run(
+        executor.aexecute(
+            "create_goal",
+            {"objective": "Finish the task", "token_budget": 1},
+        )
+    )
+
+    assert result == {
+        "error": (
+            "token_budget requires explicit PermissionRequest approval; "
+            "retry create_goal without token_budget when no budget was requested"
+        ),
+        "denied": True,
+        "recoverable": True,
+    }
+    handler.assert_not_called()
+
+
+def test_null_goal_token_budget_needs_no_permission() -> None:
+    handler = MagicMock(return_value={"ok": True})
+    executor = ToolExecutor(
+        action_handlers={"create_goal": handler},
+        interactive_approval=False,
+    )
+
+    result = asyncio.run(
+        executor.aexecute(
+            "create_goal",
+            {"objective": "Finish the task", "token_budget": None},
+        )
+    )
+
+    assert result == {"ok": True}
+    handler.assert_called_once_with(objective="Finish the task", token_budget=None)
+
+
+def test_goal_token_budget_permission_hook_can_authorize() -> None:
+    observed: list[tuple[str, str]] = []
+    registry = HookRegistry()
+
+    def allow(invocation: Any) -> HookDecision:
+        observed.append(
+            (
+                str(invocation.payload["safety_level"]),
+                str(invocation.payload["detail"]),
+            )
+        )
+        return HookDecision(action=HookAction.ALLOW)
+
+    registry.register(HookName.PERMISSION_REQUEST, allow)
+    handler = MagicMock(return_value={"ok": True})
+    executor = ToolExecutor(
+        action_handlers={"create_goal": handler},
+        hook_registry=registry,
+        interactive_approval=False,
+    )
+
+    result = asyncio.run(
+        executor.aexecute(
+            "create_goal",
+            {"objective": "Finish the task", "token_budget": 200_000},
+        )
+    )
+
+    assert result == {"ok": True}
+    assert observed == [("goal_budget", "token_budget=200000")]
+    handler.assert_called_once_with(objective="Finish the task", token_budget=200_000)
+
+
 def test_headless_rewritten_mcp_permission_fails_closed_without_console() -> None:
     class RewriteToMcp:
         async def tool_request(self, request: Any) -> Any:

--- a/tests/core/memory/test_organization_memory.py
+++ b/tests/core/memory/test_organization_memory.py
@@ -48,9 +48,8 @@ class TestSoulMd:
     def test_get_soul_default(self):
         org = MonoLakeOrganizationMemory()
         soul = org.get_soul()
-        # GEODE.md may not exist in CI — only assert if non-empty
-        if soul:
-            assert "GEODE" in soul or "Mission" in soul or "Identity" in soul
+        assert soul
+        assert "GEODE" in soul or "Mission" in soul or "Identity" in soul
 
     def test_get_soul_cached(self):
         org = MonoLakeOrganizationMemory()


### PR DESCRIPTION
## Summary
- Make the unbounded `create_goal.token_budget` value an explicit nullable-required schema field so Responses-compatible models emit `null` rather than inventing the minimum integer.
- Require the existing `PermissionRequest` boundary before any numeric Goal budget can persist.
- Ship Tier-0 `GEODE.md` in wheel/sdist artifacts and resolve it from package data in installed environments.

## Why
GPT-5.6 Luna twice generated `token_budget=1` despite an explicit no-budget request, immediately stopping Goal continuation. Separately, clean wheel installs logged `GEODE.md not found` and ran with an empty soul even though source checkouts inject that identity by default.

## GAP Audit
| GAP | Before | Closure evidence |
|---|---|---|
| Numeric Goal budget authority | Schema prose only; handler persisted model arguments verbatim | Numeric values cross `PermissionRequest`; headless fails closed; explicit hook allow succeeds |
| Responses optional-field reliability | Optional integer fell back to best-effort function calling | Official nullable-required pattern; Luna live E2E emitted `token_budget: null` |
| Distribution identity parity | `GEODE.md` absent from wheel and sdist | Artifact ratchet requires `core/GEODE.md` / root `GEODE.md`; clean venv imported packaged soul |

## Changes
| File | Change |
|---|---|
| `core/tools/definitions.json` | Nullable-required Goal budget schema |
| `core/agent/tool_executor/executor.py` | Permission gate for numeric Goal budgets |
| `core/memory/organization.py` | Source-root / package-data soul resolution |
| `pyproject.toml`, package checker | Ship and require GEODE.md in both artifacts |
| tests + generated baseline | Permission, identity, and inventory regressions |

## Verification
- Targeted Goal/hook/memory/IPC tests: 69 passed.
- GPT-5.6 Luna subscription E2E: `create_goal(null) -> calculate -> goal.continued -> get_goal -> calculate -> update_goal(complete)`; final status complete and stored budget null.
- Wheel/sdist validation: 623 / 625 files; clean venv imported `site-packages/core/GEODE.md` (10,710 chars).
- Ruff whole repo: pass; format 1,273 files: pass; mypy 546 files: pass; import contracts 4/4: pass; repo hygiene: pass.
- Full non-live suite before generated-baseline refresh: 10,379 passed, 22 skipped, 2 deselected, 1 generated-baseline drift failure. Ran the canonical generator, then architecture baseline tests 9/9 and roadmap validator passed.
- Anti-deception: no deleted/disabled tests, lint/type bypass, secret addition, dependency change, or tool-count decrease.
- Independent committed-diff review: no findings (one prior MCP attempt timed out without a result; bounded retry completed).
