### PR TITLE
docs(architecture): reconcile R2.3 delivery

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,7 +226,6 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
-| R2.3 | CAP-003, CAP-005 | `session=codex-root task=r2-3-tool-plan-convergence` | `feature/r2-3-tool-plan-convergence` | Readiness [#3049](https://github.com/mangowhoiscloud/geode/pull/3049); handler/schema/provider/defer roots and package acceptance re-audited | `2026-08-20T21:56:24Z` |
 
 ## 1. Program objective
 
@@ -521,9 +520,9 @@ and closure evidence are appended in §10.
 | BND-004 | `PARTIAL` | Skills/hooks/MCP have different discovery rules; Python feature collision/trust behavior is not unified | Each supported external surface declares non-executing discovery, precedence, collision, enablement, trust-before-load, reload, isolation, and teardown | R6.3 | BND-001, LLM-002 | `OPEN` |
 | CAP-001 | `PARTIAL` | Google service bundles exist but do not own all tool/policy relationships | Generic capability records plus `GoogleServiceDescriptor` are executable SOTs | R2.1 | BND-002 | `IN_DEVELOP` |
 | CAP-002 | `ABSENT` | `ToolRegistry` owns tool objects while other registries/lists own execution and safety | Immutable `ToolRegistration` and `ToolPlan` derive every tool consumer | R2.1 | CAP-001 | `IN_DEVELOP` |
-| CAP-003 | `MISFIT` | Native Google handlers are bound in `core/cli/tool_handlers/delegated.py` | Runtime/composition binds handlers; CLI only renders/forwards user interaction | R2.3 | CAP-002, BND-002 | `IN_PROGRESS` |
+| CAP-003 | `MISFIT` | Native Google handlers are bound in `core/cli/tool_handlers/delegated.py` | Runtime/composition binds handlers; CLI only renders/forwards user interaction | R2.3 | CAP-002, BND-002 | `IN_DEVELOP` |
 | CAP-004 | `MISFIT` | Google names repeat in safety, approval, policy, personal-data, and CLI modules | Effect/data/auth/resource metadata derives gates; no independent tool-name allowlists | R2.2 | CAP-002 | `IN_DEVELOP` |
-| CAP-005 | `PARTIAL` | `definitions.json`, tool objects, provider schemas, and defer sets can drift | Anthropic/OpenAI/deferred schemas and execution map share one plan hash and parity tests | R2.3 | CAP-002 | `IN_PROGRESS` |
+| CAP-005 | `PARTIAL` | `definitions.json`, tool objects, provider schemas, and defer sets can drift | Anthropic/OpenAI/deferred schemas and execution map share one plan hash and parity tests | R2.3 | CAP-002 | `IN_DEVELOP` |
 | CAP-006 | `ABSENT` | Adding a native/Google tool requires edits across several policy files | Change-surface fixture proves the bounded file/registration budget in §8 | R7.2 | CAP-003, CAP-004, CAP-005 | `OPEN` |
 | LOOP-001 | `ABSENT` | No immutable object freezes one step's route, policy, tool plan, and trace identity | `StepSnapshot` is created once per step and used by model/tool/telemetry paths | R3.1 | CAP-002 | `OPEN` |
 | LOOP-002 | `PARTIAL` | Mutable state is distributed across loop fields, contexts, checkpoints, and helpers | `TurnState` and explicit session/turn/step ownership replace ambiguous lifetimes | R3.1 | LOOP-001 | `OPEN` |
@@ -1928,6 +1927,7 @@ pre-release delivery evidence survives after the claim row is gone.
 | R1.7 | REL-003 | [#3033](https://github.com/mangowhoiscloud/geode/pull/3033) | `70a1f1bcd0520b33e50436cc340265b6534bc133` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full non-live tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, committed-lock validation, clean-wheel daemon IPC v1.0.23, 393 isolated kernel imports plus 42 installed-kernel tests, public-metadata parity, and independent committed-diff review all passed) |
 | R2.1 | CAP-001, CAP-002 | [#3043](https://github.com/mangowhoiscloud/geode/pull/3043) | `ba7eea3288bd443a52181151de13032f5280d263` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full non-live tests with coverage, lint/format, type check, security, Pages build, official-doc parity, macOS/Ubuntu install smoke, wheel/sdist inspection, clean installed-package smoke, and independent staged-diff review all passed; the product daemon now retains a generation/hash-bound immutable ToolPlan beside the compatibility handler map, while live consumer convergence remains required before R2.1 can reach DONE) |
 | R2.2 | CAP-004 | [#3047](https://github.com/mangowhoiscloud/geode/pull/3047) | `9038d635d0ed3989b11569de5dbfd6cb7a47db43` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full non-live tests with coverage, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, wheel/sdist and isolated installed-package checks, exact descriptor-consumer parity, and independent staged-diff review all passed; `definitions.json` convergence remains required in R2.3 before R2.2 can reach DONE) |
+| R2.3 | CAP-003, CAP-005 | [#3053](https://github.com/mangowhoiscloud/geode/pull/3053) | `ffeb41e13d4bd9c59bc1ba286300c352800f6a03` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, 10,431 non-live tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, wheel/sdist and clean installed-package checks, 399 isolated kernel imports plus 42 installed-kernel tests, installed daemon IPC v1.0.23, exact bound-plan schema/execution/provider/defer parity, and independent adversarial review all passed) |
 
 ### 10.2 Main closure evidence
 
@@ -2081,10 +2081,10 @@ R2.1 (`CAP-001`, `CAP-002`) is `IN_DEVELOP` after feature
 `ba7eea3288bd443a52181151de13032f5280d263`. The delivered boundary retains
 one immutable, generation/hash-bound native `ToolPlan` beside the compatibility
 handler map and validates ordered schema, execution, safety, and capability
-parity before product daemon sessions. R2.1 is not eligible for `DONE` until
-R2.3 (`CAP-003`, `CAP-005`) supplies the immutable CAP-002 “every tool
-consumer” evidence for live `AgenticLoop`/`ToolExecutor`, provider/deferred,
-and worker/MCP roots; those remain explicit R2.3 non-goals here.
+parity before product daemon sessions. R2.3 now supplies the immutable CAP-002
+“every tool consumer” evidence for live `AgenticLoop`/`ToolExecutor`,
+provider/deferred, and worker/MCP roots; R2.1 remains `IN_DEVELOP` until the
+corresponding main closure records complete package evidence.
 
 R2.2 (`CAP-004`) is `IN_DEVELOP` after feature
 [#3047](https://github.com/mangowhoiscloud/geode/pull/3047) merged as
@@ -2093,22 +2093,23 @@ all 14 Google and Calendar tool names to service alternatives and derives the
 migrated safety, approval, profile-policy, personal-data, delegated-handler,
 and direct-Google scope projections. Native Workspace registrations record
 declarative OAuth capabilities while Calendar remains enabled for its Google,
-MCP, and Apple alternatives. R2.2 is not eligible for `DONE` until R2.3 closes
-the remaining independent `definitions.json` schema edit surface; handler
-ownership and provider/deferred projection remain R2.3, while deterministic
-resource-key and data-policy derivation remains R2.4. The active R8.3 claim and
+MCP, and Apple alternatives. R2.3 now closes the remaining independent
+`definitions.json` schema, handler-ownership, and provider/deferred projection
+surfaces. Deterministic resource-key and data-policy derivation remains R2.4;
+R2.2 remains `IN_DEVELOP` until main closure. The active R8.3 claim and
 publication clock remain independent and unchanged.
 
-R2.3 (`CAP-003`, `CAP-005`) is `IN_PROGRESS` under the active claim for
-`feature/r2-3-tool-plan-convergence`, based on readiness
-[#3049](https://github.com/mangowhoiscloud/geode/pull/3049). Implementation
-starts only after this claim merges and a new worktree is allocated from the
-updated `develop`. CAP-002 and BND-002 are `IN_DEVELOP`. The package owns one
-immutable, generation/hash-bound plan across handler construction,
+R2.3 (`CAP-003`, `CAP-005`) is `IN_DEVELOP` after feature
+[#3053](https://github.com/mangowhoiscloud/geode/pull/3053) merged as
+`ffeb41e13d4bd9c59bc1ba286300c352800f6a03`. One immutable,
+generation/hash-bound plan now owns handler construction,
 `AgenticLoop`/`ToolExecutor`, worker/MCP, provider, and deferred projections
-with exact schema/execution parity and bounded diagnostics. R2.3 authorizes no
-R2.4 resource/data-policy work or R3.1 step/turn lifetime work. The active
-R8.3 claim and publication clock remain unchanged; R2.4, R3.1, and R9.1 remain
-`OPEN` pending their own serialized transactions. R8.2 (`STORE-003`) remains
-`OPEN` behind REL-004 and STORE-001; R8.4 (`BND-008`) additionally waits for
-STORE-003.
+with exact schema/execution parity, explicit transient overlays, and bounded
+diagnostics. Public product worker and daemon roots inject composition; the
+direct kernel worker and uncomposed `SharedServices` construction fail closed.
+R2.4 (`TRUST-003`) is next in master order but remains `OPEN`
+pending its own serialized whole-package readiness transaction. R3.1 and R9.1
+are dependency-satisfied but remain `OPEN` for later serialized transactions.
+The active R8.3 claim and publication clock remain unchanged. R8.2
+(`STORE-003`) remains `OPEN` behind REL-004 and STORE-001; R8.4 (`BND-008`)
+additionally waits for STORE-003.


### PR DESCRIPTION
## Summary
- Record R2.3 as `IN_DEVELOP` after #3053 merged to develop.
- Remove the completed R2.3 claim while preserving the independent R8.3 publication claim.
- Add exact feature/verification evidence and identify R2.4 as the next serialized readiness audit.

## Why
The architecture ledger must lead and truthfully record completed develop delivery before allocating the next package.

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | Atomic CAP-003/CAP-005 reconciliation, #3053 evidence, and §14 handoff |

## GAP Audit
| Check | Result |
|---|---|
| Package atomicity | CAP-003 and CAP-005 move together |
| Active claims | R2.3 removed; R8.3 preserved byte-for-byte |
| Newly dependency-satisfied packages | None; later packages retain independent readiness transactions |
| Scope | Roadmap-only; no runtime/schema changes |

## Verification
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- `git diff --check`
- Independent adversarial ledger review: P0/P1 none
