### PR TITLE
feat(architecture): add immutable tool plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ owns only the package version and sync date.
 The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
-The current snapshot records 590 production Python files,
-688 test Python files,
+The current snapshot records 592 production Python files,
+689 test Python files,
 87 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ functional change.
 
 ## [Unreleased]
 
+### Architecture
+
+- **Tool composition now has an immutable validation snapshot.** The product
+  handler composer joins model-facing specs, execution origins, existing safety
+  classifications, and capability requirements into a content-addressed
+  `ToolPlan` before constructing a session. Duplicate or unbound registrations
+  fail early, while current handler ordering and provider payloads remain
+  unchanged. Google OAuth's eight service bundles now derive from one frozen
+  descriptor catalog without changing login or token behavior.
+
 ## [1.0.23] - 2026-08-20
 
 > Bundled product boundaries, a self-improving product ring, and an isolated

--- a/core/auth/google_oauth.py
+++ b/core/auth/google_oauth.py
@@ -35,6 +35,10 @@ import httpx
 
 from core.memory.atomic_write import atomic_write_json
 from core.paths import GLOBAL_GOOGLE_ACCOUNTS_FILE
+from core.tools.google_capabilities import (
+    GOOGLE_SERVICE_DESCRIPTORS,
+    GoogleServiceDescriptor,
+)
 
 log = logging.getLogger(__name__)
 _ACCOUNT_STORE_LOCK = threading.RLock()
@@ -50,77 +54,12 @@ GOOGLE_SECRET_SCHEMA_VERSION = 1
 IDENTITY_SCOPES: tuple[str, ...] = ("openid", "email", "profile")
 
 
-@dataclass(frozen=True, slots=True)
-class GoogleServiceBundle:
-    """Named least-privilege scope bundle exposed by /login google."""
+GoogleServiceBundle = GoogleServiceDescriptor
+GOOGLE_SERVICE_BUNDLES = GOOGLE_SERVICE_DESCRIPTORS
 
-    name: str
-    scopes: tuple[str, ...]
-    description: str
-    risk: str
-
-
-GOOGLE_SERVICE_BUNDLES: dict[str, GoogleServiceBundle] = {
-    "gmail-send": GoogleServiceBundle(
-        "gmail-send",
-        ("https://www.googleapis.com/auth/gmail.send",),
-        "Send mail without reading the mailbox",
-        "sensitive",
-    ),
-    "gmail-read": GoogleServiceBundle(
-        "gmail-read",
-        ("https://www.googleapis.com/auth/gmail.readonly",),
-        "Search and read Gmail messages",
-        "restricted",
-    ),
-    "calendar-read": GoogleServiceBundle(
-        "calendar-read",
-        ("https://www.googleapis.com/auth/calendar.events.owned.readonly",),
-        "Read events on calendars owned by the account",
-        "sensitive",
-    ),
-    "calendar-write": GoogleServiceBundle(
-        "calendar-write",
-        ("https://www.googleapis.com/auth/calendar.events.owned",),
-        "Read and edit events on calendars owned by the account",
-        "sensitive",
-    ),
-    "workspace-files": GoogleServiceBundle(
-        "workspace-files",
-        ("https://www.googleapis.com/auth/drive.file",),
-        "Use Drive, Docs, and Sheets files created or explicitly opened by GEODE",
-        "non-sensitive",
-    ),
-    "tasks-read": GoogleServiceBundle(
-        "tasks-read",
-        ("https://www.googleapis.com/auth/tasks.readonly",),
-        "Read Google Tasks",
-        "sensitive",
-    ),
-    "tasks-write": GoogleServiceBundle(
-        "tasks-write",
-        ("https://www.googleapis.com/auth/tasks",),
-        "Read and edit Google Tasks",
-        "sensitive",
-    ),
-    "contacts-read": GoogleServiceBundle(
-        "contacts-read",
-        ("https://www.googleapis.com/auth/contacts.readonly",),
-        "Read Google Contacts through the People API",
-        "sensitive",
-    ),
-}
-
-RECOMMENDED_GOOGLE_SERVICES: tuple[str, ...] = (
-    "gmail-send",
-    "calendar-read",
-    "workspace-files",
+RECOMMENDED_GOOGLE_SERVICES: tuple[str, ...] = tuple(
+    descriptor.name for descriptor in GOOGLE_SERVICE_DESCRIPTORS.values() if descriptor.recommended
 )
-
-_SERVICE_IMPLICATIONS: dict[str, frozenset[str]] = {
-    "calendar-write": frozenset({"calendar-read"}),
-    "tasks-write": frozenset({"tasks-read"}),
-}
 
 
 class GoogleOAuthError(RuntimeError):
@@ -668,9 +607,9 @@ def normalize_google_services(services: Sequence[str]) -> tuple[str, ...]:
             f"Unknown Google service bundle(s): {', '.join(unknown)}. Available: "
             f"{', '.join(GOOGLE_SERVICE_BUNDLES)}"
         )
-    for parent, implied in _SERVICE_IMPLICATIONS.items():
-        if parent in normalized:
-            normalized.difference_update(implied)
+    for descriptor in GOOGLE_SERVICE_DESCRIPTORS.values():
+        if descriptor.name in normalized:
+            normalized.difference_update(descriptor.implies)
     return tuple(sorted(normalized))
 
 

--- a/core/llm/adapters/_anthropic_common.py
+++ b/core/llm/adapters/_anthropic_common.py
@@ -32,6 +32,7 @@ from core.llm.adapters.base import (
 # injected tool DEFINITION and the local executor never drift.
 from core.tools.computer_use import TARGET_HEIGHT as _COMPUTER_DISPLAY_HEIGHT
 from core.tools.computer_use import TARGET_WIDTH as _COMPUTER_DISPLAY_WIDTH
+from core.tools.plan import thaw_tool_schema
 
 if TYPE_CHECKING:
     import anthropic
@@ -108,7 +109,7 @@ def translate_tool(tool: ToolSpec) -> dict[str, Any]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "input_schema": tool.input_schema,
+        "input_schema": thaw_tool_schema(tool.input_schema),
     }
 
 

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -40,6 +40,7 @@ from core.llm.adapters.base import (
     UsageSummary,
 )
 from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
+from core.tools.plan import thaw_tool_schema
 
 log = logging.getLogger(__name__)
 
@@ -496,7 +497,7 @@ def translate_tool(tool: ToolSpec) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": tool.input_schema,
+            "parameters": thaw_tool_schema(tool.input_schema),
         },
     }
 
@@ -512,7 +513,7 @@ def translate_tool_for_codex(tool: ToolSpec) -> dict[str, Any]:
         "type": "function",
         "name": tool.name,
         "description": tool.description,
-        "parameters": tool.input_schema,
+        "parameters": thaw_tool_schema(tool.input_schema),
     }
 
 

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
+from core.tools.plan import ToolSpec
+
 
 class AdapterBillingType(str, Enum):  # noqa: UP042 — needs str+Enum for older serialisers
     """How an adapter's call gets billed.
@@ -85,19 +87,6 @@ class EmptyModelOutputError(RuntimeError):
             raise RuntimeError("cannot attest actionable empty output without a marker")
         for callback in self._mark_actionable_callbacks:
             callback()
-
-
-@dataclass(frozen=True)
-class ToolSpec:
-    """Tool descriptor passed to the adapter call.
-
-    Provider-agnostic — adapters translate to Anthropic ``tools`` / OpenAI
-    ``tools`` payload shape internally.
-    """
-
-    name: str
-    description: str
-    input_schema: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from core.agent.tool_executor import ToolExecutor
     from core.config.policy_source import PolicySourceBundle
     from core.observability.run_event import RunEventSinkProvider
+    from core.tools.plan import ToolPlan
 
 log = logging.getLogger(__name__)
 
@@ -123,6 +124,7 @@ class SharedServices:
     _owns_hook_system: bool = False
     lane_queue: Any = None  # Unified LaneQueue — single concurrency gate
     tool_handlers: dict[str, Any] = field(default_factory=dict)
+    tool_plan: ToolPlan | None = None
     worker_module: str = "core.agent.worker"
     agent_search_dirs: tuple[Path, ...] = ()
 
@@ -424,6 +426,7 @@ def build_shared_services(
     lane_queue: Any = None,
     verbose: bool = False,
     tool_handler_builder: Callable[..., dict[str, Any]] | None = None,
+    tool_plan_builder: Callable[..., tuple[ToolPlan, dict[str, Any]]] | None = None,
     worker_module: str = "core.agent.worker",
     agent_search_dirs: Sequence[Path] = (),
 ) -> SharedServices:
@@ -433,6 +436,28 @@ def build_shared_services(
     (per-thread, no shared mutable ref).  If *hook_system* is None, a default
     HookSystem is built via ``build_hooks()``.
     """
