### PR TITLE
docs(roadmap): claim R3.3 structural ratchets

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R3.3 | LOOP-004 | `session=codex-root task=r3-3-structural-ratchets` | `feature/r3-3-structural-ratchets` | Reconciliation/readiness [#3072](https://github.com/mangowhoiscloud/geode/pull/3072); structural closure budgets and current loop baseline re-audited | `2026-08-22T00:39:56Z` |
 
 ## 1. Program objective
 
@@ -527,7 +528,7 @@ and closure evidence are appended in §10.
 | LOOP-001 | `ABSENT` | No immutable object freezes one step's route, policy, tool plan, and trace identity | `StepSnapshot` is created once per step and used by model/tool/telemetry paths | R3.1 | CAP-002 | `IN_DEVELOP` |
 | LOOP-002 | `PARTIAL` | Mutable state is distributed across loop fields, contexts, checkpoints, and helpers | `TurnState` and explicit session/turn/step ownership replace ambiguous lifetimes | R3.1 | LOOP-001 | `IN_DEVELOP` |
 | LOOP-003 | `MISFIT` | `AgenticLoop` owns orchestration plus many independently changing policies | Visible loop delegates to bounded input/model/tool/observe/termination phases | R3.2 | LOOP-001, LOOP-002 | `IN_DEVELOP` |
-| LOOP-004 | `ABSENT` | Loop has 2,714 LOC, 67 methods, and 27 constructor args with no local ratchet | Closure budgets in §7.3 are executable and cannot regress | R3.3 | LOOP-003 | `READY` |
+| LOOP-004 | `ABSENT` | Loop has 2,714 LOC, 67 methods, and 27 constructor args with no local ratchet | Closure budgets in §7.3 are executable and cannot regress | R3.3 | LOOP-003 | `IN_PROGRESS` |
 | LOOP-005 | `MISFIT` | `SubAgentManager` combines request codec, role resolution, execution, validation, and announcements | Separate collaborators own those responsibilities; manager remains an orchestrator | R3.4 | LOOP-002 | `READY` |
 | DI-001 | `PARTIAL` | 26 module-level `ContextVar` declarations have no lifecycle classification | Generated inventory classifies request identity, diagnostics, mutable request state, request-local cache, and forbidden service lookup | R4.1 | LOOP-002 | `READY` |
 | DI-002 | `PARTIAL` | `GeodeRuntime` groups config, but `RuntimeCoreConfig` still has 17 fields | Cohesive lifecycle groups contain at most seven fields and have explicit owners/teardown | R4.2 | DI-001 | `OPEN` |
@@ -2138,17 +2139,19 @@ ordered input, model-call, provider/retry, tool, observation/compaction, and
 termination/result collaborators while preserving the existing public
 `AgenticLoop.arun`, `StepSnapshot`, and `TurnState` behavior.
 
-R3.3 (`LOOP-004`) is the earliest unclaimed `READY` package after a
-whole-package re-audit against
-`origin/develop@a130ceb75364e128cf0e273edbff65302273bb3e`; LOOP-003 is now
-`IN_DEVELOP`. The generated current baseline measures `AgenticLoop` at 2,960
-LOC, 82 methods, and 29 constructor arguments, and §7.3 defines executable
-closure budgets of at most 1,600 LOC, 40 methods, 12 direct constructor
-arguments, plus local complexity, branch, and statement ceilings. A separate
-claim is required before implementation. R3.4 (`LOOP-005`) and R4.1 (`DI-001`)
-remain unclaimed `READY` packages later in master order; their current re-audit
-baselines are `SubAgentManager` at 1,464 LOC, 24 methods, and 18 constructor
-arguments, plus 30 generated module-level `ContextVar` declarations.
+R3.3 (`LOOP-004`) is `IN_PROGRESS` under the active claim for
+`feature/r3-3-structural-ratchets` after reconciliation/readiness
+[#3072](https://github.com/mangowhoiscloud/geode/pull/3072) merged as
+`abbd1f132e91cd80e9431823fbbfbdc69a3cce0e`. Implementation may start only
+after this claim merges and a fresh worktree is allocated from the updated
+canonical `develop`. The claimed scope enforces §7.3 budgets of at most 1,600
+`agent_loop.py` LOC, 40 `AgenticLoop` methods, 12 direct constructor arguments,
+and the registered local complexity, branch, and statement ceilings without
+hiding responsibilities in generic helpers or service bags. R3.4 (`LOOP-005`)
+and R4.1 (`DI-001`) remain unclaimed `READY` packages later in master order;
+their current re-audit baselines are `SubAgentManager` at 1,464 LOC, 24 methods,
+and 18 constructor arguments, plus 30 generated module-level `ContextVar`
+declarations.
 
 R9.1 (`CODE-001`) was already dependency-satisfied and remains `OPEN` pending
 its own serialized whole-package readiness transaction later in master order.


### PR DESCRIPTION
## Summary
- Move LOOP-004 / R3.3 atomically from READY to IN_PROGRESS.
- Add the sole matching R3.3 active claim for feature/r3-3-structural-ratchets.
- Preserve R8.3 and later READY packages unchanged.

## Why
R3.3 is the earliest READY package after #3072 merged; implementation authority requires this separate canonical claim.

## Invariants
| Check | Result |
|-------|--------|
| Exact base | origin/develop@abbd1f132e91cd80e9431823fbbfbdc69a3cce0e |
| Package/status parity | PASS — LOOP-004 and R3.3 claim match |
| Claim evidence | PASS — #3072 readiness/reconciliation |
| Owner/branch | PASS — codex-root / feature/r3-3-structural-ratchets |
| R8.3 | Preserved |

## Verification
- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request — RESULT: PASS.
- uv run pytest tests/scripts/test_check_architecture_roadmap.py tests/scripts/test_resolve_architecture_roadmap_trust.py -q — PASS (48 tests).
- git diff --check — PASS.
- independent codex review --uncommitted — no findings.