### PR TITLE
docs(eval): publish Tau2 Lane 1A preflight evidence

### DIFF
--- a/docs/eval/2026-08-13-sequential-agent-benchmark-plan.md
+++ b/docs/eval/2026-08-13-sequential-agent-benchmark-plan.md
@@ -22,8 +22,8 @@ eval_contracts:
 
 작성일: 2026-08-13
 최종 갱신: 2026-08-14
-기준 코드: GEODE `origin/main@f4b3760488a80dad1186d54458f63bbb08768719`
-상태: **Lane 0C k=1 complete · artifact published. k=3 live blocked by WHAM=80%; Tau2 no-model preflight may proceed.**
+기준 코드: GEODE `origin/main@2f58eaaa65f4f92f62fdd518e3b23c596f5b8477`
+상태: **Lane 0C k=1 complete · artifact published. k=3 live blocked by WHAM=80%; Tau2 Lane 1A complete · published, Lane 1B live blocked.**
 
 ## 1. 권한과 범위
 
@@ -90,7 +90,7 @@ flowchart TD
 | 0A Common deadline | **COMPLETE · MAIN** | None; contract is the basis for 0B/0C | setup/action boundary, timeout·cancel·cleanup tests and no-model preflight PASS |
 | 0B Targeted ablation | **COMPLETE · PUBLISHED** | Preserve 7/15 vs 10/15 as diagnostic-only; no cap-default change | 30/30 valid arms, primary +3/15 = +0.20 supported, six releases/26 admitted trajectories, four timeout trajectories withheld |
 | 0C MCPMark FS30 | **K=1 COMPLETE · PUBLISHED · K=3 LIVE-BLOCKED (WHAM=80%)** | Preserve k=1 as diagnostic-only; launch fresh k=3 only after five-hour quota headroom is safe | k=1: 60/60 valid arms, exact task/reset/verifier joins, primary +2/30; k=3 remains separate |
-| 1 Tau2 base | **NO-MODEL PREFLIGHT READY · LIVE BLOCKED** | 278 IDs/pin/user/budget no-model preflight may proceed; no model calls yet | Gate 0C stability and PAYG approval before smoke→full-1→4 trials |
+| 1 Tau2 base | **1A COMPLETE · PUBLISHED; 1B LIVE-BLOCKED** | Preserve the verified no-model freeze; no model calls | Gate 0C k=3 stability plus PAYG approval and quota headroom before smoke→full-1→4 trials |
 | 2 MCPMark Verified | PENDING | service별 no-model canary | FS30 pair와 full127 headline 분리 |
 | 3 Terminal-Bench 2.1 | PENDING | 2.1 profile 정렬·oracle smoke | adapter/evidence path clean 후 89 tasks |
 
@@ -262,6 +262,21 @@ trial**이다. 공식 submission profile은 같은 agent/user arguments와 4 tri
 | 1C | 278-task full-1 | infra defect, missing receipt, quota boundary |
 | 1D | 4 trials total | trial merge without exact per-trial lineage |
 
+Lane 1A no-model preflight is **COMPLETE / PUBLISHED**. The
+[public receipt](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/dbfd948bf822a6b87da1fd8fe6ea28b12f1585e0/reports/e2e-validation/2026-08-14-tau2-lane1a-no-model-preflight.json)
+at artifact merge `dbfd948bf822a6b87da1fd8fe6ea28b12f1585e0` has file SHA-256
+`8b9ac5436d06913a46c9d0621098c2eff79b4d61d0dea30be0ba88ec933bf195` and payload
+SHA-256 `7b0018de9b5e6ea1ba66bd117d0182beb9520ba5c98adc15525de3a6ce6551d5`; it binds
+GEODE main `2f58eaaa65f4f92f62fdd518e3b23c596f5b8477` to
+`tau2==1.0.1` upstream `79975ac5741e23fbb1d2ac44262d62398a6d87bd`, the ordered
+278-ID freeze, native `gpt-5.2`-low PAYG user profile, and GPT-5.4/high
+subscription agent profile. It records zero account/model calls, no score, and
+untested auth/quota/route readiness; `promotion_authority=none`. Artifact PR #26
+was remotely read back at the exact merge commit with byte-for-byte matching
+size and SHA-256.
+Gate 1B remains blocked on Gate 0C `k=3` stability, PAYG approval, and quota
+headroom.
+
 Native headline에는 upstream GPT-5.2-low user simulator가 필요해 PAYG 승인을
 별도 확인한다. 승인이 없으면 1A에서 멈춘다. Subscription `geode_user` run을
 native headline으로 재명명하지 않는다.
@@ -337,6 +352,7 @@ Invalid/aborted attempt가 선택되면 primary metric은 `not-measurable`이다
 
 | Date | Change |
 |---|---|
