### PR TITLE
release: v1.0.21 — 재현 가능한 Petri 스캐폴드 진단

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.21] - 2026-08-11
+
+> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.
+
 ### Infrastructure
 
 - **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.20
+- **Version**: 1.0.21
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.20 — Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.21 — Autonomous Agent Runtime + Evaluation Substrate
 
 자율적인 도구 작업을 수행하는 범용 에이전트 런타임입니다. 자연어로
 요청하면 GEODE가 계획을 세우고 도구를 호출한 뒤 결과를 보고합니다. 짧은

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.20: Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.21: Autonomous Agent Runtime + Evaluation Substrate
 
 A general-purpose runtime for autonomous tool work. You ask in plain language;
 GEODE plans, calls tools, and reports, for one prompt or a long-running session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.20"
+version = "1.0.21"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/slop_ratchet_baseline.json
+++ b/scripts/slop_ratchet_baseline.json
@@ -1,18 +1,18 @@
 {
   "bypass_markers": {
     "count": 248,
-    "stamped": "1.0.20"
+    "stamped": "1.0.21"
   },
   "stale_todos": {
     "count": 2,
-    "stamped": "1.0.20"
+    "stamped": "1.0.21"
   },
   "dead_flags": {
     "count": 0,
-    "stamped": "1.0.20"
+    "stamped": "1.0.21"
   },
   "duplicated_signatures": {
     "count": 83,
-    "stamped": "1.0.20"
+    "stamped": "1.0.21"
   }
 }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.20. Last sync 2026-08-10. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.21. Last sync 2026-08-11. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.20. Last sync 2026-08-10. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.21. Last sync 2026-08-11. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -2,7 +2,7 @@
  * GEODE CHANGELOG, auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit CHANGELOG.md in the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-10
+ * Last sync: 2026-08-11
  *
  * Each entry's `body` is the raw markdown between two version headings.
  * The Changelog page renders the body with a minimal markdown renderer
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
+    "body": ""
+  },
+  {
+    "version": "1.0.21",
+    "date": "2026-08-11",
+    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
   },
   {
     "version": "1.0.20",
@@ -2498,4 +2503,4 @@ export const CHANGELOG: ChangelogEntry[] = [
   }
 ];
 
-export const CHANGELOG_SYNCED_AT = "2026-08-10";
+export const CHANGELOG_SYNCED_AT = "2026-08-11";

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -4,10 +4,10 @@
  * Auto-synced from the GEODE repo via `npm run sync-stats`.
  * Do not edit manually. Edit the GEODE repo and re-run sync.
  *
- * Last sync: 2026-08-10
+ * Last sync: 2026-08-11
  */
 
 export const GEODE_SOT = {
-  version: "1.0.20",
-  syncedAt: "2026-08-10",
+  version: "1.0.21",
+  syncedAt: "2026-08-11",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.20"
+version = "1.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- GPT-5.6 effort 진단, Codex 오류 분류, Petri CLI 인증 격리, Codex/Hermes matched scaffold 비교를 v1.0.21로 승격합니다.
- 빈 Unreleased 구간을 다시 열고 모든 버전·사이트 파생 SOT를 2026-08-11 기준으로 동기화합니다.

## Why
- 현재 develop의 세 기능 변경을 main에 올리기 전에 릴리스 계약상 버전과 CHANGELOG를 고정해야 합니다.

## Changes
| File | Change |
|---|---|
| CHANGELOG.md | Unreleased 항목을 1.0.21로 승격하고 새 빈 Unreleased 구간 추가 |
| pyproject.toml, uv.lock | 패키지 버전 1.0.21 동기화 |
| CLAUDE.md, README.md, README.ko.md | 런타임·공개 진입점 버전 동기화 |
| scripts/slop_ratchet_baseline.json | 릴리스 stamp 1.0.21 갱신 |
| site/src/data/geode/sot.ts, changelog.ts | 생성된 사이트 SOT 갱신 |
| site/public/llms.txt, llms-full.txt | 공개 LLM 인덱스 버전·날짜 갱신 |

## Verification
- ruff check: pass
- ruff format check: 1,277 files formatted
- mypy: 593 source files, 0 issues
- pytest: 10,385 passed, 22 skipped; coverage 81.07%
- Next.js static build: 237 pages pass
- llms version, slop, architecture, repository hygiene ratchets: pass
- geode version: v1.0.21

Generated with Codex