### PR TITLE
docs(gateway): Slack 실환경 E2E 근거와 경계 공개

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,6 +9,7 @@
   <img src="https://img.shields.io/badge/while(tool__use)-agentic%20loop-E0699F?style=flat-square" alt="while(tool_use)">
   <img src="https://img.shields.io/badge/scaffold%20optimization-experimental-E0699F?style=flat-square" alt="Experimental scaffold optimization">
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
+  <a href="https://github.com/mangowhoiscloud/geode/releases/latest"><img src="https://img.shields.io/github/v/release/mangowhoiscloud/geode?style=flat-square&label=release" alt="최신 릴리스"></a>
 </p>
 
 <p align="center">
@@ -331,6 +332,14 @@ Gateway의 원격 desktop control은 운영자가
 `[gateway] allow_computer_use = true`를 명시하기 전까지 차단됩니다. 제한된
 binding에서 열기 전에 [computer-use 안내](docs/setup.ko.md#선택-바운드-채널에서-computer-use)를
 확인하세요.
+
+[Slack 실환경 E2E 영수증](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json)은
+Socket Mode를 통한 일상 대화와 browser DOM UI 작업의 완료를 보존합니다. Strict
+pixel `computer_use`는 화면 캡처까지 성공했지만 활성 OpenAI subscription
+source에 호환 visual grounding이 없어 좌표를 추측하거나 provider를 몰래
+바꾸지 않고 중단했습니다. Primary 답변은 subscription route였지만 post-turn
+처리에 auxiliary GLM PAYG 호출도 있었으므로 전체 lifecycle을
+subscription-only로 표기하지 않습니다.
 
 ### Optional — Self-improving loop 설정 (`~/.geode/config.toml`)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <img src="https://img.shields.io/badge/while(tool__use)-agentic%20loop-E0699F?style=flat-square" alt="while(tool_use)">
   <img src="https://img.shields.io/badge/scaffold%20optimization-experimental-E0699F?style=flat-square" alt="Experimental scaffold optimization">
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
+  <a href="https://github.com/mangowhoiscloud/geode/releases/latest"><img src="https://img.shields.io/github/v/release/mangowhoiscloud/geode?style=flat-square&label=release" alt="Latest release"></a>
 </p>
 
 <p align="center">
@@ -404,6 +405,14 @@ Remote desktop control stays disabled in Gateway sessions unless the operator
 explicitly sets `[gateway] allow_computer_use = true`; see the
 [computer-use guide](docs/setup.md#optional-computer-use-from-a-bound-channel)
 before enabling it for a restricted binding.
+
+The [live Slack E2E receipt](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json)
+shows ordinary conversation and a browser-DOM UI task completing through Socket
+Mode. Strict pixel `computer_use` captured the desktop but stopped when the
+active OpenAI subscription source had no compatible visual grounding; it did
+not guess coordinates or silently switch providers. The primary answers used
+the subscription route, while post-turn processing also made an auxiliary GLM
+PAYG call, so the complete lifecycle is not advertised as subscription-only.
 
 ### Optional: Self-improving loop config (`~/.geode/config.toml`)
 

--- a/docs/eval/2026-08-17-slack-gateway-live-e2e.md
+++ b/docs/eval/2026-08-17-slack-gateway-live-e2e.md
@@ -1,0 +1,84 @@
+---
+eval_id: slack-gateway-live-e2e-20260817
+eval_family: slack-gateway-live-e2e
+eval_kind: ledger
+eval_status: historical
+eval_authority: routing-and-behavior-diagnostic
+eval_summary: Three live Slack Socket Mode cases covering ordinary conversation, fail-closed computer_use, and a provider-safe browser DOM fallback.
+eval_triggers:
+  - Slack gateway E2E
+  - Slack Socket Mode
+  - browser UI
+  - computer use
+  - subscription route
+eval_contracts:
+  - docs/eval/external-artifact-repository.md
+eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json
+---
+
+# Slack gateway live conversation and computer-use diagnostic
+
+## 판정
+
+2026-08-17 KST에 PR
+[#3007](https://github.com/mangowhoiscloud/geode/pull/3007)의 exact head
+`e54bde2254c4503662c59d3ac2a927b2483f0573`를 프로젝트 설정으로 실행해,
+Slack Socket Mode에서 들어온 세 요청을 GEODE가 직접 처리하도록 했다. 사람이
+GEODE의 답변이나 tool result를 수정하지 않았다.
+
+| Case | 결과 | 관측 |
+|---|---|---|
+| 일상 대화 | PASS | `gpt-5.6-sol` / Codex OAuth subscription, 1 round, 0 tools, `DAILY-CHAT-OK` |
+| strict `computer_use` | BLOCKED AS DESIGNED | macOS helper 캡처 성공. OpenAI subscription source에 visual locate가 없어 provider를 몰래 바꾸지 않고 중단 |
+| browser UI fallback | PASS | Playwright MCP로 실제 `example.com` 새 탭을 열고 DOM/접근성 snapshot에서 `Example Domain` 확인 |
+
+이는 세 사례의 live behavior diagnostic이다. benchmark 점수, 신뢰구간,
+provider leaderboard 또는 승격 근거가 아니며 `promotion_authority=none`이다.
+
+## Route boundary
+
+세 primary AgenticLoop 답변은 모두 `openai / codex-oauth / subscription` 경로를
+사용했다. 다만 세 세션 모두 primary session 종료 후 Slack processor가 답을
+반환하기 전에 `glm-payg` auxiliary text-completion이 한 번씩 성공했다. 따라서
+**주 답변은 subscription route였지만 전체 lifecycle은 subscription-only가
+아니다.** 이 경계를 숨기거나 API 비용이 없었다고 표현하면 안 된다.
+
+## Computer-use boundary
+
+OpenAI subscription backend에는 이 실행에서 source-safe visual grounding이
+구성되지 않았다. `computer_use.capture`는 1710×1107 화면 observation을 만들었지만
+function-tool wire에는 raw screenshot base64를 넣지 않는다. `locate`는 implicit GLM
+fallback을 거부했고, GEODE는 좌표를 추측해 클릭하거나 타이핑하지 않았다.
+
+웹 작업에는 같은 provider/source를 유지하면서 구조화된 browser DOM 경로를
+사용할 수 있다. 다음 case에서 GEODE는 `browser_tabs`로 `https://example.com/`을
+열고 `browser_snapshot`으로 URL, document title, visible H1을 교차 확인했다.
+이 결과는 pixel grounding 성공이 아니라 안전한 perception-ladder fallback의
+성공이다.
+
+## Evidence
+
+- Artifact repository PR:
+  [geode-eval-artifacts#27](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/27)
+- Immutable receipt:
+  [`2026-08-17-slack-gateway-live-e2e.json`](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json)
+- Artifact merge commit:
+  [`41e15ca262d5953d1c88f4767777331875c57c9f`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/41e15ca262d5953d1c88f4767777331875c57c9f)
+- Receipt SHA-256:
+  `7f706bfde3b95f186caa12c3efc9f11b5dc7332c2212e3f8d0e105732e2e5fa7`
+- Canonical develop merge:
+  `76ca740ee39100f8477c551f125086896c03fe26`
+
+Remote read-back from the exact artifact merge reproduced the receipt digest
+and its three-case, no-promotion, non-subscription-only boundary.
+
+## Privacy and limitations
+
+공개 파일에는 Slack workspace/channel ID, local username/path, session ID,
+credential, email/phone, provider reasoning body가 없다. Raw `messages.json`,
+`tools.json`, runtime log와 screenshot body는 공개하지 않고 크기와 SHA-256만
+receipt에 남겼다.
+
+단일 macOS host와 하나의 Slack workspace에서 수행한 세 사례다. Discord,
+Telegram, 다른 desktop driver, 다른 provider의 native computer tool, 로그인
+페이지, destructive UI action은 범위 밖이다.

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -10,7 +10,7 @@
     "trajectory": "core/observability/schemas/trajectory.schema.json",
     "trajectory_release": "core/observability/schemas/trajectory-release.schema.json"
   },
-  "document_count": 16,
+  "document_count": 17,
   "documents": [
     {
       "id": "agent-world-comparison",
@@ -317,6 +317,28 @@
         "docs/eval/schemas/attempt.schema.json",
         "docs/eval/schemas/run-spec.schema.json"
       ]
+    },
+    {
+      "id": "slack-gateway-live-e2e-20260817",
+      "family": "slack-gateway-live-e2e",
+      "title": "Slack gateway live conversation and computer-use diagnostic",
+      "kind": "ledger",
+      "status": "historical",
+      "authority": "routing-and-behavior-diagnostic",
+      "path": "docs/eval/2026-08-17-slack-gateway-live-e2e.md",
+      "summary": "Three live Slack Socket Mode cases covering ordinary conversation, fail-closed computer_use, and a provider-safe browser DOM fallback.",
+      "sha256": "81838ecbf9f1c088bab2bc58ad83423c0de3f3c26a30cdebfdae0058e0f0730c",
+      "triggers": [
+        "Slack Socket Mode",
+        "Slack gateway E2E",
+        "browser UI",
+        "computer use",
+        "subscription route"
+      ],
+      "contracts": [
+        "docs/eval/external-artifact-repository.md"
+      ],
+      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json"
     },
     {
       "id": "tau2-bench",

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2536,6 +2536,10 @@ channel_id = "C0ABCDEF1"     # 필수. 비어 있으면 규칙이 건너뜀
 require_mention = true
 ```
 
+## 실환경 검증
+
+2026-08-17의 [PR #3007](https://github.com/mangowhoiscloud/geode/pull/3007) head를 Slack Socket Mode에서 직접 실행했다. 일상 대화는 도구 없이 답했고, browser DOM 경로는 실제 `example.com` 탭과 제목을 확인했다. Strict pixel `computer_use`는 캡처에는 성공했지만 OpenAI subscription source에 호환 visual grounding이 없어 좌표를 추측하지 않고 중단했다. 공개 [E2E 영수증](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json)은 세 결과와 raw evidence digest를 보존한다. Primary 답변은 Codex OAuth subscription이었지만 post-turn GLM PAYG 호출도 관측돼 전체 lifecycle은 subscription-only가 아니다.
+
 ## 실패 모드
 
 | 증상 | 원인 | 해법 |
@@ -6008,7 +6012,7 @@ status dict 반환 (절대 raise하지 않음) + 히스토리 append
 URL: https://mangowhoiscloud.github.io/geode/docs/runtime/computer-use
 Markdown: https://mangowhoiscloud.github.io/geode/docs/runtime/computer-use.md
 
-컴퓨터 사용은 모델이 스크린샷으로 화면을 보고 클릭, 타이핑, 스크롤을 지시하는 기능입니다. GEODE의 구현은 `core/tools/computer_use.py`의 `ComputerUseHarness` 하나이며 host backend는 pyautogui 또는 macOS helper입니다. 매 동작 후 base64 JPEG 스크린샷을 돌려주어 모델이 결과를 관찰합니다.
+컴퓨터 사용은 모델이 스크린샷으로 화면을 보고 클릭, 타이핑, 스크롤을 지시하는 기능입니다. GEODE의 구현은 `core/tools/computer_use.py`의 `ComputerUseHarness` 하나이며 host backend는 pyautogui 또는 macOS helper입니다. Provider-native computer surface는 스크린샷을 해당 provider wire로 돌려주지만, normal function tool인 `computer_use`는 base64를 생략하고 compact observation만 반환합니다. Function-tool 경로의 시각적 좌표 선택은 활성 provider/source에 호환되는 grounding이 있을 때만 `locate`로 수행합니다.
 
 ## 동작 방식
 
@@ -6020,7 +6024,8 @@ LLM ── tool_use("computer", action, 좌표/텍스트) ──→ handle_compu
                                               ComputerUseHarness._execute_sync
                                                           │ pyautogui / macOS helper
                                                           ▼
-LLM ←──────── { result, action, screenshot(base64 JPEG) } ◄┘
+native computer ←── screenshot(provider wire) ──────────┤
+computer_use ←────── compact observation(base64 omitted) ◄┘
 ```
 
 디스패치 테이블은 프로바이더 중립입니다. Anthropic 어휘 (`left_click`, `triple_click`, `cursor_position`)와 OpenAI 어휘 (`keypress`)를 같은 핸들러로 받습니다. 지원 동작은 `screenshot`, `click`, `double_click`, `type`, `key`, `scroll`, `move`, `drag`, `wait`와 클릭 변형들입니다. 모르는 action은 지원 목록과 함께 오류로 돌아갑니다.
@@ -6048,7 +6053,7 @@ driver = "helper"
 # helper_path = "/absolute/path/to/geode-computer-helper"
 ```
 
-프로바이더가 native computer surface를 지원하면 그 경로를 쓰고, ChatGPT subscription처럼 native surface를 받지 않는 backend에는 같은 하네스를 normal function tool `computer_use`로 노출합니다.
+프로바이더가 native computer surface를 지원하면 그 경로를 쓰고, ChatGPT subscription처럼 native surface를 받지 않는 backend에는 같은 하네스를 normal function tool `computer_use`로 노출합니다. 이 경로는 다른 provider로 몰래 fallback하지 않습니다. OpenAI subscription source에 visual grounding을 별도로 구성하지 않았다면 `capture`는 가능하지만 `locate`는 dependency error로 중단되며, browser DOM·playwriter· `ui_probe` 같은 source-safe 구조 경로를 선택해야 합니다.
 
 ## 안전
 
@@ -6059,9 +6064,12 @@ driver = "helper"
 | 증상 | 원인 | 해법 |
 | --- | --- | --- |
 | 도구 목록에 `computer`가 없음 | 설정이 꺼졌거나 선택한 driver가 준비되지 않음 | `computer_use_enabled`와 pyautogui/helper 설치 상태를 확인합니다. |
+| `computer_use locate`가 dependency error | 활성 provider/source에 source-safe visual grounding이 없음 | 좌표를 추측하지 말고 `ui_probe`, browser DOM, playwriter 또는 검증된 keyboard navigation을 사용합니다. |
 | `move`가 Accessibility 오류 | OS가 입력 이벤트를 거부했거나 helper 권한이 없음 | 활성 driver/helper에 Accessibility 권한을 주고 `geode doctor`를 다시 실행합니다. |
 | 동작이 오류로 반환 | 지원하지 않는 action 이름 | 오류 응답의 `supported_actions` 목록을 확인합니다. |
 | 클릭 위치가 어긋남 | 타깃 공간과 화면 해상도 불일치 | 스케일링은 자동입니다. 멀티 디스플레이 구성에서는 활성 디스플레이 기준임을 감안합니다. |
+
+이 경계는 2026-08-17 Slack Socket Mode 실환경 검증에서 재현됐다. Strict `computer_use` 캡처는 성공하고 locate는 안전하게 중단됐으며, 별도 browser DOM case는 `Example Domain`을 확인했다. 공개 [영수증](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json)은 두 경로를 구분한다.
 
 ## 다음
 

--- a/site/src/app/docs/harness/serve-gateway/page.tsx
+++ b/site/src/app/docs/harness/serve-gateway/page.tsx
@@ -103,6 +103,19 @@ channel = "slack"
 channel_id = "C0ABCDEF1"     # 필수. 비어 있으면 규칙이 건너뜀
 require_mention = true`}</pre>
 
+            <h2>실환경 검증</h2>
+            <p>
+              2026-08-17의 <a href="https://github.com/mangowhoiscloud/geode/pull/3007">PR #3007</a> head를
+              Slack Socket Mode에서 직접 실행했다. 일상 대화는 도구 없이 답했고,
+              browser DOM 경로는 실제 <code>example.com</code> 탭과 제목을 확인했다.
+              Strict pixel <code>computer_use</code>는 캡처에는 성공했지만 OpenAI
+              subscription source에 호환 visual grounding이 없어 좌표를 추측하지
+              않고 중단했다. 공개 <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json">E2E 영수증</a>은
+              세 결과와 raw evidence digest를 보존한다. Primary 답변은 Codex OAuth
+              subscription이었지만 post-turn GLM PAYG 호출도 관측돼 전체 lifecycle은
+              subscription-only가 아니다.
+            </p>
+
             <h2>실패 모드</h2>
             <table>
               <thead>
@@ -237,6 +250,20 @@ time_budget_s = 120          # default wall-clock per message
 channel = "slack"
 channel_id = "C0ABCDEF1"     # required; an empty id skips the rule
 require_mention = true`}</pre>
+
+            <h2>Live verification</h2>
+            <p>
+              The 2026-08-17 <a href="https://github.com/mangowhoiscloud/geode/pull/3007">PR #3007</a> head
+              was exercised directly through Slack Socket Mode. Ordinary chat
+              answered without tools, and the browser-DOM path opened a real{" "}
+              <code>example.com</code> tab and verified its title. Strict pixel{" "}
+              <code>computer_use</code> captured the desktop but stopped instead
+              of guessing coordinates when the OpenAI subscription source had no
+              compatible visual grounding. The public <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json">E2E receipt</a> preserves
+              the three outcomes and raw-evidence digests. Primary answers used
+              Codex OAuth subscription, but observed post-turn GLM PAYG calls
+              mean the complete lifecycle was not subscription-only.
+            </p>
 
             <h2>Failure modes</h2>
             <table>

--- a/site/src/app/docs/runtime/computer-use/page.tsx
+++ b/site/src/app/docs/runtime/computer-use/page.tsx
@@ -19,9 +19,12 @@ export default function Page() {
               스크롤을 지시하는 기능입니다. GEODE의 구현은{" "}
               <code>core/tools/computer_use.py</code>의{" "}
               <code>ComputerUseHarness</code> 하나이며 host backend는 pyautogui
-              또는 macOS helper입니다.
-              매 동작 후 base64 JPEG 스크린샷을 돌려주어 모델이 결과를
-              관찰합니다.
+              또는 macOS helper입니다. Provider-native computer surface는
+              스크린샷을 해당 provider wire로 돌려주지만, normal function tool인{" "}
+              <code>computer_use</code>는 base64를 생략하고 compact observation만
+              반환합니다. Function-tool 경로의 시각적 좌표 선택은 활성
+              provider/source에 호환되는 grounding이 있을 때만 <code>locate</code>로
+              수행합니다.
             </p>
 
             <h2>동작 방식</h2>
@@ -32,7 +35,8 @@ export default function Page() {
                                               ComputerUseHarness._execute_sync
                                                           │ pyautogui / macOS helper
                                                           ▼
-LLM ←──────── { result, action, screenshot(base64 JPEG) } ◄┘`}</pre>
+native computer ←── screenshot(provider wire) ──────────┤
+computer_use ←────── compact observation(base64 omitted) ◄┘`}</pre>
             <p>
               디스패치 테이블은 프로바이더 중립입니다. Anthropic 어휘
               (<code>left_click</code>, <code>triple_click</code>,{" "}
@@ -105,7 +109,11 @@ driver = "helper"
               프로바이더가 native computer surface를 지원하면 그 경로를 쓰고,
               ChatGPT subscription처럼 native surface를 받지 않는 backend에는
               같은 하네스를 normal function tool <code>computer_use</code>로
-              노출합니다.
+              노출합니다. 이 경로는 다른 provider로 몰래 fallback하지 않습니다.
+              OpenAI subscription source에 visual grounding을 별도로 구성하지
+              않았다면 <code>capture</code>는 가능하지만 <code>locate</code>는
+              dependency error로 중단되며, browser DOM·playwriter·{" "}
+              <code>ui_probe</code> 같은 source-safe 구조 경로를 선택해야 합니다.
             </p>
 
             <h2>안전</h2>
@@ -128,11 +136,19 @@ driver = "helper"
               </thead>
               <tbody>
                 <tr><td>도구 목록에 <code>computer</code>가 없음</td><td>설정이 꺼졌거나 선택한 driver가 준비되지 않음</td><td><code>computer_use_enabled</code>와 pyautogui/helper 설치 상태를 확인합니다.</td></tr>
+                <tr><td><code>computer_use locate</code>가 dependency error</td><td>활성 provider/source에 source-safe visual grounding이 없음</td><td>좌표를 추측하지 말고 <code>ui_probe</code>, browser DOM, playwriter 또는 검증된 keyboard navigation을 사용합니다.</td></tr>
                 <tr><td><code>move</code>가 Accessibility 오류</td><td>OS가 입력 이벤트를 거부했거나 helper 권한이 없음</td><td>활성 driver/helper에 Accessibility 권한을 주고 <code>geode doctor</code>를 다시 실행합니다.</td></tr>
                 <tr><td>동작이 오류로 반환</td><td>지원하지 않는 action 이름</td><td>오류 응답의 <code>supported_actions</code> 목록을 확인합니다.</td></tr>
                 <tr><td>클릭 위치가 어긋남</td><td>타깃 공간과 화면 해상도 불일치</td><td>스케일링은 자동입니다. 멀티 디스플레이 구성에서는 활성 디스플레이 기준임을 감안합니다.</td></tr>
               </tbody>
             </table>
+            <p>
+              이 경계는 2026-08-17 Slack Socket Mode 실환경 검증에서 재현됐다.
+              Strict <code>computer_use</code> 캡처는 성공하고 locate는 안전하게
+              중단됐으며, 별도 browser DOM case는 <code>Example Domain</code>을
+              확인했다. 공개 <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json">영수증</a>은
+              두 경로를 구분한다.
+            </p>
 
             <h2>다음</h2>
             <ul>
@@ -148,9 +164,12 @@ driver = "helper"
               direct clicks, typing, and scrolling. GEODE&apos;s implementation
               is a single <code>ComputerUseHarness</code> in{" "}
               <code>core/tools/computer_use.py</code>, backed on the host by
-              pyautogui or the macOS helper.
-              Every action returns a base64 JPEG screenshot so the model
-              observes the result.
+              pyautogui or the macOS helper. Provider-native computer surfaces
+              return screenshots on their provider wire. The normal function
+              tool <code>computer_use</code> instead omits base64 and returns a
+              compact observation. Visual target selection on that path uses{" "}
+              <code>locate</code> only when compatible grounding exists for the
+              active provider/source.
             </p>
 
             <h2>How it runs</h2>
@@ -161,7 +180,8 @@ driver = "helper"
                                               ComputerUseHarness._execute_sync
                                                           │ pyautogui / macOS helper
                                                           ▼
-LLM ←──────── { result, action, screenshot(base64 JPEG) } ◄┘`}</pre>
+native computer ←── screenshot(provider wire) ──────────┤
+computer_use ←────── compact observation(base64 omitted) ◄┘`}</pre>
             <p>
               The dispatch table is provider-neutral: it accepts the Anthropic
               vocabulary (<code>left_click</code>, <code>triple_click</code>,{" "}
@@ -240,7 +260,12 @@ driver = "helper"
               Providers use their native computer surface when supported.
               Backends that do not accept it, including the ChatGPT subscription
               route, receive the same harness as the normal{" "}
-              <code>computer_use</code> function tool.
+              <code>computer_use</code> function tool. That path never silently
+              falls across providers. Without separately configured visual
+              grounding for the OpenAI subscription source, <code>capture</code>
+              works but <code>locate</code> returns a dependency error; choose a
+              source-safe structural path such as browser DOM, playwriter, or{" "}
+              <code>ui_probe</code> instead.
             </p>
 
             <h2>Safety</h2>
@@ -264,11 +289,19 @@ driver = "helper"
               </thead>
               <tbody>
                 <tr><td><code>computer</code> missing from the tool list</td><td>The setting is off or the selected driver is unavailable</td><td>Check <code>computer_use_enabled</code> and the pyautogui/helper installation.</td></tr>
+                <tr><td><code>computer_use locate</code> returns a dependency error</td><td>No source-safe visual grounding exists for the active provider/source</td><td>Do not guess coordinates. Use <code>ui_probe</code>, browser DOM, playwriter, or verified keyboard navigation.</td></tr>
                 <tr><td><code>move</code> returns an Accessibility error</td><td>The OS rejected the event or the helper lacks permission</td><td>Grant Accessibility to the active driver/helper and rerun <code>geode doctor</code>.</td></tr>
                 <tr><td>An action returns an error</td><td>Unsupported action name</td><td>Check the <code>supported_actions</code> list in the error response.</td></tr>
                 <tr><td>Clicks land off-target</td><td>Target-space vs screen-resolution mismatch</td><td>Scaling is automatic; on multi-display setups it works against the active display.</td></tr>
               </tbody>
             </table>
+            <p>
+              The 2026-08-17 Slack Socket Mode live run reproduced this
+              boundary: strict <code>computer_use</code> captured the desktop and
+              stopped safely at locate, while a separate browser-DOM case
+              verified <code>Example Domain</code>. The public <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/41e15ca262d5953d1c88f4767777331875c57c9f/reports/e2e-validation/2026-08-17-slack-gateway-live-e2e.json">receipt</a> keeps
+              the two paths distinct.
+            </p>
 
             <h2>Next</h2>
             <ul>


### PR DESCRIPTION
## Summary
- PR #3007의 Slack Socket Mode 실환경 검증을 immutable eval artifact와 공식 문서에 연결합니다.
- ordinary chat, fail-closed `computer_use`, provider-safe browser DOM fallback을 구분해 지원 범위를 과장하지 않습니다.
- README EN/KO에 latest-release badge와 exact artifact evidence를 추가합니다.

## Why
기능 PR은 binding/tool policy를 구현했지만, 실제 Slack 답변·Computer Use 경계·subscription/PAYG 혼합 후처리 결과는 공개 근거와 공식 문서에 아직 연결되지 않았습니다. 사용자가 재현 가능한 범위와 현재 제한을 같은 출처에서 확인할 수 있어야 합니다.

## Changes
| File | Change |
|---|---|
| `docs/eval/2026-08-17-slack-gateway-live-e2e.md` | PR #3007 실행 identity, 세 case 판정, route/privacy/claim boundary, artifact merge SHA 기록 |
| `docs/eval/index.json` | generated eval catalog에 diagnostic ledger 등록 |
| `site/src/app/docs/harness/serve-gateway/page.tsx` | Socket Mode live verification과 PR/artifact 링크 추가 |
| `site/src/app/docs/runtime/computer-use/page.tsx` | native screenshot과 function-tool compact observation을 구분하고 source-safe locate/fallback 경계 문서화 |
| `site/public/llms-full.txt` | official docs markdown export 동기화 |
| `README.md`, `README.ko.md` | GitHub latest-release badge와 Slack E2E 근거/제한 추가 |

## Impact Scope
- **Affected modules**: documentation and generated docs catalog/export only
- **Backward compatibility**: runtime behavior unchanged
- **Test changes**: none

## Verification
- [x] eval catalog — `catalog OK: 17 documents`
- [x] docs link audit — 671 links, 0 broken internal links
- [x] targeted ESLint — 0 errors (2 pre-existing `no-img-element` warnings)
- [x] Next.js production build — 237/237 static pages
- [x] `npm run export-md` — 74 markdown twins, `llms-full.txt` refreshed
- [x] render markdown lint — PASS
- [x] exact artifact URL — HTTP 200
- [x] `git diff --check` — PASS
- [x] docs-only change; CHANGELOG not required

## Reference
- Feature PR: https://github.com/mangowhoiscloud/geode/pull/3007
- Artifact PR: https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/27
- Artifact merge: `41e15ca262d5953d1c88f4767777331875c57c9f`
