### PR TITLE
docs(architecture): claim R2.3 tool-plan convergence

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R2.3 | CAP-003, CAP-005 | `session=codex-root task=r2-3-tool-plan-convergence` | `feature/r2-3-tool-plan-convergence` | Readiness [#3049](https://github.com/mangowhoiscloud/geode/pull/3049); handler/schema/provider/defer roots and package acceptance re-audited | `2026-08-20T21:56:24Z` |
 
 ## 1. Program objective
 
@@ -520,9 +521,9 @@ and closure evidence are appended in §10.
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
 | CAP-001 | `PARTIAL` | Google service bundles exist but do not own all tool/policy relationships | Generic capability records plus `GoogleServiceDescriptor` are executable SOTs | R2.1 | BND-002 | `IN_DEVELOP` |
 | CAP-002 | `ABSENT` | `ToolRegistry` owns tool objects while other registries/lists own execution and safety | Immutable `ToolRegistration` and `ToolPlan` derive every tool consumer | R2.1 | CAP-001 | `IN_DEVELOP` |
-| CAP-003 | `MISFIT` | Native Google handlers are bound in `core/cli/tool_handlers/delegated.py` | Runtime/composition binds handlers; CLI only renders/forwards user interaction | R2.3 | CAP-002, BND-002 | `READY` |
+| CAP-003 | `MISFIT` | Native Google handlers are bound in `core/cli/tool_handlers/delegated.py` | Runtime/composition binds handlers; CLI only renders/forwards user interaction | R2.3 | CAP-002, BND-002 | `IN_PROGRESS` |
 | CAP-004 | `MISFIT` | Google names repeat in safety, approval, policy, personal-data, and CLI modules | Effect/data/auth/resource metadata derives gates; no independent tool-name allowlists | R2.2 | CAP-002 | `IN_DEVELOP` |
-| CAP-005 | `PARTIAL` | `definitions.json`, tool objects, provider schemas, and defer sets can drift | Anthropic/OpenAI/deferred schemas and execution map share one plan hash and parity tests | R2.3 | CAP-002 | `READY` |
+| CAP-005 | `PARTIAL` | `definitions.json`, tool objects, provider schemas, and defer sets can drift | Anthropic/OpenAI/deferred schemas and execution map share one plan hash and parity tests | R2.3 | CAP-002 | `IN_PROGRESS` |
 | CAP-006 | `ABSENT` | Adding a native/Google tool requires edits across several policy files | Change-surface fixture proves the bounded file/registration budget in §8 | R7.2 | CAP-003, CAP-004, CAP-005 | `OPEN` |
 | LOOP-001 | `ABSENT` | No immutable object freezes one step's route, policy, tool plan, and trace identity | `StepSnapshot` is created once per step and used by model/tool/telemetry paths | R3.1 | CAP-002 | `OPEN` |
 | LOOP-002 | `PARTIAL` | Mutable state is distributed across loop fields, contexts, checkpoints, and helpers | `TurnState` and explicit session/turn/step ownership replace ambiguous lifetimes | R3.1 | LOOP-001 | `OPEN` |
@@ -2098,16 +2099,16 @@ ownership and provider/deferred projection remain R2.3, while deterministic
 resource-key and data-policy derivation remains R2.4. The active R8.3 claim and
 publication clock remain independent and unchanged.
 
-R2.3 (`CAP-003`, `CAP-005`) is the sole unclaimed `READY` package after a
-whole-package re-audit against
-`origin/develop@489f9104572e00d31e600ad1c398fd726039add6`. CAP-002 and BND-002
-are `IN_DEVELOP`. Current code retains CLI-owned handler construction and
-stores `ToolPlan` beside independent `AgenticLoop`/`ToolExecutor`, worker/MCP,
-provider, and deferred projections. Acceptance requires one immutable,
-generation/hash-bound plan across those roots with exact schema, execution,
-provider, and defer parity plus bounded diagnostics. R2.3 authorizes no R2.4
-resource/data-policy work or R3.1 step/turn lifetime work. The active R8.3
-claim and publication clock remain unchanged; R2.4, R3.1, and R9.1 remain
+R2.3 (`CAP-003`, `CAP-005`) is `IN_PROGRESS` under the active claim for
+`feature/r2-3-tool-plan-convergence`, based on readiness
+[#3049](https://github.com/mangowhoiscloud/geode/pull/3049). Implementation
+starts only after this claim merges and a new worktree is allocated from the
+updated `develop`. CAP-002 and BND-002 are `IN_DEVELOP`. The package owns one
+immutable, generation/hash-bound plan across handler construction,
+`AgenticLoop`/`ToolExecutor`, worker/MCP, provider, and deferred projections
+with exact schema/execution parity and bounded diagnostics. R2.3 authorizes no
+R2.4 resource/data-policy work or R3.1 step/turn lifetime work. The active
+R8.3 claim and publication clock remain unchanged; R2.4, R3.1, and R9.1 remain
 `OPEN` pending their own serialized transactions. R8.2 (`STORE-003`) remains
 `OPEN` behind REL-004 and STORE-001; R8.4 (`BND-008`) additionally waits for
 STORE-003.


### PR DESCRIPTION
## Summary
- CAP-003/CAP-005를 패키지 단위로 `IN_PROGRESS` 전이합니다.
- R2.3 구현 owner와 feature branch를 활성 claim으로 등록합니다.
- R8.3 claim/clock과 후속 패키지 경계를 보존합니다.

## Why
R2.3 readiness #3049가 develop에 병합되고 전체 CI가 통과했습니다. 구현 worktree를 만들기 전에 canonical ledger claim이 먼저 병합되어야 합니다.

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | CAP-003/CAP-005 claim, owner/branch, 구현 handoff |

## Verification
- `python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — PASS
- `git diff --check` — PASS
- pre-commit hooks — PASS
- independent exact-diff review — SHIP (P0/P1 없음)

## Scope
- claim-only, runtime/schema/test 변경 없음
- 구현은 이 PR merge 후 최신 develop의 새 worktree에서 시작