### PR TITLE
feat(eval): GEODE-Codex 직접 비교 하네스 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Paired MCPMark Codex comparison.** Added a filesystem-only Codex CLI arm
+  that shares MCPMark's pinned task setup and official verifier with GEODE,
+  while isolating user configuration and preserving both native exec JSONL and
+  schema-validated trajectory sidecars for direct harness diagnostics on
+  ChatGPT subscription models. The setup manifest now installs GEODE into the
+  MCPMark venv so live runs cannot fail on missing runtime dependencies.
+
 ### Infrastructure
 
 - **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -284,8 +284,8 @@ machine-readable artifact is
 | Production Python files (`core/` + `plugins/`) | 546 |
 | Test Python files | 684 |
 | `core/` Python LOC | 139,141 |
-| `plugins/` Python LOC | 41,834 |
-| Test Python LOC | 179,551 |
+| `plugins/` Python LOC | 42,240 |
+| Test Python LOC | 179,689 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 8 |

--- a/docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md
+++ b/docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md
@@ -1,0 +1,132 @@
+# GPT-5.4 GEODE × Codex MCPMark filesystem/easy paired diagnostic
+
+## Identity
+
+| Field | Value |
+|---|---|
+| Run ID | `paired-full-20260812` |
+| Date | 2026-08-12 |
+| GEODE version | 1.0.21 plus feature-worktree adapter changes |
+| Execution base | `549875803fbb94ac8fd4339a12bbfcc880112265` |
+| Branch | `codex/tau2-gpt54-official-alignment` |
+| Worktree state | Dirty by design; the adapter implementation under test was not yet committed |
+
+The eventual feature commit must be recorded before external artifact
+publication. The raw run remains diagnostic until that commit and the artifact
+repository commit are both pinned.
+
+## Frozen comparison surface
+
+| Field | Value |
+|---|---|
+| Benchmark | MCPMark upstream `filesystem/easy`; not the MCPMark Verified standard suite |
+| Harness revision | `eval-sys/mcpmark@cd45b7f57923b9b3985467f5139927575f83141c` |
+| Tasks / trials | 10 / `k=1` |
+| Agent model | GPT-5.4 subscription, `high` effort |
+| Timeout | 1,200 seconds per task |
+| Codex | `codex-cli 0.145.0`, ephemeral, strict isolated config |
+| MCP server | `@modelcontextprotocol/server-filesystem@2025.12.18` |
+| State and verifier | Same upstream setup, fixture restore, and task verifier |
+| Order | Alternating GEODE-first and Codex-first by task |
+
+The Codex sandbox was read-only. Its task-local MCP server was the only mutation
+surface; shell, direct file edits, web, apps, skills, collaboration, goals, and
+other optional tool features were disabled. The GEODE arm exposed the same MCP
+tool schemas through its `AgenticLoop` and auto-approved only those tools.
+
+## Result
+
+| Metric | GEODE | Codex CLI |
+|---|---:|---:|
+| Passed | 9 | 9 |
+| Failed | 1 | 1 |
+| Accuracy | 90.0% | 90.0% |
+| Total agent time | 747.2s | 745.5s |
+| Mean task time | 74.7s | 74.5s |
+| Median task time | 57.0s | 45.8s |
+| MCP calls | 50 | 116 |
+| Input tokens | 447,376 | 1,518,869 |
+| Cached input tokens | 195,584 | 1,366,400 |
+| Output tokens | 25,157 | 25,477 |
+| Reasoning tokens exposed separately | n/a | 10,144 |
+
+| Task | GEODE | Time / calls | Codex | Time / calls |
+|---|---|---:|---|---:|
+| `file_context/file_splitting` | PASS | 267.5s / 9 | PASS | 132.2s / 9 |
+| `file_context/pattern_matching` | PASS | 79.1s / 5 | PASS | 61.6s / 4 |
+| `file_context/uppercase` | FAIL | 66.8s / 9 | FAIL | 70.2s / 11 |
+| `file_property/largest_rename` | PASS | 24.5s / 3 | PASS | 35.7s / 5 |
+| `file_property/txt_merging` | PASS | 72.6s / 4 | PASS | 46.6s / 5 |
+| `folder_structure/structure_analysis` | PASS | 39.1s / 4 | PASS | 245.8s / 55 |
+| `legal_document/file_reorganize` | PASS | 59.8s / 5 | PASS | 44.9s / 12 |
+| `papers/papers_counting` | PASS | 45.9s / 3 | PASS | 44.7s / 4 |
+| `student_database/duplicate_name` | PASS | 37.7s / 3 | PASS | 25.3s / 3 |
+| `student_database/recommender_name` | PASS | 54.2s / 5 | PASS | 38.6s / 8 |
+
+The sole failure is exactly paired. Both agents uppercased the requested files
+but appended an LF that was absent from each source file. The pinned easy
+verifier compares exact strings, so the output is correctly scored as failure.
+No retry was used to erase it.
+
+Codex's `structure_analysis` trajectory is the largest efficiency outlier: 53
+of its 55 MCP calls were `list_directory`, producing 763,210 input tokens and a
+245.8-second task. GEODE used the available tree operation and four MCP calls.
+GEODE's slowest task was instead `file_splitting` at 267.5 seconds. The nearly
+identical total time is therefore not evidence of identical scheduling quality.
+
+## Trajectory and protocol audit
+
+| Quality | GEODE | Codex CLI |
+|---|---:|---:|
+| Sidecars | 10 | 10 |
+| Scope-complete | 10 | 10 |
+| Replay-complete | 0 | 0 |
+| Canonical events | 180 | 306 |
+| Tool call/result pairs | 50/50 | 116/116 |
+| Orphan calls/results | 0/0 | 0/0 |
+| Forbidden mutation events | 0 | 0 |
+
+Native logs remain authoritative for tool bodies and verifier evidence. Public
+sidecars store digests, explicitly mark content omission, and retain unique
+`<task>/execution.log` digest references. A schema validator recomputed all 20
+integrity envelopes after the run.
+
+Local raw paths:
+
+```text
+artifacts/eval/harnesses/mcpmark/results-paired/paired-full-20260812/
+  geode-gpt-5-4-high__filesystem-easy/run-1/
+  codex-gpt-5-4-high__filesystem-easy/run-1/
+```
+
+These paths are ignored evidence, not public URLs. Raw JSONL, tool bodies,
+temporary fixture paths, and stderr must not be copied wholesale to the public
+artifact repository.
+
+## Interpretation and next gate
+
+- Direct claim allowed: on the same ten easy tasks, model, effort, state,
+  verifier, and trial, GEODE and Codex had identical pass/fail outcomes.
+- Claim not allowed: GEODE equals Codex generally, or either score is a current
+  MCPMark Verified leaderboard result.
+- The sample has no discordant pass/fail pair and only one trial. Repetition is
+  not justified for a score delta that is currently zero.
+- The next useful cross-harness lane is Terminal-Bench 2.1 only after GEODE has
+  a faithful terminal adapter. Until then its public same-model Codex/Terminus
+  result is directional context, not a GEODE score.
+
+## Verification executed
+
+```text
+15 MCPMark adapter unit tests passed
+ruff check and format check passed for touched adapter/trajectory tests
+mypy passed for touched benchmark modules
+10,411 non-live tests passed in the full repository gate
+20/20 trajectory schemas and integrity envelopes recomputed successfully
+10/10 sidecars per arm; zero orphan tool pairs; zero Codex protocol violations
+post-fix Codex subscription-environment gate passed 1/1 with ChatGPT login
+```
+
+External artifact promotion remains pending. It requires a committed GEODE
+implementation, reviewed replay-incomplete trajectory releases for each arm,
+an append-only `geode-eval-artifacts` PR, and exact remote digest read-back.

