### PR TITLE
docs(architecture): R8.3 공개 호환성 증거 claim

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -225,6 +225,7 @@ normal review and CI; implementations start only after the claim merges.
 
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
+| R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
 
 ## 1. Program objective
 
@@ -563,7 +564,7 @@ and closure evidence are appended in §10.
 | GOAL-001 | `PARTIAL` | Explicit Goal state, contextual continuation, accounting, and trajectory events persist, but automatic continuation is owned only by one `AgenticLoop.arun()` call; no process owner discovers an active Goal after return or daemon restart, restores its checkpoint, or prevents duplicate idle launches | The existing serve process owns a bounded idle Goal continuation host that restores the same checkpoint as a new session generation, admits at most one continuation per session, uses the internal contextual-Goal path rather than a synthetic user turn, preserves Lane, PostVerify/replan, accounting, and trajectory contracts, and does not hot-loop an unchanged active Goal | R6.8 | HOOK-003, STORE-002 | `DONE` |
 | CODE-001 | `PARTIAL` | Coding work spans session/checkpoint/timeline, task preflight/TaskGraph, Goal, collaboration, worktree workflow, file/bash tools, and reviewer/verification paths, but no canonical contract maps their current writers, recovery authority, or residual coding-runtime boundaries | One reviewed coding-runtime authority contract maps every proposed record and operation to an existing or residual owner, fixes recovery/history/projection and drift/rollback invariants, and proves that no duplicate runtime store, task ledger, policy plane, or implementation API was introduced | R9.1 | STORE-002, HOOK-003, MEM-001, COLLAB-003, GOAL-001 | `OPEN` |
 | REL-003 | `MISFIT` | PyPI, GitHub Releases, repository metadata, and the changelog report v1.0.22, which predates the delivered boundary refactor | Wheel, sdist, CLI, daemon, site SOT, changelog, tag, GitHub release, and PyPI all report v1.0.23 with artifact-hash parity and no rewritten earlier-release evidence | R1.7 | BND-003, BND-006, GOV-004 | `DONE` |
-| REL-004 | `ABSENT` | No registered gate prevents the v1.0.23 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.23, and every release inside that interval retained them | R8.3 | REL-003 | `READY` |
+| REL-004 | `ABSENT` | No registered gate prevents the v1.0.23 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.23, and every release inside that interval retained them | R8.3 | REL-003 | `IN_PROGRESS` |
 | BND-008 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-004, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.4 | REL-004, STORE-003 | `OPEN` |
 
 ## 6. Dependency and merge sequence
@@ -2065,13 +2066,14 @@ closure [#3037](https://github.com/mangowhoiscloud/geode/pull/3037), and
 CI-gated main-to-develop sync
 [#3038](https://github.com/mangowhoiscloud/geode/pull/3038).
 
-R8.3 (`REL-004`) is the next package and is `READY` for a separate claim. Its
-candidate 30-day interval starts at the later official publication timestamp,
-PyPI file availability at `2026-08-20T06:53:01.550033Z`; the earliest eligible
-closure is `2026-09-19T06:53:01.550033Z`. `READY` records measurable evidence
-collection, not elapsed time or ownership, and any intervening incompatible
-release restarts the interval.
+R8.3 (`REL-004`) is `IN_PROGRESS` under the active claim for
+`feature/r8-3-publication-grace-evidence`. Its candidate interval starts at
+PyPI file availability at `2026-08-20T06:53:01.550033Z`; no closure is eligible
+before `2026-09-19T06:53:01.550033Z`, and any intervening incompatible release
+restarts the interval. This evidence-only package reuses the public
+distribution verifier and does not authorize runtime or schema changes.
 
-R2.1 and R9.1 are dependency-satisfied but remain `OPEN` pending separate
-readiness transactions. R8.2 (`STORE-003`) remains `OPEN` behind REL-004 and
-STORE-001; R8.4 (`BND-008`) additionally waits for STORE-003.
+The next serialized ledger unit is a separate R2.1 readiness audit. R9.1 is
+also dependency-satisfied but remains `OPEN` pending its own transaction. R8.2
+(`STORE-003`) remains `OPEN` behind REL-004 and STORE-001; R8.4 (`BND-008`)
+additionally waits for STORE-003.


### PR DESCRIPTION
## Summary
- REL-004/R8.3을 `READY`에서 `IN_PROGRESS`로 전이하고 단일 active claim을 기록합니다.
- claim 범위를 v1.0.23 공개 호환성 증거 수집으로 제한하며 runtime·schema 변경은 허용하지 않습니다.

## Why
R8.3 readiness가 #3039로 canonical develop에 병합됐습니다. 30일 공개 interval을 추적하려면 owner와 branch를 갖는 별도 claim이 필요하지만, 아직 elapsed-time closure나 구현 코드를 정당화하지는 않습니다.

## Changes
| File | Change |
|------|--------|
| `docs/architecture/extensibility-roadmap.md` | REL-004 IN_PROGRESS, R8.3 active claim, clock/reset/no-code 경계와 다음 R2.1 readiness 순서를 기록 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| REL-004 / R8.3 | IN_PROGRESS | `session=codex-root task=r8-3-publication-grace-evidence` |
| Implementation branch | Claimed | `feature/r8-3-publication-grace-evidence` |
| Closure floor | Preserved | `2026-09-19T06:53:01.550033Z` 이전 종료 금지; incompatible release 시 clock reset |
| Runtime/schema | Out of scope | 기존 public distribution verifier 재사용 |

## Verification
- `uv run --no-sync python -m scripts.check_architecture_roadmap --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — PASS
- `pytest -q tests/scripts/test_check_architecture_roadmap.py` — 40 passed
- `git diff --check` / repository hygiene — PASS
- 독립 read-only 검토 — P0/P1 없음

🤖 Generated with [Codex](https://openai.com/codex/)
