### PR TITLE
fix(site): MCP 진입 화살표와 경로 표기 교정

### DIFF
--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -1387,7 +1387,7 @@ function RunRow() {
                 id="run-arrow"
                 markerWidth="8"
                 markerHeight="8"
-                refX="7"
+                refX="8"
                 refY="4"
                 orient="auto"
               >
@@ -1433,43 +1433,43 @@ function RunRow() {
               </text>
 
               <path
-                d="M204 80 H280"
+                d="M204 80 H276"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M204 168 H248 V140 H280"
+                d="M204 168 H248 V140 H276"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M204 272 H280"
+                d="M204 272 H276"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M464 112 H528"
+                d="M464 112 H524"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M464 272 H528"
+                d="M464 272 H524"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M720 112 H752 V160 H780"
+                d="M720 112 H752 V160 H776"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
               />
               <path
-                d="M720 272 H752 V208 H780"
+                d="M720 272 H752 V208 H776"
                 fill="none"
                 stroke={ROSE_INK}
                 markerEnd="url(#run-arrow)"
@@ -1495,15 +1495,15 @@ function RunRow() {
               >
                 JOB
               </text>
-              <rect x="220" y="256" width="56" height="16" fill={PAPER} />
+              <rect x="208" y="256" width="64" height="16" fill={PAPER} />
               <text
-                x="248"
+                x="240"
                 y="268"
                 textAnchor="middle"
                 fill={ROSE_INK_70}
-                fontSize="8"
+                fontSize="7.5"
               >
-                STDIO
+                STDIO / HTTP
               </text>
               <rect x="732" y="132" width="64" height="16" fill={PAPER} />
               <text
@@ -1638,17 +1638,20 @@ function RunRow() {
                 fill={PAPER}
                 stroke={ROSE_INK}
               />
-              <text x="296" y="264" fill={ROSE_INK_70} fontSize="8">
+              <text x="296" y="260" fill={ROSE_INK_70} fontSize="8">
                 TOOL HOST
               </text>
               <text
                 x="296"
-                y="284"
+                y="280"
                 fill={ROSE_INK}
                 fontSize="13"
                 fontWeight="700"
               >
                 geode-mcp
+              </text>
+              <text x="296" y="294" fill={ROSE_INK_70} fontSize="7">
+                _run_agent bridge
               </text>
 
               <rect


### PR DESCRIPTION
## Summary
런타임 진입 도식의 화살표 끝이 노드 채움 아래에서 잘리던 문제를 교정했습니다. MCP 경로 표기를 실제 transport와 호출 브리지에 맞췄습니다.

## Why
SVG marker가 대상 노드 안으로 1px 돌출되어 후순위 rect에 가려졌고, 도식이 stdio만 지원하는 것처럼 읽혔습니다.

## Changes
| File | Change |
|------|--------|
| `site/src/app/portfolio/page.tsx` | marker 기준점과 연결 끝 간격 정렬, `STDIO / HTTP`, `_run_agent bridge` 표기 |

## Verification
- `scripts/preflight.sh` — all gates passed, 비-live pytest 포함
- MCP 관련 targeted pytest — 35 passed
- `npm run build` — 239 routes
- Playwright element screenshot — 화살표 잘림·텍스트 충돌 없음

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| MCP 호출 경로 | 확인 | `run_agent → _run_agent → arun_agentic_oneshot → AgenticLoop.arun` |
| transport | 교정 | stdio 기본, streamable HTTP 선택 |
| 세션 생성 | 확인 | MCP는 `create_session` 대신 격리 one-shot 직접 구성 |