### PR TITLE
docs(architecture): R5.1 adapter 분리 claim

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -226,6 +226,7 @@ normal review and CI; implementations start only after the claim merges.
 | Closure package | GAP IDs | Owner/session | Implementation branch | Claim evidence | Claimed at (UTC) |
 |---|---|---|---|---|---|
 | R8.3 | REL-004 | `session=codex-root task=r8-3-publication-grace-evidence` | `feature/r8-3-publication-grace-evidence` | Readiness [#3039](https://github.com/mangowhoiscloud/geode/pull/3039); v1.0.23 GitHub/PyPI parity and candidate interval re-audited | `2026-08-20T07:41:19Z` |
+| R5.1 | LLM-001 | `session=codex-root task=r5-1-interface-segregation` | `feature/r5-1-interface-segregation` | Reconciliation/readiness [#3092](https://github.com/mangowhoiscloud/geode/pull/3092); minimal completion protocol and optional capability surfaces re-audited | `2026-08-22T23:35:55Z` |
 
 ## 1. Program objective
 
@@ -533,7 +534,7 @@ and closure evidence are appended in §10.
 | DI-002 | `PARTIAL` | `GeodeRuntime` groups config, but `RuntimeCoreConfig` still has 17 fields | Cohesive lifecycle groups contain at most seven fields and have explicit owners/teardown | R4.2 | DI-001 | `IN_DEVELOP` |
 | DI-003 | `MISFIT` | Downstream modules obtain injectable services through globals and CLI modules | Constructor/factory injection owns services; allowed ambient context is documented and tested | R4.2 | DI-001, DI-002 | `IN_DEVELOP` |
 | DI-004 | `MISFIT` | `MCPServerManager` combines config, discovery, connection, call, trace/persistence, and lifecycle | Separate config catalog, connection pool, invoker, and persistence collaborators preserve public behavior | R4.3 | DI-002 | `IN_DEVELOP` |
-| LLM-001 | `MISFIT` | `LLMAdapter` documentation calls the contract minimal but requires streaming and introspection methods | Minimal completion protocol plus optional capability protocols; no empty stubs required | R5.1 | DI-002 | `READY` |
+| LLM-001 | `MISFIT` | `LLMAdapter` documentation calls the contract minimal but requires streaming and introspection methods | Minimal completion protocol plus optional capability protocols; no empty stubs required | R5.1 | DI-002 | `IN_PROGRESS` |
 | LLM-002 | `PARTIAL` | Eight built-ins use a mutable registry with broad bootstrap lifetime | Built-in plus entry-point discovery yields immutable session snapshots with generation and collision policy | R5.2 | LLM-001, BND-001 | `OPEN` |
 | LLM-003 | `PARTIAL` | Provider identity, credential source, transport, and adapter selection overlap | Provider profile, credential route, and transport are separate composable records | R5.3 | LLM-001, LLM-002 | `OPEN` |
 | LLM-004 | `PARTIAL` | Interactive and autonomous LLM paths share taxonomy but retain multiple retry/failover implementations | Explicit `RetryPolicy` preserves intentional differences on one classification/telemetry substrate | R5.4 | LLM-003 | `OPEN` |
@@ -2190,10 +2191,22 @@ trace persistence, and lifecycle cleanup to focused collaborators while its
 public facade and behavior remain compatible. No other manager, R5 adapter,
 or R6 protocol responsibility moved.
 
-R5.1 (`LLM-001`) is the earliest `READY`, unclaimed package in master order.
-R6.1 (`PROTO-001`, `PROTO-002`) also remains `READY` and unclaimed. Their
-required adapter and public-protocol gaps remain measurable, but neither
-package authorizes implementation until its own serialized claim merges.
+R5.1 (`LLM-001`) is `IN_PROGRESS` under the active claim for
+`feature/r5-1-interface-segregation` after reconciliation/readiness
+[#3092](https://github.com/mangowhoiscloud/geode/pull/3092) merged as
+`3f059ba467ff58cde47095ffef94730ac39fbaef`. DI-002 is `IN_DEVELOP`. The
+claimed scope makes identity plus `acomplete` the required `LLMAdapter`
+surface, moves streaming, model listing, environment diagnostics, quota,
+credential detection, web search, computer use, and text completion behind
+optional capability protocols, and removes dishonest empty stubs without
+changing provider wire behavior. It authorizes no R5.2 registry/discovery,
+R5.3 provider-profile/transport, or R5.4 retry/failover work. The implementation
+worktree may be allocated only after this claim merges and canonical `develop`
+is refreshed.
+
+R6.1 (`PROTO-001`, `PROTO-002`) remains `READY` and unclaimed. Its public
+protocol gap remains measurable but authorizes no implementation until its own
+serialized claim merges.
 
 R9.1 (`CODE-001`) was already dependency-satisfied and remains `OPEN` pending
 its own serialized whole-package readiness transaction later in master order.


### PR DESCRIPTION
## Summary

R5.1 (`LLM-001`)을 canonical roadmap에서 `READY` → `IN_PROGRESS`로 전이하고, 후속 구현 branch `feature/r5-1-interface-segregation`에 대한 exclusive claim을 등록합니다.

이 PR은 구현을 포함하지 않습니다. claim이 CI를 통과해 `develop`에 병합된 뒤에만 새 implementation worktree를 만들며, 구현 범위는 required `LLMAdapter` surface 축소와 optional capability 분리로 제한합니다.

## Why

현재 `LLMAdapter`는 문서상 “minimum viable adapter”이지만 실제 runtime-checkable Protocol은 다음을 모두 필수로 요구합니다.

- identity: `name`, `provider`, `source`, `billing_type`
- completion: `acomplete`
- streaming: `astream`
- diagnostics/introspection: `test_environment`, `list_models`, `get_quota_windows`, `detect_credential`

그 결과 completion만 제공할 수 있는 외부 adapter도 의미 없는 empty/`None` stub을 구현해야 합니다. 반면 web search, computer use, text completion은 이미 별도의 runtime-checkable capability protocol로 분리돼 있어, 같은 패턴을 streaming과 introspection에 적용할 수 있는 측정 가능한 seam이 존재합니다.

Roadmap #3092에서 DI-002가 `IN_DEVELOP`로 전이되면서 R5.1의 유일 외부 dependency가 충족됐고, #3095 이후 R5.1은 master order상 earliest unclaimed READY package입니다.

## Changes

| File | Change | Rationale |
|---|---|---|
| `docs/architecture/extensibility-roadmap.md` | `LLM-001` 상태를 `READY` → `IN_PROGRESS`로 전이 | 구현 권한을 claim protocol에 맞게 canonical ledger에 등록합니다. |
| `docs/architecture/extensibility-roadmap.md` | R5.1 active-claim 행 추가 | owner/session, implementation branch, readiness #3092, UTC claim 시각을 명시해 package exclusivity를 고정합니다. |
| `docs/architecture/extensibility-roadmap.md` | §14 allocation handoff 갱신 | 구현 acceptance와 R5.2–R5.4 비범위를 명시하고 implementation worktree의 선행 생성을 금지합니다. |

## GAP Audit

| Surface | Current state | R5.1 target |
|---|---|---|
| Required adapter contract | Identity + completion + streaming + four introspection methods | Identity + `acomplete` only |
| Streaming | 모든 adapter가 `astream`을 보유해야 함 | Optional streaming capability protocol |
| Environment diagnostics | 모든 adapter가 probe를 구현해야 함 | Capability check 뒤 선택적으로 호출 |
| Model listing | empty list stub 허용/요구 | Optional model-catalog capability |
| Quota inspection | `None` stub 허용/요구 | Optional quota capability |
| Credential detection | `None` stub 허용/요구 | Optional credential-detection capability |
| Web/computer/text completion | 이미 optional protocols 존재 | 기존 패턴과 wire behavior 보존 |

## Claimed acceptance

- `LLMAdapter`의 required surface는 identity + `acomplete`로 축소합니다.
- streaming, model listing, environment diagnostics, quota, credential detection은 각각 실제 소비자가 protocol/capability check 후 호출합니다.
- built-in adapter의 현행 성공 경로와 provider wire payload는 바꾸지 않습니다.
- 외부 completion-only adapter가 dishonest empty stub 없이 registry/dispatch에 참여할 수 있어야 합니다.
- public re-export와 runtime-checkable behavior를 characterization tests로 고정합니다.
- 기존 web search, computer use, text completion capability protocol은 중복 구현하지 않습니다.

## Explicit non-goals

- R5.2: mutable registry, entry-point discovery, collision policy, session snapshot
- R5.3: provider profile, credential route, transport/API composition
- R5.4: retry/failover taxonomy와 call-stack convergence
- provider SDK 교체, wire schema 변경, 모델 지원 확대
- R6.1 public protocol package 또는 R8.3 publication clock 변경

## Atomicity and sequencing

- R5.1은 `LLM-001` 단일 GAP package이므로 부분 전이가 없습니다.
- readiness evidence는 reconciliation #3092 / merge `3f059ba467ff58cde47095ffef94730ac39fbaef`입니다.
- claim 시각 `2026-08-22T23:35:55Z`는 #3095 merge 뒤입니다.
- 기존 R8.3 active claim은 byte-preserved합니다.
- R6.1은 `READY`/unclaimed로 유지하며, 별도 claim 전에는 구현하지 않습니다.

## Verification

- [x] `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — `architecture roadmap OK (base origin/develop)`
- [x] `uv run pytest tests/scripts/test_check_architecture_roadmap.py -q` — **40 passed**
- [x] `git diff --check` — clean
- [x] commit hooks — codespell, whitespace/EOF, merge-conflict scan, architecture exception debt passed
- [x] Scope census — one roadmap file only; no source, test, config, CHANGELOG, claim-adjacent package, or §10 evidence change

## Risk and rollback

이 PR의 runtime risk는 없습니다. 위험은 잘못된 package ownership이나 범위 과장뿐이며, exact-base validator와 단일 active-claim row가 이를 검증합니다. 구현이 중단되면 roadmap §0.3 절차에 따라 별도 reconciliation에서 `LLM-001`을 공유 상태로 되돌리고 claim을 제거합니다.

🤖 Generated with [Codex](https://Codex.com/Codex)
