### PR TITLE
docs(roadmap): verify-state 미러 정리 GAP 등록

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -566,6 +566,7 @@ and closure evidence are appended in §10.
 | REL-003 | `MISFIT` | PyPI, GitHub Releases, repository metadata, and the changelog report v1.0.22, which predates the delivered boundary refactor | Wheel, sdist, CLI, daemon, site SOT, changelog, tag, GitHub release, and PyPI all report v1.0.23 with artifact-hash parity and no rewritten earlier-release evidence | R1.7 | BND-003, BND-006, GOV-004 | `DONE` |
 | REL-004 | `ABSENT` | No registered gate prevents the v1.0.23 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.23, and every release inside that interval retained them | R8.3 | REL-003 | `IN_PROGRESS` |
 | BND-008 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-004, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.4 | REL-004, STORE-003 | `OPEN` |
+| CODE-002 | `MISFIT` | Verification state is restored from checkpoint `loop_guards`, but `_persist_verify_state` still mirrors every result into `SessionManager` columns whose accessor has no production reader | Production verify-mirror writes and the unused accessor are removed; legacy databases containing the columns still load, checkpoint recovery remains authoritative, and no new store or schema migration is introduced | R9.2 | CODE-001 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -1809,6 +1810,26 @@ Acceptance:
 - crash, race, partial-mutation, drift, redaction, and rollback failure modes
   map to observable acceptance tests, and the roadmap validator plus document
   link checks pass without any runtime-code change.
+
+#### R9.2 Verify-state mirror cleanup
+
+GAP: CODE-002.
+
+This package removes a write-only production mirror. It does not change the
+session schema or create another verification, telemetry, or recovery owner.
+
+Acceptance:
+
+- a source-and-test census confirms that checkpoint `loop_guards` own verify
+  recovery and no production caller reads `SessionManager.get_verify_state`;
+- `_persist_verify_state`, `SessionManager.upsert_verify_state`, and
+  `SessionManager.get_verify_state` leave production code, while the existing
+  verify columns remain tolerated as inert legacy schema;
+- existing databases containing those columns open without migration, and
+  checkpoint restore plus current verification metrics/events retain their
+  behavior;
+- focused verification/recovery tests and architecture gates pass without a
+  new store, schema migration, event, hook, or runtime abstraction.
 
 ## 8. Change-surface acceptance scenarios
 


### PR DESCRIPTION
## Summary

- 운영 복구에는 쓰이지 않지만 매 검증 결과를 SQLite에 계속 기록하는 verify-state 미러를 `CODE-002`로 등록합니다.
- `R9.2`를 독립 `OPEN` 패키지로 추가해, 상태 스키마를 재설계하지 않고 죽은 writer/accessor만 제거하는 후속 작업의 경계를 고정합니다.

## Why

R9.1의 authority census는 checkpoint `loop_guards`가 verify/replan 복구의 소유자임을 확정했습니다. 그러나 현재 `_persist_verify_state()`는 매 결과를 `SessionManager.upsert_verify_state()`로 이중 기록하고, `SessionManager.get_verify_state()`는 운영 호출자가 전혀 없습니다. 이 상태는 복구 권한을 갖지 않는 write-only 미러를 계속 유지하므로, 추측성 새 모델을 만들기보다 별도 cleanup GAP으로 등록해 제거 가능 범위를 명시해야 합니다.

등록을 R9.1 구현이나 R8 체인에 섞지 않았습니다. `CODE-002`는 R9.1 authority contract에만 의존하며, schema migration·새 store·새 hook/event·새 runtime abstraction을 허용하지 않습니다.

## Changes

| File | Change | Rationale |
|---|---|---|
| `docs/architecture/extensibility-roadmap.md` | master ledger 끝에 `CODE-002 / R9.2 / MISFIT / OPEN` 행 추가 | append-only ID/package 규칙을 지키면서 현재 writer와 운영 reader 부재를 고정합니다. |
| `docs/architecture/extensibility-roadmap.md` | §7에 `R9.2 Verify-state mirror cleanup` acceptance 추가 | production writer/accessor 제거, legacy-column tolerance, checkpoint recovery 불변을 각각 실행 가능한 종료 조건으로 만듭니다. |

## GAP Audit

| Surface | Current evidence | Disposition |
|---|---|---|
| Recovery authority | checkpoint `loop_guards`가 verify/replan 상태를 복원 | 유지; 새 recovery store 금지 |
| Production writer | `_persist_verify_state` → `SessionManager.upsert_verify_state` | 후속 R9.2 구현에서 제거 대상 |
| Production reader | `get_verify_state` 호출은 테스트에만 존재 | unused accessor로 분류 |
| Durable schema | 기존 `sessions` verify columns 존재 | 삭제 migration 없이 inert legacy columns로 허용 |
| Package boundary | R9.1 contract가 cleanup trigger/경계를 이미 명시 | 새 `CODE-002 / R9.2`로 독립 등록 |

## Scope and non-goals

- 이 PR은 GAP 등록만 수행합니다. `OPEN → READY`, claim, 구현, §10 evidence를 선행하지 않습니다.
- R8.3 active claim과 publication clock, R8.2/R8.4 상태는 byte-for-byte 유지합니다.
- verify/replan provenance 확장, 새 telemetry schema, 새 state API는 범위 밖입니다.
- 문서 전용 변경이므로 `CHANGELOG.md`는 변경하지 않습니다.

## Verification

- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — **PASS**
- `uv run pytest tests/scripts/test_check_architecture_roadmap.py -q` — **40 passed**
- `uv run pre-commit run --files docs/architecture/extensibility-roadmap.md` — **PASS**
- `uv run python scripts/architecture_baseline.py --check` — **PASS**
- `git diff --check` — **PASS**
- Exact base: `origin/develop@5e12edd88cca0855d6ebecd4e6ede49eb700667d`
- Changed scope: **1 file, 21 insertions, 0 deletions**

## Handoff

Merge 후에도 R9.2는 `OPEN`입니다. 다음 권한 부여는 최신 canonical `develop`에서 별도 whole-package readiness PR로 진행하고, 그 뒤 별도 claim PR이 병합되기 전에는 구현 worktree를 만들지 않습니다.

🤖 Generated with [Codex](https://codex.com)