### PR TITLE
feat(eval): promote versioned learning views to main

### DIFF
--- a/.agents/skills/geode-eval/SKILL.md
+++ b/.agents/skills/geode-eval/SKILL.md
@@ -9,6 +9,28 @@ Preserve the question, evidence, and judgement as separate authorities. Reuse
 the existing native result, trajectory, verifier receipt, and release formats;
 do not create a second copy of raw evidence.
 
+## Preserve v1 and derive learning views
+
+Read the packaged schemas before proposing new storage. `geode.trajectory@1`
+is an immutable normalized view over existing execution evidence; it already
+carries event, session, turn, and call identity, recomputed scope and replay
+integrity, and digest references to external evidence.
+
+Do not create a unified raw-log store or retrofit new fields into v1. When a
+downstream episode, attempt, or decision join needs identity or replay
+preconditions that v1 cannot express, add a new schema version with an
+explicit migration and admission rule.
+
+The v1 `outcome` object is permissive, so preserve any reward or outcome
+summary already present in an immutable artifact without treating it as label
+authority. For new learning views, keep reward, preference, process, and
+verifier labels out of the raw trajectory. Store them as digest-bound derived
+label or analysis artifacts with target identity, evaluator identity and
+revision, scope, provenance, and write authority. Call the result a
+post-training candidate, not a training dataset, until policy and environment
+identity, join closure, transition and replay semantics, privacy,
+deduplication, lineage-safe splits, and label quality pass.
+
 ## Start With The Catalog
 
 1. Read `docs/eval/index.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ owns only the package version and sync date.
 The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
-The current snapshot records 559 production Python files,
-691 test Python files,
+The current snapshot records 560 production Python files,
+693 test Python files,
 86 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Evaluation learning-view contract v2.** GEODE now validates digest-bound
+  `example → rollout → trajectory → reward` datasets while preserving native
+  receipts and the immutable `geode.trajectory@1` schema.
+- **Harbor terminal benchmark adapter.** The current GEODE AgenticLoop can run
+  as a Harbor external agent while preserving native verifier output and a
+  normalized GEODE trajectory sidecar.
+- **Native evaluation projector.** Harbor and tau2 result bundles can be
+  projected into the validated v2 learning view without rewriting native
+  receipts or collapsing infrastructure-invalid retries into reward rows.
+
 ## [1.0.26] - 2026-08-25
 
 > Immutable distribution release: installed package bytes remain read-only,

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -281,12 +281,12 @@ machine-readable artifact is
 
 | Measure | Current tree |
 |---|---:|
-| Production Python files (`core/` + `evals/` + `evolve/`) | 559 |
-| Test Python files | 691 |
+| Production Python files (`core/` + `evals/` + `evolve/`) | 560 |
+| Test Python files | 693 |
 | `core/` Python LOC | 123,591 |
-| `evals/` Python LOC | 27,297 |
+| `evals/` Python LOC | 27,526 |
 | `evolve/` Python LOC | 31,923 |
-| Test Python LOC | 186,741 |
+| Test Python LOC | 186,946 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 5 |

--- a/docs/eval/data-model.md
+++ b/docs/eval/data-model.md
@@ -1,0 +1,51 @@
+---
+eval_id: eval-data-model
+eval_family: eval-data-model
+eval_kind: contract
+eval_status: canonical
+eval_authority: derived-view-contract
+eval_summary: Versioned joins for examples, rollouts, immutable trajectories, and evaluator-owned rewards.
+eval_triggers:
+  - example rollout trajectory reward
+  - learning data
+  - evaluation data model
+eval_contracts:
+  - docs/eval/schemas/example.schema.json
+  - docs/eval/schemas/rollout.schema.json
+  - docs/eval/schemas/reward.schema.json
+  - docs/eval/schemas/learning-view-manifest.schema.json
+  - core/observability/schemas/trajectory.schema.json
+---
+
+# Evaluation data model
+
+The canonical join is `example → rollout → trajectory → reward`.
+
+- An **example** is a versioned benchmark input. Native task IDs remain source
+  identity; `example_id` is the cross-suite join key.
+- A **rollout** is one policy interacting with one example under one seed.
+  Infrastructure retries are rollout attempts and never increase rollout count.
+- A **trajectory** remains `geode.trajectory@1`. A rollout selects its own
+  session scope by digest and session IDs instead of copying or editing that
+  immutable record.
+- A **reward** is an evaluator-owned derived label. A zero is observed data;
+  `null` means missing. Validity and safety vetoes remain rollout properties and
+  cannot be averaged into reward.
+
+`geode.eval-learning-view@2` versions the joined release, not the native
+benchmark receipt. Native results, retry manifests, verifier receipts, and
+session records remain their respective authorities.
+
+## Admission rules
+
+1. Every rollout references one existing example and a digest-matching native
+   receipt and trajectory.
+2. `selected_attempt_id` must be one of the rollout's attempt IDs.
+3. Invalid or aborted rollouts cannot be selected for reward.
+4. Every reward references one valid, selected rollout and the same example.
+5. Reward locators must resolve in the digest-bound native receipt. Missing
+   labels remain explicit and are never rewritten as zero.
+
+The v2 view is a post-training candidate only. Training admission additionally
+requires privacy review, deduplication, lineage-safe splits, replay semantics,
+and label-quality checks.

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -11,7 +11,7 @@
     "trajectory": "core/observability/schemas/trajectory.schema.json",
     "trajectory_release": "core/observability/schemas/trajectory-release.schema.json"
   },
-  "document_count": 18,
+  "document_count": 19,
   "documents": [
     {
       "id": "agent-world-comparison",
@@ -83,6 +83,29 @@
         "docs/eval/schemas/analysis.schema.json",
         "docs/eval/schemas/attempt.schema.json",
         "docs/eval/schemas/run-spec.schema.json"
+      ]
+    },
+    {
+      "id": "eval-data-model",
+      "family": "eval-data-model",
+      "title": "Evaluation data model",
+      "kind": "contract",
+      "status": "canonical",
+      "authority": "derived-view-contract",
+      "path": "docs/eval/data-model.md",
+      "summary": "Versioned joins for examples, rollouts, immutable trajectories, and evaluator-owned rewards.",
+      "sha256": "03907ade36cd4420139226039a2adcfb935cd351a8b6849882be684e2edc462d",
+      "triggers": [
+        "evaluation data model",
+        "example rollout trajectory reward",
+        "learning data"
+      ],
+      "contracts": [
+        "core/observability/schemas/trajectory.schema.json",
+        "docs/eval/schemas/example.schema.json",
+        "docs/eval/schemas/learning-view-manifest.schema.json",
+        "docs/eval/schemas/reward.schema.json",
+        "docs/eval/schemas/rollout.schema.json"
       ]
     },
     {

--- a/docs/eval/schemas/example.schema.json
+++ b/docs/eval/schemas/example.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mangowhoiscloud/geode/main/docs/eval/schemas/example.schema.json",
+  "title": "GEODE evaluation example v1",
+  "type": "object",
+  "required": ["schema_id", "schema_version", "example_id", "suite", "dataset", "source_task_id", "stratum_id", "input_sha256"],
+  "properties": {
+    "schema_id": {"const": "geode.eval-example@1"},
+    "schema_version": {"const": 1},
+    "example_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "suite": {"type": "string", "minLength": 1, "maxLength": 128},
+    "dataset": {
+      "type": "object",
+      "required": ["name", "revision"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 256},
+        "revision": {"type": "string", "minLength": 1, "maxLength": 256}
+      },
+      "additionalProperties": false
+    },
+    "source_task_id": {"type": "string", "minLength": 1, "maxLength": 256},
+    "stratum_id": {"type": ["string", "null"], "maxLength": 128},
+    "input_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+  },
+  "additionalProperties": false
+}

--- a/docs/eval/schemas/learning-view-manifest.schema.json
+++ b/docs/eval/schemas/learning-view-manifest.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mangowhoiscloud/geode/main/docs/eval/schemas/learning-view-manifest.schema.json",
+  "title": "GEODE evaluation learning view manifest v2",
+  "type": "object",
+  "required": ["schema_id", "schema_version", "run_id", "created_at", "record_order", "files"],
+  "properties": {
+    "schema_id": {"const": "geode.eval-learning-view@2"},
+    "schema_version": {"const": 2},
+    "run_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "record_order": {"const": ["example", "rollout", "trajectory", "reward"]},
+    "files": {
+      "type": "object",
+      "required": ["examples", "rollouts", "rewards"],
+      "properties": {
+        "examples": {"$ref": "#/$defs/jsonlFile"},
+        "rollouts": {"$ref": "#/$defs/jsonlFile"},
+        "rewards": {"$ref": "#/$defs/jsonlFile"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "jsonlFile": {
+      "type": "object",
+      "required": ["path", "sha256", "rows", "record_schema"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 512},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "rows": {"type": "integer", "minimum": 0},
+        "record_schema": {"type": "string", "minLength": 1, "maxLength": 128}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/eval/schemas/reward.schema.json
+++ b/docs/eval/schemas/reward.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mangowhoiscloud/geode/main/docs/eval/schemas/reward.schema.json",
+  "title": "GEODE evaluation reward v1",
+  "type": "object",
+  "required": ["schema_id", "schema_version", "reward_id", "rollout_id", "example_id", "evaluator", "measurement_status", "value", "components", "source", "created_at"],
+  "properties": {
+    "schema_id": {"const": "geode.eval-reward@1"},
+    "schema_version": {"const": 1},
+    "reward_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "rollout_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "example_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "evaluator": {
+      "type": "object",
+      "required": ["name", "revision", "authority"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 128},
+        "revision": {"type": "string", "minLength": 1, "maxLength": 256},
+        "authority": {"enum": ["suite-native", "deterministic", "llm-judge", "human"]}
+      },
+      "additionalProperties": false
+    },
+    "measurement_status": {"enum": ["measured", "missing"]},
+    "value": {"type": ["number", "null"]},
+    "components": {"type": "object", "additionalProperties": {"type": ["number", "boolean", "null"]}},
+    "source": {
+      "type": "object",
+      "required": ["path", "sha256", "source_locator"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 512},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "source_locator": {"type": "string", "pattern": "^/"}
+      },
+      "additionalProperties": false
+    },
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"measurement_status": {"const": "measured"}}},
+      "then": {"properties": {"value": {"type": "number"}}}
+    },
+    {
+      "if": {"properties": {"measurement_status": {"const": "missing"}}},
+      "then": {"properties": {"value": {"type": "null"}}}
+    }
+  ],
+  "additionalProperties": false
+}

--- a/docs/eval/schemas/rollout.schema.json
+++ b/docs/eval/schemas/rollout.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mangowhoiscloud/geode/main/docs/eval/schemas/rollout.schema.json",
+  "title": "GEODE evaluation rollout v1",
+  "type": "object",
+  "required": ["schema_id", "schema_version", "run_id", "rollout_id", "example_id", "rollout_index", "seed", "policy", "rollout_attempt_ids", "selected_attempt_id", "trajectory", "native_result", "timing", "validity", "termination_reason", "selected_for_reward"],
+  "properties": {
+    "schema_id": {"const": "geode.eval-rollout@1"},
+    "schema_version": {"const": 1},
+    "run_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"},
+    "rollout_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "example_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,255}$"},
+    "rollout_index": {"type": "integer", "minimum": 0},
+    "seed": {"type": ["integer", "string"]},
+    "policy": {
+      "type": "object",
+      "required": ["model", "provider", "source", "effort", "geode_revision"],
+      "properties": {
+        "model": {"type": "string", "minLength": 1, "maxLength": 128},
+        "provider": {"type": "string", "minLength": 1, "maxLength": 80},
+        "source": {"type": "string", "minLength": 1, "maxLength": 80},
+        "effort": {"type": "string", "minLength": 1, "maxLength": 80},
+        "geode_revision": {"type": "string", "pattern": "^[a-f0-9]{40}$"}
+      },
+      "additionalProperties": false
+    },
+    "rollout_attempt_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 256}
+    },
+    "selected_attempt_id": {"type": ["string", "null"], "maxLength": 256},
+    "trajectory": {"$ref": "#/$defs/artifactReference"},
+    "native_result": {"$ref": "#/$defs/artifactReferenceWithLocator"},
+    "timing": {
+      "type": "object",
+      "required": ["started_at", "finished_at", "wall_seconds"],
+      "properties": {
+        "started_at": {"type": ["string", "null"], "format": "date-time"},
+        "finished_at": {"type": ["string", "null"], "format": "date-time"},
+        "wall_seconds": {"type": ["number", "null"], "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "validity": {"enum": ["valid", "invalid", "aborted"]},
+    "termination_reason": {"type": "string", "minLength": 1, "maxLength": 160},
+    "selected_for_reward": {"type": "boolean"}
+  },
+  "$defs": {
+    "artifactReference": {
+      "type": "object",
+      "required": ["path", "sha256", "trajectory_id", "session_ids"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 512},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "trajectory_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "session_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      },
+      "additionalProperties": false
+    },
+    "artifactReferenceWithLocator": {
+      "type": "object",
+      "required": ["path", "sha256", "source_locator"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 512},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "source_locator": {"type": "string", "pattern": "^/"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"validity": {"const": "valid"}}},
+      "then": {"properties": {"selected_attempt_id": {"type": "string", "minLength": 1}}}
+    },
+    {
+      "if": {"properties": {"validity": {"enum": ["invalid", "aborted"]}}},
+      "then": {"properties": {"selected_for_reward": {"const": false}}}
+    }
+  ],
+  "additionalProperties": false
+}

--- a/evals/benchmarks/harbor_geode_agent.py
+++ b/evals/benchmarks/harbor_geode_agent.py
@@ -1,0 +1,229 @@
+"""Harbor external-agent adapter for GEODE terminal benchmarks."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.metadata
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+
+    class HarborBaseAgent:
+        logs_dir: Path
+        model_name: str | None
+
+        def __init__(
+            self,
+            logs_dir: Path,
+            model_name: str | None = None,
+            **kwargs: Any,
+        ) -> None: ...
+
+else:
+    try:
+        HarborBaseAgent = importlib.import_module("harbor.agents.base").BaseAgent
+    except ImportError:  # Harbor is an opt-in benchmark dependency.
+        HarborBaseAgent = object
+
+
+@dataclass
+class HarborExecTool:
+    environment: Any
+
+    @property
+    def name(self) -> str:
+        return "terminal_exec"
+
+    @property
+    def description(self) -> str:
+        return "Run one shell command in the isolated benchmark environment."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["command"],
+            "properties": {
+                "command": {"type": "string", "minLength": 1},
+                "cwd": {"type": ["string", "null"]},
+                "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 600,
+                    "default": 120,
+                },
+            },
+            "additionalProperties": False,
+        }
+
+    async def aexecute(self, **kwargs: Any) -> dict[str, Any]:
+        kwargs.pop("_tool_context", None)
+        command = str(kwargs.pop("command"))
+        cwd_raw = kwargs.pop("cwd", None)
+        cwd = str(cwd_raw) if cwd_raw is not None else None
+        timeout_seconds = int(kwargs.pop("timeout_seconds", 120))
+        result = await self.environment.exec(
+            command=command,
+            cwd=cwd,
+            timeout_sec=timeout_seconds,
+        )
+        return {
+            "result": result.stdout or "",
+            "stderr": result.stderr or "",
+            "return_code": result.return_code,
+        }
+
+
+def _usage(result: Any) -> dict[str, int | float]:
+    usage = getattr(result, "usage", None)
+    to_dict = getattr(usage, "to_dict", None)
+    raw = to_dict() if callable(to_dict) else {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _build_loop(
+    environment: Any,
+    *,
+    model: str,
+    provider: str,
+    source: str,
+    effort: str,
+    timeout: float,
+) -> Any:
+    from core.agent.conversation import ConversationContext
+    from core.agent.loop import AgenticLoop, AgenticLoopConfig
+    from core.agent.tool_executor import ToolExecutor
+    from core.llm.adapters.registry import bootstrap_builtins
+    from core.tools.registry import ToolRegistry
+    from core.wiring.runtime import build_policy_sources
+
+    from evals.run_timeline import current_run_timeline as current_activity_sink
+
+    policy_sources = build_policy_sources()
+    bootstrap_builtins(policy_sources=policy_sources)
+    tool = HarborExecTool(environment)
+    registry = ToolRegistry()
+    registry.register(tool)
+    executor = ToolExecutor(
+        action_handlers={tool.name: tool.aexecute},
+        auto_approve=True,
+        hitl_level=0,
+        tool_input_schemas={tool.name: tool.parameters},
+    )
+    return AgenticLoop(
+        ConversationContext(max_turns=200),
+        executor,
+        config=AgenticLoopConfig(
+            source=source,
+            effort=effort,
+            max_tokens=32768,
+            max_rounds=0,
+            time_budget_s=timeout,
+            allowed_tool_names={tool.name},
+            force_include_allowed_tools=True,
+            system_prompt_override=(
+                "Agent: GEODE inside a Harbor terminal benchmark. Complete the task in the "
+                "isolated environment using terminal_exec. Inspect before editing, use command "
+                "results as evidence, and stop after the requested state is verified."
+            ),
+        ),
+        model=model,
+        provider=provider,
+        tool_registry=registry,
+        quiet=True,
+        activity_sink_provider=current_activity_sink,
+        policy_sources=policy_sources,
+    )
+
+
+class GeodeHarborAgent(HarborBaseAgent):
+    """Run the current GEODE AgenticLoop against Harbor's external environment."""
+
+    @staticmethod
+    def name() -> str:
+        return "geode"
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        model_name: str | None = None,
+        *,
+        provider: str = "openai",
+        source: str = "subscription",
+        effort: str = "max",
+        agent_timeout_sec: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(logs_dir=logs_dir, model_name=model_name, **kwargs)
+        self.provider = provider
+        self.source = source
+        self.effort = effort
+        self.agent_timeout_sec = float(agent_timeout_sec or 1200)
+
+    def version(self) -> str:
+        return importlib.metadata.version("geode-agent")
+
+    async def setup(self, environment: Any) -> None:
+        return None
+
+    async def run(self, instruction: str, environment: Any, context: Any) -> None:
+        from core.observability.trajectory import export_trajectory, trajectory_from_sessions
+
+        model = (self.model_name or "gpt-5.6-terra").removeprefix("geode/")
+        loop = _build_loop(
+            environment,
+            model=model,
+            provider=self.provider,
+            source=self.source,
+            effort=self.effort,
+            timeout=self.agent_timeout_sec,
+        )
+        previous = os.environ.get("GEODE_CODEX_OAUTH_FAIL_EMPTY_TEXT")
+        os.environ["GEODE_CODEX_OAUTH_FAIL_EMPTY_TEXT"] = "1"
+        try:
+            result = await loop.arun(instruction)
+            if getattr(result, "error", None):
+                await loop.amark_session_error()
+            else:
+                await loop.amark_session_completed()
+        except BaseException:
+            await loop.amark_session_error()
+            raise
+        finally:
+            if previous is None:
+                os.environ.pop("GEODE_CODEX_OAUTH_FAIL_EMPTY_TEXT", None)
+            else:
+                os.environ["GEODE_CODEX_OAUTH_FAIL_EMPTY_TEXT"] = previous
+
+        usage = _usage(result)
+        context.n_input_tokens = int(usage.get("input_tokens") or 0)
+        context.n_cache_tokens = int(usage.get("cache_read_input_tokens") or 0)
+        context.n_output_tokens = int(usage.get("output_tokens") or 0)
+        context.cost_usd = float(usage.get("cost_usd") or 0.0)
+        context.metadata = {
+            "geode_session_id": loop._session_id,
+            "termination_reason": str(getattr(result, "termination_reason", "unknown")),
+            "rounds": int(getattr(result, "rounds", 0) or 0),
+        }
+        trajectory = trajectory_from_sessions(
+            [loop._session_id],
+            trajectory_id=f"harbor-{loop._session_id}",
+            source={
+                "harness": "harbor",
+                "session": loop._session_id,
+                "task": hashlib.sha256(instruction.encode()).hexdigest(),
+            },
+            outcome=context.metadata,
+            provenance={"adapter": "evals.benchmarks.harbor_geode_agent"},
+            privacy={"review_state": "local", "native_results_embedded": False},
+            trajectory_class=("benchmark", "terminal", "tool", "lifecycle"),
+            content_policy="digest",
+        )
+        export_trajectory(self.logs_dir / "geode-trajectory.json", trajectory)
+
+
+__all__ = ["GeodeHarborAgent", "HarborExecTool"]

--- a/scripts/eval/learning_view.py
+++ b/scripts/eval/learning_view.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate the v2 example → rollout → trajectory → reward learning view."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.eval import contract
+
+SCHEMAS = {
+    "examples": ("geode.eval-example@1", "example.schema.json"),
+    "rollouts": ("geode.eval-rollout@1", "rollout.schema.json"),
+    "rewards": ("geode.eval-reward@1", "reward.schema.json"),
+}
+
+
+def _resolve(base: Path, value: str, *, label: str) -> Path:
+    contract._validate_relative_reference(value, label=label)
+    path = (base / value).resolve()
+    if not path.is_relative_to(base.resolve()):
+        raise ValueError(f"{label}: path escapes manifest directory")
+    if not path.is_file():
+        raise ValueError(f"{label}: file does not exist: {value}")
+    return path
+
+
+def _jsonl(path: Path, schema: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            raise ValueError(f"{path}:{line_number}: blank JSONL row")
+        value = contract._strict_json_loads(line, label=f"{path}:{line_number}")
+        if not isinstance(value, dict):
+            raise ValueError(f"{path}:{line_number}: expected object")
+        contract._validate_schema(value, schema, label=f"{path}:{line_number}")
+        rows.append(value)
+    return rows
+
+
+def _artifact(base: Path, ref: dict[str, Any], *, label: str) -> Path:
+    path = _resolve(base, str(ref["path"]), label=label)
+    if contract._sha256(path) != ref["sha256"]:
+        raise ValueError(f"{label}: SHA-256 mismatch")
+    return path
+
+
+def _unique(rows: list[dict[str, Any]], key: str, *, label: str) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        value = str(row[key])
+        if value in indexed:
+            raise ValueError(f"{label}: duplicate {key}: {value}")
+        indexed[value] = row
+    return indexed
+
+
+def validate_learning_view(path: Path) -> dict[str, int | str]:
+    path = path.resolve()
+    manifest = contract._load_json_object(path)
+    contract._validate_schema(
+        manifest,
+        "learning-view-manifest.schema.json",
+        label=str(path),
+    )
+    base = path.parent
+    loaded: dict[str, list[dict[str, Any]]] = {}
+    for name, (schema_id, schema_file) in SCHEMAS.items():
+        ref = manifest["files"][name]
+        if ref["record_schema"] != schema_id:
+            raise ValueError(f"{path}: {name} record_schema must be {schema_id}")
+        record_file = _artifact(base, ref, label=f"{path}:{name}")
+        rows = _jsonl(record_file, schema_file)
+        if len(rows) != ref["rows"]:
+            raise ValueError(f"{path}: {name} row count mismatch")
+        loaded[name] = rows
+
+    examples = _unique(loaded["examples"], "example_id", label="examples")
+    rollouts = _unique(loaded["rollouts"], "rollout_id", label="rollouts")
+    rewards = _unique(loaded["rewards"], "reward_id", label="rewards")
+
+    rewarded_rollouts: set[str] = set()
+    for rollout_id, rollout in rollouts.items():
+        example_id = str(rollout["example_id"])
+        if example_id not in examples:
+            raise ValueError(f"rollout {rollout_id}: unknown example_id {example_id}")
+        if rollout["run_id"] != manifest["run_id"]:
+            raise ValueError(f"rollout {rollout_id}: run_id does not match manifest")
+        selected = rollout["selected_attempt_id"]
+        if selected is not None and selected not in rollout["rollout_attempt_ids"]:
+            raise ValueError(f"rollout {rollout_id}: selected attempt is outside retry lineage")
+
+        trajectory_path = _artifact(
+            base,
+            rollout["trajectory"],
+            label=f"rollout {rollout_id}:trajectory",
+        )
+        trajectory = contract._load_json_object(trajectory_path)
+        from core.observability.record_schema import validate_record
+        from core.observability.trajectory import verify_trajectory_integrity
+
+        validate_record(trajectory, schema_id="geode.trajectory@1")
+        verify_trajectory_integrity(trajectory)
+        if trajectory["trajectory_id"] != rollout["trajectory"]["trajectory_id"]:
+            raise ValueError(f"rollout {rollout_id}: trajectory_id mismatch")
+        available_sessions = {
+            str(event["session_id"]) for event in trajectory["events"] if event["session_id"]
+        }
+        parents = trajectory["source"].get("parents") or []
+        available_sessions.update(str(parent) for parent in parents)
+        requested_sessions = set(rollout["trajectory"]["session_ids"])
+        if not requested_sessions.issubset(available_sessions):
+            raise ValueError(f"rollout {rollout_id}: trajectory session scope is not present")
+
+        native_path = _artifact(
+            base,
+            rollout["native_result"],
+            label=f"rollout {rollout_id}:native_result",
+        )
+        native = contract._strict_json_loads(
+            native_path.read_text(encoding="utf-8"), label=str(native_path)
+        )
+        contract._resolve_json_pointer(
+            native,
+            rollout["native_result"]["source_locator"],
+            label=f"rollout {rollout_id}:native_result",
+        )
+
+    reward_targets: set[tuple[str, str, str]] = set()
+    for reward_id, reward in rewards.items():
+        rollout_id = str(reward["rollout_id"])
+        target_rollout = rollouts.get(rollout_id)
+        if target_rollout is None:
+            raise ValueError(f"reward {reward_id}: unknown rollout_id {rollout_id}")
+        if reward["example_id"] != target_rollout["example_id"]:
+            raise ValueError(f"reward {reward_id}: example_id does not match rollout")
+        if target_rollout["validity"] != "valid" or not target_rollout["selected_for_reward"]:
+            raise ValueError(f"reward {reward_id}: rollout is not reward-admitted")
+        evaluator = reward["evaluator"]
+        target = (rollout_id, str(evaluator["name"]), str(evaluator["revision"]))
+        if target in reward_targets:
+            raise ValueError(f"reward {reward_id}: duplicate evaluator target")
+        reward_targets.add(target)
+        rewarded_rollouts.add(rollout_id)
+
+        source_path = _artifact(base, reward["source"], label=f"reward {reward_id}:source")
+        source_payload = contract._strict_json_loads(
+            source_path.read_text(encoding="utf-8"), label=str(source_path)
+        )
+        observed = contract._resolve_json_pointer(
+            source_payload,
+            reward["source"]["source_locator"],
+            label=f"reward {reward_id}:source",
+        )
+        if reward["measurement_status"] == "measured" and not contract._metric_values_match(
+            reward["value"], observed
+        ):
+            raise ValueError(f"reward {reward_id}: value does not match evaluator source")
+
+    expected_rewards = {
+        rollout_id for rollout_id, rollout in rollouts.items() if rollout["selected_for_reward"]
+    }
+    if expected_rewards != rewarded_rollouts:
+        raise ValueError("reward coverage does not match selected_for_reward rollouts")
+    return {
+        "run_id": str(manifest["run_id"]),
+        "examples": len(examples),
+        "rollouts": len(rollouts),
+        "rewards": len(rewards),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    args = parser.parse_args()
+    try:
+        result = validate_learning_view(args.manifest)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"learning-view error: {exc}")
+        raise SystemExit(1) from exc
+    message = "learning view OK: {run_id} examples={examples} rollouts={rollouts} rewards={rewards}"
+    print(message.format(**result))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/project_learning_view.py
+++ b/scripts/eval/project_learning_view.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Project Harbor or tau2 native output into the GEODE v2 learning view."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.eval.learning_view import validate_learning_view
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_sha(value: Any) -> str:
+    payload = json.dumps(
+        value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def _sessions(trajectory: dict[str, Any]) -> list[str]:
+    values = {str(value) for value in trajectory["source"].get("parents") or []}
+    values.update(
+        str(event["session_id"]) for event in trajectory["events"] if event.get("session_id")
+    )
+    return sorted(values)
+
+
+def _wall_seconds(started_at: str, finished_at: str) -> float:
+    elapsed = datetime.fromisoformat(finished_at) - datetime.fromisoformat(started_at)
+    return elapsed.total_seconds()
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    body = "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows)
+    path.write_text(body, encoding="utf-8")
+
+
+def _harbor(root: Path, spec: dict[str, Any]) -> tuple[list[dict[str, Any]], ...]:
+    examples: list[dict[str, Any]] = []
+    rollouts: list[dict[str, Any]] = []
+    rewards: list[dict[str, Any]] = []
+    revision = spec["reproduction"]["harness"]["revision"]
+    for native_path in sorted((root / "native" / "harbor").glob("*/result.json")):
+        native = _load(native_path)
+        task_id = str(native["task_name"])
+        slug = _slug(task_id.removeprefix("terminal-bench/"))
+        example_id = f"tb21.{slug}"
+        rollout_id = f"{spec['run_id']}.{slug}.0"
+        trajectory_path = native_path.parent / "agent" / "geode-trajectory.json"
+        trajectory = _load(trajectory_path)
+        started = str(native["started_at"])
+        finished = str(native["finished_at"])
+        attempt_id = str(native["trial_name"])
+        native_ref = {
+            "path": _relative(root, native_path),
+            "sha256": _sha(native_path),
+            "source_locator": "/verifier_result/rewards/reward",
+        }
+        examples.append(
+            {
+                "schema_id": "geode.eval-example@1",
+                "schema_version": 1,
+                "example_id": example_id,
+                "suite": "terminal-bench-2.1",
+                "dataset": {
+                    "name": spec["reproduction"]["harness"]["source"],
+                    "revision": revision,
+                },
+                "source_task_id": task_id,
+                "stratum_id": None,
+                "input_sha256": str(native["task_checksum"]),
+            }
+        )
+        rollouts.append(
+            {
+                "schema_id": "geode.eval-rollout@1",
+                "schema_version": 1,
+                "run_id": spec["run_id"],
+                "rollout_id": rollout_id,
+                "example_id": example_id,
+                "rollout_index": 0,
+                "seed": spec["reproduction"]["execution"]["seed_schedule"][0],
+                "policy": {
+                    "model": spec["reproduction"]["model"]["label"],
+                    "provider": spec["reproduction"]["model"]["provider"],
+                    "source": spec["reproduction"]["model"]["route"],
+                    "effort": "max",
+                    "geode_revision": spec["reproduction"]["geode"]["revision"],
+                },
+                "rollout_attempt_ids": [attempt_id],
+                "selected_attempt_id": attempt_id,
+                "trajectory": {
+                    "path": _relative(root, trajectory_path),
+                    "sha256": _sha(trajectory_path),
+                    "trajectory_id": trajectory["trajectory_id"],
+                    "session_ids": _sessions(trajectory),
+                },
+                "native_result": native_ref,
+                "timing": {
+                    "started_at": started,
+                    "finished_at": finished,
+                    "wall_seconds": _wall_seconds(started, finished),
+                },
+                "validity": "valid",
+                "termination_reason": native["agent_result"]["metadata"]["termination_reason"],
+                "selected_for_reward": True,
+            }
+        )
+        rewards.append(
+            {
+                "schema_id": "geode.eval-reward@1",
+                "schema_version": 1,
+                "reward_id": f"{rollout_id}.terminal-bench",
+                "rollout_id": rollout_id,
+                "example_id": example_id,
+                "evaluator": {
+                    "name": "terminal-bench-2.1",
+                    "revision": revision,
+                    "authority": "suite-native",
+                },
+                "measurement_status": "measured",
+                "value": native["verifier_result"]["rewards"]["reward"],
+                "components": {},
+                "source": native_ref,
+                "created_at": finished,
+            }
+        )
+    return examples, rollouts, rewards
+
+
+def _tau2(root: Path, spec: dict[str, Any]) -> tuple[list[dict[str, Any]], ...]:
+    grouped: dict[tuple[str, str], list[tuple[Path, dict[str, Any]]]] = {}
+    for native_path in sorted((root / "native" / "simulations").glob("*/results.json")):
+        native = _load(native_path)
+        domain = str(native["info"]["environment_info"]["domain_name"])
+        task_id = str(native["tasks"][0]["id"])
+        grouped.setdefault((domain, task_id), []).append((native_path, native))
+
+    examples: list[dict[str, Any]] = []
+    rollouts: list[dict[str, Any]] = []
+    rewards: list[dict[str, Any]] = []
+    revision = spec["reproduction"]["harness"]["revision"]
+    for (domain, task_id), attempts in sorted(grouped.items()):
+        selected = next(
+            (
+                item
+                for item in reversed(attempts)
+                if item[1]["simulations"][0]["reward_info"] is not None
+                and item[1]["simulations"][0]["reward_info"].get("reward") is not None
+            ),
+            None,
+        )
+        if selected is None:
+            continue
+        native_path, native = selected
+        simulation = native["simulations"][0]
+        task = native["tasks"][0]
+        selected_run_id = native_path.parent.name
+        trajectory_path = (
+            root / "native" / "trajectories" / f"{selected_run_id}.geode-trajectory.json"
+        )
+        trajectory = _load(trajectory_path)
+        selected_manifest = _load(
+            root / "native" / "trajectories" / f"{selected_run_id}.attempt-manifest.json"
+        )
+        selected_attempt_id = str(selected_manifest["final_results"][0]["selected_attempt_id"])
+        lineage: list[str] = []
+        for attempt_path, _ in attempts:
+            manifest_name = f"{attempt_path.parent.name}.attempt-manifest.json"
+            manifest_path = root / "native" / "trajectories" / manifest_name
+            lineage.extend(str(row["attempt_id"]) for row in _load(manifest_path)["attempts"])
+        slug = _slug(f"{domain}-{task_id}")
+        example_id = f"tau2.{slug}"
+        rollout_id = f"{spec['run_id']}.{slug}.0"
+        native_ref = {
+            "path": _relative(root, native_path),
+            "sha256": _sha(native_path),
+            "source_locator": "/simulations/0/reward_info/reward",
+        }
+        started = f"{simulation['start_time']}+09:00"
+        finished = f"{simulation['end_time']}+09:00"
+        examples.append(
+            {
+                "schema_id": "geode.eval-example@1",
+                "schema_version": 1,
+                "example_id": example_id,
+                "suite": "tau2-1.0.1",
+                "dataset": {"name": "sierra-research/tau2-bench", "revision": revision},
+                "source_task_id": task_id,
+                "stratum_id": domain,
+                "input_sha256": _canonical_sha(task),
+            }
+        )
+        rollouts.append(
+            {
+                "schema_id": "geode.eval-rollout@1",
+                "schema_version": 1,
+                "run_id": spec["run_id"],
+                "rollout_id": rollout_id,
+                "example_id": example_id,
+                "rollout_index": 0,
+                "seed": selected_manifest["attempts"][0]["seed"],
+                "policy": {
+                    "model": spec["reproduction"]["model"]["label"],
+                    "provider": spec["reproduction"]["model"]["provider"],
+                    "source": spec["reproduction"]["model"]["route"],
+                    "effort": "max",
+                    "geode_revision": spec["reproduction"]["geode"]["revision"],
+                },
+                "rollout_attempt_ids": lineage,
+                "selected_attempt_id": selected_attempt_id,
+                "trajectory": {
+                    "path": _relative(root, trajectory_path),
+                    "sha256": _sha(trajectory_path),
+                    "trajectory_id": trajectory["trajectory_id"],
+                    "session_ids": _sessions(trajectory),
+                },
+                "native_result": native_ref,
+                "timing": {
+                    "started_at": started,
+                    "finished_at": finished,
+                    "wall_seconds": simulation["duration"],
+                },
+                "validity": "valid",
+                "termination_reason": simulation["termination_reason"],
+                "selected_for_reward": True,
+            }
+        )
+        reward_info = simulation["reward_info"]
+        components = {
+            key: value
+            for key, value in (reward_info.get("reward_breakdown") or {}).items()
+            if isinstance(value, (bool, int, float)) or value is None
+        }
+        rewards.append(
+            {
+                "schema_id": "geode.eval-reward@1",
+                "schema_version": 1,
+                "reward_id": f"{rollout_id}.tau2",
+                "rollout_id": rollout_id,
+                "example_id": example_id,
+                "evaluator": {
+                    "name": "tau2-bench",
+                    "revision": revision,
+                    "authority": "suite-native",
+                },
+                "measurement_status": "measured",
+                "value": reward_info["reward"],
+                "components": components,
+                "source": native_ref,
+                "created_at": finished,
+            }
+        )
+    return examples, rollouts, rewards
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("suite", choices=("harbor", "tau2"))
+    parser.add_argument("run_dir", type=Path)
+    args = parser.parse_args()
+    root = args.run_dir.resolve()
+    spec = _load(root / "run-spec.json")
+    examples, rollouts, rewards = (
+        _harbor(root, spec) if args.suite == "harbor" else _tau2(root, spec)
+    )
+    files = {
+        "examples": ("examples.jsonl", "geode.eval-example@1", examples),
+        "rollouts": ("rollouts.jsonl", "geode.eval-rollout@1", rollouts),
+        "rewards": ("rewards.jsonl", "geode.eval-reward@1", rewards),
+    }
+    manifest_files: dict[str, Any] = {}
+    for name, (filename, schema, rows) in files.items():
+        path = root / filename
+        _write_jsonl(path, rows)
+        manifest_files[name] = {
+            "path": filename,
+            "sha256": _sha(path),
+            "rows": len(rows),
+            "record_schema": schema,
+        }
+    manifest = {
+        "schema_id": "geode.eval-learning-view@2",
+        "schema_version": 2,
+        "run_id": spec["run_id"],
+        "created_at": datetime.now().astimezone().isoformat(),
+        "record_order": ["example", "rollout", "trajectory", "reward"],
+        "files": manifest_files,
+    }
+    manifest_path = root / "learning-view-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
+    print(validate_learning_view(manifest_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6354,7 +6354,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1538 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1539 KB — fetch the Markdown twin above for the complete page)
 
 ---
 
@@ -6514,8 +6514,8 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 
 | 측정값 | 현재 트리 |
 | --- | --- |
-| 프로덕션 Python 파일 | 559 |
-| 테스트 Python 파일 | 691 |
+| 프로덕션 Python 파일 | 560 |
+| 테스트 Python 파일 | 693 |
 | 도구 정의 / 모델 실행 / 유효 스키마 / 정책 | 86 / 86 / 86 / 86 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 5 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -530,16 +530,16 @@
       "python_loc": 123591
     },
     "evals": {
-      "python_files": 81,
-      "python_loc": 27297
+      "python_files": 82,
+      "python_loc": 27526
     },
     "evolve": {
       "python_files": 66,
       "python_loc": 31923
     },
     "tests": {
-      "python_files": 691,
-      "python_loc": 186741
+      "python_files": 693,
+      "python_loc": 186946
     }
   },
   "schema_version": 6,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Added\n\n- **Evaluation learning-view contract v2.** GEODE now validates digest-bound\n  `example → rollout → trajectory → reward` datasets while preserving native\n  receipts and the immutable `geode.trajectory@1` schema.\n- **Harbor terminal benchmark adapter.** The current GEODE AgenticLoop can run\n  as a Harbor external agent while preserving native verifier output and a\n  normalized GEODE trajectory sidecar.\n- **Native evaluation projector.** Harbor and tau2 result bundles can be\n  projected into the validated v2 learning view without rewriting native\n  receipts or collapsing infrastructure-invalid retries into reward rows."
   },
   {
     "version": "1.0.26",

--- a/tests/evals/benchmarks/test_harbor_geode_agent.py
+++ b/tests/evals/benchmarks/test_harbor_geode_agent.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from evals.benchmarks.harbor_geode_agent import HarborExecTool
+
+
+class _Environment:
+    def __init__(self) -> None:
+        self.call: dict[str, object] = {}
+
+    async def exec(self, **kwargs: object) -> SimpleNamespace:
+        self.call = kwargs
+        return SimpleNamespace(stdout="ok\n", stderr="", return_code=0)
+
+
+def test_harbor_exec_tool_preserves_environment_result() -> None:
+    environment = _Environment()
+    result = asyncio.run(
+        HarborExecTool(environment).aexecute(
+            command="pwd",
+            cwd="/root",
+            timeout_seconds=7,
+        )
+    )
+    assert environment.call == {"command": "pwd", "cwd": "/root", "timeout_sec": 7}
+    assert result == {"result": "ok\n", "stderr": "", "return_code": 0}

--- a/tests/scripts/test_eval_learning_view.py
+++ b/tests/scripts/test_eval_learning_view.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from core.observability.trajectory import build_trajectory
+from scripts.eval.learning_view import validate_learning_view
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fixture(tmp_path: Path) -> Path:
+    native = tmp_path / "native.json"
+    _write_json(native, {"simulations": [{"reward": 1.0}]})
+    trajectory = tmp_path / "trajectory.json"
+    _write_json(
+        trajectory,
+        build_trajectory(
+            trajectory_id="trajectory-1",
+            source={"harness": "fixture", "session": "run-1", "parents": ["session-1"]},
+            events=[
+                {
+                    "kind": "fixture.event",
+                    "actor": "agent",
+                    "session_id": "session-1",
+                    "payload": {"ok": True},
+                }
+            ],
+            outcome={},
+            provenance={},
+            privacy={},
+            captured_at="2026-08-25T00:00:00Z",
+        ),
+    )
+    examples = tmp_path / "examples.jsonl"
+    _write_jsonl(
+        examples,
+        [
+            {
+                "schema_id": "geode.eval-example@1",
+                "schema_version": 1,
+                "example_id": "fixture.task-1",
+                "suite": "fixture",
+                "dataset": {"name": "fixture", "revision": "1"},
+                "source_task_id": "task-1",
+                "stratum_id": None,
+                "input_sha256": "a" * 64,
+            }
+        ],
+    )
+    rollouts = tmp_path / "rollouts.jsonl"
+    _write_jsonl(
+        rollouts,
+        [
+            {
+                "schema_id": "geode.eval-rollout@1",
+                "schema_version": 1,
+                "run_id": "run-1",
+                "rollout_id": "run-1.task-1.0",
+                "example_id": "fixture.task-1",
+                "rollout_index": 0,
+                "seed": 7,
+                "policy": {
+                    "model": "fixture",
+                    "provider": "none",
+                    "source": "local",
+                    "effort": "none",
+                    "geode_revision": "b" * 40,
+                },
+                "rollout_attempt_ids": ["attempt-1"],
+                "selected_attempt_id": "attempt-1",
+                "trajectory": {
+                    "path": trajectory.name,
+                    "sha256": _sha(trajectory),
+                    "trajectory_id": "trajectory-1",
+                    "session_ids": ["session-1"],
+                },
+                "native_result": {
+                    "path": native.name,
+                    "sha256": _sha(native),
+                    "source_locator": "/simulations/0",
+                },
+                "timing": {
+                    "started_at": "2026-08-25T00:00:00Z",
+                    "finished_at": "2026-08-25T00:00:01Z",
+                    "wall_seconds": 1.0,
+                },
+                "validity": "valid",
+                "termination_reason": "completed",
+                "selected_for_reward": True,
+            }
+        ],
+    )
+    rewards = tmp_path / "rewards.jsonl"
+    _write_jsonl(
+        rewards,
+        [
+            {
+                "schema_id": "geode.eval-reward@1",
+                "schema_version": 1,
+                "reward_id": "reward.run-1.task-1.0",
+                "rollout_id": "run-1.task-1.0",
+                "example_id": "fixture.task-1",
+                "evaluator": {"name": "fixture", "revision": "1", "authority": "suite-native"},
+                "measurement_status": "measured",
+                "value": 1.0,
+                "components": {},
+                "source": {
+                    "path": native.name,
+                    "sha256": _sha(native),
+                    "source_locator": "/simulations/0/reward",
+                },
+                "created_at": "2026-08-25T00:00:02Z",
+            }
+        ],
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_json(
+        manifest,
+        {
+            "schema_id": "geode.eval-learning-view@2",
+            "schema_version": 2,
+            "run_id": "run-1",
+            "created_at": "2026-08-25T00:00:03Z",
+            "record_order": ["example", "rollout", "trajectory", "reward"],
+            "files": {
+                name: {
+                    "path": path.name,
+                    "sha256": _sha(path),
+                    "rows": 1,
+                    "record_schema": schema,
+                }
+                for name, path, schema in (
+                    ("examples", examples, "geode.eval-example@1"),
+                    ("rollouts", rollouts, "geode.eval-rollout@1"),
+                    ("rewards", rewards, "geode.eval-reward@1"),
+                )
+            },
+        },
+    )
+    return manifest
+
+
+def test_learning_view_validates_closed_joins(tmp_path: Path) -> None:
+    assert validate_learning_view(_fixture(tmp_path)) == {
+        "run_id": "run-1",
+        "examples": 1,
+        "rollouts": 1,
+        "rewards": 1,
+    }
+
+
+def test_learning_view_rejects_reward_for_invalid_rollout(tmp_path: Path) -> None:
+    manifest = _fixture(tmp_path)
+    rollouts = tmp_path / "rollouts.jsonl"
+    row = json.loads(rollouts.read_text())
+    row["validity"] = "invalid"
+    row["selected_attempt_id"] = None
+    row["selected_for_reward"] = False
+    _write_jsonl(rollouts, [row])
+    payload = json.loads(manifest.read_text())
+    payload["files"]["rollouts"]["sha256"] = _sha(rollouts)
+    _write_json(manifest, payload)
+    with pytest.raises(ValueError, match=r"not reward-admitted|coverage"):
+        validate_learning_view(manifest)


### PR DESCRIPTION
## Summary

- #3174에서 검증·병합된 versioned eval learning views와 native projectors를 `main`으로 승격합니다.
- immutable `geode.trajectory@1`을 유지하면서 example/rollout/reward v2 파생 계약을 추가합니다.
- GEODE 기반 Terminal-Bench 실행을 위한 Harbor adapter와 Harbor/tau2 native projection을 함께 배포합니다.

## Why

학습·평가 결과를 trajectory 원본에 덧붙이지 않고, 재현 가능한 manifest와 별도 reward contract로 투영할 필요가 있습니다. retry는 하나의 rollout 안에 유지하고, zero reward와 missing reward를 구분하며, source/evaluator revision을 manifest에 고정합니다.

## Changes

| Surface | Change |
|---|---|
| Data contracts | example/rollout/reward 및 learning-view manifest v2 schema 추가 |
| Projection | Harbor와 tau2 결과를 native learning views로 변환 |
| Evaluation runtime | GEODE-backed Harbor agent adapter 추가 |
| Documentation | eval data model, index, skill, changelog, public LLM index 동기화 |
| Architecture metadata | generated baseline과 roadmap 수치 동기화 |

## GAP Audit

| Gap | Before | Resolution |
|---|---|---|
| Immutable trajectory와 학습용 파생 데이터 결합 | reward/retry lineage가 trajectory 원본과 분리된 표준 계약 부재 | immutable trajectory를 보존하고 versioned example/rollout/reward views 도입 |
| 외부 benchmark 결과 수렴 | Harbor/tau2 결과를 동일 learning-view contract로 투영하는 native path 부재 | native projectors와 revision-pinned manifest 추가 |
| Harbor execution | GEODE runtime을 Terminal-Bench/Harbor agent로 호출하는 adapter 부재 | `HarborGeodeAgent` 추가 |

## Verification

- Feature PR #3174: 62 targeted tests 성공
- Feature PR #3174: ruff, format, codespell, mypy, bandit, deptry 성공
- Feature PR #3174: CI Gate 성공
- Feature PR #3174: Linux/macOS install smoke 성공
- Feature PR #3174: Next.js static export 성공
- Pilot views: 3 examples / 3 rollouts / 3 rewards validation 성공
- GitFlow sync #3176: 19 checks 성공, `main` ancestry 검증 성공

## Release impact

- package SemVer 변경 없음
- PyPI 재배포 없음
- main 병합 후 GitHub Pages가 최신 공식 문서를 배포합니다.