+| 2026-08-14 | Tau2 Lane 1A no-model freeze 완료·게시: GEODE main `2f58eaaa` / Tau2 `79975ac` / 278 ordered IDs, native GPT-5.2-low PAYG user and GPT-5.4/high subscription agent profiles bound with zero model calls and no score. Exact receipt bytes were remotely verified at artifact merge `dbfd948b`; Gate 1B remains blocked on Gate 0C k=3, PAYG approval, and quota headroom |
 | 2026-08-14 | Gate 0C prospective common-deadline FS30 k=1 완료·게시: GEODE 23/30 대 Codex 21/30, primary +2/30=+6.67%p supported diagnostic-only. 60/60 valid arms, paired buckets 17/3/6/4, one GEODE score-bearing timeout, exact token coverage 29/30 vs 30/30, 59 admitted trajectories/one withheld 보존. `promotion_authority=none`; fresh k=3 live는 WHAM=80%에서 차단하고 Tau2 no-model preflight만 허용 |
 | 2026-08-14 | Gate 0B prospective k=3 완료·게시: `guard-25000` 7/15 대 `unlimited-0` 10/15, primary +3/15=+0.20 supported diagnostic-only. Four matched score-bearing timeouts, exact token coverage 13/15 per arm, prior invalid attempt denominator 0, six reviewed releases/26 admitted trajectories 보존. Lane 0C를 NEXT로 승격 |
 | 2026-08-13 | Gate 0B runner implementation: 기존 serial runner에 5-task×2-cap×3-repeat profile, effective cap/offload receipt, direct `CallToolResult` truncation reconstruction, dependency/import preflight를 연결. Live run과 score/artifact는 아직 없음 |

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -170,8 +170,11 @@ Agent-World 비교 정본: [agent-world-comparison-contract.md](agent-world-comp
 [`2026-08-13-sequential-agent-benchmark-plan.md`](2026-08-13-sequential-agent-benchmark-plan.md)가
 소유한다. Gate 0C FS30 `k=1`은 완료됐고 다음 score-bearing 단계는 별도 fresh
 root의 **FS30 `k=3` stability**다. 현재 `WHAM=80%`에서는 live launch를
-차단한다. Tau2의 278-ID/pin/user/budget no-model preflight는 진행할 수 있지만
-Tau2 live call은 Gate 0C stability와 별도 PAYG 승인을 기다린다. MCPMark
+차단한다. Tau2 Lane 1A의 278-ID/pin/user/budget no-model freeze는
+[artifact merge `dbfd948b`](tau2-bench.md#2026-08-14-lane-1a-no-model-freeze)에
+게시해 완료했다. 모델·계정 호출과 score는 0이고 `promotion_authority=none`이다.
+Tau2 live call은 Gate 0C `k=3`
+stability, 별도 PAYG 승인, quota headroom을 기다린다. MCPMark
 Verified와 Terminal-Bench 2.1은 앞선 lane이 clean할 때만 진행한다.
 
 ## Public benchmark serving contract
@@ -249,6 +252,7 @@ Verified 다음에 τ²-bench를 둔다.
 
 | 일자 | 변경 |
 |---|---|
+| 2026-08-14 | Tau2 Lane 1A 278-ID/pin/user/budget no-model freeze 완료·게시. 모델/계정 호출과 score는 0이며 exact receipt bytes를 artifact merge `dbfd948b`에서 원격 재검증; Gate 1B는 Gate 0C k=3, PAYG 승인, quota headroom 대기 |
 | 2026-08-14 | GPT-5.4/high MCPMark Gate 0C common-deadline FS30 k=1 게시: GEODE 23/30, Codex 21/30, frozen delta +2/30=+6.67%p supported diagnostic-only. 60/60 valid arms, paired buckets 17/3/6/4, one GEODE score-bearing timeout, exact token coverage 29/30 vs 30/30, 59 admitted trajectories/one withheld를 artifact commit `1160fec`에서 원격 재검증. `promotion_authority=none`; fresh k=3 live는 WHAM=80%에서 차단 |
 | 2026-08-14 | GPT-5.4/high MCPMark Gate 0B k=3 direct diagnostic 게시: `guard-25000` 7/15, `unlimited-0` 10/15, frozen delta +3/15=+0.20 supported. 30/30 valid arms와 six reviewed releases/26 admitted trajectories를 artifact commit `17133f0`에서 원격 재검증; 제품 기본값 변경 권한은 없음 |
 | 2026-08-13 | GPT-5.4/high MCPMark filesystem/standard native outcome 21/30 vs 20/30과 3,381 events / 1,430 exact pairs를 보존. 사후 source audit에서 equal-hard-deadline preregistration 위반을 찾아 prospective hypothesis를 invalidated로 정정하고, append-only correction을 artifact commit `e5d442f`에서 원격 재검증. 점수는 retrospective description만 허용 |

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -92,7 +92,7 @@
       "authority": "routing",
       "path": "docs/eval/README.md",
       "summary": "Machine and human entrypoint for GEODE evaluation contracts, benchmark ledgers, evidence, and publication.",
-      "sha256": "b743e9d9612e2eb96764e2b46afe099c5bbbbfe90ca711a9a57295b7e492b911",
+      "sha256": "ed6090d48731ff76b6193c510bf2336725761b6085d33e6655bfda9c6fc0a897",
       "triggers": [
         "artifact",
         "benchmark",
@@ -303,7 +303,7 @@
       "authority": "execution-status",
       "path": "docs/eval/2026-08-13-sequential-agent-benchmark-plan.md",
       "summary": "Sequential execution SOT for the corrective MCPMark pair, tau2 base domains, MCPMark Verified, and Terminal-Bench 2.1.",
-      "sha256": "b33254b56d0e12cecfa51c18f57f136193541483cd502199d6eeb8d3b3c8b44b",
+      "sha256": "55109463844b25327f757cd5f47e0c3f199a65329dd8bb9870ebc5943dd5667c",
       "triggers": [
         "MCPMark Verified",
         "MCPMark corrective pair",
@@ -327,7 +327,7 @@
       "authority": "suite-profile",
       "path": "docs/eval/tau2-bench.md",
       "summary": "GEODE evaluation profile, evidence ledger, and rollout plan for the tau2 conversational tool-use benchmark.",
-      "sha256": "1bc03893fa7f4553b9056c0f2288186b28a18b66450f73ebc7978a64a5b7a2ae",
+      "sha256": "57d563618e6133e6276fa993dd9077a2366abde97ca2c74b87a740a288f65543",
       "triggers": [
         "conversational tool use",
         "tau-bench",

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -21,10 +21,27 @@ eval_contracts:
 Multi-turn tool-agent-user 시뮬레이션 벤치. 에이전트와 LLM 시뮬 유저가 공유 world state를 tool로 변경하며 대화. **pass^k의 발상지**.
 
 - **Repo**: [sierra-research/tau2-bench](https://github.com/sierra-research/tau2-bench)
-- **현재 측정 핀**: `668d3bcd135c02aa3438f987ef45735b7c163ee3`, `tau2==1.0.1` (2026-08-12 확인)
+- **현재 측정 핀**: `79975ac5741e23fbb1d2ac44262d62398a6d87bd`, `tau2==1.0.1` (2026-08-14 Lane 1A published freeze)
 - **라이센스**: MIT (`LICENSE`)
 - **현재 공개 surface**: airline / retail / telecom / telecom-workflow / banking-knowledge와 text / voice runner. 과거 `1901a30`, `tau2==1.0.0` 기록은 해당 실행의 역사적 핀으로만 유지한다.
 - **Frontier 인용**: GPT-5.5 system card (**telecom 98.0%**), Anthropic 인용
+
+## 2026-08-14 Lane 1A no-model freeze
+
+Lane 1A is **COMPLETE / PUBLISHED**, not a measured result. The
+[no-model receipt](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/dbfd948bf822a6b87da1fd8fe6ea28b12f1585e0/reports/e2e-validation/2026-08-14-tau2-lane1a-no-model-preflight.json)
+at artifact merge `dbfd948bf822a6b87da1fd8fe6ea28b12f1585e0` binds GEODE main `2f58eaaa65f4f92f62fdd518e3b23c596f5b8477`
+to `tau2==1.0.1` upstream `79975ac5741e23fbb1d2ac44262d62398a6d87bd`, 278
+ordered base IDs, GPT-5.4/high subscription `geode_agent`, and the native
+GPT-5.2/low PAYG `user_simulator`. Receipt file SHA-256:
+`8b9ac5436d06913a46c9d0621098c2eff79b4d61d0dea30be0ba88ec933bf195`; payload
+SHA-256: `7b0018de9b5e6ea1ba66bd117d0182beb9520ba5c98adc15525de3a6ce6551d5`.
+It records zero account/model calls and no score; auth, quota, and route
+readiness remain untested, and `promotion_authority=none`. Exact-commit remote
+read-back matched all 463,637 bytes and file SHA-256 after artifact PR #26
+merged.
+Gate 1B remains blocked on Gate 0C `k=3` stability, PAYG approval, and quota
+headroom.
 
 ## 2026-08-12 OpenAI/Codex 기준 정렬
 


### PR DESCRIPTION
## Summary
- Publish the Tau2 Lane 1A no-model preflight receipt and mark the lane complete.
- Keep Lane 1B blocked on Gate 0C k=3, PAYG approval, and quota headroom.

## Why
The implementation and reset/profile verification were already on Main, but the execution plan still described the preflight as pending. Artifact PR #26 now preserves the exact zero-call receipt at merge dbfd948bf822a6b87da1fd8fe6ea28b12f1585e0.

## Changes
| File | Change |
|---|---|
| Sequential benchmark plan | Record Lane 1A as complete/published and retain the live blockers. |
| Eval README | Route readers to the published Tau2 receipt. |
| Tau2 suite profile | Pin upstream 79975ac, the 278-task freeze, runtime profile, receipt hashes, and no-promotion boundary. |
| Eval catalog | Refresh hashes for the three edited documents. |

## Verification
- Eval catalog write/check: 16 documents.
- Eval contract tests: 55 passed.
- Site static link audit: no broken internal links.
- Site lint: 0 errors (pre-existing warnings only).
- Site build: 237 static paths.
- Site markdown export: 74 twins; generated tracked files current.
- Independent review: SHIP, P0/P1 0.
- git diff --check: passed.
