### PR TITLE
docs(architecture): register immutable distribution lifecycle gaps

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -568,6 +568,10 @@ and closure evidence are appended in §10.
 | BND-008 | `ABSENT` | The current `core/self_improving` import and source/module launcher surface has no enumerated consumer census, old-to-new migration map, or removal-only closure gate | After REL-004, every repository and documented consumer is classified, migration guidance names canonical replacements, only the forwarding facade and legacy launchers are removed, and installed-wheel import/CLI/MCP/config/state parity proves the canonical product remains intact | R8.4 | REL-004, STORE-003 | `SUPERSEDED` |
 | CODE-002 | `MISFIT` | Verification state is restored from checkpoint `loop_guards`, but `_persist_verify_state` still mirrors every result into `SessionManager` columns whose accessor has no production reader | Production verify-mirror writes and the unused accessor are removed; legacy databases containing the columns still load, checkpoint recovery remains authoritative, and no new store or schema migration is introduced | R9.2 | CODE-001 | `DONE` |
 | BND-009 | `MISFIT` | `geode_product` combines runtime composition with evaluation and hill-climbing, while `plugins`, `core/self_improving`, Homebrew candidate files, and the unverified computer sandbox preserve duplicate or unsupported ownership surfaces | One documented migration leaves `core` as the GEODE runtime, moves measurement to `evals` and hill-climbing to `evolve`, removes every obsolete package/scaffold without a replacement stub, preserves one-way `evolve -> evals -> core` dependencies and operator behavior, migrates tracked state with byte parity, and proves the final wheel/sdist/install/release contain only the declared roots | R8.5 | BND-006, REL-003 | `DONE` |
+| DIST-001 | `MISFIT` | A clean `geode-agent` wheel resolves the default scaffold-search SoT to `site-packages/evolve/scaffold_search/state`, where mutation, result, epoch, and policy writers append or replace files and then attempt Git commits from a non-repository install root | Installed distributions are immutable: read-only packaged snapshots remain readable, every mutation/promotion writer requires an explicit writable GEODE Git workspace before its first side effect, worker overrides remain isolated, upgrades cannot erase run history, and an installed-wheel poison test proves no distribution file or `RECORD` digest changes | R10.1 | BND-009 | `OPEN` |
+| DIST-002 | `MISFIT` | The packaged macOS helper build script defaults its generated app bundle to `<distribution>/.geode/ComputerUseHelper`, which may be read-only and is replaced by package upgrades | Packaged helper sources are read-only inputs, generated helper bytes live under one existing operator-owned GEODE home resolver, source and wheel installs share that resolver, and setup/status tests prove the distribution tree stays unchanged | R10.1 | BND-009 | `OPEN` |
+| DIST-003 | `PARTIAL` | The wheel force-includes every `.geode/skills` directory even when a skill references repository-only scripts/docs or a personal absolute workspace, while installed smoke proves only that selected skill bodies load | One exact self-contained builtin-skill allowlist is packaged; repository and personal skills remain in their existing external tiers; every bundled local command/asset reference resolves in a clean wheel; and installed smoke rejects repo-only, personal-path, or dangling bundled skills | R10.1 | BND-003, BND-004 | `OPEN` |
+| DIST-004 | `MISFIT` | `geode update` replaces the live uv-tool environment and verifies the new CLI before stopping the old daemon, allowing a running process to observe a mixed old-process/new-files installation | A running daemon is drained and stopped before live tool replacement, failed updates remain fail-closed without starting a second daemon, successful restart proves CLI/IPC daemon version parity, and ordering tests cover running, stopped, failed-stop, failed-install, and no-restart paths | R10.1 | BND-003, REL-003 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -1876,6 +1880,39 @@ Acceptance:
 - focused verification/recovery tests and architecture gates pass without a
   new store, schema migration, event, hook, or runtime abstraction.
 
+### R10 — Installed distribution lifecycle
+
+#### R10.1 Immutable package, explicit workspace, and safe update
+
+GAPs: DIST-001, DIST-002, DIST-003, DIST-004.
+
+Keep one public `geode-agent` wheel containing `core`, `evals`, and `evolve`.
+The wheel owns immutable Python code and self-contained static runtime assets;
+it does not own a writable Git workspace, rolling experiment state, generated
+native helpers, repository development skills, or personal workflows.
+
+Acceptance:
+
+- scaffold mutation, promotion, and tracked-ledger writes require an explicit
+  writable GEODE Git workspace and fail before any side effect when launched
+  from only an installed distribution; read-only packaged reference data and
+  existing `GEODE_STATE_ROOT` worker isolation remain compatible;
+- the macOS helper build reads packaged source but writes the app bundle only
+  below the existing operator-owned GEODE home, with source/wheel path parity
+  and no package-root fallback;
+- the wheel contains an exact allowlist of self-contained builtin skills;
+  repository-only skills remain under repository scope and personal skills
+  under user scope, while clean-install validation resolves every bundled
+  local command and asset reference;
+- an updater with a running daemon drains and stops it before replacing the
+  uv-tool environment, then restarts through the installed entry point and
+  proves CLI/IPC daemon version parity; stop or install failure never starts a
+  second daemon;
+- wheel/sdist content gates, clean full/kernel installs, installed unit tests,
+  daemon smoke, updater ordering tests, and a distribution-tree digest poison
+  test pass without publishing a second wheel or adding a workspace manager,
+  package registry, plugin SDK, or compatibility stub.
+
 ## 8. Change-surface acceptance scenarios
 
 These black-box scenarios define extensibility more usefully than class count.
