### PR TITLE
release: finalize v1.0.21 metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,6 @@ functional change.
 
 ## [Unreleased]
 
-### Infrastructure
-
-- **Core Metadata 2.5 release validation.** Raised the Twine floor to 7.0 so
-  stable releases validate current Hatchling-built wheels instead of failing
-  after the full release test suite.
-
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.
@@ -66,6 +60,9 @@ functional change.
 - **Release/type-check parity.** CI now type-checks with the audit extra used
   by stable releases, and the Petri scaffold utilities satisfy those installed
   Inspect/Petri type contracts instead of failing only during promotion.
+- **Core Metadata 2.5 release validation.** Raised the Twine floor to 7.0 so
+  stable releases validate current Hatchling-built wheels instead of failing
+  after the full release test suite.
 
 ### Fixed
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5995,7 +5995,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1503 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1502 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,12 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Infrastructure\n\n- **Core Metadata 2.5 release validation.** Raised the Twine floor to 7.0 so\n  stable releases validate current Hatchling-built wheels instead of failing\n  after the full release test suite."
+    "body": ""
   },
   {
     "version": "1.0.21",
     "date": "2026-08-11",
-    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
+    "body": "> Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.\n\n### Infrastructure\n\n- **Matched Petri Dish scaffold comparison.** Added a pinned Codex CLI / Hermes\n  ACP comparison task with a shared sandbox, model, seed, turn ceiling, and\n  judge rubric, plus an Inspect archive sanitizer that removes private\n  reasoning and host-home paths while preserving scores for public evidence.\n- **Release/type-check parity.** CI now type-checks with the audit extra used\n  by stable releases, and the Petri scaffold utilities satisfy those installed\n  Inspect/Petri type contracts instead of failing only during promotion.\n- **Core Metadata 2.5 release validation.** Raised the Twine floor to 7.0 so\n  stable releases validate current Hatchling-built wheels instead of failing\n  after the full release test suite.\n\n### Fixed\n\n- **Codex overload classification.** Generic SSE `APIError` overload responses\n  are now recorded as provider-server failures instead of unknown errors, so\n  retry hooks and operator diagnostics retain the real failure category.\n- **Isolated Claude CLI subscription authentication.** Petri audit subprocesses\n  no longer inherit a parent `ANTHROPIC_API_KEY`, so Claude CLI auditor and\n  judge roles consistently use the operator's Claude subscription login."
   },
   {
     "version": "1.0.20",


### PR DESCRIPTION
## Summary
- Move the Core Metadata 2.5 validator repair from `[Unreleased]` into the still-unpublished v1.0.21 release notes.
- Regenerate the public changelog index and `llms-full.txt` projection.

## Why
v1.0.21 has no tag, GitHub Release, or PyPI artifact. The Twine 7 repair is part of the release that will be retried, so leaving it under `[Unreleased]` would make the published release notes incomplete.

## Changes
| File | Change |
|---|---|
| `CHANGELOG.md` | Attribute the validator repair to v1.0.21. |
| `site/src/data/geode/changelog.ts` | Regenerate the public changelog projection. |
| `site/public/llms-full.txt` | Regenerate the public LLM index size marker. |

## Verification
- `npm run sync-stats`
- `npm ci`
- `npm run build` — 237 static pages
- `npm run export-md` — 74 markdown twins
- Generated public-doc files are clean after regeneration.
