### PR TITLE
docs(eval): surface paired benchmark wall time

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3806,6 +3806,7 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   Observed delta +1 / 30 (+3.33 pp); prospective hypothesis invalidated
 -   GEODE 1,646 events / 703 exact tool pairs; Codex 1,735 / 727
 -   GEODE fresh input 4,204,759 vs Codex 1,444,927; no token-efficiency claim
+-   Task wall: GEODE 7,842.4s vs Codex 6,970.2s (+12.5%); no causal efficiency claim
 -   Both releases scope-complete, replay-incomplete, zero orphan tool events
 
 ```

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -282,6 +282,7 @@ const mcpmarkFilesystemStandardGpt54Paired: BenchmarkMeasurement = {
     "Observed delta +1 / 30 (+3.33 pp); prospective hypothesis invalidated",
     "GEODE 1,646 events / 703 exact tool pairs; Codex 1,735 / 727",
     "GEODE fresh input 4,204,759 vs Codex 1,444,927; no token-efficiency claim",
+    "Task wall: GEODE 7,842.4s vs Codex 6,970.2s (+12.5%); no causal efficiency claim",
     "Both releases scope-complete, replay-incomplete, zero orphan tool events",
   ],
   command: `# Illustrative one-task invocation only; exact runner is withheld.


### PR DESCRIPTION
## Summary
- Add the measured per-arm task wall time to the canonical public benchmark measurement.
- Regenerate llms-full.txt so agent-facing documentation exposes the same value.

## Why
The canonical run report already recorded GEODE 7,842.4s and Codex 6,970.2s, but the public benchmark ledger omitted that comparison. The new line preserves the correction boundary: this is descriptive and does not support a causal efficiency claim.

## GAP Audit
| Surface | Before | After |
|---|---|---|
| Run report | Exact wall time present | Unchanged |
| Public measurement SOT | Wall time absent | Exact values plus +12.5% caveat |
| LLM index | Wall time absent | Regenerated from rendered page |
| CHANGELOG/catalog | No duplicate score authority | Unchanged |

## Changes
| File | Change |
|---|---|
| site/src/data/geode/benchmark-measurements.ts | Add one descriptive task-wall metric line |
| site/public/llms-full.txt | Regenerate the matching agent-facing index |

## Verification
- npm run build: 237 static pages
- npm run export-md: 74 Markdown twins and llms-full.txt
- npm run lint: 0 errors; 45 pre-existing warnings
- 41 targeted llms/docs/site inventory tests passed
- git diff --check passed