### PR TITLE
docs(readme): align bilingual product and evidence boundaries

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -50,6 +50,38 @@ loop는 scaffold 후보를 변이시키고 증거 기반 안전성 게이트로 
 
 ---
 
+## 하나의 배포판, 세 가지 경계
+
+`geode-agent` wheel은 네 개 명령을 함께 배포하지만, 설치된 패키지를 쓰기
+가능한 작업공간으로 사용하지 않습니다.
+
+| 경계 | 책임 | 명령 |
+|---|---|---|
+| `core` | 런타임, 운영자 CLI, 데몬, MCP 서버 | `geode`, `geode-mcp` |
+| `evals` | audit, 벤치마크 어댑터, 증거 생성 | `geode-eval` |
+| `evolve` | 실험적 scaffold 탐색과 Crucible | `geode-evolve` |
+
+설치된 코드와 번들 asset은 불변입니다. 런타임·실험 산출물은 `~/.geode/`
+(또는 명시적 state override)에 두며, 변이와 승격에는 쓰기 가능한 GEODE Git
+checkout이 필요합니다. 자세한 내용은
+[배포 lifecycle](docs/architecture/immutable-distribution-lifecycle.md)을 참고하세요.
+
+## 평가 증거
+
+GEODE는 조건이 다른 run을 하나의 제품 점수로 합치지 않습니다. 공개 결과는
+harness revision, task set, model route, effort, timeout, attempt lineage에
+각각 고정됩니다.
+
+| 트랙 | 공개 증거 경계 |
+|---|---|
+| [Tau2](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2) | native-user와 GEODE-user 트랙을 분리하며, 미완료·quota 오염 run은 aggregate score 권한 없이 보존합니다. |
+| [MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark) | 서비스 coverage, 과거 available-services 결과, 정정된 paired 관측, full-Verified 한계를 구분합니다. |
+
+원본 receipt와 개인정보 검토를 통과한 trajectory는
+[평가 artifact 저장소](https://github.com/mangowhoiscloud/geode-eval-artifacts)에 보존합니다.
+
+---
+
 ## 실험적 scaffold 최적화 loop
 
 GEODE에는 실험적인 **non-parametric scaffold 최적화 loop**가 있습니다.
@@ -138,7 +170,8 @@ geode setup
 
 Wizard 가 세 가지 경로를 제시합니다: ChatGPT 구독, API 키 (붙여넣기), dry-run 으로 일단 둘러보기. 기존 `~/.codex/auth.json` 자격도 가져올 수 있지만, 추론을 위해 Codex CLI를 실행하지는 않습니다.
 
-GEODE 설치 전에 이미 `codex auth login` 을 해뒀다면 다음 `geode` 실행에서 토큰을 감지할 수 있습니다. 그 외에는 Codex CLI 설치가 필요 없습니다.
+Codex CLI가 이미 ChatGPT 로그인을 마쳤다면 다음 `geode` 실행에서 그 토큰을
+감지할 수 있습니다. 그 외에는 Codex CLI 설치가 필요 없습니다.
 
 ### 3단계 — 경로별 수동 안내 (참고용)
 
@@ -155,9 +188,11 @@ geode                                 # GEODE 시작
 # 세션 안에서: /login openai         # ChatGPT device-code 로그인
 ```
 
-**지원 플랜** ([Codex CLI 공식 문서](https://developers.openai.com/codex/cli/) 기준): Plus, Pro, Business, Edu, Enterprise.
+**지원 플랜** ([Codex 공식 가격 문서](https://developers.openai.com/codex/pricing/) 기준): Plus, Pro, Business, Edu, Enterprise.
 
-**할당량** (OpenAI 공시 기준, 5시간 윈도): Plus 는 약 15–80 메시지, Pro 20x 는 최대 1,600 메시지. Edu / Enterprise 는 고정 한도 없이 워크스페이스 크레딧으로 정산됩니다. 이 두 플랜은 워크스페이스 관리자가 "Allow members to use Codex Local" 을 켜야 사인인이 작동합니다.
+**할당량** (OpenAI 공시 기준, 5시간 윈도): Plus는 약 15–80 메시지,
+Pro 20x는 최대 1,600 메시지입니다. Enterprise와 Edu 한도는 workspace가
+flexible credit 또는 legacy per-seat 방식 중 무엇을 쓰는지에 따라 달라집니다.
 
 **참고할 점**:
 - **gpt-5.5 는 구독 전용입니다.** GPT-5.6 Sol/Terra/Luna와 GPT-5.4는 듀얼 레인입니다. 구독 프로필이 활성화되면 ChatGPT OAuth, API 키 프로필을 선택하면 Platform API를 사용합니다. 5.5가 필요하면 ChatGPT 구독이 필요합니다.
@@ -193,7 +228,8 @@ chmod 600 ~/.geode/.env
 
 OpenAI 또는 ZhipuAI GLM 도 쓰고 싶다면 같은 파일에 `OPENAI_API_KEY=sk-proj-...` 또는 `ZAI_API_KEY=...` 추가. GEODE 는 사용 가능한 키를 자동으로 선택합니다.
 
-**실제 비용 감각.** 단일 프롬프트는 약 3,000 토큰, $0.01 정도. 도구 호출 10개 들어간 긴 리서치 세션은 보통 $0.05–$0.30. 무료 $5 크레딧이면 약 500번 프롬프트 가능합니다. 한도를 명시적으로 잠그고 싶으면 `~/.geode/config.toml` 에 설정하세요.
+**비용 제어.** 가격은 model과 workload에 따라 달라집니다. provider의 최신
+가격을 확인한 뒤 `~/.geode/config.toml`에 hard cap을 설정하세요.
 
 ```toml
 [cost]
@@ -349,7 +385,11 @@ geode config migrate-petri-toml --yes    # [self_improving_loop.petri.*] 를 con
 
 ## 설정
 
-시크릿은 `.env`에, 동작은 `config.toml`에 둡니다. `.env`는 시크릿 전용, `config.toml`은 동작 전용이라 두 층은 충돌하지 않고 각각 우선순위 규칙이 하나씩 있습니다.
+시크릿은 `.env`에, 동작은 `config.toml`에 둡니다. `.env`는 시크릿 전용,
+`config.toml`은 동작 전용이라 두 층은 충돌하지 않고 각각 우선순위 규칙이
+하나씩 있습니다. 상세 경로 설계는
+[storage hierarchy](docs/architecture/storage-hierarchy.md), 독립 다이어그램은
+[context/config paths](docs/diagrams/geode-context-config-paths.html)를 참고하세요.
 
 - 전역 `~/.geode/.env`가 권위를 갖는 시크릿 저장소입니다. 프로젝트 `./.env`는 전역에 없는 키만 채우고 전역 키를 덮지 못합니다. `~/.geode/.env`의 `OPENAI_API_KEY`는 프로젝트 `./.env`가 비어 있어도 이깁니다.
 - 프로젝트 `./.geode/config.toml`이 전역 `~/.geode/config.toml`을 덮습니다. 동작은 프로젝트마다 조정합니다.
@@ -408,7 +448,7 @@ PyPI 설치라면 `uv tool install geode-agent` 실행. 소스 체크아웃이�
 <details>
 <summary><strong>"401 Unauthorized" 또는 "Invalid API key"</strong> — 잘못된 키, 만료된 키, 또는 잘못된 파일 위치.</summary>
 
-`cat ~/.geode/.env` 로 확인 — 키는 `sk-ant-` (Anthropic), `sk-proj-` (OpenAI), `id.secret` (ZhipuAI GLM) 으로 시작해야 함. 공백이나 따옴표 추가되지 않았는지 체크. ChatGPT 구독 경로(Path A)면 `codex auth login` 재실행해서 OAuth 토큰 갱신.
+`cat ~/.geode/.env` 로 확인 — 키는 `sk-ant-` (Anthropic), `sk-proj-` (OpenAI), `id.secret` (ZhipuAI GLM) 으로 시작해야 함. 공백이나 따옴표 추가되지 않았는지 체크. ChatGPT 구독 경로(Path A)면 GEODE 안에서 `/login openai`를 다시 실행.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v1.0.26: Autonomous Agent Runtime + Evaluation Substrate
+# GEODE v1.0.26 — Autonomous Agent Runtime + Evaluation Substrate
 
 A general-purpose runtime for autonomous tool work. You ask in plain language;
 GEODE plans, calls tools, and reports, for one prompt or a long-running session.
@@ -50,74 +50,35 @@ sustained self-improvement.
 
 ---
 
-## Benchmark snapshot: Tau2 native user-simulator track
+## One distribution, three boundaries
 
-GEODE keeps benchmark numbers tied to the exact runtime and model route that
-produced them. The 2026-07-03/04 Tau2 run below used **GEODE v0.99.269** with
-the public `evals/benchmarks` tau2 adapter, `sierra-research/tau2-bench@1901a30`
-(`tau2==1.0.0`), `gpt-5.2` through OpenAI **PAYG**, agent reasoning effort
-`high`, `max_steps=200`, and tau2's native `user_simulator` using
-`gpt-4.1-2025-04-14` with effort `medium`.
+The `geode-agent` wheel ships four commands without turning the installed
+package into a writable workspace:
 
-| Domain | Tasks | Reward / pass^1 | Notable action checks | Duration |
-|---|---:|---:|---|---:|
-| Airline base | 50 | **0.8200** (41 / 50) | read 81/91, write 33/49 | avg 284.10s / max 979.65s |
-| Retail base | 114 | **0.7632** (87 / 114) | read 320/354, write 140/174 | avg 206.52s / max 873.92s |
-| Telecom base | 114 | **0.8772** (100 / 114) | write 471/496, generic 20/20 | avg 252.87s / max 818.58s |
-| **Weighted total** | **278** | **0.8201** (228 / 278) | domain action schemas differ | - |
+| Boundary | Responsibility | Commands |
+|---|---|---|
+| `core` | Runtime, operator CLI, daemon, MCP server | `geode`, `geode-mcp` |
+| `evals` | Audits, benchmark adapters, evidence production | `geode-eval` |
+| `evolve` | Experimental scaffold search and Crucible | `geode-evolve` |
 
-Raw run logs are preserved in
-[`geode-eval-artifacts/tau2/simulations/`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/tau2/simulations)
-(`geode-gpt-5-2-high-native-user-*-base-20260703/results.json` — per-task
-rewards, action checks, and full simulation transcripts).
-These numbers are directly comparable to GEODE reruns with the same harness,
-split, user simulator, model route, and max-step settings. They should not be
-mixed with the earlier `geode_user` smoke rows. Compared with frontier Tau2
-headlines, this is an independently run GEODE adapter measurement, not the
-providers' internal research setup.
+Installed code and bundled assets are immutable. Runtime and experiment output
+lives under `~/.geode/` (or an explicit state override), while mutation and
+promotion require a writable GEODE Git checkout. See the
+[distribution lifecycle](docs/architecture/immutable-distribution-lifecycle.md).
 
-The current weak spot is not gross tool availability. It is **required action
-coverage under compound tasks**: Retail failures often miss DB/write side
-effects, while Telecom failures cluster around MMS/APN/app-permission/roaming
-combinations where one necessary user or agent action is omitted.
+## Evaluation evidence
 
-The latest subscription-route regression (2026-08-02) used `gpt-5.4` at
-effort `high` for both GEODE agent and GEODE user. The exact
-`mock/create_task_1` diagnostic remained **0/1** because the model supplied an
-unrequested optional `description=""`; the first Telecom-small roaming task
-passed **1/1** with every required DB, user-action, mobile-status, and speed
-check. These two diagnostic rows are not the native-user headline. Their 158
-canonical events and ten exact tool pairs are pinned to
-[`geode-eval-artifacts@f588ce9`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/f588ce9fd23b9123732b45c4dbe202136691d3fe/trajectories/tau2-geode-gpt54-afaab52b-mock-telecom-small-20260801T173245Z-2dc79cb569f0).
+GEODE does not collapse unlike runs into one product score. Every published
+result stays bound to its harness revision, task set, model route, effort,
+timeout, and attempt lineage.
 
-## Benchmark snapshot: MCPMark Verified available-services track
+| Track | Public evidence boundary |
+|---|---|
+| [Tau2](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2) | Native-user and GEODE-user tracks remain separate; incomplete or quota-contaminated runs are retained without receiving aggregate-score authority. |
+| [MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark) | Service coverage, historical available-services results, corrected paired observations, and full-Verified limitations remain explicit. |
 
-The 2026-07-04 MCPMark run used **GEODE v0.99.269-era code** on branch
-`feature/mcpmark-agentworld-run`, `eval-sys/mcpmark@cd45b7f`, GEODE's public
-`evals/benchmarks` MCPMark adapter, `gpt-5.5` through the OpenAI
-**Codex subscription** route, and reasoning effort `xhigh`.
-
-This is not a full MCPMark Verified leaderboard score. It covers the standard
-service slices that were runnable in the local environment; Notion was blocked
-by missing `notion_state.json`, and Playwright/WebArena was blocked by missing
-Docker images/browser service stack.
-
-| MCPMark service | Tasks | Passed | Accuracy | Notes |
-|---|---:|---:|---:|---|
-| Filesystem standard | 30 | 25 | **83.3%** | `papers/author_folders` counted as a failed no-result transport run after two attempts |
-| Postgres standard | 21 | 20 | **95.2%** | Uses `postgres-mcp==0.3.0` in unrestricted mode |
-| GitHub standard | 23 | 19 | **82.6%** | Uses `ghcr.io/github/github-mcp-server:v0.15.0`; transient repos cleaned up |
-| **Measured total** | **74** | **64** | **86.5%** | filesystem + postgres + github only |
-
-Raw run logs are preserved in
-[`geode-eval-artifacts/mcpmark/results-geode-agentworld/`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/main/mcpmark/results-geode-agentworld)
-(`geode-gpt55-xhigh-20260704-mcpmark-verified-*` — per-task `meta.json`
-verifier results, `messages.json` final answers or empty placeholders, and
-`execution.log` ordered MCP action/result records where produced). The public
-MCPMark snapshot does not retain full model dialogue; see its
-[trajectory contract](https://github.com/mangowhoiscloud/geode-eval-artifacts/blob/main/TRAJECTORIES.md).
-These rows are directly comparable only to the same MCPMark commit, service
-set, GEODE adapter, model route, and timeout settings.
+Raw receipts and privacy-reviewed trajectories live in the
+[evaluation artifact repository](https://github.com/mangowhoiscloud/geode-eval-artifacts).
 
 ---
 
@@ -210,7 +171,8 @@ geode setup
 
 The wizard offers three paths: ChatGPT subscription, API key (paste and go), or skip into dry-run mode for now. It can also import an existing `~/.codex/auth.json` credential, but GEODE does not execute Codex CLI for inference.
 
-If you already ran `codex auth login`, the next `geode` invocation can detect that token. Codex CLI is otherwise optional.
+If Codex CLI has already signed in with ChatGPT, the next `geode` invocation
+can detect that token. Codex CLI is otherwise optional.
 
 ### Step 3: Pick a path (manual reference)
 
@@ -227,9 +189,11 @@ geode                                 # start GEODE
 # inside the session: /login openai   # ChatGPT device-code login
 ```
 
-**Plans that work** (per the [official Codex CLI docs](https://developers.openai.com/codex/cli/)): Plus, Pro, Business, Edu, Enterprise.
+**Plans that work** (per the [official Codex pricing page](https://developers.openai.com/codex/pricing/)): Plus, Pro, Business, Edu, Enterprise.
 
-**Quotas** (OpenAI-published, per 5-hour window): roughly 15–80 messages on Plus, up to 1,600 on Pro 20x. Edu and Enterprise have no fixed cap; usage scales with your workspace credits. Your admin needs to flip "Allow members to use Codex Local" before sign-in works on those tiers.
+**Quotas** (OpenAI-published, per 5-hour window): roughly 15–80 messages on
+Plus and up to 1,600 on Pro 20x. Enterprise and Edu limits depend on whether
+the workspace uses flexible credits or legacy per-seat limits.
 
 **Tier notes**:
 - **gpt-5.5 is subscription-only.** GPT-5.6 Sol/Terra/Luna and GPT-5.4 are dual-lane: GEODE uses ChatGPT OAuth when a subscription profile is active and the Platform API when an API-key profile is selected. If you want 5.5, you need ChatGPT.
@@ -265,7 +229,8 @@ chmod 600 ~/.geode/.env
 
 Want OpenAI or ZhipuAI GLM instead? Add `OPENAI_API_KEY=sk-proj-...` or `ZAI_API_KEY=...` to the same file. GEODE picks whichever is available.
 
-**What it costs in practice.** A single prompt runs around 3,000 tokens, about $0.01. A research session with ten tool calls usually lands between $0.05 and $0.30. Your $5 free credit lasts roughly 500 prompts. Set a hard cap in `~/.geode/config.toml`:
+**Cost control.** Provider prices vary by model and workload. Check the
+provider's current pricing, then set a hard cap in `~/.geode/config.toml`:
 
 ```toml
 [cost]
@@ -481,7 +446,7 @@ For a PyPI install, run `uv tool install geode-agent`. For a source checkout, ru
 <details>
 <summary><strong>"401 Unauthorized" or "Invalid API key"</strong>, wrong key, expired key, or wrong file location.</summary>
 
-Check `cat ~/.geode/.env` and confirm the key starts with `sk-ant-` (Anthropic), `sk-proj-` (OpenAI), or `id.secret` (ZhipuAI GLM). Make sure there are no extra spaces or quote characters. If you used the ChatGPT subscription path (Path A), re-run `codex auth login` to refresh the OAuth token.
+Check `cat ~/.geode/.env` and confirm the key starts with `sk-ant-` (Anthropic), `sk-proj-` (OpenAI), or `id.secret` (ZhipuAI GLM). Make sure there are no extra spaces or quote characters. If you used the ChatGPT subscription path (Path A), run `/login openai` again inside GEODE.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- README 영문·한국어의 상위 정보 구조와 외부 근거 링크를 맞췄습니다.
- v1.0.26의 단일 `geode-agent` wheel 안에서 `core` / `evals` / `evolve`가 맡는 책임과 네 CLI를 첫 화면에 명시했습니다.
- 영문에만 복제돼 있던 과거 Tau2/MCPMark 숫자 원문을 제거하고, 조건·정정·무효화 기록을 계속 갱신하는 공식 벤치마크 페이지와 원본 artifact 저장소를 양 언어의 정본으로 연결했습니다.
- 현재 공식 OpenAI 문서와 맞지 않던 `codex auth login`, Enterprise/Edu 한도, 출처 없는 무료 크레딧·프롬프트 비용 문구를 바로잡았습니다.

## Why
README는 설치 전에 가장 먼저 읽는 공개 계약인데 다음 네 GAP이 있었습니다.

| GAP | Before | After |
|---|---|---|
| 한·영 정보 구조 | 영문에만 벤치마크 snapshot 두 섹션이 있어 74줄 차이 | 양쪽 모두 같은 11개 상위 섹션과 같은 외부 URL 집합 |
| 평가 정본 | 오래된 run 숫자와 설명이 README와 현재 벤치마크 ledger에 중복 | README는 비교 가능성 원칙과 canonical ledger/artifact 링크만 소유 |
| 패키지 정체성 | `core` / `evals` / `evolve`, `geode-eval`, `geode-evolve`가 첫 화면에 없음 | 단일 배포판의 세 책임 경계와 네 entry point를 명시 |
| 구독·비용 안내 | 폐기된 Codex 로그인 명령, 과도하게 일반화한 조직 플랜 한도, 무근거 비용 예시 | GEODE `/login openai`와 현재 OpenAI pricing 계약만 유지 |

## Changes
| File | Change |
|---|---|
| `README.md` | 중복된 역사적 benchmark 본문을 canonical evidence routing으로 축약하고, 배포 경계·현행 인증/가격 안내를 반영 |
| `README.ko.md` | 동일한 배포·평가 계약을 추가하고 configuration path·현행 인증/가격 안내까지 영문과 맞춤 |

## Verification
- `uv run pytest tests/integration/test_check_official_docs.py -q` — **5 passed**
- `uv run python scripts/check_official_docs.py --skip-build` — **PASS**
- `npm ci` (`site/`) — **450 packages audited, 0 vulnerabilities**
- `uv run python scripts/check_official_docs.py` — **PASS**; Next.js **239** static pages, docs Markdown twin **75**개, generated diff 0
- `lychee --no-progress README.md README.ko.md` — **110 checked / 110 OK / 0 errors**
- `uv run geode version` — **GEODE v1.0.26**
- `uv run geode-eval --help`, `uv run geode-evolve --help`, `uv run geode-mcp --help` — **PASS**
- `git diff --check` — **PASS**
- commit pre-commit hooks — **PASS**

전체 runtime pytest는 실행하지 않았습니다. 변경은 README 두 파일뿐이며 공식 docs build와 release-surface gate로 검증했습니다. 문서 전용 변경이므로 `CHANGELOG.md`는 갱신하지 않았습니다.
