### PR TITLE
docs(architecture): classify product package boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@
 - **Language**: Python 3.12+, type-hinted, uv-managed.
 - **Layout**: two top-level packages.
   - `core/` — domain-agnostic runtime.
-  - `plugins/` — domain extensions (`petri_audit`, `seed_generation`, `benchmark_harness`).
+  - `plugins/` — legacy namespace for bundled product features
+    (`benchmark_harness`, `crucible`, `petri_audit`, `seed_generation`), not a
+    third-party extension ABI.
 - **Quality bar**: ruff, mypy, pytest plus a prompt-hash ratchet. CI breaks on red.
 - **Public site**: `site/` (Next.js 16 static export, deployed to GitHub Pages).
 
@@ -39,6 +41,9 @@ For architecture and extensibility work, read
 for GAP IDs, merge order, status, acceptance criteria, and closure evidence in
 that program. Older architecture audits and dated plans are design evidence,
 not competing status ledgers.
+
+The current package classification and product-shell migration boundary lives
+in `docs/architecture/package-classification.md`.
 
 Use `docs/workflow.md` as the canonical workflow summary and
 `.claude/skills/geode-workflow/` as the progressive-disclosure execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,6 @@ uv run geode
 uv run geode "summarize the latest AI research trends"
 uv run geode "compare React vs Vue for a new project"
 uv run geode "schedule daily standup reminder at 9am"
