### PR TITLE
docs(roadmap): R1.1 패키지 분류 작업 재클레임

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,6 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
+| R1.1 | BND-001 | `session=codex-2026-08-15 task=r1-1-package-classification` | `feature/r1-1-package-classification` | R1.1 readiness reconciled by [#2776](https://github.com/mangowhoiscloud/geode/pull/2776); abandoned claim released by [#2918](https://github.com/mangowhoiscloud/geode/pull/2918); current `develop` re-audit confirms delivered GOV-002 and the bounded §7 classification/migration-map contract | 2026-08-14T17:42:40Z |
 
 ## 1. Program objective
 
@@ -512,7 +513,7 @@ and closure evidence are appended in §10.
 | GOV-002 | `PARTIAL` | Hand-audited counts disagree with `AGENTS.md` (78 tools/56 hooks vs 67/65 prose) | One generated architecture baseline and a drift check own the counts | R0.2 | GOV-001 | `DONE` |
 | GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `DONE` |
 | GOV-004 | `PARTIAL` | 24 import ignores and very high global Ruff ceilings lack uniform owner/expiry metadata | Every exception is removed or recorded per symbol/edge with owner, rationale, expiry, and ratchet | R0.3 | GOV-002 | `DONE` |
-| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `READY` |
+| BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `IN_PROGRESS` |
 | BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `OPEN` |
 | BND-003 | `ABSENT` | One-off core-only probe fails at `core.cli`; CI does not test an installed kernel without features | Isolated wheel/package test boots and runs kernel tests without bundled/third-party modules | R1.3 | BND-001, BND-002, BND-006 | `OPEN` |
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
@@ -1969,12 +1970,11 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-R1.1 is `READY` and unclaimed. Its 2026-07-18 implementation attempt was
-abandoned after opening no implementation PR, so the stale branch is not
-delivery evidence and must not be merged wholesale. Before resuming, re-audit
-its useful decisions against current `origin/develop`, merge a fresh claim that
-names the new owner and branch, and allocate that branch from the resulting
-canonical tip. R1.1 delivers only the package-classification
+After this claim merges, allocate `feature/r1-1-package-classification` from
+the updated `origin/develop` tip and verify that its branch and owner match the
+canonical R1.1 active claim. The abandoned 2026-07-18 branch remains
+non-delivery evidence and must not be merged wholesale. R1.1 delivers only the
+package-classification
 ADR and product-shell migration map; it does not move implementation modules.
 R1.4 (`BND-005`) and R1.2 (`BND-002`) remain `OPEN` until R1.1 supplies that
 classification contract. R1.5 (`BND-006`) then waits for both the neutral seams


### PR DESCRIPTION
## Summary

- R1.1/BND-001을 `READY`에서 `IN_PROGRESS`로 전환합니다.
- 새 구현 브랜치와 소유자를 active claim에 고정하고, 폐기된 2026-07-18 브랜치는 delivery evidence가 아님을 유지합니다.

## Why

R1.1은 현재 가장 이른 `READY` 패키지입니다. 패키지 분류 ADR과 product-shell migration map 작업을 시작하려면 canonical `develop`에 별도 claim이 먼저 병합되어야 합니다.

## Changes

| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | R1.1 active claim 추가, BND-001을 `IN_PROGRESS`로 전환, §14를 새 claim 이후 실행 순서와 일치시킴 |

## GAP Audit

| Item | Status | Notes |
|---|---|---|
| BND-001 / R1.1 | Claimed | 구현 범위는 ADR과 migration map뿐이며 production module 이동은 금지 |
| CODE-001 / R9.1 | Deferred | R1.1 이후 별도 readiness/claim 필요 |

## Verification

- `scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — PASS
- `pytest -q tests/scripts/test_check_architecture_roadmap.py` — 40 passed
- `git diff --check` — PASS
- `scripts/check_repo_hygiene.py` — PASS
- pre-commit hooks — PASS
- 독립 committed-diff review — SHIP
- standalone 기본 `pymarkdown scan`은 frontmatter·긴 원장 표 등 기존 파일 전체의 baseline 위반을 보고해 비차단 참고로만 기록합니다. 이번 diff 전용 pre-commit 문서 게이트는 PASS입니다.

## Scope boundary

- roadmap 한 파일만 변경
- CHANGELOG 불필요(roadmap-only)
- 구현 코드, schema, dependency, module move 없음
