### PR TITLE
fix: align audit type checks with release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         if: needs.changes.outputs.code == 'true'
       - if: needs.changes.outputs.code == 'true'
-        run: uv sync
+        run: uv sync --extra audit
       - if: needs.changes.outputs.code == 'true'
         run: uv run mypy core/ plugins/ scripts/
       - name: Prompt integrity check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **Release/type-check parity.** CI now type-checks with the audit extra used
+  by stable releases, and the Petri scaffold utilities satisfy those installed
+  Inspect/Petri type contracts instead of failing only during promotion.
+
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -285,7 +285,7 @@ machine-readable artifact is
 | Test Python files | 684 |
 | `core/` Python LOC | 139,141 |
 | `plugins/` Python LOC | 41,834 |
-| Test Python LOC | 179,553 |
+| Test Python LOC | 179,551 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/scripts/eval/petri_dish_scaffold_compare.py
+++ b/scripts/eval/petri_dish_scaffold_compare.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from inspect_ai import Task
 
 HERMES_REVISION = "c0106e50e7ecedb3ce34e785d949725dc4e0e457"
 CODEX_CLI_VERSION = "0.145.0"
@@ -56,7 +59,6 @@ def _interactive_hermes() -> Any:
     """Build the Inspect SWE ACP factory without adding a runtime dependency."""
     from inspect_ai.agent import (
         AgentState,
-        BridgedToolsSpec,
         SandboxAgentBridge,
         agent,
         sandbox_agent_bridge,
@@ -82,7 +84,7 @@ def _interactive_hermes() -> Any:
                 model_aliases=self.model_map,
                 filter=self.filter,
                 retry_refusals=self.retry_refusals,
-                bridged_tools=cast(list[BridgedToolsSpec], self.bridged_tools) or None,
+                bridged_tools=self.bridged_tools or None,
                 port=port,
             ) as bridge:
                 bridge_url = f"http://127.0.0.1:{bridge.port}/v1"
@@ -124,16 +126,16 @@ def _self_check() -> None:
     assert config["tools"]["tool_search"]["enabled"] == "off"
 
 
-try:
-    from inspect_ai import Task, task
-except ImportError:  # lets the file's self-check run without audit dependencies
-    Task = Any
-
-    def task(fn: Any) -> Any:
+def _optional_task(fn: Any) -> Any:
+    """Apply Inspect's task decorator when the audit extra is installed."""
+    try:
+        from inspect_ai import task
+    except ImportError:  # lets the self-check run without audit dependencies
         return fn
+    return task(fn)
 
 
-@task
+@_optional_task
 def scaffold_audit(
     agent_type: Literal["codex_cli", "hermes_agent"] = "codex_cli",
     seed_instructions: str | list[str] | None = None,
@@ -141,7 +143,7 @@ def scaffold_audit(
     docker_image: str | None = None,
 ) -> Task:
     """Return one matched Petri Dish task; only ``agent_type`` may differ."""
-    from inspect_ai import Task
+    from inspect_ai import Task as InspectTask
     from inspect_petri import audit_judge, audit_solver
     from inspect_swe import interactive_codex_cli
     from petri_dish._prompts import AUDITOR_SYSTEM_PROMPT
@@ -172,7 +174,7 @@ def scaffold_audit(
     for sample in samples:
         sample.sandbox = _make_sandbox_spec(docker_image)
 
-    return Task(
+    return InspectTask(
         dataset=samples,
         solver=audit_solver(
             auditor=dish_auditor(

--- a/scripts/eval/sanitize_inspect_eval.py
+++ b/scripts/eval/sanitize_inspect_eval.py
@@ -49,6 +49,8 @@ def main() -> None:
     write_eval_log(public, args.destination)
 
     readback = read_eval_log(args.destination)
+    if not source.samples or not readback.samples:
+        raise ValueError("Inspect archive must contain at least one sample")
     assert readback.status == source.status
     assert readback.samples[0].scores == source.samples[0].scores
     print(json.dumps(stats, sort_keys=True))

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -536,7 +536,7 @@
     },
     "tests": {
       "python_files": 684,
-      "python_loc": 179553
+      "python_loc": 179551
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Infrastructure\n\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion."
   },
   {
     "version": "1.0.21",

--- a/tests/core/cli/test_lifecycle_commands.py
+++ b/tests/core/cli/test_lifecycle_commands.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from core.cli.commands.lifecycle import (
+    SERVE_STARTUP_TIMEOUT_S,
     _clean_stale_artifacts,
     _cleanup_legacy_transcripts,
     _find_serve_pid,
@@ -179,14 +180,11 @@ class TestStop:
 
 class TestStartServe:
     def test_default_timeout_allows_twenty_second_boot(self, tmp_path: Path) -> None:
+        assert SERVE_STARTUP_TIMEOUT_S >= 20.0
         executable = str(tmp_path / "bin" / "geode")
         with (
             patch("core.cli.commands.lifecycle.subprocess.Popen") as popen,
             patch("core.cli.ipc_client.is_serve_running", return_value=True),
-            patch(
-                "core.cli.commands.lifecycle.time.monotonic",
-                side_effect=[0.0, 20.0],
-            ),
         ):
             assert _start_serve_background(executable=executable)
 


### PR DESCRIPTION
## Summary
- Align CI type checking with the audit dependencies used by stable release promotion.
- Fix installed Inspect/Petri typing in the matched scaffold runner and sanitizer.
- Remove a parallel-test clock mock that could exhaust its finite side effect.

## Why
Stable v1.0.21 promotion stopped before publication because the release environment installed audit dependencies and exposed five type errors that default CI did not see. The first repair CI then exposed an independent lifecycle-test flake caused by patching the shared time module with two finite values.

## GAP Audit

| GAP | Before | After |
|---|---|---|
| CI/release dependency parity | CI type check used the default environment | CI type check installs the audit extra |
| Optional task decorator | Runtime fallback rebound imported names | One typed optional decorator owns the fallback |
| Eval sample validation | Optional samples were indexed directly | Empty or missing samples fail explicitly |
| Startup-timeout test | Shared monotonic clock had a finite mock | Contract value is checked directly |

## Changes

| File | Change |
|---|---|
| .github/workflows/ci.yml | Type check installs the audit extra |
| scripts/eval/petri_dish_scaffold_compare.py | Remove redundant cast and optional-import rebinding |
| scripts/eval/sanitize_inspect_eval.py | Validate samples before score comparison |
| tests/core/cli/test_lifecycle_commands.py | Remove the shared-clock flake |
| CHANGELOG.md and generated changelog | Record release/type-check parity |

## Verification
- uv run mypy core plugins scripts tests/integration/test_prepare_hf_release_bundle.py tests/integration/test_check_official_docs.py
- uv run ruff check core/ tests/ plugins/ scripts/
- uv run ruff format --check core/ tests/ plugins/ scripts/
- uv run pytest tests/core/cli/test_lifecycle_commands.py -q: 47 passed
- Hermes eval sanitizer round-trip preserved status and scores
- pre-commit hooks passed