### PR TITLE
release: v1.0.25 — post-migration integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ functional change.
 
 ## [Unreleased]
 
+## [1.0.25] - 2026-08-24
+
+> Post-migration integrity release: packaged guidance, release checks, and
+> generated documentation now agree on the shipped `core` / `evals` / `evolve`
+> boundary, with duplicate and speculative state authorities removed.
+
 ### Fixed
 
 - **Post-migration package guidance now matches the shipped roots.** Bundled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent. The core runtime is an **AgenticLoop** (`while tool_use`) — sub-agents, plans, and batches are all instances of the same loop. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 1.0.24
+- **Version**: 1.0.25
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Points**: `geode` (`core.cli:app`, Typer) / `geode-mcp` (`core.mcp_server:main`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -30,7 +30,7 @@
   <a href="README.md">English</a>
 </p>
 
-# GEODE v1.0.24 — Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.25 — Autonomous Agent Runtime + Evaluation Substrate
 
 자율적인 도구 작업을 수행하는 범용 에이전트 런타임입니다. 자연어로
 요청하면 GEODE가 계획을 세우고 도구를 호출한 뒤 결과를 보고합니다. 짧은

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.24: Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.25: Autonomous Agent Runtime + Evaluation Substrate
 
 A general-purpose runtime for autonomous tool work. You ask in plain language;
 GEODE plans, calls tools, and reports, for one prompt or a long-running session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "1.0.24"
+version = "1.0.25"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.24. Last sync 2026-08-24. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
+Version v1.0.25. Last sync 2026-08-24. Full content of every docs page, one file (llms-full.txt convention). Per-page index: /llms.txt.
 
 ## Overview . 개요
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > GEODE is an autonomous agent runtime and evaluation substrate: an inner agentic loop runs tasks (research, analysis, automation, scheduling), while an experimental safety-gated outer loop mutates and evaluates scaffold candidates.
 
-Version v1.0.24. Last sync 2026-08-24. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
+Version v1.0.25. Last sync 2026-08-24. Docs links point to clean markdown twins (.md); drop the .md suffix for the rendered page.
 
 ## Start here
 

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Fixed\n\n- **Post-migration package guidance now matches the shipped roots.** Bundled\n  runtime skills and release scaffolds describe `core`, `evals`, and `evolve`;\n  package gates require those skill contracts, the self-improving hub reuses\n  the ledger's TSV schema, an unused deferred epoch-archive stub is removed,\n  and explicit retirement assertions no longer create slop-audit false\n  positives."
+    "body": ""
+  },
+  {
+    "version": "1.0.25",
+    "date": "2026-08-24",
+    "body": "> Post-migration integrity release: packaged guidance, release checks, and\n> generated documentation now agree on the shipped `core` / `evals` / `evolve`\n> boundary, with duplicate and speculative state authorities removed.\n\n### Fixed\n\n- **Post-migration package guidance now matches the shipped roots.** Bundled\n  runtime skills and release scaffolds describe `core`, `evals`, and `evolve`;\n  package gates require those skill contracts, the self-improving hub reuses\n  the ledger's TSV schema, an unused deferred epoch-archive stub is removed,\n  and explicit retirement assertions no longer create slop-audit false\n  positives."
   },
   {
     "version": "1.0.24",

--- a/site/src/data/geode/sot.ts
+++ b/site/src/data/geode/sot.ts
@@ -8,6 +8,6 @@
  */
 
 export const GEODE_SOT = {
-  version: "1.0.24",
+  version: "1.0.25",
   syncedAt: "2026-08-24",
 } as const;

--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,7 @@ http = [
 
 [[package]]
 name = "geode-agent"
-version = "1.0.24"
+version = "1.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

[#3158](https://github.com/mangowhoiscloud/geode/pull/3158)에서 닫은 post-BND-009 잔여를 정식 패치 릴리스 **v1.0.25**로 승격합니다.

이번 PR은 새 런타임 기능을 추가하지 않습니다. 현재 `develop@257cc4132`의 미배포 수정 한 건을 버전·lockfile·CHANGELOG·README·개발 scaffold·공개 사이트 SOT·LLM 인덱스에 동일하게 고정하는 **release-stamp 전용 거래**입니다.

## Why

v1.0.24는 `core` / `evals` / `evolve` 경계 마이그레이션을 공개했지만, 병합 뒤 실측에서 다음 잔여가 확인됐습니다.

- 배포되는 architecture skill과 release 예제가 제거된 namespace를 현재형으로 설명함
- wheel/sdist/격리 설치 gate가 두 bundled skill 누락을 검출하지 못함
- self-improving hub가 ledger의 12열 TSV schema를 복제함
- 실행 소비자가 없는 epoch archive convention/TODO가 남아 있음

#3158은 새 framework 없이 이 네 항목을 최소 수정으로 닫았고, 전체 CI 및 독립 리뷰를 통과했습니다. v1.0.25는 그 결과를 공식 패키지와 문서 채널에 배포합니다.

## Release surfaces

| File | Change | Contract |
|---|---|---|
| `pyproject.toml` | `1.0.24 → 1.0.25` | Python package version authority |
| `uv.lock` | root package version 동기화 | stale lockfile 차단 |
| `README.md`, `README.ko.md` | 공개 헤더 `v1.0.25` | 설치 표면 parity |
| `CLAUDE.md` | scaffold version `1.0.25` | 개발 SOT parity |
| `CHANGELOG.md` | 빈 `[Unreleased]` + `[1.0.25] - 2026-08-24` | #3158만 릴리스 범위로 승격 |
| `site/src/data/geode/sot.ts` | generator가 `1.0.25` 기록 | 공개 사이트 SOT |
| `site/src/data/geode/changelog.ts` | CHANGELOG projection 재생성 | 공개 변경 이력 parity |
| `site/public/llms.txt`, `llms-full.txt` | 헤더 `v1.0.25` 재생성 | 기계 소비 문서 parity |

최종 diff는 정확히 **10 files, 20 insertions, 9 deletions**입니다.

## Included change

### #3158 — post-migration package integrity

- 번들 `geode-context` / `slop-audit` skill이 실제 `core` / `evals` / `evolve` 경계를 설명
- wheel/sdist/installed-package gate가 네 핵심 bundled skill을 실제 load
- hub TSV header가 `evolve.scaffold_search.ledger.RESULTS_TSV_HEADER`를 단일 authority로 사용
- 소비자 없는 `_archive` README/TODO 삭제
- retirement assertions는 줄 단위 `# slop:keep`만 사용해 미래 stale 참조 감시를 보존
- canonical roadmap은 상태 전이 없이 generated metrics만 갱신

## Compatibility and risk

- **Runtime/API/CLI**: #3158 외 동작 변경 없음
- **Package roots**: `core`, `evals`, `evolve` 유지; retired alias 재도입 없음
- **State/schema**: 사용자 데이터·DB migration 없음
- **Dependencies**: 새 Python/Node dependency 없음; `uv.lock`은 root version만 변경
- **Rollback**: 공개 전 PR revert 가능. 공개 후에는 tag를 이동하거나 artifact를 덮어쓰지 않고 후속 patch만 허용
- **External mutation**: 이 PR 자체는 없음. tag/GitHub Release/PyPI는 main 승격 뒤 `release.yml`만 수행

## Verification

### Version and generated surfaces

- [x] `uv lock --check`
- [x] `uv run geode version` → `GEODE v1.0.25`
- [x] `scripts/check_llms_version.py` → llms headers + `sot.ts` clean at v1.0.25
- [x] exact release-targeted suite → **30 passed**
- [x] `scripts/preflight.sh` → **all gates passed**

### Official docs

- [x] `scripts/check_official_docs.py`
  - architecture baseline + eval catalog clean
  - 697 link occurrences / broken internal link 0
  - 239 static routes built
  - 75 markdown twins + `llms-full.txt` reproduced with zero diff
- [x] `npm audit --audit-level=moderate` in `site/` → **0 vulnerabilities**

### Packaging and installed behavior

- [x] `uv build --clear` + `twine check dist/*`
- [x] artifact gate → wheel **658 files**, sdist **660 files**
- [x] clean wheel install → `GEODE v1.0.25`, `installed package OK`
- [x] installed daemon IPC smoke → `1.0.25`
- [x] kernel projection → **412 modules**, installed kernel package OK
- [x] wheel-only kernel tests → **59 passed**

### Review and anti-deception

- [x] committed 10-surface diff independent review → **SHIP; P0/P1/P2 none**
- [x] working tree clean; generated files byte-identical after regeneration
- [x] no test deletion, skip/xfail, lint/type/security/config weakening
- [x] GitHub Release, Git tag, PyPI `1.0.25` all absent before PR
- [ ] live/paid provider tests — not run; release contains no provider behavior change

## Publication sequence

1. CI-green squash merge to `develop`
2. required GitFlow ancestry check and `main → develop` sync if main has unique content
3. CI-green `develop → main` merge
4. manual `release.yml` dispatch for `version=1.0.25`
5. annotated tag, GitHub Release, PyPI wheel/sdist digest parity, exact-version `uvx` verification
6. final `main → develop` ancestry sync if required

공개 성공은 5단계의 workflow·digest·uvx 검증 전에는 주장하지 않습니다.
