### PR TITLE
chore(sync): merge Main into develop after Gate 0C report

### DIFF
--- a/docs/eval/2026-08-13-sequential-agent-benchmark-plan.md
+++ b/docs/eval/2026-08-13-sequential-agent-benchmark-plan.md
@@ -22,8 +22,8 @@ eval_contracts:
 
 작성일: 2026-08-13
 최종 갱신: 2026-08-14
-기준 코드: GEODE `origin/main@02f71fae260f050a5ab02af943cfd2244441da7f`
-상태: **Lane 0B complete · artifact published. Lane 0C next.**
+기준 코드: GEODE `origin/main@f4b3760488a80dad1186d54458f63bbb08768719`
+상태: **Lane 0C k=1 complete · artifact published. k=3 live blocked by WHAM=80%; Tau2 no-model preflight may proceed.**
 
 ## 1. 권한과 범위
 
@@ -49,6 +49,7 @@ eval_contracts:
 
 | 근거 | 현재 판정 | 다음에 닫을 GAP |
 |---|---|---|
+| [GPT-5.4 MCPMark Gate 0C corrective FS30](2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md) | Prospective common-deadline k=1 direct pair: GEODE 23/30, Codex 21/30, signed delta +2/30 = +6.67%p supported. One GEODE score-bearing timeout; token coverage 29/30 vs 30/30 | Fresh k=3 stability is still required; live launch blocked while WHAM=80%; no promotion authority |
 | [GPT-5.4 MCPMark Gate 0B tool-cap ablation](2026-08-14-mcpmark-gate0b-tool-cap-gpt54-high.md) | Prospective k=3 direct diagnostic: `guard-25000` 7/15, `unlimited-0` 10/15, signed delta +0.20 supported. Four matched score-bearing timeouts; token totals exact on 13/15 per arm only | Product-default change is not authorized; proceed to common-deadline FS30 k=1 |
 | [GPT-5.4 MCPMark FS30 observation](2026-08-13-mcpmark-geode-codex-gpt54-filesystem-standard.md) | GEODE 21/30, Codex 20/30. Timeout 시작 경계가 달라 retrospective description만 허용 | 동일 timed surface와 공개 runner |
 | GPT-5.4 Tau2 base 3-domain | `geode_agent + geode_user` 200/278 | native GPT-5.2-low user와 4 trials는 별도 official-profile 측정 |
@@ -88,8 +89,8 @@ flowchart TD
 |---|---|---|---|
 | 0A Common deadline | **COMPLETE · MAIN** | None; contract is the basis for 0B/0C | setup/action boundary, timeout·cancel·cleanup tests and no-model preflight PASS |
 | 0B Targeted ablation | **COMPLETE · PUBLISHED** | Preserve 7/15 vs 10/15 as diagnostic-only; no cap-default change | 30/30 valid arms, primary +3/15 = +0.20 supported, six releases/26 admitted trajectories, four timeout trajectories withheld |
-| 0C MCPMark FS30 | **NEXT** | GPT-5.4/high one-task smoke, then fresh 30-task k=1 | 60 native receipts, exact task/reset/verifier joins, infrastructure errors 0 |
-| 1 Tau2 base | BLOCKED-LIVE | 278 IDs/pin/user/budget no-model preflight | PAYG 승인 뒤 smoke→full-1→4 trials |
+| 0C MCPMark FS30 | **K=1 COMPLETE · PUBLISHED · K=3 LIVE-BLOCKED (WHAM=80%)** | Preserve k=1 as diagnostic-only; launch fresh k=3 only after five-hour quota headroom is safe | k=1: 60/60 valid arms, exact task/reset/verifier joins, primary +2/30; k=3 remains separate |
+| 1 Tau2 base | **NO-MODEL PREFLIGHT READY · LIVE BLOCKED** | 278 IDs/pin/user/budget no-model preflight may proceed; no model calls yet | Gate 0C stability and PAYG approval before smoke→full-1→4 trials |
 | 2 MCPMark Verified | PENDING | service별 no-model canary | FS30 pair와 full127 headline 분리 |
 | 3 Terminal-Bench 2.1 | PENDING | 2.1 profile 정렬·oracle smoke | adapter/evidence path clean 후 89 tasks |
 
@@ -222,6 +223,32 @@ ID의 attempt-000은 timeout outcome classification 결함으로 sequence 14에�
 4. `k=1`이 clean이고 quota가 안전하면 같은 계약으로 `k=3` stability lane을
    실행한다. 이미 끝난 k=1을 k=3의 일부로 사후 편입하지 않는다.
 
+Gate 0C `k=1`은 2026-08-14 완료됐다. 공통 adapter-owned 1,200초 action
+deadline과 score-bearing semantic fixture를 결속한 30-task pair에서 GEODE는
+23/30, Codex는 21/30이었고 frozen primary delta는
+`(23-21)/30 = +0.066667 = +6.67%p`이므로 diagnostic hypothesis는 supported다.
+Paired bucket은 `both-pass=17`, `both-fail=3`, `GEODE-only=6`, `Codex-only=4`다.
+
+선택된 `attempt-001-complete`는 valid/mixed이며 60/60 arms를 완료했다. GEODE
+`papers/author_folders` 한 건은 common owner가 증명한 score-bearing timeout이고,
+cleanup·verifier가 완결돼 infrastructure-invalid가 아니다. 그 row의 native token
+usage는 null이므로 exact token coverage는 GEODE 29/30, Codex 30/30이다.
+
+Native execution log는 GEODE 644 calls/51 errors, Codex 678/17을 기록했다.
+Normalized trajectory는 GEODE internal recovery 한 건을 별도 projection해
+645 attempts이며 Codex는 678이다. Read/repeated-read references는 GEODE
+798/81, Codex 838/213이다. 이 secondary behavior와 unmatched token coverage는
+효율·인과·제품 정책 권한을 만들지 않는다.
+
+59개 scope-complete trajectory를 공개하고 GEODE timeout trajectory 한 개는
+withheld했다. Artifact:
+`mangowhoiscloud/geode-eval-artifacts@1160fecfe4447f0a3f4cf30a414f29c61776d012/mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/`.
+`promotion_authority=none`이며 fresh `k=3` stability가 남아 있다.
+
+현재 machine `WHAM=80%`에서는 `k=3` live launch를 시작하지 않는다. Tau2의
+278-ID/pin/user/budget no-model preflight는 병행할 수 있지만, Tau2 score-bearing
+model call은 Gate 0C stability와 별도 PAYG 승인을 기다린다.
+
 ## 6. Lane 1 — tau2 base three-domain
 
 공식 base workload는 Airline 50 + Retail 114 + Telecom 114 = **278 tasks per
@@ -310,6 +337,7 @@ Invalid/aborted attempt가 선택되면 primary metric은 `not-measurable`이다
 
 | Date | Change |
 |---|---|
+| 2026-08-14 | Gate 0C prospective common-deadline FS30 k=1 완료·게시: GEODE 23/30 대 Codex 21/30, primary +2/30=+6.67%p supported diagnostic-only. 60/60 valid arms, paired buckets 17/3/6/4, one GEODE score-bearing timeout, exact token coverage 29/30 vs 30/30, 59 admitted trajectories/one withheld 보존. `promotion_authority=none`; fresh k=3 live는 WHAM=80%에서 차단하고 Tau2 no-model preflight만 허용 |
 | 2026-08-14 | Gate 0B prospective k=3 완료·게시: `guard-25000` 7/15 대 `unlimited-0` 10/15, primary +3/15=+0.20 supported diagnostic-only. Four matched score-bearing timeouts, exact token coverage 13/15 per arm, prior invalid attempt denominator 0, six reviewed releases/26 admitted trajectories 보존. Lane 0C를 NEXT로 승격 |
 | 2026-08-13 | Gate 0B runner implementation: 기존 serial runner에 5-task×2-cap×3-repeat profile, effective cap/offload receipt, direct `CallToolResult` truncation reconstruction, dependency/import preflight를 연결. Live run과 score/artifact는 아직 없음 |
 | 2026-08-13 | Gate 0A main release: PR #2973 구현을 PR #2975로 main에 승격 |

