### PR TITLE
docs(architecture): claim R2.4 implementation

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R2.4 | TRUST-003 | `session=codex-root task=r2-4-resource-data-policy` | `feature/r2-4-resource-data-policy` | Readiness [#3055](https://github.com/mangowhoiscloud/geode/pull/3055); plan-owned minimum safety policy, data handling, approval, and deterministic resource serialization re-audited | `2026-08-21T00:41:51Z` |
 
 ## 1. Program objective
 
@@ -543,7 +544,7 @@ and closure evidence are appended in §10.
 | STORE-002 | `PARTIAL` | Logging/transcript/resume/replay plan still contains staged/open parity work | Each subsystem has one declared writer, resume contract, replay doctrine, retention, and redaction test | R6.2 | STORE-001 | `DONE` |
 | TRUST-001 | `ABSENT` | Registration/enabled status does not uniformly distinguish trusted authority | Installed, enabled, trusted, and granted-capability states are separate and observable; executable code is never imported before trust approval | R6.3 | BND-004 | `OPEN` |
 | TRUST-002 | `PARTIAL` | Extension seams can receive broader runtime objects than required, and arbitrary in-process Python cannot be capability-confined | Trusted in-process code receives narrow ports for API discipline; untrusted executable code runs out of process behind a brokered capability boundary | R6.3 | DI-002, TRUST-001, TRUST-003 | `OPEN` |
-| TRUST-003 | `ABSENT` | Mutation serialization is not derived from explicit tool resource metadata | `resource_keys(args)` drives per-resource serialization; no argument-name heuristic | R2.4 | CAP-004 | `READY` |
+| TRUST-003 | `ABSENT` | Mutation serialization is not derived from explicit tool resource metadata | `resource_keys(args)` drives per-resource serialization; no argument-name heuristic | R2.4 | CAP-004 | `IN_PROGRESS` |
 | VER-001 | `PARTIAL` | Quality gates pass but lack core-only, reverse-import, exception-budget, and tool-plan drift tests | All architecture gates in §9 run in CI and locally | R7.1 | BND-003, BND-004, CAP-005, LOOP-004, DI-003, LLM-002, PROTO-002, GOV-004, VER-003 | `OPEN` |
 | VER-002 | `ABSENT` | No contract suite measures how many central edits each extension type requires | Six extension scenarios in §8 pass without forbidden edits | R7.2 | CAP-006, LLM-002, BND-004 | `OPEN` |
 | VER-003 | `PARTIAL` | Public/internal metric prose drifts from executable counts | `sync-stats` or one shared generator updates site, AGENTS facts, and roadmap baseline; check mode is green | R0.2 | GOV-001 | `DONE` |
@@ -2107,18 +2108,19 @@ generation/hash-bound plan now owns handler construction,
 with exact schema/execution parity, explicit transient overlays, and bounded
 diagnostics. Public product worker and daemon roots inject composition; the
 direct kernel worker and uncomposed `SharedServices` construction fail closed.
-R2.4 (`TRUST-003`) is the sole unclaimed `READY` package after a whole-package
-re-audit against
-`origin/develop@2865a0fe5007769eb648b74fb78200733041ad06`. CAP-004 is
-`IN_DEVELOP`. The current `ToolPlan` captures only partial safety metadata,
+R2.4 (`TRUST-003`) is `IN_PROGRESS` under the active claim for
+`feature/r2-4-resource-data-policy`, based on readiness
+[#3055](https://github.com/mangowhoiscloud/geode/pull/3055). Implementation
+starts only after this claim merges and a new worktree is allocated from the
+updated `develop`. CAP-004 is `IN_DEVELOP`. The current `ToolPlan` captures
+only partial safety metadata,
 while approval, personal-data, headless/sub-agent, profile-policy, and mutation
 scheduling still consume independent tool-name sets; deterministic resource
 keys are absent, and write/dangerous calls are only serialized within one tool
 batch. Acceptance requires one plan-owned minimum policy across those readers,
 effective-request resource serialization, and fail-closed monotone overrides.
-This authorizes no R2.3
-binding/provider work, R3.1 step/turn lifetime work, or R6.3 extension-trust
-work; a separate claim is required before implementation. R3.1 and R9.1 are
+The package authorizes no R2.3 binding/provider work, R3.1 step/turn lifetime
+work, or R6.3 extension-trust work. R3.1 and R9.1 are
 dependency-satisfied but remain `OPEN` for later serialized transactions. The
 active R8.3 claim and publication clock remain unchanged. R8.2 (`STORE-003`)
 remains `OPEN` behind REL-004 and STORE-001; R8.4 (`BND-008`) additionally


### PR DESCRIPTION
## Summary
- Claim R2.4 / TRUST-003 for `feature/r2-4-resource-data-policy`.
- Move the package atomically from `READY` to `IN_PROGRESS`.
- Preserve the independent R8.3 publication-grace claim and all later package states.

## Why
Readiness #3055 established R2.4 as the sole unclaimed READY package. This separate claim transaction must merge before an implementation worktree is allocated.

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | TRUST-003 status, one R2.4 claim row, and §14 implementation handoff |

## GAP Audit
| Check | Result |
|---|---|
| Base | `origin/develop@ca3db1da26412e0d13f2cc4361cfa7610fff9c8d` |
| Package | R2.4 / TRUST-003 only |
| Owner | `session=codex-root task=r2-4-resource-data-policy` |
| Intended branch | `feature/r2-4-resource-data-policy` |
| Claim evidence | Readiness #3055 |
| Implementation allocation | No implementation branch/worktree exists before claim merge |
| Parallel claim | R8.3 row and publication clock unchanged |

## Verification
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- `git diff --check`
- Independent claim audit: P0/P1 none
