### PR TITLE
ci: promote Metadata 2.5 PyPI publishing repair

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
           name: geode-${{ inputs.version }}-release-artifacts
           path: release-artifacts
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         if: needs.stable-promotion-preflight.outputs.pypi-complete != 'true'
         with:
           packages-dir: release-artifacts/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action
+  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5
+  wheel already approved by the release build gate.
+
 ## [1.0.21] - 2026-08-11
 
 > Reproducible GPT-5.6 effort diagnostics and matched Petri Dish scaffold evidence.

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -5995,7 +5995,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1502 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1503 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Infrastructure\n\n- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action\n  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5\n  wheel already approved by the release build gate."
   },
   {
     "version": "1.0.21",


### PR DESCRIPTION
## Summary
- Promote the official PyPA publish-action v1.14.2 pin to `main`.
- Preserve the existing immutable v1.0.21 tag and GitHub Release.

## Why
The v1.0.21 build, tests, runtime smoke, Twine 7 metadata check, package content gate, clean-wheel install, GitHub tag, and GitHub Release all succeeded. PyPI alone remains unpublished because the previously pinned official action v1.14.0 used an older internal validator. PyPA v1.14.2 explicitly ships Twine 7 for Core Metadata 2.5.

## GAP Audit
| Surface | State |
|---|---|
| v1.0.21 tag / GitHub Release | Published and immutable at the original release SHA |
| PyPI v1.0.21 | Not published (404) |
| New action container | Twine 7.0.0; exact GEODE wheel and sdist pass |
| Retry contract | Workflow can run from new main while checking out the exact existing v1.0.21 tag |

## Changes
| File | Change |
|---|---|
| `.github/workflows/release.yml` | Pin official PyPA v1.14.2 immutable SHA. |
| Changelog projections | Record the workflow repair under Unreleased. |

## Verification
- Exact new action container passed Metadata 2.5 validation for both artifacts.
- PR #2955: all 10 CI checks passed, including full tests, audit-aware mypy, Pages, security, and OS installs.
- PR #2956: canonical main-to-develop sync; all reported checks passed.
