### PR TITLE
release: finalize v1.0.21 promotion repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,6 @@ functional change.
 
 ## [Unreleased]
 
-### Infrastructure
-
-- **Release/type-check parity.** CI now type-checks with the audit extra used
-  by stable releases, and the Petri scaffold utilities satisfy those installed
-  Inspect/Petri type contracts instead of failing only during promotion.
-
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.
@@ -63,6 +57,9 @@ functional change.
   ACP comparison task with a shared sandbox, model, seed, turn ceiling, and
   judge rubric, plus an Inspect archive sanitizer that removes private
   reasoning and host-home paths while preserving scores for public evidence.
+- **Release/type-check parity.** CI now type-checks with the audit extra used
+  by stable releases, and the Petri scaffold utilities satisfy those installed
+  Inspect/Petri type contracts instead of failing only during promotion.
 
 ### Fixed
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,12 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Infrastructure\n\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion."
+    "body": ""
   },
   {
     "version": "1.0.21",
     "date": "2026-08-11",
-    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
+    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
   },
   {
     "version": "1.0.20",


### PR DESCRIPTION
## Summary
- Finalize the unpublished v1.0.21 release notes after repairing the promotion gate.
- Keep Unreleased empty and retain the existing 1.0.21 version stamps.

## Why
The first stable promotion stopped before creating a tag, GitHub Release, or PyPI artifact. The repair landed in develop through PR #2948, so the retry-safe same-version flow needs that infrastructure fix folded into the still-unpublished 1.0.21 notes.

## Changes

| File | Change |
|---|---|
| CHANGELOG.md | Move release/type-check parity from Unreleased into 1.0.21 |
| site/src/data/geode/changelog.ts | Regenerate the public changelog projection |

## Verification
- v1.0.21 remains absent from tags, GitHub Releases, and PyPI before this PR
- GEODE v1.0.21
- mypy: 595 source files
- architecture baseline clean
- llms version clean