+    if tool_handler_builder is not None and tool_plan_builder is not None:
+        raise ValueError("tool_handler_builder and tool_plan_builder are mutually exclusive")
+
+    # Validate composition before allocating hooks or process-global offload state.
+    tool_plan = None
+    if tool_plan_builder is not None:
+        tool_plan, tool_handlers = tool_plan_builder(
+            verbose=verbose,
+            mcp_manager=mcp_manager,
+            skill_registry=skill_registry,
+        )
+    else:
+        if tool_handler_builder is None:
+            from core.cli.tool_handlers import _build_tool_handlers
+
+            tool_handler_builder = _build_tool_handlers
+        tool_handlers = tool_handler_builder(
+            verbose=verbose,
+            mcp_manager=mcp_manager,
+            skill_registry=skill_registry,
+        )
+
     # Build hooks if not provided
     owns_hook_system = hook_system is None
     if hook_system is None:
@@ -475,17 +500,6 @@ def build_shared_services(
         hooks=hook_system,
     )
 
-    # Build tool handlers — no agentic_ref (uses ContextVar instead)
-    if tool_handler_builder is None:
-        from core.cli.tool_handlers import _build_tool_handlers
-
-        tool_handler_builder = _build_tool_handlers
-    tool_handlers = tool_handler_builder(
-        verbose=verbose,
-        mcp_manager=mcp_manager,
-        skill_registry=skill_registry,
-    )
-
     # Resolve cost budget
     cost_budget = 0.0
     try:
