### PR TITLE
release: v1.0.20 — goal budget and packaged identity hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.20] - 2026-08-10
+
+> Permission-gated Goal budgets and packaged Tier-0 runtime identity.
+
 ### Fixed
 
 - **Hardened explicit Goal budgets and packaged identity.** A model-supplied

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.19
+- **Version**: 1.0.20
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.19 — Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.20 — Autonomous Agent Runtime + Evaluation Substrate
 
 자율적인 도구 작업을 수행하는 범용 에이전트 런타임입니다. 자연어로
 요청하면 GEODE가 계획을 세우고 도구를 호출한 뒤 결과를 보고합니다. 짧은

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.19: Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.20: Autonomous Agent Runtime + Evaluation Substrate
 
 A general-purpose runtime for autonomous tool work. You ask in plain language;
 GEODE plans, calls tools, and reports, for one prompt or a long-running session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.19"
+version = "1.0.20"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
     "count": 248,
-    "stamped": "1.0.19"
+    "stamped": "1.0.20"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.19"
+    "stamped": "1.0.20"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.19"
+    "stamped": "1.0.20"
   },
   "duplicated_signatures": {
     "count": 83,
-    "stamped": "1.0.19"
+    "stamped": "1.0.20"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.19. Last sync 2026-08-09. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.20. Last sync 2026-08-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.19. Last sync 2026-08-09. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.20. Last sync 2026-08-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-09
+ * Last sync: 2026-08-10
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- **Hardened explicit Goal budgets and packaged identity.** A model-supplied\n  numeric `create_goal.token_budget` now crosses the existing\n  `PermissionRequest` boundary before persistence, while the OpenAI-compatible\n  schema represents the unbounded default as required `null` instead of a\n  best-effort optional integer. This prevents an unsolicited minimum value\n  from immediately budget-limiting a Goal. Distribution artifacts now include\n  the Tier-0 `GEODE.md` identity used by source checkouts instead of silently\n  running installed wheels with an empty soul."
+    "body": ""
+  },
+  {
+    "version": "1.0.20",
+    "date": "2026-08-10",
+    "body": "> Permission-gated Goal budgets and packaged Tier-0 runtime identity.\n\n### Fixed\n\n- **Hardened explicit Goal budgets and packaged identity.** A model-supplied\n  numeric `create_goal.token_budget` now crosses the existing\n  `PermissionRequest` boundary before persistence, while the OpenAI-compatible\n  schema represents the unbounded default as required `null` instead of a\n  best-effort optional integer. This prevents an unsolicited minimum value\n  from immediately budget-limiting a Goal. Distribution artifacts now include\n  the Tier-0 `GEODE.md` identity used by source checkouts instead of silently\n  running installed wheels with an empty soul."
   },
   {
     "version": "1.0.19",
@@ -2493,4 +2498,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-08-09";
+export const CHANGELOG_SYNCED_AT = "2026-08-10";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-09
+ * Last sync: 2026-08-10
  */
 
 export const GEODE_SOT = {
-  version: "1.0.19",
-  syncedAt: "2026-08-09",
+  version: "1.0.20",
+  syncedAt: "2026-08-10",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.19"
+version = "1.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Promote the verified Goal-budget and packaged Tier-0 identity fixes as GEODE v1.0.20.

## Why
- Main must not retain functional entries under Unreleased.
- The feature landing passed full CI, Luna subscription E2E, and package-content verification.

## Changes
| File | Change |
|------|--------|
| CHANGELOG.md | Promote the Goal/package fix into v1.0.20 and restore an empty Unreleased section. |
| pyproject.toml, CLAUDE.md, README files, uv.lock | Bump the release version to 1.0.20. |
| site generated metadata | Regenerate version, changelog, and LLM indexes. |
| slop ratchet baseline | Restamp the unchanged debt counts for 1.0.20. |

## Verification
- Feature PR #2938: full CI, Pages build, and Ubuntu/macOS install smoke passed.
- uv run ruff check core/ tests/ plugins/ scripts/
- uv run ruff format --check core/ tests/ plugins/ scripts/
- uv run mypy core/ plugins/ scripts/
- uv run lint-imports
- uv build; package artifact checker passed (623 wheel files, 625 sdist files).
- Focused Goal/hook/identity tests passed.
- Clean Python 3.12 no-dependency wheel probe found core/GEODE.md (10,710 chars) at version 1.0.20.
- Next.js static export completed for 237 pages; npm audit found 0 vulnerabilities.