### PR TITLE
release: v1.0.21 promotion repair (develop → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         if: needs.changes.outputs.code == 'true'
       - if: needs.changes.outputs.code == 'true'
-        run: uv sync
+        run: uv sync --extra audit
       - if: needs.changes.outputs.code == 'true'
         run: uv run mypy core/ plugins/ scripts/
       - name: Prompt integrity check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **Release/type-check parity.** CI now type-checks with the audit extra used
+  by stable releases, and the Petri scaffold utilities satisfy those installed
+  Inspect/Petri type contracts instead of failing only during promotion.
+
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,6 @@ functional change.
 
 ## [Unreleased]
 
-### Infrastructure
-
-- **Release/type-check parity.** CI now type-checks with the audit extra used
-  by stable releases, and the Petri scaffold utilities satisfy those installed
-  Inspect/Petri type contracts instead of failing only during promotion.
-
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.
@@ -63,6 +57,9 @@ functional change.
   ACP comparison task with a shared sandbox, model, seed, turn ceiling, and
   judge rubric, plus an Inspect archive sanitizer that removes private
   reasoning and host-home paths while preserving scores for public evidence.
+- **Release/type-check parity.** CI now type-checks with the audit extra used
+  by stable releases, and the Petri scaffold utilities satisfy those installed
+  Inspect/Petri type contracts instead of failing only during promotion.
 
 ### Fixed
 

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -285,7 +285,7 @@ machine-readable artifact is
 | Test Python files | 684 |
 | `core/` Python LOC | 139,141 |
 | `plugins/` Python LOC | 41,834 |
-| Test Python LOC | 179,553 |
+| Test Python LOC | 179,551 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/scripts/eval/petri_dish_scaffold_compare.py
+++ b/scripts/eval/petri_dish_scaffold_compare.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from inspect_ai import Task
 
 HERMES_REVISION = "c0106e50e7ecedb3ce34e785d949725dc4e0e457"
 CODEX_CLI_VERSION = "0.145.0"
@@ -56,7 +59,6 @@ def _interactive_hermes() -> Any:
     """Build the Inspect SWE ACP factory without adding a runtime dependency."""
     from inspect_ai.agent import (
         AgentState,
-        BridgedToolsSpec,
         SandboxAgentBridge,
         agent,
         sandbox_agent_bridge,
@@ -82,7 +84,7 @@ def _interactive_hermes() -> Any:
                 model_aliases=self.model_map,
                 filter=self.filter,
                 retry_refusals=self.retry_refusals,
-                bridged_tools=cast(list[BridgedToolsSpec], self.bridged_tools) or None,
+                bridged_tools=self.bridged_tools or None,
                 port=port,
             ) as bridge:
                 bridge_url = f"http://127.0.0.1:{bridge.port}/v1"
@@ -124,16 +126,16 @@ def _self_check() -> None:
     assert config["tools"]["tool_search"]["enabled"] == "off"
 
 
-try:
-    from inspect_ai import Task, task
-except ImportError:  # lets the file's self-check run without audit dependencies
-    Task = Any
-
-    def task(fn: Any) -> Any:
+def _optional_task(fn: Any) -> Any:
+    """Apply Inspect's task decorator when the audit extra is installed."""
+    try:
+        from inspect_ai import task
+    except ImportError:  # lets the self-check run without audit dependencies
         return fn
+    return task(fn)
 
 
-@task
+@_optional_task
 def scaffold_audit(
     agent_type: Literal["codex_cli", "hermes_agent"] = "codex_cli",
     seed_instructions: str | list[str] | None = None,
@@ -141,7 +143,7 @@ def scaffold_audit(
     docker_image: str | None = None,
 ) -> Task:
     """Return one matched Petri Dish task; only ``agent_type`` may differ."""
-    from inspect_ai import Task
+    from inspect_ai import Task as InspectTask
     from inspect_petri import audit_judge, audit_solver
     from inspect_swe import interactive_codex_cli
     from petri_dish._prompts import AUDITOR_SYSTEM_PROMPT
@@ -172,7 +174,7 @@ def scaffold_audit(
     for sample in samples:
         sample.sandbox = _make_sandbox_spec(docker_image)
 
-    return Task(
+    return InspectTask(
         dataset=samples,
         solver=audit_solver(
             auditor=dish_auditor(

--- a/scripts/eval/sanitize_inspect_eval.py
+++ b/scripts/eval/sanitize_inspect_eval.py
@@ -49,6 +49,8 @@ def main() -> None:
     write_eval_log(public, args.destination)
 
     readback = read_eval_log(args.destination)
+    if not source.samples or not readback.samples:
+        raise ValueError("Inspect archive must contain at least one sample")
     assert readback.status == source.status
     assert readback.samples[0].scores == source.samples[0].scores
     print(json.dumps(stats, sort_keys=True))

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -536,7 +536,7 @@
     },
     "tests": {
       "python_files": 684,
-      "python_loc": 179553
+      "python_loc": 179551
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,12 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Infrastructure\n\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion."
+    "body": ""
   },
   {
     "version": "1.0.21",
     "date": "2026-08-11",
-    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
+    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
   },
   {
     "version": "1.0.20",

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Infrastructure\n\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion."
   },
   {
     "version": "1.0.21",

--- a/tests/core/cli/test_lifecycle_commands.py
+++ b/tests/core/cli/test_lifecycle_commands.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from core.cli.commands.lifecycle import (
+    SERVE_STARTUP_TIMEOUT_S,
     _clean_stale_artifacts,
     _cleanup_legacy_transcripts,
     _find_serve_pid,
@@ -179,14 +180,11 @@ class TestStop:
 
 class TestStartServe:
     def test_default_timeout_allows_twenty_second_boot(self, tmp_path: Path) -> None:
+        assert SERVE_STARTUP_TIMEOUT_S >= 20.0
         executable = str(tmp_path / "bin" / "geode")
         with (
             patch("core.cli.commands.lifecycle.subprocess.Popen") as popen,
             patch("core.cli.ipc_client.is_serve_running", return_value=True),
-            patch(
-                "core.cli.commands.lifecycle.time.monotonic",
-                side_effect=[0.0, 20.0],
-            ),
         ):
             assert _start_serve_background(executable=executable)
 


### PR DESCRIPTION
## Summary
- Promote the v1.0.21 stable-promotion repair from develop to main.
- Preserve the already stamped 1.0.21 version and empty Unreleased section.

## Why
The first release workflow found audit-dependent type errors before publishing any artifact. PR #2948 fixed the type contracts, aligned CI with release dependencies, and removed a parallel clock-test flake. PR #2949 finalized the still-unpublished 1.0.21 notes.

## Included
- PR #2948: release/audit type-check parity and deterministic startup-timeout test
- PR #2949: unpublished v1.0.21 changelog finalization

## Verification
- PR #2948 full CI green, including 595-module audit Type Check and 5m57s test suite
- PR #2949 full CI green, including 5m21s test suite
- v1.0.21 remains absent from tags, GitHub Releases, and PyPI before promotion