### PR TITLE
docs(skills): remove retired slop baseline reference

### DIFF
--- a/.claude/skills/geode-changelog/SKILL.md
+++ b/.claude/skills/geode-changelog/SKILL.md
@@ -74,7 +74,7 @@ view vX.Y.Z` (errors with not-found), and the exact-version PyPI JSON
 burned — correct forward with the next free number instead. To reclaim:
 rename the CHANGELOG heading in place with a retraction blurb, restamp the
 5 locations + site SoT (`sync-stats.mjs` + `check_llms_version.py --fix`)
-+ `scripts/slop_ratchet_baseline.json` + `uv.lock`, and land through the
++ `uv.lock`, and land through the
 normal PR chain.
 
 ## Scope Rules — What to Record / What Not to Record


### PR DESCRIPTION
## Summary
- Remove the final active instruction that asked release work to restamp the retired slop-ratchet baseline.

## Why
PR #3015 deleted the count ratchet and baseline, but the ignored-yet-tracked changelog skill retained one stale operational reference.

## Changes
| File | Change |
|---|---|
| .claude/skills/geode-changelog/SKILL.md | Remove the deleted baseline from the version-restamp checklist |

## Verification
- tracked active-tree grep for retired ratchet names: zero matches
- git diff --check: pass
- commit hooks: codespell, whitespace, EOF, conflict checks pass

Existing whole-file pymarkdown debt in this skill predates and is unrelated to the one-line correction.