--- a/docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md
+++ b/docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md
@@ -1,0 +1,257 @@
+---
+eval_id: mcpmark-gate0c-filesystem30-gpt54-high-20260814
+eval_family: mcpmark
+eval_kind: ledger
+eval_status: historical
+eval_authority: paired-runtime-diagnostic
+eval_summary: Prospective common-deadline k=1 comparison of GEODE and Codex on 30 MCPMark filesystem/standard tasks with GPT-5.4/high; GEODE passed 23/30 versus Codex 21/30, a diagnostic-only +2/30 = +6.67 percentage-point delta.
+eval_triggers:
+  - MCPMark Gate 0C
+  - common action deadline
+  - GEODE Codex comparison
+  - GPT-5.4 benchmark
+  - paired runtime diagnostic
+eval_contracts:
+  - docs/eval/schemas/run-spec.schema.json
+  - docs/eval/schemas/attempt.schema.json
+  - docs/eval/schemas/analysis.schema.json
+  - core/observability/schemas/trajectory.schema.json
+  - core/observability/schemas/trajectory-release.schema.json
+eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04
+---
+
+# GPT-5.4 MCPMark Gate 0C — corrective FS30 paired diagnostic
+
+## 판정
+
+동일한 MCPMark `filesystem/standard` 30개 task, semantic fixture, verifier,
+GPT-5.4 subscription route, effort `high`, 공통 1,200초 action deadline에서
+실행한 prospective paired `k=1` diagnostic에서 GEODE는 **23/30(76.7%)**,
+Codex는 **21/30(70.0%)**를 기록했다. 사전등록 primary metric은
+`(GEODE passes - Codex passes) / 30 = 2/30 = +0.066667`, 즉
+**+6.67%p**다. 동결된 하한 `-0.10`보다 높으므로 가설은 **supported**다.
+
+이 판정은 공통 timed action surface를 가진 한 번의 직접 paired-runtime
+diagnostic에 한정된다. `promotion_authority=none`이며 fresh `k=3` 안정성,
+MCPMark Verified 127-task headline, API-key leaderboard, 제품 기본값 변경,
+GEODE가 일반적으로 더 정확하거나 효율적이라는 인과 주장의 근거가 아니다.
+두 arm은 task/state/verifier/model/effort/deadline을 맞췄지만 서로 다른 runtime
+scaffold와 tool-result 정책을 유지했다.
+
+## Research contract
+
+| Field | Frozen value |
+|---|---|
+| Research question | 같은 30개 MCPMark Filesystem task, semantic fixture state, verifier, GPT-5.4/high subscription route, 공통 timed action surface에서 GEODE와 Codex의 verifier accuracy는 어떻게 다른가? |
+| Research gap | 이전 FS30 관측은 timeout 시작 경계가 달랐고 fixture receipt가 score-bearing file mtime과 empty directory를 결속하지 않았다. |
+| Hypothesis | 30-task workload에서 GEODE verifier accuracy가 Codex보다 10%p 넘게 낮지 않다. |
+| Primary metric | `(sum(GEODE passes) - sum(Codex passes)) / 30` |
+| Decision rule | signed delta가 `-0.10` 이상이면 `supported`, 더 낮으면 `not-supported` |
+| Secondary | arm accuracy, paired bucket, cache-excluded input, output/reasoning, action/envelope wall, MCP calls/errors, read/re-read, termination class |
+| Invalidation | frozen deadline/model/route/schema/task/semantic fixture/verifier/reset/GEODE 25K cap 불일치, cleanup 실패, native/verifier/deadline/trajectory 누락, unrecovered quota·transport escape |
+| Authority | `diagnostic`, direct paired runtime, `promotion_authority=none` |
+
+## Frozen identity
+
+| Field | Value |
+|---|---|
+| Run ID | `mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z` |
+| Registration | prospective; frozen 2026-08-13 19:09:22 UTC |
+| Execution | 2026-08-14 04:10:39–08:05:25 KST, 3:54:46 elapsed |
+| GEODE | `f4b3760488a80dad1186d54458f63bbb08768719` from clean `origin/main` |
+| Harness | `eval-sys/mcpmark@cd45b7f57923b9b3985467f5139927575f83141c` plus verifier compatibility patch SHA-256 `3f41f13a8edf7b40f411bf0a76412c28fc9629338d9e5051d5633dc064c563e6` |
+| Codex comparator | `codex-cli 0.145.0`; source `openai/codex@dad1db87bb5ad4b92af6b0f58502d12453681f81`; executable SHA-256 `1da3f4e0e96028b8a771814293c3033dafd1971f943f6c7e79b0897fe705f590` |
+| Model route | GPT-5.4, subscription, effort `high`, both arms |
+| Workload | ordered `filesystem/standard` 30 tasks × 2 arms × `k=1` = 60 arms |
+| Workload SHA-256 | `50483308573ce407abaf0700885d56c6df0453557669dddce9edcece83710433` |
+| Fixture aggregate SHA-256 | `c8cfb2815f63ded54a7d79ffed2e0719190bb2dc1e571112a6012f97f95e9f17` |
+| Semantic fixture SHA-256 | `273477d554250f4f076e69651e29689ed71095ec1b3fe3e054094be82f574fbf` |
+| Tool schema SHA-256 | `1ad42161dcd16c1d786f859b71a52123fca9daa5c4a4d64864ff240ea150165f` |
+| Order | task별 두 arm 직렬; odd task `GEODE→Codex`, even task `Codex→GEODE`; overlap·resume 없음 |
+| Deadline | adapter `execute` entry부터 native runtime return까지 공통 absolute 1,200초; fixture setup과 post-action verifier는 범위 밖 |
+| GEODE arm | frozen `GEODE_MAX_TOOL_RESULT_TOKENS=25000`; offload store unbound |
+| Codex arm | isolated native Codex CLI runtime |
+
+## Primary result
+
+| Metric | GEODE | Codex | GEODE − Codex |
+|---|---:|---:|---:|
+| Verifier pass | **23 / 30** | **21 / 30** | **+2** |
+| Pass rate | **76.7%** | **70.0%** | **+6.67%p** |
+| Score-bearing deadline expiration | 1 | 0 | +1 |
+| Exact native-token coverage | 29 / 30 | 30 / 30 | unmatched |
+
+Paired bucket은 `both-pass=17`, `both-fail=3`, `GEODE-only-pass=6`,
+`Codex-only-pass=4`다.
+
+| Bucket | Tasks |
+|---|---|
+| GEODE only (6) | `desktop_template/file_arrangement`, `legal_document/solution_tracing`, `student_database/duplicate_name`, `student_database/gradebased_score`, `threestudio/output_analysis`, `threestudio/requirements_completion` |
+| Codex only (4) | `folder_structure/structure_mirror`, `papers/organize_legacy_papers`, `votenet/debugging`, `votenet/requirements_writing` |
+| Both fail (3) | `desktop_template/budget_computation`, `file_context/pattern_matching`, `papers/author_folders` |
+
+Discordant pair가 10개이고 `k=1`이므로 +6.67%p를 안정된 arm 우위로 일반화하지
+않는다. Fresh `k=3` replication이 남아 있다.
+
+## Full-arm behavior
+
+아래 값은 timeout을 포함한 각 arm의 **30/30 전체 action** 집계다.
+
+| Metric | GEODE | Codex | GEODE − Codex |
+|---|---:|---:|---:|
+| Action elapsed | 8,463.252s | 5,484.322s | +2,978.930s (+54.3%) |
+| Runner envelope | 8,536.382s | 5,548.725s | +2,987.657s (+53.8%) |
+| Native execution-log MCP calls | 644 | 678 | −34 (−5.0%) |
+| Native execution-log MCP errors | 51 | 17 | +34 (+200.0%) |
+| Native execution-log error rate | 7.92% | 2.51% | +5.41%p |
+| Read references | 798 | 838 | −40 (−4.8%) |
+| Unique read references | 717 | 625 | +92 (+14.7%) |
+| Repeated read references | 81 | 213 | −132 (−62.0%) |
+| Deadline expirations | 1 | 0 | +1 |
+
+GEODE는 top-level call과 repeated read가 적었지만 action wall과 native-log error가
+더 많았다. 이것은 서로 다른 scaffold가 낸 descriptive behavior다. Secondary
+metric은 frozen accuracy 판정을 뒤집지 않으며, 한 번의 run으로 속도·오류·재독의
+원인을 확정하지 않는다.
+
+### Call-count authority
+
+Native log와 normalized trajectory는 다른 단위를 센다. 둘을 같은 `MCP calls`로
+섞지 않는다.
+
+| Surface | GEODE | Codex | Meaning |
+|---|---:|---:|---|
+| Native execution-log calls / errors | 644 / 51 | 678 / 17 | top-level native log row; GEODE internal recovery attempt 제외 |
+| Normalized source-trajectory attempts | 645 | 678 | canonical call/result attempt; GEODE recovery projection 포함 |
+| Recovery-projected attempts | 1 | 0 | `votenet/requirements_writing`에서 GEODE internal recovery 한 건 |
+| Published release call/result pairs | 603 / 603 | 678 / 678 | scope-complete trajectory만; GEODE timeout의 42 attempts는 withheld |
+
+따라서 GEODE의 `644 → 645`는 누락이나 score 보정이 아니라 한 recovery attempt를
+별도 canonical pair로 투영한 결과다. `votenet/requirements_writing`의 native
+log는 15 calls지만 normalized trajectory는 16 attempts이며, 최종 verifier
+결과는 FAIL이다.
+
+## Token accounting — GEODE 29/30, Codex 30/30
+
+GEODE의 `papers/author_folders` timeout은 final native usage completion을 만들지
+않았다. 그 row는 `0`이 아니라 **missing/null**이다.
+
+| Metric | GEODE (29 covered) | Codex (30 covered) |
+|---|---:|---:|
+| Native input | 6,056,271 | 14,625,891 |
+| Cache-read | 2,936,320 | 13,301,504 |
+| Fresh input (`input-cache_read-cache_write`) | 3,119,951 | 1,324,387 |
+| Output | 313,287 | 256,627 |
+| Reasoning | 213,167 | 122,757 |
+
+Coverage가 맞지 않고 scaffold별 cache accounting도 다르므로 이 합계를 arm당 평균,
+완전한 token cost, billing, token-efficiency claim으로 사용하지 않는다.
+
+## Timeout and stream diagnostics
+
+GEODE `papers/author_folders`는 adapter-owned deadline에서 1,200.005초 후
+`right_censored`로 종료됐고 runner envelope은 1,202.773초였다. Bounded cleanup과
+verifier receipt가 완결돼 infrastructure-invalid가 아니라 score-bearing FAIL이다.
+Native token usage는 null이고 scope-incomplete trajectory는 공개 release에서
+제외했다. 같은 task의 Codex arm은 deadline 없이 정상 종료 후 verifier FAIL이었다.
+
+GEODE private stderr에는 동일한
+`responses.stream ... incomplete chunked read` adapter diagnostic이 네 task에서
+기록됐다. 네 건 모두 runner 밖으로 unrecovered transport error를 내보내지 않았다.
+
+| Task | Final action / verifier outcome |
+|---|---|
+| `desktop/timeline_extraction` | normal complete / PASS |
+| `desktop_template/file_arrangement` | normal complete / PASS |
+| `papers/author_folders` | adapter-owned deadline expiration / FAIL |
+| `student_database/gradebased_score` | normal complete / PASS |
+
+이 raw stream diagnostic은 provider/runtime 관찰 증거이며 primary denominator나
+공개 trajectory payload로 승격하지 않는다. 별도로 위의
+`votenet/requirements_writing` 한 건만 normalized recovery-projected tool attempt를
+가진다.
+
+## Attempt lineage
+
+선택된 `attempt-001-complete`는 valid/mixed다. 122개 contiguous runner event
+(`run_started` 1 + `arm_started` 60 + `arm_finished` 60 + `run_completed` 1),
+60개 고유 arm, sequence 0–121, 완전한 reset·identity·verifier join을 가지며
+`run_stopped`는 없다. Infrastructure-invalid predecessor나 denominator 대체 retry는
+없다.
+
+## Trajectory and publication
+
+| Quality | GEODE | Codex | Total |
+|---|---:|---:|---:|
+| Source trajectories | 30 | 30 | 60 |
+| Published scope-complete trajectories | 29 | 30 | 59 |
+| Withheld scope-incomplete trajectories | 1 | 0 | 1 |
+| Published canonical events | 1,438 | 1,653 | 3,091 |
+| Published exact call/result pairs | 603 | 678 | 1,281 |
+| Orphan calls / results | 0 / 0 | 0 / 0 | 0 / 0 |
+| Missing call IDs / required turn IDs | 0 / 0 | 0 / 0 | 0 / 0 |
+| Replay-complete trajectories | 0 / 29 | 0 / 30 | 0 / 59 |
+
+Publication projection은 **69 public files / 3,065,229 bytes**와
+**510 withheld-private files / 41,174,366 bytes**를 모두 SHA-256으로 결속한다.
+Source hashes, local-identity scrub, secret scan은 통과했다. Raw model messages,
+tool bodies, local paths, account material, runner logs와 native private artifacts는
+공개하지 않는다.
+
+- [Artifact commit](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/1160fecfe4447f0a3f4cf30a414f29c61776d012)
+- [Artifact publication PR #25](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/25)
+- [Selected run bundle](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z)
+- [Public trajectory receipt/index](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/1160fecfe4447f0a3f4cf30a414f29c61776d012/mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/trajectory-index.json)
+- [GEODE trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04)
+- [Codex trajectory release](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef)
+- [Local publication disclosure receipt](2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.publication.json)
+
+`runner-result.json`이 primary score의 단일 authority다. `analysis.json`은 그 JSON
+Pointer를 읽어 판정하고, `diagnostic-receipt.json`은 secondary behavior,
+`trajectory-index.json`과 release manifests는 행동 projection과 공개 무결성을
+소유한다. Artifact PR #25는 2026-08-13T23:46:58Z에 commit
+`1160fecfe4447f0a3f4cf30a414f29c61776d012`로 merge되었다. Exact-commit remote
+read-back은 2026-08-13T23:49:26Z에 69/69 files, 3,065,229 bytes, missing/size/SHA
+mismatch 0으로 통과했고 두 release manifest와 모든 privacy scan class도
+검증했다. 로컬 disclosure receipt의 source manifest SHA-256은
+`e8a10e53e606b22c2d0b7f31fdd0b74b27c336e4d2f081b90d4318c5abe24324`다. 이
+manifest 자체는 69-file public allowlist에 포함하지 않았으므로 원격 manifest
+URL을 주장하지 않는다.
+
+## Implications and next sequence
+
+1. Gate 0C `k=1`의 frozen 질문에는 답했다. 공통 action deadline에서 GEODE는
+   23/30, Codex는 21/30이었고 `-10%p` non-inferiority-style diagnostic threshold를
+   통과했다.
+2. 승격은 없다. 한 repetition과 서로 다른 scaffold는 정확도 우위, 일반 효율,
+   제품 정책을 승인하지 않는다.
+3. 다음 score-bearing 단계는 **fresh FS30 `k=3` stability**다. 완료된 `k=1`을
+   사후에 `k=3` 일부로 편입하지 않는다.
+4. 현재 machine `WHAM=80%`이므로 `k=3` live launch는 차단한다. Five-hour quota
+   headroom이 안전해진 뒤에만 새 run roots로 실행한다.
+5. Tau2 278-ID/pin/user/budget **no-model preflight는 지금 진행할 수 있다**.
+   이것은 순차 score-bearing gate를 건너뛰지 않으며, Tau2 live smoke/full run은
+   Gate 0C stability와 별도 PAYG 승인을 기다린다.
+
+## Verification
+
+- Run spec SHA-256: `e4e9abbdd326f093bb1d513aa2800609f1566b0819929f341623011bb5fa1bb0`
+- Runner plan SHA-256: `304ba159b8cbf02ff8943d2e5a890a29d842976757f5399f4cba23c313de19b5`
+- Runner events SHA-256: `f13029f29aa249730e59154f9be6853a56eb9a1fbec9b163fae78cb643104099`
+- Native result SHA-256: `3c5763e4c13ca7a9b39627b30fd35145aebf83e43e8c791a0556e89fc5f4a017`
+- Diagnostic receipt SHA-256: `8d64b53f83440b573f762b203942828b9a12e693b5763b28ec4555a0e9637ca4`
+- Attempts SHA-256: `04d8afb9c6228b8698080fd9d9e3d48aa5fd3dc684e7c4ba702a4c9389359110`
+- Trajectory index SHA-256: `610d2c59ccc46a5713217e87d55589456fbb9c31a90e1b203ad261ce45c03cdb`
+- Analysis SHA-256: `78c1931cb3fff215ebdf8c5665ce8106ac4ed965ce31fdfc40c3f0b4f2eb35e9`
+- GEODE release manifest SHA-256: `9d6773caad049cf81f67bc6024f8a9c63688e6793af160a2f70fb50bee5ae969`
+- Codex release manifest SHA-256: `feeba0d6f5efc62e63321846517210c92453a94cf20e5080772e03db6e53a4b3`
+- Publication manifest SHA-256: `e8a10e53e606b22c2d0b7f31fdd0b74b27c336e4d2f081b90d4318c5abe24324`
+- Published disclosure receipt SHA-256: `573da4aae34042460eccb467f683bfd7e2621ae3cb85e4385e5adaad183d33ef`
+- Eval contract validation: run spec, selected attempts, and analysis passed.
+- Runner integrity: 122 events, sequences 0–121, 60/60 arms, no `run_stopped`.
+- Trajectory integrity: 59 admitted trajectories, 3,091 events, 1,281 exact pairs,
+  zero orphan/missing IDs; one score-bearing timeout trajectory withheld.
+- Publication review: 69 public and 510 withheld-private byte/SHA entries accounted
+  for; source hash, secret, and local-identity checks passed. Exact-commit remote
+  read-back passed at `1160fecfe4447f0a3f4cf30a414f29c61776d012`: 69/69 files,
+  3,065,229 bytes, zero missing/size/SHA mismatches.

--- a/docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.publication.json
+++ b/docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.publication.json
@@ -1,0 +1,4595 @@
+{
+  "artifact_repository": {
+    "base_revision": "17133f0c8e893b6d765fcef69712ba0867bd573a",
+    "destination_prefix": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z",
+    "url": "https://github.com/mangowhoiscloud/geode-eval-artifacts"
+  },
+  "entries": [
+    {
+      "bytes": 11532,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/analysis.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/analysis.json",
+      "sha256": "78c1931cb3fff215ebdf8c5665ce8106ac4ed965ce31fdfc40c3f0b4f2eb35e9"
+    },
+    {
+      "bytes": 1339,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/attempts.jsonl",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/attempts.jsonl",
+      "sha256": "04d8afb9c6228b8698080fd9d9e3d48aa5fd3dc684e7c4ba702a4c9389359110"
+    },
+    {
+      "bytes": 190789,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/diagnostic-receipt.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/diagnostic-receipt.json",
+      "sha256": "8d64b53f83440b573f762b203942828b9a12e693b5763b28ec4555a0e9637ca4"
+    },
+    {
+      "bytes": 6084,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/run-spec.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/run-spec.json",
+      "sha256": "e4e9abbdd326f093bb1d513aa2800609f1566b0819929f341623011bb5fa1bb0"
+    },
+    {
+      "bytes": 182543,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-events.jsonl",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/runner-events.jsonl",
+      "sha256": "f13029f29aa249730e59154f9be6853a56eb9a1fbec9b163fae78cb643104099"
+    },
+    {
+      "bytes": 4947,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-plan.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/runner-plan.json",
+      "sha256": "304ba159b8cbf02ff8943d2e5a890a29d842976757f5399f4cba23c313de19b5"
+    },
+    {
+      "bytes": 491,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-result.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/runner-result.json",
+      "sha256": "3c5763e4c13ca7a9b39627b30fd35145aebf83e43e8c791a0556e89fc5f4a017"
+    },
+    {
+      "bytes": 60478,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-index.json",
+      "remote_path": "mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/trajectory-index.json",
+      "sha256": "610d2c59ccc46a5713217e87d55589456fbb9c31a90e1b203ad261ce45c03cdb"
+    },
+    {
+      "bytes": 12550,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/manifest.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/manifest.json",
+      "sha256": "feeba0d6f5efc62e63321846517210c92453a94cf20e5080772e03db6e53a4b3"
+    },
+    {
+      "bytes": 21075,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__music_report.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__music_report.json",
+      "sha256": "027f45983f7ad3a45e12bfc4bbfdfb3e24cf3c0b16e73f8b600b356913b7828a"
+    },
+    {
+      "bytes": 96273,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__project_management.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__project_management.json",
+      "sha256": "8c28e2ecb1dceb9fd07e0a7f657b165358ad40488a713709000e7a0f71a10ed0"
+    },
+    {
+      "bytes": 16491,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__timeline_extraction.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop__timeline_extraction.json",
+      "sha256": "9570fc063f7b1cf3047e6b501aaa01cf869252933f866bccdaca45c5f7440a9b"
+    },
+    {
+      "bytes": 14944,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__budget_computation.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__budget_computation.json",
+      "sha256": "abe4eab6a967cdaf7ce910f1a51ebb081a4be6b47ac733ceaba5a509312b0625"
+    },
+    {
+      "bytes": 20152,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__contact_information.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__contact_information.json",
+      "sha256": "4b1f7d6541a925a4a846d498610b65d6682af9af2cc2be1d8187459b30b64373"
+    },
+    {
+      "bytes": 111712,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__file_arrangement.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/desktop_template__file_arrangement.json",
+      "sha256": "bb5345351cd8773a04edf6c53b14faace8808c15d5e9b9c83a819dbf5469c3cf"
+    },
+    {
+      "bytes": 38516,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__duplicates_searching.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__duplicates_searching.json",
+      "sha256": "2dc0830530ee66c5a58139b66e3224b1a8edd0077fc321dbecc7f55031ededfb"
+    },
+    {
+      "bytes": 14956,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__file_merging.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__file_merging.json",
+      "sha256": "13445bdc4ae834eab25ac7c17fc1f32507a55dfc8dae16b72ab1763be55e9ee0"
+    },
+    {
+      "bytes": 33981,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__file_splitting.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__file_splitting.json",
+      "sha256": "c767534dde96832386274012a0e9c7c7ea677fa8f7a94b4302566d75107b62c0"
+    },
+    {
+      "bytes": 20186,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__pattern_matching.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__pattern_matching.json",
+      "sha256": "f0970a260c3ac78666da5c948298de01d626d884a157a0354cf3507aa6c1d7f7"
+    },
+    {
+      "bytes": 31264,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__uppercase.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_context__uppercase.json",
+      "sha256": "c286b3fde3e89a118ff7cb05cf80630d7b0861898769aa26b7d4ac400928d6b5"
+    },
+    {
+      "bytes": 35001,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_property__size_classification.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_property__size_classification.json",
+      "sha256": "1e1c59b9c95229d42f01d3ad95d1de649db99bb6cc42403d92215d1b87950ef0"
+    },
+    {
+      "bytes": 54533,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_property__time_classification.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/file_property__time_classification.json",
+      "sha256": "e855960414c89e51c1d3e3efbbb011d274bf1a1ce0dc2684e4c3c81676654f43"
+    },
+    {
+      "bytes": 115351,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/folder_structure__structure_analysis.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/folder_structure__structure_analysis.json",
+      "sha256": "358daf9071ccacb2da14337034edbf4ecd6e9c07dff6a7963d4c704863336ed1"
+    },
+    {
+      "bytes": 58674,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/folder_structure__structure_mirror.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/folder_structure__structure_mirror.json",
+      "sha256": "6b1a72321ea14ddcd7d73a6841ee03241dd6f695680273e673b6c9146da8db71"
+    },
+    {
+      "bytes": 25376,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__dispute_review.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__dispute_review.json",
+      "sha256": "472b9923cd08736c37338fbb7636c96e71c88cbdd4472e88edb0bde053bdb885"
+    },
+    {
+      "bytes": 31553,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__individual_comments.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__individual_comments.json",
+      "sha256": "1cd67749ce680b4ea8b6fb201dd6837dab4573bc88e6fb0f29fc5e1734c5dec8"
+    },
+    {
+      "bytes": 28831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__solution_tracing.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/legal_document__solution_tracing.json",
+      "sha256": "5974efd2b1504ac54734c2e4ba0b754a4a966496a10b46547b5df9e9500e5bcb"
+    },
+    {
+      "bytes": 161053,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__author_folders.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__author_folders.json",
+      "sha256": "75a4df8da3cbfecc7a6ffe25c21debda1b5164c033326730f0ef7c541c7b3ffb"
+    },
+    {
+      "bytes": 14930,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__find_math_paper.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__find_math_paper.json",
+      "sha256": "dd1024e5d5f6905cfeea63848dafdbf3766dd60575dbac2b911372b7446789ed"
+    },
+    {
+      "bytes": 63800,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__organize_legacy_papers.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/papers__organize_legacy_papers.json",
+      "sha256": "89fbb59597954bb1faede8cce00619a610a4893ebf7937c1c51380a9016b9db5"
+    },
+    {
+      "bytes": 12802,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__duplicate_name.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__duplicate_name.json",
+      "sha256": "e3d1ed92f98a7deb9b24d3071553626b9f1b7f809d731d7a5c14fdaf0424ec0e"
+    },
+    {
+      "bytes": 64572,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__english_talent.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__english_talent.json",
+      "sha256": "d8a3a24157cff7377f3ed1a8e95f3324ab7dda55005d8e4cc072d0e112e31b76"
+    },
+    {
+      "bytes": 32210,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__gradebased_score.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/student_database__gradebased_score.json",
+      "sha256": "908be6663bf1ebbadf89708b0b0965efa50c04d97f30ac06b2c5baa14e751c4d"
+    },
+    {
+      "bytes": 15885,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__code_locating.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__code_locating.json",
+      "sha256": "6894b09e1275f6b40e4936f966f78b6cf200fe87d6e6a5b1c9c7a2deb94a57f5"
+    },
+    {
+      "bytes": 24146,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__output_analysis.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__output_analysis.json",
+      "sha256": "6fabcbf6e14427cc90794636e68b7b57a61f36c80be23c7cdf8e89f2a6fe6238"
+    },
+    {
+      "bytes": 45130,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__requirements_completion.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/threestudio__requirements_completion.json",
+      "sha256": "918d41ed87b56ab53d3f57ebb9b8d14a31a6d579a0ff5c11e81fa741c294fdb1"
+    },
+    {
+      "bytes": 32179,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__dataset_comparison.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__dataset_comparison.json",
+      "sha256": "76cffdbdbc6aea052ba956c5fe3843db8575a2ae9a79615e06e729895f9a5777"
+    },
+    {
+      "bytes": 30915,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__debugging.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__debugging.json",
+      "sha256": "4722a68095cc6ed25d4f885c0356cb3ecddbaefa103f80584b6604df58af6694"
+    },
+    {
+      "bytes": 29421,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__requirements_writing.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-codex-20260813T230525Z-feeba0d6f5ef/tasks/votenet__requirements_writing.json",
+      "sha256": "7c50fa0b89a9e9a21ee23aa2a2b2996d9649d2e64f2ac607a34534a4f0c3c378"
+    },
+    {
+      "bytes": 11380,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/manifest.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/manifest.json",
+      "sha256": "9d6773caad049cf81f67bc6024f8a9c63688e6793af160a2f70fb50bee5ae969"
+    },
+    {
+      "bytes": 17272,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__music_report.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__music_report.json",
+      "sha256": "b1b502dda9eb700477e74c6471c479ebda83c339c25448c2dd940d04b9dfeeae"
+    },
+    {
+      "bytes": 101212,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__project_management.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__project_management.json",
+      "sha256": "46d0fede931f666aba0e86a309a876d03fc9c2e4888b44d7e2bc8f940b02d330"
+    },
+    {
+      "bytes": 15575,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__timeline_extraction.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop__timeline_extraction.json",
+      "sha256": "2eeb3bdd2191329601e7429cb5c044f6848fee94c2c0545f1348e4e9298652c1"
+    },
+    {
+      "bytes": 15580,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__budget_computation.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__budget_computation.json",
+      "sha256": "9c31a97e2285423ce6ac8489a3f0a0129dc679c13fd9177a6156ac3ddb59cc37"
+    },
+    {
+      "bytes": 17289,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__contact_information.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__contact_information.json",
+      "sha256": "12a85c31e169dd75373922cc1ae74c33a0626dca8fc0699930ec760badd5cdf8"
+    },
+    {
+      "bytes": 73748,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__file_arrangement.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/desktop_template__file_arrangement.json",
+      "sha256": "019dc21e3c329d41d1f8c882a498f0598f1c256d8cd1aa887b9359aad338a34e"
+    },
+    {
+      "bytes": 41204,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__duplicates_searching.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__duplicates_searching.json",
+      "sha256": "0c101ce444f209056280bd9ab4001e7552e92d5cbd1c721c9647bc5d08d632a8"
+    },
+    {
+      "bytes": 15593,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__file_merging.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__file_merging.json",
+      "sha256": "bb0953b35df24c92c66b715385b169e2bd7e49d5e852593e641b861acf3fa551"
+    },
+    {
+      "bytes": 39564,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__file_splitting.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__file_splitting.json",
+      "sha256": "92a8acd0ffbf5c4eb3b850b1b40e34e76d7a94f04246bbd8c08b3bc66bc08f85"
+    },
+    {
+      "bytes": 24125,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__pattern_matching.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__pattern_matching.json",
+      "sha256": "09745918bc04b39cefcbe0917d6d7e63ffb44809cf8700d8765d2a4482be5b7b"
+    },
+    {
+      "bytes": 34360,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__uppercase.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_context__uppercase.json",
+      "sha256": "be8f1372df691bb1c1625f8ee4db5fc1612b9336a8510696a3b76b1db7db8c88"
+    },
+    {
+      "bytes": 34409,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_property__size_classification.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_property__size_classification.json",
+      "sha256": "e069afa46acce62cdb33bb73bdf728374e76f4ba61ad93c7ed03a7254f00dcbd"
+    },
+    {
+      "bytes": 65241,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_property__time_classification.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/file_property__time_classification.json",
+      "sha256": "849ad471ae6a474a3ea3074478317c5bf6760298d4f8bbcbb3d11e7cc7fce2a1"
+    },
+    {
+      "bytes": 201201,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/folder_structure__structure_analysis.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/folder_structure__structure_analysis.json",
+      "sha256": "2691784804660f47e42973623a471b971a79fbc5dea8344b501e6238bc1f5365"
+    },
+    {
+      "bytes": 80827,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/folder_structure__structure_mirror.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/folder_structure__structure_mirror.json",
+      "sha256": "2aae78249dd579d85285721b2cd472667320e086b9cb6ff66408e7834c2159db"
+    },
+    {
+      "bytes": 25889,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__dispute_review.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__dispute_review.json",
+      "sha256": "cac1a1c0cde818cd92da4fdbff3b42884e3846b25e70c12ecc55bebb4831e95c"
+    },
+    {
+      "bytes": 44788,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__individual_comments.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__individual_comments.json",
+      "sha256": "0c1c48f24e5fd521cf9217e0ee470fe1bef6dfd9046d57d42969f9cdfc3dea2e"
+    },
+    {
+      "bytes": 60272,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__solution_tracing.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/legal_document__solution_tracing.json",
+      "sha256": "a839eceec8e3d747252270f7a39fa904e6ec4b2f29a72ebe6d0c1283349c2813"
+    },
+    {
+      "bytes": 22446,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/papers__find_math_paper.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/papers__find_math_paper.json",
+      "sha256": "a0aec12bcddfbefca88a3733feab42640a8c82b1002eab2052f709af703c8c66"
+    },
+    {
+      "bytes": 73854,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/papers__organize_legacy_papers.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/papers__organize_legacy_papers.json",
+      "sha256": "da3282272464fecb248096b4f2628c12c05fd416128abce4bfea8db0cb1a254f"
+    },
+    {
+      "bytes": 13871,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__duplicate_name.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__duplicate_name.json",
+      "sha256": "91e41d5995ce35de681d90da6d78db5ceff5f15a842ab0ca38429739dd1a3d62"
+    },
+    {
+      "bytes": 32839,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__english_talent.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__english_talent.json",
+      "sha256": "a30989fe1ee89f1f212148aa43bc774a751178a1b4ef2751bc4dbf2c807e8d55"
+    },
+    {
+      "bytes": 20720,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__gradebased_score.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/student_database__gradebased_score.json",
+      "sha256": "846e1bf55d1bb1da722a68f330b18238060414990d3f5891715a9fafd42ae428"
+    },
+    {
+      "bytes": 17271,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__code_locating.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__code_locating.json",
+      "sha256": "bcce748159c64a06d384abf9a77bea3d8fdf703beb09f9ed7d8ce98f42a346aa"
+    },
+    {
+      "bytes": 31016,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__output_analysis.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__output_analysis.json",
+      "sha256": "2e9c33c57638ba1083daa2632157220107a5306cdf45a3023f5fb3cfc9020fac"
+    },
+    {
+      "bytes": 80771,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__requirements_completion.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/threestudio__requirements_completion.json",
+      "sha256": "3b3d580d016e44eda47f2ba6cb5616b781c4156f2ddb0d9d98dccab423b00a9d"
+    },
+    {
+      "bytes": 17312,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__dataset_comparison.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__dataset_comparison.json",
+      "sha256": "e23489e0589d63ce892677205cd20fc8859597cb268463c640604f260df70d4d"
+    },
+    {
+      "bytes": 32711,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__debugging.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__debugging.json",
+      "sha256": "72c6752035d4050f22775d4f7761c171d559fc9188485f545499e211f9f2a064"
+    },
+    {
+      "bytes": 36224,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/trajectory-releases/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__requirements_writing.json",
+      "remote_path": "trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04/tasks/votenet__requirements_writing.json",
+      "sha256": "c6060edc6ee63b7a08f77617535b35faff3a9a6ed9ddb5f87928d05ab3828525"
+    },
+    {
+      "bytes": 715,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "218c11e5070b79ee190c7cd5758f897464333798bc75e73623a73c4ce91d76a0"
+    },
+    {
+      "bytes": 29267,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1110ba441d9a8f160b2cae7b3b8ae6d2347dfee6d9a9f088baf37008e139b74a"
+    },
+    {
+      "bytes": 3619,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "297cbe7555481f96d26b243ec0e86c97808817849e511bb36028505e208f64c7"
+    },
+    {
+      "bytes": 21072,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7ce381f76c46f77a3ffc570da74c914f78060ab443d16669e0f99a1c96abe609"
+    },
+    {
+      "bytes": 215,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fac40af538f955e400eeda503e0d1c27ee72ded079be6e49da48e02d2afc0fcb"
+    },
+    {
+      "bytes": 1631,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__music_report/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "10d2367ad7dbc9c482e3b67709d837da7068effbbaca288dd3bf424edd843628"
+    },
+    {
+      "bytes": 1382,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c58b0d436a05a50762a47793eb061a4fc9caa93c946bb82d38f895d090513f84"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4ee65f360cbedfdd3168b435703528ae88a46b230653473c69fb42b1bb58183c"
+    },
+    {
+      "bytes": 21530,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4f94da58c08a7a173a86c706fe4ace37383c6d6ae42aa2d49e466c679d29a7ea"
+    },
+    {
+      "bytes": 17269,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__music_report/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5b9ace605c30d550f3c95a259b8230cb690c16b5ee1c70acc5a7d8c58ac29c58"
+    },
+    {
+      "bytes": 146,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__music_report/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c583fa859ea5b9da7caf96f86042c40b4f550e5c15a060756dc162b181c4cafd"
+    },
+    {
+      "bytes": 1684,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__music_report/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fc714d207114a5d4215ec2b9febc2767e6c40ec90ebb5c95aef5a17248f3a2b2"
+    },
+    {
+      "bytes": 1380,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/01-desktop__music_report--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2812f792743a1c213e0fd3f254830f6f781f3510812191b2dfc81cc1e512320b"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5dd4990eeef193850287de60c764b76c81b5a80ba8001d3337ecb537e726e966"
+    },
+    {
+      "bytes": 164419,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "85b262c5fed63daf7e2c5fa03403c96f13caccc9680dbf70e5d156d257d1cec3"
+    },
+    {
+      "bytes": 4203,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "92c9db9bc42bbecda82aff2b2fe2f9727a41f98354cf2aef7f6f6235abbc288d"
+    },
+    {
+      "bytes": 96270,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c831021b51e128cd32322868f6993621db5390849a1c485970f23cdc0cbc556e"
+    },
+    {
+      "bytes": 521,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ee2402382351dd50786e8427df48cedd9fa926a703b2be9852e2a8a13938bdec"
+    },
+    {
+      "bytes": 1925,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__project_management/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9c2167d5c6681df39499f3c296358b716c8d9cfebbd04a7f69458d12ae6c2306"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a423fb265f89c75dace987be65b2136ea1abc660741e6e47fc0860646a9f2486"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5a2a299e282bc15cae4b683012543e67fea27eaaefc1320ddf6919c7f3398692"
+    },
+    {
+      "bytes": 98031,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9427b758d913f2d216dbab54edb34ea34e1f45416627e72cc4feaea19906e5e1"
+    },
+    {
+      "bytes": 101209,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__project_management/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "19a828aada0318e1a420c19d0ee307650f2e23676cfdcd9db380eb9a82f6fce4"
+    },
+    {
+      "bytes": 657,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__project_management/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0bb4ba6c66be45e67d3d6eb388915a95eecf41e75cae3cb3a4858a8e335b0580"
+    },
+    {
+      "bytes": 1970,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__project_management/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d418fedb527d91d679bb5c048d929269fe468c86a458ba1730dd21d4849292b8"
+    },
+    {
+      "bytes": 1403,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/02-desktop__project_management--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c0b8aaae51c83976f9aef77303d0170b0222eeb33826e813c64169e6a584ba6a"
+    },
+    {
+      "bytes": 719,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8848cec5bb80cddc4ab28e752243e5aa05e6ba737a5da1e4477e649bf134e8f9"
+    },
+    {
+      "bytes": 189144,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5d5dec69289eb9fa30de575d592bd047b982d7f01110f4f6272a57f16dd83658"
+    },
+    {
+      "bytes": 3473,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b8390168db5cc417497cc19abd02cca65226e123a5bdf60c09aef54e586ae1f4"
+    },
+    {
+      "bytes": 16488,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c7cb077cdd576b95988c1381bec7b56c3dfd586009ffe6264c4ebe5fa65ebbbf"
+    },
+    {
+      "bytes": 244,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9a99d63ff3d0f9d6ef54ca21f99c26beb2f532ba86ca18ab195e7d4ba46a46fe"
+    },
+    {
+      "bytes": 1593,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "09d5391d8038e912c4b40e479a1932a0c55a55fe416e4095d553e32bc242bbc8"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "42ff3ab7baa865c83019359188538db72639660282c7dd82c96261f6abb2edb9"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "dae233cb42946c5cfec421549f29fac2b1cf236024b52539188d7c50ddce8d31"
+    },
+    {
+      "bytes": 137168,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5b70e5719ebde3341e018eb46fe4c32f02eec85d710196b8ddaecccb28465744"
+    },
+    {
+      "bytes": 15572,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7448bb75f424c0c7aa20064345d69d48628d9023fc21e1c49b25cef3666efcd8"
+    },
+    {
+      "bytes": 113,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "156211c430e1b49f7793e3aa163feee1d794f9c0b759812e7ef09bedd64cec3c"
+    },
+    {
+      "bytes": 1633,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop__timeline_extraction/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cd2d84a6e283c1717aa49c78e23ca1dc4d468301cfdf7ed0a539e008e7ecaa79"
+    },
+    {
+      "bytes": 1387,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/03-desktop__timeline_extraction--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c4eac7c8620221ec95d82b287e942d39c2864d73978ba77ed8f8608e7555fe84"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0048432ef46e205af5ac3a295029d78f74dd27076e975b573b4343a44b77d581"
+    },
+    {
+      "bytes": 38394,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "71d6b5a679b068f506bdb7425ea5277629703b603750969875157d70176f155b"
+    },
+    {
+      "bytes": 3485,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bbe9ca8a9ee8b811259dd5b976e62e4d803b615a86b0f92a7e41929a8de6aa76"
+    },
+    {
+      "bytes": 14941,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "492f6bbc977416b3e5444f116e58f5d18e8fe1d774c9660b1e21bed6f91cf904"
+    },
+    {
+      "bytes": 77,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "53a5e6a49c52b96921ac14f91910e01d9368e6aba8156dcf777bc34245126851"
+    },
+    {
+      "bytes": 1534,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b2cda2a2a3c10cec8e1cb1c6fb46cce90e650097949d07d824fac8cdb034bc54"
+    },
+    {
+      "bytes": 1389,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5563a63c76d964c37be67ab5b1c54c8bbd2241ef92251633b17fdf4a36806edc"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "886eb37dd0c60f2b47618d2da73b794170dc1c2127988f5c07c6e4b20a5263f1"
+    },
+    {
+      "bytes": 29350,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2a97d0c735d3e81d85727965838104b2529886002ba7b403fafd6c2f08e57cda"
+    },
+    {
+      "bytes": 15577,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "48ee6e5e064f3ca8a4d56370c9d9740dd633366ca7267e2a5c660ec78ef881c5"
+    },
+    {
+      "bytes": 60,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "76103a37a442208dbe3713e423f639fbc43d0000121d861cff94a14d20beb4c6"
+    },
+    {
+      "bytes": 1666,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__budget_computation/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f3171a732ce4de7f5410a8fe4b93770ef81ca5d3d3babe308f6dc8570d90bd5c"
+    },
+    {
+      "bytes": 1392,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/04-desktop_template__budget_computation--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "09ca80f675eb3b9f62e8494763e71754ee2b4355dcb240c02eea2e9c349ecfe8"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ae95b573de913eae2eaa3983c4166705aadf7e8bbfae89fb11182baddbff9c62"
+    },
+    {
+      "bytes": 51004,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b5dd393069e1ec2fc8e33baa48f00626b74b2b16977bb2d9a60a0495a69c7e35"
+    },
+    {
+      "bytes": 3193,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "332766cf2ae83584cdf430b7028af3e9c9f255f0c8f393ec8d4310e2138e216b"
+    },
+    {
+      "bytes": 20149,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cfc46dbd5b5add7980b32bc5dbd54999ad92060032e7f61bd48ac62c1a519f1c"
+    },
+    {
+      "bytes": 133,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "92222471df828cec61145d2aa56969d63558f92eeba5f6b4d5071117c0fa542e"
+    },
+    {
+      "bytes": 1604,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "be424dbff30f9e9e5092ec4d9c0220f5065e465f09d18aba4370fcee13d10c82"
+    },
+    {
+      "bytes": 1404,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f5b4752d93bb2ca1a09161127a8589478be655fcee53a438fa1beb55839386e9"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "124ba3babbd60119d31645626eeb7054844c0db195eba6b21df7f2e22b672090"
+    },
+    {
+      "bytes": 31213,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b38207c01f33e181459efe62a8fd8e689366e56c2aebf358c763187f7ee1784a"
+    },
+    {
+      "bytes": 17286,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2d85dc06b76940d7d07cf7c8ae7394dc26658bee70449df6312dc15c12faef5c"
+    },
+    {
+      "bytes": 79,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "430d97d1750c80f7064d0238446bf52645fafee6f527e20066eded5c497b7afa"
+    },
+    {
+      "bytes": 1644,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__contact_information/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "62dd8b6ca4ef6a1ccce8b8f91db6e9341ac994405968e53fbae6eb863764df9b"
+    },
+    {
+      "bytes": 1396,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/05-desktop_template__contact_information--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bd4a4fcb118a61bbe30fd966364706ff5eaa7d699d0008d8014ed786140e16fe"
+    },
+    {
+      "bytes": 719,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "99cfb5d064f0c2f93f839174a0e95336c11401454c01d43a7f0adbb02e11bbcf"
+    },
+    {
+      "bytes": 121992,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e442d8c0a0cb254d45e904c8c316557c64077d3d9b16a1bf690cc8b9a2172076"
+    },
+    {
+      "bytes": 4361,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "747df622b8a74191feb0c8381a4683b07657fb7c38013f1521f059cdf515985a"
+    },
+    {
+      "bytes": 111709,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a5374a0f4b8bb6fbf246875b76f0a74c668538966e042e5307b904442f440d33"
+    },
+    {
+      "bytes": 516,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d5c6cabae5e06b2f67b6445dce7326deb92fc31f0265f0ccedfbd291084ba43a"
+    },
+    {
+      "bytes": 1846,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "19a9dda189d8c6ac3b89416c7b789620a01b5d80d00d520bfae3e65cb585b0dc"
+    },
+    {
+      "bytes": 1402,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a7bec04f8da51285a38668618772ea71891f43192d7914d2120f48aaeb6da749"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5f8ac02f387e782051ccec1fc98b975bb2116d948b5165abb1bc28818a1ea88f"
+    },
+    {
+      "bytes": 82900,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "51f921e58643475c738e15796bc460ddad9f7ca4ef0d6b98dd9e44a815bc6f40"
+    },
+    {
+      "bytes": 73745,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3c5dc80e649fa3b0e45c9b68b157e15ce284e32b07bb5872ab428bf62ce3b72d"
+    },
+    {
+      "bytes": 397,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f388ac1750cb5199b6aafafaed80552a8cb9f4014bb223f7b5930ffb0ddac934"
+    },
+    {
+      "bytes": 2090,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/desktop_template__file_arrangement/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d6912bd5eb4f1f40a36f08c3c2d926b7f1faf81147e6a7ec5dd11f41f027d467"
+    },
+    {
+      "bytes": 1400,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/06-desktop_template__file_arrangement--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "54958f627acb29b49f6147b11d1a271c9600e633587b190b23294cbff55ed8e9"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "37da3361702dc2dbc2ad93caaffe7127c9e23a0e1815f8afc2d1716f3a3c802c"
+    },
+    {
+      "bytes": 61642,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ab8bf1003db98f1477f9b8e3b7606e715ae9366c1e3885386a3b4ced25a8483e"
+    },
+    {
+      "bytes": 5529,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "19cbb0da38b379dd415d07ed0b581c5550c430c13a6d39da27f7e6cc506b85a2"
+    },
+    {
+      "bytes": 38513,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6a97efe2f7178f99b8c14ccb6a5bb5af9b8977c2f43b607167e63cb6d21552ef"
+    },
+    {
+      "bytes": 489,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5f28bf4c496a87b6da71a4d6f941b7218e1d15dccee620e4b6c49ac8f9222fd4"
+    },
+    {
+      "bytes": 1528,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9dee36014fffc83613f19080e903378a13070198270fddb3dd4fa75dd89f24b9"
+    },
+    {
+      "bytes": 1394,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "48c8a94c2f4c9c72e6c349cb4bda5dfa76ec7d5fa4dd30aa2a60a3a91dd326bd"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "044365f874871dbe24cc11812dcf10b4952add812f51ac15f2a92e240c21871a"
+    },
+    {
+      "bytes": 52071,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b745e5adbd399202a5e64fe51ef954dc2678e5d7cb9ab82713a6fd383a56e12b"
+    },
+    {
+      "bytes": 41201,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4904c142e884e0df64234a93ba7353208d7984d81e4b85c95b2000b3cc2cf8f9"
+    },
+    {
+      "bytes": 895,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d07227493d5027763979b912cf98b24debd6977e16b7523dcfd342020521347f"
+    },
+    {
+      "bytes": 1569,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__duplicates_searching/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c7560a2d0c9a85eff8e8ed870fcbb78083ca4c15b7e6259d40753a89a12c0b9d"
+    },
+    {
+      "bytes": 1390,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/07-file_context__duplicates_searching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0990ed889d4e774114c28cc5944d8e781bfc55d6003e6311e5f4dfef20382033"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2a32ad324d4e8ac778246f90f47ca640a4fb9a2b46b0f891a27392516cca41e1"
+    },
+    {
+      "bytes": 24519,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3dccf4f8278700ab76923fd6b45ad32d34bab3c3a98c8a581d45349dca524d92"
+    },
+    {
+      "bytes": 3047,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e18ec207110235884aafdfb2bd6c2637fad67d207845bb18ec3aa827856f99f2"
+    },
+    {
+      "bytes": 14953,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "03831b0c6760b6d967860754cf999a9ca04819b6bae015be70a46f0801ef9657"
+    },
+    {
+      "bytes": 332,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5b683f507cb2398934b19208a13ac766170390c3de6c6cf2d13a90e78f76609e"
+    },
+    {
+      "bytes": 1491,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_merging/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cefb7a8aefe275201782abab9d18b856a338171245148243559242465968f96d"
+    },
+    {
+      "bytes": 1385,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2548859eaa6b344139e8f4dafae56f8e3299aef25ff046708a3963ac2b0b86cc"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "54c7d589e1ad40669f202eee84c0429f88e6aabd0d4a447520ca99844d85031a"
+    },
+    {
+      "bytes": 14964,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "34f66466cddf94c6dfa5645e50bb91cbec2174a47c30b23b95a22d73aed9cb1d"
+    },
+    {
+      "bytes": 15590,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_merging/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "94cc08f0f484adc848730f379613cecc718f4b0e0a3b1eee58d02da50ad37bcf"
+    },
+    {
+      "bytes": 352,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_merging/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5104dbf72ecde88c6f7ee2adf0706fe7740d238d807676f71cd8e1ba78835fc8"
+    },
+    {
+      "bytes": 1531,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_merging/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "647e8421626b6a56bbff0f03452c09ed013c7914110ed04d9896b34c542e2c10"
+    },
+    {
+      "bytes": 1383,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/08-file_context__file_merging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d9f33aae553b185f6d76263e540dbcfb45754ec8de6025e98e8ba31cbebb0256"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "964dd0fba4581a757ebd19a905346a4a15333a3f20232d770283826e7c81d1e0"
+    },
+    {
+      "bytes": 30163,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "06a08a37e696c52044975c18a91ec94e8a5c77535acece8df7824b607327299f"
+    },
+    {
+      "bytes": 4361,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2ce1145a9d2117753cd483a263c35bde3e9393b424b75405828db3a2fc1a5219"
+    },
+    {
+      "bytes": 33978,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cb3c98e7bdf26bd0815b7bc8cbdfafa750b9b955e6a578b2bb436571f4822fac"
+    },
+    {
+      "bytes": 223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "74658e8dc85c5166ff29af46d9261e24112cd2c00b5edb3990e6dee60ae2b744"
+    },
+    {
+      "bytes": 1294,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4c07c71af1880b38b7921978e54066467d255a9543cc7096eeefc81e158e90f4"
+    },
+    {
+      "bytes": 1398,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9999cc4a98aeb271ac4b3fd6c36ce6f4af5a42235b7daaa8335830e4817b295d"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4d49251518d77372fffd199625d934b6fac447cccfca3afa3427e14cf46f39d8"
+    },
+    {
+      "bytes": 27087,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bdd1f6bcbfa6a0c43f7a1771ed94883621b2b1f53b5433525b7c48d73844d0ef"
+    },
+    {
+      "bytes": 39561,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a5dc645fc67db4042971663a0d101e98106a2d6e9087e5f23e11819ca0d19160"
+    },
+    {
+      "bytes": 322,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b359201cdd3af1c49d872d1af659149e99f48d4ed2cba0012075a8040ab8c435"
+    },
+    {
+      "bytes": 1337,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__file_splitting/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d085a1b73fab52654ab26ebf2357759113aeee00520cad4039790c3ad127682f"
+    },
+    {
+      "bytes": 1400,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/09-file_context__file_splitting--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "75a80167ed18d7a9497c3bfee733c090df2347648a010e92546e7b9b88a5893c"
+    },
+    {
+      "bytes": 715,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "52bf7e2d5991f3dcafc350b427e013028738b2b969acc691556700ad8bdc07e5"
+    },
+    {
+      "bytes": 37794,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f79b662fa110831e95c75dac92bc33480e354ca2ed119abf4316483c0cc3d4cf"
+    },
+    {
+      "bytes": 3631,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "64f7ab6717f53241d00492f0246ed9fd1fc5f5b2334cd07a7fc9d63772df25ac"
+    },
+    {
+      "bytes": 20183,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "09f77c0649f9f57c51de4a7700e8677cb0c7619451127002dc093abee43bd41c"
+    },
+    {
+      "bytes": 76,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "baaf47d89a02fd38bcd9bf0d6a8169eaf952ea5c885ee5ea7ed2eb748c2b1e39"
+    },
+    {
+      "bytes": 1347,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "deb57722c5456f1775134a88d6f047f4fa75f4809adc9c6ddc94ac5c898e7930"
+    },
+    {
+      "bytes": 1388,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "02d7ecae0c950e5262c44101153243de268c4aa574faec5a168ceefe4ac44bfe"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "86caf66ac40b57b2070ac39b1218140555fa17c63800b4f46857616ab1a309b6"
+    },
+    {
+      "bytes": 31030,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "68dcf1deb76f02aeb58ac11f57b9d1d5cc052ea48df26537d90264436e331f5e"
+    },
+    {
+      "bytes": 24122,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "370297ad2079a30ed54a47f67daa98d0cbc197f4d2d5e8c7985b2ff57e71d01d"
+    },
+    {
+      "bytes": 118,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b0f64911362f34eeaaffc8aa0107694d0888540486f9cba74f12622c9395db25"
+    },
+    {
+      "bytes": 1356,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__pattern_matching/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6b99ef074910d01ec0b4f1a925817e7d2189129d0ea2fcc3e1d391b36a9d0e53"
+    },
+    {
+      "bytes": 1392,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/10-file_context__pattern_matching--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "11b71619180e79f321bcc28af806470029892cdeb6120fc5c76a6b2e0b52098b"
+    },
+    {
+      "bytes": 721,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "aed91029887f580c3e57843b1393d25f0e9453000673a2b7fb5431e783942aa6"
+    },
+    {
+      "bytes": 36270,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0de6937de20a2c22448bef5ad3755e565259d77f9babf000f8bd0b92e764f8e1"
+    },
+    {
+      "bytes": 5091,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f0b62e2ede532ef2d4020bf45fea0f8d831f894ca4611c9d59c443212f13fbec"
+    },
+    {
+      "bytes": 31261,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d6a350e4d21ad2719eb9bc80c2b543d2976903d2b911cd55867160579c92190a"
+    },
+    {
+      "bytes": 331,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d42949898a2e3868addd82074a533239723d11c49312ce06a3afc5c93e9af571"
+    },
+    {
+      "bytes": 1590,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_context__uppercase/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "71f843d6b03d12295e3a228a1690889032aea892fd6d27a0ee274265e2cdf51f"
+    },
+    {
+      "bytes": 1396,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1ccedb1e2d1e94384bb7d96048778b8968794fb540fda38883d854c0e14c9b15"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "45976b91ba5e55136bea7c3eb9d1d44751b004e210833d9d818f79c147aac1e1"
+    },
+    {
+      "bytes": 24874,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "989d1223b11ad2c2962d3878e106ffb83784f39136ffdae585025e3d9fb1a4ff"
+    },
+    {
+      "bytes": 34357,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__uppercase/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3b248baae99f505a17c9d4e43ea3cd0076444ec93bfb982202dfaf7c483c7b59"
+    },
+    {
+      "bytes": 154,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__uppercase/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8fece3705151818cd47067bf150e1c985b6bfb676db89f82c0d18798fae8a3f0"
+    },
+    {
+      "bytes": 1628,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_context__uppercase/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "eea6674a39fd46007d4ae965436c7a6095a8393b5a54666a630dacfa34adf749"
+    },
+    {
+      "bytes": 1387,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/11-file_context__uppercase--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "07e78c2ec2c991de8bc2f617a14ee573be96073be4b2d1fd778792f8b9200cc0"
+    },
+    {
+      "bytes": 716,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a3bdec44d678f276424f9e25f0bcad1dcc4f4a8572d1349992a5cad9dd095dc6"
+    },
+    {
+      "bytes": 31877,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d60f505b9c7ff3971291a2c2cccecf159beaad2e5f50dc76e4967d028e8dc10c"
+    },
+    {
+      "bytes": 5529,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7e59dde08818322aba6b4c87b410d15356b210c1ea6911499a039d4d8d177829"
+    },
+    {
+      "bytes": 34998,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f7bd23e667fb01909b6cb4f845916c6a205bf61d745fc7663490f26d7ea76819"
+    },
+    {
+      "bytes": 457,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2bd7a4962d4f48c7da5378191ae142dd1e825ae86332d0134adcaf3fea9a25eb"
+    },
+    {
+      "bytes": 1391,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__size_classification/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6bf4ee2513683ed9588b754b2416dd2d67a6e850c5f59772b39ad02f34aaa922"
+    },
+    {
+      "bytes": 1392,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4452f47a65f1583785597e4db107d9569473d59d0ee27b8a1b0d7e0fc63885c5"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b42b006c95bb1356c95c7aaba871d7da8aa551f4c467db44f2c5914190a82d1a"
+    },
+    {
+      "bytes": 20874,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a69330785674860f03f08a1c08e5e684162a2708f4ef03c648c5f34119daaeca"
+    },
+    {
+      "bytes": 34406,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__size_classification/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6aaa49206c244210f74e3fdeda5d8e2310cabf5046849a735dd9f18ecafe447c"
+    },
+    {
+      "bytes": 371,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__size_classification/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1032e23f44c44b2d958a9b5b9b0a43df3b6635c37460c2cb34fe400716965ee2"
+    },
+    {
+      "bytes": 1429,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__size_classification/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3fe1ddf46468ceb7c226a0f1a38068def0d6d32b955d9cfe6c75ac842ae7b2a5"
+    },
+    {
+      "bytes": 1384,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/12-file_property__size_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fa5cd48639e426df31599a6a4281f53c42771733f837d4630ca065dd95dfe1ff"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f26a88bdf80f6e1129ce66aa920c7dc07bc4f2ec19582fb2202660dfbb8ad7b3"
+    },
+    {
+      "bytes": 50822,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c39fdfdf9978ba6924ef621ea6796d66bd52b127fd95277ec19b9b7b51b83698"
+    },
+    {
+      "bytes": 7281,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1908b9c7986c496e03b7baf7ead1ab5e65f3e17b4144d60d6c442194d8771ca9"
+    },
+    {
+      "bytes": 54530,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "74d9749ba61f54a10a1c013d06756806a1306f95f2a692001d9e1c98f9bf2f2f"
+    },
+    {
+      "bytes": 361,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9d342b16a925841d1115beaa8743c8862d549612296a52514a4eb5d0733f6b3e"
+    },
+    {
+      "bytes": 1401,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/file_property__time_classification/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8f16e4cc25f8b9b4c570b9edb7a8bfddc7ae81a051d3baab75db59e965c2905b"
+    },
+    {
+      "bytes": 1399,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "aa4d36b7b938072380d4514b373068ebdebb21284db4166e54a97f210f10ddbd"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "459478fa5de76ec48fff08ce20c882ae678ec1c336a60d1858355f72a28ada6b"
+    },
+    {
+      "bytes": 42170,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2db10c23a7191b706e086b7dd248542fa27ddb1803b1e1c29281c9fa8fb3d838"
+    },
+    {
+      "bytes": 65238,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__time_classification/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0459c37f9e220a3230976580fd27a81a7bb88bd818b995f2afa5ff7e9467d575"
+    },
+    {
+      "bytes": 652,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__time_classification/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2d1cae9c43639dadf2f58aacbcb39279043bd7f0ab88cae70d4029dd041185fc"
+    },
+    {
+      "bytes": 1453,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/file_property__time_classification/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "04969310e8ab6616061616d80df4ae3fb1095b7f6c1ebdd5a5654e2be29a112f"
+    },
+    {
+      "bytes": 1397,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/13-file_property__time_classification--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1b68ab22eb870b8c6500e10d2e18f0b63865dc92414ba78036d9399300297800"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "34a506fb88d251bc0d65bf3efaeb768a4dc15bfd89d278d5a92d4bfa2799d575"
+    },
+    {
+      "bytes": 161781,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4c9c2a1c2fc9b9dcd0287b7856b0a68591aa261f43add15ed80b2ee5b723ce83"
+    },
+    {
+      "bytes": 12245,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5040b0bc83fdb9910586d6708fdfc2e8a3199d87ab5c8ac7f20dfe8e2bbc73b7"
+    },
+    {
+      "bytes": 115348,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d06eb2748b92b250aee374849776b19419a069705386c73d820bc4d1b10a6337"
+    },
+    {
+      "bytes": 168,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c0419ed7e8d24ab109e221f8cd51b77fbc8085f57aab7331838dd15da4cdb0cf"
+    },
+    {
+      "bytes": 2029,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "731f50440f24bdac404f84224526beadcab461ff4fa0651b5d86d709f6e4106e"
+    },
+    {
+      "bytes": 1415,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d98278e594768cf5cef96b2b4a96f5332399c86d608645487f9787873f786a23"
+    },
+    {
+      "bytes": 903,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2ac8561e721b79cf3bb4babc070ef7e4de3c5edd0cf79203e3c789318f359e8f"
+    },
+    {
+      "bytes": 279698,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fe1c0777a13e93808636086d006aff8dae6abb6995cca3aa4fb6a4a836187ce3"
+    },
+    {
+      "bytes": 201198,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2d9b2cd85c45bc7e475b585de6ab93bbe61e2226091415e7ae3fd9e3616c63c1"
+    },
+    {
+      "bytes": 144,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "095babb405ca71714d70b082c5537d811af9fb0329c9b3f12442f7c66b9459b7"
+    },
+    {
+      "bytes": 2073,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_analysis/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4cb986effe5b9715e8562fee0477511aada780c00b8f98e816c80a3e57bb9af3"
+    },
+    {
+      "bytes": 1417,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/14-folder_structure__structure_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "75ae07956d68ed36f213ff0b63a1d9bd1f35bb02110bbd14a3c9c578e7da3f26"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "dbfd5918e5c596fa2cd4c17acb886ec243a3ff1e1ff80a761116b085dd754184"
+    },
+    {
+      "bytes": 93276,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0357bd381e779578895c6fc10c6226db77a0408c89347ed9cb3209af149fb7c8"
+    },
+    {
+      "bytes": 3777,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0a02cbf8fd0dba9dd9e8b50051d73ceca0dda7eca41e3ff4f333b5f8a6a9d248"
+    },
+    {
+      "bytes": 58671,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8ed1e91f926067e2c12c0009fbd886263cb46395c8f33b6597fe7e932f708b8b"
+    },
+    {
+      "bytes": 593,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "495d5be862f9686140651d5bb1dd8bf98c9c98d34484bc50125da7d9168b5b61"
+    },
+    {
+      "bytes": 4024,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1592a894a8e18a75cfa9474aa8e42f22bdf538f259a006b416fd5e7c315e34c3"
+    },
+    {
+      "bytes": 1404,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3ea4dc67df2c6b0373d2dd37516ef666dba4bee4a3b342c1ff85da44d25dc01d"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a2fd5ed47e0f06a26804327609c5ed6189228c5fa45f71493984a5de9e52cb5c"
+    },
+    {
+      "bytes": 95936,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ba3762632fd745296e62b2c94ffc5754761c5a023e15180674e6b3c7c36c5901"
+    },
+    {
+      "bytes": 80824,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5b6442002ae02d3117de44a363497fafef3198c7a344d1ddd6d036302b97e9e5"
+    },
+    {
+      "bytes": 447,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "63ffe8b7bdab5ff73bad096c2272ac498ae2a118dd1d2525794d921573844401"
+    },
+    {
+      "bytes": 4057,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/folder_structure__structure_mirror/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "67ab0351a5a663d783f14b83809908bf6b37e381765d9988db1c61d4b5dfbcde"
+    },
+    {
+      "bytes": 1410,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/15-folder_structure__structure_mirror--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fabb79c264091a99dfb7a1bed2bbcb4a5a1fd79c1ec513d8c9556d426e8787af"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0a37168c43b56420a61b56bb11a60ec75a073b1f28f5f0b106bdd3013c7d8f66"
+    },
+    {
+      "bytes": 1449653,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3bfae08c206481ee138b4f7da1025c335a2295af9e8f81d302a231645b54703d"
+    },
+    {
+      "bytes": 3777,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "caaf346ddbdb2d892b41b87b17ce1288561fd00376ed46f89e0a97f29855b032"
+    },
+    {
+      "bytes": 25373,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "814943554621f176989e44d9bcc26baa8550a7d9ef05dae9ee737d066c9f4295"
+    },
+    {
+      "bytes": 147,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a6b625d036dc96679cd72ec39a4d13546bd7d1181adb776c784332d3b6ad84f3"
+    },
+    {
+      "bytes": 1249,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e22032e6544b4ae1f0ff95564f82fdba3402d333cc6188f9472d4aab389c5f2b"
+    },
+    {
+      "bytes": 1396,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e2d418fffcc50640e1e35d6dbe5768623ddf4efeeb6bd01a19dad41572282ba7"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "64693d6a226f137f66f291602a73d1686ba21a69ae42c1d0d0991e3dac69380a"
+    },
+    {
+      "bytes": 1134028,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f737ec4992f865e520dfd2f5edc2f3d8a34c440f9f952c8f1edb92093fa61881"
+    },
+    {
+      "bytes": 25886,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ceae062ce3284c3605f8578ea04884f57e1b47dfbcb7fb09ebd9a788ed0d0801"
+    },
+    {
+      "bytes": 103,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ceaffbe2e42d826176f2231f3dc87a787883efaccf748bcae9dc39e8e2ffa9d3"
+    },
+    {
+      "bytes": 1302,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__dispute_review/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c7d9ed113bb83bdcce13685f3ec955a269f9fe772812bc3be91a8584c8771dec"
+    },
+    {
+      "bytes": 1402,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/16-legal_document__dispute_review--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5b84a2dcf1c1b91cf7a8511084c6cc27fb7ae910336e7c3337b1e85f88a809e1"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "52d94e114f0cb949f809c14aafdd7e32a35ddd5c014217b3966d5cc5ca64233b"
+    },
+    {
+      "bytes": 1760043,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c3a5b1f9529fc2e372b0fcc831a81b8bd0feece1c49b01fc6f785bf19d64beee"
+    },
+    {
+      "bytes": 4945,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "282617b90bce578540d07a2e38822837a987cd038742d35087db71633e92ecbe"
+    },
+    {
+      "bytes": 31550,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "efc58205efda12f29dde89500e6c2e2bc9e4c33905e9e8c95cc58c8468eaf110"
+    },
+    {
+      "bytes": 243,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "97e84839e05f16c238fa0e757d35dfa3e53545748050cf23ed8b558b7c2408fe"
+    },
+    {
+      "bytes": 1315,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cd736e4a475eff169475142bbc32b8f50316f7c05f70e4716033ce47d62d6801"
+    },
+    {
+      "bytes": 1402,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6bb6c2f4002606ad1f682af2a8f35e8747eae69c25e7e3a62c62efbe6978c0f9"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3e57220dd0f8c4a2c418c9cb6b7cb047659d64bde914624b5dcf3017a61b571f"
+    },
+    {
+      "bytes": 2510933,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1fac8aa57de2d33c4b8850c48578461f61328bf4fbfa983bfc80c526f75cb0d0"
+    },
+    {
+      "bytes": 44785,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ff2cd9da3ecfa43519d5dd22267612344a4ad4eaf106a784f99205d447d3bce8"
+    },
+    {
+      "bytes": 75,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6d7ac5ee5ae1d4282f181673c52df09f251bef94cbfbe6cf8d16bf5b00bb4599"
+    },
+    {
+      "bytes": 1364,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__individual_comments/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8be590079133452065469c1db3fb7ed1d114b515ba664f4af1148f2322efd1e0"
+    },
+    {
+      "bytes": 1398,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/17-legal_document__individual_comments--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "67cb5d5662a336275cf8850d70915cd901505de0695476a647cd236d28735e51"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b531d59032e62914d606f83064191a5425748ed96da976ad9cd09512c159562b"
+    },
+    {
+      "bytes": 1650806,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2605003f8177b1a1c0a9def85f1c980fab1cf77ce856f0000cf8177883080676"
+    },
+    {
+      "bytes": 3485,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "45ae8954cc2d0a223b14518c35792700151e0ed4c7af8b5a3320e35e711c4f1b"
+    },
+    {
+      "bytes": 28828,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2489a592fc02b61d0e40d834f8660190b315bb40fe3fbf595a32963c212d9e62"
+    },
+    {
+      "bytes": 248,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "281a4877a70c2c7c96fac614efd89e3ddb7e9b376b58513cac43b7d2663cc5e0"
+    },
+    {
+      "bytes": 1314,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "be90f581f45f3d3837caaaca57fa8688edb81077cd17c87c676247fc456dbeea"
+    },
+    {
+      "bytes": 1398,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1f1e48cc2b14f34145c9188cb8f69a4b322f6bbf45072c44ded77dd34dd11b0f"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "14792febcd86bd76d2fdc26ab9dd996250f46045327eac4cbc9823f08a86e661"
+    },
+    {
+      "bytes": 5649678,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6fd9f82265a3a471a6104a5ad8ab96cf3f15e78ef0f0f793baca42fc2598b445"
+    },
+    {
+      "bytes": 60269,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "288610def5b66e5bd08d405b2744e6777efd75e427440c7a10f86ad17e6dae83"
+    },
+    {
+      "bytes": 64,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f9c582ea8cf40530b7094f14d7ece4e79e03657e34390a106d106ae6f3713aa5"
+    },
+    {
+      "bytes": 1318,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/legal_document__solution_tracing/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b79f89083dbabea39339b713dd5b71f529febc11d49d4f093acc31c439f6baea"
+    },
+    {
+      "bytes": 1406,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/18-legal_document__solution_tracing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bef52472bd30c009cc0f5e14c237872799b24a482cf8a93de7e85862e5127a0f"
+    },
+    {
+      "bytes": 715,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "159fe72b7998618c0755dcfbd7dd2cdffaeb37eec88f391ee3d3e972bd37bbce"
+    },
+    {
+      "bytes": 737438,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b3a5d7c05e89737680d895939170b67da3bff99425cf25f3057d11802eafdf38"
+    },
+    {
+      "bytes": 5967,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0d577d5093cc45736f378d60cc0be10fe9b38c8cb9b1fb1d52ca02739d13a000"
+    },
+    {
+      "bytes": 161050,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e96f0c74e65199153c64c2d809d6e489019704f694f71793410db3395f7a476e"
+    },
+    {
+      "bytes": 469,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0ae3edb023fdc306032a9db7d515f9d2e42abcdcd02c47a0717ffcfff60f0d25"
+    },
+    {
+      "bytes": 1895,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__author_folders/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6fb8663d4975dc757bc36a5fb0dbb538024186cef0c6ce795ea4d8db1c524c14"
+    },
+    {
+      "bytes": 1402,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "06fa7325a7fb15f7a26bbff24659a6b3d30d479562cf8775733910b5c50abbbd"
+    },
+    {
+      "bytes": 912,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "91176378f2c1a8648a608a5b6d0cf28756bcdb03e0ceb493ef93def214187562"
+    },
+    {
+      "bytes": 10619539,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6a3d40074e47a8dec613b8ff9f04c2fb34fca74dbe43a6e537874ffef7ace9df"
+    },
+    {
+      "bytes": 77693,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__author_folders/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b2277b76f34f46556960c3f9cc81a5208e637b595fb98add5103fd1eb40471af"
+    },
+    {
+      "bytes": 48,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__author_folders/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "460d89daf24f632f71b43d463153ef8d0dfecdbcb04b2ff30e6a67f2d06a0125"
+    },
+    {
+      "bytes": 5046,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__author_folders/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a2826e6f113d12ec4b8c08ddc466fd1e97b86452d3b00903e8856d2c7ad18091"
+    },
+    {
+      "bytes": 1327,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/19-papers__author_folders--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "26f9039434d3b329a4abdcf82b1b5e39b768bab865875f116c3a713e7e43a1d2"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5e2e6f7c2d07f29a8f7cf03a0b82df9fee475d945d0a1495ea14daef5cfe818c"
+    },
+    {
+      "bytes": 503701,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "930d12dfcc746802af01c86a9d94464b84733a96dbb14d0704df97ac234dc4ea"
+    },
+    {
+      "bytes": 2609,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "28e104b20a40c4196443bb030c819155efefca2eba6894a07fef10aa97e88e3b"
+    },
+    {
+      "bytes": 14927,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "905bd061dafc9e5d09ecbf19b497755d412e4bd6bffd7a4b27d88164af3f9656"
+    },
+    {
+      "bytes": 309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "91f10ad69caae7320b65e31ead9f3ca826e8c59368c638d7057914a783c3ac61"
+    },
+    {
+      "bytes": 1036,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8cecb7f0c02b585cf0827ea14421c4f18f25a65861f019fe808cb3aeb0685249"
+    },
+    {
+      "bytes": 1385,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9bce10c314b71cd63a7fdb6ec5b0f971b976833b8c58b5da8a646db8b61aaace"
+    },
+    {
+      "bytes": 906,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0c9f17ef3c6d3ff6da488669a3618aa1ae2e0c0399e853d5afa668d834c1654a"
+    },
+    {
+      "bytes": 257793,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6959c4b4f91430df39e2abe81361e90a3f38e69600ac94a314d495f9e039bec6"
+    },
+    {
+      "bytes": 22443,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "92534e516d660d9b013bc974b141d729a9ed06cf6517327bc9ae0fae3e7d8902"
+    },
+    {
+      "bytes": 266,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0f9a9dbd6cf7729b53659a76eb7203684d11203bf4a146bc1325389796013d24"
+    },
+    {
+      "bytes": 1078,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__find_math_paper/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b049cbc847a62e0469ebf75fbdb6070efb942ee43ca99498a5801f16a4dc6910"
+    },
+    {
+      "bytes": 1385,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/20-papers__find_math_paper--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0add9a5b4a6e7ab3a3426de781684f6f270d02ab5808a173959f4666dccf6e7e"
+    },
+    {
+      "bytes": 715,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e4209569c190d7b69026e293a3ff0542818ce45dc96342d17e41bbe62f2d969e"
+    },
+    {
+      "bytes": 1392483,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a0c8a058d2d89ddb9edadc1475429395065308a6f62dfe3c15c5a30eb7214d8a"
+    },
+    {
+      "bytes": 8157,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4e032594a08fca2e056fbcf3f22addb24bbbbd6ffac427a177d6acf8ea517d15"
+    },
+    {
+      "bytes": 63797,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6572b01b529b7fb3f4dafc697d25002ac12d29cfd9f0e6dcabe4601b00ef5266"
+    },
+    {
+      "bytes": 401,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "271187e9fa88eaa1b8d298311ff049f33a4f9326ca25c3e8655c77e027fbc728"
+    },
+    {
+      "bytes": 1985,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "49fbb8c7b48a095d4d68d56f5762277187bfa12bab91feb142f35793ff9c5e65"
+    },
+    {
+      "bytes": 1400,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b3914f7dda1fe5724d105953a7fc6ed44673214022764c509a9be3d13d7eaf4e"
+    },
+    {
+      "bytes": 909,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2524a0b4a28a579d7996105622aac27c4abcd505f71638f631e354b55a9d1bce"
+    },
+    {
+      "bytes": 1854779,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "44236469675f0a10d5f670080de2e813b85b7f585a662c8f6ccd5cabea9954e6"
+    },
+    {
+      "bytes": 73851,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c590455563472cbf41056cb891a9189d29efd6256449c424c3c19cad288d8701"
+    },
+    {
+      "bytes": 498,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "71ae7aebe5459435eafa055c06c4ec1d2bdfe43339efd7ba5c4393b98c22afe7"
+    },
+    {
+      "bytes": 1941,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/papers__organize_legacy_papers/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ea592fd54bd146407d9d2c1e55ffc17ec129e982198b24b367f3ec0adeae4f75"
+    },
+    {
+      "bytes": 1394,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/21-papers__organize_legacy_papers--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "dc1068d25b30d0bf7fb0dba60f02009f5a14364b03d00fcd39397514aa991b70"
+    },
+    {
+      "bytes": 720,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bcc0f4b14c093e2c5e5c7a606f2a84f584aaebf445149d7b81357509ece2674a"
+    },
+    {
+      "bytes": 18053,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "65bcf184b3ef9b0dc09a30be9e46d10a25e62c8a8c161dbc3cd036ba1c4b2194"
+    },
+    {
+      "bytes": 2609,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b2f0a5b4c7b97d5beec82b2f79238d4894ac0e0baf9d05300bc50aa07cecddbb"
+    },
+    {
+      "bytes": 12799,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fb37515afbf8d1c18a45a968bb561fdccd472eb09e357e011d56e5b6cc28e2a9"
+    },
+    {
+      "bytes": 188,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3a3e5d2d1f768f8a2cfeb99ccfe843899e4e311e8fddc1d5f859e3a8987f7ff0"
+    },
+    {
+      "bytes": 1065,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "093fa3abd133dd94ed296181e03742bedd1151b22c7a00951a0d311065bdea84"
+    },
+    {
+      "bytes": 1392,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cd7c56922656a39a86ace23e7551daa0a162b2f0e1cf8fb452b3536a6d3e38a9"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e7515ed5a0029982f42a45c6ba3726e375ec692196738da319e6582c2963b266"
+    },
+    {
+      "bytes": 15246,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "37a6b76e16f5e4137b5f1cac17dd9b490ef94f3843fae51c0bd269b75630addf"
+    },
+    {
+      "bytes": 13868,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "82671afb28bb612248770acd1173c053237e3a37eacbbb8591d92dd8242474c3"
+    },
+    {
+      "bytes": 651,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2c4aaff95c1b167d7f8e5919bedb815885df75ef7ddb3c589a9a6d0edf648101"
+    },
+    {
+      "bytes": 1327,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__duplicate_name/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9dc385526ba0a325b6a86cf2c6a98ab9520d2f6158144e6aa2eb38dd9812b48c"
+    },
+    {
+      "bytes": 1390,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/22-student_database__duplicate_name--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a56e1f7749982e4bce91effb99c6d091ebd41714f8089b3ac2b35ad060fb7493"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d610bf85f921fdf412184b2edac38691120f556570198b254036f1f31f46d51a"
+    },
+    {
+      "bytes": 769326,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "df85f6075cb0df63ac84f8e7cf87885600a0297b5083c4b6a8c7a6dfb98532b9"
+    },
+    {
+      "bytes": 3631,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8a02e2269443b8c3a032c189a02e429374fab7bbbc40333bdbbe3874d3c8c555"
+    },
+    {
+      "bytes": 64569,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "09fc35a7b37a7ee52b7e7b3693879f95df24cfaa1d79fe0f91a198238262e777"
+    },
+    {
+      "bytes": 150,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5af63523674a5a01182a954c9e523a5243d0668cc89dc16f5d272a48def08365"
+    },
+    {
+      "bytes": 1328,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__english_talent/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3da4cf43f647d70c14635bdd4f646aa006dff74986463b8fe26915617bad6e4d"
+    },
+    {
+      "bytes": 1406,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ec88dc8a341556830f4f4d1f2c7d9a5d5cc674c4ad532b787376c711a113421c"
+    },
+    {
+      "bytes": 910,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "69fa4ee21dc50b1c771e1d115510020507750280d843771916749ae828c98f8e"
+    },
+    {
+      "bytes": 858181,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "327cb213b3befeef4591873bc4840ba386368842d6da9435e320ba227e706ed1"
+    },
+    {
+      "bytes": 32836,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__english_talent/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c65a522e9364575953df32f87951af077d7563db40e9cf9b63755aa029116389"
+    },
+    {
+      "bytes": 129,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__english_talent/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d294a510ab6dd1be6047d31c06b42d6e6a275a90e73fb336f10986d35fef48ae"
+    },
+    {
+      "bytes": 1371,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__english_talent/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "429448759e9cef1fc3aa1b0abe2ac80d633906d50c8da0b3e4ea132dce8916b4"
+    },
+    {
+      "bytes": 1410,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/23-student_database__english_talent--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8a9d3d481a1423663ff9a0d6e72410d3eaf7243a9def90c2c6bb6509a99f9ba0"
+    },
+    {
+      "bytes": 714,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0449cfaffb020c3e153b88a0071538641096b563e9fafb8a48e1eeca9a0e24a8"
+    },
+    {
+      "bytes": 545434,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c22bccddcc2799a451625eed0b4c76754504ab9756dcb7fc2bb4fe601fcf33d8"
+    },
+    {
+      "bytes": 3777,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4bc6534baf3e5efced955c01efaa58d1b3b1098a93afd3c4d156092a99495207"
+    },
+    {
+      "bytes": 32207,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "81eee3d95474130604be31bf3a3f006c487e965ed32d158cf51f474214668f6f"
+    },
+    {
+      "bytes": 417,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ce02ed8d635cc951d23317760a6b8f5788f28a07602748d985c479e27b1fc318"
+    },
+    {
+      "bytes": 1584,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e14069979afde6ffdae7546f5367cbdd257dc37338b71543b4feeabdb0bc7aa2"
+    },
+    {
+      "bytes": 1404,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e5e7d81a360833182395294390acb89f30489fa4466c4abb1df936f0898ea9f3"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3e40601b338340016577f80c8fa3155508f0660ece72269e120b17ea67877fea"
+    },
+    {
+      "bytes": 354587,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "539d1be97faf57a671a9730094bff4489193cafcffc4546a9818bcfc711d14e4"
+    },
+    {
+      "bytes": 20717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "196bd7df7ca432f2b40365dc39fa0f768140f0da34c3d96a85566cbbd1b78a9e"
+    },
+    {
+      "bytes": 296,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3771fd72e2b9271bf05d40f1ecd0c68f2b6f1fb4341c98538ca445fdc69cb9b7"
+    },
+    {
+      "bytes": 1541,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/student_database__gradebased_score/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "56dc69a1a0f3453670d823bce5c3f9cb39a245e29f9107e8379472d65b35f063"
+    },
+    {
+      "bytes": 1408,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/24-student_database__gradebased_score--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "633af1f6227e4b447fba83322490b7f39e325bfb638f881770b70553cd2e3cfc"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "fe55e1bb164ec1374816c0b59f854d77eec3f2c1be01d4cb25cb05b3c613517f"
+    },
+    {
+      "bytes": 719,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bc875566e50a98d9fdfd2beeca00e1c63643c28b6f0606dfe72519da0c1e2328"
+    },
+    {
+      "bytes": 143279,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7d2faeffed448fd7a91d271df1e478f7bdbb6f5fab0814d639678b88b37029a4"
+    },
+    {
+      "bytes": 2609,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3e10d289bf51ccf6a5a8f26874761dcf099ee858c0539d6e40ae96d9182b1657"
+    },
+    {
+      "bytes": 15882,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "03c226e5394179fceecd4f30c999b9755db2ad1a47e65e97d9b9f9f405b0216d"
+    },
+    {
+      "bytes": 47,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8c2fbfcbc3063f10846d31e414a69aac5c0454c15f34cb959e1169980a63a97f"
+    },
+    {
+      "bytes": 1407,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d3aba401331d0db3e5ae70f7dbb004c58a2c63fac7bb0a90e3a1f1707c364234"
+    },
+    {
+      "bytes": 1380,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8255848abbd76a399b661f7baf0786d9d7eca603bbca25143f33ae887c0266a1"
+    },
+    {
+      "bytes": 905,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f6f6d1ce6b39a65d22ff15717b1266a946d3e39682fea1c97d7669e29d40fe8a"
+    },
+    {
+      "bytes": 21375,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4cfd99bc3831b6c21ec4becffa2a908cb189625886a54524c0d6dc382cc3f1de"
+    },
+    {
+      "bytes": 17268,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0a6e4d8a3505e5931038c63b00527a8f17ac3b7f8908cc7b33579617b5e28378"
+    },
+    {
+      "bytes": 7,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "26ddfaa64268cfee84e47d699914c4754da1f3057b3c4da10f09f8bf883f96b3"
+    },
+    {
+      "bytes": 1443,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/25-threestudio__code_locating--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__code_locating/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "20563ee47ac1afb22112c44fbe345415372c83da4daf665cd66336e568019d3c"
+    },
+    {
+      "bytes": 1387,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "407724e91db9884e8d63ad1e434ec70328c78b614d08a097c26ad702dab9b3fc"
+    },
+    {
+      "bytes": 711,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1cf61d0c33ac4dd49590f527b936f1ed117b1963b9b6c1c65591d7f8f10b661e"
+    },
+    {
+      "bytes": 105285,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4282c04b4b3d5ca8c0c96e90c8ddd538b3ddcbebe0c36d7e7c410469e90f429a"
+    },
+    {
+      "bytes": 2609,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b5fdb3988c68c1f2a08bec21de402ff3ff3bb55d4f538a04803484c4d56eb049"
+    },
+    {
+      "bytes": 24143,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "37fdfb5c687b57f7c52ab3d00d6f4034fea123d916dfc182b9001b3d1767151f"
+    },
+    {
+      "bytes": 74,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1a075cce32ce4aff20989fa1b3a317b45aa131ce99a0fb4721e644c4d8406c2d"
+    },
+    {
+      "bytes": 1246,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a1d4dd9fe19189b64ba0355512593c2157a997a6b911df3fb83d8b6fe8f72f94"
+    },
+    {
+      "bytes": 1401,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0a288a1473081ae7328437ac22ac2fa7738fb43a3091c9785bba209f974fbcf0"
+    },
+    {
+      "bytes": 910,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1482cba766b21999fa066a085aa4d4e58c063267c6a7f1c3656e137516535646"
+    },
+    {
+      "bytes": 175850,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e5571485918ab3286b5986fba077b1091123053ace8bfa135b04856a98cd3400"
+    },
+    {
+      "bytes": 31013,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c59162f7a1edb37551995c479edb484cf16c75148f58661c625125ee147f9cc1"
+    },
+    {
+      "bytes": 7,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "26ddfaa64268cfee84e47d699914c4754da1f3057b3c4da10f09f8bf883f96b3"
+    },
+    {
+      "bytes": 1330,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/26-threestudio__output_analysis--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__output_analysis/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "dca510487187733724275e9127031a6b37c8352f8baac86dce55c7b9ac2234db"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d19777ed153eb8c9f43bf01b54eedadbc535a0b8e8f92532e36c47fb8cea1c65"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "df0978809e6b79125b098892642fd0c06c52f510a2ec43360337f420efd791ed"
+    },
+    {
+      "bytes": 635711,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c5b120203c3eb0fcedcddb6d3ff68e4f4f8f16fe61cc013e6282559303b074f9"
+    },
+    {
+      "bytes": 4799,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "36dcb63fe3a1c97ad9942d08a0c464b840291ccbc4d9bbed3fc415cf6b833b0a"
+    },
+    {
+      "bytes": 45127,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1dff7851ccbab4a6e358a34ee0c4ce9f1302e08da5ab55a2692a2430d17db072"
+    },
+    {
+      "bytes": 241,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "991e5dddccb846c2e2e950b76d27ea69d18d4a6d94f763ecae87c568b5079aed"
+    },
+    {
+      "bytes": 1395,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "20aa0c7df2d5d50201ee9b957b900a74b03cdb5f51f275a9f4fad50bc6651c80"
+    },
+    {
+      "bytes": 1411,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "eeffc6ac62ea63ba6f96219ba5236924757f4ed0282823295960c06ddccc45c5"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "453f79ed06ed4dc36afb3a951908420e0c063fff80b9b2b85083e6ba032d90fa"
+    },
+    {
+      "bytes": 790324,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a88db0884b81654df8697fae7e8f7ed5bc566f5736ab5903d105ec8249c02c9f"
+    },
+    {
+      "bytes": 80768,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a2b6dce7a654e8e66b6c2dfb40ec97c59e9e3592f03f5dbb8d44e806b6fa618e"
+    },
+    {
+      "bytes": 441,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "02b54271fe6af145e6d50c622bb2ad45512cf2720b8d7bb70ca7b282c0789a54"
+    },
+    {
+      "bytes": 1558,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/27-threestudio__requirements_completion--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/threestudio__requirements_completion/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "276783a9c5504a06844c85d7d52becb6205e03b4e5977aed134b932b9ed99663"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3edbdab47799a68184cc146aa39ebc8771f267bfa08916e2ae57a5f378a3f3cc"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "eab38ad71a7382b2a2d870bef4b3903f17e05020bd14d25fe4c3c8f6a27aadc3"
+    },
+    {
+      "bytes": 330573,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "db20561621a3be34b92cf9548c535458a3a13405caebe8b8b806a6837fd03bbd"
+    },
+    {
+      "bytes": 3339,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5de801f33b12a5486e1240a141998bef2de3d657eebc49956e940aef04a7218e"
+    },
+    {
+      "bytes": 32176,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9571868897082b376098724fb935c7ab375ac7739bb8a4eaa616eac3465ba512"
+    },
+    {
+      "bytes": 347,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1e7cd6e891793a275956e4c8bb024987a094d9f5f91b404608ea3c0bbc608c3b"
+    },
+    {
+      "bytes": 1397,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8401f173fa2210dc267fac5e7a6673dc1654869e89fd992f1c7fe3651ff76dee"
+    },
+    {
+      "bytes": 1387,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ceb59202c2a7949b15b7fa60aed4cf163af244a83756331e43b7f68501af2a5c"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "90710d6afec9cea21f42aee62f1cd4b9825973cd4c1be5c521daa287c773087e"
+    },
+    {
+      "bytes": 193717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "378edc258ecab19ae8f30d1e39bb2699cf7f6a17b9d41920502e954d86a3c7a9"
+    },
+    {
+      "bytes": 17309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1a943c35a07ad30e815770811e7b12c74008a4df3caf376441bb3e43088b0d17"
+    },
+    {
+      "bytes": 336,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "35f862890f08af5c9d1047f5c9a33e2f5c8497048903b801f51d6e8b917befea"
+    },
+    {
+      "bytes": 1438,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/28-votenet__dataset_comparison--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__dataset_comparison/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "54748cf29d183670d722bbf1f3856e962b19b6be957797db8c9641283c98638c"
+    },
+    {
+      "bytes": 1390,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "76ae0c248279c88bc0091513dcfb9b99f7712df62a57651e7ea539df35c3c0a9"
+    },
+    {
+      "bytes": 717,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0dc0485484c2487107b1162c63ecb7093330453c893d82b5c7d404064d51ca59"
+    },
+    {
+      "bytes": 185170,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "47922965a1f4ac18e3fc6bfe1cc83436d482b9b6a080f14bbe92dcaea8c2aab9"
+    },
+    {
+      "bytes": 4507,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a9f1239ff4838f7a20986454116451282cc419913f296459df9eb210c906bc7f"
+    },
+    {
+      "bytes": 30912,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "88888ede50f9f0271d00bdda4dbfd48153d1fb9e5850232283fd1f6df35c3779"
+    },
+    {
+      "bytes": 109,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b0e5a37abddaf48da553c299d63deea09c86640b977326525c71124ddb01189d"
+    },
+    {
+      "bytes": 1253,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__debugging/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b37e65ad7250253907f87e3dd3181aae11335802a7bd2d9b82cec1f7b9318c87"
+    },
+    {
+      "bytes": 1395,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "47fbe1101b4e24db24cb6f8e7cb7cfc50385bdd2f4fc6d8bf69ec32258e0b42e"
+    },
+    {
+      "bytes": 907,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c53eade0e156f235054d804265505a166eac158e45943a68213c99adf2addbdb"
+    },
+    {
+      "bytes": 190651,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6b6374adf268b9476f1fbf3cfc0b3cfb222cb822f6316483d90cd73ea6bef652"
+    },
+    {
+      "bytes": 32708,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__debugging/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bbae27bba43bf75f0fa7430e1223fd1179d5ceb202db00fc12b7c76d7cbe6a07"
+    },
+    {
+      "bytes": 7,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__debugging/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "26ddfaa64268cfee84e47d699914c4754da1f3057b3c4da10f09f8bf883f96b3"
+    },
+    {
+      "bytes": 1354,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/29-votenet__debugging--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__debugging/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "acbb98f0e435f496229e726b0875ec71c1b5e39f72ffdf78d26eb293decc4872"
+    },
+    {
+      "bytes": 1395,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c9ed60ceea3954197b841accd8a03f0ad55ca2bd220398ff5dad7a75f9294216"
+    },
+    {
+      "bytes": 718,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2fceb3585c6affda73c1dd817858304f63b78c501eafc39e9adef4b17d17aecd"
+    },
+    {
+      "bytes": 384092,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b567f31500817710389669837087b05037a5060d26c88848b555d75f8f83e106"
+    },
+    {
+      "bytes": 2901,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7f9472e82f05fb11b50d2cf799b4818cbf20a87f8ec6563f112fa4997d28ffe9"
+    },
+    {
+      "bytes": 29418,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6ccb0c2a31a4fc6ae3d934e9b35fea66ef68f4fcd35253bd97fcf44540533bf9"
+    },
+    {
+      "bytes": 269,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "76077adb20281d7bb9ac24e90624b664ea8cc0aef1b81b34070eebdf2d143d02"
+    },
+    {
+      "bytes": 1373,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--codex/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/codex-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0901232baf7136731230368897cee75f3d3888b6eac7276d5f5b604afefd77a3"
+    },
+    {
+      "bytes": 1393,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/summary.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7ba3004ed16368b725c12a4c77d270b1b9352d126fd32cb0559fdbb555aa022c"
+    },
+    {
+      "bytes": 908,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.deadline.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5257f8056a7f92089f7b779a0fc691cea75ebaa7dfbd99c6a7c51b2628063ff1"
+    },
+    {
+      "bytes": 521626,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "419136a172c50d686d05bf26aefbfa5bfae39adc091a99cb51cbe589a52bfdd8"
+    },
+    {
+      "bytes": 36221,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/execution.trajectory.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "4392a296e3f2cc29dcbc891a9d29a2a8d4edc86bcfb2ff25f9eeddefc7adb77c"
+    },
+    {
+      "bytes": 444,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/messages.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "64d7d7742bc800785c210412941dcb5a22790ecfe2215fba6fb90846a27d3251"
+    },
+    {
+      "bytes": 1326,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/native-results/30-votenet__requirements_writing--geode/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z/geode-gpt-5-4-high__filesystem/run-1/votenet__requirements_writing/meta.json",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ff30f259b3950b602783bc3b8d6ab63fe37713e54535fb72eab820ec4559856f"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/01-desktop__music_report--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4144,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/01-desktop__music_report--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "3460612a0cee5cb1e3c7195e49d4f3bf75cf96838c77cec8c41e41ebaca68c2d"
+    },
+    {
+      "bytes": 296,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/01-desktop__music_report--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9683065964d4a4469cbd35733b5937bfe453eebdfce4eaeb500d2ede6aea7848"
+    },
+    {
+      "bytes": 4144,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/01-desktop__music_report--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6946511e0c99ee1d2571150627ab74b6f15649c110075f98a5211e8baf70c009"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/02-desktop__project_management--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4454,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/02-desktop__project_management--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "42da590b1cd70031ca0b7e1792578a04065f1508b993207098d0411f4c715413"
+    },
+    {
+      "bytes": 302,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/02-desktop__project_management--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "dcd4a9a295a29d59f43ea2c4b71d555da74494d0af341e56c86d93a620f2a428"
+    },
+    {
+      "bytes": 4482,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/02-desktop__project_management--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b1d25c75fdd0e186a66702dcf40a69687fbb06b7ff479500c201cea4dbe30c5b"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/03-desktop__timeline_extraction--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4129,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/03-desktop__timeline_extraction--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "836497c1f7fe48b0c9543562715c422b7efd6ccc6827db581f87b0dea2c7a7e2"
+    },
+    {
+      "bytes": 593,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/03-desktop__timeline_extraction--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ae63ac09ca4df18e35c2e7863824a453ddcb152303713ba8fa57705df772d90d"
+    },
+    {
+      "bytes": 4129,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/03-desktop__timeline_extraction--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cb428f5bd6640d5ae402a5353897f840fb14b9d3750133eb6097af59f82c7d03"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/04-desktop_template__budget_computation--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4142,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/04-desktop_template__budget_computation--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "24f5011026a73a1a68f3903b7f67ebbd0555a5d8131e5fcf7effade66b125bdc"
+    },
+    {
+      "bytes": 311,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/04-desktop_template__budget_computation--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0c6e1dcf9ed9602d7a5472e2aa2631e3cb2f2cf993f8d072e67f13cbbddf3971"
+    },
+    {
+      "bytes": 4230,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/04-desktop_template__budget_computation--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1c1a220721753fbd57b23c5a77b5e6a8cbe31800114e20031ef9a138210c7acd"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/05-desktop_template__contact_information--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4188,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/05-desktop_template__contact_information--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "13af8e2612fdffd541be441ffc33df4c6498795cea6ca140c0251e23ead4d590"
+    },
+    {
+      "bytes": 312,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/05-desktop_template__contact_information--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9f09ba793683a3266244f7eb0a9233ba2497ff942fed67249a3b91de523a698a"
+    },
+    {
+      "bytes": 4188,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/05-desktop_template__contact_information--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a77fcc430a75faf56277abba7cad572ecc57d86dbe1680252c66bf80754bca92"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/06-desktop_template__file_arrangement--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4439,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/06-desktop_template__file_arrangement--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e8ce1c09bad3d7d1551c88c93d54359cd6f50c7e42027655986a18bec8124257"
+    },
+    {
+      "bytes": 599,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/06-desktop_template__file_arrangement--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bd01fc0dab7b0aaa62a66adaa577c91b667f275c8a3d75f70909d6869b84f0b2"
+    },
+    {
+      "bytes": 4642,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/06-desktop_template__file_arrangement--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "839823a4a6229d7b9364dcfbc0ef41e56df761f52d9127a3c71efb88fbe2b257"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/07-file_context__duplicates_searching--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4103,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/07-file_context__duplicates_searching--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e80509e44f3c18ee477736ea6b3e4ee8c88a3f61d4c1a453bbdf3ac2c247a857"
+    },
+    {
+      "bytes": 309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/07-file_context__duplicates_searching--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9f37d96d27b2c101c7ff01a651336743c22b9d4cf91bea7923b28389d0ca1e36"
+    },
+    {
+      "bytes": 4130,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/07-file_context__duplicates_searching--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0fecc7417c9395228acd64a694d4f279cf9b0f8f7b71ab77ab35c2225b259dbe"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/08-file_context__file_merging--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4037,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/08-file_context__file_merging--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1664382e5e15c6090c49aaf35673a132417e73f9250f0f94caae9e5c42487720"
+    },
+    {
+      "bytes": 301,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/08-file_context__file_merging--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "c8f38e8efe3b9bd0be873be169002e5afa66aa22b959ea087bb39934df03c1da"
+    },
+    {
+      "bytes": 4037,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/08-file_context__file_merging--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "39871a4d53f301117866339c2c4f1984fc99611d568337dd41d7d7f35368d3d3"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/09-file_context__file_splitting--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3847,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/09-file_context__file_splitting--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "572fb3e061668cb4ac48e09275fc8fc8fa3468d98c44ce116af661bf3a9cc1ef"
+    },
+    {
+      "bytes": 303,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/09-file_context__file_splitting--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "34f62d3c3e11924bc0f6ce0cc1013068a223c19d9ce44c59fd03373bd23d40e3"
+    },
+    {
+      "bytes": 3875,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/09-file_context__file_splitting--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "77ed6fb61cd15418176f17bf63a0ec5d9616464b38d3ca0cfa856b7c07d8ae0a"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/10-file_context__pattern_matching--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3931,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/10-file_context__pattern_matching--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "37c45f6e89b0744d91b26bbd3e60cc5df7b37a6ff20fe954be09844222af7286"
+    },
+    {
+      "bytes": 305,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/10-file_context__pattern_matching--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5c9d314df7c234032113739f6100133e6fa89ff32ed93840e35c0003e916b791"
+    },
+    {
+      "bytes": 3923,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/10-file_context__pattern_matching--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9d2029eff8215fe099191d39de01b664ca25bf504d79f53529afdab9f88c442a"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/11-file_context__uppercase--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4119,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/11-file_context__uppercase--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6b4e0162d35a85f04db15165f4bd1cb853bccdf485e10b17cc4330d50b596696"
+    },
+    {
+      "bytes": 298,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/11-file_context__uppercase--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "813a0b48a08265ec2e6d5246073be7beb23cc58e1b58a76246691943a0197628"
+    },
+    {
+      "bytes": 4144,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/11-file_context__uppercase--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cd0be2f5c8af524cd2d34a61dd7149966dc16f4489ed7d5a0f6083da515f83f3"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/12-file_property__size_classification--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3973,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/12-file_property__size_classification--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "93dcb7aba68fc436ee103ed6275afd862a44b312fbefcd2372285c67e7948caf"
+    },
+    {
+      "bytes": 309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/12-file_property__size_classification--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "821cb4cba9d1c2e5665d44ad332a68b717a6b18fa61d822a6755159c94885c55"
+    },
+    {
+      "bytes": 3999,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/12-file_property__size_classification--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "46e0c9c919014f526c976871d373ce26b1e7382d14970cf78a4900e1bbec33cd"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/13-file_property__time_classification--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3982,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/13-file_property__time_classification--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "97a1cbd83c492c0278d44296f89a346dbeca1a5b7639ecf7e74e8e299ce3def0"
+    },
+    {
+      "bytes": 309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/13-file_property__time_classification--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ccc9e9b9ace42cd4ee43c885efbbd1596a6a0a25ba4f1e12a5623261c24c81ce"
+    },
+    {
+      "bytes": 4010,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/13-file_property__time_classification--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1bed0bc886bbf4d8fcc2c9960ecbb028d524c479c55a7e2f97803d963b2e2111"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/14-folder_structure__structure_analysis--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4605,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/14-folder_structure__structure_analysis--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d69652c997b536b83872e215ecc77a8773d65afd97b287fc992638f07fc1658b"
+    },
+    {
+      "bytes": 310,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/14-folder_structure__structure_analysis--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e5b26e65d01ceb2cd5d635b3b84fd2d1ca67eda71aa2ac0d5b7ddc66a649da47"
+    },
+    {
+      "bytes": 4638,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/14-folder_structure__structure_analysis--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6042cf88674952f40fb447db0a425face8195237f1f07201fccbd5d28aebed43"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/15-folder_structure__structure_mirror--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 6582,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/15-folder_structure__structure_mirror--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "8e0f8b033e2dfc2f5151e1c405ecdb8a3c9941293d931f4c594e60f26c7d07b7"
+    },
+    {
+      "bytes": 309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/15-folder_structure__structure_mirror--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "15afae4a01eebd8c36e1db5dceec644cf8effc5cbc888c4f2f968cd5f04e144c"
+    },
+    {
+      "bytes": 6610,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/15-folder_structure__structure_mirror--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d4f0ede7f12805db8be720d2b827e33962abf1d01da08472a698d3804f4eea8c"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/16-legal_document__dispute_review--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3814,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/16-legal_document__dispute_review--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a5ebece93fbbfca52befc51bbafbab29a9545f212259fdef94c050295e17b957"
+    },
+    {
+      "bytes": 305,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/16-legal_document__dispute_review--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5890229addc3825df46d06237b77d537895e4287fb6411c85cde42445eee9ae0"
+    },
+    {
+      "bytes": 3843,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/16-legal_document__dispute_review--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b37ea88aa04b1507ff52b486d5e30d00c3e9051440c0164a50047c1f310b1868"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/17-legal_document__individual_comments--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3897,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/17-legal_document__individual_comments--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2d053c4d637d28159c8d09afb5a2f3bf8647fd9b7d0d731dbd07855719c87897"
+    },
+    {
+      "bytes": 310,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/17-legal_document__individual_comments--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1052c1bbf2381721ff2e0e901add89870e6f4b50e9d493bbba00e2affb9e733b"
+    },
+    {
+      "bytes": 3924,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/17-legal_document__individual_comments--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "cb13350527632493b98cad7bbca1de4343fadab66f0afa3a2df089ce09e4f31b"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/18-legal_document__solution_tracing--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3905,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/18-legal_document__solution_tracing--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "70a8f2063cc0ef82945b199df1a7ffc87f8972108db51037161a7c7240da6afd"
+    },
+    {
+      "bytes": 307,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/18-legal_document__solution_tracing--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2000eeed55efef92c10adf5a749ce4a8f740d82fc1915957a8a8d374cdeb463f"
+    },
+    {
+      "bytes": 3875,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/18-legal_document__solution_tracing--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "27228bcfe1b6678e8cef3f05d73c40fa1092e5b957cad9e3df1dc4d130e5fc81"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/19-papers__author_folders--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4432,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/19-papers__author_folders--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "82d632acd8f3d6e85b9ffbd9e4ccd58117df2f1650e496f04c7d6e3d321bac93"
+    },
+    {
+      "bytes": 587,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/19-papers__author_folders--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "642ef4dcff4c7f72f92017c71d8d8031b1e894b559bfe19d16d67de0e95beb0e"
+    },
+    {
+      "bytes": 7829,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/19-papers__author_folders--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "09fa0020a4c94317831ca8b554ade4262c979ad30c4a42e7032ad5a5367bcd09"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/20-papers__find_math_paper--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3574,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/20-papers__find_math_paper--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7fe317fc331fbc238f5cbfa4096d82bb3481a66ce2d9488bdf9999c934de9649"
+    },
+    {
+      "bytes": 298,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/20-papers__find_math_paper--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "aa739127c0aba0f89e29825aa4d8b75f0424702cce01cef9fff0118d6c86ee78"
+    },
+    {
+      "bytes": 3600,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/20-papers__find_math_paper--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "6e6d3bdde423a3987e2ed5d3cd73c9f6a4bd4c2dc78ba13f7f6d09b74bc8ef61"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/21-papers__organize_legacy_papers--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4519,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/21-papers__organize_legacy_papers--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "f890395903e61d906338b0debe6980ddc9c354a5dfe7d0000e44c7bf7be7af96"
+    },
+    {
+      "bytes": 305,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/21-papers__organize_legacy_papers--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "771889791f70a9a32ee44711d707aaabdfb5b396f3d8f7e30023e95401959ee9"
+    },
+    {
+      "bytes": 4478,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/21-papers__organize_legacy_papers--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e0649a0aaef1c017c031b51dc6c974ede038d17fab9726576b0460403043ae0c"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/22-student_database__duplicate_name--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3673,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/22-student_database__duplicate_name--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b0654b0e367bf4bf9df511e12f904236ed2bf5455a539e44b49757280cb5ace1"
+    },
+    {
+      "bytes": 307,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/22-student_database__duplicate_name--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0257ceac58e0b33314edb724d87759dfc97cd2038a4773b6cb78500ec76288aa"
+    },
+    {
+      "bytes": 3867,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/22-student_database__duplicate_name--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "2b6277dcaec7ac1dff8842758184980f39cf970ec0b4102289e9b26081c1aaba"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/23-student_database__english_talent--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3902,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/23-student_database__english_talent--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "17ca1467476b8b849b1ba450018eb6d7fe35bf8970db8a2321d2d836656c4240"
+    },
+    {
+      "bytes": 307,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/23-student_database__english_talent--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "41dfd0b3a427bfa23b696dc3a58a102de97790fdc0b983990f3dbe00cbbe8002"
+    },
+    {
+      "bytes": 3930,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/23-student_database__english_talent--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "d987efac1afc0700be0f61df366e7d19144a0bb2d905e4d6e630953d421f91f5"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/24-student_database__gradebased_score--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4191,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/24-student_database__gradebased_score--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "bd15da6af85686065fa44a9a0a634df73cdaebbac33d289f05e9c391e9aeef55"
+    },
+    {
+      "bytes": 599,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/24-student_database__gradebased_score--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "35018e9b184c1a90b7087961539e476c1b126745017ff7e4407c45cb4bc5781e"
+    },
+    {
+      "bytes": 4109,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/24-student_database__gradebased_score--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ee9532222c5b429dd1029fb2a47c7eefe0fcbb5de787994c63ec1172f9e8e3d8"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/25-threestudio__code_locating--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3943,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/25-threestudio__code_locating--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "1c5cb204373d5ae9d552efde657770e916b68d37873ebfd7a0368c5ed905ae72"
+    },
+    {
+      "bytes": 301,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/25-threestudio__code_locating--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "93ff3fe54ef3bb93cf9886ac5d0362333203286b088b80414f82cdcc2ea4b64b"
+    },
+    {
+      "bytes": 3944,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/25-threestudio__code_locating--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "038911b7c0a33b099294916bb0c3c3d4f72f8dd012f4e5f5f6b1d0efd1d98f9e"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/26-threestudio__output_analysis--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3828,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/26-threestudio__output_analysis--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "208f92fdc6b3cc5453780ef63961664e80d3b49ddfc4aae99cc5948caf063bae"
+    },
+    {
+      "bytes": 303,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/26-threestudio__output_analysis--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "7b81f77b3391381f670c0835a9fa9b4156b8f6e37ba329ecde5ffc69771e4721"
+    },
+    {
+      "bytes": 3873,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/26-threestudio__output_analysis--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "49b6982ecab9d5bd9851430f0b281ffe23cfb2375254cb8a7cf70600419b62bb"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/27-threestudio__requirements_completion--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 4002,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/27-threestudio__requirements_completion--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "68adb3dc6b1dd81e16aaa067f4ff8131caeb50e479ba4f55eedda9c3a77c0399"
+    },
+    {
+      "bytes": 311,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/27-threestudio__requirements_completion--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "a9ea8569441d16a9bc9622ff68ae5fdae46be8781c14ff8356a8c6cb044b0bb6"
+    },
+    {
+      "bytes": 4115,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/27-threestudio__requirements_completion--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "9f463a7afc9173e3a37d3e3a1f32544ed11e67942e4a59c5cf0e6e64dad8ca81"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/28-votenet__dataset_comparison--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3942,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/28-votenet__dataset_comparison--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0dd9202cf391b766eccda18b03978bce8ab601b34de1b0ec55ef3e902b9d557b"
+    },
+    {
+      "bytes": 302,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/28-votenet__dataset_comparison--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "ca69bffe0370297e84f51bd7a32a9a726606d323fd88b223a4c3aab8ede8ce13"
+    },
+    {
+      "bytes": 3942,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/28-votenet__dataset_comparison--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "5d50209ff94e148b1b05a7bbb3500973c9d52eb0645e11d5e36d98eb99207a50"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/29-votenet__debugging--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3761,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/29-votenet__debugging--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "b6057e9e890b57aa59d88313a14430715d56d00a3021c1b536de1a06b06dd96d"
+    },
+    {
+      "bytes": 293,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/29-votenet__debugging--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0541ed38c9b0f0fd38162cba6f80aaacce77d6cd65a2ff8ca3f9379b0c85c7bc"
+    },
+    {
+      "bytes": 3869,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/29-votenet__debugging--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "33e9a6fb897a834feae59dbd9049f913c7cb88b9b8498714c44e4e4d753ed36e"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/30-votenet__requirements_writing--codex/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 3925,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/30-votenet__requirements_writing--codex/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "34faabbb92eb562528b3b3d8e846aa01bf34c6e4eb43a3c065c6a014db420746"
+    },
+    {
+      "bytes": 304,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/30-votenet__requirements_writing--geode/stderr.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "0ab9764beff806ce3910beab0475250713faf6d05fb6bf3caba17f56eba30870"
+    },
+    {
+      "bytes": 3887,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-attempt-001/runner-logs/30-votenet__requirements_writing--geode/stdout.log",
+      "reason": "raw execution evidence may contain local paths, model messages, tool bodies, or subscription diagnostics",
+      "remote_path": null,
+      "sha256": "225d0ede1dda1fde8d1117aaa683d5b74236e612a562d709fd6750f5c0cb73b4"
+    }
+  ],
+  "geode": {
+    "repository": "https://github.com/mangowhoiscloud/geode",
+    "revision": "f4b3760488a80dad1186d54458f63bbb08768719",
+    "run_record": "docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md"
+  },
+  "publication": {
+    "artifact_merge_revision": "1160fecfe4447f0a3f4cf30a414f29c61776d012",
+    "published_at": "2026-08-13T23:46:58Z",
+    "remote_readback": {
+      "bytes_verified": 3065229,
+      "files_verified": 69,
+      "status": "passed",
+      "verified_at": "2026-08-13T23:49:26Z"
+    },
+    "status": "published"
+  },
+  "run_id": "mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z",
+  "schema": "geode.eval-artifact-publication.v1",
+  "verification": {
+    "local_identity_scrubbed": true,
+    "secret_scan_passed": true,
+    "source_hashes_verified": true
+  }
+}

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -18,7 +18,7 @@ eval_contracts:
   - docs/eval/schemas/analysis.schema.json
   - docs/eval/schemas/attempt.schema.json
   - docs/eval/schemas/run-spec.schema.json
-eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/17133f0c8e893b6d765fcef69712ba0867bd573a/trajectories/mcpmark-gate0b-gpt54-high-mcpmark-gate0b-tool-cap-gpt54-high-20260813t142345z-bcf57b5eee65-20260813T173103Z-bf8ad9ea9717
+eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04
 ---
 
 # GEODE Evaluation Index and Roadmap
@@ -74,7 +74,20 @@ pointers under `docs/eval/`; the artifact repository keeps the bytes behind
 those claims. See [External Evaluation Artifact Repository](external-artifact-repository.md)
 for path mappings, disclosure rules, and the publication manifest scaffold.
 
-The latest prospective runtime diagnostic is pinned to artifact commit
+The latest prospective paired-runtime diagnostic is pinned to artifact commit
+[`1160fec`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/1160fecfe4447f0a3f4cf30a414f29c61776d012):
+on all 30 pinned MCPMark `filesystem/standard` tasks with GPT-5.4 subscription,
+effort `high`, and a common adapter-owned action deadline, GEODE scored
+**23/30** and Codex CLI **21/30**, for a signed delta of
+**+2/30 = +6.67 percentage points**. The paired buckets were 17 both-pass,
+3 both-fail, 6 GEODE-only, and 4 Codex-only. One GEODE timeout remained a
+score-bearing FAIL; exact token coverage is 29/30 for GEODE and 30/30 for
+Codex. This is one direct `k=1` diagnostic with `promotion_authority=none`,
+not a stability, efficiency, API-key leaderboard, or full 127-task Verified
+claim. See the
+[run record](2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md).
+
+The preceding targeted runtime diagnostic is pinned to artifact commit
 [`17133f0`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/17133f0c8e893b6d765fcef69712ba0867bd573a):
 on five large-result MCPMark tasks at k=3, GPT-5.4/high scored
 `guard-25000` **7/15** and `unlimited-0` **10/15**, so the frozen signed delta
@@ -155,9 +168,11 @@ Agent-World 비교 정본: [agent-world-comparison-contract.md](agent-world-comp
 
 현재 순서·게이트·실행 상태는
 [`2026-08-13-sequential-agent-benchmark-plan.md`](2026-08-13-sequential-agent-benchmark-plan.md)가
-소유한다. 다음 score-bearing 단계는 **공통 deadline 증명 → targeted ablation →
-MCPMark FS30 corrective pair → Tau2 base 3-domain**이다. MCPMark Verified와
-Terminal-Bench 2.1은 앞선 lane이 clean할 때만 진행한다.
+소유한다. Gate 0C FS30 `k=1`은 완료됐고 다음 score-bearing 단계는 별도 fresh
+root의 **FS30 `k=3` stability**다. 현재 `WHAM=80%`에서는 live launch를
+차단한다. Tau2의 278-ID/pin/user/budget no-model preflight는 진행할 수 있지만
+Tau2 live call은 Gate 0C stability와 별도 PAYG 승인을 기다린다. MCPMark
+Verified와 Terminal-Bench 2.1은 앞선 lane이 clean할 때만 진행한다.
 
 ## Public benchmark serving contract
 
@@ -234,6 +249,7 @@ Verified 다음에 τ²-bench를 둔다.
 
 | 일자 | 변경 |
 |---|---|
+| 2026-08-14 | GPT-5.4/high MCPMark Gate 0C common-deadline FS30 k=1 게시: GEODE 23/30, Codex 21/30, frozen delta +2/30=+6.67%p supported diagnostic-only. 60/60 valid arms, paired buckets 17/3/6/4, one GEODE score-bearing timeout, exact token coverage 29/30 vs 30/30, 59 admitted trajectories/one withheld를 artifact commit `1160fec`에서 원격 재검증. `promotion_authority=none`; fresh k=3 live는 WHAM=80%에서 차단 |
 | 2026-08-14 | GPT-5.4/high MCPMark Gate 0B k=3 direct diagnostic 게시: `guard-25000` 7/15, `unlimited-0` 10/15, frozen delta +3/15=+0.20 supported. 30/30 valid arms와 six reviewed releases/26 admitted trajectories를 artifact commit `17133f0`에서 원격 재검증; 제품 기본값 변경 권한은 없음 |
 | 2026-08-13 | GPT-5.4/high MCPMark filesystem/standard native outcome 21/30 vs 20/30과 3,381 events / 1,430 exact pairs를 보존. 사후 source audit에서 equal-hard-deadline preregistration 위반을 찾아 prospective hypothesis를 invalidated로 정정하고, append-only correction을 artifact commit `e5d442f`에서 원격 재검증. 점수는 retrospective description만 허용 |
 | 2026-08-12 | GPT-5.4 subscription `high` matched MCPMark filesystem/easy 재실행: 9/10 유지, 입력 447,376→314,219(−29.8%), 출력 25,157→20,385(−19.0%), 188 events / 54 exact tool pairs. 검토된 trajectory release와 보고서를 artifact commit `2c2d1f0`에 게시하고 원격 read-back 검증 |

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -10,7 +10,7 @@
     "trajectory": "core/observability/schemas/trajectory.schema.json",
     "trajectory_release": "core/observability/schemas/trajectory-release.schema.json"
   },
-  "document_count": 15,
+  "document_count": 16,
   "documents": [
     {
       "id": "agent-world-comparison",
@@ -92,7 +92,7 @@
       "authority": "routing",
       "path": "docs/eval/README.md",
       "summary": "Machine and human entrypoint for GEODE evaluation contracts, benchmark ledgers, evidence, and publication.",
-      "sha256": "38dbcd3f9fe47ecb7aa8f06bd0106401148903f39fa404c645947bd4ad5c5368",
+      "sha256": "b743e9d9612e2eb96764e2b46afe099c5bbbbfe90ca711a9a57295b7e492b911",
       "triggers": [
         "artifact",
         "benchmark",
@@ -108,7 +108,7 @@
         "docs/eval/schemas/attempt.schema.json",
         "docs/eval/schemas/run-spec.schema.json"
       ],
-      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/17133f0c8e893b6d765fcef69712ba0867bd573a/trajectories/mcpmark-gate0b-gpt54-high-mcpmark-gate0b-tool-cap-gpt54-high-20260813t142345z-bcf57b5eee65-20260813T173103Z-bf8ad9ea9717"
+      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04"
     },
     {
       "id": "external-artifact-repository",
@@ -221,6 +221,32 @@
       ]
     },
     {
+      "id": "mcpmark-gate0c-filesystem30-gpt54-high-20260814",
+      "family": "mcpmark",
+      "title": "GPT-5.4 MCPMark Gate 0C — corrective FS30 paired diagnostic",
+      "kind": "ledger",
+      "status": "historical",
+      "authority": "paired-runtime-diagnostic",
+      "path": "docs/eval/2026-08-14-mcpmark-gate0c-filesystem30-gpt54-high.md",
+      "summary": "Prospective common-deadline k=1 comparison of GEODE and Codex on 30 MCPMark filesystem/standard tasks with GPT-5.4/high; GEODE passed 23/30 versus Codex 21/30, a diagnostic-only +2/30 = +6.67 percentage-point delta.",
+      "sha256": "856fbab0af3c73a12fd1dece1b4151f25bed0ff1ffc2a0c069ba7d65c7bf5c57",
+      "triggers": [
+        "GEODE Codex comparison",
+        "GPT-5.4 benchmark",
+        "MCPMark Gate 0C",
+        "common action deadline",
+        "paired runtime diagnostic"
+      ],
+      "contracts": [
+        "core/observability/schemas/trajectory-release.schema.json",
+        "core/observability/schemas/trajectory.schema.json",
+        "docs/eval/schemas/analysis.schema.json",
+        "docs/eval/schemas/attempt.schema.json",
+        "docs/eval/schemas/run-spec.schema.json"
+      ],
+      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1160fecfe4447f0a3f4cf30a414f29c61776d012/trajectories/mcpmark-gate0c-gpt54-high-mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z-geode-20260813T230525Z-9d6773caad04"
+    },
+    {
       "id": "mcpmark-geode-codex-gpt54-filesystem-standard-20260813",
       "family": "mcpmark",
       "title": "GPT-5.4 GEODE × Codex MCPMark filesystem/standard corrected observation",
@@ -277,7 +303,7 @@
       "authority": "execution-status",
       "path": "docs/eval/2026-08-13-sequential-agent-benchmark-plan.md",
       "summary": "Sequential execution SOT for the corrective MCPMark pair, tau2 base domains, MCPMark Verified, and Terminal-Bench 2.1.",
-      "sha256": "23dd3dcba3ae07406d94c252735b70fb9b151a644652e84c8236d8b225e01e7f",
+      "sha256": "b33254b56d0e12cecfa51c18f57f136193541483cd502199d6eeb8d3b3c8b44b",
       "triggers": [
         "MCPMark Verified",
         "MCPMark corrective pair",

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3799,6 +3799,30 @@ GEODE_MCPMARK_GITHUB_REPO_VISIBILITY=public \
 -   GitHub fixture repositories were made public during execution so the Docker GitHub MCP server could use normal public-repo semantics; all transient repos were deleted by cleanup.
 -   The filesystem score counts papers/author\_folders as a failed no-result transport run after two attempts without meta output.
 
+**filesystem/standard Gate 0C common-deadline diagnostic** · 2026-08-14 KST · gpt-5.4 · subscription · high
+
+<table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>filesystem/standard 30-task paired k=1</code></td></tr><tr><td>Model</td><td><code>gpt-5.4</code></td></tr><tr><td>Provider</td><td><code>openai / codex-cli</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>high</code></td></tr><tr><td>Route</td><td>GEODE AgenticLoop and isolated Codex CLI paired by task</td></tr><tr><td>Harness</td><td><code>eval-sys/mcpmark@cd45b7f, GEODE@f4b37604, Codex CLI 0.145.0@dad1db87</code></td></tr><tr><td>Diagnostic-only verifier pass rate</td><td><strong>GEODE 76.7% (23 / 30) · Codex 70.0% (21 / 30) · Δ +6.67 pp</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@1160fecfe4447f0a3f4cf30a414f29c61776d012/mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z</code></td></tr></tbody></table>
+
+-   Paired outcomes: 17 both-pass / 3 both-fail / 6 GEODE-only / 4 Codex-only
+-   Exact token coverage: GEODE 29 / 30 attempts; Codex 30 / 30
+-   All-arm action wall: GEODE 8,463.252s vs Codex 5,484.322s; runner envelopes 8,536.382s vs 5,548.725s
+-   Native execution-log calls/errors: GEODE 644 / 51 vs Codex 678 / 17
+-   Normalized trajectory attempts: GEODE 645 including one recovery projection vs Codex 678
+-   Read/repeated-read references: GEODE 798 / 81 vs Codex 838 / 213
+-   One GEODE score-bearing deadline expiration; its token usage is null and its scope-incomplete trajectory is withheld
+
+```
+# Requires the pinned MCPMark checkout and verifier patch, frozen run spec,
+# isolated runtime home, and working GPT-5.4 subscription authentication.
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark_pair   --profile filesystem30-geode-codex   --run-spec <frozen-run-spec.json>   --mcpmark-root artifacts/eval/harnesses/mcpmark   --output-dir <fresh-output-dir>   --python .venv/bin/python
+```
+
+-   The prospective -10 percentage-point threshold was supported, but promotion\_authority remains none.
+-   This is one direct paired repetition, not k=3 stability, a full MCPMark Verified headline, or an API-key leaderboard claim.
+-   The common action deadline excludes fixture setup and the post-action verifier; runtime scaffolds and tool-result policies remain different.
+-   Token totals have unmatched coverage and do not support a billing or token-efficiency claim.
+-   Fifty-nine scope-complete trajectories are admitted; the one GEODE timeout trajectory remains withheld.
+
 **filesystem/standard Gate 0B tool-result-cap diagnostic** · 2026-08-13–14 KST · gpt-5.4 · subscription · high
 
 <table><tbody><tr><td>Status</td><td><code>complete</code></td></tr><tr><td>Suite/domain</td><td><code>filesystem/standard targeted 5 tasks × 3 repetitions</code></td></tr><tr><td>Model</td><td><code>gpt-5.4</code></td></tr><tr><td>Provider</td><td><code>openai</code></td></tr><tr><td>Source</td><td><code>subscription</code></td></tr><tr><td>Effort</td><td><code>high</code></td></tr><tr><td>Route</td><td>GEODE AgenticLoop paired 25K and unlimited tool-result-cap arms</td></tr><tr><td>Harness</td><td><code>eval-sys/mcpmark@cd45b7f, GEODE@02f71fae</code></td></tr><tr><td>Diagnostic-only verifier pass rate</td><td><strong>25K 46.7% (7 / 15) · unlimited 66.7% (10 / 15) · Δ +20.0 pp</strong></td></tr><tr><td>Artifact</td><td><code>geode-eval-artifacts@17133f0c8e893b6d765fcef69712ba0867bd573a/mcpmark/results-paired/mcpmark-gate0b-tool-cap-gpt54-high-20260813t142345z</code></td></tr></tbody></table>

--- a/site/src/data/geode/benchmark-measurements.ts
+++ b/site/src/data/geode/benchmark-measurements.ts
@@ -345,6 +345,51 @@ const mcpmarkGate0BToolCapGpt54: BenchmarkMeasurement = {
   ],
 };
 
+const mcpmarkGate0CFilesystem30Gpt54: BenchmarkMeasurement = {
+  id: "mcpmark-gate0c-filesystem30-20260814-gpt54-high",
+  group: "mcpmark",
+  title: "filesystem/standard Gate 0C common-deadline diagnostic",
+  measuredAt: "2026-08-14 KST",
+  suite: "filesystem/standard 30-task paired k=1",
+  status: "complete",
+  model: "gpt-5.4",
+  provider: "openai / codex-cli",
+  source: "subscription",
+  effort: "high",
+  route: "GEODE AgenticLoop and isolated Codex CLI paired by task",
+  harness:
+    "eval-sys/mcpmark@cd45b7f, GEODE@f4b37604, Codex CLI 0.145.0@dad1db87",
+  artifact:
+    "geode-eval-artifacts@1160fecfe4447f0a3f4cf30a414f29c61776d012/mcpmark/results-paired/mcpmark-gate0c-filesystem30-gpt54-high-20260813t190922z",
+  scoreLabel: "Diagnostic-only verifier pass rate",
+  scoreValue:
+    "GEODE 76.7% (23 / 30) · Codex 70.0% (21 / 30) · Δ +6.67 pp",
+  secondary: [
+    "Paired outcomes: 17 both-pass / 3 both-fail / 6 GEODE-only / 4 Codex-only",
+    "Exact token coverage: GEODE 29 / 30 attempts; Codex 30 / 30",
+    "All-arm action wall: GEODE 8,463.252s vs Codex 5,484.322s; runner envelopes 8,536.382s vs 5,548.725s",
+    "Native execution-log calls/errors: GEODE 644 / 51 vs Codex 678 / 17",
+    "Normalized trajectory attempts: GEODE 645 including one recovery projection vs Codex 678",
+    "Read/repeated-read references: GEODE 798 / 81 vs Codex 838 / 213",
+    "One GEODE score-bearing deadline expiration; its token usage is null and its scope-incomplete trajectory is withheld",
+  ],
+  command: `# Requires the pinned MCPMark checkout and verifier patch, frozen run spec,
+# isolated runtime home, and working GPT-5.4 subscription authentication.
+.venv/bin/python -m plugins.benchmark_harness.run_mcpmark_pair \
+  --profile filesystem30-geode-codex \
+  --run-spec <frozen-run-spec.json> \
+  --mcpmark-root artifacts/eval/harnesses/mcpmark \
+  --output-dir <fresh-output-dir> \
+  --python .venv/bin/python`,
+  notes: [
+    "The prospective -10 percentage-point threshold was supported, but promotion_authority remains none.",
+    "This is one direct paired repetition, not k=3 stability, a full MCPMark Verified headline, or an API-key leaderboard claim.",
+    "The common action deadline excludes fixture setup and the post-action verifier; runtime scaffolds and tool-result policies remain different.",
+    "Token totals have unmatched coverage and do not support a billing or token-efficiency claim.",
+    "Fifty-nine scope-complete trajectories are admitted; the one GEODE timeout trajectory remains withheld.",
+  ],
+};
+
 const mcpmarkFilesystemEasyParallel: BenchmarkMeasurement = {
   id: "mcpmark-filesystem-easy-parallel-20260703-gpt55-xhigh",
   group: "mcpmark",
@@ -1418,6 +1463,7 @@ export const BENCHMARK_GROUPS: BenchmarkGroup[] = [
     ],
     measurements: [
       mcpmarkVerifiedAvailable,
+      mcpmarkGate0CFilesystem30Gpt54,
       mcpmarkGate0BToolCapGpt54,
       mcpmarkFilesystemStandardGpt54Paired,
       mcpmarkFilesystemEasyGpt54TokenEfficiency,


### PR DESCRIPTION
## Summary
- Sync the published Gate 0C FS30 report and public ledger from `main` into `develop`.

## Why
PR #2992 intentionally landed the main-maintained evaluation record on `main`. This content-only sync restores branch parity without rebasing or duplicating the report commit.

## Verification
- Source head: `main@4e0ae7bfa358b72451a182ae4a4babc5c026f2a2`
- Target head before PR: `develop@5fdff9111c9ba4ee32ecfedda7e150b3f001f34a`
- Merge-base: `f4b3760488a80dad1186d54458f63bbb08768719`
- Three-way merge preview has no conflicts.
- PR #2992 CI and Pages build were fully green.
