### PR TITLE
fix: preserve Codex overload diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
 The current snapshot records 546 production Python files,
-683 test Python files,
+684 test Python files,
 87 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ functional change.
 
 ### Fixed
 
+- **Codex overload classification.** Generic SSE `APIError` overload responses
+  are now recorded as provider-server failures instead of unknown errors, so
+  retry hooks and operator diagnostics retain the real failure category.
 - **Isolated Claude CLI subscription authentication.** Petri audit subprocesses
   no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and
   judge roles consistently use the operator's Claude subscription login.

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -579,6 +579,10 @@ def _classify_openai_error(exc: Exception) -> tuple[str, str, str] | None:
         if _looks_like_context_overflow(exc):
             return _ERROR_CLASSIFICATION["context_overflow"]
         return _ERROR_CLASSIFICATION["bad_request"]
+    # The Codex SSE backend can emit overload as a generic APIError rather
+    # than an HTTP-backed InternalServerError (live effort sweep 2026-08-11).
+    if isinstance(exc, openai.APIError) and "overloaded" in str(exc).lower():
+        return _ERROR_CLASSIFICATION["server"]
     return None
 
 

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -282,10 +282,10 @@ machine-readable artifact is
 | Measure | Current tree |
 |---|---:|
 | Production Python files (`core/` + `plugins/`) | 546 |
-| Test Python files | 683 |
-| `core/` Python LOC | 139,137 |
+| Test Python files | 684 |
+| `core/` Python LOC | 139,141 |
 | `plugins/` Python LOC | 41,834 |
-| Test Python LOC | 179,485 |
+| Test Python LOC | 179,553 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -2,7 +2,7 @@
 
 > Action/tool-execution 4종 벤치마크. GEODE의 quality ratchet(P4)에 통합 예정.
 > 각 문서는 **사례 + 필요 인프라 + 4-Phase 진행 시나리오**를 담음.
-> 마지막 갱신: 2026-08-03
+> 마지막 갱신: 2026-08-11
 
 ## Raw artifact repository
 
@@ -13,6 +13,12 @@ repository. GEODE keeps interpretation, comparison boundaries, and digest
 pointers under `docs/eval/`; the artifact repository keeps the bytes behind
 those claims. See [External Evaluation Artifact Repository](external-artifact-repository.md)
 for path mappings, disclosure rules, and the publication manifest scaffold.
+
+The latest route-contract diagnostic is the immutable
+[2026-08-11 GPT-5.6 effort-surface record](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/7a788211c2194f7118b40b63e19f071b6e7091fb/reports/e2e-validation/2026-08-11-gpt56-luna-terra-sol-effort-surface.md):
+all 18 Luna/Terra/Sol × six-effort combinations passed on the OpenAI
+subscription route. Its six retained transient overloads are transport
+evidence, not a quality comparison; `promotion_authority=none`.
 
 The latest runtime-contract record is the immutable
 [2026-08-10 Goal/deep-research behavior release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/abad7de44a23cd0756fe1edb5b61a86ed715cc8f/trajectories/geode-agenticloop-goal-deep-research-gpt56-luna-max-2026-08-10-20260809T191233Z-a19174d30764):

--- a/docs/eval/external-artifact-repository.md
+++ b/docs/eval/external-artifact-repository.md
@@ -16,6 +16,20 @@ not JFrog Artifactory or an opaque object-store upload. The publication unit is
 an allowlisted directory, and GitHub read-back from the exact merge commit is
 part of the evidence.
 
+The 2026-08-11 GPT-5.6 effort-surface measurement is pinned to artifact commit
+[`7a78821`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/7a788211c2194f7118b40b63e19f071b6e7091fb)
+from
+[`geode-eval-artifacts#18`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/18).
+All 18 Luna/Terra/Sol × `none|low|medium|high|xhigh|max` combinations preserved
+the requested Responses wire value and exact `EFFORT_OK` contract through the
+OpenAI subscription route. The append-only
+[`JSONL`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/7a788211c2194f7118b40b63e19f071b6e7091fb/reports/e2e-validation/2026-08-11-gpt56-luna-terra-sol-effort-surface.jsonl)
+retains 24 provider attempts, including six transient overloads, and has
+SHA-256
+`7abcfb5d7e6899363f1c975a94ac16a622189d53fb59e40b4fc8f7e5b2ec9de9`.
+Remote read-back reproduced that digest. This proves route and backend
+acceptance only; it has no quality or promotion authority.
+
 The 2026-08-10 Goal and deep-research behavior release is pinned to artifact
 commit
 [`abad7de`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/abad7de44a23cd0756fe1edb5b61a86ed715cc8f)

