### PR TITLE
docs(architecture): register causal evaluation gaps

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -232,8 +232,10 @@ The initial audit verdict was **B+, conditionally approved**. The 2026-08-25
 full-ledger audit against
 `origin/develop@bfb6aedd28c47a6d796945c5ce5b39be24e4b8d8` confirms that all
 62 GAPs are terminal: 56 are `DONE` and six are `SUPERSEDED`. There is no
-remaining execution unit or active claim; §14 records the final release and
-GitFlow evidence.
+remaining unit from that audit; §14 records its final release and GitFlow
+evidence. The 2026-08-26 ACES/Scroll audit subsequently registered two new
+`OPEN` evaluation GAPs under R11.1. They do not alter the 62 terminal rows, and
+there is no active claim.
 
 The program is complete when GEODE has:
 
@@ -571,6 +573,8 @@ and closure evidence are appended in §10.
 | DIST-002 | `MISFIT` | The packaged macOS helper build script defaults its generated app bundle to `<distribution>/.geode/ComputerUseHelper`, which may be read-only and is replaced by package upgrades | Packaged helper sources are read-only inputs, generated helper bytes live under one existing operator-owned GEODE home resolver, source and wheel installs share that resolver, and setup/status tests prove the distribution tree stays unchanged | R10.1 | BND-009 | `DONE` |
 | DIST-003 | `PARTIAL` | The wheel force-includes every `.geode/skills` directory even when a skill references repository-only scripts/docs or a personal absolute workspace, while installed smoke proves only that selected skill bodies load | One exact self-contained builtin-skill allowlist is packaged; repository and personal skills remain in their existing external tiers; every bundled local command/asset reference resolves in a clean wheel; and installed smoke rejects repo-only, personal-path, or dangling bundled skills | R10.1 | BND-003, BND-004 | `DONE` |
 | DIST-004 | `MISFIT` | `geode update` replaces the live uv-tool environment and verifies the new CLI before stopping the old daemon, allowing a running process to observe a mixed old-process/new-files installation | A running daemon is drained and stopped before live tool replacement, failed updates remain fail-closed without starting a second daemon, successful restart proves CLI/IPC daemon version parity, and ordering tests cover running, stopped, failed-stop, failed-install, and no-restart paths | R10.1 | BND-003, REL-003 | `DONE` |
