### PR TITLE
feat(tools): derive Google policy from descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,10 @@ functional change.
   `ToolPlan` before constructing a session. Duplicate or unbound registrations
   fail early, while current handler ordering and provider payloads remain
   unchanged. Google OAuth's eight service bundles now derive from one frozen
-  descriptor catalog without changing login or token behavior.
+  descriptor catalog without changing login or token behavior. Google tool
+  associations now derive personal-data, write-policy, consent, delegated
+  handler, and OAuth-scope projections from that catalog while preserving the
+  existing Workspace and Calendar behavior.
 
 ## [1.0.23] - 2026-08-20
 

--- a/core/agent/approval.py
+++ b/core/agent/approval.py
@@ -29,6 +29,7 @@ from core.agent.safety import (
     is_bash_command_read_only,
 )
 from core.hooks.system import HookEvent
+from core.tools.google_capabilities import GOOGLE_TOOL_SERVICES
 from core.ui import spinner_glyph
 from core.ui.console import console
 
@@ -45,6 +46,13 @@ _T = TypeVar("_T")
 # options line replaces them. Anything else (e.g. the computer-control
 # question) is a real question and still renders above the options line.
 _BARE_PROMPT_LABELS = frozenset({"Allow?", "Proceed?"})
+
+
+def _personal_service_label(tool_name: str) -> str:
+    services = GOOGLE_TOOL_SERVICES.get(tool_name, ())
+    if any(service.name.startswith("calendar-") for service in services):
+        return "Calendar"
+    return "Google Workspace"
 
 
 def _approval_header(tool_name: str, category: str) -> str:
@@ -726,7 +734,7 @@ class ApprovalWorkflow:
         record: ApprovalRecord | None = None,
     ) -> bool:
         """Confirm one personal-data read or mutation without a cached bypass."""
-        service = "Calendar" if tool_name.startswith("calendar_") else "Google Workspace"
+        service = _personal_service_label(tool_name)
         is_mutation = tool_name in WRITE_TOOLS
         summary = (
             self._write_summary(tool_name, tool_input)
@@ -779,7 +787,7 @@ class ApprovalWorkflow:
         record: ApprovalRecord | None = None,
     ) -> bool:
         """Async personal-data confirmation."""
