### PR TITLE
docs(architecture): ready namespace convergence

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -566,7 +566,7 @@ and closure evidence are appended in §10.
 | REL-004 | `ABSENT` | No registered gate prevents the v1.0.23 compatibility facade or preserved state roots from being retired immediately after a local tag, draft release, or registry publication | Official GitHub Release and PyPI evidence proves compatible public artifacts continuously exposed the facade and preserved roots for a final qualifying interval of at least 30 consecutive days, starting no earlier than v1.0.23, and every release inside that interval retained them | R8.3 | REL-003 | `SUPERSEDED` |
 | BND-008 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-004, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.4 | REL-004, STORE-003 | `SUPERSEDED` |
 | CODE-002 | `MISFIT` | Verification state is restored from checkpoint `loop_guards`, but `_persist_verify_state` still mirrors every result into `SessionManager` columns whose accessor has no production reader | Production verify-mirror writes and the unused accessor are removed; legacy databases containing the columns still load, checkpoint recovery remains authoritative, and no new store or schema migration is introduced | R9.2 | CODE-001 | `DONE` |
-| BND-009 | `MISFIT` | `geode_product` combines runtime composition with evaluation and hill-climbing, while `plugins`, `core/self_improving`, Homebrew candidate files, and the unverified computer sandbox preserve duplicate or unsupported ownership surfaces | One documented migration leaves `core` as the GEODE runtime, moves measurement to `evals` and hill-climbing to `evolve`, removes every obsolete package/scaffold without a replacement stub, preserves one-way `evolve -> evals -> core` dependencies and operator behavior, migrates tracked state with byte parity, and proves the final wheel/sdist/install/release contain only the declared roots | R8.5 | BND-006, REL-003 | `OPEN` |
+| BND-009 | `MISFIT` | `geode_product` combines runtime composition with evaluation and hill-climbing, while `plugins`, `core/self_improving`, Homebrew candidate files, and the unverified computer sandbox preserve duplicate or unsupported ownership surfaces | One documented migration leaves `core` as the GEODE runtime, moves measurement to `evals` and hill-climbing to `evolve`, removes every obsolete package/scaffold without a replacement stub, preserves one-way `evolve -> evals -> core` dependencies and operator behavior, migrates tracked state with byte parity, and proves the final wheel/sdist/install/release contain only the declared roots | R8.5 | BND-006, REL-003 | `READY` |
 
 ## 6. Dependency and merge sequence
 
@@ -2187,20 +2187,22 @@ Commit-pinned primary source references used by the 2026-07-17 audit:
 
 ## 14. Immediate next unit
 
-The operator-directed namespace decision was re-audited against
-`origin/develop@6f665ad951854a4e4e429a9c73f2ea6afa290a77`. It supersedes the
-remaining R8.3 publication claim and the separately staged R8.2/R8.4 path;
-their immutable criteria and decision evidence remain in this ledger.
+R8.5 (`BND-009`) is the sole unclaimed `READY` package after a whole-package
+re-audit against
+`origin/develop@ae585a8e591994d0fb25a1d75a05968209be0524`. Its external
+dependencies, `BND-006` and `REL-003`, are `DONE`. The measured gap remains
+exactly the mixed `geode_product` ownership, duplicate `plugins` and
+`core/self_improving` paths, unsupported Homebrew/sandbox scaffolds, and the
+absence of a committed `core`/`evals`/`evolve` migration record and package
+gate. Readiness authorizes only the registered namespace convergence and
+verified patch release; it does not authorize a compatibility facade, archive,
+new plugin framework, or a second runtime.
 
 The master ledger contains 58 GAPs: 48 `DONE`, six `SUPERSEDED`, three
