### PR TITLE
release: promote MCPMark wall-time measurement

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3806,6 +3806,7 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   Observed delta +1 / 30 (+3.33 pp); prospective hypothesis invalidated
 -   GEODE 1,646 events / 703 exact tool pairs; Codex 1,735 / 727
 -   GEODE fresh input 4,204,759 vs Codex 1,444,927; no token-efficiency claim
+-   Task wall: GEODE 7,842.4s vs Codex 6,970.2s (+12.5%); no causal efficiency claim
 -   Both releases scope-complete, replay-incomplete, zero orphan tool events
 
 ```

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -282,6 +282,7 @@ const mcpmarkFilesystemStandardGpt54Paired: BenchmarkMeasurement = {
     "Observed delta +1 / 30 (+3.33 pp); prospective hypothesis invalidated",
     "GEODE 1,646 events / 703 exact tool pairs; Codex 1,735 / 727",
     "GEODE fresh input 4,204,759 vs Codex 1,444,927; no token-efficiency claim",
+    "Task wall: GEODE 7,842.4s vs Codex 6,970.2s (+12.5%); no causal efficiency claim",
     "Both releases scope-complete, replay-incomplete, zero orphan tool events",
   ],
   command: `# Illustrative one-task invocation only; exact runner is withheld.


### PR DESCRIPTION
## Summary
- Promote the CI-green public benchmark wall-time measurement from develop to main.
- Keep the measurement explicitly descriptive: GEODE 7,842.4s vs Codex 6,970.2s (+12.5%), with no causal efficiency claim.

## Included PR
- #2971 docs(eval): surface paired benchmark wall time

## Verification
- Feature PR Gate passed.
- Test passed in 5m27s.
- Next.js static export passed with 237 pages.
- Render lint, lint/format, type check, security, and macOS/Ubuntu install checks passed.