@@ -2222,3 +2259,9 @@ The architecture and extensibility completion program has no remaining
 executable unit. Future architecture work must begin with a new GAP and closure
 package through the serialized registration protocol in §0.3; it must not
 reopen or rewrite this evidence.
+
+A 2026-08-25 G-of-4 distribution audit against
+`origin/develop@50be9bce9043b549cbe95e8320f4496223509a71` registered R10.1 as
+the next execution unit without rewriting the prior closure. DIST-001 through
+DIST-004 are `OPEN`, there is no active claim, and implementation remains
+forbidden until separate readiness and claim transactions merge.


### PR DESCRIPTION
## Summary

- G-of-4 및 frontier harness 비교에서 확인된 설치 artifact 수명주기 결함을 네 개의 안정 GAP으로 등록합니다.
- `R10.1`을 하나의 원자적 work package로 추가하되 모든 GAP은 `OPEN`으로 시작하며, readiness/claim/implementation을 이 PR에 섞지 않습니다.
- 기존 `core + evals + evolve` 단일 wheel은 유지하고, package 분할이나 새 workspace manager 없이 불변 package / 외부 state·workspace 경계를 닫는 acceptance를 고정합니다.

## Why

Python wheel 자체는 GEODE에 적합하지만, 현재 설치 경로는 다음 네 지점에서 installed distribution을 가변 작업공간처럼 취급하거나 그 불변성을 충분히 검증하지 못합니다.

1. `evolve/scaffold_search/state`의 rolling ledger·policy writer가 clean wheel에서 `site-packages`를 기본 SoT로 해석하고 Git commit까지 시도합니다.
2. macOS computer-use helper가 package root 아래에 생성물을 빌드합니다.
3. 전체 `.geode/skills` wildcard가 repository-only command/docs와 개인 workspace를 전제하는 skill까지 builtin으로 배포합니다.
4. `geode update`가 기존 daemon을 중지하기 전에 live uv-tool environment를 교체합니다.

Codex CLI/Cloud, OpenClaw, autoresearch와 PyPA wheel 계약은 모두 동일한 경계를 가리킵니다: 설치물은 immutable code/static assets이고, mutable state·Git workspace·generated binaries는 operator-owned root에 있어야 합니다.

## GAP Audit

| GAP | Audit | Current evidence | Measurable exit |
|---|---|---|---|
| DIST-001 | MISFIT | installed `site-packages/evolve/.../state`에 append/replace 후 non-repo Git commit 시도 | mutation writer가 명시적 writable GEODE Git workspace를 요구하고 package/RECORD digest가 불변 |
| DIST-002 | MISFIT | helper 기본 출력이 `<distribution>/.geode/ComputerUseHelper` | packaged source는 read-only, 생성물은 기존 GEODE home resolver 아래 한 위치 |
| DIST-003 | PARTIAL | wildcard builtin skill과 `--help`/body-load 중심 smoke | exact self-contained allowlist 및 clean-wheel local reference resolution |
| DIST-004 | MISFIT | live uv-tool replacement 후 old daemon stop | stop/drain → install → restart → CLI/IPC version parity의 실행 순서 |

## Changes

| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | `DIST-001`~`DIST-004` OPEN rows, 새 `R10.1` package/acceptance, prior closure를 보존하는 §14 registration note 추가 |

## Invariants

- 기존 GAP/evidence row는 수정·재정렬하지 않았습니다.
- 새 GAP 네 개는 모두 하나의 새 package `R10.1`에만 선택됩니다.
- 모든 외부 dependency는 canonical ledger에서 `DONE`입니다.
- active claim, readiness, implementation, CHANGELOG, runtime code 변경은 없습니다.
- 단일 public wheel, existing state overrides, existing skill tiers를 보존합니다.

## Non-goals

- `core`, `evals`, `evolve`를 별도 PyPI distribution으로 분할하지 않습니다.
- 현재 kernel projection을 public slim wheel로 승격하지 않습니다.
- 새 plugin SDK, workspace manager, package registry, compatibility stub을 만들지 않습니다.
- 이 registration PR은 구현을 승인하지 않습니다.

## Verification

- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — PASS
- `git diff --check origin/develop...HEAD` — PASS
- pre-commit hooks — PASS
- Codex MCP read-only independent review of commit `522dd13fb1556de874399c093721d15d60fdae4b` — SHIP
- exact base before push: `origin/develop@50be9bce9043b549cbe95e8320f4496223509a71` (`0 behind / 1 ahead`)