-`IN_DEVELOP`, and one `OPEN`. There are no active claims and no `READY`,
-`IN_PROGRESS`, `BLOCKED`, `REJECTED`, or unexplained rows.
-
-R8.5 (`BND-009`) is the sole next package. Its external dependencies,
-`BND-006` and `REL-003`, are `DONE`, but this registration does not authorize
-implementation. A separate whole-package readiness PR must move it from
-`OPEN` to `READY`; a later claim PR must name the implementation owner and
-branch before a new worktree is allocated.
+`IN_DEVELOP`, and one `READY`. There are no active claims and no `OPEN`,
+`IN_PROGRESS`, `BLOCKED`, `REJECTED`, or unexplained rows. A separate claim PR
+must name the implementation owner and branch before a new worktree is
+allocated.
 
 R7.2 (`CAP-006`, `VER-002`) and R7.3 (`VER-004`) remain `IN_DEVELOP` until
 the final full-program release audit closes their cross-package evidence.


### PR DESCRIPTION
## Summary

- R8.5 (`BND-009`)를 `OPEN`에서 `READY`로 전이합니다.
- `core` / `evals` / `evolve` 수렴 작업의 현재 GAP과 경계를 최신 `origin/develop`에서 재감사했습니다.
- 구현 권한은 부여하지 않으며, 별도 claim PR 병합 전에는 구현 worktree를 만들지 않습니다.

## Why

등록 PR #3141은 기존 R8.3 대기열을 운영자 결정에 따라 대체하고, 즉시 namespace convergence와 patch release를 하나의 새 패키지로 등록했습니다. 이번 PR은 그 등록이 canonical `develop`에 병합된 뒤 실제 코드와 ledger를 다시 대조해, 작업 범위가 측정 가능하고 선행 의존성이 충족됐는지 확인하는 readiness 거래입니다.

`geode_product`는 런타임 조립, 평가, hill-climbing을 함께 소유하고 있으며 `plugins`, `core/self_improving`, Homebrew 후보, 미검증 computer sandbox가 중복 또는 지원되지 않는 표면을 남깁니다. 선행 GAP `BND-006`과 `REL-003`은 모두 `DONE`이고, 이 문제를 해결하는 다음 package는 R8.5 하나뿐입니다.

## Changes

| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | `BND-009`를 `OPEN` → `READY`로 전이 |
| `docs/architecture/extensibility-roadmap.md` | 최신 base SHA, 실측 GAP, 허용 범위와 금지 범위를 §14에 기록 |

## GAP Audit

| 항목 | 판정 | 근거 |
|---|---|---|
| 선행 의존성 | 충족 | `BND-006`, `REL-003` 모두 `DONE` |
| package 원자성 | 충족 | R8.5는 `BND-009` 단일 GAP |
| 현재 결함 | 실재 | runtime/eval/evolve 소유권 혼합, 중복 facade, dummy 배포 표면, migration/package gate 부재 |
| 다음 순서 | 단독 | 다른 `READY`/`OPEN` package와 active claim 없음 |
| 구현 권한 | 없음 | 별도 claim PR과 canonical merge 이후에만 worktree 할당 |

## Scope Boundaries

- 허용: `core` runtime, `evals` measurement, `evolve` hill-climbing으로 수렴하고 obsolete surface를 제거하는 등록 범위
- 금지: compatibility facade, archive 복제, 새 plugin framework, 두 번째 runtime, claim 전 구현
- 보존: 기존 완료·superseded evidence와 R7.2/R7.3 `IN_DEVELOP` 상태

## Verification

- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — PASS
- `uv run pytest -q tests/scripts/test_check_architecture_roadmap.py` — 40 passed
- `uv run ruff check docs/architecture/extensibility-roadmap.md` — PASS (no Python files)
- `git diff --check origin/develop` — PASS
- pre-commit hooks — PASS

## Non-goals

- 코드, 패키지, state, entry point를 변경하지 않습니다.
- R8.5를 claim하거나 구현 worktree를 미리 만들지 않습니다.
- release version을 이 PR에서 변경하지 않습니다.