+| EVAL-001 | `ABSENT` | Runtime Skills have loader, package, and policy checks but no paired evaluation that changes only target-skill availability | A native paired benchmark freezes model, task, workspace, tools, scorer, seed, and repetitions; reports verifier-first with-skill lift, activation, cost, and negative controls; and binds results to existing run-spec, attempt, trajectory, reward, and analysis authorities | R11.1 | BND-004, VER-001 | `OPEN` |
+| EVAL-002 | `PARTIAL` | Session events, FTS recall, compaction, and tool offload exist, but no deterministic benchmark classifies exact recovery after compaction, restart, expiry, or corruption | An offline recoverability benchmark uses current session and offload authorities, stable event or digest references, and an immutable receipt to distinguish exact, summary-only, unavailable, and corrupt evidence without a second transcript, unbounded retention, or live model call | R11.1 | STORE-002, VER-001 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -663,6 +667,12 @@ Public release truth is re-audited against the official
 [GitHub Releases](https://github.com/mangowhoiscloud/geode/releases) surfaces
 immediately before the cut. As audited on 2026-08-20, both identify v1.0.22 as
 the latest public release, matching repository metadata and the changelog.
+
+R11.1 is a post-closure measurement package over delivered Skill and session
+authorities. It must establish causal skill attribution and deterministic
+context-recoverability evidence before any later package may add a new context
+store, retention class, eviction index, or executable namespace. Any such
+runtime change requires its own measured GAP and serialized package.
 
 ## 7. Phase work packages
 
@@ -1912,6 +1922,37 @@ Acceptance:
   test pass without publishing a second wheel or adding a workspace manager,
   package registry, plugin SDK, or compatibility stub.
 
+### R11 — Causal evaluation and context recoverability
+
+#### R11.1 Skill attribution and recoverability gates
+
+GAPs: EVAL-001, EVAL-002.
+
+This package measures the current runtime before changing it. Evaluation code
+lives under `evals`, reuses the existing run-spec, attempt, trajectory, reward,
+and analysis contracts, and treats native runtime evidence as referenced input
+rather than copying it into another raw store.
+
+Acceptance:
+
+- a deterministic paired runner rejects any arm drift beyond target-skill
+  availability and preserves ordered workload, seed, repetition, model,
+  workspace, tool, scorer, and budget identity;
+- an initial runtime-Skill suite covers explicit, implicit, contextual, and
+  negative-control prompts, reports native-verifier lift separately from
+  activation, irrelevant behavior, tokens, time, and safety, and does not use
+  an equal-weight composite as promotion authority;
+- a deterministic context fixture spans exact historical values, conflicting
+  updates, far-apart evidence, and large tool output across compaction,
+  restart, expiry, and corruption, with immutable receipts classifying
+  `exact`, `summary-only`, `unavailable`, or `corrupt` evidence;
+- the suite consumes `sessions.db:session_events`, current FTS/session APIs, and
+  tool-offload references without creating a second transcript, raw-evidence
+  database, persistent Python kernel, eviction index, or unbounded retention;
+- live model execution remains outside this package until a frozen run spec
+  names the model route, seeds, repetitions, cost budget, privacy boundary, and
+  explicit approval.
+
 ## 8. Change-surface acceptance scenarios
 
 These black-box scenarios define extensibility more usefully than class count.
@@ -2257,12 +2298,13 @@ Tracking-only closure
 as `bd88f44998e78e8ac7220120d29960845be4f81d`, and the required canonical
 `main` → `develop` sync
 [#3171](https://github.com/mangowhoiscloud/geode/pull/3171) merged as
-`bfb6aedd28c47a6d796945c5ce5b39be24e4b8d8`. The master ledger now contains
-62 terminal GAPs: 56 `DONE` and six `SUPERSEDED`, with no active claims and no
-`OPEN`, `READY`, `IN_PROGRESS`, `IN_DEVELOP`, `BLOCKED`, `REJECTED`, or
-unexplained rows.
+`bfb6aedd28c47a6d796945c5ce5b39be24e4b8d8`. That audit closed 62 GAPs: 56
+`DONE` and six `SUPERSEDED`, with no active claims or unexplained rows at the
+time.
 
-The architecture and extensibility completion program has no remaining
-executable unit. Future architecture work must begin with a new GAP and closure
-package through the serialized registration protocol in §0.3; it must not
-reopen or rewrite this evidence.
+The 2026-08-26 ACES/Scroll audit preserves that evidence and registers R11.1
+with `EVAL-001` and `EVAL-002` as `OPEN`. No implementation or claim is
+authorized by registration alone; R11.1 must pass the serialized readiness and
+claim protocol in §0.3. The package measures delivered behavior first and does
+not authorize a new context store, persistent interpreter, or retention
+expansion.


### PR DESCRIPTION
## Summary
- Register R11.1 as the post-closure measurement package for causal Skill attribution and context recoverability.
- Add EVAL-001 and EVAL-002 as OPEN without authorizing implementation or a new runtime store.

## Why
The ACES audit found that GEODE validates Skill loading and policy but cannot measure the causal effect of target-skill availability. The Scroll audit found that GEODE has session events, FTS, compaction, and offload but no deterministic receipt that distinguishes exact recovery from summary-only, unavailable, or corrupt evidence. Measuring both gaps before changing the runtime avoids speculative storage and execution machinery.

## GAP Audit
| GAP | Current evidence | Registered exit |
|---|---|---|
| EVAL-001 | Loader/package/policy checks exist; paired with-skill vs without-skill attribution is absent | Native verifier-first paired benchmark on existing run-spec, attempt, trajectory, reward, and analysis authorities |
| EVAL-002 | Current persistence and recall surfaces are separate and unmeasured as one recoverability contract | Offline immutable receipt over existing session/offload authorities; no second transcript or live model call |

## Changes
| File | Change |
|---|---|
| docs/architecture/extensibility-roadmap.md | Add two OPEN GAP rows, R11.1 acceptance, sequencing guard, and post-closure ledger status |

## Verification
- uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request — PASS
- git diff --check — PASS
- pre-commit hooks — PASS

## Scope guards
- Registration only: no READY/IN_PROGRESS transition and no claim row.
- No new context store, retention expansion, eviction index, or persistent interpreter.
- Live model evaluation remains approval-gated behind a frozen run spec.