### PR TITLE
docs(roadmap): claim R1.2 reverse dependency removal

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,6 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
+| R1.2 | BND-002 | `session=codex-root task=r1-2-reverse-dependency-removal` | `feature/r1-2-reverse-dependency-removal` | R1.1 delivery was reconciled by [#3002](https://github.com/mangowhoiscloud/geode/pull/3002); current `develop` re-audit confirms BND-001 remains delivered and the bounded §7 reverse-dependency contract remains measurable | 2026-08-19T05:43:24Z |
 
 ## 1. Program objective
 
@@ -513,7 +514,7 @@ and closure evidence are appended in §10.
 | GOV-003 | `MISFIT` | Old plans describe removed paths and implemented work as current gaps | Overlapping docs carry a historical-status banner and point here | R0.1 | GOV-001 | `DONE` |
 | GOV-004 | `PARTIAL` | 24 import ignores and very high global Ruff ceilings lack uniform owner/expiry metadata | Every exception is removed or recorded per symbol/edge with owner, rationale, expiry, and ratchet | R0.3 | GOV-002 | `DONE` |
 | BND-001 | `MISFIT` | `plugins/` contains first-party features that `core` imports | Every package is classified kernel, product shell, bundled feature, or external extension; names match semantics | R1.1 | GOV-002 | `IN_DEVELOP` |
-| BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `READY` |
+| BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `IN_PROGRESS` |
 | BND-003 | `ABSENT` | One-off core-only probe fails at `core.cli`; CI does not test an installed kernel without features | Isolated wheel/package test boots and runs kernel tests without bundled/third-party modules | R1.3 | BND-001, BND-002, BND-006 | `OPEN` |
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
 | CAP-001 | `PARTIAL` | Google service bundles exist but do not own all tool/policy relationships | Generic capability records plus `GoogleServiceDescriptor` are executable SOTs | R2.1 | BND-002 | `OPEN` |
@@ -1974,10 +1975,10 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 R1.4 is delivered on `develop` by
 [#3004](https://github.com/mangowhoiscloud/geode/pull/3004) /
 `e20584650809d8b4f2480d45fe01359aa95a28f2`; its active claim is released and
-its durable feature/merge evidence is recorded in §10.1. R1.2 (`BND-002`) is
-the earliest `READY` package and remains unclaimed. Its claim must be recorded
-by a fresh roadmap-only claim PR before an implementation worktree is
-allocated.
+its durable feature/merge evidence is recorded in §10.1. This transaction
+claims the earliest ready package, R1.2 (`BND-002`). After the claim merges,
+allocate `feature/r1-2-reverse-dependency-removal` from the updated
+`origin/develop` tip.
 
 R1.5 (`BND-006`) now has the neutral-seam dependency from R1.4 satisfied, but
 remains `OPEN` until the reverse-dependency removal in R1.2 is delivered and


### PR DESCRIPTION
## Summary
- R1.2 / BND-002를 구현 가능한 상태로 원자적으로 claim합니다.
- 실제 코드 변경은 이 PR에 포함하지 않습니다.

## Why
R1.2는 현재 가장 이른 READY 패키지입니다. 로드맵 규약상 claim이 develop에 병합되기 전에는 구현 worktree를 만들 수 없습니다.

## Changes
| File | Change |
|------|--------|
| docs/architecture/extensibility-roadmap.md | active claim 추가, BND-002를 IN_PROGRESS로 전이, 다음 실행 지침 갱신 |

## Verification
- /Users/mango/workspace/geode/.venv/bin/python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request
- /Users/mango/workspace/geode/.venv/bin/pytest -q tests/scripts/test_check_architecture_roadmap.py (40 passed)
- /Users/mango/workspace/geode/.venv/bin/pymarkdown --config .pymarkdown.json scan docs/architecture/extensibility-roadmap.md
- git diff --check
- 독립 committed-diff review: SHIP, P0/P1 없음