-
-# Domain analysis plugins are distributed separately from GEODE core.
 ```
 
 ## SOT (Source of Truth)
@@ -43,6 +41,7 @@ uv run geode "schedule daily standup reminder at 9am"
 | Test-Time Compute Grounding | `.claude/skills/stanford-test-time-compute/` | Stanford CS329A Part 2 evidence and GEODE/Eco²/SIL/Crucible application boundaries |
 | Agent-World Benchmark | `docs/eval/agent-world-comparison-contract.md` + `.claude/skills/agent-world-benchmark/` | Three-suite comparison profile, paired runtime control, replication, and artifact contract |
 | Architecture/Extensibility Program | `docs/architecture/extensibility-roadmap.md` | Single execution SOT for GAP IDs, merge order, status, acceptance, and closure evidence |
+| Package Classification | `docs/architecture/package-classification.md` | Closed kernel, product shell, bundled feature, and external extension boundaries |
 | Hook System | `docs/architecture/hook-system.md` | HookSystem 56 events |
 | Scaffold | `CLAUDE.md` | Development workflow, quality gates, CANNOT/CAN (this file) |
 
@@ -50,7 +49,7 @@ uv run geode "schedule daily standup reminder at 9am"
 
 Production code splits into two top-level Python packages:
 - `core/` — general-purpose autonomous agent runtime. 5-layer stack (layer diagram → `GEODE.md` → Architecture).
-- `plugins/` — first-party auxiliary plugins.
+- `plugins/` — legacy namespace for bundled product features; it is not a third-party extension ABI.
 
 Check module count: `find core/ -name "*.py" | wc -l` for core, `find plugins/ -name "*.py" | wc -l` for plugins.
 Key entry points: `core/agent/loop/`(AgenticLoop), `core/runtime.py`(bootstrap).
@@ -70,8 +69,8 @@ uv run mypy core/ plugins/
 
 ### Expected Test Results
 
-Core tests pass without bundled analysis fixtures. External packages own their
-own fixture/E2E gates.
+Core tests pass without bundled analysis fixtures. Bundled features own their
+feature-specific fixture and E2E gates.
 
 ## Implementation Workflow
 

--- a/docs/architecture/naming-conventions.md
+++ b/docs/architecture/naming-conventions.md
@@ -3,6 +3,7 @@ title: GEODE naming conventions — RESTful resource orientation
 status: living
 related:
   - docs/architecture/domain-free-core-audit.md
+  - docs/architecture/package-classification.md
   - pyproject.toml ([tool.ruff.lint.flake8-tidy-imports.banned-api])
   - core/domains/port.py (DomainPort method taxonomy)
 ---
@@ -22,29 +23,12 @@ PR.
 
 ---
 
-## 1. Plugin internal layout
+## 1. Bundled-feature layout
 
-A plugin (`plugins/<domain>/`) is a Python package whose internal structure
-follows two complementary rules:
-
-| Pattern | When to use | Examples |
-|---------|-------------|----------|
-| **Mirror core** — `plugins/<domain>/<X>/<Y>.py` matches `core/<X>/<Y>.py` | A multi-file core subpackage is being domain-extracted | `core/cli/{batch,ip_names,search}.py` → `plugins/game_ip/cli/{batch,ip_names,search}.py`; `core/tools/data_tools.py:QueryMonoLakeTool` → `plugins/game_ip/tools/data_tools.py` |
-| **Flat intent-named** — `plugins/<domain>/<noun>.py` at the package root | A single file/fragment is extracted, OR the file is a plugin-specific aggregation that has no obvious single-file core counterpart | `plugins/game_ip/{adapter,axes,wiring,prompt,scoring_constants}.py` |
-
-**Why two rules?**
-- A plugin's surface should read like *its own resources*, not like a
-  carbon-copy of `core/`'s incidental layout. `axes.py`, `prompt.py`,
-  `wiring.py`, `adapter.py` are first-class plugin resources.
-- But when `core/<X>/` had a coherent multi-file subpackage that gets
-  extracted, mirroring preserves intuition for developers who already know
-  the core layout.
-
-**The test**: an external developer scanning `plugins/game_ip/` should be
-able to predict what each name contains without opening it.
-
-Domain-shaped subpackages (`nodes/`, `fixtures/`, `config/`) are intent-named
-by definition — they describe the plugin's own structure, not core's.
+The current `plugins/` directory is a legacy namespace for first-party bundled
+product features, not an external extension contract. Its exhaustive
+classification and future `geode_product` targets are fixed by
+[`package-classification.md`](package-classification.md).
 
 ---
 

--- a/docs/architecture/package-classification.md
+++ b/docs/architecture/package-classification.md
@@ -1,0 +1,129 @@
+---
+title: Package classification and product-shell migration
+status: accepted
+decision: BND-001 / R1.1
+authority: package-classification
+related:
+  - docs/architecture/extensibility-roadmap.md
+  - docs/architecture/domain-free-core-audit.md
+  - site/src/data/geode/architecture-baseline.json
+---
+
+# Package classification and product-shell migration
+
+This decision classifies the packages that ship with GEODE and fixes their
+future dependency ring. The architecture roadmap remains the authority for
+status, package ordering, and implementation permission.
+
+## Context
+
+The base `geode-agent` distribution currently ships the `core` and `plugins`
+Python packages together. `plugins/` contains four first-party features, while
+the self-improving control plane still lives under `core/self_improving`.
+Current code also imports `plugins` from `core`; the generated architecture
+baseline owns the live import-site count.
+
+Those facts do not describe an external plugin system. An external extension
+must be independently discoverable, enableable, removable, installable, and
+testable. None of the five packages classified here meets that test today.
+
+R1.1 is a boundary decision only. It moves no module, import, entry point,
+state root, package data, registration, or writer.
+
+## Decision
+
+GEODE uses three dependency rings:
+
+```text
+third-party extensions
+        │
+        ▼
+geode_product + bundled features
+        │
+        ▼
+core (closed kernel)
+```
+
+- `core` is the closed agent kernel. Product composition and opt-in product
+  workflows leave it through later roadmap packages.
+- `geode_product` is the canonical first-party product-shell namespace. It
+  will own CLI/server composition and bundled product features after their
+  registered moves.
+- Skills, filesystem hooks, MCP servers, and explicitly supported external
+  Python entry points are extension surfaces. Bundled features do not become
+  an extension SDK merely because they move outside `core`.
+- The base distribution continues to ship the kernel and bundled product
+  ring together. This classification does not create separate wheels.
+
+`geode_product` is chosen instead of preserving the misleading `plugins`
+name: the latter implies independently managed extensions that do not exist.
+The old paths remain current implementations until their move owners land.
+
+### Exhaustive current classification
+
+| Current source | Classification | Canonical target | Move owner |
+|---|---|---|---|
+| `plugins.benchmark_harness` | bundled product feature | `geode_product.benchmark_harness` | BND-002 |
+| `plugins.crucible` | bundled product feature | `geode_product.crucible` | BND-002 |
+| `plugins.petri_audit` | bundled product feature | `geode_product.petri_audit` | BND-002 |
+| `plugins.seed_generation` | bundled product feature | `geode_product.seed_generation` | BND-002 |
+| `core.self_improving` | bundled product feature in the wrong ring | `geode_product.self_improving` | BND-005, then BND-006 |
+
+There is no independently removable external extension, misplaced kernel
+concern, or compatibility-only package among these current source packages.
+An old path becomes a compatibility facade only after its canonical code has
+moved.
+
+Petri, seed generation, and self-improving remain cohesive sibling features.
+Benchmark harness and Crucible remain sibling evaluation features. They are
+not folded into one generic feature package.
+
+## Migration map
+
+Every migration preserves the current public and operator-visible surfaces
+until its registered compatibility gate permits removal.
+
+| Source | Existing surfaces to preserve | State and package data | Test owner | Migration and rollback |
+|---|---|---|---|---|
+| `plugins.benchmark_harness` | Root exports and public adapters; `python -m plugins.benchmark_harness.{cli,run_mcpmark,run_mcpmark_pair,tau2_geode_agent}`; `scripts/eval` wrappers | Plugin manifest, Tau2 policy, and pinned MCPMark patch remain package data; external harnesses, native results, and run evidence keep their caller-owned `artifacts/eval` paths | `tests/plugins/benchmark_harness` plus Crucible harness-boundary, Tau2, and triad tests | BND-002 preserves adapter/module strings and package-data identity; it moves this reciprocal-import cluster with Crucible together or lands cold-import-safe forwarders before either switch; rollback changes routing without touching evidence |
+| `plugins.crucible` | Root exports; `python -m plugins.crucible`; producer modules and `scripts/eval` wrappers | `program.md` and `producers/context_graph.json` remain package data; campaign/attempt evidence, row caches, sealed state under the Git common directory, and `refs/crucible/**` keep their existing authorities | `tests/plugins/crucible` plus the benchmark Tau2 adapter tests | BND-002 preserves command/import/object identity and cold imports; it shares a migration cluster with the benchmark harness; rollback changes routing without moving state, refs, or immutable evidence |
+| `plugins.petri_audit` | Import root and registration side effects; `geode audit`, `petri-archive`, and `audit-agreement`; `/audit` and `/petri`; native audit tools; Inspect model entry points; internal MCP bridge module | `~/.geode/petri/logs`, operator configuration, agreement and seed-staging data, usage diagnostics, and tracked publication bundles keep their owners | `tests/plugins/petri_audit` plus existing CLI, config, LLM, self-improving, and tool integration tests | BND-002 preserves lazy optional-extra registration, command/tool names, string-based entry points, and old module identity; rollback restores registration imports without moving logs or config |
+| `plugins.seed_generation` | Import root and exported symbols; `geode audit-seeds`, `/audit-seeds`; native seed tools | `STATE_SEED_GENERATION_DIR`, unified config, the legacy override file, handoff/checkpoint data, Petri inputs, and publication bundles keep their current owners | `tests/plugins/seed_generation` plus existing CLI, tool, self-improving, and Petri integration tests | BND-002 preserves the CLI/slash/tool surfaces, exported-object identity, and sibling Petri dependency; rollback changes routing only |
+| `core.self_improving` | Import root; four documented `python -m core.self_improving.*` launchers; `/self-improving`, `/sil`, `geode campaign`; scheduler, hook, and MCP consumers | Tracked `core/self_improving/state`, runtime `~/.geode/self-improving`, handoff roots, and `GEODE_STATE_ROOT` semantics do not move with code | `tests/core/self_improving` plus existing agent, CLI, config, hook, LLM, observability, orchestration, Petri, and seed integration tests | BND-005 extracts neutral seams; BND-006 moves one implementation and keeps launcher forwarders; BND-007 may remove forwarders only after REL-002 and STORE-003; rollback restores composition without dual writers |
+
+The four `plugins.*` paths have no registered retirement package. Their
+removal is forbidden until a later roadmap transaction defines a public
+compatibility gate. `core.self_improving` retirement is already bounded by
+BND-007, REL-002, and STORE-003.
+
+Test ownership follows behavior, not directory renames: feature-unit tests may
+move with their implementation, kernel-contract tests stay with the kernel,
+and old-path compatibility tests remain until the owning facade-retirement
+gate closes.
+
+Benchmark harness and Crucible are one migration strongly connected component:
+each imports Tau2 surfaces from the other. BND-002 must switch them as one
+compatibility cluster or stage both forwarders before changing composition;
+warmed imports alone are not sufficient evidence.
+
+## Rejected alternatives
+
+- **Keep calling `plugins/` an external plugin layer.** The packages are
+  bundled and not independently removable, so the name promises a contract
+  that does not exist.
+- **Split every feature into a distribution now.** No independent consumer
+  requires that boundary.
+- **Leave self-improving in `core`.** Campaign, mutation, evaluation,
+  promotion, CLI/MCP, scheduler, and state policy are product concerns.
+- **Create one feature mega-package.** It would erase distinct evaluation,
+  seed, and campaign ownership.
+- **Add a classification manifest or checker.** The five-row decision is
+  static; the generated architecture baseline already owns repository census,
+  and later GAPs own executable migration gates.
+
+## Scope boundary
+
+R1.1 adds no package type, registry, loader, schema, dependency, CI gate, or
+runtime API. Reverse-import removal belongs to BND-002, neutral seam extraction
+to BND-005, the self-improving move to BND-006, installed-kernel proof to
+BND-003, and compatibility retirement to BND-007.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,5 +1,5 @@
-"""GEODE plugin namespace.
+"""Legacy namespace for GEODE's bundled product features.
 
-GEODE core ships domain-neutral runtime code plus first-party auxiliary
-plugins such as Petri audit.
+These modules ship in the base distribution and are not a third-party plugin
+ABI. See ``docs/architecture/package-classification.md``.
 """

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6163,7 +6163,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/develop/architecture.md
 
 ## 서브시스템 지도
 
-프로덕션 코드는 두 패키지입니다. `core/`는 범용 자율 에이전트 런타임이고, `plugins/`는 1차 보조 플러그인(petri\_audit, seed\_generation)입니다. `core/`의 서브시스템은 5계층 스택에 정렬됩니다.
+현재 프로덕션 소스는 두 패키지입니다. `core/`는 범용 자율 에이전트 런타임이고, `plugins/`는 함께 배포되는 1차 제품 기능의 기존 네임스페이스입니다. 독립 설치되는 외부 플러그인 계약은 아닙니다. `core/`의 서브시스템은 5계층 스택에 정렬됩니다.
 
 ```
 Self-Improving  core/self_improving/  train.py + measure/fitness/gate/ledger + loop/{mutate,observe,inject}

--- a/site/src/app/docs/develop/architecture/page.tsx
+++ b/site/src/app/docs/develop/architecture/page.tsx
@@ -25,9 +25,10 @@ export default function Page() {
 
             <h2>서브시스템 지도</h2>
             <p>
-              프로덕션 코드는 두 패키지입니다. <code>core/</code>는 범용 자율
-              에이전트 런타임이고, <code>plugins/</code>는 1차 보조
-              플러그인(petri_audit, seed_generation)입니다. <code>core/</code>의
+              현재 프로덕션 소스는 두 패키지입니다. <code>core/</code>는 범용
+              자율 에이전트 런타임이고, <code>plugins/</code>는 함께 배포되는
+              1차 제품 기능의 기존 네임스페이스입니다. 독립 설치되는 외부
+              플러그인 계약은 아닙니다. <code>core/</code>의
               서브시스템은 5계층 스택에 정렬됩니다.
             </p>
             <pre>{`Self-Improving  core/self_improving/  train.py + measure/fitness/gate/ledger + loop/{mutate,observe,inject}
@@ -149,11 +150,12 @@ margin 게이트  (gate.py)
 
             <h2>Subsystem map</h2>
             <p>
-              Production code splits into two packages: <code>core/</code> is
-              the general-purpose autonomous agent runtime, and{" "}
-              <code>plugins/</code> holds the first-party plugins (petri_audit,
-              seed_generation). The subsystems inside <code>core/</code> line up
-              with the five-layer stack.
+              Production source currently spans two packages: <code>core/</code>{" "}
+              is the general-purpose autonomous agent runtime, while{" "}
+              <code>plugins/</code> is the legacy namespace for bundled
+              first-party product features. It is not an independently
+              installed third-party plugin contract. The subsystems inside{" "}
+              <code>core/</code> line up with the five-layer stack.
             </p>
             <pre>{`Self-Improving  core/self_improving/  train.py + measure/fitness/gate/ledger + loop/{mutate,observe,inject}
 Agent           core/agent/           AgenticLoop (while tool_use), sub_agent, system_prompt


### PR DESCRIPTION
## Summary

- Classify every bundled package and select `geode_product` as the honest product-shell namespace.
- Record the public surfaces, state owners, test owners, compatibility boundaries, and rollback path for each later move.
- Correct contributor and public architecture wording that described bundled features as third-party plugins.

## Why

`plugins/` currently contains repository-owned features shipped in the base wheel, while `core/self_improving` is a product control plane inside the closed kernel. R1.1/BND-001 requires an explicit package classification and migration map before any module move.

## GAP Audit

| Surface | Finding | Disposition |
|---|---|---|
| Package classification | Five bundled features had no accepted exhaustive map | Add one ADR and map |
| Product shell | `plugins` is a misnamed current boundary | Select `geode_product`; move nothing in R1.1 |
| Benchmark/Crucible | Reciprocal Tau2 imports form one migration SCC | Require one compatibility cluster or both forwarders before switching |
| State and evidence | Code paths and durable data have different owners | Preserve every current owner; no state move |
| Existing abandoned branch | Included a duplicate TOML/checker/test framework and stale release wording | Reuse only verified decision evidence; do not merge or recreate the framework |

## Changes

| File | Change |
|---|---|
| `docs/architecture/package-classification.md` | Accepted R1.1 ADR and five-row migration map |
| `AGENTS.md`, `CLAUDE.md`, `plugins/__init__.py` | Contributor-facing package semantics and ADR routing |
| `docs/architecture/naming-conventions.md` | Replace obsolete plugin-layout guidance with the accepted classification pointer |
| `site/src/app/docs/develop/architecture/page.tsx` | Correct Korean and English public architecture wording |
| `site/public/llms-full.txt` | Regenerated public documentation output |

## Verification

- R1.1 independent review: SHIP, P0/P1 none
- Ponytail review: SHIP; 39 duplicate lines removed
- Architecture roadmap validator: PASS
- Architecture baseline: PASS
- Documentation links and canon: PASS
- 29 focused pytest cases: PASS
- Site ESLint: 0 errors (pre-existing warnings only)
- Next.js static build: 237 pages
- Official docs generation/commit parity gate: PASS
- Ruff, format, codespell, mypy, bandit, deptry, and repository pre-commit hooks: PASS
- Repository hygiene and diff check: PASS

No runtime module, import, state path, entry point, dependency, schema, or writer changes in this PR.