-        service = "Calendar" if tool_name.startswith("calendar_") else "Google Workspace"
+        service = _personal_service_label(tool_name)
         is_mutation = tool_name in WRITE_TOOLS
         summary = (
             self._write_summary(tool_name, tool_input)

--- a/core/agent/safety.py
+++ b/core/agent/safety.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 
+from core.tools.google_capabilities import GOOGLE_WRITE_TOOLS
 from core.tools.personal_data import PERSONAL_DATA_TOOLS
 
 # --dangerously-skip-permissions — PER-SESSION state (not process-global).
@@ -90,13 +91,7 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "profile_update",
         "profile_preference",
         "profile_learn",
-        "calendar_create_event",
-        "calendar_sync_scheduler",
-        "gmail_send",
-        "google_drive_create",
-        "google_docs_write",
-        "google_sheets_write",
-        "google_tasks_write",
+        *GOOGLE_WRITE_TOOLS,
         "manage_context",
         "switch_model",
         "document_ingest",

--- a/core/cli/tool_handlers/delegated.py
+++ b/core/cli/tool_handlers/delegated.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from core.cli.tool_handlers.clarification import _safe_delegate
 from core.cli.tool_handlers.registration import UniqueEntries
+from core.tools.google_capabilities import GOOGLE_TOOL_BINDINGS
 
 _DELEGATED_TOOLS = UniqueEntries[str, tuple[str, str]](
     (
@@ -55,43 +56,13 @@ _DELEGATED_TOOLS = UniqueEntries[str, tuple[str, str]](
         ),
         ("profile_learn", ("core.tools.profile_tools", "ProfileLearnTool")),
         # Google Workspace — credentials are registered by /login google.
-        ("gmail_search", ("core.tools.google_workspace", "GmailSearchTool")),
-        ("gmail_send", ("core.tools.google_workspace", "GmailSendTool")),
-        (
-            "google_drive_search",
-            ("core.tools.google_workspace", "GoogleDriveSearchTool"),
-        ),
-        (
-            "google_drive_create",
-            ("core.tools.google_workspace", "GoogleDriveCreateTool"),
-        ),
-        (
-            "google_docs_read",
-            ("core.tools.google_workspace", "GoogleDocsReadTool"),
-        ),
-        (
-            "google_docs_write",
-            ("core.tools.google_workspace", "GoogleDocsWriteTool"),
-        ),
-        (
-            "google_sheets_read",
-            ("core.tools.google_workspace", "GoogleSheetsReadTool"),
-        ),
-        (
-            "google_sheets_write",
-            ("core.tools.google_workspace", "GoogleSheetsWriteTool"),
-        ),
-        (
-            "google_tasks_list",
-            ("core.tools.google_workspace", "GoogleTasksListTool"),
-        ),
-        (
-            "google_tasks_write",
-            ("core.tools.google_workspace", "GoogleTasksWriteTool"),
-        ),
-        (
-            "google_contacts_list",
-            ("core.tools.google_workspace", "GoogleContactsListTool"),
+        # Calendar bindings have no handler_class and stay in the composite
+        # Calendar builder (Google direct/MCP/Apple); only native Workspace
+        # classes use this lazy delegated factory.
+        *(
+            (name, ("core.tools.google_workspace", binding.handler_class))
+            for name, binding in GOOGLE_TOOL_BINDINGS.items()
+            if binding.handler_class is not None
         ),
     )
 )

--- a/core/mcp/google_workspace_calendar.py
+++ b/core/mcp/google_workspace_calendar.py
@@ -10,10 +10,11 @@ from core.mcp.google_workspace_client import (
     GoogleWorkspaceClient,
     get_google_workspace_client,
 )
+from core.tools.google_capabilities import google_scopes_for_tool
 
-CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.events.owned.readonly"
-CALENDAR_WRITE_SCOPE = "https://www.googleapis.com/auth/calendar.events.owned"
-_CALENDAR_SCOPES = (CALENDAR_READ_SCOPE, CALENDAR_WRITE_SCOPE)
+CALENDAR_READ_SCOPE = google_scopes_for_tool("calendar_list_events")[0]
+CALENDAR_WRITE_SCOPE = google_scopes_for_tool("calendar_create_event", write=True)[0]
+_CALENDAR_SCOPES = google_scopes_for_tool("calendar_list_events")
 
 
 class GoogleWorkspaceCalendarAdapter:

--- a/core/tools/google_capabilities.py
+++ b/core/tools/google_capabilities.py
@@ -32,6 +32,25 @@ class GoogleServiceDescriptor:
         object.__setattr__(self, "implies", tuple(self.implies))
 
 
+@dataclass(frozen=True, slots=True)
+class GoogleToolBinding:
+    """Static Google auth and delegated-handler metadata for one tool.
+
+    Calendar tools remain composite (Google direct, MCP, or Apple). Their
+    service names describe only the direct Google adapter's accepted scopes;
+    they are not a runtime availability gate.
+    """
+
+    name: str
+    read_services: tuple[str, ...] = ()
+    write_services: tuple[str, ...] = ()
+    handler_class: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "read_services", tuple(self.read_services))
+        object.__setattr__(self, "write_services", tuple(self.write_services))
+
+
 def _descriptor_catalog(
     entries: tuple[GoogleServiceDescriptor, ...],
 ) -> Mapping[str, GoogleServiceDescriptor]:
@@ -134,3 +153,102 @@ _GOOGLE_SERVICE_DESCRIPTOR_VALUES = (
 GOOGLE_SERVICE_DESCRIPTORS: Mapping[str, GoogleServiceDescriptor] = _descriptor_catalog(
     _GOOGLE_SERVICE_DESCRIPTOR_VALUES
 )
+
+
+def _tool_binding_catalog(
+    entries: tuple[GoogleToolBinding, ...],
+) -> Mapping[str, GoogleToolBinding]:
+    catalog: dict[str, GoogleToolBinding] = {}
+    for binding in entries:
+        if not binding.name or binding.name in catalog:
+            raise ValueError(f"duplicate or empty Google tool binding: {binding.name}")
+        services = (*binding.read_services, *binding.write_services)
+        if not services or set(services) - GOOGLE_SERVICE_DESCRIPTORS.keys():
+            raise ValueError(f"invalid Google services for tool: {binding.name}")
+        catalog[binding.name] = binding
+    return MappingProxyType(catalog)
+
+
+_GOOGLE_TOOL_BINDING_VALUES = (
+    GoogleToolBinding("gmail_search", ("gmail-read",), handler_class="GmailSearchTool"),
+    GoogleToolBinding("gmail_send", write_services=("gmail-send",), handler_class="GmailSendTool"),
+    GoogleToolBinding(
+        "google_drive_search", ("workspace-files",), handler_class="GoogleDriveSearchTool"
+    ),
+    GoogleToolBinding(
+        "google_drive_create",
+        write_services=("workspace-files",),
+        handler_class="GoogleDriveCreateTool",
+    ),
+    GoogleToolBinding("google_docs_read", ("workspace-files",), handler_class="GoogleDocsReadTool"),
+    GoogleToolBinding(
+        "google_docs_write",
+        write_services=("workspace-files",),
+        handler_class="GoogleDocsWriteTool",
+    ),
+    GoogleToolBinding(
+        "google_sheets_read", ("workspace-files",), handler_class="GoogleSheetsReadTool"
+    ),
+    GoogleToolBinding(
+        "google_sheets_write",
+        write_services=("workspace-files",),
+        handler_class="GoogleSheetsWriteTool",
+    ),
+    GoogleToolBinding(
+        "google_tasks_list", ("tasks-read", "tasks-write"), handler_class="GoogleTasksListTool"
+    ),
+    GoogleToolBinding(
+        "google_tasks_write",
+        write_services=("tasks-write",),
+        handler_class="GoogleTasksWriteTool",
+    ),
+    GoogleToolBinding(
+        "google_contacts_list", ("contacts-read",), handler_class="GoogleContactsListTool"
+    ),
+    GoogleToolBinding("calendar_list_events", ("calendar-read", "calendar-write")),
+    GoogleToolBinding("calendar_create_event", write_services=("calendar-write",)),
+    GoogleToolBinding(
+        "calendar_sync_scheduler",
+        ("calendar-read", "calendar-write"),
+        ("calendar-write",),
+    ),
+)
+GOOGLE_TOOL_BINDINGS: Mapping[str, GoogleToolBinding] = _tool_binding_catalog(
+    _GOOGLE_TOOL_BINDING_VALUES
+)
+
+
+def _services_for_binding(binding: GoogleToolBinding) -> tuple[GoogleServiceDescriptor, ...]:
+    names = dict.fromkeys((*binding.read_services, *binding.write_services))
+    return tuple(GOOGLE_SERVICE_DESCRIPTORS[name] for name in names)
+
+
+GOOGLE_TOOL_SERVICES: Mapping[str, tuple[GoogleServiceDescriptor, ...]] = MappingProxyType(
+    {name: _services_for_binding(binding) for name, binding in GOOGLE_TOOL_BINDINGS.items()}
+)
+GOOGLE_WRITE_TOOLS = frozenset(
+    name for name, binding in GOOGLE_TOOL_BINDINGS.items() if binding.write_services
+)
+GOOGLE_READ_TOOLS = frozenset(
+    name
+    for name, binding in GOOGLE_TOOL_BINDINGS.items()
+    if binding.read_services and not binding.write_services
+)
+GOOGLE_PERSONAL_DATA_TOOLS = GOOGLE_READ_TOOLS | GOOGLE_WRITE_TOOLS
+
+
+def google_scopes_for_tool(tool_name: str, *, write: bool = False) -> tuple[str, ...]:
+    """Return accepted OAuth scopes for one direct Google operation."""
+    binding = GOOGLE_TOOL_BINDINGS[tool_name]
+    service_names = binding.write_services if write else binding.read_services
+    if not service_names:
+        raise ValueError(
+            f"Google tool does not support {'write' if write else 'read'}: {tool_name}"
+        )
+    return tuple(
+        dict.fromkeys(
+            scope
+            for service_name in service_names
+            for scope in GOOGLE_SERVICE_DESCRIPTORS[service_name].scopes
+        )
+    )

--- a/core/tools/google_workspace.py
+++ b/core/tools/google_workspace.py
@@ -17,14 +17,7 @@ from core.mcp.google_workspace_client import (
     get_google_workspace_client,
 )
 from core.tools.base import tool_error
-
-GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
-GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
-DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
-TASKS_READ_SCOPE = "https://www.googleapis.com/auth/tasks.readonly"
-TASKS_WRITE_SCOPE = "https://www.googleapis.com/auth/tasks"
-CONTACTS_READ_SCOPE = "https://www.googleapis.com/auth/contacts.readonly"
-_TASKS_READ_SCOPES = (TASKS_READ_SCOPE, TASKS_WRITE_SCOPE)
+from core.tools.google_capabilities import google_scopes_for_tool
 
 
 class _GoogleToolBase:
@@ -96,7 +89,7 @@ class GmailSearchTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "GET",
                 "https://gmail.googleapis.com/gmail/v1/users/me/messages",
-                required_scopes=(GMAIL_READ_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name),
                 params={
                     "q": str(kwargs.get("query", "")),
                     "maxResults": limit,
@@ -137,7 +130,7 @@ class GmailSearchTool(_GoogleToolBase):
         payload = await self._google.request_json(
             "GET",
             f"https://gmail.googleapis.com/gmail/v1/users/me/messages/{safe_id}",
-            required_scopes=(GMAIL_READ_SCOPE,),
+            required_scopes=google_scopes_for_tool(self.name),
             params={
                 "format": "full" if include_body else "metadata",
                 "metadataHeaders": ["Subject", "From", "To", "Date"],
@@ -215,7 +208,7 @@ class GmailSendTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "POST",
                 "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-                required_scopes=(GMAIL_SEND_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name, write=True),
                 json_body=body,
             )
             return {
@@ -264,7 +257,7 @@ class GoogleDriveSearchTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "GET",
                 "https://www.googleapis.com/drive/v3/files",
-                required_scopes=(DRIVE_FILE_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name),
                 params={
                     "q": q,
                     "pageSize": max(1, min(int(kwargs.get("max_results", 20)), 100)),
@@ -320,7 +313,7 @@ class GoogleDriveCreateTool(_GoogleToolBase):
                 payload = await self._google.request_json(
                     "POST",
                     "https://www.googleapis.com/drive/v3/files",
-                    required_scopes=(DRIVE_FILE_SCOPE,),
+                    required_scopes=google_scopes_for_tool(self.name, write=True),
                     params={"fields": "id,name,mimeType,webViewLink"},
                     json_body=metadata,
                 )
@@ -346,7 +339,7 @@ class GoogleDriveCreateTool(_GoogleToolBase):
         response = await self._google.request(
             "POST",
             "https://www.googleapis.com/upload/drive/v3/files",
-            required_scopes=(DRIVE_FILE_SCOPE,),
+            required_scopes=google_scopes_for_tool(self.name, write=True),
             params={"uploadType": "multipart", "fields": "id,name,mimeType,webViewLink,size"},
             content=raw,
             headers={"Content-Type": f"multipart/related; boundary={boundary}"},
@@ -381,7 +374,7 @@ class GoogleDocsReadTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "GET",
                 f"https://docs.googleapis.com/v1/documents/{document_id}",
-                required_scopes=(DRIVE_FILE_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name),
             )
             text = _document_text(payload)
             max_chars = max(0, min(int(kwargs.get("max_chars", 30000)), 100000))
@@ -430,7 +423,7 @@ class GoogleDocsWriteTool(_GoogleToolBase):
                 created = await self._google.request_json(
                     "POST",
                     "https://docs.googleapis.com/v1/documents",
-                    required_scopes=(DRIVE_FILE_SCOPE,),
+                    required_scopes=google_scopes_for_tool(self.name, write=True),
                     json_body={"title": title},
                 )
                 document_id = str(created.get("documentId", ""))
@@ -442,7 +435,7 @@ class GoogleDocsWriteTool(_GoogleToolBase):
                 current = await self._google.request_json(
                     "GET",
                     f"https://docs.googleapis.com/v1/documents/{quote(document_id, safe='')}",
-                    required_scopes=(DRIVE_FILE_SCOPE,),
+                    required_scopes=google_scopes_for_tool(self.name, write=True),
                 )
                 index = max(1, _document_end_index(current) - 1)
             else:
@@ -453,7 +446,7 @@ class GoogleDocsWriteTool(_GoogleToolBase):
                     "https://docs.googleapis.com/v1/documents/"
                     f"{quote(document_id, safe='')}:batchUpdate"
                 ),
-                required_scopes=(DRIVE_FILE_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name, write=True),
                 json_body={
                     "requests": [{"insertText": {"location": {"index": index}, "text": text}}]
                 },
@@ -501,7 +494,7 @@ class GoogleSheetsReadTool(_GoogleToolBase):
                     "https://sheets.googleapis.com/v4/spreadsheets/"
                     f"{spreadsheet_id}/values/{cell_range}"
                 ),
-                required_scopes=(DRIVE_FILE_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name),
                 params={
                     "majorDimension": str(kwargs.get("major_dimension", "ROWS")),
                 },
@@ -553,7 +546,7 @@ class GoogleSheetsWriteTool(_GoogleToolBase):
                 created = await self._google.request_json(
                     "POST",
                     "https://sheets.googleapis.com/v4/spreadsheets",
-                    required_scopes=(DRIVE_FILE_SCOPE,),
+                    required_scopes=google_scopes_for_tool(self.name, write=True),
                     json_body={"properties": {"title": title}},
                 )
                 spreadsheet_id = str(created.get("spreadsheetId", ""))
@@ -604,7 +597,7 @@ class GoogleSheetsWriteTool(_GoogleToolBase):
                 "https://sheets.googleapis.com/v4/spreadsheets/"
                 f"{quote(spreadsheet_id, safe='')}/values/{quote(cell_range, safe='')}{suffix}"
             ),
-            required_scopes=(DRIVE_FILE_SCOPE,),
+            required_scopes=google_scopes_for_tool(self.name, write=True),
             params={"valueInputOption": "USER_ENTERED"},
             json_body={"range": cell_range, "majorDimension": "ROWS", "values": values},
         )
@@ -637,7 +630,7 @@ class GoogleTasksListTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "GET",
                 f"https://tasks.googleapis.com/tasks/v1/lists/{tasklist_id}/tasks",
-                required_scopes=_TASKS_READ_SCOPES,
+                required_scopes=google_scopes_for_tool(self.name),
                 any_scope=True,
                 params={
                     "maxResults": max(1, min(int(kwargs.get("max_results", 50)), 100)),
@@ -704,7 +697,7 @@ class GoogleTasksWriteTool(_GoogleToolBase):
                 payload = await self._google.request_json(
                     "POST",
                     base,
-                    required_scopes=(TASKS_WRITE_SCOPE,),
+                    required_scopes=google_scopes_for_tool(self.name, write=True),
                     json_body=body,
                 )
             else:
@@ -716,14 +709,14 @@ class GoogleTasksWriteTool(_GoogleToolBase):
                     payload = await self._google.request_json(
                         "PATCH",
                         url,
-                        required_scopes=(TASKS_WRITE_SCOPE,),
+                        required_scopes=google_scopes_for_tool(self.name, write=True),
                         json_body={"status": "completed"},
                     )
                 elif action == "delete":
                     payload = await self._google.request_json(
                         "DELETE",
                         url,
-                        required_scopes=(TASKS_WRITE_SCOPE,),
+                        required_scopes=google_scopes_for_tool(self.name, write=True),
                     )
                 else:
                     raise ValueError(f"Unsupported Tasks action: {action}")
@@ -774,7 +767,7 @@ class GoogleContactsListTool(_GoogleToolBase):
             payload = await self._google.request_json(
                 "GET",
                 "https://people.googleapis.com/v1/people/me/connections",
-                required_scopes=(CONTACTS_READ_SCOPE,),
+                required_scopes=google_scopes_for_tool(self.name),
                 params={
                     "personFields": "names,emailAddresses,phoneNumbers,organizations",
                     "pageSize": max(1, min(int(kwargs.get("max_results", 100)), 1000)),

--- a/core/tools/personal_data.py
+++ b/core/tools/personal_data.py
@@ -11,31 +11,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
-GOOGLE_WORKSPACE_READ_TOOLS: frozenset[str] = frozenset(
-    {
-        "gmail_search",
-        "google_drive_search",
-        "google_docs_read",
-        "google_sheets_read",
-        "google_tasks_list",
-        "google_contacts_list",
-        "calendar_list_events",
-    }
+from core.tools.google_capabilities import (
+    GOOGLE_PERSONAL_DATA_TOOLS,
+    GOOGLE_READ_TOOLS,
+    GOOGLE_WRITE_TOOLS,
 )
 
-GOOGLE_WORKSPACE_MUTATION_TOOLS: frozenset[str] = frozenset(
-    {
-        "gmail_send",
-        "google_drive_create",
-        "google_docs_write",
-        "google_sheets_write",
-        "google_tasks_write",
-        "calendar_create_event",
-        "calendar_sync_scheduler",
-    }
-)
-
-PERSONAL_DATA_TOOLS: frozenset[str] = GOOGLE_WORKSPACE_READ_TOOLS | GOOGLE_WORKSPACE_MUTATION_TOOLS
+GOOGLE_WORKSPACE_READ_TOOLS: frozenset[str] = GOOGLE_READ_TOOLS
+GOOGLE_WORKSPACE_MUTATION_TOOLS: frozenset[str] = GOOGLE_WRITE_TOOLS
+PERSONAL_DATA_TOOLS: frozenset[str] = GOOGLE_PERSONAL_DATA_TOOLS
 PERSONAL_DATA_ERROR_OMITTED = "personal account operation failed; details omitted"
 
 

--- a/core/tools/policy.py
+++ b/core/tools/policy.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from core.tools.google_capabilities import GOOGLE_WRITE_TOOLS
+
 log = logging.getLogger(__name__)
 
 
@@ -203,13 +205,7 @@ class ProfilePolicy:
                         "set_api_key",
                         "manage_login",
                         "profile_update",
-                        "calendar_create_event",
-                        "calendar_sync_scheduler",
-                        "gmail_send",
-                        "google_drive_create",
-                        "google_docs_write",
-                        "google_sheets_write",
-                        "google_tasks_write",
+                        *GOOGLE_WRITE_TOOLS,
                     },
                 )
             )

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -285,10 +285,10 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `geode_product/` + `plugins/`) | 592 |
 | Test Python files | 689 |
-| `core/` Python LOC | 121,351 |
-| `geode_product/` Python LOC | 61,768 |
+| `core/` Python LOC | 121,417 |
+| `geode_product/` Python LOC | 61,789 |
 | `plugins/` Python LOC | 213 |
-| Test Python LOC | 183,727 |
+| Test Python LOC | 183,884 |
 | Tool definitions / executable registrations / valid schemas | 87 / 90 / 87 (definition-only 0; execution-only 3; invalid schema 0) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 7 |

--- a/docs/plans/2026-08-20-r2-2-google-descriptor-pilot.md
+++ b/docs/plans/2026-08-20-r2-2-google-descriptor-pilot.md
@@ -1,0 +1,77 @@
+# R2.2 Google Descriptor Consumer Migration
+
+Status: implementation authorized by roadmap claim [#3046](https://github.com/mangowhoiscloud/geode/pull/3046)
+
+Base: `origin/develop@52f3f853108f56c726ef0a9bc8fb9a1dd88686b4`
+
+GAP: `CAP-004`
+
+## Outcome
+
+Keep the eight existing `GoogleServiceDescriptor` records as the service SOT
+and add one frozen tool-to-service association catalog. Derive OAuth scope
+hints, personal-data
+classification, write policy, approval, and headless/sub-agent projections from
+that immutable catalog without changing the 14 tool names, schemas, handlers,
+consent prompts, or API behavior.
+
+This package does not add another registry. `definitions.json` remains the model
+schema SOT, the existing handler composer remains the execution SOT, and R2.1's
+`ToolPlan` remains the validated snapshot boundary. The definitions edit surface
+cannot close honestly before R2.3 makes providers consume the plan, so this
+package remains `IN_DEVELOP` until that registered follow-up supplies the final
+R2.2 exit evidence.
+
+## Measured gap
+
+- eight service descriptors own scopes, risk, API service IDs, implications,
+  and recommended defaults, but no tool associations;
+- fourteen Google/Calendar names are repeated across personal-data, safety,
+  profile policy, approval, delegated handlers, and schemas;
+- the eleven Workspace classes and Calendar adapter repeat OAuth scope choices;
+- current behavior already has strong consent, OAuth, keyring, headless,
+  sub-agent, bounded-result, and request-shape tests.
+
+## Boundary
+
+1. Add one frozen tool association record with read/write service alternatives;
+   reject duplicate tools and unknown services before exposing the catalog.
+2. Derive immutable tool-to-service, read, write, and personal-data projections.
+3. Point the existing Google consumers at those projections. Keep handler class
+   construction local to the existing delegated-handler owner.
+4. Preserve `/login google`, scope implication, multi-account persistence,
+   per-call consent, headless/sub-agent denial, redaction, and bounded results.
+5. Update `[Unreleased]`, then run targeted and repository gates.
+
+## Non-goals
+
+- R2.3 handler ownership, provider/deferred projection, or live plan consumption;
+- R2.4 resource-key or data-policy derivation;
+- a runtime API-availability probe, plugin system, or mutable global registry;
+- changing tool schemas, wire names, approval copy, or Google request payloads.
+- claiming `DONE` while `definitions.json` remains an independent schema edit
+  surface; R2.3 owns that convergence.
+
+## Acceptance
+
+- all 14 Google/Calendar tools have one association; Calendar and Tasks retain
+  their existing read-or-write scope alternatives and Calendar remains usable
+  through its non-Google adapters;
+- read/write/personal/headless/sub-agent projections are descriptor-derived and
+  byte-for-byte equivalent to the existing behavior;
+- implied write services authorize the existing read scope behavior;
+- all eleven Workspace tools and Calendar read/write calls use descriptor-owned
+  scope requirements;
+- adding or moving a tool association cannot silently leave a stale independent
+  Google name list in the five runtime consumers migrated here; the sixth,
+  `definitions.json`, is an explicit R2.3 closure dependency rather than a
+  second schema authority;
+- targeted tests, ruff, format, mypy, import-linter, architecture baseline,
+  package/install checks, official docs, and the full non-live suite pass.
+
+## GitFlow
+
+One functional PR from `feature/r2-2-google-descriptor-pilot` targets `develop`.
+After merge, a roadmap-only reconciliation records evidence, removes the claim,
+and performs the next whole-ledger readiness audit. Main promotion waits until
+the remaining planned packages have converged on `develop`.

--- a/geode_product/tool_handlers.py
+++ b/geode_product/tool_handlers.py
@@ -94,8 +94,15 @@ def compose_tool_plan(
     from core.cli.routing import compose_command_registry
     from core.cli.tool_handlers import _build_tool_handler_catalog
     from core.tools.base import load_all_tool_definitions
+    from core.tools.google_capabilities import GOOGLE_TOOL_BINDINGS
     from core.tools.personal_data import PERSONAL_DATA_TOOLS
-    from core.tools.plan import ExecutionBinding, SafetyPolicy, ToolSpec, compile_tool_plan
+    from core.tools.plan import (
+        CapabilityRequirement,
+        ExecutionBinding,
+        SafetyPolicy,
+        ToolSpec,
+        compile_tool_plan,
+    )
 
     from geode_product.cli import PRODUCT_COMMAND_SPECS
 
@@ -150,8 +157,22 @@ def compose_tool_plan(
         )
         for item in definitions
     }
+    capabilities = {
+        name: CapabilityRequirement(
+            services=tuple(dict.fromkeys((*binding.read_services, *binding.write_services))),
+            auth=("google-oauth",),
+        )
+        for name, binding in GOOGLE_TOOL_BINDINGS.items()
+        if binding.handler_class is not None
+    }
     return (
-        compile_tool_plan(specs, bindings, safety=safety, previous=previous),
+        compile_tool_plan(
+            specs,
+            bindings,
+            safety=safety,
+            capabilities=capabilities,
+            previous=previous,
+        ),
         dict(catalog.handlers),
     )
 

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -66,7 +66,7 @@
       {
         "context_name": "geode_skip_permissions",
         "has_default": true,
-        "line": 24,
+        "line": 25,
         "path": "core/agent/safety.py",
         "symbol": "_skip_permissions_var"
       },
@@ -366,11 +366,11 @@
   "packages": {
     "core": {
       "python_files": 400,
-      "python_loc": 121351
+      "python_loc": 121417
     },
     "geode_product": {
       "python_files": 160,
-      "python_loc": 61768
+      "python_loc": 61789
     },
     "plugins": {
       "python_files": 32,
@@ -378,7 +378,7 @@
     },
     "tests": {
       "python_files": 689,
-      "python_loc": 183727
+      "python_loc": 183884
     }
   },
   "schema_version": 3,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Architecture\n\n- **Tool composition now has an immutable validation snapshot.** The product\n  handler composer joins model-facing specs, execution origins, existing safety\n  classifications, and capability requirements into a content-addressed\n  `ToolPlan` before constructing a session. Duplicate or unbound registrations\n  fail early, while current handler ordering and provider payloads remain\n  unchanged. Google OAuth's eight service bundles now derive from one frozen\n  descriptor catalog without changing login or token behavior."
+    "body": "### Architecture\n\n- **Tool composition now has an immutable validation snapshot.** The product\n  handler composer joins model-facing specs, execution origins, existing safety\n  classifications, and capability requirements into a content-addressed\n  `ToolPlan` before constructing a session. Duplicate or unbound registrations\n  fail early, while current handler ordering and provider payloads remain\n  unchanged. Google OAuth's eight service bundles now derive from one frozen\n  descriptor catalog without changing login or token behavior. Google tool\n  associations now derive personal-data, write-policy, consent, delegated\n  handler, and OAuth-scope projections from that catalog while preserving the\n  existing Workspace and Calendar behavior."
   },
   {
     "version": "1.0.23",

--- a/tests/core/agent/test_google_workspace_consent.py
+++ b/tests/core/agent/test_google_workspace_consent.py
@@ -20,6 +20,18 @@ from core.agent.safety import (
 from core.agent.sub_agent import SUBAGENT_DENIED_TOOLS
 from core.hooks import HookEvent
 from core.memory.session_checkpoint import SessionCheckpoint, SessionState
+from core.tools.google_capabilities import (
+    GOOGLE_PERSONAL_DATA_TOOLS,
+    GOOGLE_READ_TOOLS,
+    GOOGLE_TOOL_BINDINGS,
+    GOOGLE_WRITE_TOOLS,
+)
+from core.tools.personal_data import (
+    GOOGLE_WORKSPACE_MUTATION_TOOLS,
+    GOOGLE_WORKSPACE_READ_TOOLS,
+    PERSONAL_DATA_TOOLS,
+)
+from core.tools.policy import ProfilePolicy
 
 READ_TOOLS = {
     "gmail_search",
@@ -40,6 +52,56 @@ WRITE_GOOGLE_TOOLS = {
     "calendar_create_event",
     "calendar_sync_scheduler",
 }
+
+
+def test_google_classification_consumers_share_descriptor_projections() -> None:
+    assert GOOGLE_READ_TOOLS == READ_TOOLS
+    assert GOOGLE_WRITE_TOOLS == WRITE_GOOGLE_TOOLS
+    assert GOOGLE_PERSONAL_DATA_TOOLS == READ_TOOLS | WRITE_GOOGLE_TOOLS
+    assert GOOGLE_WORKSPACE_READ_TOOLS is GOOGLE_READ_TOOLS
+    assert GOOGLE_WORKSPACE_MUTATION_TOOLS is GOOGLE_WRITE_TOOLS
+    assert PERSONAL_DATA_TOOLS is GOOGLE_PERSONAL_DATA_TOOLS
+    assert SENSITIVE_TOOLS is GOOGLE_PERSONAL_DATA_TOOLS
+
+    profile_write_policy = next(
+        policy
+        for policy in ProfilePolicy(allow_write=False).to_policies()
+        if policy.name.endswith(":no_write")
+    )
+    assert profile_write_policy.denied_tools >= GOOGLE_WRITE_TOOLS
+
+
+def test_google_delegated_handlers_derive_from_descriptor_bindings() -> None:
+    from core.cli.tool_handlers.delegated import _DELEGATED_TOOLS
+
+    delegated = tuple(
+        name for name, binding in GOOGLE_TOOL_BINDINGS.items() if binding.handler_class is not None
+    )
+    actual = tuple(
+        name
+        for name, (module, _class_name) in _DELEGATED_TOOLS.items()
+        if module == "core.tools.google_workspace"
+    )
+
+    assert delegated == (
+        "gmail_search",
+        "gmail_send",
+        "google_drive_search",
+        "google_drive_create",
+        "google_docs_read",
+        "google_docs_write",
+        "google_sheets_read",
+        "google_sheets_write",
+        "google_tasks_list",
+        "google_tasks_write",
+        "google_contacts_list",
+    )
+    assert actual == delegated
+    for name in delegated:
+        assert _DELEGATED_TOOLS[name] == (
+            "core.tools.google_workspace",
+            GOOGLE_TOOL_BINDINGS[name].handler_class,
+        )
 
 
 def test_google_reads_require_personal_data_consent() -> None:

--- a/tests/core/auth/test_google_oauth.py
+++ b/tests/core/auth/test_google_oauth.py
@@ -33,7 +33,11 @@ from core.auth.google_oauth import (
 from core.tools import google_capabilities
 from core.tools.google_capabilities import (
     GOOGLE_SERVICE_DESCRIPTORS,
+    GOOGLE_TOOL_BINDINGS,
+    GOOGLE_TOOL_SERVICES,
     GoogleServiceDescriptor,
+    GoogleToolBinding,
+    google_scopes_for_tool,
 )
 
 
@@ -211,6 +215,51 @@ def test_google_service_descriptor_is_deeply_immutable_and_duplicate_safe() -> N
                 replace(descriptor, name="b", implies=("a",)),
             )
         )
+
+
+def test_google_tool_bindings_preserve_services_handlers_and_scope_alternatives() -> None:
+    assert {
+        name: (binding.read_services, binding.write_services, binding.handler_class)
+        for name, binding in GOOGLE_TOOL_BINDINGS.items()
+    } == {
+        "gmail_search": (("gmail-read",), (), "GmailSearchTool"),
+        "gmail_send": ((), ("gmail-send",), "GmailSendTool"),
+        "google_drive_search": (("workspace-files",), (), "GoogleDriveSearchTool"),
+        "google_drive_create": ((), ("workspace-files",), "GoogleDriveCreateTool"),
+        "google_docs_read": (("workspace-files",), (), "GoogleDocsReadTool"),
+        "google_docs_write": ((), ("workspace-files",), "GoogleDocsWriteTool"),
+        "google_sheets_read": (("workspace-files",), (), "GoogleSheetsReadTool"),
+        "google_sheets_write": ((), ("workspace-files",), "GoogleSheetsWriteTool"),
+        "google_tasks_list": (("tasks-read", "tasks-write"), (), "GoogleTasksListTool"),
+        "google_tasks_write": ((), ("tasks-write",), "GoogleTasksWriteTool"),
+        "google_contacts_list": (("contacts-read",), (), "GoogleContactsListTool"),
+        "calendar_list_events": (("calendar-read", "calendar-write"), (), None),
+        "calendar_create_event": ((), ("calendar-write",), None),
+        "calendar_sync_scheduler": (
+            ("calendar-read", "calendar-write"),
+            ("calendar-write",),
+            None,
+        ),
+    }
+    assert tuple(service.name for service in GOOGLE_TOOL_SERVICES["google_tasks_list"]) == (
+        "tasks-read",
+        "tasks-write",
+    )
+    assert google_scopes_for_tool("calendar_list_events") == (
+        "https://www.googleapis.com/auth/calendar.events.owned.readonly",
+        "https://www.googleapis.com/auth/calendar.events.owned",
+    )
+    assert google_scopes_for_tool("calendar_sync_scheduler", write=True) == (
+        "https://www.googleapis.com/auth/calendar.events.owned",
+    )
+
+
+def test_google_tool_binding_catalog_rejects_duplicate_and_unknown_services() -> None:
+    binding = GoogleToolBinding("future_read", ("gmail-read",))
+    with pytest.raises(ValueError, match="duplicate or empty Google tool binding"):
+        google_capabilities._tool_binding_catalog((binding, binding))
+    with pytest.raises(ValueError, match="invalid Google services for tool"):
+        google_capabilities._tool_binding_catalog((GoogleToolBinding("future_read", ("missing",)),))
 
 
 def test_unknown_service_bundle_is_rejected() -> None:

--- a/tests/core/tools/test_google_workspace.py
+++ b/tests/core/tools/test_google_workspace.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 import pytest
 from core.mcp.google_workspace_client import GoogleWorkspaceAuthError
+from core.tools.google_capabilities import google_scopes_for_tool
 from core.tools.google_workspace import (
     GmailSearchTool,
     GmailSendTool,
@@ -106,7 +107,7 @@ def test_gmail_search_returns_bounded_plain_text() -> None:
     assert message["subject"] == "Subject"
     assert message["body"] == "hello"
     assert message["body_truncated"] is True
-    assert client.calls[0]["required_scopes"] == ("https://www.googleapis.com/auth/gmail.readonly",)
+    assert client.calls[0]["required_scopes"] == google_scopes_for_tool("gmail_search")
 
 
 def test_gmail_send_builds_rfc_message_and_rejects_header_injection() -> None:
@@ -126,6 +127,7 @@ def test_gmail_send_builds_rfc_message_and_rejects_header_injection() -> None:
     assert message["To"] == "reader@example.com"
     assert message["Subject"] == "Hello"
     assert message.get_body(preferencelist=("plain",)).get_content().strip() == "Body text"
+    assert client.calls[0]["required_scopes"] == google_scopes_for_tool("gmail_send", write=True)
 
     rejected = asyncio.run(
         GmailSendTool(StubGoogleClient()).aexecute(
@@ -153,6 +155,9 @@ def test_drive_search_and_create_use_drive_file_scope() -> None:
     result = asyncio.run(GoogleDriveSearchTool(search_client).aexecute(query="Report"))
     assert result["result"]["files"][0]["id"] == "f1"
     assert "name contains 'Report'" in search_client.calls[0]["params"]["q"]
+    assert search_client.calls[0]["required_scopes"] == google_scopes_for_tool(
+        "google_drive_search"
+    )
 
     create_client = StubGoogleClient(
         {"id": "folder-1", "name": "Reports", "mimeType": "application/vnd.google-apps.folder"}
@@ -162,6 +167,9 @@ def test_drive_search_and_create_use_drive_file_scope() -> None:
     )
     assert created["result"]["created"] is True
     assert create_client.calls[0]["json_body"]["mimeType"].endswith("folder")
+    assert create_client.calls[0]["required_scopes"] == google_scopes_for_tool(
+        "google_drive_create", write=True
+    )
 
 
 def test_docs_read_and_append_contracts() -> None:
@@ -183,6 +191,7 @@ def test_docs_read_and_append_contracts() -> None:
     result = asyncio.run(GoogleDocsReadTool(read_client).aexecute(document_id="doc-1", max_chars=3))
     assert result["result"]["text"] == "abc"
     assert result["result"]["truncated"] is True
+    assert read_client.calls[0]["required_scopes"] == google_scopes_for_tool("google_docs_read")
 
     write_client = StubGoogleClient(
         {"body": {"content": [{"endIndex": 12}]}},
@@ -198,6 +207,10 @@ def test_docs_read_and_append_contracts() -> None:
     assert written["result"]["updated"] is True
     insert = write_client.calls[1]["json_body"]["requests"][0]["insertText"]
     assert insert == {"location": {"index": 11}, "text": "more"}
+    assert all(
+        call["required_scopes"] == google_scopes_for_tool("google_docs_write", write=True)
+        for call in write_client.calls
+    )
 
 
 def test_sheets_tasks_and_contacts_return_structured_results() -> None:
@@ -209,6 +222,7 @@ def test_sheets_tasks_and_contacts_return_structured_results() -> None:
         )
     )
     assert sheet_result["result"]["row_count"] == 2
+    assert sheets.calls[0]["required_scopes"] == google_scopes_for_tool("google_sheets_read")
 
     tasks = StubGoogleClient(
         {"items": [{"id": "task-1", "title": "Review", "status": "needsAction"}]}
@@ -216,6 +230,7 @@ def test_sheets_tasks_and_contacts_return_structured_results() -> None:
     task_result = asyncio.run(GoogleTasksListTool(tasks).aexecute())
     assert task_result["result"]["tasks"][0]["title"] == "Review"
     assert tasks.calls[0]["any_scope"] is True
+    assert tasks.calls[0]["required_scopes"] == google_scopes_for_tool("google_tasks_list")
 
     contacts = StubGoogleClient(
         {
@@ -232,6 +247,23 @@ def test_sheets_tasks_and_contacts_return_structured_results() -> None:
     )
     contact_result = asyncio.run(GoogleContactsListTool(contacts).aexecute())
     assert contact_result["result"]["contacts"][0]["name"] == "Ada"
+    assert contacts.calls[0]["required_scopes"] == google_scopes_for_tool("google_contacts_list")
+
+
+def test_sheets_and_tasks_writes_use_their_own_descriptor_bindings() -> None:
+    sheets = StubGoogleClient({"spreadsheetId": "sheet-1"})
+    result = asyncio.run(GoogleSheetsWriteTool(sheets).aexecute(action="create", title="Review"))
+    assert result["result"]["spreadsheet_id"] == "sheet-1"
+    assert sheets.calls[0]["required_scopes"] == google_scopes_for_tool(
+        "google_sheets_write", write=True
+    )
+
+    tasks = StubGoogleClient({"id": "task-1", "title": "Review"})
+    result = asyncio.run(GoogleTasksWriteTool(tasks).aexecute(action="create", title="Review"))
+    assert result["result"]["task_id"] == "task-1"
+    assert tasks.calls[0]["required_scopes"] == google_scopes_for_tool(
+        "google_tasks_write", write=True
+    )
 
 
 def test_missing_authorization_returns_reconnect_hint() -> None:

--- a/tests/integration/test_product_composition.py
+++ b/tests/integration/test_product_composition.py
@@ -262,6 +262,7 @@ def test_product_composition_compiles_one_lossless_immutable_plan() -> None:
     from core.agent.tool_executor.executor import SPECIAL_EXECUTION_BINDINGS
     from core.cli.tool_handlers import _build_tool_handler_catalog
     from core.tools.base import load_all_tool_definitions
+    from core.tools.google_capabilities import GOOGLE_TOOL_BINDINGS
     from geode_product.tool_handlers import compose_tool_plan, product_handler_groups
 
     definitions = load_all_tool_definitions()
@@ -285,3 +286,16 @@ def test_product_composition_compiles_one_lossless_immutable_plan() -> None:
     assert policies["gmail_search"].consent_required is True
     assert policies["gmail_search"].allow_headless is False
     assert policies["gmail_search"].allow_subagents is False
+
+    capabilities = {item.spec.name: item.capability for item in plan.registrations}
+    for name, binding in GOOGLE_TOOL_BINDINGS.items():
+        if binding.handler_class is None:
+            assert capabilities[name].services == ()
+            assert capabilities[name].auth == ()
+        else:
+            assert capabilities[name].services == tuple(
+                sorted({*binding.read_services, *binding.write_services})
+            )
+            assert capabilities[name].auth == ("google-oauth",)
+        assert capabilities[name].available is True
+        assert plan.outcomes[name].value == "enabled"


### PR DESCRIPTION
## Summary
- Derive Google scopes, personal-data classification, write policy, consent labels, delegated handlers, and ToolPlan capability metadata from one frozen catalog.
- Preserve all 14 tool names, native Workspace behavior, and Calendar Google/MCP/Apple alternatives.

## Why
Google service metadata existed, but tool associations and policy lists were repeated across six consumers. An association change could leave auth, consent, or handler behavior stale.

## GAP Audit
| GAP | Before | After |
|---|---|---|
| CAP-004 | Service descriptors had no tool association; names and scopes were repeated | One immutable association catalog feeds the migrated consumers |
| CAP-004 closure | definitions.json remains an independent schema edit surface | Explicitly deferred to R2.3; R2.2 remains IN_DEVELOP |

## Changes
| Area | Change |
|---|---|
| Google descriptors | Add frozen 14-tool bindings, immutable views, and per-tool scope projection |
| Runtime consumers | Rewire safety, personal data, approval, profile policy, delegated handlers, Workspace calls, and Calendar direct-Google scopes |
| ToolPlan | Record Google OAuth capability for the 11 native Workspace tools only; keep composite Calendar empty and enabled |
| Evidence | Add exact compatibility, per-operation scope, delegated parity, and ToolPlan assertions; refresh generated inventory and changelog twin |

## Verification
- Relevant regression suite: 250 passed; final focused assertions: 42 passed.
- Ruff check/format: passed across 1,330 files.
- mypy: passed across 592 source files.
- import-linter: 5/5 contracts passed.
- Architecture baseline and docs canonical checks passed.
- Site: 237 routes built; 74 Markdown twins and llms-full exported.
- Package: wheel/sdist build, twine, artifact inspection, isolated full-wheel install passed.
- Kernel projection: 395 modules imported; 42 installed-wheel unit tests passed.
- Full managed-sandbox non-live run: 10,295 passed, 61 skipped, 75 failed, 1 error. Failures were environment permission, network, socket, Swift, and uv-cache constraints and are not reported as green; required GitHub CI remains merge authority.
- Independent final audit: SHIP to PR/CI, P0/P1 none, no bypass or safe deletion candidate.