### PR TITLE
docs(architecture): claim R1.5 product relocation

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,6 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
+| R1.5 | BND-006 | `session=codex-root task=r1-5-bundled-self-improving-relocation` | `feature/r1-5-bundled-self-improving-relocation` | R1.2 delivery and R1.5 whole-package readiness were reconciled by [#3023](https://github.com/mangowhoiscloud/geode/pull/3023); BND-002 and BND-005 remain delivered on canonical `develop` and BND-007 remains the registered retirement gate | 2026-08-20T00:09:45Z |
 
 ## 1. Program objective
 
@@ -548,7 +549,7 @@ and closure evidence are appended in §10.
 | VER-003 | `PARTIAL` | Public/internal metric prose drifts from executable counts | `sync-stats` or one shared generator updates site, AGENTS facts, and roadmap baseline; check mode is green | R0.2 | GOV-001 | `DONE` |
 | VER-004 | `PARTIAL` | Cold-start and runtime metrics exist, but refactors lack one architecture regression baseline | Startup, first-turn, tool-plan build, memory, and event-write budgets are pinned and non-regressing | R7.3 | CAP-005, LOOP-003, DI-004, LLM-004, PROTO-002, STORE-002 | `OPEN` |
 | BND-005 | `MISFIT` | Generic agent/provider/observability consumers import self-improving transcript, SoT-resolution, and prompt-injection helpers | Neutral policy snapshot/source, context-contribution, run identity, and activity-sink contracts replace every classified-kernel import of a self-improving helper without changing runtime behavior | R1.4 | BND-001 | `IN_DEVELOP` |
-| BND-006 | `MISFIT` | `core/self_improving` contains 39 Python files and 16,159 LOC of opt-in campaign, Petri/seed orchestration, mutation, gate, CLI/MCP, scheduler, and state policy | One cohesive first-party bundled feature owns the control plane outside the kernel; outer composition wires it, classified kernel modules import it zero times outside the exact forwarding-facade allowlist, a retirement GAP is registered before implementation, and v1.0 commands/imports/config/state behavior pass compatibility and installed-wheel tests | R1.5 | BND-002, BND-005 | `READY` |
+| BND-006 | `MISFIT` | `core/self_improving` contains 39 Python files and 16,159 LOC of opt-in campaign, Petri/seed orchestration, mutation, gate, CLI/MCP, scheduler, and state policy | One cohesive first-party bundled feature owns the control plane outside the kernel; outer composition wires it, classified kernel modules import it zero times outside the exact forwarding-facade allowlist, a retirement GAP is registered before implementation, and v1.0 commands/imports/config/state behavior pass compatibility and installed-wheel tests | R1.5 | BND-002, BND-005 | `IN_PROGRESS` |
 | REL-001 | `MISFIT` | PyPI and GitHub Releases still publish v1.0.0, while repository metadata and the changelog declare an untagged, unpublished v1.1.0; the operator selected v1.0.1 as the next public release | Wheel, sdist, CLI, daemon, site SOT, changelog, tag, GitHub release, and PyPI all report v1.0.1 with artifact-hash parity and no rewritten v1.0.0 evidence | R1.6 | BND-003, BND-006, GOV-004 | `OPEN` |
 | REL-002 | `ABSENT` | No registered gate prevents the v1.0.1 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.1, and every release inside that interval retained them | R8.0 | REL-001 | `OPEN` |
 | BND-007 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-002, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.1 | REL-002, STORE-003 | `OPEN` |
@@ -1973,16 +1974,12 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-R1.2 is delivered on `develop` by
-[#3022](https://github.com/mangowhoiscloud/geode/pull/3022) /
-`200a11efd421cf84efdbb0c107a2caa79e8378bf`; its active claim is released and
-its durable feature/merge evidence is recorded in §10.1. The whole-package
-readiness re-audit confirms R1.5 (`BND-006`) now has both BND-002 and BND-005
-satisfied, so it is the sole earliest `READY` package and remains unclaimed.
-Before allocating an R1.5 implementation worktree, merge a fresh roadmap-only
-claim from the then-current `origin/develop` tip. The registered BND-007
-retirement package satisfies R1.5's planning prerequisite without authorizing
-facade removal.
+This transaction claims R1.5 (`BND-006`), the sole earliest ready package,
+after R1.2 delivery and whole-package readiness were reconciled by
+[#3023](https://github.com/mangowhoiscloud/geode/pull/3023). After this claim
+merges, allocate `feature/r1-5-bundled-self-improving-relocation` from the
+updated `origin/develop` tip. The registered BND-007 retirement package
+satisfies R1.5's planning prerequisite without authorizing facade removal.
 R1.6 (`REL-001`) remains `OPEN` until R0.3, R1.3, and R1.5 are delivered; it
 then owns the v1.0.1 release checkpoint and does not authorize facade removal.
 R8.0 (`REL-002`) remains `OPEN` until REL-001 reaches `DONE`; its 30-day clock


### PR DESCRIPTION
## Summary
- Claim R1.5/BND-006 as the sole earliest READY package.
- Record the implementation owner, branch, and R1.2 reconciliation evidence.
- Move BND-006 atomically from READY to IN_PROGRESS.

## Why
The roadmap requires a merged claim before any R1.5 implementation worktree is allocated.

## Changes
| File | Change |
|---|---|
| docs/architecture/extensibility-roadmap.md | R1.5 active claim, status transition, immediate-next instruction |

## Verification
- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request
- git diff --check