### PR TITLE
docs(roadmap): claim R3.4 sub-agent decomposition

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R3.4 | LOOP-005 | `session=codex-root task=r3-4-subagent-decomposition` | `feature/r3-4-subagent-decomposition` | Reconciliation/readiness [#3069](https://github.com/mangowhoiscloud/geode/pull/3069); sub-agent collaborator split and current manager baseline re-audited | `2026-08-22T02:49:01Z` |
 
 ## 1. Program objective
 
@@ -528,7 +529,7 @@ and closure evidence are appended in §10.
 | LOOP-002 | `PARTIAL` | Mutable state is distributed across loop fields, contexts, checkpoints, and helpers | `TurnState` and explicit session/turn/step ownership replace ambiguous lifetimes | R3.1 | LOOP-001 | `IN_DEVELOP` |
 | LOOP-003 | `MISFIT` | `AgenticLoop` owns orchestration plus many independently changing policies | Visible loop delegates to bounded input/model/tool/observe/termination phases | R3.2 | LOOP-001, LOOP-002 | `IN_DEVELOP` |
 | LOOP-004 | `ABSENT` | Loop has 2,714 LOC, 67 methods, and 27 constructor args with no local ratchet | Closure budgets in §7.3 are executable and cannot regress | R3.3 | LOOP-003 | `IN_DEVELOP` |
-| LOOP-005 | `MISFIT` | `SubAgentManager` combines request codec, role resolution, execution, validation, and announcements | Separate collaborators own those responsibilities; manager remains an orchestrator | R3.4 | LOOP-002 | `READY` |
+| LOOP-005 | `MISFIT` | `SubAgentManager` combines request codec, role resolution, execution, validation, and announcements | Separate collaborators own those responsibilities; manager remains an orchestrator | R3.4 | LOOP-002 | `IN_PROGRESS` |
 | DI-001 | `PARTIAL` | 26 module-level `ContextVar` declarations have no lifecycle classification | Generated inventory classifies request identity, diagnostics, mutable request state, request-local cache, and forbidden service lookup | R4.1 | LOOP-002 | `READY` |
 | DI-002 | `PARTIAL` | `GeodeRuntime` groups config, but `RuntimeCoreConfig` still has 17 fields | Cohesive lifecycle groups contain at most seven fields and have explicit owners/teardown | R4.2 | DI-001 | `OPEN` |
 | DI-003 | `MISFIT` | Downstream modules obtain injectable services through globals and CLI modules | Constructor/factory injection owns services; allowed ambient context is documented and tested | R4.2 | DI-001, DI-002 | `OPEN` |
@@ -2147,11 +2148,20 @@ arguments, complexity at most 30, branches at most 35, and statements at most
 120; the obsolete constructor exception is removed and legacy policy keywords
 still map to `AgenticLoopConfig`.
 
-R3.4 (`LOOP-005`) is the earliest unclaimed `READY` package in master order.
-R4.1 (`DI-001`) is also unclaimed `READY` but remains later in master order;
-both require their own claim transactions. Their current baselines are
-`SubAgentManager` at 1,464 LOC, 24 methods, and 18 constructor arguments, plus
-30 generated module-level `ContextVar` declarations.
+R3.4 (`LOOP-005`) is `IN_PROGRESS` under the active claim for
+`feature/r3-4-subagent-decomposition` after reconciliation/readiness
+[#3069](https://github.com/mangowhoiscloud/geode/pull/3069) merged as
+`250ea5ae776e58820ced466579524a3af0bf5fa6`. Implementation may start only
+after this claim merges and a fresh worktree is allocated from the updated
+canonical `develop`. The claimed scope extracts the request codec, role/tool
+policy resolver, worker launcher, result validator, best-of judge, and
+announcement publisher while preserving max depth, session cap, Lane
+concurrency, task isolation, and cancellation. The current baseline is
+`SubAgentManager` at 1,464 LOC, 24 methods, and 18 constructor arguments.
+
+R4.1 (`DI-001`) remains the sole unclaimed `READY` package later in master
+order and requires its own claim transaction. Its generated baseline remains
+30 module-level `ContextVar` declarations.
 
 R9.1 (`CODE-001`) was already dependency-satisfied and remains `OPEN` pending
 its own serialized whole-package readiness transaction later in master order.


### PR DESCRIPTION
## Summary
- Claim R3.4 as the next master-sequence implementation package.
- Move `LOOP-005` from `READY` to `IN_PROGRESS`.
- Preserve the independent R8.3 claim and publication clock.

## Why
R3.3 is reconciled on canonical develop, and R3.4 is the earliest READY package in master order. The claim must merge before implementation worktree allocation.

## Changes
| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | Add the R3.4 claim, transition LOOP-005, and record the exact implementation handoff. |

## GAP Audit
| Package | GAP | Before | After |
|---|---|---|---|
| R3.4 | LOOP-005 | READY | IN_PROGRESS |

## Verification
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request`
- `git diff --check`
- Independent `codex review --uncommitted`: clean