--- a/docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md
+++ b/docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md
@@ -10,10 +10,13 @@
 | Execution base | `549875803fbb94ac8fd4339a12bbfcc880112265` |
 | Branch | `codex/tau2-gpt54-official-alignment` |
 | Worktree state | Dirty by design; the adapter implementation under test was not yet committed |
+| Implementation commit | `85967a498451f493055cb94738410378d6eddbe9` |
+| Artifact commit | `9095f7f8b07bd93b41748ef89a32fc2540288d3e` |
 
-The eventual feature commit must be recorded before external artifact
-publication. The raw run remains diagnostic until that commit and the artifact
-repository commit are both pinned.
+The execution used the stated dirty feature worktree; commit `85967a498` pins
+the tested adapter content after the run. The reviewed public projection was
+merged separately at the artifact commit above. This provenance keeps the run
+diagnostic rather than pretending it executed from a clean release tag.
 
 ## Frozen comparison surface
 
@@ -103,6 +106,16 @@ These paths are ignored evidence, not public URLs. Raw JSONL, tool bodies,
 temporary fixture paths, and stderr must not be copied wholesale to the public
 artifact repository.
 
+Reviewed public releases:
+
+- [GEODE trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/9095f7f8b07bd93b41748ef89a32fc2540288d3e/trajectories/mcpmark-geode-gpt54-high-geode-codex-paired-filesystem-easy-20260812T060733Z-3ea7869be85a)
+  — manifest SHA-256 `3ea7869be85a2a058c204f7768c40e25b63cb5fcf2f10ae090aa01b701d33d53`
+- [Codex trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/9095f7f8b07bd93b41748ef89a32fc2540288d3e/trajectories/mcpmark-codex-gpt54-high-geode-codex-paired-filesystem-easy-20260812T060733Z-871a6c2ae92c)
+  — manifest SHA-256 `871a6c2ae92cc77c7d195cc1aa669b4afa017bfaadb76bedd1f727c5b96b2ff7`
+
+Both manifests were fetched again from artifact-repository `main` after merge
+and verified byte-for-byte against these independently retained anchors.
+
 ## Interpretation and next gate
 
 - Direct claim allowed: on the same ten easy tasks, model, effort, state,
@@ -127,6 +140,7 @@ mypy passed for touched benchmark modules
 post-fix Codex subscription-environment gate passed 1/1 with ChatGPT login
 ```
 
-External artifact promotion remains pending. It requires a committed GEODE
-implementation, reviewed replay-incomplete trajectory releases for each arm,
-an append-only `geode-eval-artifacts` PR, and exact remote digest read-back.
+External artifact promotion completed through
+[`geode-eval-artifacts#20`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/20).
+Only the two reviewed replay-incomplete trajectory releases and their run
+report were published; native logs remain local.

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -4,11 +4,47 @@
 
 Multi-turn tool-agent-user 시뮬레이션 벤치. 에이전트와 LLM 시뮬 유저가 공유 world state를 tool로 변경하며 대화. **pass^k의 발상지**.
 
