### PR TITLE
docs(architecture): claim R2.1 capability records

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R2.1 | CAP-001, CAP-002 | `session=codex-root task=r2-1-capability-records` | `feature/r2-1-capability-records` | Readiness [#3041](https://github.com/mangowhoiscloud/geode/pull/3041); package acceptance and current capability/tool consumers re-audited | `2026-08-20T08:06:08Z` |
 
 ## 1. Program objective
 
@@ -518,8 +519,8 @@ and closure evidence are appended in §10.
 | BND-002 | `MISFIT` | 31 `core` → `plugins` import sites across 14 files | AST gate reports zero reverse dependency; composition owns feature registration | R1.2 | BND-001 | `IN_DEVELOP` |
 | BND-003 | `ABSENT` | One-off core-only probe fails at `core.cli`; CI does not test an installed kernel without features | Isolated wheel/package test boots and runs kernel tests without bundled/third-party modules | R1.3 | BND-001, BND-002, BND-006 | `IN_DEVELOP` |
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
-| CAP-001 | `PARTIAL` | Google service bundles exist but do not own all tool/policy relationships | Generic capability records plus `GoogleServiceDescriptor` are executable SOTs | R2.1 | BND-002 | `READY` |
-| CAP-002 | `ABSENT` | `ToolRegistry` owns tool objects while other registries/lists own execution and safety | Immutable `ToolRegistration` and `ToolPlan` derive every tool consumer | R2.1 | CAP-001 | `READY` |
+| CAP-001 | `PARTIAL` | Google service bundles exist but do not own all tool/policy relationships | Generic capability records plus `GoogleServiceDescriptor` are executable SOTs | R2.1 | BND-002 | `IN_PROGRESS` |
+| CAP-002 | `ABSENT` | `ToolRegistry` owns tool objects while other registries/lists own execution and safety | Immutable `ToolRegistration` and `ToolPlan` derive every tool consumer | R2.1 | CAP-001 | `IN_PROGRESS` |
 | CAP-003 | `MISFIT` | Native Google handlers are bound in `core/cli/tool_handlers/delegated.py` | Runtime/composition binds handlers; CLI only renders/forwards user interaction | R2.3 | CAP-002, BND-002 | `OPEN` |
 | CAP-004 | `MISFIT` | Google names repeat in safety, approval, policy, personal-data, and CLI modules | Effect/data/auth/resource metadata derives gates; no independent tool-name allowlists | R2.2 | CAP-002 | `OPEN` |
 | CAP-005 | `PARTIAL` | `definitions.json`, tool objects, provider schemas, and defer sets can drift | Anthropic/OpenAI/deferred schemas and execution map share one plan hash and parity tests | R2.3 | CAP-002 | `OPEN` |
@@ -2073,9 +2074,12 @@ before `2026-09-19T06:53:01.550033Z`, and any intervening incompatible release
 restarts the interval. This evidence-only package reuses the public
 distribution verifier and does not authorize runtime or schema changes.
 
-R2.1 (`CAP-001`, `CAP-002`) is the sole unclaimed `READY` package in the
-master sequence and requires a separate claim. BND-002 is `IN_DEVELOP`, and
-the CAP-002-to-CAP-001 edge is internal to R2.1. R9.1 is also
-dependency-satisfied but remains `OPEN` pending its own serialized readiness
-transaction. R8.2 (`STORE-003`) remains `OPEN` behind REL-004 and STORE-001;
-R8.4 (`BND-008`) additionally waits for STORE-003.
+R2.1 (`CAP-001`, `CAP-002`) is `IN_PROGRESS` under the active claim for
+`feature/r2-1-capability-records`, based on readiness
+[#3041](https://github.com/mangowhoiscloud/geode/pull/3041). Implementation
+starts only after this claim lands and a new worktree is allocated from the
+updated `develop`. BND-002 is `IN_DEVELOP`, and the CAP-002-to-CAP-001 edge is
+internal to R2.1. R9.1 is also dependency-satisfied but remains `OPEN` pending
+its own serialized readiness transaction. R8.2 (`STORE-003`) remains `OPEN`
+behind REL-004 and STORE-001; R8.4 (`BND-008`) additionally waits for
+STORE-003.


### PR DESCRIPTION
## Summary
- Claim R2.1 by moving CAP-001 and CAP-002 together from READY to IN_PROGRESS.
- Record the implementation owner and branch without starting implementation early.
- Preserve the parallel R8.3 evidence claim and keep R9.1 as a separate OPEN transaction.

## Why
R2.1 became the sole unclaimed READY package after #3041. The roadmap protocol requires a merged claim before allocating the implementation worktree.

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | Atomic R2.1 status transition, active claim, and immediate-next update |

## GAP Audit
| Package | GAPs | Result |
|---|---|---|
| R2.1 | CAP-001, CAP-002 | READY package and acceptance criteria re-audited; claimed atomically |

## Verification
- `uv run --no-sync python -m scripts.check_architecture_roadmap --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- `python -m pytest tests/scripts/test_check_architecture_roadmap.py -q` (40 passed)
- `git diff --check`
- Independent adversarial review: SHIP, P0/P1 none
