### PR TITLE
docs(plan): ground agentic reward modeling boundary

### DIFF
--- a/docs/plans/2026-08-05-agentic-learning-data-horizon.md
+++ b/docs/plans/2026-08-05-agentic-learning-data-horizon.md
@@ -47,11 +47,17 @@ as evidence of past intent, not as current consumers.
 |---|---|---:|---|
 | [DPO paper](https://arxiv.org/abs/2305.18290) | Direct preference objective, reference-policy relationship | A | Single-response experiments do not define a complete long-horizon agent data contract |
 | [DeepSeekMath](https://arxiv.org/abs/2402.03300) | GRPO origin and group-relative PPO variant | A | Mathematics-focused rollout setting |
+| [Stanford CS329A Part 4](https://cs329a.stanford.edu/) | ReAct, RLEF, and Constitutional AI as three different feedback/update surfaces | A | Lecture framing is secondary to the cited papers for algorithm details |
+| [RLEF](https://proceedings.mlr.press/v267/gehring25a.html) | Public execution feedback, private-test reward, and PPO update contract | A | Short, single-program CodeContests tasks; training system and checkpoints are not public |
+| [DeepSeek-R1](https://arxiv.org/abs/2501.12948) | Rule-verifiable reasoning reward and the boundary against neural reward models | A | Long-horizon tool environments are not the primary setting |
+| [DAPO](https://arxiv.org/abs/2503.14476) | Dynamic sampling and optimization stability for outcome-reward RL | A | Token-level loss is not process-level reward |
 | [Hugging Face TRL DPO](https://github.com/huggingface/trl/blob/main/docs/source/dpo_trainer.md) | Current tool-calling preference dataset shape | A | Trainer-specific materialization format, not a universal storage standard |
 | [NVIDIA NeMo RL DPO](https://docs.nvidia.com/nemo/rl/nightly/guides/dpo.html) | Independent implementation evidence for ranked and binary preference inputs | A | Trainer-specific configuration and preprocessing |
 | [GLM-5](https://arxiv.org/abs/2602.15763) | Asynchronous agent-RL and train/inference alignment | A | Training infrastructure disclosure is not a requirement for inference-only runtimes |
 | [Kimi K2.5](https://arxiv.org/abs/2602.02276) | PARL orchestrator/subagent credit boundary | A | System report; not an interchangeable DPO recipe |
 | [Kimi K3 report](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf) | Multi-effort RL, partial rollout, persistent sandbox state | A | Frontier training infrastructure exceeds GEODE's present role |
+| [Agent-World](https://arxiv.org/abs/2604.18292) | Executable environment and verifier co-evolution | A | The outer benchmark must stay fixed while the training arena evolves |
+| [Qwen-UI-Agent](https://arxiv.org/abs/2607.28227) | Separate local action feedback and delayed terminal environment reward | A | Very recent self-report without independent replication |
 
 The reviewed sources do not require an inference harness to own a trainer.
 They instead make exact context, action, observation, environment, verifier,
@@ -71,6 +77,45 @@ and policy/compute identity material to training quality.
 5. A successful final outcome does not identify which subagent step deserved
    credit. K2.5 therefore trains the orchestrator while treating frozen
    subagent outputs as observations.
+
+### 2.3 Feedback is not one object
+
+The Part 4 lineage fixes four terms that must remain separate:
+
+| Surface | Signal | Consumer | Update target |
+|---|---|---|---|
+| ReAct | tool or environment observation | next inference turn | context only |
+| RLEF public tests | execution diagnostics | next code-generation turn | context during rollout |
+| RLEF private tests | terminal task reward | PPO trainer | policy weights and value model |
+| Constitutional critique | critique and revision | SFT data construction | response policy |
+| Constitutional preference | pairwise AI/human preference | preference model and RL | preference model and policy weights |
+| GEODE Verify/PostVerify | verdict and bounded repair instruction | runtime finalization | next attempt or delivery state |
+| SIL/Crucible | artifact-bound comparison verdict | external search controller | behavior SoT or private search ref |
+
+RLEF's task reward is not a generic binary `0/1` field. It uses `+1` when all
+tests pass, `-1` when any test fails at termination, and `-0.2` for an
+intermediate response without valid code, plus a reference-policy KL penalty
+with `beta=0.05`. Public test output is an observation; private tests are the
+privileged reward oracle. The policy is token-level, the value estimate and
+advantage are turn-level, and the optimizer is PPO. Calling this runtime retry,
+process reward, GSPO, or hill climbing would collapse different operators.
+
+The current Chinese frontier reports reinforce the same boundary:
+
+- DeepSeek-R1 prefers rule-verifiable accuracy and format rewards for
+  verifiable reasoning because neural reward models create a reward-hacking
+  surface.
+- DAPO changes sampling and policy-loss stability around outcome reward; its
+  token-level loss does not create step labels.
+- GLM-5 preserves token IDs, policy version, sandbox failure attribution, and
+  train/inference alignment before applying asynchronous agent RL.
+- Kimi K2.5 updates the orchestrator and treats frozen child trajectories as
+  observations instead of inventing child credit from the parent outcome.
+- Kimi K3 and Qwen-UI-Agent ground delayed reward in final environment state,
+  while public diagnostics or local action checks support repair.
+
+These are requirements on evidence identity and ownership. They do not require
+GEODE to add a trainer.
 
 ## 3. Current GEODE evidence
 
@@ -132,6 +177,29 @@ The production `AgenticLoop` tool surface is not derived solely from
 `PolicyChain`; it is also shaped by `_tool_factory`, `allowed_tool_names`,
 headless denial, approval, and `ToolExecutor`. A universal `Policy` class would
 hide this difference rather than fix it.
+
+### 3.4 Hill-climbing census
+
+`AgenticLoop` is not hill climbing. It performs observation-conditioned tool
+execution and, after a terminal candidate, runs
+`PreVerify -> verifier -> PostVerify -> Stop`. A retryable failure starts a
+bounded continuation and may trigger replanning on the next `arun`, but the
+runtime keeps no scored incumbent, compares no local challenger, and updates
+no model weights.
+
+Two external surfaces are in the hill-climbing family:
+
+| Surface | Exact current operator | Mutable target | Classification |
+|---|---|---|---|
+| SIL | one mutation, compare with prior baseline, keep or revert | one behavior SoT section | elitist `(1+1)-ES` local search |
+| Crucible train | candidate child of current head, paired gate, KEEP-only ref advance | loop-local private search ref | gated single-lineage local search |
+
+Crucible `REJECT` and `INVALID` leave the search head unchanged, and every
+`PromotionVerdict` has `promotion_authority="none"`. It is therefore a bounded
+scaffold search protocol, not policy-gradient RL or product release. RLEF,
+DeepSeek-R1, DAPO, GLM-5, and Kimi training update model weights and should not
+be grouped with these frozen-model search loops merely because all optimize a
+score.
 
 ## 4. Dead-code finding and immediate action
 
@@ -246,6 +314,37 @@ create a learning-only snapshot hierarchy.
 Strengthen typed provenance and verifier/evidence correlation without changing
 native receipt authority. Reward stays a component vector plus hard gates;
 scalarization is a versioned derived decision.
+
+The first admitted view has four non-compensable groups:
+
+```text
+outcome    = native task completion and final-state checks
+process    = action validity, tool/result pairing, verify misses, repair effect
+cost       = tokens, latency, tool calls, critical-path depth
+constraints= permission, safety, privacy, evaluator validity, infrastructure health
+```
+
+Each value remains a typed `RewardAtom` with a target episode or transition,
+source/version, evidence digest, and validity status. Constraint failures are
+vetoes, not negative numbers that a high task score can outweigh. Domain-owned
+views may derive a versioned scalar or pairwise order offline, but the runtime
+does not own a universal reward table.
+
+The smallest validating experiment uses existing Tau2 and Crucible artifacts:
+
+1. select same-contract baseline/candidate pairs plus semantic, infrastructure,
+   and false-terminal failures;
+2. project the four groups without another live model call;
+3. verify that infrastructure rows are quarantined, native success remains the
+   terminal authority, and safety/identity failures cannot be compensated;
+4. measure ranking stability under weight perturbation and agreement with the
+   native verdict;
+5. publish only the derived manifest and receipt digests, never duplicate the
+   native receipt bytes.
+
+This experiment tests whether the evidence contract can support later search
+or training. It does not claim that the derived score is a learned reward
+model.
 
 ### Stage D — preference projection
 

--- a/docs/plans/2026-08-05-agentic-learning-data-horizon.md
+++ b/docs/plans/2026-08-05-agentic-learning-data-horizon.md
@@ -5,6 +5,7 @@
 > [`../architecture/extensibility-roadmap.md`](../architecture/extensibility-roadmap.md).
 
 Date: 2026-08-05
+Last grounded: 2026-08-12 against `origin/develop@70f8e926e`
 
 ## 1. Decision
 
@@ -47,8 +48,8 @@ as evidence of past intent, not as current consumers.
 |---|---|---:|---|
 | [DPO paper](https://arxiv.org/abs/2305.18290) | Direct preference objective, reference-policy relationship | A | Single-response experiments do not define a complete long-horizon agent data contract |
 | [DeepSeekMath](https://arxiv.org/abs/2402.03300) | GRPO origin and group-relative PPO variant | A | Mathematics-focused rollout setting |
-| [Stanford CS329A Part 4](https://cs329a.stanford.edu/) | ReAct, RLEF, and Constitutional AI as three different feedback/update surfaces | A | Lecture framing is secondary to the cited papers for algorithm details |
-| [RLEF](https://proceedings.mlr.press/v267/gehring25a.html) | Public execution feedback, private-test reward, and PPO update contract | A | Short, single-program CodeContests tasks; training system and checkpoints are not public |
+| [Stanford CS329A Part 4](https://www.youtube.com/watch?v=Lxh9RF5S-K0) | ReAct, RLEF, and Constitutional AI as three different feedback/update surfaces | A | Lecture framing is secondary to the cited papers for algorithm details |
+| [RLEF](https://proceedings.mlr.press/v267/gehring25a.html) | Public execution feedback, private-test reward, and PPO update contract | A | Short CodeContests setting; not a long-horizon agent contract |
 | [DeepSeek-R1](https://arxiv.org/abs/2501.12948) | Rule-verifiable reasoning reward and the boundary against neural reward models | A | Long-horizon tool environments are not the primary setting |
 | [DAPO](https://arxiv.org/abs/2503.14476) | Dynamic sampling and optimization stability for outcome-reward RL | A | Token-level loss is not process-level reward |
 | [Hugging Face TRL DPO](https://github.com/huggingface/trl/blob/main/docs/source/dpo_trainer.md) | Current tool-calling preference dataset shape | A | Trainer-specific materialization format, not a universal storage standard |
@@ -80,7 +81,8 @@ and policy/compute identity material to training quality.
 
 ### 2.3 Feedback is not one object
 
-The Part 4 lineage fixes four terms that must remain separate:
+The Part 4 lineage separates feedback surfaces by signal, consumer, and update
+target:
 
 | Surface | Signal | Consumer | Update target |
 |---|---|---|---|
@@ -88,7 +90,7 @@ The Part 4 lineage fixes four terms that must remain separate:
 | RLEF public tests | execution diagnostics | next code-generation turn | context during rollout |
 | RLEF private tests | terminal task reward | PPO trainer | policy weights and value model |
 | Constitutional critique | critique and revision | SFT data construction | response policy |
-| Constitutional preference | pairwise AI/human preference | preference model and RL | preference model and policy weights |
+| Constitutional preference | pairwise AI preference | preference model and RL | preference model and policy weights |
 | GEODE Verify/PostVerify | verdict and bounded repair instruction | runtime finalization | next attempt or delivery state |
 | SIL/Crucible | artifact-bound comparison verdict | external search controller | behavior SoT or private search ref |
 
@@ -102,9 +104,9 @@ process reward, GSPO, or hill climbing would collapse different operators.
 
 The current Chinese frontier reports reinforce the same boundary:
 
-- DeepSeek-R1 prefers rule-verifiable accuracy and format rewards for
-  verifiable reasoning because neural reward models create a reward-hacking
-  surface.
+- DeepSeek-R1-Zero uses rule-verifiable accuracy and format rewards for
+  verifiable reasoning tasks; the report abstains from neural reward models on
+  those tasks because of reward-hacking risk.
 - DAPO changes sampling and policy-loss stability around outcome reward; its
   token-level loss does not create step labels.
 - GLM-5 preserves token IDs, policy version, sandbox failure attribution, and
@@ -315,7 +317,8 @@ Strengthen typed provenance and verifier/evidence correlation without changing
 native receipt authority. Reward stays a component vector plus hard gates;
 scalarization is a versioned derived decision.
 
-The first admitted view has four non-compensable groups:
+The first admitted view preserves four groups separately; constraints are
+non-compensable:
 
 ```text
 outcome    = native task completion and final-state checks
@@ -324,11 +327,11 @@ cost       = tokens, latency, tool calls, critical-path depth
 constraints= permission, safety, privacy, evaluator validity, infrastructure health
 ```
 
-Each value remains a typed `RewardAtom` with a target episode or transition,
-source/version, evidence digest, and validity status. Constraint failures are
-vetoes, not negative numbers that a high task score can outweigh. Domain-owned
-views may derive a versioned scalar or pairwise order offline, but the runtime
-does not own a universal reward table.
+Stage C would project each value as a typed `RewardAtom` with a target episode
+or transition, source/version, evidence digest, and validity status. Constraint
+failures are vetoes, not negative numbers that a high task score can outweigh.
+Domain-owned views may derive a versioned scalar or pairwise order offline, but
+the runtime does not own a universal reward table.
 
 The smallest validating experiment uses existing Tau2 and Crucible artifacts:
 

--- a/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
+++ b/docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md
@@ -16,7 +16,7 @@ register any untracked architecture GAP through
 [`extensibility-roadmap.md`](../architecture/extensibility-roadmap.md) and
 follow that ledger's claim protocol.
 
-### Delivery checkpoint
+## Delivery checkpoint
 
 The MEM-001 slice implements only the measured deletion-first boundary:
 
@@ -788,7 +788,8 @@ A `RewardView` is a versioned offline configuration over atoms. Hard
 permission, safety, verifier, and promotion contracts remain vetoes; they are
 not converted into a compensable scalar. This supports:
 
-- hill-climbing: compare artifact-bound candidate runs under the same contract;
+- external scaffold hill-climbing: compare artifact-bound candidate runs under
+  the same contract; the runtime `AgenticLoop` itself has no incumbent update;
 - DPO: export controlled chosen/rejected trajectory pairs;
 - GRPO: export same-initial-state sampling groups and relative rewards;
 - process reward modeling: target atoms to `transition_id` rather than only the


### PR DESCRIPTION
## Summary

- Preserve the runtime/training boundary for future agentic learning-data work.
- Separate observation, terminal reward, preference, verifier control, and external search feedback instead of treating them as one reward surface.
- Record which GEODE surfaces are runtime control versus external hill-climbing scaffolds.

## Why

The original local-only grounding work contained useful, still-novel design evidence, but several statements overstated source claims or described future schema as if it already existed. This salvage rebases that work onto current `develop`, retains the validated material, and corrects those boundaries before review.

This is documentation-only. It does not introduce a trainer, reward model, `RewardAtom` implementation, or runtime behavior change.

## GAP Audit

| GAP | Before | Resolution |
|---|---|---|
| Feedback taxonomy | Observation, terminal reward, preference, and verifier control could read as one reward concept | Separate each surface by signal, consumer, and update target |
| RLEF evidence | Included an unsupported absence claim about public training assets | Limit the claim to the paper's short CodeContests setting |
| DeepSeek scope | Generalized R1-Zero's rule-verifiable reward choice to all DeepSeek-R1 training | Scope the statement to R1-Zero and verifiable reasoning tasks |
| Constitutional preference | Mixed AI-generated and human preference authority | Identify the Constitutional AI row as pairwise AI preference |
| Reward composition | Called all four groups non-compensable | Preserve outcome/process/cost separately and reserve veto semantics for constraints |
| Schema status | Described `RewardAtom` as an existing runtime type | Mark it explicitly as a future Stage C projection |
| Search semantics | Could imply GEODE's runtime loop itself is hill-climbing | Clarify that SIL and Crucible are external local-search scaffolds; the runtime loop has no incumbent update |

## Changes

| File | Change |
|---|---|
| `docs/plans/2026-08-05-agentic-learning-data-horizon.md` | Add the primary-source matrix, feedback/update taxonomy, current GEODE hill-climbing census, and a bounded future evaluation-admission experiment; apply eight source and implementation-boundary corrections |
| `docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md` | Repair the delivery-checkpoint heading and clarify runtime versus external-scaffold hill-climbing |

## Verification

- `uv run pymarkdown --config .pymarkdown.json scan docs/plans/2026-08-05-agentic-learning-data-horizon.md docs/plans/2026-08-07-runtime-memory-trajectory-convergence.md` — passed
- `git diff --check origin/develop...HEAD` — passed
- `uv run python scripts/check_repo_hygiene.py` — passed
- Commit hooks: codespell, whitespace, end-of-file, merge-conflict, and repository policy checks — passed or correctly skipped for docs-only scope

Runtime, type, and live-provider tests were not run because this PR changes only internal Markdown plans. No changelog entry is required for documentation-only changes.