-- **Repo**: [sierra-research/tau2-bench](https://github.com/sierra-research/tau2-bench) — 1.1k★
-- **마지막 commit**: 2026-05-05 (live submissions PR, 매주 갱신)
-- **라이센스**: MIT (`LICENSE`, grounded at harness revision `1901a30`)
-- **버전 히스토리**: v1 NeurIPS '24 → v² 2025 (telecom dual-control) → v0.2.0 2025-10-06 (web leaderboard) → v0.2.1 2025-11 (RL support). τ³(banking+voice)은 paper만, 코드 미공개
+- **Repo**: [sierra-research/tau2-bench](https://github.com/sierra-research/tau2-bench)
+- **현재 측정 핀**: `668d3bcd135c02aa3438f987ef45735b7c163ee3`, `tau2==1.0.1` (2026-08-12 확인)
+- **라이센스**: MIT (`LICENSE`)
+- **현재 공개 surface**: airline / retail / telecom / telecom-workflow / banking-knowledge와 text / voice runner. 과거 `1901a30`, `tau2==1.0.0` 기록은 해당 실행의 역사적 핀으로만 유지한다.
 - **Frontier 인용**: GPT-5.5 system card (**telecom 98.0%**), Anthropic 인용
+
+## 2026-08-12 OpenAI/Codex 기준 정렬
+
+공개 Codex 저장소 `dad1db87bb5ad4b92af6b0f58502d12453681f81`에는
+Tau2 runner, task manifest, prompt 또는 실행 설정이 없다. OpenAI가 공개한
+것은 GPT-5.4의 **research-environment model evaluation**이다. 따라서 아래
+수치는 Codex CLI 재현 설정이 아니라 `paper-reference` 비교군이다.
+
+| 공개 행 | 도메인 | effort | 점수 | 공개되지 않은 항목 |
+|---|---|---|---:|---|
+| OpenAI GPT-5.4 headline | Telecom | `xhigh` | 98.9% | harness/task revision, prompt, user simulator, trials, seed, limits, retry, timeout, concurrency |
+| OpenAI GPT-5.4 no-reasoning | Telecom | `none` | 64.3% | 위와 동일 |
+
+[OpenAI 발표](https://openai.com/index/introducing-gpt-5-4/)는 기본 평가를
+`xhigh`로 실행했다고 밝히고, 별도 no-reasoning 표에 `none` 결과를 싣는다.
+또한 production ChatGPT와 출력이 다를 수 있는 연구 환경임을 명시한다.
+
+재현 가능한 최신 GPT-5.4 공식 제출은 Sierra의 **다른 레인**이다.
+`tau2==1.0.1`, banking-knowledge 97개 전체, GPT-5.4 `xhigh`, native
+`user_simulator=gpt-5.2` / effort `low`, 4 trials, seed 300, AllTools,
+standard scaffold이며 pass^1은 39.43%다. Telecom/Codex 결과가 아니므로
+OpenAI 98.9%와 합치거나 대체하지 않는다. 원본은
+[Sierra submission](https://github.com/sierra-research/tau2-bench/blob/main/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json)과
+[submission guide](https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md)에 있다.
+
+GEODE 측정 계약과 실행 게이트는
+[`2026-08-12-gpt54-tau2-openai-reference-alignment.md`](../plans/2026-08-12-gpt54-tau2-openai-reference-alignment.md)에 고정한다.
+핵심 판정은 다음과 같다.
+
+- OpenAI 행과 GEODE 결과의 비교는 `paper-reference`, directional only다.
+- PAYG 없는 subscription 측정은 evaluator-owned `crucible_user`를 쓰며,
+  Sierra의 native GPT-5.2 user와는 별도 profile이다.
+- `none`과 `xhigh` GEODE arm은 user, task order, limits, seed를 동일하게
+  고정해 effort 효과만 측정한다.
+- 2026-08-03의 200/278 결과는 이전 harness와 `geode_user`를 쓴
+  longitudinal diagnostic이므로 새 결과와 직접 증감 비교하지 않는다.
 
 ## 사례
 

--- a/docs/plans/2026-08-12-gpt54-tau2-openai-reference-alignment.md
+++ b/docs/plans/2026-08-12-gpt54-tau2-openai-reference-alignment.md
@@ -1,0 +1,102 @@
+# GPT-5.4 Tau2 OpenAI reference alignment
+
+Status: source-grounded and no-model preflight complete; live execution pending
+explicit approval. Date: 2026-08-12.
+
+## 1. Decision
+
+There is no public "Codex Tau2 configuration" to reproduce. The current
+public Codex source has no Tau2 integration, and OpenAI publishes scores from
+an undisclosed research harness. GEODE will therefore keep three identities
+separate:
+
+| Identity | What is public | Claim class |
+|---|---|---|
+| OpenAI GPT-5.4 | Telecom 98.9% at `xhigh`; 64.3% at `none`; research environment | `paper-reference`, directional only |
+| Sierra GPT-5.4 submission | banking-knowledge 97 tasks x 4 trials; `xhigh`; GPT-5.2-low user; seed 300; AllTools; Tau2 1.0.1 | suite-official, different domain/profile |
+| GEODE GPT-5.4 | runtime, route, user, task pack, limits and evidence below | GEODE product-route measurement |
+
+Sources are the [OpenAI GPT-5.4 release](https://openai.com/index/introducing-gpt-5-4/),
+the [Sierra GPT-5.4 submission](https://github.com/sierra-research/tau2-bench/blob/main/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json),
+and the [Tau2 submission guide](https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md).
+
+## 2. Grounded revisions
+
+| Surface | Frozen evidence |
+|---|---|
+| Codex source audit | `openai/codex@dad1db87bb5ad4b92af6b0f58502d12453681f81`; zero Tau2 references |
+| Tau2 harness | `sierra-research/tau2-bench@668d3bcd135c02aa3438f987ef45735b7c163ee3`; `tau2==1.0.1` |
+| Harness preflight | `tau2 check-data` passed; telecom `base` contains 114 ordered tasks |
+| Ordered Telecom base IDs | canonical JSON SHA-256 `eed4303eea9aa5a9e12847e55ffa3083c5d010a375af1364fb24a6c6fa4b8377` |
+| GEODE effort surface | GPT-5.4 accepts `none`, `low`, `medium`, `high`, `xhigh`; adapter forwards the value to Responses `reasoning.effort` |
+
+The GEODE commit is frozen only after the feature/release workflow reaches the
+exact executable head. A moving branch name is not a measurement identity.
+
+## 3. GEODE measurement profile
+
+The first comparison is an effort ablation, not an attempted reproduction of
+OpenAI's hidden harness.
+
+| Field | Shared value |
+|---|---|
+| Domain / split | Telecom / `base`, all 114 tasks in pinned split order |
+| Agent | `geode_agent`, GPT-5.4, OpenAI subscription |
+| User | evaluator-owned `crucible_user`, GPT-5.4, OpenAI subscription, effort `low` |
+| Agent efforts | arm A `none`; arm B `xhigh` |
+| Trials / seed | one complete trial first; seed 300 |
+| Limits | `max_steps=200`, `max_errors=10`, `max_retries=3`, timeout 3600s |
+| Concurrency | 2, matching the last valid GEODE full-cycle operating profile |
+| Agent/user budgets | 600s / 180s; 32,768 / 8,192 tokens; unlimited inner rounds (`0`) |
+| Score authority | native Tau2 result and executable state/action checks |
+| Invalid attempts | auth, quota, transport exhaustion, harness fault and incomplete coverage excluded, never scored zero |
+| Evidence | native result, runtime profile, attempt manifest, normalized trajectory, verifier receipt, redaction and publication manifests |
+
+Why the user differs: the public OpenAI row does not identify its simulator.
+Tau2 recommends GPT-5.2 and Sierra used GPT-5.2-low, but GEODE cannot route
+GPT-5.2 through the current subscription account. Replacing it with an
+unrecorded model would be false parity. `crucible_user` keeps the evaluator
+outside the candidate mutation surface and makes the deviation explicit.
+
+The current upstream defaults `max_steps=200`, `max_errors=10`,
+`max_retries=3`, seed 300 and concurrency 3 are implementation defaults, not
+published OpenAI run settings. GEODE uses concurrency 2 as an operational
+quota control and records it as a deviation rather than presenting it as
+official.
+
+## 4. Execution gates
+
+1. Copy the existing comparison-manifest template once per arm; freeze the
+   exact GEODE commit, all 114 ordered IDs, hashes, limits and destinations.
+2. Diff the manifests. Only `run_id`, agent effort and arm-specific evidence
+   paths may differ.
+3. Run one fixed Telecom task on each arm. Stop on auth, empty-output,
+   unpaired-tool, state-reset or quota failure.
+4. Run all 114 tasks once per arm. Reject a partial or contaminated aggregate.
+5. Only after the paired one-trial run is valid, decide whether the cost of
+   four trials is justified for a suite-oriented estimate.
+6. Publish append-only to `geode-eval-artifacts`; pin its commit in the Tau2
+   ledger. Never merge the OpenAI, Sierra and GEODE rows into one headline.
+
+The one-trial run reports raw numerator/denominator, component rewards,
+termination, latency, token/tool usage, task-level paired flips and invalid
+attempts. It does not report `pass^4`, `mean_accuracy@8`, or a causal Codex
+scaffold effect.
+
+## 5. Comparability map
+
+```text
+OpenAI research score (hidden harness/user/tasks)
+        -> directional model reference only
+
+Sierra GPT-5.4 banking submission (public 97 x 4 contract)
+        -> reproducible suite reference, wrong domain for Telecom
+
+GEODE GPT-5.4 none <-> GEODE GPT-5.4 xhigh
+same current harness + tasks + evaluator-owned user + limits + seed
+        -> valid GEODE effort ablation
+```
+
+The next live action is the two-arm single-task smoke. It spends subscription
+quota and therefore remains outside this documentation-only change until the
+operator explicitly approves the live run.

--- a/docs/plans/2026-08-12-mcpmark-codex-paired-comparison.md
+++ b/docs/plans/2026-08-12-mcpmark-codex-paired-comparison.md
@@ -1,6 +1,6 @@
 # MCPMark filesystem/easy: GEODE × Codex paired comparison
 
-Date: 2026-08-12. Status: diagnostic complete.
+Date: 2026-08-12. Status: diagnostic and artifact publication complete.
 
 ## Decision
 
@@ -97,6 +97,11 @@ deliberately replay-incomplete because private prompt, reasoning, and tool bodie
 are represented by digests. The artifact audit caught and corrected two
 publication-contract defects before promotion: digested Codex bodies now count
 as reduced replay fidelity, and per-task native receipt references are unique.
+
+The reviewed releases were merged through
+[`geode-eval-artifacts#20`](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/20)
+at `9095f7f8b07bd93b41748ef89a32fc2540288d3e`. Remote `main` read-back matched
+the independently retained manifest anchors for both arms.
 
 ## Reproduction
 

--- a/docs/plans/2026-08-12-mcpmark-codex-paired-comparison.md
+++ b/docs/plans/2026-08-12-mcpmark-codex-paired-comparison.md
@@ -1,0 +1,139 @@
+# MCPMark filesystem/easy: GEODE × Codex paired comparison
+
+Date: 2026-08-12. Status: diagnostic complete.
+
+## Decision
+
+Use the current MCPMark repository's `filesystem/easy` suite as the first direct GEODE–Codex
+comparison. Both arms use the same pinned upstream checkout, task fixture,
+MCP server, task order, timeout, GPT-5.4 subscription route, `high` effort,
+and official verifier. Only the agent harness changes.
+
+This is not the 127-task MCPMark Verified standard suite and is not eligible
+for its public leaderboard. “Official verifier” below means the verifier shipped
+with each pinned easy task, not a Verified leaderboard submission.
+
+Terminal-Bench 2.1 remains the stronger public scaffold leaderboard, but it is
+not this experiment: GEODE has no Terminal-Bench adapter and a full verified
+Codex run is materially more expensive. Tau2 remains the stateful-dialogue
+lane; no public Codex Tau2 configuration is available to reproduce directly.
+
+## Comparison contract
+
+| Axis | GEODE arm | Codex arm |
+|---|---|---|
+| Harness | MCPMark `cd45b7f` | same |
+| Suite | `filesystem/easy`, 10 tasks | same |
+| Model | GPT-5.4 subscription | same |
+| Effort | `high` | `high` |
+| State + verifier | upstream MCPMark | same |
+| MCP server | pinned upstream filesystem server | same |
+| Agent loop | GEODE `AgenticLoop` | `codex exec` 0.145.0 |
+| Native mutation path | MCP tools | MCP tools only; read-only Codex sandbox |
+| Repetition | `k=1` diagnostic | same |
+
+The result is a direct **harness comparison**, not a model leaderboard result.
+The Codex arm intentionally ignores the operator's Codex config and exec-policy
+rules, uses an empty temporary working directory, disables session persistence,
+and injects only the per-task MCP server. The isolated server's tools are
+pre-approved because non-interactive Codex otherwise cancels mutating MCP calls;
+the sandbox remains read-only and non-MCP tool features are disabled. Automatic
+skill/app/collaboration instructions are also disabled. This removes global
+connectors, project rules, writable shell access, and unrelated tool schemas
+from the model-facing comparison surface.
+
+`turn_count` is not a cross-harness metric: MCPMark receives GEODE loop rounds,
+whereas `codex exec` exposes one outer turn for the whole task. Compare verifier
+pass, MCP calls, aggregate tokens, wall time, and failure class instead.
+
+## Gates
+
+1. Unit gate: command construction, JSONL parsing, model label, registration.
+2. Config gate: `codex exec --strict-config` accepts the isolated MCP config.
+3. One-task gate: run the same fixed easy task once in both arms.
+4. Stop conditions: quota/auth failure, state setup failure, non-MCP mutation,
+   malformed JSONL, missing official verifier receipt, or unequal task identity.
+5. Full diagnostic: only after gate 3 passes, run all 10 easy tasks once per arm.
+
+The 10-task run is diagnostic, not publication-grade. Task execution order was
+counterbalanced by alternating which arm ran first. Repeated trials are deferred
+because the first trial produced no pass/fail discordance.
+
+## Result
+
+Both arms scored **9/10 (90%)** and failed the same task. There is therefore no
+observed pass-rate advantage for either harness in this sample.
+
+| Metric | GEODE | Codex CLI |
+|---|---:|---:|
+| Passed | 9/10 | 9/10 |
+| Agent wall time | 747.2s | 745.5s |
+| Median task time | 57.0s | 45.8s |
+| MCP calls | 50 | 116 |
+| Input tokens, native counter | 447,376 | 1,518,869 |
+| Cached input tokens | 195,584 | 1,366,400 |
+| Output tokens | 25,157 | 25,477 |
+| Canonical events | 180 | 306 |
+| Exact tool pairs | 50/50 | 116/116 |
+| Protocol violations | 0 | 0 |
+
+The input counters are native adapter measurements and do not have proven
+cross-product billing equivalence. GEODE rounds and Codex outer turns are also
+not comparable. Wall time is comparable at the task boundary.
+
+The shared failure was `file_context/uppercase`. Both agents wrote all five
+uppercase files with one extra trailing LF; the source files ended in `.` and
+the pinned easy verifier requires exact content equality. This is shared action
+behavior, not evidence of a GEODE-only regression.
+
+The aggregate wall-time tie hides different tails. GEODE spent 267.5s on
+`file_splitting`; Codex spent 245.8s and 55 MCP calls on `structure_analysis`,
+including 53 `list_directory` calls, where GEODE used four calls and completed
+in 39.1s. A larger repeated study should report tail behavior and call economy,
+not only pass rate.
+
+All 20 normalized trajectories are schema-valid and scope-complete. They are
+deliberately replay-incomplete because private prompt, reasoning, and tool bodies
+are represented by digests. The artifact audit caught and corrected two
+publication-contract defects before promotion: digested Codex bodies now count
+as reduced replay fidelity, and per-task native receipt references are unique.
+
+## Reproduction
+
+Run from the pinned MCPMark checkout with GEODE on `PYTHONPATH`. MCPMark's model
+loader requires an `OPENAI_API_KEY` value even though both adapters use ChatGPT
+subscription auth; `dummy` satisfies only that upstream preflight and is never
+sent to a model provider.
+
+```bash
+cd artifacts/eval/harnesses/mcpmark
+export PYTHONPATH=/absolute/path/to/geode
+
+OPENAI_API_KEY=dummy .venv/bin/python \
+  -m plugins.benchmark_harness.run_mcpmark \
+  --mcp filesystem --task-suite easy --tasks file_context/uppercase \
+  --models geode-gpt-5.4 --agent geode --reasoning-effort high \
+  --k 1 --timeout 1200 --exp-name paired-smoke-geode \
+  --output-dir ./results-paired
+
+OPENAI_API_KEY=dummy .venv/bin/python \
+  -m plugins.benchmark_harness.run_mcpmark \
+  --mcp filesystem --task-suite easy --tasks file_context/uppercase \
+  --models codex-gpt-5.4 --agent codex --reasoning-effort high \
+  --k 1 --timeout 1200 --exp-name paired-smoke-codex \
+  --output-dir ./results-paired
+```
+
+For the 10-task diagnostic, change `--tasks` to `all` while retaining every
+other field. The detailed run record is
+[`docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md`](../eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md).
+
+## External context, not merged into the score
+
+- Terminal-Bench 2.1 reports GPT-5.4 at 77.3% with Codex CLI and 54.8% with
+  Terminus 2 under the same task suite, showing that scaffold choice can move
+  results materially: <https://www.tbench.ai/news/terminal-bench-2-1>
+- MCPMark Verified defines the current isolated, verifier-backed task contract:
+  <https://github.com/eval-sys/mcpmark>
+- Codex non-interactive JSONL and subscription authentication are documented in
+  the Codex CLI manual: <https://developers.openai.com/codex/noninteractive>

--- a/plugins/benchmark_harness/README.md
+++ b/plugins/benchmark_harness/README.md
@@ -6,8 +6,9 @@ benchmark repositories remain ignored local checkouts under
 
 It covers:
 
-- `mcpmark`: upstream `eval-sys/mcpmark` pinned by commit, with a GEODE
-  `BaseMCPAgent` adapter in `mcpmark_geode_agent.py`.
+- `mcpmark`: upstream `eval-sys/mcpmark` pinned by commit, with GEODE and
+  filesystem-only Codex CLI `BaseMCPAgent` adapters in
+  `mcpmark_geode_agent.py`.
 - `tau2-bench`: upstream `sierra-research/tau2-bench` pinned by commit, with
   the GEODE participant adapter in `tau2_geode_agent.py`.
 
@@ -29,7 +30,7 @@ python -m plugins.benchmark_harness.cli healthcheck tau2-bench
 instead of executing them. This keeps the public plugin side-effect free; live
 benchmark sessions can run the emitted commands explicitly.
 
-For MCPMark, register the GEODE agent inside an upstream checkout before
+For MCPMark, register both comparison agents inside an upstream checkout before
 running `pipeline.py`:
 
 ```python
@@ -38,3 +39,8 @@ from src.agents import AGENT_REGISTRY
 
 register_mcpmark_agent(AGENT_REGISTRY)
 ```
+
+Use `--agent geode --models geode-gpt-5.4` for GEODE or
+`--agent codex --models codex-gpt-5.4` for the isolated Codex CLI arm. The Codex
+adapter currently accepts only `--mcp filesystem`; other services remain out of
+scope until this paired diagnostic shows a real need.

--- a/plugins/benchmark_harness/benchmark_harness.plugin.toml
+++ b/plugins/benchmark_harness/benchmark_harness.plugin.toml
@@ -16,6 +16,7 @@ install = [
   "python3.12 -m venv .venv",
   ".venv/bin/python -m pip install --upgrade pip",
   ".venv/bin/pip install -e .",
+  ".venv/bin/pip install -e ../../../..",
 ]
 public_adapter = "plugins.benchmark_harness.mcpmark_geode_agent"
 required_env = []

--- a/plugins/benchmark_harness/mcpmark_geode_agent.py
+++ b/plugins/benchmark_harness/mcpmark_geode_agent.py
@@ -1,4 +1,4 @@
-"""GEODE adapter for MCPMark.
+"""GEODE and Codex CLI adapters for MCPMark.
 
 This module is public-safe and can be imported from an upstream MCPMark checkout.
 It intentionally depends on MCPMark only at runtime so GEODE can ship the adapter
@@ -13,18 +13,108 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.agent.loop.models import is_successful_task_termination
 
-from plugins.benchmark_harness.trajectory_artifacts import export_mcpmark_trajectory
+from plugins.benchmark_harness.trajectory_artifacts import (
+    export_codex_mcpmark_trajectory,
+    export_mcpmark_trajectory,
+)
 
 if TYPE_CHECKING:
     from core.hooks.middleware import ToolCallRequest
 
 log = logging.getLogger(__name__)
+
+_CODEX_DISABLED_FEATURES = (
+    "apps",
+    "browser_use",
+    "computer_use",
+    "goals",
+    "image_generation",
+    "multi_agent",
+    "shell_tool",
+    "skill_search",
+    "unified_exec",
+    "workspace_dependencies",
+)
+
+
+def _codex_mcp_config(command: str, args: list[str], timeout: int) -> str:
+    """Build the inline TOML accepted by ``codex exec -c``."""
+    return (
+        "{command="
+        f"{json.dumps(command)},args={json.dumps(args)},"
+        f"startup_timeout_sec=120,tool_timeout_sec={timeout},"
+        'required=true,default_tools_approval_mode="approve"'
+        "}"
+    )
+
+
+def _summarize_codex_exec(stdout: str) -> dict[str, Any]:
+    """Reduce the stable ``codex exec --json`` stream for MCPMark reporting."""
+    summary: dict[str, Any] = {
+        "thread_id": "",
+        "output": "",
+        "turn_count": 0,
+        "mcp_tool_calls": 0,
+        "token_usage": {
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 0,
+            "reasoning_tokens": 0,
+            "total_tokens": 0,
+        },
+        "error": "",
+    }
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            summary["thread_id"] = str(event.get("thread_id") or "")
+        elif event_type == "item.completed":
+            item = event.get("item") or {}
+            if item.get("type") == "agent_message":
+                summary["output"] = str(item.get("text") or "")
+            elif item.get("type") == "mcp_tool_call":
+                summary["mcp_tool_calls"] += 1
+        elif event_type == "turn.completed":
+            summary["turn_count"] += 1
+            usage = event.get("usage") or {}
+            tokens = summary["token_usage"]
+            for source, target in (
+                ("input_tokens", "input_tokens"),
+                ("cached_input_tokens", "cached_input_tokens"),
+                ("cache_write_input_tokens", "cache_write_input_tokens"),
+                ("output_tokens", "output_tokens"),
+                ("reasoning_output_tokens", "reasoning_tokens"),
+            ):
+                tokens[target] += int(usage.get(source) or 0)
+            tokens["total_tokens"] = tokens["input_tokens"] + tokens["output_tokens"]
+        elif event_type == "turn.failed":
+            summary["error"] = str((event.get("error") or {}).get("message") or "turn failed")
+        elif event_type == "error":
+            summary["error"] = str(event.get("message") or "codex exec failed")
+    return summary
+
+
+def _codex_model(label: str) -> str:
+    return label.removeprefix("codex-").removeprefix("openai/")
+
+
+def _codex_subscription_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in ("CODEX_ACCESS_TOKEN", "CODEX_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        env.pop(name, None)
+    return env
 
 
 def _jsonish(value: Any) -> str:
@@ -401,6 +491,143 @@ class GeodeMCPMarkAgent(BaseMCPAgent):
             }
 
 
+class CodexMCPMarkAgent(BaseMCPAgent):
+    """Filesystem MCPMark adapter backed by ``codex exec`` subscription auth."""
+
+    async def execute(
+        self, instruction: str, tool_call_log_file: str | None = None
+    ) -> dict[str, Any]:
+        start_time = time.time()
+        self._reset_progress()
+        self._refresh_service_config()
+        model = _codex_model(self.litellm_input_model_name)
+        if self.mcp_service != "filesystem":
+            raise ValueError("Codex MCPMark comparison currently supports filesystem only")
+
+        server = self._create_stdio_server()
+        params = server.params
+        mcp_config = _codex_mcp_config(params.command, list(params.args), int(self.timeout))
+        effort = str(self.reasoning_effort or "default")
+        prompt = (
+            "Mode: MCPMark benchmark.\n"
+            "Action surface: mcpmark MCP tools only.\n"
+            "Forbidden: shell commands, direct filesystem APIs, patches, web tools, "
+            "and delegation.\n"
+            "Completion: mutate the MCP-backed fixture exactly as requested, then "
+            "report briefly.\n\n"
+            f"Task:\n{instruction}"
+        )
+
+        with tempfile.TemporaryDirectory(prefix="geode-mcpmark-codex-") as runner_dir:
+            command = [
+                "codex",
+                "exec",
+                "--json",
+                "--ephemeral",
+                "--ignore-user-config",
+                "--ignore-rules",
+                "--strict-config",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "read-only",
+                "--cd",
+                runner_dir,
+                "--model",
+                model,
+                "-c",
+                f"model_reasoning_effort={json.dumps(effort)}",
+                "-c",
+                'approval_policy="never"',
+                "-c",
+                "skills.include_instructions=false",
+                "-c",
+                "skills.bundled.enabled=false",
+                "-c",
+                "include_apps_instructions=false",
+                "-c",
+                "include_collaboration_mode_instructions=false",
+                "-c",
+                "tools.web_search=false",
+                "-c",
+                f"mcp_servers.mcpmark={mcp_config}",
+            ]
+            for feature in _CODEX_DISABLED_FEATURES:
+                command.extend(("--disable", feature))
+            command.append("-")
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                env=_codex_subscription_environment(),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    process.communicate(prompt.encode("utf-8")), timeout=float(self.timeout)
+                )
+            except TimeoutError as exc:
+                process.kill()
+                await process.communicate()
+                raise TimeoutError(
+                    f"codex exec exceeded MCPMark timeout ({self.timeout}s)"
+                ) from exc
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        if tool_call_log_file:
+            log_path = Path(tool_call_log_file)
+            log_path.write_text(stdout, encoding="utf-8")
+            if stderr:
+                log_path.with_suffix(".stderr.log").write_text(stderr, encoding="utf-8")
+
+        summary = _summarize_codex_exec(stdout)
+        execution_time = time.time() - start_time
+        error = summary["error"]
+        if process.returncode and not error:
+            error = stderr.strip() or f"codex exec exited {process.returncode}"
+        task_success = process.returncode == 0 and not error and summary["turn_count"] > 0
+        if tool_call_log_file:
+            try:
+                trajectory_path = export_codex_mcpmark_trajectory(
+                    exec_log_path=Path(tool_call_log_file),
+                    instruction=instruction,
+                    model=model,
+                    effort=effort,
+                )
+                trajectory_status = "written"
+                trajectory_error = None
+            except Exception as exc:
+                log.warning("Codex MCPMark trajectory sidecar export failed: %s", exc)
+                trajectory_path = None
+                trajectory_status = "failed"
+                trajectory_error = str(exc)
+        else:
+            trajectory_path = None
+            trajectory_status = "not_requested"
+            trajectory_error = None
+        self.usage_tracker.update(
+            success=task_success,
+            token_usage=summary["token_usage"],
+            turn_count=summary["turn_count"],
+            execution_time=execution_time,
+        )
+        return {
+            "success": task_success,
+            "output": summary["output"] or "Task completed",
+            "token_usage": summary["token_usage"],
+            "turn_count": summary["turn_count"],
+            "execution_time": execution_time,
+            "litellm_run_model_name": f"codex/{model}",
+            "codex_thread_id": summary["thread_id"],
+            "mcp_tool_calls": summary["mcp_tool_calls"],
+            "geode_trajectory": str(trajectory_path) if trajectory_path else None,
+            "geode_trajectory_status": trajectory_status,
+            "geode_trajectory_error": trajectory_error,
+            "error": error or None,
+        }
+
+
 def register_mcpmark_agent(registry: dict[str, Any]) -> None:
     _patch_mcpmark_github_visibility()
     registry["geode"] = GeodeMCPMarkAgent
+    registry["codex"] = CodexMCPMarkAgent

--- a/plugins/benchmark_harness/trajectory_artifacts.py
+++ b/plugins/benchmark_harness/trajectory_artifacts.py
@@ -306,9 +306,187 @@ def export_mcpmark_trajectory(
     return export_trajectory(trajectory_path, trajectory)
 
 
+def export_codex_mcpmark_trajectory(
+    *,
+    exec_log_path: Path,
+    instruction: str,
+    model: str,
+    effort: str,
+) -> Path:
+    """Project ``codex exec --json`` onto the shared immutable trajectory schema."""
+    from core.observability.trajectory import build_trajectory, export_trajectory
+
+    rows = [json.loads(line) for line in exec_log_path.read_text(encoding="utf-8").splitlines()]
+    thread_id = next(
+        (str(row.get("thread_id") or "") for row in rows if row.get("type") == "thread.started"),
+        "",
+    )
+    turn_id = "turn-1"
+    events: list[dict[str, Any]] = []
+
+    def digest(value: Any) -> dict[str, Any]:
+        encoded = json.dumps(
+            value, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str
+        ).encode("utf-8")
+        return {
+            "_omitted_payload_sha256": hashlib.sha256(encoded).hexdigest(),
+            "_omitted_payload_bytes": len(encoded),
+            "_content_omitted": ["native_value"],
+        }
+
+    events.append(
+        {
+            "kind": "user_message",
+            "actor": "user",
+            "turn_id": turn_id,
+            "payload": {"content": digest(instruction)},
+        }
+    )
+    protocol_violations = 0
+    turn_completed = False
+    failure = ""
+    for row in rows:
+        event_type = row.get("type")
+        if event_type == "item.completed":
+            item = row.get("item") or {}
+            item_type = str(item.get("type") or "")
+            call_id = str(item.get("id") or "")
+            if item_type == "mcp_tool_call":
+                tool = str(item.get("tool") or "")
+                events.extend(
+                    (
+                        {
+                            "kind": "tool_call",
+                            "actor": "assistant",
+                            "turn_id": turn_id,
+                            "call_id": call_id,
+                            "payload": {
+                                "server": item.get("server"),
+                                "tool": tool,
+                                "arguments": digest(item.get("arguments")),
+                            },
+                        },
+                        {
+                            "kind": "tool_result",
+                            "actor": "tool",
+                            "turn_id": turn_id,
+                            "call_id": call_id,
+                            "payload": {
+                                "tool": tool,
+                                "status": item.get("status"),
+                                "result": digest(item.get("result")),
+                                "error": digest(item.get("error")),
+                            },
+                        },
+                    )
+                )
+            elif item_type == "agent_message":
+                events.append(
+                    {
+                        "kind": "assistant_message",
+                        "actor": "assistant",
+                        "turn_id": turn_id,
+                        "payload": {"content": digest(item.get("text"))},
+                    }
+                )
+            elif item_type == "reasoning":
+                events.append(
+                    {
+                        "kind": "reasoning.summary",
+                        "actor": "assistant",
+                        "turn_id": turn_id,
+                        "payload": {"content": digest(item.get("text"))},
+                    }
+                )
+            elif item_type in {"command_execution", "file_change", "collab_tool_call"}:
+                protocol_violations += 1
+                events.append(
+                    {
+                        "kind": "benchmark.protocol_violation",
+                        "actor": "assistant",
+                        "turn_id": turn_id,
+                        "call_id": call_id,
+                        "payload": {"item_type": item_type, "item": digest(item)},
+                    }
+                )
+        elif event_type == "turn.completed":
+            turn_completed = True
+            events.append(
+                {
+                    "kind": "turn.completed",
+                    "actor": "system",
+                    "turn_id": turn_id,
+                    "payload": {"usage": row.get("usage") or {}},
+                }
+            )
+        elif event_type in {"turn.failed", "error"}:
+            error = row.get("error") if event_type == "turn.failed" else row
+            failure = str((error or {}).get("message") or event_type)
+            events.append(
+                {
+                    "kind": "turn.failed",
+                    "actor": "system",
+                    "turn_id": turn_id,
+                    "payload": {"error": digest(error)},
+                }
+            )
+
+    raw_sha256 = hashlib.sha256(exec_log_path.read_bytes()).hexdigest()
+    trajectory = build_trajectory(
+        trajectory_id=f"mcpmark-codex-{thread_id or raw_sha256[:16]}",
+        source={
+            "harness": "mcpmark",
+            "run": thread_id or raw_sha256[:16],
+            "session": thread_id or "ephemeral-codex-exec",
+            "task": hashlib.sha256(instruction.encode("utf-8")).hexdigest(),
+            "parents": [],
+        },
+        events=events,
+        outcome={
+            "success": turn_completed and not failure and protocol_violations == 0,
+            "failure": failure,
+            "protocol_violations": protocol_violations,
+        },
+        provenance={
+            "adapter": "plugins.benchmark_harness.trajectory_artifacts",
+            "model": model,
+            "provider": "codex-cli",
+            "source": "subscription",
+            "effort": effort,
+            "native_schema": "codex exec JSONL",
+        },
+        privacy={
+            "review_state": "local",
+            "native_results_embedded": False,
+            "payloads": "prompt, reasoning, tool bodies, and responses replaced by SHA-256 digests",
+        },
+        integrity={
+            "scope_complete": True,
+            "replay_complete": False,
+            "replay_incompleteness": [
+                "codex exec JSONL omits per-event timestamps and internal model-call boundaries"
+            ],
+        },
+        evidence_refs=[
+            {
+                "kind": "native_receipt",
+                "schema_id": "codex.exec.jsonl@native",
+                "reference": raw_sha256,
+                "authority": "Codex exec JSONL event stream",
+            }
+        ],
+        artifact_digests=_existing_digests((exec_log_path,)),
+        trajectory_class=("benchmark", "dialogue", "tool"),
+    )
+    return export_trajectory(exec_log_path.with_name("execution.trajectory.json"), trajectory)
+
+
 def _existing_digests(paths: Sequence[Path]) -> list[dict[str, str]]:
     return [
-        {"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+        {
+            "path": f"{path.parent.name}/{path.name}",
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
         for path in paths
         if path.is_file()
     ]
@@ -322,6 +500,7 @@ def _slug(value: str) -> str:
 
 __all__ = [
     "close_benchmark_session",
+    "export_codex_mcpmark_trajectory",
     "export_mcpmark_trajectory",
     "export_tau2_trajectory",
     "geode_session_trace",

--- a/plugins/crucible/producers/context_graph.json
+++ b/plugins/crucible/producers/context_graph.json
@@ -50,7 +50,7 @@
         "benchmark",
         "trajectory"
       ],
-      "contentSha256": "103a272dcfef4ee7b858a7bb86635ef32846a5a6bb6abe293e180f5ea686f1cc"
+      "contentSha256": "6121e6f07e1e55ed0646e63ce6e21b3ecc17cae229cdbd86b112cf2891f40cf5"
     },
     {
       "id": "file:plugins/benchmark_harness/tau2_turn_supervisor.py",

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -532,11 +532,11 @@
     },
     "plugins": {
       "python_files": 111,
-      "python_loc": 41834
+      "python_loc": 42240
     },
     "tests": {
       "python_files": 684,
-      "python_loc": 179551
+      "python_loc": 179689
     }
   },
   "schema_version": 1,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Infrastructure\n\n- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action\n  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5\n  wheel already approved by the release build gate."
+    "body": "### Added\n\n- **Paired MCPMark Codex comparison.** Added a filesystem-only Codex CLI arm\n  that shares MCPMark's pinned task setup and official verifier with GEODE,\n  while isolating user configuration and preserving both native exec JSONL and\n  schema-validated trajectory sidecars for direct harness diagnostics on\n  ChatGPT subscription models. The setup manifest now installs GEODE into the\n  MCPMark venv so live runs cannot fail on missing runtime dependencies.\n\n### Infrastructure\n\n- **PyPI Core Metadata 2.5 publishing.** Updated the pinned PyPA publish action\n  to v1.14.2 so its internal Twine 7 validator accepts the same Metadata 2.5\n  wheel already approved by the release build gate."
   },
   {
     "version": "1.0.21",

--- a/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
+++ b/tests/plugins/benchmark_harness/test_mcpmark_adapter.py
@@ -5,15 +5,23 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from plugins.benchmark_harness.mcpmark_geode_agent import (
+    _CODEX_DISABLED_FEATURES,
     MCPMarkGeodeTool,
     _build_loop,
+    _codex_mcp_config,
+    _codex_model,
+    _codex_subscription_environment,
     _github_repo_visibility,
     _normalize_tool_arguments,
     _patch_mcpmark_github_visibility,
     _route_from_model,
+    _summarize_codex_exec,
     register_mcpmark_agent,
 )
-from plugins.benchmark_harness.trajectory_artifacts import export_mcpmark_trajectory
+from plugins.benchmark_harness.trajectory_artifacts import (
+    export_codex_mcpmark_trajectory,
+    export_mcpmark_trajectory,
+)
 
 
 def test_mcpmark_loop_validates_colliding_tool_with_mcp_schema() -> None:
@@ -88,7 +96,137 @@ def test_route_from_geode_model_label() -> None:
 def test_register_mcpmark_agent() -> None:
     registry: dict[str, object] = {}
     register_mcpmark_agent(registry)
-    assert "geode" in registry
+    assert set(registry) == {"codex", "geode"}
+
+
+def test_codex_mcpmark_command_contract() -> None:
+    config = _codex_mcp_config("npx", ["-y", "server", "fixture"], 300)
+
+    assert config == (
+        '{command="npx",args=["-y", "server", "fixture"],'
+        "startup_timeout_sec=120,tool_timeout_sec=300,required=true,"
+        'default_tools_approval_mode="approve"}'
+    )
+    assert _codex_model("codex-gpt-5.4") == "gpt-5.4"
+    assert _codex_model("openai/gpt-5.4") == "gpt-5.4"
+    assert {"apps", "multi_agent", "shell_tool", "unified_exec"} <= set(_CODEX_DISABLED_FEATURES)
+
+
+def test_codex_subscription_environment_drops_api_overrides(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "access-token")
+    monkeypatch.setenv("CODEX_API_KEY", "api-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "upstream-placeholder")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.invalid")
+    monkeypatch.setenv("CODEX_HOME", "/kept/login-home")
+
+    env = _codex_subscription_environment()
+
+    assert "CODEX_ACCESS_TOKEN" not in env
+    assert "CODEX_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "OPENAI_BASE_URL" not in env
+    assert env["CODEX_HOME"] == "/kept/login-home"
+
+
+def test_summarize_codex_exec_keeps_usage_tools_and_failure() -> None:
+    events = [
+        {"type": "thread.started", "thread_id": "thread-1"},
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "item-1",
+                "type": "mcp_tool_call",
+                "server": "mcpmark",
+                "tool": "write_file",
+                "status": "completed",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {"id": "item-2", "type": "agent_message", "text": "done"},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 40,
+                "cache_write_input_tokens": 5,
+                "output_tokens": 20,
+                "reasoning_output_tokens": 8,
+            },
+        },
+    ]
+    summary = _summarize_codex_exec("\n".join(json.dumps(event) for event in events))
+
+    assert summary == {
+        "thread_id": "thread-1",
+        "output": "done",
+        "turn_count": 1,
+        "mcp_tool_calls": 1,
+        "token_usage": {
+            "input_tokens": 100,
+            "cached_input_tokens": 40,
+            "cache_write_input_tokens": 5,
+            "output_tokens": 20,
+            "reasoning_tokens": 8,
+            "total_tokens": 120,
+        },
+        "error": "",
+    }
+
+    failed = _summarize_codex_exec(
+        json.dumps({"type": "turn.failed", "error": {"message": "quota"}})
+    )
+    assert failed["error"] == "quota"
+
+
+def test_codex_mcpmark_export_uses_shared_trajectory_schema(tmp_path) -> None:
+    log_path = tmp_path / "execution.log"
+    rows = [
+        {"type": "thread.started", "thread_id": "thread-1"},
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "call-1",
+                "type": "mcp_tool_call",
+                "server": "mcpmark",
+                "tool": "write_file",
+                "arguments": {"path": "private/file.txt", "content": "private"},
+                "result": {"content": [{"type": "text", "text": "wrote private/file.txt"}]},
+                "error": None,
+                "status": "completed",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {"id": "message-1", "type": "agent_message", "text": "private done"},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        },
+    ]
+    log_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    exported = export_codex_mcpmark_trajectory(
+        exec_log_path=log_path,
+        instruction="private benchmark task",
+        model="gpt-5.4",
+        effort="high",
+    )
+    artifact = json.loads(exported.read_text(encoding="utf-8"))
+
+    assert artifact["schema_id"] == "geode.trajectory@1"
+    assert artifact["source"]["session"] == "thread-1"
+    assert artifact["integrity"]["quality"]["tool_pairing"]["paired"] == 1
+    assert artifact["integrity"]["quality"]["replay_fidelity"] == "reduced"
+    assert artifact["integrity"]["quality"]["payload_issue_events"] == 4
+    assert artifact["outcome"]["protocol_violations"] == 0
+    assert artifact["artifact_digests"][0]["path"] == f"{tmp_path.name}/execution.log"
+    serialized = json.dumps(artifact)
+    assert "private benchmark task" not in serialized
+    assert "private/file.txt" not in serialized
+    assert "private done" not in serialized
 
 
 def test_github_repo_visibility_defaults_private(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- 같은 GPT-5.4 subscription, effort, MCPMark fixture와 verifier에서 GEODE `AgenticLoop`와 Codex CLI만 교체하는 직접 비교 arm을 추가했습니다.
- OpenAI 공식 GPT-5.4 Tau2 설정을 GEODE 재현 계약과 분리해 기록하고, MCPMark filesystem/easy 10-task paired diagnostic을 실제 실행해 양쪽 9/10을 보존했습니다.
- Codex native JSONL을 `geode.trajectory@1`로 투영하되 private body는 digest 처리하고, scope/replay fidelity와 per-task receipt identity를 기계 검증합니다.

## Why

외부 leaderboard 숫자는 모델, user simulator, task split, harness revision이 섞여 GEODE 런타임 효과를 분리하지 못했습니다. 같은 모델·state·verifier·task에서 agent harness만 바꾸는 paired control이 필요했고, 결과뿐 아니라 tool trajectory와 프로토콜 위반을 동일 schema로 비교할 데이터 계약도 없었습니다.

## Changes

| File | Change |
|---|---|
| `plugins/benchmark_harness/mcpmark_geode_agent.py` | filesystem-only Codex CLI adapter, isolated strict config, ChatGPT-only auth environment, timeout/usage/native JSONL 수집 |
| `plugins/benchmark_harness/trajectory_artifacts.py` | Codex JSONL → canonical trajectory 투영, digest privacy, tool pairing, protocol-violation 기록, unique receipt refs |
| `plugins/benchmark_harness/benchmark_harness.plugin.toml` | upstream MCPMark venv에 현재 GEODE worktree 설치 명령 추가 |
| `tests/plugins/benchmark_harness/test_mcpmark_adapter.py` | command/auth/parser/privacy/pairing 회귀 계약 추가 |
| `plugins/crucible/producers/context_graph.json` | 변경된 trajectory bridge source attestation 갱신 |
| `site/src/data/geode/architecture-baseline.json` / `docs/architecture/extensibility-roadmap.md` | 생성 architecture LOC inventory 갱신 |
| `docs/eval/2026-08-12-mcpmark-geode-codex-gpt54-paired.md` | 10-task 결과, task별 시간/호출, trajectory 품질, 비교 한계 기록 |
| `docs/plans/2026-08-12-mcpmark-codex-paired-comparison.md` | 비교 계약, stop gate, 재현 명령, 판단 기록 |
| `docs/eval/tau2-bench.md` / `docs/plans/2026-08-12-gpt54-tau2-openai-reference-alignment.md` | OpenAI GPT-5.4 Tau2 banking_knowledge 설정과 GEODE base-domain 계약의 비동일성 명시 |
| `CHANGELOG.md` / benchmark README | 사용자 표면과 설치·실행법 동기화 |

## GAP Audit

| Item | Status | Evidence |
|---|---|---|
| 동일 모델 GEODE-Codex 직접 비교 arm | Implemented | 같은 10 tasks, GPT-5.4 high, fixture, server, verifier; harness만 교체 |
| Codex 비-MCP 우회 방지 | Implemented | read-only sandbox, empty cwd, optional tools disabled, 0 protocol violations |
| subscription 경로 오염 방지 | Implemented | API/base URL/access-token env 제거 후 별도 live gate 1/1 PASS |
| canonical trajectory | Implemented | 20/20 schema-valid, 166/166 exact tool pairs, orphan 0 |
| replay fidelity 정직성 | Implemented | digest body를 content omission으로 표시; replay-complete 0/20 |
| MCPMark Verified leaderboard 직접 주장 | Dropped | 이번 suite는 filesystem/easy이며 127-task Verified standard가 아님 |
| 반복 trial | Deferred | k=1에서 pass/fail discordance 0; 추가 quota의 정보가치가 낮음 |
| Terminal-Bench adapter | Deferred | MCPMark control 뒤에도 실제 필요가 측정되지 않음 |

## Result

- GEODE: **9/10**, 747.2s, 50 MCP calls
- Codex CLI: **9/10**, 745.5s, 116 MCP calls
- 공통 실패: `file_context/uppercase` — 원본에 없던 trailing LF를 양쪽 모두 추가
- 주요 tail 차이: Codex `structure_analysis` 245.8s / 55 calls, GEODE 39.1s / 4 calls
- 주장 범위: 이 10-task k=1 control에서 outcome parity. 일반적인 GEODE=Codex 동등성이나 MCPMark Verified leaderboard 점수는 주장하지 않음.

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ scripts/` — 0 errors
- [x] `uv run ruff format --check core/ tests/ plugins/ scripts/` — 1,277 files formatted
- [x] `uv run mypy core/ plugins/` — 546 source files, 0 issues
- [x] `uv run lint-imports` — 4 contracts kept
- [x] `uv run bandit -r core/ plugins/ -c pyproject.toml -q` — pass
- [x] `uv run pytest tests/ -m "not live" -q` — 10,411 collected tests, full gate pass
- [x] benchmark-harness targeted suite — 57 passed
- [x] live ChatGPT subscription post-fix gate — 1/1 PASS
- [x] MCPMark paired Action E2E — 20 task arms completed, 18 PASS / 2 paired behavioral FAIL
- [x] trajectory integrity — 20/20 valid, 166/166 paired calls/results, 0 orphan, 0 protocol violations
- [x] `uv run python scripts/architecture_baseline.py --check` — OK
- [x] `git diff --check` — clean

## Publication boundary

Raw result directories remain ignored local evidence. External `geode-eval-artifacts` publication is intentionally sequenced after this implementation commit is fixed: reviewed replay-incomplete trajectory releases, append-only artifact PR, then exact remote digest read-back.

## References

- MCPMark upstream: https://github.com/eval-sys/mcpmark/tree/cd45b7f57923b9b3985467f5139927575f83141c
- Codex non-interactive mode: https://developers.openai.com/codex/noninteractive
- Terminal-Bench 2.1 harness-direction context: https://www.tbench.ai/news/terminal-bench-2-1

🤖 Generated with Codex