### PR TITLE
docs(roadmap): reconcile R1.4 delivery

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,7 +225,6 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
-| R1.4 | BND-005 | `session=codex-2026-08-15 task=r1-4-neutral-self-improving-seams` | `feature/r1-4-neutral-self-improving-seams` | R1.1 delivery and R1.4 readiness reconciled by [#3002](https://github.com/mangowhoiscloud/geode/pull/3002); current `develop` re-audit confirms BND-001 is delivered and the bounded §7 neutral-seam contract remains measurable | 2026-08-14T18:30:03Z |
 
 ## 1. Program objective
 
@@ -547,7 +546,7 @@ and closure evidence are appended in §10.
 | VER-002 | `ABSENT` | No contract suite measures how many central edits each extension type requires | Six extension scenarios in §8 pass without forbidden edits | R7.2 | CAP-006, LLM-002, BND-004 | `OPEN` |
 | VER-003 | `PARTIAL` | Public/internal metric prose drifts from executable counts | `sync-stats` or one shared generator updates site, AGENTS facts, and roadmap baseline; check mode is green | R0.2 | GOV-001 | `DONE` |
 | VER-004 | `PARTIAL` | Cold-start and runtime metrics exist, but refactors lack one architecture regression baseline | Startup, first-turn, tool-plan build, memory, and event-write budgets are pinned and non-regressing | R7.3 | CAP-005, LOOP-003, DI-004, LLM-004, PROTO-002, STORE-002 | `OPEN` |
-| BND-005 | `MISFIT` | Generic agent/provider/observability consumers import self-improving transcript, SoT-resolution, and prompt-injection helpers | Neutral policy snapshot/source, context-contribution, run identity, and activity-sink contracts replace every classified-kernel import of a self-improving helper without changing runtime behavior | R1.4 | BND-001 | `IN_PROGRESS` |
+| BND-005 | `MISFIT` | Generic agent/provider/observability consumers import self-improving transcript, SoT-resolution, and prompt-injection helpers | Neutral policy snapshot/source, context-contribution, run identity, and activity-sink contracts replace every classified-kernel import of a self-improving helper without changing runtime behavior | R1.4 | BND-001 | `IN_DEVELOP` |
 | BND-006 | `MISFIT` | `core/self_improving` contains 39 Python files and 16,159 LOC of opt-in campaign, Petri/seed orchestration, mutation, gate, CLI/MCP, scheduler, and state policy | One cohesive first-party bundled feature owns the control plane outside the kernel; outer composition wires it, classified kernel modules import it zero times outside the exact forwarding-facade allowlist, a retirement GAP is registered before implementation, and v1.0 commands/imports/config/state behavior pass compatibility and installed-wheel tests | R1.5 | BND-002, BND-005 | `OPEN` |
 | REL-001 | `MISFIT` | PyPI and GitHub Releases still publish v1.0.0, while repository metadata and the changelog declare an untagged, unpublished v1.1.0; the operator selected v1.0.1 as the next public release | Wheel, sdist, CLI, daemon, site SOT, changelog, tag, GitHub release, and PyPI all report v1.0.1 with artifact-hash parity and no rewritten v1.0.0 evidence | R1.6 | BND-003, BND-006, GOV-004 | `OPEN` |
 | REL-002 | `ABSENT` | No registered gate prevents the v1.0.1 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.1, and every release inside that interval retained them | R8.0 | REL-001 | `OPEN` |
@@ -1840,6 +1839,7 @@ pre-release delivery evidence survives after the claim row is gone.
 | R6.7 | MEM-001 | [#2903](https://github.com/mangowhoiscloud/geode/pull/2903) | `a7a59b69f18589bec82eb515b482355924ac9467` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, 10,407 non-live tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, independent GPT-5.6-Luna max review with its sole P2 fixed, 13-of-13 public-hook subscription E2E, and immutable eval-artifact [#15](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/15) with manifest `aba8839af72cd4d96e7e22979affac98e04cbe027fff41e3b67732e75720103d` all passed) |
 | R6.8 | GOAL-001 | [#2931](https://github.com/mangowhoiscloud/geode/pull/2931) | `543994952dddd068695d5717e02263322aaafd38` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, 10,377 non-live tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, deterministic hosted-restart/Lane/terminal-race coverage, GPT-5.6-sol committed-diff review with all seven findings resolved, and immutable eval-artifact [#16](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/16) all passed) |
 | R1.1 | BND-001 | [#3001](https://github.com/mangowhoiscloud/geode/pull/3001) | `1e62473d5a391a750068fbb8de20e303c168ce60` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full tests, lint/format, type check, security, Pages build, official-doc parity, macOS/Ubuntu install smoke, and independent committed-diff review all passed) |
+| R1.4 | BND-005 | [#3004](https://github.com/mangowhoiscloud/geode/pull/3004) | `e20584650809d8b4f2480d45fe01359aa95a28f2` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, import-linter 5/5, slop ratchet 83/83, and independent committed-diff review all passed; policy paths and RunTimeline storage remain product-owned, no durable state migrated, and thin compatibility facades preserve historical readers) |
 
 ### 10.2 Main closure evidence
 
@@ -1971,19 +1971,18 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-R1.1 is delivered on `develop` by
-[#3001](https://github.com/mangowhoiscloud/geode/pull/3001) /
-`1e62473d5a391a750068fbb8de20e303c168ce60`; its active claim is released and
-its durable feature/merge evidence is recorded in §10.1. The preceding
-dependency and exit-criteria re-audit made both R1.4 (`BND-005`) and R1.2
-(`BND-002`) ready; this transaction claims R1.4 and leaves R1.2 unclaimed.
+R1.4 is delivered on `develop` by
+[#3004](https://github.com/mangowhoiscloud/geode/pull/3004) /
+`e20584650809d8b4f2480d45fe01359aa95a28f2`; its active claim is released and
+its durable feature/merge evidence is recorded in §10.1. R1.2 (`BND-002`) is
+the earliest `READY` package and remains unclaimed. Its claim must be recorded
+by a fresh roadmap-only claim PR before an implementation worktree is
+allocated.
 
-After this claim merges, allocate `feature/r1-4-neutral-self-improving-seams`
-from the updated `origin/develop` tip. R1.2 (`BND-002`) remains ready and
-unclaimed; it becomes the next claim-eligible package after this claim merges.
-R1.5 (`BND-006`) then waits for both the neutral seams in R1.4 and the
-reverse-dependency removal in R1.2; the registered BND-007 retirement package
-satisfies its planning prerequisite without authorizing removal.
+R1.5 (`BND-006`) now has the neutral-seam dependency from R1.4 satisfied, but
+remains `OPEN` until the reverse-dependency removal in R1.2 is delivered and
+its whole-package readiness is re-audited. The registered BND-007 retirement
+package satisfies its planning prerequisite without authorizing removal.
 R1.6 (`REL-001`) remains `OPEN` until R0.3, R1.3, and R1.5 are delivered; it
 then owns the v1.0.1 release checkpoint and does not authorize facade removal.
 R8.0 (`REL-002`) remains `OPEN` until REL-001 reaches `DONE`; its 30-day clock


### PR DESCRIPTION
## Summary
- Move BND-005 / R1.4 from IN_PROGRESS to IN_DEVELOP after feature PR #3004 merged.
- Remove the released active claim and append the exact develop merge evidence.
- Set R1.2 as the sole next claim-eligible READY package while R1.5 remains OPEN.

## Why
The roadmap protocol requires a serialized post-implementation transaction after the feature merge. The implementation PR must not predict its own delivery state.

## Changes
| File | Change |
|---|---|
| docs/architecture/extensibility-roadmap.md | Release R1.4 claim, record #3004 and e20584650809d8b4f2480d45fe01359aa95a28f2, and refresh the immediate next unit |

## Invariants
| Check | Result |
|---|---|
| Unique GAP/package selection | BND-005 belongs only to R1.4 |
| Package-atomic transition | R1.4 has one GAP and moves as a unit |
| Active-claim parity | Claim removed with IN_PROGRESS exit |
| Evidence parity | #3004 and exact develop merge SHA recorded in §10.1 |
| Dependency readiness | R1.2 remains the only READY package; R1.5 remains OPEN |
| Scope | Roadmap only; no baseline, dependency, runtime, or main-closure changes |

## Verification
- /Users/mango/workspace/geode/.venv/bin/python -m scripts.check_architecture_roadmap --check --base-ref origin/develop --target-branch develop --event-mode pull_request — RESULT: PASS
- 40 roadmap validator tests passed.
- git diff --check passed.
- Independent exact-diff review: SHIP, P0/P1 none.