### PR TITLE
docs(architecture): R4.3 manager split claim

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R4.3 | DI-004 | `session=codex-root task=r4-3-mcp-manager-split` | `feature/r4-3-mcp-manager-split` | Reconciliation/readiness [#3092](https://github.com/mangowhoiscloud/geode/pull/3092); manager responsibility split and behavior-preservation acceptance re-audited | `2026-08-22T22:08:24Z` |
 
 ## 1. Program objective
 
@@ -532,7 +533,7 @@ and closure evidence are appended in §10.
 | DI-001 | `PARTIAL` | 26 module-level `ContextVar` declarations have no lifecycle classification | Generated inventory classifies request identity, diagnostics, mutable request state, request-local cache, and forbidden service lookup | R4.1 | LOOP-002 | `IN_DEVELOP` |
 | DI-002 | `PARTIAL` | `GeodeRuntime` groups config, but `RuntimeCoreConfig` still has 17 fields | Cohesive lifecycle groups contain at most seven fields and have explicit owners/teardown | R4.2 | DI-001 | `IN_DEVELOP` |
 | DI-003 | `MISFIT` | Downstream modules obtain injectable services through globals and CLI modules | Constructor/factory injection owns services; allowed ambient context is documented and tested | R4.2 | DI-001, DI-002 | `IN_DEVELOP` |
-| DI-004 | `MISFIT` | `MCPServerManager` combines config, discovery, connection, call, trace/persistence, and lifecycle | Separate config catalog, connection pool, invoker, and persistence collaborators preserve public behavior | R4.3 | DI-002 | `READY` |
+| DI-004 | `MISFIT` | `MCPServerManager` combines config, discovery, connection, call, trace/persistence, and lifecycle | Separate config catalog, connection pool, invoker, and persistence collaborators preserve public behavior | R4.3 | DI-002 | `IN_PROGRESS` |
 | LLM-001 | `MISFIT` | `LLMAdapter` documentation calls the contract minimal but requires streaming and introspection methods | Minimal completion protocol plus optional capability protocols; no empty stubs required | R5.1 | DI-002 | `READY` |
 | LLM-002 | `PARTIAL` | Eight built-ins use a mutable registry with broad bootstrap lifetime | Built-in plus entry-point discovery yields immutable session snapshots with generation and collision policy | R5.2 | LLM-001, BND-001 | `OPEN` |
 | LLM-003 | `PARTIAL` | Provider identity, credential source, transport, and adapter selection overlap | Provider profile, credential route, and transport are separate composable records | R5.3 | LLM-001, LLM-002 | `OPEN` |
@@ -2181,17 +2182,21 @@ composition-root, constructor, or `ToolContext` injection. The eleven ambient
 service locators are removed, lifecycle shutdown remains runtime-owned, and no
 durable schema or provider/tool contract migrated.
 
-R4.3 (`DI-004`), R5.1 (`LLM-001`), and R6.1 (`PROTO-001`, `PROTO-002`) are
-newly dependency-satisfied `READY` packages after whole-package re-audit
-against `origin/develop@d7f566e12ce96adabd74e6c268d53336ec12fc81`. Their
-§7 acceptance remains measurable: `MCPServerManager` still combines catalog,
-connection, invocation, trace/persistence, and lifecycle responsibilities;
-the required adapter surface still mixes completion with optional
-capabilities; and public protocol projections still need one versioned,
-negotiated compatibility envelope. R4.3 is the earliest unclaimed package in
-master order and requires a separate claim PR before implementation. R5.1 and
-R6.1 remain unclaimed and authorize no implementation until their own
-serialized claims merge.
+R4.3 (`DI-004`) is `IN_PROGRESS` under the active claim for
+`feature/r4-3-mcp-manager-split` after reconciliation/readiness
+[#3092](https://github.com/mangowhoiscloud/geode/pull/3092) merged as
+`3f059ba467ff58cde47095ffef94730ac39fbaef`. DI-002 is `IN_DEVELOP`. The
+claimed scope splits the current `MCPServerManager` configuration catalog,
+discovery, connection pool, invoker/result guard, trace/persistence, and
+lifecycle responsibilities while preserving public behavior. It authorizes no
+other manager refactor without a new GAP and no R5 adapter or R6 protocol work.
+The implementation worktree may be allocated only after this claim merges and
+canonical `develop` is refreshed.
+
+R5.1 (`LLM-001`) and R6.1 (`PROTO-001`, `PROTO-002`) remain `READY` and
+unclaimed. Their current required adapter and public-protocol gaps remain
+measurable, but neither package authorizes implementation until its own
+serialized claim merges.
 
 R9.1 (`CODE-001`) was already dependency-satisfied and remains `OPEN` pending
 its own serialized whole-package readiness transaction later in master order.


### PR DESCRIPTION
## Summary

Canonical `develop`에서 가장 이른 unclaimed `READY` package인 R4.3(`DI-004`)을 독점 claim합니다. `DI-004`를 `IN_PROGRESS`로 옮기고 owner·구현 branch·readiness evidence·UTC claim 시각을 §0.4에 기록하며, §14에는 구현 범위와 비범위를 고정합니다.

이 PR은 구현 코드를 포함하지 않습니다. merge 후 갱신된 `origin/develop`에서 `feature/r4-3-mcp-manager-split` worktree를 새로 할당해야만 구현이 시작됩니다.

## Why

R4.2 reconciliation #3092가 `3f059ba467ff58cde47095ffef94730ac39fbaef`로 병합되면서 R4.3, R5.1, R6.1이 `READY`가 되었습니다. Master-ledger 순서상 R4.3이 첫 package이므로, 다음 구현 권한은 다른 READY package가 아니라 R4.3에 먼저 부여해야 합니다.

현재 `MCPServerManager`는 configuration load, discovery, connection/subprocess lifecycle, tool lookup/call, result guarding/cache, health/reload, trace/persistence와 signal teardown을 한 클래스가 함께 소유합니다. Claim은 이 측정된 책임 분리를 승인하되, R5 adapter plane이나 R6 protocol envelope, 다른 large manager refactor로 범위를 넓히지 않습니다.

## GAP Audit

| Item | Canonical evidence | Claim decision |
|---|---|---|
| Package | R4.3 / `DI-004` is the earliest `READY` package after #3092 | Claim exactly R4.3 |
| Dependency | `DI-002` is `IN_DEVELOP` | Readiness remains valid |
| Current gap | `MCPServerManager` still owns catalog, discovery, connection, invocation/result guard, trace/persistence, lifecycle | Measurable implementation target |
| Owner | `session=codex-root task=r4-3-mcp-manager-split` | One exclusive active-claim row |
| Intended branch | `feature/r4-3-mcp-manager-split` | Implementation worktree only after this PR merges |
| Parallel release claim | R8.3 / `REL-004` publication clock | Byte-preserved and independent |
| Later READY packages | R5.1 / `LLM-001`; R6.1 / `PROTO-001`, `PROTO-002` | Remain `READY`, unclaimed, and unauthorized for implementation |

## Changes

### Canonical ledger

- `docs/architecture/extensibility-roadmap.md:226`: append one R4.3 active-claim row with owner, intended branch, #3092 evidence, and `2026-08-22T22:08:24Z` timestamp.
- `docs/architecture/extensibility-roadmap.md:533`: transition only `DI-004` from `READY` to `IN_PROGRESS`.
- `docs/architecture/extensibility-roadmap.md:2182`: replace readiness prose with claim authority, dependency fact, exact implementation scope, non-goals, and the post-merge worktree gate.

### Secondary code/config changes

None.

### Documentation/config changes

No CHANGELOG entry: this is a roadmap-only ownership transaction with no functional behavior change.

## Impact Scope

- **Runtime behavior**: unchanged.
- **Data/schema**: unchanged.
- **Backward compatibility**: unchanged.
- **Test changes**: added 0 / modified 0 / deleted 0.
- **Authorization**: only R4.3 becomes implementable, and only after claim merge plus a fresh canonical-base worktree allocation.

## Design Decisions

- **R4.3 before R5.1/R6.1**: all three are READY, but §6/§14 master order selects the earliest package; READY is not permission to bypass claim order.
- **One GAP, one package-atomic row**: R4.3 contains only `DI-004`, so no sibling row can be partially claimed.
- **No speculative manager framework**: the claim names concrete collaborators required by §7; implementation must reuse current public behavior and add a new GAP before touching another manager.
- **No premature worktree**: branch intent is ledger metadata, not evidence that implementation has begun.

## Verification

- [x] Base is canonical `origin/develop@3f059ba467ff58cde47095ffef94730ac39fbaef` (#3092).
- [x] Claim timestamp is after #3092 merge and is valid ISO-8601 UTC.
- [x] `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — **PASS**, `architecture roadmap OK (base origin/develop)`.
- [x] `git diff --check` — **PASS**.
- [x] `uv run python scripts/check_repo_hygiene.py` — **PASS**.
- [x] Pre-commit hooks — **PASS**; Python-only hooks correctly skipped because this diff changes one Markdown ledger file.
- [x] Independent read-only Codex review — **SHIP, P0/P1/P2 none**.
- [x] No test deletion, skip/xfail, lint/type bypass, generated artifact drift, or configuration weakening.

Full pytest/ruff/mypy/package checks were not rerun locally because this is a claim-only Markdown transaction; mandatory PR CI remains the merge authority.

## Risk and Rollback

The risk is authorization drift: claiming a later package, mismatching the active-claim row and status, or allocating implementation before ownership is canonical. The target-aware validator enforces package/claim parity and legal transition; the branch/worktree rule is repeated in §14. Rollback is a single roadmap commit revert with no runtime or data effect.

## Merge Protocol

- Target: `develop`
- Merge: squash only after every required check is green
- After merge: fetch canonical `develop`, verify the R4.3 claim, then allocate `feature/r4-3-mcp-manager-split`
- Next code PR preserves `DI-004=IN_PROGRESS`; reconciliation happens only after implementation merge

🤖 Generated with [Codex](https://codex.com/)