@@ -512,6 +526,7 @@ def build_shared_services(
         _owns_hook_system=owns_hook_system,
         lane_queue=lane_queue,
         tool_handlers=tool_handlers,
+        tool_plan=tool_plan,
         worker_module=worker_module,
         agent_search_dirs=tuple(agent_search_dirs),
         _cost_budget=cost_budget,

--- a/core/tools/google_capabilities.py
+++ b/core/tools/google_capabilities.py
@@ -1,0 +1,136 @@
+"""Immutable Google Workspace service capability metadata.
+
+API service IDs follow https://developers.google.com/workspace/guides/enable-apis.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True, slots=True)
+class GoogleServiceDescriptor:
+    """One least-privilege OAuth bundle and its static prerequisites.
+
+    ``required_api_services`` holds Google Service Usage IDs accepted by
+    ``gcloud services enable``; it is not an API host allowlist or runtime probe.
+    """
+
+    name: str
+    scopes: tuple[str, ...]
+    description: str
+    risk: str
+    required_api_services: tuple[str, ...] = ()
+    implies: tuple[str, ...] = ()
+    recommended: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "scopes", tuple(self.scopes))
+        object.__setattr__(self, "required_api_services", tuple(self.required_api_services))
+        object.__setattr__(self, "implies", tuple(self.implies))
+
+
+def _descriptor_catalog(
+    entries: tuple[GoogleServiceDescriptor, ...],
+) -> Mapping[str, GoogleServiceDescriptor]:
+    catalog: dict[str, GoogleServiceDescriptor] = {}
+    for descriptor in entries:
+        if descriptor.name in catalog:
+            raise ValueError(f"duplicate Google service descriptor: {descriptor.name}")
+        catalog[descriptor.name] = descriptor
+    for descriptor in catalog.values():
+        invalid = set(descriptor.implies) - catalog.keys()
+        if descriptor.name in descriptor.implies or invalid:
+            raise ValueError(f"invalid Google service implications: {descriptor.name}")
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visiting:
+            raise ValueError(f"cyclic Google service implications: {name}")
+        if name in visited:
+            return
+        visiting.add(name)
+        for implied in catalog[name].implies:
+            visit(implied)
+        visiting.remove(name)
+        visited.add(name)
+
+    for name in catalog:
+        visit(name)
+    return MappingProxyType(catalog)
+
+
+_GOOGLE_SERVICE_DESCRIPTOR_VALUES = (
+    GoogleServiceDescriptor(
+        "gmail-send",
+        ("https://www.googleapis.com/auth/gmail.send",),
+        "Send mail without reading the mailbox",
+        "sensitive",
+        ("gmail.googleapis.com",),
+        recommended=True,
+    ),
+    GoogleServiceDescriptor(
+        "gmail-read",
+        ("https://www.googleapis.com/auth/gmail.readonly",),
+        "Search and read Gmail messages",
+        "restricted",
+        ("gmail.googleapis.com",),
+    ),
+    GoogleServiceDescriptor(
+        "calendar-read",
+        ("https://www.googleapis.com/auth/calendar.events.owned.readonly",),
+        "Read events on calendars owned by the account",
+        "sensitive",
+        ("calendar-json.googleapis.com",),
+        recommended=True,
+    ),
+    GoogleServiceDescriptor(
+        "calendar-write",
+        ("https://www.googleapis.com/auth/calendar.events.owned",),
+        "Read and edit events on calendars owned by the account",
+        "sensitive",
+        ("calendar-json.googleapis.com",),
+        implies=("calendar-read",),
+    ),
+    GoogleServiceDescriptor(
+        "workspace-files",
+        ("https://www.googleapis.com/auth/drive.file",),
+        "Use Drive, Docs, and Sheets files created or explicitly opened by GEODE",
+        "non-sensitive",
+        (
+            "drive.googleapis.com",
+            "docs.googleapis.com",
+            "sheets.googleapis.com",
+        ),
+        recommended=True,
+    ),
+    GoogleServiceDescriptor(
+        "tasks-read",
+        ("https://www.googleapis.com/auth/tasks.readonly",),
+        "Read Google Tasks",
+        "sensitive",
+        ("tasks.googleapis.com",),
+    ),
+    GoogleServiceDescriptor(
+        "tasks-write",
+        ("https://www.googleapis.com/auth/tasks",),
+        "Read and edit Google Tasks",
+        "sensitive",
+        ("tasks.googleapis.com",),
+        implies=("tasks-read",),
+    ),
+    GoogleServiceDescriptor(
+        "contacts-read",
+        ("https://www.googleapis.com/auth/contacts.readonly",),
+        "Read Google Contacts through the People API",
+        "sensitive",
+        ("people.googleapis.com",),
+    ),
+)
+GOOGLE_SERVICE_DESCRIPTORS: Mapping[str, GoogleServiceDescriptor] = _descriptor_catalog(
+    _GOOGLE_SERVICE_DESCRIPTOR_VALUES
+)

--- a/core/tools/plan.py
+++ b/core/tools/plan.py
@@ -1,0 +1,342 @@
+"""Immutable tool metadata and content-addressed plan compilation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+
+class _ImmutableMapping(Mapping[str, Any]):
+    """Read-only JSON object without a mutable builtin base."""
+
+    __slots__ = ("_values",)
+    _values: Mapping[str, Any]
+
+    def __init__(self, values: Mapping[str, Any]) -> None:
+        object.__setattr__(self, "_values", MappingProxyType(dict(values)))
+
+    def __setattr__(self, _name: str, _value: Any) -> None:
+        raise AttributeError("tool schemas are immutable")
+
+    def __delattr__(self, _name: str) -> None:
+        raise AttributeError("tool schemas are immutable")
+
+    def __getitem__(self, key: str) -> Any:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __copy__(self) -> _ImmutableMapping:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> _ImmutableMapping:
+        return self
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise TypeError("tool schema numbers must be finite")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("tool schema object keys must be strings")
+        return _ImmutableMapping({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    raise TypeError(f"tool schema values must be JSON-compatible, got {type(value).__name__}")
+
+
+def thaw_tool_schema(value: Any) -> Any:
+    """Return plain JSON containers for provider SDK boundaries."""
+    if isinstance(value, Mapping):
+        return {key: thaw_tool_schema(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [thaw_tool_schema(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Provider-neutral model-facing tool descriptor."""
+
+    name: str
+    description: str
+    input_schema: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("tool name cannot be empty")
+        frozen = _freeze_json(self.input_schema)
+        if not isinstance(frozen, Mapping):
+            raise TypeError("tool input_schema must be a JSON object")
+        object.__setattr__(self, "input_schema", frozen)
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> ToolSpec:
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionBinding:
+    """Stable identity for one handler or named executor route."""
+
+    name: str
+    origin: str
+    route: str = "handler"
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("execution binding name cannot be empty")
+        if not self.origin.strip():
+            raise ValueError("binding origin cannot be empty")
+        if self.route not in {"handler", "special"}:
+            raise ValueError(f"execution binding {self.name!r} has invalid route {self.route!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyPolicy:
+    """Minimum effect, data, consent, and runtime safety constraints."""
+
+    effect: str = "read"
+    data_class: str = "public"
+    consent_required: bool = False
+    allow_headless: bool = True
+    allow_subagents: bool = True
+    denied: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.effect.strip() or not self.data_class.strip():
+            raise ValueError("safety effect and data class cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityRequirement:
+    """Provider, service, and authorization requirements for one tool."""
+
+    providers: tuple[str, ...] = ()
+    services: tuple[str, ...] = ()
+    auth: tuple[str, ...] = ()
+    available: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "providers", _canonical_requirement(self.providers))
+        object.__setattr__(self, "services", _canonical_requirement(self.services))
+        object.__setattr__(self, "auth", _canonical_requirement(self.auth))
+
+
+def _canonical_requirement(values: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError("capability requirements must be an iterable of strings")
+    captured = tuple(values)
+    if any(not isinstance(item, str) or not item.strip() for item in captured):
+        raise ValueError("capability requirement values cannot be empty")
+    return tuple(sorted(set(captured)))
+
+
+@dataclass(frozen=True, slots=True)
+class ToolRegistration:
+    """Joined tool metadata used to derive every plan projection."""
+
+    spec: ToolSpec
+    execution: ExecutionBinding
+    safety: SafetyPolicy
+    capability: CapabilityRequirement
+
+    def __post_init__(self) -> None:
+        if self.spec.name != self.execution.name:
+            raise ValueError(
+                f"tool registration name mismatch: {self.spec.name!r} vs {self.execution.name!r}"
+            )
+
+
+class ToolDecision(StrEnum):
+    ENABLED = "enabled"
+    UNAVAILABLE_CAPABILITY = "unavailable_capability"
+    DENIED_POLICY = "denied_policy"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolPlan:
+    """One immutable, generation-aware tool catalog snapshot."""
+
+    generation: int
+    content_hash: str
+    registrations: tuple[ToolRegistration, ...]
+    schema_map: Mapping[str, ToolSpec]
+    execution_map: Mapping[str, ExecutionBinding]
+    outcomes: Mapping[str, ToolDecision]
+
+    def __post_init__(self) -> None:
+        registrations = tuple(self.registrations)
+        schemas = dict(self.schema_map)
+        executions = dict(self.execution_map)
+        outcomes = dict(self.outcomes)
+        by_name = {item.spec.name: item for item in registrations}
+        if self.generation < 1:
+            raise ValueError("tool plan generation must be positive")
+        if len(by_name) != len(registrations):
+            raise ValueError("tool plan contains duplicate registrations")
+        if set(outcomes) != set(by_name):
+            raise ValueError("tool plan outcomes must cover every registration")
+        if any(outcomes[name] is not _decision(item) for name, item in by_name.items()):
+            raise ValueError("tool plan outcomes do not match registration metadata")
+        enabled = tuple(name for name in by_name if outcomes[name] is ToolDecision.ENABLED)
+        if tuple(schemas) != enabled or tuple(executions) != enabled:
+            raise ValueError("tool plan schema/execution maps must match enabled registrations")
+        if any(
+            schemas[name] != by_name[name].spec or executions[name] != by_name[name].execution
+            for name in enabled
+        ):
+            raise ValueError("tool plan projection does not match its registrations")
+        if self.content_hash != _content_hash(registrations):
+            raise ValueError("tool plan content hash does not match its registrations")
+        object.__setattr__(self, "registrations", registrations)
+        object.__setattr__(self, "schema_map", MappingProxyType(schemas))
+        object.__setattr__(self, "execution_map", MappingProxyType(executions))
+        object.__setattr__(self, "outcomes", MappingProxyType(outcomes))
+
+
+def _collect_specs(
+    entries: Iterable[tuple[ToolSpec, str]],
+) -> dict[str, tuple[ToolSpec, str]]:
+    collected: dict[str, tuple[ToolSpec, str]] = {}
+    for spec, origin in entries:
+        previous = collected.get(spec.name)
+        if previous is not None:
+            raise ValueError(f"duplicate tool spec {spec.name!r}: {previous[1]} vs {origin}")
+        collected[spec.name] = (spec, origin)
+    return collected
+
+
+def _collect_bindings(entries: Iterable[ExecutionBinding]) -> dict[str, ExecutionBinding]:
+    collected: dict[str, ExecutionBinding] = {}
+    for binding in entries:
+        previous = collected.get(binding.name)
+        if previous is not None:
+            raise ValueError(
+                f"duplicate execution binding {binding.name!r}: "
+                f"{previous.origin} vs {binding.origin}"
+            )
+        collected[binding.name] = binding
+    return collected
+
+
+def _decision(registration: ToolRegistration) -> ToolDecision:
+    if registration.safety.denied:
+        return ToolDecision.DENIED_POLICY
+    if not registration.capability.available:
+        return ToolDecision.UNAVAILABLE_CAPABILITY
+    return ToolDecision.ENABLED
+
+
+def _content_hash(registrations: tuple[ToolRegistration, ...]) -> str:
+    payload = [
+        {
+            "name": item.spec.name,
+            "description": item.spec.description,
+            "input_schema": thaw_tool_schema(item.spec.input_schema),
+            "execution": {
+                "origin": item.execution.origin,
+                "route": item.execution.route,
+            },
+            "safety": {
+                "effect": item.safety.effect,
+                "data_class": item.safety.data_class,
+                "consent_required": item.safety.consent_required,
+                "allow_headless": item.safety.allow_headless,
+                "allow_subagents": item.safety.allow_subagents,
+                "denied": item.safety.denied,
+            },
+            "capability": {
+                "providers": item.capability.providers,
+                "services": item.capability.services,
+                "auth": item.capability.auth,
+                "available": item.capability.available,
+            },
+            "outcome": _decision(item).value,
+        }
+        for item in registrations
+    ]
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compile_tool_plan(
+    specs: Iterable[tuple[ToolSpec, str]],
+    bindings: Iterable[ExecutionBinding],
+    *,
+    safety: Mapping[str, SafetyPolicy] | None = None,
+    capabilities: Mapping[str, CapabilityRequirement] | None = None,
+    previous: ToolPlan | None = None,
+) -> ToolPlan:
+    """Validate and compile separate schema/execution inputs into one snapshot."""
+    specs_by_name = _collect_specs(specs)
+    bindings_by_name = _collect_bindings(bindings)
+    spec_names = set(specs_by_name)
+    binding_names = set(bindings_by_name)
+    if missing := sorted(spec_names - binding_names):
+        raise ValueError(f"missing execution bindings: {', '.join(missing)}")
+    if missing := sorted(binding_names - spec_names):
+        raise ValueError(f"missing tool specs: {', '.join(missing)}")
+
+    safety = safety or {}
+    capabilities = capabilities or {}
+    if unknown := sorted((set(safety) | set(capabilities)) - spec_names):
+        raise ValueError(f"metadata references unknown tools: {', '.join(unknown)}")
+
+    registrations = tuple(
+        ToolRegistration(
+            spec=specs_by_name[name][0],
+            execution=bindings_by_name[name],
+            safety=safety.get(name, SafetyPolicy()),
+            capability=capabilities.get(name, CapabilityRequirement()),
+        )
+        for name in specs_by_name
+    )
+    content_hash = _content_hash(registrations)
+    if previous is not None and previous.content_hash == content_hash:
+        return previous
+
+    outcomes = {item.spec.name: _decision(item) for item in registrations}
+    enabled = tuple(
+        item for item in registrations if outcomes[item.spec.name] is ToolDecision.ENABLED
+    )
+    schema_map = MappingProxyType({item.spec.name: item.spec for item in enabled})
+    execution_map = MappingProxyType({item.spec.name: item.execution for item in enabled})
+    return ToolPlan(
+        generation=1 if previous is None else previous.generation + 1,
+        content_hash=content_hash,
+        registrations=registrations,
+        schema_map=schema_map,
+        execution_map=execution_map,
+        outcomes=MappingProxyType(outcomes),
+    )
+
+
+__all__ = [
+    "CapabilityRequirement",
+    "ExecutionBinding",
+    "SafetyPolicy",
+    "ToolDecision",
+    "ToolPlan",
+    "ToolRegistration",
+    "ToolSpec",
+    "compile_tool_plan",
+    "thaw_tool_schema",
+]

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -283,12 +283,12 @@ machine-readable artifact is
 
 | Measure | Current tree |
 |---|---:|
-| Production Python files (`core/` + `geode_product/` + `plugins/`) | 590 |
-| Test Python files | 688 |
-| `core/` Python LOC | 120,928 |
-| `geode_product/` Python LOC | 61,687 |
+| Production Python files (`core/` + `geode_product/` + `plugins/`) | 592 |
+| Test Python files | 689 |
+| `core/` Python LOC | 121,351 |
+| `geode_product/` Python LOC | 61,768 |
 | `plugins/` Python LOC | 213 |
-| Test Python LOC | 183,135 |
+| Test Python LOC | 183,727 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 7 |

--- a/docs/plans/2026-08-20-r2-1-capability-tool-plan.md
+++ b/docs/plans/2026-08-20-r2-1-capability-tool-plan.md
@@ -1,0 +1,155 @@
+# R2.1 Capability and Tool Plan
+
+Status: implementation authorized by roadmap claim [#3042](https://github.com/mangowhoiscloud/geode/pull/3042)
+
+Base: `origin/develop@7161bb22f502d9c005f101bf987c60dc8b93b394`
+
+GAPs: `CAP-001`, `CAP-002`
+
+## Outcome
+
+Compile the existing model-visible tool definitions and executable bindings into
+one immutable, generation-aware `ToolPlan`, then fail before session construction
+when that snapshot is inconsistent. Existing schema and execution consumers keep
+their byte-compatible projections in R2.1; R2.3 moves them onto the plan.
+
+This package does not add another mutable registry. It reuses the existing
+definition loader, collision-checked handler composer, `ToolRegistry` extension
+surface, MCP discovery, and provider adapters.
+
+## Measured baseline
+
+- `definitions.json`: 87 model-visible definitions.
+- product-composed handler map: 82 handlers.
+- special executor paths: 8 names.
+- every definition has an execution path today, but the proof is assembled by a
+  test from separate sets rather than owned by runtime composition.
+- three execution-only internal routes (`computer`, `doctor_slack`,
+  `recall_tool_result`) are not model-visible definitions and must stay outside
+  the public plan.
+- `GeodeRuntime.tool_registry` contains a separate 15-tool object catalog that
+  is not the `SharedServices` schema/handler plane.
+- Google OAuth owns eight frozen service bundles, while service implications,
+  scopes, tool schemas, personal-data classification, and approval policy are
+  spread across separate modules.
+
+## Decision criteria
+
+| Source | Adopt | Do not copy |
+|---|---|---|
+| Codex | one registration joins spec and executor; one router is frozen in step context | crate taxonomy, namespace/exposure hierarchy |
+| Hermes Agent | monotonic generation, availability before snapshot, canonical capability hash | mutable global registry state, TTL grace, last-writer-wins override |
+| OpenClaw | attempt-local policy-filtered catalog and collision evidence | catalog cache and object-identity fingerprint |
+| Cursor | schema and execute live in one custom-tool contract; unknown/denied tools fail before use | opaque classifier policy or undocumented runtime assumptions |
+| GoF | Command for execution, immutable Composite value for the plan, Strategy/Adapter only at existing provider seams | interfaces or factories with one implementation |
+
+Pinned primary sources:
+
+- [Codex ToolExecutor](https://github.com/openai/codex/blob/e3e5ad28470f6a225301518c30a66e749a880164/codex-rs/tools/src/tool_executor.rs#L91-L119), [ToolRegistry](https://github.com/openai/codex/blob/e3e5ad28470f6a225301518c30a66e749a880164/codex-rs/core/src/tools/registry.rs#L271-L383), and [StepContext](https://github.com/openai/codex/blob/e3e5ad28470f6a225301518c30a66e749a880164/codex-rs/core/src/session/step_context.rs#L13-L43)
+- [Hermes ToolEntry](https://github.com/NousResearch/hermes-agent/blob/27562ad5f80e90f7d552f92dbd4af7f1f511c3c8/tools/registry.py#L204-L233), [generation/snapshot](https://github.com/NousResearch/hermes-agent/blob/27562ad5f80e90f7d552f92dbd4af7f1f511c3c8/tools/registry.py#L426-L484), and [capability hash](https://github.com/NousResearch/hermes-agent/blob/27562ad5f80e90f7d552f92dbd4af7f1f511c3c8/hermes_cli/plugin_capabilities.py#L66-L190)
+- [OpenClaw tool registration](https://github.com/openclaw/openclaw/blob/ab7fc490d68bdd0dc89199ddc0898e590070e13d/src/plugins/registry-registrars-tools-hooks.ts#L223-L268), [attempt catalog](https://github.com/openclaw/openclaw/blob/ab7fc490d68bdd0dc89199ddc0898e590070e13d/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts#L1-L142), and [policy pipeline](https://github.com/openclaw/openclaw/blob/ab7fc490d68bdd0dc89199ddc0898e590070e13d/src/agents/tool-policy-pipeline.ts#L135-L228)
+- [Cursor Python SDK](https://cursor.com/docs/sdk/python) and [tool approval](https://docs.cursor.com/context/model-context-protocol)
+
+## Boundary
+
+```mermaid
+flowchart LR
+    D["definitions.json\nmodel schema"] --> C["ToolPlan compiler"]
+    H["handler catalog\nname + origin"] --> C
+    S["special and MCP bindings"] --> C
+    P["policy + capability decisions"] --> C
+    C --> T["immutable ToolPlan\ngeneration + SHA-256"]
+    T --> V["pre-session parity validation"]
+    T --> M["backward-compatible schema projection"]
+    T --> E["backward-compatible execution projection"]
+    R["compile with previous plan"] --> N["same object or next generation"]
+    T -. "prior snapshot unchanged" .-> N
+```
+
+Dependency direction remains `geode_product -> core`. Product composition
+supplies product handlers and descriptors; the neutral compiler has no product
+imports and no process-global setter.
+
+## Minimal records
+
+Names may change while implementing, but these responsibilities stay separate.
+The existing adapter `ToolSpec` moves to neutral ownership and remains re-exported
+from its old import path; no second `ToolSpec` is introduced.
+
+| Record | Current producer | Immediate consumer / boundary |
+|---|---|---|
+| `ToolSpec` | `definitions.json` and existing `ToolRegistry` objects | compiler plus the unchanged adapter re-export |
+| `ExecutionBinding` | existing origin-aware handler catalog and special bindings | compiler parity validation and compatibility execution projection |
+| `SafetyPolicy` | read-only snapshot of existing safety classifications | compiler decision result; no new tool-name list or approval engine |
+| `CapabilityRequirement` | explicit registration input | compiler decision result; availability and policy denial stay distinct |
+| `ToolRegistration` | declarative definitions plus the origin-aware product handler catalog | compiler input; no second mutable registrar |
+| `ToolPlan` | pure compiler | pre-session validation and compatibility projections |
+| `GoogleServiceDescriptor` | existing eight bundles plus implication/recommended data | existing OAuth compatibility view; tool association migrates in R2.2 |
+
+The compiler hashes canonical stable metadata only. Raw callables remain in the
+existing compatibility handler map until R2.3, outside plan identity. Hashes
+also exclude secrets, ambient environment values, and timestamps. Resource-key
+resolution remains owned by R2.4.
+
+## Implementation order
+
+1. Add behavior characterization for current schema/execution parity, duplicate
+   failure, internal-only routes, Google bundle compatibility, and provider
+   projection equality.
+2. Add the neutral immutable records and pure compiler. Reuse the existing
+   `ToolSpec`, `UniqueEntries`, origin-aware handler catalog, stdlib frozen
+   dataclasses, tuples, `MappingProxyType`, canonical JSON, and SHA-256.
+3. Compile at the existing product composition boundary and fail before session
+   construction on duplicate, missing, or mismatched bindings. Keep current
+   schema/execution projections byte-compatible; no global registry.
+4. Keep the validated plan beside its compatibility handler map in the existing
+   `SharedServices` composition owner. `compile(inputs, previous=None)` returns
+   the same plan for identical stable metadata and generation + 1 for changed
+   metadata, leaving the prior value unchanged.
+5. Move the existing Google bundle data behind `GoogleServiceDescriptor` and
+   retain the current OAuth import surface as a thin compatibility export.
+6. Keep the public `ToolRegistry` API and its extension/benchmark compatibility
+   role unchanged. R2.3 adapts dynamic registry and MCP snapshots when it moves
+   live model/execution consumers; R2.1 does not create a parallel adapter.
+7. Update `[Unreleased]`, architecture inventory, and directly affected public
+   architecture docs; run generated-doc parity only after final source bytes.
+
+## Explicit non-goals
+
+- R2.2 Google policy/name-list consumer migration.
+- R2.3 provider-specific schema convergence, live `AgenticLoop`/`ToolExecutor`
+  plan consumption, worker/MCP root convergence, and CLI handler relocation.
+- R3.1 full route/policy/trace `StepSnapshot`.
+- plugin hot reload, trust lifecycle, catalog caching, or a second manifest.
+- changing user-visible tool names, schemas, approval behavior, or provider
+  payload bytes except to reject a previously hidden schema/executor mismatch.
+
+## Acceptance
+
+- duplicate names fail before a session starts and report both origins;
+- model schema names and execution binding names are identical for every plan;
+- unavailable capability and denied policy remain distinct machine-readable
+  compiler outcomes without changing the current runtime denial path;
+- two builds from identical inputs have identical content hash;
+- identical content returns the same plan object and generation; a changed
+  catalog increments generation and leaves the prior plan unchanged;
+- the product-composed handler and special-binding sets cover every
+  model-visible definition, while the three declared internal-only routes stay
+  outside the plan; any unbound model-visible definition fails instead of being
+  filtered away;
+- current Anthropic/OpenAI wire payloads remain byte-equivalent before and
+  after the neutral `ToolSpec` ownership move;
+- the existing public `ToolRegistry` keeps its compatibility behavior, while
+  the origin-aware product handler composition feeds lossless compiler inputs;
+- existing Google bundle callers observe the same names, scopes, risks, and
+  implications;
+- targeted tests, ruff, format, mypy, import-linter, package/install smoke,
+  architecture baseline, official-doc checks, and the full non-live suite pass.
+
+## GitFlow
+
+One functional PR from `feature/r2-1-capability-records` targets `develop` and
+names both GAPs. After merge, a roadmap-only reconciliation moves both rows to
+`IN_DEVELOP`, records one shared evidence row, removes the claim, and re-audits
+the next package. Main promotion follows only after the ordinary main-to-develop
+sync precondition.

--- a/geode_product/tool_handlers.py
+++ b/geode_product/tool_handlers.py
@@ -21,10 +21,13 @@ tools into the GEODE ToolExecutor:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from core.cli.tool_handlers.delegated import make_delegate_handler
 from core.cli.tool_handlers.registration import UniqueEntries
+
+if TYPE_CHECKING:
+    from core.tools.plan import ToolPlan
 
 _SEED_TOOL_CLASSES = (
     (
@@ -44,6 +47,8 @@ _SEED_TOOL_CLASSES = (
     ),
 )
 
+_INTERNAL_ONLY_HANDLERS = frozenset({"computer", "doctor_slack", "recall_tool_result"})
+
 
 def product_handler_groups() -> tuple[tuple[str, UniqueEntries[str, Any]], ...]:
     """Return the product-owned batches consumed by the core composer."""
@@ -60,18 +65,94 @@ def build_tool_handlers(
     mcp_manager: Any = None,
     skill_registry: Any = None,
 ) -> dict[str, Any]:
-    """Compose the kernel and product handler groups once."""
+    """Compose and validate the kernel and product handler groups once."""
+    _plan, handlers = compose_tool_plan(
+        verbose=verbose,
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+    )
+    return handlers
+
+
+def compose_tool_plan(
+    *,
+    verbose: bool = False,
+    mcp_manager: Any = None,
+    skill_registry: Any = None,
+    previous: ToolPlan | None = None,
+) -> tuple[ToolPlan, dict[str, Any]]:
+    """Validate the current product catalog without changing its projections."""
+    from core.agent.safety import (
+        DANGEROUS_TOOLS,
+        EXPENSIVE_TOOLS,
+        HEADLESS_DENIED_TOOLS,
+        SENSITIVE_TOOLS,
+        WRITE_TOOLS,
+    )
+    from core.agent.sub_agent import SUBAGENT_DENIED_TOOLS
+    from core.agent.tool_executor.executor import SPECIAL_EXECUTION_BINDINGS
     from core.cli.routing import compose_command_registry
-    from core.cli.tool_handlers import build_tool_handlers as build_core_tool_handlers
+    from core.cli.tool_handlers import _build_tool_handler_catalog
+    from core.tools.base import load_all_tool_definitions
+    from core.tools.personal_data import PERSONAL_DATA_TOOLS
+    from core.tools.plan import ExecutionBinding, SafetyPolicy, ToolSpec, compile_tool_plan
 
     from geode_product.cli import PRODUCT_COMMAND_SPECS
 
-    return build_core_tool_handlers(
-        verbose=verbose,
+    catalog = _build_tool_handler_catalog(
         mcp_manager=mcp_manager,
         skill_registry=skill_registry,
         command_registry=compose_command_registry(PRODUCT_COMMAND_SPECS),
         extra_groups=product_handler_groups(),
+    )
+    if invalid := [name for name, handler in catalog.handlers.items() if not callable(handler)]:
+        raise TypeError(f"tool handlers must be callable: {', '.join(invalid)}")
+    definitions = load_all_tool_definitions()
+    specs = tuple(
+        (
+            ToolSpec(
+                name=item["name"],
+                description=item["description"],
+                input_schema=item["input_schema"],
+            ),
+            f"core/tools/definitions.json[{index}]",
+        )
+        for index, item in enumerate(definitions)
+    )
+    bindings = tuple(
+        ExecutionBinding(name=name, origin=catalog.origins[name])
+        for name in catalog.handlers
+        if name not in _INTERNAL_ONLY_HANDLERS
+    ) + tuple(
+        ExecutionBinding(
+            name=name,
+            origin="core.agent.tool_executor.special",
+            route="special",
+        )
+        for name in sorted(SPECIAL_EXECUTION_BINDINGS)
+    )
+    gated = DANGEROUS_TOOLS | SENSITIVE_TOOLS | WRITE_TOOLS | set(EXPENSIVE_TOOLS)
+    safety = {
+        item["name"]: SafetyPolicy(
+            effect=(
+                "system"
+                if item["name"] in DANGEROUS_TOOLS
+                else "write"
+                if item["name"] in WRITE_TOOLS
+                else "external"
+                if item["name"] in SENSITIVE_TOOLS or item["name"] in EXPENSIVE_TOOLS
+                else "read"
+            ),
+            data_class="personal" if item["name"] in PERSONAL_DATA_TOOLS else "public",
+            consent_required=item["name"] in gated,
+            allow_headless=item["name"] not in HEADLESS_DENIED_TOOLS,
+            allow_subagents=item["name"] not in SUBAGENT_DENIED_TOOLS,
+        )
+        for item in definitions
+    }
+    return (
+        compile_tool_plan(specs, bindings, safety=safety, previous=previous),
+        dict(catalog.handlers),
     )
 
 

--- a/geode_product/wiring.py
+++ b/geode_product/wiring.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import typer
 
-from geode_product.tool_handlers import build_tool_handlers
+from geode_product.tool_handlers import compose_tool_plan
 
 
 def build_policy_sources() -> Any:
@@ -111,7 +111,7 @@ def build_shared_services(**kwargs: Any) -> Any:
     kwargs.setdefault("feature_hook_registrar", register_hooks)
     return build_core_services(
         **kwargs,
-        tool_handler_builder=build_tool_handlers,
+        tool_plan_builder=compose_tool_plan,
         worker_module="geode_product.worker",
         agent_search_dirs=(Path(__file__).parent / "seed_generation" / "agents",),
     )

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6104,7 +6104,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1514 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1515 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -6264,8 +6264,8 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 
 | 측정값 | 현재 트리 |
 | --- | --- |
-| 프로덕션 Python 파일 | 590 |
-| 테스트 Python 파일 | 688 |
+| 프로덕션 Python 파일 | 592 |
+| 테스트 Python 파일 | 689 |
 | 도구 정의 / 실행 등록 / 유효 스키마 | 87 / 90 / 87 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 7 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -365,20 +365,20 @@
   },
   "packages": {
     "core": {
-      "python_files": 398,
-      "python_loc": 120928
+      "python_files": 400,
+      "python_loc": 121351
     },
     "geode_product": {
       "python_files": 160,
-      "python_loc": 61687
+      "python_loc": 61768
     },
     "plugins": {
       "python_files": 32,
       "python_loc": 213
     },
     "tests": {
-      "python_files": 688,
-      "python_loc": 183135
+      "python_files": 689,
+      "python_loc": 183727
     }
   },
   "schema_version": 3,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Architecture\n\n- **Tool composition now has an immutable validation snapshot.** The product\n  handler composer joins model-facing specs, execution origins, existing safety\n  classifications, and capability requirements into a content-addressed\n  `ToolPlan` before constructing a session. Duplicate or unbound registrations\n  fail early, while current handler ordering and provider payloads remain\n  unchanged. Google OAuth's eight service bundles now derive from one frozen\n  descriptor catalog without changing login or token behavior."
   },
   {
     "version": "1.0.23",

--- a/tests/core/auth/test_google_oauth.py
+++ b/tests/core/auth/test_google_oauth.py
@@ -7,18 +7,21 @@ import os
 import urllib.request
 from dataclasses import replace
 from pathlib import Path
+from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 from core.auth.google_oauth import (
     GOOGLE_SERVICE_BUNDLES,
+    RECOMMENDED_GOOGLE_SERVICES,
     GoogleAccount,
     GoogleAccountStore,
     GoogleCredentialStoreError,
     GoogleLoopbackReceiver,
     GoogleOAuthError,
     GoogleSecret,
+    GoogleServiceBundle,
     KeyringGoogleSecretStore,
     build_google_authorization_url,
     google_scopes_for_services,
@@ -26,6 +29,11 @@ from core.auth.google_oauth import (
     login_google,
     normalize_google_services,
     revoke_google_account,
+)
+from core.tools import google_capabilities
+from core.tools.google_capabilities import (
+    GOOGLE_SERVICE_DESCRIPTORS,
+    GoogleServiceDescriptor,
 )
 
 
@@ -74,6 +82,135 @@ def test_service_bundles_collapse_implied_read_scopes() -> None:
     scopes = google_scopes_for_services(["gmail-send", "calendar-read"])
     assert "openid" in scopes
     assert GOOGLE_SERVICE_BUNDLES["gmail-send"].scopes[0] in scopes
+
+
+def test_google_service_bundle_catalog_is_stable() -> None:
+    assert {
+        name: (bundle.name, bundle.scopes, bundle.description, bundle.risk)
+        for name, bundle in GOOGLE_SERVICE_BUNDLES.items()
+    } == {
+        "gmail-send": (
+            "gmail-send",
+            ("https://www.googleapis.com/auth/gmail.send",),
+            "Send mail without reading the mailbox",
+            "sensitive",
+        ),
+        "gmail-read": (
+            "gmail-read",
+            ("https://www.googleapis.com/auth/gmail.readonly",),
+            "Search and read Gmail messages",
+            "restricted",
+        ),
+        "calendar-read": (
+            "calendar-read",
+            ("https://www.googleapis.com/auth/calendar.events.owned.readonly",),
+            "Read events on calendars owned by the account",
+            "sensitive",
+        ),
+        "calendar-write": (
+            "calendar-write",
+            ("https://www.googleapis.com/auth/calendar.events.owned",),
+            "Read and edit events on calendars owned by the account",
+            "sensitive",
+        ),
+        "workspace-files": (
+            "workspace-files",
+            ("https://www.googleapis.com/auth/drive.file",),
+            "Use Drive, Docs, and Sheets files created or explicitly opened by GEODE",
+            "non-sensitive",
+        ),
+        "tasks-read": (
+            "tasks-read",
+            ("https://www.googleapis.com/auth/tasks.readonly",),
+            "Read Google Tasks",
+            "sensitive",
+        ),
+        "tasks-write": (
+            "tasks-write",
+            ("https://www.googleapis.com/auth/tasks",),
+            "Read and edit Google Tasks",
+            "sensitive",
+        ),
+        "contacts-read": (
+            "contacts-read",
+            ("https://www.googleapis.com/auth/contacts.readonly",),
+            "Read Google Contacts through the People API",
+            "sensitive",
+        ),
+    }
+
+
+def test_google_service_descriptors_own_static_requirements() -> None:
+    assert GOOGLE_SERVICE_BUNDLES is GOOGLE_SERVICE_DESCRIPTORS
+    assert GoogleServiceBundle is GoogleServiceDescriptor
+    assert RECOMMENDED_GOOGLE_SERVICES == (
+        "gmail-send",
+        "calendar-read",
+        "workspace-files",
+    )
+    assert {
+        name: (
+            descriptor.required_api_services,
+            descriptor.implies,
+            descriptor.recommended,
+        )
+        for name, descriptor in GOOGLE_SERVICE_DESCRIPTORS.items()
+    } == {
+        "gmail-send": (("gmail.googleapis.com",), (), True),
+        "gmail-read": (("gmail.googleapis.com",), (), False),
+        "calendar-read": (("calendar-json.googleapis.com",), (), True),
+        "calendar-write": (
+            ("calendar-json.googleapis.com",),
+            ("calendar-read",),
+            False,
+        ),
+        "workspace-files": (
+            (
+                "drive.googleapis.com",
+                "docs.googleapis.com",
+                "sheets.googleapis.com",
+            ),
+            (),
+            True,
+        ),
+        "tasks-read": (("tasks.googleapis.com",), (), False),
+        "tasks-write": (("tasks.googleapis.com",), ("tasks-read",), False),
+        "contacts-read": (("people.googleapis.com",), (), False),
+    }
+    assert not hasattr(GOOGLE_SERVICE_DESCRIPTORS, "__setitem__")
+    assert GoogleServiceDescriptor("test", (), "Test", "sensitive").required_api_services == ()
+
+
+def test_google_service_descriptor_is_deeply_immutable_and_duplicate_safe() -> None:
+    scopes = ["scope"]
+    services = ["service.googleapis.com"]
+    implied = ["parent"]
+    descriptor = GoogleServiceDescriptor(
+        "test",
+        cast(Any, scopes),
+        "Test",
+        "sensitive",
+        cast(Any, services),
+        cast(Any, implied),
+    )
+    scopes.clear()
+    services.clear()
+    implied.clear()
+
+    assert descriptor.scopes == ("scope",)
+    assert descriptor.required_api_services == ("service.googleapis.com",)
+    assert descriptor.implies == ("parent",)
+    with pytest.raises(ValueError, match="duplicate Google service descriptor: test"):
+        google_capabilities._descriptor_catalog((descriptor, descriptor))
+    with pytest.raises(ValueError, match="invalid Google service implications: test"):
+        google_capabilities._descriptor_catalog((replace(descriptor, implies=("missing",)),))
+    with pytest.raises(ValueError, match="cyclic Google service implications"):
+        google_capabilities._descriptor_catalog(
+            (
+                replace(descriptor, name="a", implies=("b",)),
+                replace(descriptor, name="b", implies=("a",)),
+            )
+        )
 
 
 def test_unknown_service_bundle_is_rejected() -> None:

--- a/tests/core/server/test_shared_services.py
+++ b/tests/core/server/test_shared_services.py
@@ -327,6 +327,45 @@ class TestBuildSharedServices:
         services = build_shared_services()
         assert len(services.tool_handlers) > 0
 
+    def test_tool_plan_builder_keeps_plan_and_handlers_together(self) -> None:
+        plan = object()
+        handlers = {"test_tool": MagicMock()}
+        builder = MagicMock(return_value=(plan, handlers))
+
+        services = build_shared_services(
+            hook_system=MagicMock(),
+            lane_queue=MagicMock(),
+            tool_plan_builder=builder,
+        )
+
+        assert services.tool_plan is plan
+        assert services.tool_handlers is handlers
+        builder.assert_called_once_with(
+            verbose=False,
+            mcp_manager=None,
+            skill_registry=None,
+        )
+
+    def test_tool_composition_has_one_authority(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            build_shared_services(
+                tool_handler_builder=MagicMock(),
+                tool_plan_builder=MagicMock(),
+            )
+
+    def test_tool_plan_failure_precedes_process_side_effects(self) -> None:
+        builder = MagicMock(side_effect=ValueError("invalid plan"))
+
+        with (
+            patch("core.wiring.bootstrap.build_hooks") as build_hooks,
+            patch("core.wiring.bootstrap.build_tool_offload") as build_tool_offload,
+            pytest.raises(ValueError, match="invalid plan"),
+        ):
+            build_shared_services(tool_plan_builder=builder)
+
+        build_hooks.assert_not_called()
+        build_tool_offload.assert_not_called()
+
     def test_explicit_composition_reaches_every_session_owner(self) -> None:
         from core.hooks import MiddlewareRegistry
 

--- a/tests/core/tools/test_tool_plan.py
+++ b/tests/core/tools/test_tool_plan.py
@@ -1,0 +1,267 @@
+"""Immutable tool-plan compilation contracts."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from collections.abc import Mapping
+from typing import Any, cast
+
+import pytest
+from core.tools.plan import (
+    CapabilityRequirement,
+    ExecutionBinding,
+    SafetyPolicy,
+    ToolDecision,
+    ToolSpec,
+    compile_tool_plan,
+)
+
+
+def _spec(name: str = "search", *, description: str = "Search") -> ToolSpec:
+    return ToolSpec(
+        name=name,
+        description=description,
+        input_schema={
+            "type": "object",
+            "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+            "required": ["tags"],
+        },
+    )
+
+
+def _binding(
+    name: str = "search", *, origin: str = "handlers.search", route: str = "handler"
+) -> ExecutionBinding:
+    return ExecutionBinding(name=name, origin=origin, route=route)
+
+
+def test_records_reject_missing_identity_before_compilation() -> None:
+    with pytest.raises(ValueError, match="tool name cannot be empty"):
+        ToolSpec(name="", description="Search", input_schema={})
+    with pytest.raises(ValueError, match="binding origin cannot be empty"):
+        ExecutionBinding(name="search", origin="")
+    with pytest.raises(TypeError, match="input_schema must be a JSON object"):
+        ToolSpec(name="search", description="Search", input_schema=cast(Any, []))
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_tool_spec_rejects_non_json_numbers(value: float) -> None:
+    with pytest.raises(TypeError, match="numbers must be finite"):
+        ToolSpec(name="search", description="Search", input_schema={"default": value})
+
+
+def test_tool_spec_schema_is_recursively_immutable_and_adapter_compatible() -> None:
+    source = {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        "required": ["tags"],
+    }
+    spec = ToolSpec(name="search", description="Search", input_schema=source)
+    source["properties"]["tags"]["type"] = "string"
+
+    assert isinstance(spec.input_schema, Mapping)
+    assert spec.input_schema["properties"]["tags"]["type"] == "array"
+    with pytest.raises(TypeError):
+        spec.input_schema["properties"]["tags"]["type"] = "string"
+    with pytest.raises(AttributeError):
+        spec.input_schema["required"].append("query")
+    with pytest.raises(AttributeError):
+        cast(Any, spec.input_schema)._values = {}
+    with pytest.raises(AttributeError):
+        del cast(Any, spec.input_schema)._values
+    with pytest.raises(AttributeError):
+        spec.__dict__["input_schema"] = {}
+    assert copy.deepcopy(spec).input_schema is spec.input_schema
+    assert dataclasses.asdict(spec)["input_schema"] == spec.input_schema
+
+
+def test_compile_rejects_duplicate_names_with_both_origins() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"duplicate tool spec 'search': definitions\[0\] vs extension\.json",
+    ):
+        compile_tool_plan(
+            ((_spec(), "definitions[0]"), (_spec(), "extension.json")),
+            (_binding(),),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"duplicate execution binding 'search': handlers\.search vs extension\.search",
+    ):
+        compile_tool_plan(
+            ((_spec(), "definitions[0]"),),
+            (_binding(), _binding(origin="extension.search")),
+        )
+
+
+def test_execution_binding_records_handler_or_named_route_identity() -> None:
+    special = ExecutionBinding(
+        name="search",
+        origin="ToolExecutor.special",
+        route="special",
+    )
+
+    assert special.route == "special"
+    with pytest.raises(ValueError, match="invalid route"):
+        ExecutionBinding(name="search", origin="handlers.search", route="")
+    with pytest.raises(ValueError, match="invalid route"):
+        ExecutionBinding(name="search", origin="handlers.search", route="unknown")
+
+
+@pytest.mark.parametrize(
+    ("specs", "bindings", "message"),
+    [
+        (((_spec(), "definitions[0]"),), (), "missing execution bindings: search"),
+        ((), (_binding(),), "missing tool specs: search"),
+    ],
+)
+def test_compile_requires_exact_schema_execution_parity(
+    specs: tuple[tuple[ToolSpec, str], ...],
+    bindings: tuple[ExecutionBinding, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        compile_tool_plan(specs, bindings)
+
+
+def test_compiler_is_content_addressed_and_generation_aware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = _spec()
+    binding = _binding()
+    plan = compile_tool_plan(((spec, "definitions[0]"),), (binding,))
+
+    monkeypatch.setenv("GEODE_FAKE_SECRET", "must-not-affect-plan")
+    same = compile_tool_plan(((spec, "definitions[0]"),), (binding,), previous=plan)
+    changed = compile_tool_plan(
+        ((_spec(description="Changed"), "definitions[0]"),),
+        (_binding(),),
+        previous=plan,
+    )
+
+    assert same is plan
+    assert plan.generation == 1
+    assert changed.generation == 2
+    assert changed.content_hash != plan.content_hash
+    assert plan.schema_map["search"].description == "Search"
+    assert set(changed.schema_map) == set(changed.execution_map) == {"search"}
+
+
+def test_compiler_preserves_provider_visible_definition_order() -> None:
+    plan = compile_tool_plan(
+        ((_spec("zeta"), "definitions[0]"), (_spec("alpha"), "definitions[1]")),
+        (_binding("alpha"), _binding("zeta")),
+    )
+    reordered = compile_tool_plan(
+        ((_spec("alpha"), "definitions[1]"), (_spec("zeta"), "definitions[0]")),
+        (_binding("zeta"), _binding("alpha")),
+        previous=plan,
+    )
+
+    assert list(plan.schema_map) == list(plan.execution_map) == ["zeta", "alpha"]
+    assert list(reordered.schema_map) == ["alpha", "zeta"]
+    assert reordered.content_hash != plan.content_hash
+    assert reordered.generation == plan.generation + 1
+
+
+def test_compiler_distinguishes_capability_unavailable_from_policy_denied() -> None:
+    unavailable = compile_tool_plan(
+        ((_spec(), "definitions[0]"),),
+        (_binding(),),
+        capabilities={"search": CapabilityRequirement(available=False)},
+    )
+    denied = compile_tool_plan(
+        ((_spec(), "definitions[0]"),),
+        (_binding(),),
+        safety={"search": SafetyPolicy(denied=True)},
+    )
+
+    assert unavailable.outcomes["search"] is ToolDecision.UNAVAILABLE_CAPABILITY
+    assert denied.outcomes["search"] is ToolDecision.DENIED_POLICY
+    assert unavailable.schema_map == unavailable.execution_map == {}
+    assert denied.schema_map == denied.execution_map == {}
+
+
+def test_plan_mappings_and_registration_metadata_are_immutable() -> None:
+    plan = compile_tool_plan(
+        ((_spec(), "definitions[0]"),),
+        (_binding(),),
+        safety={"search": SafetyPolicy(effect="external", data_class="personal")},
+        capabilities={
+            "search": CapabilityRequirement(
+                providers=("openai",), services=("search",), auth=("oauth",)
+            )
+        },
+    )
+
+    assert isinstance(plan.schema_map, Mapping)
+    with pytest.raises(TypeError):
+        plan.schema_map["other"] = _spec("other")
+    registration = plan.registrations[0]
+    assert registration.safety.effect == "external"
+    assert registration.safety.data_class == "personal"
+    assert registration.capability.providers == ("openai",)
+
+
+def test_capability_requirements_have_canonical_set_identity() -> None:
+    first = CapabilityRequirement(
+        providers=("openai", "anthropic", "openai"),
+        services=("search", "files"),
+        auth=("oauth", "oauth"),
+    )
+    second = CapabilityRequirement(
+        providers=("anthropic", "openai"),
+        services=("files", "search"),
+        auth=("oauth",),
+    )
+
+    assert first == second
+    generated = CapabilityRequirement(providers=(item for item in ("openai", "openai")))
+    assert generated.providers == ("openai",)
+    with pytest.raises(TypeError, match="iterable of strings"):
+        CapabilityRequirement(providers=cast(Any, "openai"))
+
+
+def test_direct_tool_plan_construction_copies_mutable_containers() -> None:
+    original = compile_tool_plan(
+        ((_spec(), "definitions[0]"),),
+        (_binding(),),
+    )
+    registrations = list(original.registrations)
+    schemas = dict(original.schema_map)
+    executions = dict(original.execution_map)
+    outcomes = dict(original.outcomes)
+    copied = type(original)(
+        1,
+        original.content_hash,
+        cast(Any, registrations),
+        schemas,
+        executions,
+        outcomes,
+    )
+
+    registrations.clear()
+    schemas.clear()
+    executions.clear()
+    outcomes.clear()
+    assert len(copied.registrations) == len(copied.schema_map) == len(copied.execution_map) == 1
+    assert len(copied.outcomes) == 1
+
+
+def test_direct_tool_plan_construction_rejects_projection_reordering() -> None:
+    original = compile_tool_plan(
+        ((_spec("zeta"), "definitions[0]"), (_spec("alpha"), "definitions[1]")),
+        (_binding("zeta"), _binding("alpha")),
+    )
+
+    with pytest.raises(ValueError, match="maps must match enabled registrations"):
+        type(original)(
+            original.generation,
+            original.content_hash,
+            original.registrations,
+            dict(reversed(original.schema_map.items())),
+            dict(reversed(original.execution_map.items())),
+            original.outcomes,
+        )

--- a/tests/integration/test_product_composition.py
+++ b/tests/integration/test_product_composition.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import runpy
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
+
+import pytest
 
 PRODUCT_TOOLS = {
     "petri_audit",
@@ -14,6 +18,19 @@ PRODUCT_TOOLS = {
     "seed_debate_turn",
     "freeze_paper_snapshot",
 }
+_INTERNAL_ONLY_HANDLERS = {"computer", "doctor_slack", "recall_tool_result"}
+_PRODUCT_HANDLER_ORIGINS = {
+    "eval_dspy_optimize": "product-audit",
+    "eval_inspect_viz": "product-audit",
+    "freeze_paper_snapshot": "product-seed",
+    "geode_seed_pool_search": "product-seed",
+    "petri_audit": "product-audit",
+    "seed_debate_turn": "product-seed",
+}
+
+
+def _handler(**_: Any) -> dict[str, bool]:
+    return {"ok": True}
 
 
 def test_product_tools_are_added_only_by_product_composition() -> None:
@@ -79,7 +96,7 @@ def test_product_owns_self_improving_typer_commands() -> None:
 def test_daemon_composition_supplies_product_workers_tools_and_prompts(monkeypatch) -> None:
     from core.server.supervised import services
     from geode_product import wiring
-    from geode_product.tool_handlers import build_tool_handlers
+    from geode_product.tool_handlers import compose_tool_plan
 
     build_core = Mock(return_value="services")
     policy_sources = object()
@@ -89,7 +106,7 @@ def test_daemon_composition_supplies_product_workers_tools_and_prompts(monkeypat
     assert wiring.build_shared_services(marker=True) == "services"
     assert build_core.call_args.kwargs == {
         "marker": True,
-        "tool_handler_builder": build_tool_handlers,
+        "tool_plan_builder": compose_tool_plan,
         "worker_module": "geode_product.worker",
         "agent_search_dirs": (Path(wiring.__file__).parent / "seed_generation" / "agents",),
         "policy_sources": policy_sources,
@@ -136,3 +153,135 @@ def test_mcp_entrypoint_supplies_the_product_handler_builder(monkeypatch) -> Non
         agent_runner=mcp_server.run_agent,
         feature_registrar=register_mcp_tools,
     )
+
+
+def test_model_definitions_and_execution_surfaces_have_exact_parity() -> None:
+    from core.agent.tool_executor.executor import SPECIAL_EXECUTION_BINDINGS
+    from core.cli.tool_handlers import _build_tool_handler_catalog
+    from core.tools.base import load_all_tool_definitions
+    from geode_product.tool_handlers import product_handler_groups
+
+    definitions = {item["name"] for item in load_all_tool_definitions()}
+    catalog = _build_tool_handler_catalog(extra_groups=product_handler_groups())
+    handlers = set(catalog.handlers)
+    special_bindings = set(SPECIAL_EXECUTION_BINDINGS)
+    executable = handlers | special_bindings
+
+    assert handlers.isdisjoint(special_bindings)
+    assert definitions - executable == set()
+    assert executable - definitions == _INTERNAL_ONLY_HANDLERS
+
+
+def test_product_handlers_retain_their_composition_origins() -> None:
+    from core.cli.tool_handlers import _build_tool_handler_catalog
+    from geode_product.tool_handlers import product_handler_groups
+
+    catalog = _build_tool_handler_catalog(extra_groups=product_handler_groups())
+
+    assert {
+        name: catalog.origins[name] for name in _PRODUCT_HANDLER_ORIGINS
+    } == _PRODUCT_HANDLER_ORIGINS
+    assert set(catalog.handlers) == set(catalog.origins)
+
+
+def test_product_handler_collision_fails_before_catalog_snapshot() -> None:
+    from core.cli.tool_handlers import _build_tool_handler_catalog
+    from core.cli.tool_handlers.registration import UniqueEntries
+    from geode_product.tool_handlers import product_handler_groups
+
+    conflicting_groups = (
+        *product_handler_groups(),
+        ("product-conflict", UniqueEntries((("petri_audit", _handler),))),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"duplicate tool handler registration: 'petri_audit' "
+            r"\(product-audit vs product-conflict\)"
+        ),
+    ):
+        _build_tool_handler_catalog(extra_groups=conflicting_groups)
+
+
+def test_product_composition_rejects_non_callable_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from geode_product.tool_handlers import compose_tool_plan
+
+    monkeypatch.setattr(
+        "core.cli.tool_handlers._build_tool_handler_catalog",
+        lambda **_kwargs: SimpleNamespace(
+            handlers={"broken": None},
+            origins={"broken": "broken-source"},
+        ),
+    )
+
+    with pytest.raises(TypeError, match="tool handlers must be callable: broken"):
+        compose_tool_plan()
+
+
+def test_provider_tool_projections_preserve_existing_wire_payloads() -> None:
+    from core.llm.adapters._anthropic_common import translate_tool as translate_anthropic_tool
+    from core.llm.adapters._openai_common import translate_tool as translate_openai_tool
+    from core.llm.adapters.base import ToolSpec
+    from core.tools.base import load_all_tool_definitions
+
+    definitions = load_all_tool_definitions()
+    specs = tuple(
+        ToolSpec(
+            name=item["name"],
+            description=item["description"],
+            input_schema=item["input_schema"],
+        )
+        for item in definitions
+    )
+
+    assert list(map(translate_anthropic_tool, specs)) == [
+        {
+            "name": item["name"],
+            "description": item["description"],
+            "input_schema": item["input_schema"],
+        }
+        for item in definitions
+    ]
+    assert list(map(translate_openai_tool, specs)) == [
+        {
+            "type": "function",
+            "function": {
+                "name": item["name"],
+                "description": item["description"],
+                "parameters": item["input_schema"],
+            },
+        }
+        for item in definitions
+    ]
+
+
+def test_product_composition_compiles_one_lossless_immutable_plan() -> None:
+    from core.agent.tool_executor.executor import SPECIAL_EXECUTION_BINDINGS
+    from core.cli.tool_handlers import _build_tool_handler_catalog
+    from core.tools.base import load_all_tool_definitions
+    from geode_product.tool_handlers import compose_tool_plan, product_handler_groups
+
+    definitions = load_all_tool_definitions()
+    catalog = _build_tool_handler_catalog(extra_groups=product_handler_groups())
+    plan, handlers = compose_tool_plan()
+    same, rebuilt_handlers = compose_tool_plan(previous=plan)
+
+    assert same is plan
+    assert list(plan.schema_map) == [item["name"] for item in definitions]
+    assert set(plan.schema_map) == set(plan.execution_map)
+    assert list(handlers) == list(rebuilt_handlers) == list(catalog.handlers)
+    assert set(handlers) - set(plan.execution_map) == _INTERNAL_ONLY_HANDLERS
+    assert {
+        name for name, binding in plan.execution_map.items() if binding.route == "special"
+    } == set(SPECIAL_EXECUTION_BINDINGS)
+    assert plan.execution_map["petri_audit"].origin == "product-audit"
+
+    policies = {item.spec.name: item.safety for item in plan.registrations}
+    assert policies["run_bash"].effect == "system"
+    assert policies["gmail_search"].data_class == "personal"
+    assert policies["gmail_search"].consent_required is True
+    assert policies["gmail_search"].allow_headless is False
+    assert policies["gmail_search"].allow_subagents is False


### PR DESCRIPTION
## Summary
- Add an immutable, generation/hash-bound `ToolPlan` compiled before product daemon sessions.
- Join existing schema, execution origin, safety, and capability metadata without changing handler order or provider payloads.
- Consolidate Google OAuth service metadata into one frozen descriptor catalog while preserving the public bundle API.

## Why
R2.1 / CAP-001 and CAP-002 require registration records and a validated immutable plan boundary before later consumer migration. The previous model, execution, safety, and Google capability planes were separate and could drift until dispatch.

## GAP Audit
| GAP | Before | After | Deferred owner |
|---|---|---|---|
| CAP-001 | No immutable joined registration or Google service descriptor SOT | Immutable records, compiler, and lossless Google descriptor projection | R2.2 migrates remaining name-list consumers |
| CAP-002 | Schema/execution parity checked by separate inventories | Product daemon retains one pre-session ToolPlan beside the compatibility handler map | R2.3 moves live AgenticLoop/ToolExecutor/provider/worker/MCP consumers |

## Changes
| Area | Change |
|---|---|
| `core/tools/plan.py` | Immutable ToolSpec/registration/plan records, canonical hash, generation, ordered projections, fail-loud validation |
| `core/tools/google_capabilities.py` | Frozen eight-service Google descriptor catalog and implication validation |
| product composition | Compile before hook/offload side effects; retain plan in SharedServices; preserve handler compatibility |
| provider adapters | Thaw immutable schema containers only at SDK wire boundaries |
| tests/docs | Characterization, immutability, parity, Google compatibility, generated baseline and changelog |

## Verification
- `pytest` full non-live under managed sandbox: all product failures fixed; remaining 40 failures + 1 setup error were environment-only socket/DNS/Swift/uv-cache restrictions or the explicit temporary-home mismatch.
- Those environment-affected files: 144 passed under normal macOS permissions; two temporary-home path tests passed separately.
- Final focused plan/composition/server/auth/provider suite: 90 passed in sandbox plus 4 loopback tests passed under normal macOS permissions.
- `ruff check` and `ruff format --check`: passed (1,330 files).
- `mypy core/ geode_product/ plugins/`: passed (592 files).
- `lint-imports`: 5 contracts kept, 0 broken.
- architecture baseline, roadmap validator, official docs gate, Next static build (237 pages), Markdown export: passed.
- wheel/sdist content + Twine metadata: passed (669 / 671 files).
- clean wheel install: `GEODE v1.0.23`; `check_installed_package.py` passed.
- pre-commit hooks and independent adversarial review: passed; no P0/P1.
