### PR TITLE
ci: publish Core Metadata 2.5 artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
           name: geode-${{ inputs.version }}-release-artifacts
           path: release-artifacts
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         if: needs.stable-promotion-preflight.outputs.pypi-complete != 'true'
         with:
           packages-dir: release-artifacts/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action
+  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5
+  wheel already approved by the release build gate.
+
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5995,7 +5995,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1502 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1503 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Infrastructure\n\n- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action\n  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5\n  wheel already approved by the release build gate."
   },
   {
     "version": "1.0.21",


### PR DESCRIPTION
## Summary
- Update the pinned official PyPA publish action from v1.14.0 to v1.14.2.
- Preserve immutable-SHA pinning while enabling Core Metadata 2.5 uploads.
- Synchronize the public changelog projection.

## Why
The v1.0.21 release passed the complete build, test, runtime smoke, Twine 7 metadata, package-content, and clean-wheel gates. GitHub Release creation then succeeded, but the separately pinned PyPA action v1.14.0 rejected the same Metadata 2.5 wheel with its internal older Twine. PyPI remains unpublished. PyPA v1.14.2 explicitly upgrades its internal validator to Twine 7 for Metadata 2.5 uploads.

## GAP Audit
| Surface | Before | After |
|---|---|---|
| Build gate | Twine 7 accepts Metadata 2.5 | Unchanged |
| PyPI action | v1.14.0 internal validator rejects 2.5 | v1.14.2 internal Twine 7 accepts 2.5 |
| GitHub release | v1.0.21 published at immutable tag | Preserved |
| PyPI | 404 / no files | Retry remains fail-closed until protected workflow succeeds |

## Changes
| File | Change |
|---|---|
| `.github/workflows/release.yml` | Pin `pypa/gh-action-pypi-publish` v1.14.2 SHA. |
| `CHANGELOG.md` | Record the publishing compatibility repair under Unreleased. |
| Public changelog outputs | Regenerate index and llms-full projection. |

## Verification
- Official PyPA release: v1.14.2 explicitly adds Twine 7 and Metadata 2.5 upload support.
- Pulled exact action image `ghcr.io/pypa/gh-action-pypi-publish:dc37677...`.
- Container reports Twine 7.0.0.
- The exact container passed `twine check` for the GEODE v1.0.21 wheel and sdist.
- `yamllint --strict` passed for the workflow.
- Local site build passed: 237 pages; 74 markdown twins.