--- a/scripts/probes/probe_effort_surface.py
+++ b/scripts/probes/probe_effort_surface.py
@@ -1,0 +1,261 @@
+"""Measure every effort level exposed by GEODE's model picker.
+
+The probe uses the production-resolved adapters, appends one JSONL row per
+attempt, and stops on the first failed wire or response contract. Re-running
+with the same output file skips prior passes and retries the failed pair.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+SCHEMA = "geode.effort-surface-measurement@1"
+PROMPT = "Return only this token: EFFORT_OK"
+SYSTEM_PROMPT = "Follow the user's output instruction exactly."
+
+
+def visible_effort_surface(
+    model_ids: tuple[str, ...] = (),
+) -> tuple[tuple[str, str, str], ...]:
+    """Return picker order as ``(model, provider, effort)`` rows."""
+    from core.cli.commands._state import get_model_profiles
+    from core.cli.effort_picker import supported_efforts
+
+    surface = tuple(
+        (profile.id, profile.provider, effort)
+        for profile in get_model_profiles()
+        for effort in supported_efforts(profile.id, profile.provider)
+    )
+    if not model_ids:
+        return surface
+    rows_by_model = {model: tuple(row for row in surface if row[0] == model) for model in model_ids}
+    unknown = [model for model, rows in rows_by_model.items() if not rows]
+    if unknown:
+        raise ValueError(f"models have no exposed effort surface: {', '.join(unknown)}")
+    return tuple(row for model in model_ids for row in rows_by_model[model])
+
+
+def _wire_effort(request: Any, provider: str, source: str) -> str | None:
+    if provider == "anthropic":
+        from core.llm.adapters._anthropic_common import build_create_kwargs
+
+        return build_create_kwargs(request).get("output_config", {}).get("effort")
+
+    from core.llm.adapters._openai_common import build_responses_kwargs
+
+    return (
+        build_responses_kwargs(
+            request,
+            backend="codex" if source == "subscription" else "platform",
+            adapter_name="effort-surface-measurement",
+        )
+        .get("reasoning", {})
+        .get("effort")
+    )
+
+
+def _passed_keys(output: Path) -> set[tuple[str, str]]:
+    if not output.exists():
+        return set()
+    passed: set[tuple[str, str]] = set()
+    for line_number, line in enumerate(output.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at {output}:{line_number}") from exc
+        if row.get("status") == "pass":
+            passed.add((str(row["model"]), str(row["requested_effort"])))
+    return passed
+
+
+def _append(output: Path, row: dict[str, Any]) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _reasoning_tokens(raw_response: Any) -> int | None:
+    usage = getattr(raw_response, "usage", None)
+    details = getattr(usage, "output_tokens_details", None)
+    value = getattr(details, "reasoning_tokens", None)
+    return int(value) if value is not None else None
+
+
+async def _acomplete_with_runtime_retry(
+    adapter: Any,
+    request: Any,
+    *,
+    timeout_s: float,
+    retry_history: list[dict[str, Any]],
+    sleep: Any = asyncio.sleep,
+) -> Any:
+    """Mirror AgenticLoop's five-attempt retry for pre-response failures."""
+    from core.llm.errors import classify_llm_error
+
+    retryable = {"connection", "server", "timeout", "unknown"}
+    for attempt in range(1, 6):
+        try:
+            return await asyncio.wait_for(adapter.acomplete(request), timeout_s)
+        except Exception as exc:
+            category, _, _ = classify_llm_error(exc)
+            retry_history.append(
+                {
+                    "attempt": attempt,
+                    "error_type": type(exc).__name__,
+                    "error_category": category,
+                    "error": str(exc)[:2000],
+                }
+            )
+            if category not in retryable or attempt == 5:
+                raise
+            await sleep(min(2**attempt, 30))
+    raise AssertionError("bounded effort measurement retry did not terminate")
+
+
+async def measure(
+    output: Path,
+    *,
+    timeout_s: float,
+    producer_revision: str,
+    model_ids: tuple[str, ...] = (),
+) -> int:
+    from core.llm.adapters._source_inference import infer_source
+    from core.llm.adapters.base import AdapterCallRequest, Message
+    from core.llm.adapters.registry import bootstrap_builtins, resolve_for
+
+    bootstrap_builtins()
+    surface = visible_effort_surface(model_ids)
+    adapters = {
+        provider: resolve_for(provider, infer_source(provider)) for _, provider, _ in surface
+    }
+    passed = _passed_keys(output)
+
+    for ordinal, (model, provider, effort) in enumerate(surface, 1):
+        if (model, effort) in passed:
+            print(f"SKIP {ordinal:02d}/{len(surface)} {model} effort={effort}", flush=True)
+            continue
+
+        request = AdapterCallRequest(
+            model=model,
+            messages=(Message(role="user", content=PROMPT),),
+            system_prompt=SYSTEM_PROMPT,
+            max_tokens=256,
+            effort=effort,
+        )
+        started_at = datetime.now(UTC).isoformat()
+        started = time.perf_counter()
+        adapter = adapters[provider]
+        wire_effort = _wire_effort(request, provider, adapter.source)
+        common = {
+            "schema": SCHEMA,
+            "producer_revision": producer_revision,
+            "ordinal": ordinal,
+            "surface_size": len(surface),
+            "model": model,
+            "provider": provider,
+            "adapter": adapter.name,
+            "adapter_source": adapter.source,
+            "requested_effort": effort,
+            "wire_effort": wire_effort,
+            "started_at": started_at,
+        }
+        if wire_effort != effort:
+            row = {
+                **common,
+                "status": "fail",
+                "failure_stage": "wire",
+                "error_type": "EffortWireMismatch",
+                "error": f"requested={effort!r} wire={wire_effort!r}",
+                "latency_ms": 0,
+            }
+            _append(output, row)
+            print(f"FAIL {ordinal:02d}/{len(surface)} {model} effort={effort} wire mismatch")
+            return 1
+
+        print(f"RUN  {ordinal:02d}/{len(surface)} {model} effort={effort}", flush=True)
+        retry_history: list[dict[str, Any]] = []
+        try:
+            result = await _acomplete_with_runtime_retry(
+                adapter,
+                request,
+                timeout_s=timeout_s,
+                retry_history=retry_history,
+            )
+            text = result.text.strip()
+            contract_ok = text == "EFFORT_OK" and not result.tool_uses
+            row = {
+                **common,
+                "status": "pass" if contract_ok else "fail",
+                "failure_stage": None if contract_ok else "response_contract",
+                "completed_at": datetime.now(UTC).isoformat(),
+                "latency_ms": round((time.perf_counter() - started) * 1000),
+                "stop_reason": result.stop_reason,
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+                "cached_input_tokens": result.usage.cached_input_tokens,
+                "reasoning_tokens": _reasoning_tokens(result.raw_response),
+                "reasoning_item_count": len(result.reasoning_items),
+                "reasoning_summary_count": len(result.reasoning_summaries),
+                "response_text": text,
+                "response_sha256": hashlib.sha256(result.text.encode()).hexdigest(),
+                "tool_use_count": len(result.tool_uses),
+                "attempt_count": len(retry_history) + 1,
+                "retry_history": retry_history,
+            }
+        except Exception as exc:
+            row = {
+                **common,
+                "status": "fail",
+                "failure_stage": "adapter_call",
+                "completed_at": datetime.now(UTC).isoformat(),
+                "latency_ms": round((time.perf_counter() - started) * 1000),
+                "error_type": type(exc).__name__,
+                "error": str(exc)[:2000],
+                "attempt_count": len(retry_history),
+                "retry_history": retry_history,
+            }
+
+        _append(output, row)
+        print(
+            f"{row['status'].upper():4s} {ordinal:02d}/{len(surface)} {model} "
+            f"effort={effort} latency_ms={row['latency_ms']}",
+            flush=True,
+        )
+        if row["status"] != "pass":
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--producer-revision", required=True)
+    parser.add_argument("--model", action="append", default=[])
+    parser.add_argument("--timeout-s", type=float, default=300.0)
+    args = parser.parse_args()
+    if args.timeout_s <= 0:
+        parser.error("--timeout-s must be positive")
+    return asyncio.run(
+        measure(
+            args.output.resolve(),
+            timeout_s=args.timeout_s,
+            producer_revision=args.producer_revision,
+            model_ids=tuple(args.model),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5995,7 +5995,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1501 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1502 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -6156,7 +6156,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 | 측정값 | 현재 트리 |
 | --- | --- |
 | 프로덕션 Python 파일 | 546 |
-| 테스트 Python 파일 | 683 |
+| 테스트 Python 파일 | 684 |
 | 도구 정의 / 실행 등록 / 유효 스키마 | 87 / 90 / 87 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 8 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,15 +528,15 @@
   "packages": {
     "core": {
       "python_files": 435,
-      "python_loc": 139137
+      "python_loc": 139141
     },
     "plugins": {
       "python_files": 111,
       "python_loc": 41834
     },
     "tests": {
-      "python_files": 683,
-      "python_loc": 179485
+      "python_files": 684,
+      "python_loc": 179553
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
+    "body": "### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
   },
   {
     "version": "1.0.20",

--- a/tests/core/llm/test_classify_llm_error.py
+++ b/tests/core/llm/test_classify_llm_error.py
@@ -176,6 +176,17 @@ class TestClassifyOpenAiSdkErrorsUnchanged:
         error_type, _severity, _hint = classify_llm_error(exc)
         assert error_type == "context_overflow"
 
+    def test_codex_sse_generic_overload_error(self) -> None:
+        import openai
+
+        exc = openai.APIError(
+            "Our servers are currently overloaded. Please try again later.",
+            request=httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses"),
+            body=None,
+        )
+        error_type, _severity, _hint = classify_llm_error(exc)
+        assert error_type == "server"
+
 
 @pytest.mark.parametrize(
     "message",

--- a/tests/scripts/test_probe_effort_surface.py
+++ b/tests/scripts/test_probe_effort_surface.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from scripts.probes.probe_effort_surface import (
+    _acomplete_with_runtime_retry,
+    visible_effort_surface,
+)
+
+
+def test_visible_effort_surface_matches_picker() -> None:
+    surface = visible_effort_surface()
+
+    assert len(surface) == 61
+    assert len(surface) == len(set(surface))
+    assert ("gpt-5.6-sol", "openai", "max") in surface
+    assert ("claude-fable-5", "anthropic", "xhigh") in surface
+
+
+def test_visible_effort_surface_honors_explicit_model_order() -> None:
+    surface = visible_effort_surface(("gpt-5.6-luna", "gpt-5.6-sol"))
+
+    assert len(surface) == 12
+    assert [model for model, _, _ in surface[:6]] == ["gpt-5.6-luna"] * 6
+    assert [model for model, _, _ in surface[6:]] == ["gpt-5.6-sol"] * 6
+
+
+def test_measurement_retries_pre_response_transient_once() -> None:
+    class FlakyAdapter:
+        calls = 0
+
+        async def acomplete(self, request: object) -> object:
+            del request
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("servers are currently overloaded")
+            return SimpleNamespace(text="EFFORT_OK")
+
+    async def no_sleep(_: float) -> None:
+        return None
+
+    adapter = FlakyAdapter()
+    history: list[dict[str, object]] = []
+    result = asyncio.run(
+        _acomplete_with_runtime_retry(
+            adapter,
+            object(),
+            timeout_s=1,
+            retry_history=history,
+            sleep=no_sleep,
+        )
+    )
+
+    assert result.text == "EFFORT_OK"
+    assert adapter.calls == 2
+    assert history[0]["error_category"] == "unknown"


### PR DESCRIPTION
## Summary
- Add a resumable live probe for the complete GPT-5.6 Luna/Terra/Sol effort surface.
- Classify generic Codex SSE overload API errors as provider-server failures.
- Pin the immutable 18/18 measurement record published in eval-artifacts PR #18.

## Why
All six GEODE-exposed effort values needed live picker-to-wire and backend-acceptance evidence on each requested GPT-5.6 subscription target. The first stopped run also exposed that Codex overloads could arrive as generic openai.APIError and lose their real category.

## GAP Audit
| GAP | Before | After |
|---|---|---|
| Reproducible effort sweep | No resumable all-effort probe | Append-only, stop-on-failure probe with exact route/wire/response contract |
| Generic Codex overload category | unknown | server |
| Public evidence | No Luna/Terra/Sol six-effort record | eval-artifacts #18, 18/18 final passes, digest-pinned |

## Changes
| File | Change |
|---|---|
| core/llm/errors.py | Narrow generic APIError overload classification |
| scripts/probes/probe_effort_surface.py | Production-resolved effort measurement and same-pair retry |
| tests | Classifier regression, picker inventory/order, retry recovery |
| docs/eval | Immutable artifact commit, path, digest, and interpretation boundary |
| generated architecture inventory | Refresh test-file and LOC counts |

## Verification
- Live OpenAI subscription sweep: 18/18 combinations passed; requested effort matched wire effort 18/18; exact response matched 18/18
- Full CI-equivalent test gate: 10,385 passed, 22 skipped, coverage 81.06%
- Ruff lint and format: pass
- mypy core/plugins/scripts: pass
- import contracts: 4/4 kept
- prompt integrity, architecture baseline, pre-commit security/dependency checks: pass
- Eval JSON/JSONL parse and public privacy scan: pass
- Remote artifact read-back SHA-256: 7abcfb5d7e6899363f1c975a94ac16a622189d53fb59e40b4fc8f7e5b2ec9de9

## Evidence
- https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/18
- https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/7a788211c2194f7118b40b63e19f071b6e7091fb