### PR TITLE
docs(roadmap): reconcile R3.2 delivery

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,7 +226,6 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
-| R3.2 | LOOP-003 | `session=codex-root task=r3-2-phase-collaborators` | `feature/r3-2-phase-collaborators` | Reconciliation/readiness [#3069](https://github.com/mangowhoiscloud/geode/pull/3069); six bounded loop phases and compatibility acceptance re-audited | `2026-08-21T12:36:16Z` |
 
 ## 1. Program objective
 
@@ -527,8 +526,8 @@ and closure evidence are appended in §10.
 | CAP-006 | `ABSENT` | Adding a native/Google tool requires edits across several policy files | Change-surface fixture proves the bounded file/registration budget in §8 | R7.2 | CAP-003, CAP-004, CAP-005 | `OPEN` |
 | LOOP-001 | `ABSENT` | No immutable object freezes one step's route, policy, tool plan, and trace identity | `StepSnapshot` is created once per step and used by model/tool/telemetry paths | R3.1 | CAP-002 | `IN_DEVELOP` |
 | LOOP-002 | `PARTIAL` | Mutable state is distributed across loop fields, contexts, checkpoints, and helpers | `TurnState` and explicit session/turn/step ownership replace ambiguous lifetimes | R3.1 | LOOP-001 | `IN_DEVELOP` |
-| LOOP-003 | `MISFIT` | `AgenticLoop` owns orchestration plus many independently changing policies | Visible loop delegates to bounded input/model/tool/observe/termination phases | R3.2 | LOOP-001, LOOP-002 | `IN_PROGRESS` |
-| LOOP-004 | `ABSENT` | Loop has 2,714 LOC, 67 methods, and 27 constructor args with no local ratchet | Closure budgets in §7.3 are executable and cannot regress | R3.3 | LOOP-003 | `OPEN` |
+| LOOP-003 | `MISFIT` | `AgenticLoop` owns orchestration plus many independently changing policies | Visible loop delegates to bounded input/model/tool/observe/termination phases | R3.2 | LOOP-001, LOOP-002 | `IN_DEVELOP` |
+| LOOP-004 | `ABSENT` | Loop has 2,714 LOC, 67 methods, and 27 constructor args with no local ratchet | Closure budgets in §7.3 are executable and cannot regress | R3.3 | LOOP-003 | `READY` |
 | LOOP-005 | `MISFIT` | `SubAgentManager` combines request codec, role resolution, execution, validation, and announcements | Separate collaborators own those responsibilities; manager remains an orchestrator | R3.4 | LOOP-002 | `READY` |
 | DI-001 | `PARTIAL` | 26 module-level `ContextVar` declarations have no lifecycle classification | Generated inventory classifies request identity, diagnostics, mutable request state, request-local cache, and forbidden service lookup | R4.1 | LOOP-002 | `READY` |
 | DI-002 | `PARTIAL` | `GeodeRuntime` groups config, but `RuntimeCoreConfig` still has 17 fields | Cohesive lifecycle groups contain at most seven fields and have explicit owners/teardown | R4.2 | DI-001 | `OPEN` |
@@ -1932,6 +1931,7 @@ pre-release delivery evidence survives after the claim row is gone.
 | R2.3 | CAP-003, CAP-005 | [#3053](https://github.com/mangowhoiscloud/geode/pull/3053) | `ffeb41e13d4bd9c59bc1ba286300c352800f6a03` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, 10,431 non-live tests, lint/format, type check, security, Pages build, macOS/Ubuntu install smoke, wheel/sdist and clean installed-package checks, 399 isolated kernel imports plus 42 installed-kernel tests, installed daemon IPC v1.0.23, exact bound-plan schema/execution/provider/defer parity, and independent adversarial review all passed) |
 | R2.4 | TRUST-003 | [#3060](https://github.com/mangowhoiscloud/geode/pull/3060) | `709ccb0d0eb31080ed3b17896d4056f784db0281` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, 10,431 selected non-live tests, lint/format, type check, security, Pages build, official-doc parity, macOS/Ubuntu install smoke, wheel/sdist inspection, clean installed-package smoke, 396 isolated kernel imports plus 42 installed-kernel tests, plan-owned safety/redaction/resource-lock poison coverage, and independent committed-diff review all passed) |
 | R3.1 | LOOP-001, LOOP-002 | [#3067](https://github.com/mangowhoiscloud/geode/pull/3067) with follow-up [#3068](https://github.com/mangowhoiscloud/geode/pull/3068) | `e6ccaf73e1ff6027e510bfc5e4e16b8679f369e4` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature and follow-up CI Gates, 10,398 non-live tests, lint/format, type check, security, Pages build, official-doc parity, macOS/Ubuntu install smoke, additive event schema v5 with public-hook v1 query compatibility, exact step/turn/model/tool/telemetry correlation coverage, and independent committed-diff review all passed; the original feature merged as `c3e309f01e939e69bd22876df7f79b41731ac733`) |
+| R3.2 | LOOP-003 | [#3071](https://github.com/mangowhoiscloud/geode/pull/3071) | `a130ceb75364e128cf0e273edbff65302273bb3e` | `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS (feature CI Gate, full non-live tests, lint/format, type check, security, Pages build, official-doc parity, macOS/Ubuntu install smoke, wheel/sdist and clean installed-package checks, 397 isolated kernel imports plus 42 installed-kernel tests, ordered six-phase characterization, and two independent committed-diff reviews all passed) |
 
 ### 10.2 Main closure evidence
 
@@ -2131,20 +2131,24 @@ usage identity for each step, while `TurnState` owns mutable turn
 accumulation. Additive event schema v5 persists `step_id`; public-hook v1
 queries and prior stored rows remain compatible.
 
-R3.2 (`LOOP-003`) is `IN_PROGRESS` under the active claim for
-`feature/r3-2-phase-collaborators` after reconciliation/readiness
-[#3069](https://github.com/mangowhoiscloud/geode/pull/3069) merged as
-`250ea5ae776e58820ced466579524a3af0bf5fa6`. Implementation may start only
-after this claim merges and a fresh worktree is allocated from the updated
-canonical `develop`. The claimed scope extracts the six ordered input,
-model-call, provider/retry, tool, observation/compaction, and termination/result
-phases behind the existing `AgenticLoop.arun` behavior. It authorizes no R3.3
-budget change, R3.4 sub-agent decomposition, or R4 service restructuring.
+R3.2 (`LOOP-003`) is `IN_DEVELOP` after feature
+[#3071](https://github.com/mangowhoiscloud/geode/pull/3071) merged as
+`a130ceb75364e128cf0e273edbff65302273bb3e`. The physical turn now calls six
+ordered input, model-call, provider/retry, tool, observation/compaction, and
+termination/result collaborators while preserving the existing public
+`AgenticLoop.arun`, `StepSnapshot`, and `TurnState` behavior.
 
-R3.4 (`LOOP-005`) and R4.1 (`DI-001`) remain unclaimed `READY` packages. Their
-current re-audit baselines are `SubAgentManager` at 1,464 LOC, 24 methods, and
-18 constructor arguments, plus 30 generated module-level `ContextVar`
-declarations. R3.3 remains `OPEN` behind LOOP-003 delivery.
+R3.3 (`LOOP-004`) is the earliest unclaimed `READY` package after a
+whole-package re-audit against
+`origin/develop@a130ceb75364e128cf0e273edbff65302273bb3e`; LOOP-003 is now
+`IN_DEVELOP`. The generated current baseline measures `AgenticLoop` at 2,960
+LOC, 82 methods, and 29 constructor arguments, and §7.3 defines executable
+closure budgets of at most 1,600 LOC, 40 methods, 12 direct constructor
+arguments, plus local complexity, branch, and statement ceilings. A separate
+claim is required before implementation. R3.4 (`LOOP-005`) and R4.1 (`DI-001`)
+remain unclaimed `READY` packages later in master order; their current re-audit
+baselines are `SubAgentManager` at 1,464 LOC, 24 methods, and 18 constructor
+arguments, plus 30 generated module-level `ContextVar` declarations.
 
 R9.1 (`CODE-001`) was already dependency-satisfied and remains `OPEN` pending
 its own serialized whole-package readiness transaction later in master order.


### PR DESCRIPTION
## Summary
- Move LOOP-003 atomically from IN_PROGRESS to IN_DEVELOP.
- Remove the R3.2 active claim and append exact #3071 / a130ceb7 delivery evidence.
- Move newly dependency-satisfied LOOP-004 / R3.3 from OPEN to READY after whole-package re-audit.
- Preserve the R8.3 claim and publication clock byte-for-byte.

## Why
R3.2 merged to canonical develop and the ledger must trail that code delivery before the next package can be claimed.

## Invariants
| Check | Result |
|-------|--------|
| Unique GAP/package IDs | PASS |
| Package-atomic transition | PASS — R3.2 has one GAP; R3.3 has one GAP |
| Active-claim parity | PASS — R3.2 claim removed with IN_DEVELOP transition |
| Dependency readiness | PASS — LOOP-003 is IN_DEVELOP, satisfying LOOP-004 |
| Master order | PASS — R3.3 is earliest unclaimed READY |
| R8.3 claim/clock | Preserved |

## Verification
- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request — RESULT: PASS.
- uv run pytest tests/scripts/test_check_architecture_roadmap.py tests/scripts/test_resolve_architecture_roadmap_trust.py -q — PASS (48 tests).
- git diff --check — PASS.
- independent codex review --uncommitted — no findings.