### PR TITLE
docs(evals): publish repeated skill-attribution diagnostic

### DIFF
--- a/docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.md
+++ b/docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.md
@@ -1,0 +1,170 @@
+---
+eval_id: skill-attribution-sol-max-paired-r3-20260826t130119z
+eval_family: skill-context-evaluation
+eval_kind: ledger
+eval_status: historical
+eval_authority: paired-skill-diagnostic
+eval_summary: Prospective three-repetition diagnostic after SA-GAP-01 through SA-GAP-03 closure; all 72 arms were valid, repetition deltas were +4, -3, and -1, and the aggregate signed native-verifier delta was 0/36.
+eval_triggers:
+  - skill attribution
+  - gpt-5.6-sol
+  - ACES
+  - paired runtime skill
+  - repeated diagnostic
+eval_contracts:
+  - docs/eval/schemas/run-spec.schema.json
+  - docs/eval/schemas/attempt.schema.json
+  - docs/eval/schemas/analysis.schema.json
+  - docs/eval/schemas/publication.schema.json
+  - core/observability/schemas/trajectory.schema.json
+---
+
+# Runtime skill attribution — Sol/max repeated paired diagnostic
+
+## 판정
+
+SA-GAP-01부터 SA-GAP-03까지 닫은 뒤 동일한 12개 synthetic case를 세 번
+반복했다. 각 pair는 runtime, model, route, reasoning effort, tool schema,
+initial-state fixture, timeout, concurrency를 고정하고 target skill의 registry
+가용성만 바꿨다. 72개 arm이 모두 유효했고 retry와 safety violation은 없었다.
+
+With-skill과 without-skill은 각각 **18/36**을 통과했다. 사전등록 primary
+delta는 **0/36 = 0.0**이므로 “총 signed delta가 0보다 크다”는 가설은
+**not-supported**다. 반복별 delta도 `+4/12`, `-3/12`, `-1/12`로 방향이
+안정적이지 않았다. 이 결과는 측정 및 artifact publication에는 유효하지만,
+runtime/package 승격이나 일반적인 skill 효과 주장에는 사용할 수 없다.
+
+## Frozen contract
+
+| Field | Value |
+|---|---|
+| Run ID | `skill-attribution-sol-max-paired-r3-20260826t130119z` |
+| Freeze | prospective, `2026-08-26T13:01:19Z` |
+| Run-spec SHA-256 | `4b9aae3140bc6dbf82247893cdd6128294d29f944df254ea87563e60d68744dd` |
+| GEODE revision | `9ff286071aab68825afa8158aa7ee982cea9c4b8` (`develop`) |
+| Fixture SHA-256 | `cf41a9ddcc10dca76c921f71e09537505f76d9a01281180a8e2ba2e39650b3ea` |
+| Tool-schema SHA-256 | `ca0d86355f7296738d952c98de19115f43cd7ecf4527dba8503de89b827539b5` |
+| Model | `gpt-5.6-sol`, max, OpenAI subscription |
+| Treatment | exactly one target skill available vs unavailable |
+| Model-visible tools | `use_skill`, `get_grill`, `update_grill` |
+| Timeout / concurrency / repetitions | 180s per arm / 1 / 3 |
+| Initial-state reset | fresh child process, state root, and session per arm |
+| Promotion authority | none |
+
+## Primary and secondary results
+
+| Metric | With skill | Without skill | Delta / total |
+|---|---:|---:|---:|
+| Valid arms | 36 | 36 | 72/72 |
+| Verifier passes | 18 | 18 | **0/36 (0.0)** |
+| Skill activations | 25 | 0 | +25 |
+| Irrelevant actions | 9 | 20 | -11 |
+| Input tokens | 262,187 | 188,285 | +73,902 |
+| Output tokens | 32,138 | 33,466 | -1,328 |
+| Total tokens | 294,325 | 221,751 | +72,574 |
+| Sum of arm elapsed time | 973.580s | 919.527s | +54.054s |
+
+Infrastructure-invalid arms, retries, and safety violations were all zero.
+The run used 450,472 input tokens and 65,604 output tokens, or 516,076 total.
+
+### By repetition
+
+| Repetition | With pass | Without pass | +1 / tie / -1 | Signed delta |
+|---|---:|---:|---:|---:|
+| r1 | 8 | 4 | 4 / 8 / 0 | +4/12 |
+| r2 | 5 | 8 | 0 / 9 / 3 | -3/12 |
+| r3 | 5 | 6 | 2 / 7 / 3 | -1/12 |
+| Total | 18 | 18 | 6 / 24 / 6 | **0/36** |
+
+Discordant pair는 treatment win 6개와 control win 6개로 정확히 같았다.
+세 반복만으로 모집단 효과를 추정하지 않으며, 이 표는 방향 불안정성을
+보이는 기술 통계다.
+
+### By target skill
+
+| Skill | Pairs | With pass | Without pass | Delta | Activation delta | Irrelevant-action delta | Token delta |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `deep-researcher` | 12 | 6 | 7 | -1 | +7 | -6 | +9,262 |
+| `grilling` | 12 | 8 | 7 | +1 | +9 | -4 | +27,775 |
+| `slop-audit` | 12 | 4 | 4 | 0 | +9 | -1 | +35,537 |
+
+### By prompt class
+
+| Prompt class | Pairs | With pass | Without pass | Delta |
+|---|---:|---:|---:|---:|
+| contextual | 9 | 6 | 7 | -1 |
+| explicit | 9 | 3 | 3 | 0 |
+| implicit | 9 | 5 | 3 | +2 |
+| negative control | 9 | 4 | 5 | -1 |
+
+세 skill의 negative control 18개 arm에서는 skill activation과 tool call이
+모두 0이었다. 따라서 이전 run의 seeded, trigger-bearing control 문제는 새
+측정에서 재현되지 않았다.
+
+## GAP closure and remaining limits
+
+| Gap | Closure evidence | Status / next evidence |
+|---|---|---|
+| SA-GAP-01 — hidden verifier IDs | fixture loader가 model-visible context에 없는 required evidence/finding/question ID를 거부하고, research fixture가 required finding ID를 노출한다 | closed before freeze; all 72 arms admitted under the corrected invariant |
+| SA-GAP-02 — answer-only grilling terms | verifier가 answer, question options, recommendation을 하나의 structured prose surface로 채점한다 | closed before freeze; frozen verifier was unchanged during the run |
+| SA-GAP-03 — biased negative control | negative fixture에서 decision trigger와 seeded `GrillStore` state를 제거했다 | closed empirically; 18/18 negative-control arms had zero activation and zero tool calls |
+| SA-GAP-04 — narrow capability surface | model-visible tools are only `use_skill`, `get_grill`, and `update_grill`; context is synthetic | a separately preregistered native-capability suite needs web/file/delegation authorities before claiming full skill value |
+| SA-GAP-05 — unstable treatment direction | repetition deltas were +4, -3, and -1, with aggregate 0 | redesign the intervention hypothesis before another run; do not add repetitions merely to search for a positive result |
+| SA-GAP-06 — task-specific structured-output ambiguity | all six `research-implicit` arms failed with unexpected or malformed `questions`; no parser error was hidden | preregister task-specific empty/question rules or separate schemas before rerun; do not change this frozen verifier post hoc |
+| Exact-term interpretation limit | deterministic required terms measure lexical contract compliance, not semantic equivalence | any blinded semantic audit must be a separate preregistered secondary authority |
+| Replay intentionally incomplete | digest trajectory omits system/session/model content | keep content private; use the reviewed scope-complete release for audit, not replay claims |
+
+SA-GAP-01 through SA-GAP-03 are measurement-contract closures, not proof that
+skills improve outcomes. SA-GAP-04 through SA-GAP-06 prevent that stronger
+interpretation. The zero result remains immutable; the verifier was not tuned
+after observing it.
+
+## Attempt lineage
+
+The first frozen run, `skill-attribution-sol-max-paired-20260826t110744z`,
+remains infrastructure-invalid because the provider rejected its model-facing
+schema before generation. The next valid run,
+[`skill-attribution-sol-max-paired-20260826t113400z`](2026-08-26-skill-attribution-sol-max-paired.md),
+reported +4/12 but exposed SA-GAP-01 through SA-GAP-03 and had one repetition.
+PR [#3220](https://github.com/mangowhoiscloud/geode/pull/3220) closed those
+contract gaps before this run was frozen. No predecessor arm was relabelled,
+replaced, or added to this denominator.
+
+## Artifact and privacy contract
+
+The native run bundle and learning view passed their repository validators:
+72 attempts, 12 examples, 72 rollouts, 72 rewards, four declared run artifacts,
+and one analysis record. The source run contained 589 files (2,398,227 bytes).
+The reviewed public boundary contains 303 files (1,398,399 bytes); 289 source
+files remain withheld.
+
+The public trajectory is scope-complete for all 72 outcomes and intentionally
+not replay-complete. Its release manifest binds 75 source digests and 630
+events with zero configured secret-scan findings. Raw per-arm native results,
+model text, tool payloads, local trajectories, child stdout/stderr, runtime
+state, OAuth material, and operator logs remain private.
+
+## Publication
+
+The append-only artifact PR
+[mangowhoiscloud/geode-eval-artifacts#32](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/32)
+was squash-merged as
+[`1efee3d0f4bfda3464b23b298a36f9a97f5fa691`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/1efee3d0f4bfda3464b23b298a36f9a97f5fa691).
+The immutable destination is
+[`skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1efee3d0f4bfda3464b23b298a36f9a97f5fa691/skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z).
+
+All 303 public entries (1,398,399 bytes) were downloaded again from the exact
+merge revision and matched their frozen sizes and SHA-256 digests; mismatch
+count was zero. The trajectory release manifest SHA-256 is
+`f6ee84d7139a3c33905ae48bb420519083890444d52aa0a4f82aee046b7f385a`.
+The final publication manifest is
+`docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.publication.json`
+(SHA-256
+`42c1cd6b8bda434e76f8659dbccef765f49e1382a80e5a1df653f1f9f98205b1`).
+
+## Release readiness
+
+Current judgment: **measurement-valid and artifact-publication ready; the
+positive skill-lift hypothesis is not supported, so runtime promotion and
+package release are not ready**. No tag, PyPI upload, package-version change,
+leaderboard claim, or main promotion is authorized by this diagnostic.

--- a/docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.publication.json
+++ b/docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.publication.json
@@ -1,0 +1,4472 @@
+{
+  "artifact_repository": {
+    "base_revision": "fa352cb5f54e9f0ad6198c03dd180e27be388b5b",
+    "destination_prefix": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z",
+    "url": "https://github.com/mangowhoiscloud/geode-eval-artifacts"
+  },
+  "entries": [
+    {
+      "bytes": 8578,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/analysis.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/analysis.json",
+      "sha256": "09c95a244de355711e555a913bfed45137714d4336b69ef55fe23a04eefece79"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/arm-result.json",
+      "sha256": "6c5a3fee49ebcf65eb2e3f4c3179c1da5376308dfe98b8fade452354eb842fec"
+    },
+    {
+      "bytes": 7128,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b235482daaf3be114bcbce96baabf92c1e4c55b4a0d6d1f9b9b7d6e5c5228f68"
+    },
+    {
+      "bytes": 614,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/request.json",
+      "sha256": "ab115416e61dc968e55cce53621fdea8e29dd58b361fbf4ee8170764e40b83b2"
+    },
+    {
+      "bytes": 832,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/reward.json",
+      "sha256": "c4ad22f2766d519d621a71957a7a349a794515d2650bed1351460f10ebbef6a0"
+    },
+    {
+      "bytes": 12769,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "95bd5108601a03bebad1657ac188f73de7b0066aa05b1cae841c1ce4cd912186"
+    },
+    {
+      "bytes": 674,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill/verifier-receipt.json",
+      "sha256": "ee3642109a795c9e256a2df46c92a6da648763f65b826699adf693eff724673b"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/arm-result.json",
+      "sha256": "33d152efd06a8a3aed794940d61646e8a1b300e0e0c6fd40f48a7e7eb48992b3"
+    },
+    {
+      "bytes": 4302,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8d24005fa35f2c79dcdf848ac2c90d23299ea8a424e5448896701cc96e6de1f9"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/request.json",
+      "sha256": "d47be4d3b7ed4b44f250d3ecc5924fc2dd70c1970ae74f8dafe24bf5a305a548"
+    },
+    {
+      "bytes": 839,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/reward.json",
+      "sha256": "c88cf726604bbb01dfff1853528e08660bf8f53a7a839e5aad0de0192ef51faa"
+    },
+    {
+      "bytes": 11042,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0057b51e730795eed00ecaf1bef193debce9e8ff7bbc704cb69ee3d24e14eac1"
+    },
+    {
+      "bytes": 677,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill/verifier-receipt.json",
+      "sha256": "5e7328f0161db15c429ee398d7142667e7cb644bdb2a0922601d6931ae0beb88"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/arm-result.json",
+      "sha256": "b098f908aaaf00af5c23a63393304aca02e750c63aa077920ecdb01742be5332"
+    },
+    {
+      "bytes": 7298,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "1e2a6e426638c62d1dc459f29d0dd3d411443d3f93adb17f1acbecef9daaed18"
+    },
+    {
+      "bytes": 614,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/request.json",
+      "sha256": "e8cf96f56d860aa3d905bd20001d4e6a6e70f5399c6189bcbde571703e33e4bb"
+    },
+    {
+      "bytes": 832,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/reward.json",
+      "sha256": "c414009a6515f5febfad3b5856c00e3e4f5e5652586c497743231429a7cf9a68"
+    },
+    {
+      "bytes": 12770,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "5f7c0fdcd38e204f2533ef00c68e4a8fd4a2dbb303bffbb7a2fa12f5e9753128"
+    },
+    {
+      "bytes": 674,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill/verifier-receipt.json",
+      "sha256": "6adf65f22d57d307979068e2e1d9897be951b10f62da8054ebac45a03b68d94d"
+    },
+    {
+      "bytes": 1329,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/arm-result.json",
+      "sha256": "264a88c94a2f003fc1c7aa67b95e080c17b449815c3ace060345f084942fce73"
+    },
+    {
+      "bytes": 4813,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "6d98f6db857f4bbd76315e9370630e012eb003b333eeef3bc85cb1ef38aeb974"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/request.json",
+      "sha256": "fac2c9344f454231a42ffd8b37925ca3969089e5388e9f7174017c60f96bc348"
+    },
+    {
+      "bytes": 839,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/reward.json",
+      "sha256": "49cd709ecc4c559544f3a946eddf596ddcdb13d771cfee95c74949e9013c9a8d"
+    },
+    {
+      "bytes": 11045,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "5375789757198e29c88fb9fb0764880fcb7c5137a227b1fe27a1cd95e2932fc4"
+    },
+    {
+      "bytes": 677,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill/verifier-receipt.json",
+      "sha256": "25bedeacbe2323c196a6558cb39f1bcc38ce00e99bad862a69ce0751d4d1f193"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/arm-result.json",
+      "sha256": "85ad3b3101be5b5caf6bc0e5b90fc56b8f7b250eb0e8d7da76a1132f9e229e3c"
+    },
+    {
+      "bytes": 7763,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b920287b5605d27f8eb04c58ffd3205ec4bbcbae48bdbe4f7b0d73b5552f3bbe"
+    },
+    {
+      "bytes": 614,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/request.json",
+      "sha256": "8e87e03a06ca530e56913c4e13a1788a7fab4ce78db37ddeedcb675e9ede62e3"
+    },
+    {
+      "bytes": 832,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/reward.json",
+      "sha256": "66fe707778462c6f3eb2ad1e0c143823fa5f7f80f4722937c1c3aab1256ae906"
+    },
+    {
+      "bytes": 12770,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "2e1a0454f74a4c24884943fefc138e3b708724fc99bb642512872b9a4cd9b707"
+    },
+    {
+      "bytes": 674,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill/verifier-receipt.json",
+      "sha256": "57faefb6b4b2e025c00578340789fe2228d268b118fdb4e161a4122d8dca31f9"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/arm-result.json",
+      "sha256": "7e92318d004dbf97337ad58abb97658dc064cabdeebbf663359acf83b3bef85f"
+    },
+    {
+      "bytes": 5334,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "739b8cc2b9ce0c46c26f783450094ebc5a431f3f21c346e21a777f9b66177926"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/request.json",
+      "sha256": "42e3c26d0a7490027cdb4f275e4117e3f9cf31aed0fd8f292a3f276eb46f1060"
+    },
+    {
+      "bytes": 839,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/reward.json",
+      "sha256": "c8e963afe5adc488aeb155c60709014ee74d58d8d03bc49f1636cadbfe5a84f7"
+    },
+    {
+      "bytes": 12770,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8af2c13fd511678fb2b409107d8e27e4ed9264795860ffcfb12ab5fd8df3a409"
+    },
+    {
+      "bytes": 677,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill/verifier-receipt.json",
+      "sha256": "65f45edfac69f40fd98c77324e37e80f17f4e1ac58829440d5a57a757ab926e7"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/arm-result.json",
+      "sha256": "44868923881f32aaf3e10f936040652355e50e4d752370b62288c7f12649ae75"
+    },
+    {
+      "bytes": 12279,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0128b2bf55c9251306724e01751bda4bcf534052067385173a9580b4b7794961"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/request.json",
+      "sha256": "2f1221bc5846b53fcc59577aa57b331f3cce9155ef60bc1a3348f5c53994125c"
+    },
+    {
+      "bytes": 827,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/reward.json",
+      "sha256": "8968157cb0966160f48897b98fd33bfa6776189bca436e22ad65e5366360d4b6"
+    },
+    {
+      "bytes": 12773,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "f8a6bbd600deb8f4eac8feaaf8fe36f7390d06f9d0e41aa82aab3b50740b4f1f"
+    },
+    {
+      "bytes": 696,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "c6c6098e83aa6daf9a2e2e4e28474c49cf669c963fcf1e5799bf44d65222cbd0"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/arm-result.json",
+      "sha256": "d9b7d8a85a93f133dde5353c1f38ee82e639750ea6f245d15c6246def4fea12c"
+    },
+    {
+      "bytes": 9990,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "492d34d749a33b97bf981850fa0a034bfab82bb7d80fc69ee6589c6f54ac8b38"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/request.json",
+      "sha256": "0b69a47ddba9d3606ed212d779b063f4be315ea61cc7ea15d47cb41106d68004"
+    },
+    {
+      "bytes": 834,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/reward.json",
+      "sha256": "d327205e5cf0cadb8c77c84e8a4db3b6191440f83200a85955f1976ad4ad3873"
+    },
+    {
+      "bytes": 12774,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "aa8e4dd328340e21b46824e9e5b38c0977db89b95bd804ccf96247c9d6c6e3bb"
+    },
+    {
+      "bytes": 699,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "61c3649aaa45bc9eced6d9a3b92ecd61c46dead26abec13f7041d5cd9fc3074e"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/arm-result.json",
+      "sha256": "4ac58cb892e8c4b308c2ff24e5c66fdf228681d290cdeb0153d7c7b9fa3d4451"
+    },
+    {
+      "bytes": 13987,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b8b614215b52e551828c26fbcdfeea6e14da0d658df53fa6bf8785d008dac51c"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/request.json",
+      "sha256": "4e95082f23607ec107aa9a29d82c8d589220fcbfb5e9d81d9b1968d4dd799772"
+    },
+    {
+      "bytes": 827,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/reward.json",
+      "sha256": "d13a740f96cdeff9efb1331bd43c4675e48a2cbcdee34103d6b16220328cab97"
+    },
+    {
+      "bytes": 12773,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9089c36710aba73d2661e4b63461bf31e46d5b3e4713271dad3c5412386b870f"
+    },
+    {
+      "bytes": 696,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "9078cdefd4d72b6bd5e41943f169b9ee46ed411fbbf395df26c927b4a4306c3b"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/arm-result.json",
+      "sha256": "4f273cc34beae3bb59640ffe1c42a10edccdf3a64aeb9913a641f59b5daa478b"
+    },
+    {
+      "bytes": 10882,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d721c46ca5da280b6faeb2633c6262ec3d114a12b810d6746da50b383705c7a4"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/request.json",
+      "sha256": "d41e073d870df8773be6be74f12219d72d91147595754eed610e9b1c2385e920"
+    },
+    {
+      "bytes": 833,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/reward.json",
+      "sha256": "6048ae4fff0a7c0009681995dd6da5795ada308eab21bf78c2804acfe8cc570e"
+    },
+    {
+      "bytes": 12772,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9ce9f516883a3f7399de85f39ecb913b76946d85dde2fd870f3c00340074f07d"
+    },
+    {
+      "bytes": 673,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "009bf5fc920f4188f3229752c36346d9d6798384b8dadb54b32aa9cce98eafd4"
+    },
+    {
+      "bytes": 1323,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/arm-result.json",
+      "sha256": "cb1c995aea935bd9def50ed899839099294371115a5ebc47bdb41fcdfe9fa2e8"
+    },
+    {
+      "bytes": 11904,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "94b264bfdbab4f71990eec40f6d37ec84ab8d5935ddace53ab646a766eb2da5c"
+    },
+    {
+      "bytes": 599,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/request.json",
+      "sha256": "bc772bf23c2c14515de412d23f90a0be8b4bc7728a436b4e0efb9768a5e26061"
+    },
+    {
+      "bytes": 826,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/reward.json",
+      "sha256": "ebd900d148b4956450b057b0d6bf796ec8a8361a4a0fb05bdd95fd813032b9fc"
+    },
+    {
+      "bytes": 12771,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "2ed3162590918e0fbb565b2084c938d815851bd56d64e676c89863e9f74dafdf"
+    },
+    {
+      "bytes": 670,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "52cec1c20c69ff1683014c181edf3f74c9a55e9854b7a1d31d737050622bf1b7"
+    },
+    {
+      "bytes": 1329,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/arm-result.json",
+      "sha256": "969bb629afbf2482d7443345ceace34eb5b9ca71200987ba452a10e856fa9739"
+    },
+    {
+      "bytes": 9430,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ecd91991d340be6ba18052f154445ba4d090e46c68f8f6b37663daa9518a6896"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/request.json",
+      "sha256": "de7898af714b810a5d60fd203c54dfee443d17ffc4e1d550090729a0d92429f1"
+    },
+    {
+      "bytes": 834,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/reward.json",
+      "sha256": "efcce4f7684f8f496458e835f384fdd1cd87d3dfc831ea6469fbe3e4cdb1c588"
+    },
+    {
+      "bytes": 12773,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "acf3c8d9353255ef69a64919c2a573bfe875ac6eceae003c2841512aa7ca6843"
+    },
+    {
+      "bytes": 718,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "0ba3280d474a046b796f21dba1273b2b3344d074d1d740b7d1ad995af2389037"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/arm-result.json",
+      "sha256": "57f2e2719365e7a04ecf46d0b6437c8afb301b512b48acc9ac3569503f10cab5"
+    },
+    {
+      "bytes": 9294,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d67ecf0bc0d7b15a9ae695a9f5c98d69e7dee90b94a0c8007538b5383699566b"
+    },
+    {
+      "bytes": 597,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/request.json",
+      "sha256": "48eee84fbb6dc4116172436cfb3fe52a91a582f5dd24bbde79f5124b2744caff"
+    },
+    {
+      "bytes": 826,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/reward.json",
+      "sha256": "93bd0d185df932a1e7b03c02d59a544f41ac32ff79237b4078c9807cfdd3c968"
+    },
+    {
+      "bytes": 12771,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "21befcab7d7c6aa5d2be39ce5b218de63ef22b649da322d28a2bc0e0822c9b80"
+    },
+    {
+      "bytes": 670,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "778768fbcbffa00365b0a5d6fbbf74bed6b5a1f97c2d82a32d7ac2a6bc08dc4b"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/arm-result.json",
+      "sha256": "36fd99e50742850c050411442050e592399988c8c463982954a3890aff7349f2"
+    },
+    {
+      "bytes": 6248,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9f2d4d67ce6077475fadd3439f4b84e2528b08063d610271b7b3ce9b761a5bb8"
+    },
+    {
+      "bytes": 582,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/request.json",
+      "sha256": "da5854bf41e1dea49e7069999c2efc4e2c1bdf389295cb0ea44af912bfdd56e6"
+    },
+    {
+      "bytes": 834,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/reward.json",
+      "sha256": "5257889323d9a2e94cb0d1cc4883602c3ecdd0bc88613ee43e2a57ca55c873a5"
+    },
+    {
+      "bytes": 11044,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "6a3914d57f217a70514e4d8b74f7a6f95913afbedd27687f6ecc869f469cad57"
+    },
+    {
+      "bytes": 698,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "081fbff18e39603d560e7b0f3457899886e60bc686098a0d57064458f0a9aac6"
+    },
+    {
+      "bytes": 1323,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/arm-result.json",
+      "sha256": "f08c151411796552a95e8ebd7ded88ae7c0b8e971422ab8e1144ca15901261cf"
+    },
+    {
+      "bytes": 9752,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "652f21bf58caaf89550f93617089fec9212e42ce94797c5bc88e548aa1cbda42"
+    },
+    {
+      "bytes": 597,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/request.json",
+      "sha256": "a4c2094e528a3f459517803db0337331baceb757adfec214835842a99517230b"
+    },
+    {
+      "bytes": 826,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/reward.json",
+      "sha256": "1b296c2c4be6d003d7f4de2242f492ad8a51266a71b1fe4956dfa0b94c4ed764"
+    },
+    {
+      "bytes": 12771,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "10c9bd4e78906f6fd5684d14c31430dd26ff64a4fd45b386df5fb54e24c1b928"
+    },
+    {
+      "bytes": 670,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "63730137ed2029c814775c4534b5198123d1778bafa35d1a8c220e250ade38aa"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/arm-result.json",
+      "sha256": "01bb741468911977c6259e85455c9c2c712ce5ca855b71d1d1e188efe3e5c719"
+    },
+    {
+      "bytes": 6466,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0314a2cc189001e11c10317a97a2e8c8ec2229c647639ec41094cf7d541feaf8"
+    },
+    {
+      "bytes": 582,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/request.json",
+      "sha256": "2ca730617f7b6d0e572460d383253be58a9d5f2c63a6df99d1e0147fea7396f1"
+    },
+    {
+      "bytes": 833,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/reward.json",
+      "sha256": "867ecb4430525d16f0e4a8ee3c9a62cea269abb86c74e1ea0a48c37ee28644aa"
+    },
+    {
+      "bytes": 11043,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c751d762a89c495671fd2bf7cc37919add058d94040bef47f229efb521688d1f"
+    },
+    {
+      "bytes": 673,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "b51229b495fd417f6f85461750e075989af35ef90ee6f645ebc04d48700088b1"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/arm-result.json",
+      "sha256": "3021d935b0055ea67485a1fc4414d0d205967b2643a0dda6ab6d4575a963870f"
+    },
+    {
+      "bytes": 9598,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "21bc23929587286cfb46db8cced96950c4e7dd693bfd5ae0d92eefc35545b6b9"
+    },
+    {
+      "bytes": 597,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/request.json",
+      "sha256": "51fa9a0ca66337f1d9cf47ca74e181246d05b8a214b63f59438472bc2235db0f"
+    },
+    {
+      "bytes": 826,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/reward.json",
+      "sha256": "a06c5f43a228625990989c912da8d61b91511e9716dd3eaeea9f7b6636e9b7e9"
+    },
+    {
+      "bytes": 12770,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "113fd436e50bbd7078d8101faeaee68fd3a0b468b86cfc02b564b078bba9eb13"
+    },
+    {
+      "bytes": 670,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "7c5c381b164e7ce784c0315abb4cf6228b10a18c8b560347ea60f68c7a5c1925"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/arm-result.json",
+      "sha256": "05c844f8d7a01ab5f4765d9ef76c7b602637f2f2f8d88e083ff74ff98ef7d1ca"
+    },
+    {
+      "bytes": 6803,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c8acd957d0122370b9bf9aaae8860aa51fbfd6485d9b54229663d4069d47a7d9"
+    },
+    {
+      "bytes": 582,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/request.json",
+      "sha256": "2e72f5ee2cf6285fd07c33e262723ef662a9e95ce0d0ce6be0d81d3f673e25c2"
+    },
+    {
+      "bytes": 833,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/reward.json",
+      "sha256": "84351e1bc5b5a3b50444e9af6ff3d4942e997a73d249bce43dc18674b0ba52ad"
+    },
+    {
+      "bytes": 11042,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d758da8e493a67f062029972f730cc5c9b8017c1f010f70c01976f2d9d8d7c16"
+    },
+    {
+      "bytes": 673,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "526ea77de8b4a0c39e6b0aad812e5f6958c5293a06859fee288a7d6648e835e8"
+    },
+    {
+      "bytes": 1323,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/arm-result.json",
+      "sha256": "214b475d3a0a955df173983c3420f6c58fcc793ea6584a2afb4d2d613b99e766"
+    },
+    {
+      "bytes": 1025,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "cc03c5a7a4bde8eb801bc075a642a71f2854e4f1a6fd7619bb1e4f25db1fcb0a"
+    },
+    {
+      "bytes": 605,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/request.json",
+      "sha256": "4b538b91245b00ccb212031813fb92dc1f02cd1405646dced26a60ed088799ef"
+    },
+    {
+      "bytes": 828,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/reward.json",
+      "sha256": "14ae77242fcaef9edc37382dda690275dfdcd45ebb54e93a2f81da2c68c1fd8e"
+    },
+    {
+      "bytes": 8223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b227fbf3cc9d49823e5d38eaf7a9f852760a5d6718139531caa1f6716821905f"
+    },
+    {
+      "bytes": 714,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill/verifier-receipt.json",
+      "sha256": "00322cb7fd13e3f9c0243e1833c2f16ca9f67c81abc1d1110cc1520dbe23ae99"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/arm-result.json",
+      "sha256": "248de667bbe072e9819b0618f64693248b81a31b2565010d994a99672cbdc564"
+    },
+    {
+      "bytes": 1051,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "a492b4f7e9db0e9a847006ddd36020a8ad0c1dceaf32a070a3f3c6e22a6e86d8"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/request.json",
+      "sha256": "f1077070b67cbdfd2e8ce3775fb3ba6798521f8270efe5bdc2024b812fe99b04"
+    },
+    {
+      "bytes": 834,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/reward.json",
+      "sha256": "f4c74b2db04d966092cdbf41991e973cb9e1a83ed9be1e69c6b9b8a7f064c588"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "1e438eb7039d0c70f122f0d034c3e3b1e4f87aaa2d6cfc068044712f7f87c9a7"
+    },
+    {
+      "bytes": 717,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill/verifier-receipt.json",
+      "sha256": "da63a707e6c84f5a7904ccc44c2bc86087421cf317c0187c3615b4db9a2877ca"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/arm-result.json",
+      "sha256": "7b75f91a1d11440cc1766ae19aae8153e80383ccc0f584b68acfaae4ae0e3e98"
+    },
+    {
+      "bytes": 1068,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "a1ea5e7685a5b548bca21b4df4f8d5680baf203c79c71652897f41c1770661ff"
+    },
+    {
+      "bytes": 605,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/request.json",
+      "sha256": "edd78622c2e3759eee7a5b6a4113fd2d425d62517c7870a180adb104d04cd1be"
+    },
+    {
+      "bytes": 827,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/reward.json",
+      "sha256": "3d418f34b4055dcc4953a8d475c1d3f510e2595f18c035120a1335f36ac3b984"
+    },
+    {
+      "bytes": 8222,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c466f4d0c62a94a373ae725bd0588bc1974616f24dd4ba1605ed718b638804ba"
+    },
+    {
+      "bytes": 670,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill/verifier-receipt.json",
+      "sha256": "6794c8533071084042af4cab0ac8225dbb05a14c1e6d5d7939fdfd7058902562"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/arm-result.json",
+      "sha256": "60965639821e3e3c86e751d23136023405886778667948ace8825d1b62a0837b"
+    },
+    {
+      "bytes": 1046,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "cce1cf8a4c2cf2476e6d5320d5c65f94c5f9b661d2d467ebcd9ce771688b30f9"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/request.json",
+      "sha256": "7e86d86087979825c193b35775568521559d8736a13ae99460b18f30a77b93ff"
+    },
+    {
+      "bytes": 833,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/reward.json",
+      "sha256": "9406d09617bc4ad8bb3651e7a1b9edc6c3425780c116b8661d90a306b760e8f2"
+    },
+    {
+      "bytes": 8226,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ff44b9800666e942e972ba0c123e836389ab41a8b9d2f86248713fb00a4f5a81"
+    },
+    {
+      "bytes": 673,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill/verifier-receipt.json",
+      "sha256": "abda47332c334fd18115bddab195880d846d642d2ce0cc536dac3a9885ac8ccc"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/arm-result.json",
+      "sha256": "b464b18402a87c7e88be3d13d0671213bd78f5f2990356891937eb8a7d10c473"
+    },
+    {
+      "bytes": 1044,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "97614fa37eb50515fe9988f062e9a0256d3f8e8d5136c71c4e05950e8a5c601b"
+    },
+    {
+      "bytes": 605,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/request.json",
+      "sha256": "f034ec95cf3036c107d663aef4f2068e6375b261bd27b1dbb00e2d8717e97974"
+    },
+    {
+      "bytes": 828,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/reward.json",
+      "sha256": "551c37b846bc3a8ecf92077d283d8691045518c9e5edd3de1b601d8fde8bcfc6"
+    },
+    {
+      "bytes": 8223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7d6446de3ba9e69f6aa6d0e1f7355e789cfdcca794204af80e2b97f1ea32d886"
+    },
+    {
+      "bytes": 714,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill/verifier-receipt.json",
+      "sha256": "69e0ce8ef6877f924dc4004e4dd574ceaed16b0d8b2702e6b8c29848077171f9"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/arm-result.json",
+      "sha256": "d8381319f813a7ceb181da4945f6ff079c57e278b0695d1306604d67ece8d0ae"
+    },
+    {
+      "bytes": 1049,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0649d71e66b1460f9f442a8abc23b20346dc91c90bfdef2493473789c6fa6965"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/request.json",
+      "sha256": "bfd6967e5a75de5f60dee971b133068c958525db57b7249352a2254e88d92cae"
+    },
+    {
+      "bytes": 834,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/reward.json",
+      "sha256": "641af55c5432d8efab18eca54d2da6d2e013630f783b390d8b5b4a616dfdb7c2"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "3e6b00a6868857c94d4bb839d370846ff7cbcd4bc2dc7b66682265d752520a05"
+    },
+    {
+      "bytes": 717,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill/verifier-receipt.json",
+      "sha256": "f7369b7e08017859b752845020ed2181ffce35e054d39c18dd5134ef2a2eeee9"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/arm-result.json",
+      "sha256": "16889991d0d62e20ff5aada95aea07704f3ceabce2bf1d9f285f9e4005ce6166"
+    },
+    {
+      "bytes": 1510,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "eebe7c180a83b46875ab8db3558227b47f667bd02234bb365f5820dc1dc4342b"
+    },
+    {
+      "bytes": 624,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/request.json",
+      "sha256": "91d9978c5e6aa69648925c17e8a2366116d91b5b4e2e5e9899e5cf3516db38e8"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/reward.json",
+      "sha256": "0b135224cd214bdb89f0f16925d665899f3b8840734a4c2e683f2ba4f8570648"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "672edbf9d77bfe527a4d157a6104cdc044564ae4cdf25345eb1ef5780d0a245e"
+    },
+    {
+      "bytes": 680,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill/verifier-receipt.json",
+      "sha256": "e2085a7ced8f2791e9b9fb4f3eeee69a66af6a7d59f5316f39542fd93c6ff759"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/arm-result.json",
+      "sha256": "85eeb6cded026dbcc8529c80b66d1b0f131c16a03568e3b133fd9934de2ebf29"
+    },
+    {
+      "bytes": 1601,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "af7774838f636007f3a2186d4086b4c0db1b4cb6896380705f7a61cb848be342"
+    },
+    {
+      "bytes": 602,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/request.json",
+      "sha256": "8d5795efbceadc875eff14210107b5d797501fb4cc5edb70a0452035f71e39a6"
+    },
+    {
+      "bytes": 848,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/reward.json",
+      "sha256": "6935ce11e1d7faaab7dbff025093102ff9d132b6395f4571f36846c2f397d2e3"
+    },
+    {
+      "bytes": 8231,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "53d968edba0b14f06376efa1fbb650e96539b76d7286d90c1db50f35f2bd237f"
+    },
+    {
+      "bytes": 683,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill/verifier-receipt.json",
+      "sha256": "48523560f9d90cd4e2045595fb20a1f3451c8c419427c47f6254afde47a6cc68"
+    },
+    {
+      "bytes": 1327,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/arm-result.json",
+      "sha256": "58d964b2e591704ac33809172058b5eeb122d9aba3ddcc231b58e1fa2298d5a7"
+    },
+    {
+      "bytes": 1557,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "daa147ecd212307c521c4345578402096eabdf2b578a464c0af81406ebf2f192"
+    },
+    {
+      "bytes": 624,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/request.json",
+      "sha256": "e81a69c37dd1c91eabee5797780b6f817e8ca4e9b1fdfae43e07d0679a58d6a7"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/reward.json",
+      "sha256": "960648c7f92aa8d465e5311956cc8f001dc9934cec48e5f3e9336bd65a59fd08"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "f2f9c68a4f3aaff07139306d65a5d14cc29cf0b4a56ed7ba5e635b744e75402e"
+    },
+    {
+      "bytes": 680,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill/verifier-receipt.json",
+      "sha256": "46b2cf071e394a05fae7c1dd5dd2ea165ed9b253039ba113f8799bc1523c5211"
+    },
+    {
+      "bytes": 1331,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/arm-result.json",
+      "sha256": "099c882a96df2aee8ced9d5b953db67c8dbae4d42b91e515d6c30f028e17df80"
+    },
+    {
+      "bytes": 1530,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ec79af5a61a35c8db8a7797918499367d2f02100cc973088d3c7ebd29aed4984"
+    },
+    {
+      "bytes": 602,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/request.json",
+      "sha256": "c36ee44e37cfc4cfac25e3809141312e6caa7bc7e55567eb1c39968c21d08cb5"
+    },
+    {
+      "bytes": 848,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/reward.json",
+      "sha256": "8af15b8398fa8fa6dfb219782965c1559f5379e30c43b9c49a2f11c24ee91e99"
+    },
+    {
+      "bytes": 8231,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ae1390cc00d0246f54c867310c84e5cef1f8e26ae14ab31e06b3b81eb8d8d8e8"
+    },
+    {
+      "bytes": 683,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill/verifier-receipt.json",
+      "sha256": "f9253f99d06be1c3d991d5649383acae4ab1b2721d194b553ee78165b6e9e88d"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/arm-result.json",
+      "sha256": "753c4ca24f009f58f895ca5b2aa756c367592f615b42ddee7fc33440e4e1b634"
+    },
+    {
+      "bytes": 5266,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9bfd9d0a8fb72e4cd1725deebce806f30f1d6f95bde376c5a29b54ec406ec144"
+    },
+    {
+      "bytes": 624,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/request.json",
+      "sha256": "95269035b3bab8c783679d7d1ead1eb1780d0ad0ff70f3bc0b74862545c476d9"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/reward.json",
+      "sha256": "fcbf1eda697053b237bcaf0d74fdcffe6deedda08a3972ba6d572859a04dc3c1"
+    },
+    {
+      "bytes": 9952,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c28f548541aef20b29b793c76dd0474c7269ef776e3dc1eae928c254aba73209"
+    },
+    {
+      "bytes": 704,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill/verifier-receipt.json",
+      "sha256": "b1b1314b600bdf6e69bdb5289bb51ab5584a1abc6995f907686984a2a9904a10"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/arm-result.json",
+      "sha256": "33c9d565e4d7389e242d390b9f09178eacaae45081d365e469d5cf3044ae1e59"
+    },
+    {
+      "bytes": 1568,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "47045a2825854d16e38d10f0d429d14df9983636465f1cdd2bb576d4d4a14da0"
+    },
+    {
+      "bytes": 602,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/request.json",
+      "sha256": "03d47772ad25acb3791267dce76905d93f55405c3cb54985afc1e59c63814ce2"
+    },
+    {
+      "bytes": 848,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/reward.json",
+      "sha256": "7f028e0d68436a1cf76b492d7ddc9a3cfbece243b8d52169c3d7be1fd2db2072"
+    },
+    {
+      "bytes": 8231,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "4f7c74c8fae51b1c10b234ee047c59db7550b4b1441f96f79add5617785fa95f"
+    },
+    {
+      "bytes": 683,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill/verifier-receipt.json",
+      "sha256": "78e024f6203a21df12da86ff53430dabf518322e29e86681940f73162c69912a"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/arm-result.json",
+      "sha256": "3bf43c2ac1abc78ab548ab801f426cc1efe431c9631283043c4815da0d7e015e"
+    },
+    {
+      "bytes": 5751,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "2d6d52c7d9e56e7a38862b00433c691bd7b4514fd7054b95058f616cbaca29b6"
+    },
+    {
+      "bytes": 612,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/request.json",
+      "sha256": "b89f2e530a96cfb55af9337807abac49275a91922b4832754f80653c8a923b4b"
+    },
+    {
+      "bytes": 835,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/reward.json",
+      "sha256": "59593820b12bced5426fa3d665b228f838e14855d7a4ab8288f13a9ec0d86da2"
+    },
+    {
+      "bytes": 9950,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "fefddcbfd85af1ed6562ad1a5ef33bc5cd8ff5df8d5c1823828c86de57de77d1"
+    },
+    {
+      "bytes": 676,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "4d42c89a676d34dad9069412e7f6abef1b2d502dc34f22de59db3dcc0f2e27f8"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/arm-result.json",
+      "sha256": "a3cb3805b6f96a26e101ef8a55478a18f6ca44cc4e2d3214f129e8ee7a7bc17f"
+    },
+    {
+      "bytes": 2048,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "cd55d38ddad214ac09fde91d6e1d5cb336ce61a8a54348b116b41d27dc5fa54e"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/request.json",
+      "sha256": "4cc9cb9849cf80141b1d9e85c313a3571070fb135e99603692c806b91fe68cab"
+    },
+    {
+      "bytes": 843,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/reward.json",
+      "sha256": "d0d7f21c1dd457407871271ac07846a5287f812a9e1158bc85825407d29d27cf"
+    },
+    {
+      "bytes": 9956,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "68fbbbec351418d750fdf47ef98bc426e406ec63bcb80f1a191d15c0eda1f7d5"
+    },
+    {
+      "bytes": 703,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "d36017dcce006db658e7781d0d8807be37d730a48f5d417b7830a448f01957c7"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/arm-result.json",
+      "sha256": "f80e0e92aa4dfe595b36228500dbb305070af0395f10cda78f83294f82f045a2"
+    },
+    {
+      "bytes": 5524,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8b18e349886a6290a42f1ee0107aa1e5f5ab69c4d95ebc9c40ebc7a51edefd72"
+    },
+    {
+      "bytes": 612,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/request.json",
+      "sha256": "363c052ffb9914853efe4b9b763451f83e74db86d50e873461a9d3779e7ecc3a"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/reward.json",
+      "sha256": "f9289af1636dd07ddbf9a7145e2ce4cb1c52561df72fab8403890a122bf5cb1c"
+    },
+    {
+      "bytes": 9951,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7527957c031c09cc62e905aeea738b6235b5449527a5a9dc0ded4e4037b68d7e"
+    },
+    {
+      "bytes": 700,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "00de6a8e3b8c730529ff108aed7f48c6419c7eda08b43f40b570ed7e38cd68c3"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/arm-result.json",
+      "sha256": "7ddc8bf7abcb2a33b21bc19e426bf633dd4c17a554f131ef1b627b961b750f11"
+    },
+    {
+      "bytes": 2069,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7408f6cfb09ceae21b5ed20fce2987b7b94bb44d6d39d1e5ed2f2e8b8c955ad7"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/request.json",
+      "sha256": "2e34f8937363c772b135f8133d36451f01014eb53e834575656fac55dd13f42e"
+    },
+    {
+      "bytes": 843,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/reward.json",
+      "sha256": "56a66bdb1d6d0554298ce2148f4a6885645c4c8959fbb16b56ca214885c9b6ab"
+    },
+    {
+      "bytes": 9956,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "205e37574e93105e14369e9bae801be46e9d51968fd95e29bd01df6c5d17dba9"
+    },
+    {
+      "bytes": 703,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "f2882e48951f3212cd310df8714c3c5338673f73159612e4f554395f1ec2fa84"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/arm-result.json",
+      "sha256": "55e8024c6563fe5a94c26bdcdf22e72183ccb4f3a9a2a16eb4c3f891b65cbf70"
+    },
+    {
+      "bytes": 5755,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "f060acd74d4801f50d4da67e83896bb9cde1f23ee8413da239cad41adb206651"
+    },
+    {
+      "bytes": 612,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/request.json",
+      "sha256": "def0cb029c9ae4fad728c6ab2d28c69fafb5a2779ef44bb97f22e24b8df0ef66"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/reward.json",
+      "sha256": "152e8c7e93c98f2e1fa229e37b683c0cf808af7916ba3152925850712ad17e6e"
+    },
+    {
+      "bytes": 9951,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d9a717cca0500b8da30e94edfd20684eca709da570a6696bcca0bccdd5ef03dd"
+    },
+    {
+      "bytes": 700,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "f2f3e531e570763c8387fc1577c517523d0a47a20c8a27384ef2f262d3e755e1"
+    },
+    {
+      "bytes": 1329,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/arm-result.json",
+      "sha256": "232c2cc4c5a0fafa95002e3f3dc0fb3cfc44ed0d1f3d1d525e444dc969b4ff70"
+    },
+    {
+      "bytes": 2064,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "bbb86f489b414dc7f1b2222c376735a7585a3e26bab061a561960659098bf062"
+    },
+    {
+      "bytes": 590,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/request.json",
+      "sha256": "2861dd36455889c8c4729bdc0350bfc26a6d53b696e49536058a1dd6efc12e8d"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/reward.json",
+      "sha256": "c87836fdcef6fd97536d7620c73c18af19635bb337fd354413b545539e5cc432"
+    },
+    {
+      "bytes": 9954,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0ac4eeb2fa315be2c39e5ded75316cbdf55c4c88b534762473720ed1c9c382e7"
+    },
+    {
+      "bytes": 679,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "fd5631ebf98da9a020a8c4bcae547c7a084f41ee7d6ecfedb10bf90ef8fe7d76"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/arm-result.json",
+      "sha256": "3e248c267576abb7009cf07714d8c8f47bc2398e7b01f3c0b991eb5f68868616"
+    },
+    {
+      "bytes": 6262,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "157055cabd41e2e91b110c858587cdae0150bb739f733562a775f0c4188bbc8e"
+    },
+    {
+      "bytes": 613,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/request.json",
+      "sha256": "11c079b6c8735ce70be3222323095860f4e0188eb1003d3ba53b711046cb5c17"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/reward.json",
+      "sha256": "c7d080208df565654606099446e9132cfdf66db1cfa708ecbb153fda661960e9"
+    },
+    {
+      "bytes": 9953,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "52d4a8da741b4475d4e5527c6ebaa505e28cb2ac201c27517f9301e5f9b7c6b2"
+    },
+    {
+      "bytes": 743,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "185515376a920bffeebf4c24787ef501832181b6005f6d3e9be3cd359c6f4c4d"
+    },
+    {
+      "bytes": 1330,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/arm-result.json",
+      "sha256": "699555d28180948d6b7723f6c5a545c56d1b762d1248bb760dc8be7a7e393dd4"
+    },
+    {
+      "bytes": 2282,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "cfc89ad889b3d1baae1c4f96334feb17bd21fb9bb464a95bf74622be70b78a65"
+    },
+    {
+      "bytes": 591,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/request.json",
+      "sha256": "7823d5a5f755a48de20b98fcf9da0c98e75a2124f2f97c4eb1e61acbfc6a8448"
+    },
+    {
+      "bytes": 843,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/reward.json",
+      "sha256": "c7deab8c50ffe780681685098eb23d1cf6a72ef5ec7e01d0068b6a8867ce73fd"
+    },
+    {
+      "bytes": 9952,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "5b009b7ad9c9ab9de83eae28cc0b60921655cccccdb27038d418924983ab177a"
+    },
+    {
+      "bytes": 746,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "e503f786afb0a6cf1c077b9de61d448a3c49a16af42325d7652552ffa5b6d744"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/arm-result.json",
+      "sha256": "58c8a9a05099e040577ad46e8e8986dad871b4113874c68d482b0e817c025cde"
+    },
+    {
+      "bytes": 6082,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "946c5c22b9f63863dfd86f04721e52e2a8dd833e2e32c0ebb1231036d4b147f3"
+    },
+    {
+      "bytes": 613,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/request.json",
+      "sha256": "01cbc8a9d4a38870906316a886b2357e7d45f92441cdcc69262995e70056353b"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/reward.json",
+      "sha256": "99466a0e2b4e7cc43520dab3498010d41311cbe20fa477d06bc1b66cfb9fe3a4"
+    },
+    {
+      "bytes": 9952,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "94b43fac9d707e620674082b6fda9b58f4355180b1e1ecfab3e25486d127a75c"
+    },
+    {
+      "bytes": 764,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "2b03d6dcf8b8ddb8ff61e0cb50dd57cb45525743f5a8ba896c4118e2e584b994"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/arm-result.json",
+      "sha256": "89e961c9b8f84584dbd3db44f3644e41e96a0f180450758a047a95d4411448c7"
+    },
+    {
+      "bytes": 4124,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "34eee6f70578cefce6ba327dbd14e67c33c530b240ba02181f74a4d04cb2700d"
+    },
+    {
+      "bytes": 591,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/request.json",
+      "sha256": "19d3c87896e96f07787ba8cd3e4a32a2b1f12a831f9ea49c03f16662fc199893"
+    },
+    {
+      "bytes": 843,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/reward.json",
+      "sha256": "5343a86f6782cc82db1b6eb92d31e27325eb82c1cf6b6f35152dd4ed3668798f"
+    },
+    {
+      "bytes": 11693,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "f46fb814b7e709f2b2252a48f9d5d3f0b25830dc628bcd04f2556d35d1a1f491"
+    },
+    {
+      "bytes": 746,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "d27dc37f712fbced39fd959814c20385d850906026fb1ddcbb4c352646c5d29a"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/arm-result.json",
+      "sha256": "5db3334de4d81a6955afa894d1d249c5f808c9a4e0825905e81b515f425aba43"
+    },
+    {
+      "bytes": 6052,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c87a8397e4e510dcb1dcfb55603200717d87eb15d096885c66dc8a33314fef39"
+    },
+    {
+      "bytes": 613,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/request.json",
+      "sha256": "4c37f44a9dd63a1a0f1ef3e80f087ee640ccfb28a4523fd17fbac585baffe7ef"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/reward.json",
+      "sha256": "6819988ad07a597b9b5aaebc800484aecc197a70e8f0308c5737e2fbc5065edd"
+    },
+    {
+      "bytes": 9953,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "2c3b508451941b2d8ee803cc77c32fbfae246132c9ab29799ab54ee09a29db51"
+    },
+    {
+      "bytes": 764,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "3e4d6c2f8493bd9aa65ded9dd1570491101a1be5659ef17150d08078f7d3e2e2"
+    },
+    {
+      "bytes": 1331,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/arm-result.json",
+      "sha256": "7eba427ab9341dbbb8526b5d35ce23082fede6b1670c520fe7c0ba3d36700c22"
+    },
+    {
+      "bytes": 2136,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9596f96f4ce9f13722813a30c11b1596b5c610d2079ad89f3a882ab724d0442a"
+    },
+    {
+      "bytes": 591,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/request.json",
+      "sha256": "f0eba2ed1ed2b098ae70b88ac499d61c6560355a06fd4b3971bfbdbbb1783a6e"
+    },
+    {
+      "bytes": 843,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/reward.json",
+      "sha256": "012664d2b00f08952371d9f3a1f57613d04abc98a318425eadf143090add9027"
+    },
+    {
+      "bytes": 8232,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d7236a5cd0c8457e00c350659d1238ee48f92ab473e0b4ee9508e999e47f426a"
+    },
+    {
+      "bytes": 767,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "bb916dc2d1e7ddede923548fbdb2dadb8c9a6296ec1aca96361f03c913eefce5"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/arm-result.json",
+      "sha256": "03df2c616a160fb4c6d82a8a8d2637826987e3de4918c5b472a92a2ec27cc534"
+    },
+    {
+      "bytes": 987,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "a944cdd8d4f398b563148c39d90d8288d19ece5862c074b6d1e5d67cdbea1098"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/request.json",
+      "sha256": "0aa08d3756a85b5dc8b507b3549b49e78f877e2931cc4204800bb42fe3a0e351"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/reward.json",
+      "sha256": "5468ffa58ee3a127e8313b59c96381b1b52488c79ebd94307d81c8653343d715"
+    },
+    {
+      "bytes": 8225,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7682f4ece0daf1c771f4f1f2d0ac52e6dded33777fbc35e4592294c66961c8b0"
+    },
+    {
+      "bytes": 676,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill/verifier-receipt.json",
+      "sha256": "e0750eed6edae9a5004627c5e89ca99289ef4c25e271280f79d1de2dcd754c24"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/arm-result.json",
+      "sha256": "4d24d14c11e520ddd66f143f1695f072ef608adad2652a3a4f938cb3dfd0d81b"
+    },
+    {
+      "bytes": 962,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7b8c7073042a776fb6d3da64a90936cb622622b2d14392158713cf41220919c4"
+    },
+    {
+      "bytes": 579,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/request.json",
+      "sha256": "039947f8071a5a11ef60a4392c4448f2f094b9d15c9507c4bba00f2e3f1ee24c"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/reward.json",
+      "sha256": "aa95c1fb3458259929a5c7a2515cfb74c8c7c02f1057f0aed5010a1e76ee888f"
+    },
+    {
+      "bytes": 8229,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "df1844e5df4aa593f9e733acadc65150a5c2fedb4237cde5b43d4dab566d3775"
+    },
+    {
+      "bytes": 679,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill/verifier-receipt.json",
+      "sha256": "fc5664919d8b7c433a625c9bb987bc3485598ea358576159bde4de987de916f1"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/arm-result.json",
+      "sha256": "baeee1fbcef54d036c93d407dfdd52357fd1b14fba012bb7a26eab4fa8ce2716"
+    },
+    {
+      "bytes": 973,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ff7f8a3322e63c6975a2fcc4a6080073e642491e4dc5707fa1d6bed0c5de599a"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/request.json",
+      "sha256": "6b693979c716a7e0d88145b541ca4f0f3dbd853e7f6b0aa31fd6f41eeaa70da0"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/reward.json",
+      "sha256": "2e7bd0812a9ca1afe532f2725b905cccdf7d2176468b4d45d13d6649dddb36a2"
+    },
+    {
+      "bytes": 8224,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "bde2b5f02b6cc68cca6287a734df1fb59a20b1b7c70082217a1ae688dde1907f"
+    },
+    {
+      "bytes": 676,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill/verifier-receipt.json",
+      "sha256": "3920605ea43bdf8e3365b0cbbcb9d0f8fb4f81768430674d0bea8e4b71e95d00"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/arm-result.json",
+      "sha256": "05b851a51e9fc8dc15a072cc8c698bc0fde61db5e1b386435985e7fb64baef7c"
+    },
+    {
+      "bytes": 981,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "fb27e1236b483b780d7979aa4d0942df745ed3c8107a7530ee8cd89d35aa9715"
+    },
+    {
+      "bytes": 579,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/request.json",
+      "sha256": "1ab5646906824741d340e70fb172da940f870c581c76f41a1033d86e253fd4e3"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/reward.json",
+      "sha256": "bc4b2dfca64ad3b62fb558ea30e32e982f632f95622197ea6088c11f711fc0fe"
+    },
+    {
+      "bytes": 8229,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e22f9f57090e5d7564001375366c98b4f9ac01357661aa6a99fada9fd8e11752"
+    },
+    {
+      "bytes": 679,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill/verifier-receipt.json",
+      "sha256": "183fccd49ba5e6773e9d7f7931037e8a6650ca0970262bbec423d0e70cce3a4e"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/arm-result.json",
+      "sha256": "d93eceefc09e2fd3e55492ad7dbe77d4fb9233b28653bdd8cc5147cd822a7e19"
+    },
+    {
+      "bytes": 987,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "035fef55dbfec172463838b2856feccadaa84e13935ed8f3a5b12787cfddb27f"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/request.json",
+      "sha256": "b76ecf0c06ae126e7db127d55fce69aaca647e8fc166f20dd367dbd0a5d764b2"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/reward.json",
+      "sha256": "0ff60c35c448747660414a81d6456b5a2740f945f7c603ee514c9d22f9385454"
+    },
+    {
+      "bytes": 8224,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "4e9dc366e7d46c2d8ca34849c61a5ed087e78421317485ff53ed2f99fb29a38f"
+    },
+    {
+      "bytes": 676,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill/verifier-receipt.json",
+      "sha256": "21d551432f828676bb7a9ce0337b6870c320e8867d9186ad5c77104b69875ce1"
+    },
+    {
+      "bytes": 1329,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/arm-result.json",
+      "sha256": "75c2933893ed556238fb706c45bd6e29fc6301d3d5e8f23eaa8c07befb4253c3"
+    },
+    {
+      "bytes": 994,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "232e938cc798e1e2a9ed56871980276ae17d01249a6d4c3cd1779b708be3e2c0"
+    },
+    {
+      "bytes": 579,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/request.json",
+      "sha256": "65ce976610e2957fade1f5c9dd30bcf3f6c41656147d9a61878aee4bf8e53f21"
+    },
+    {
+      "bytes": 842,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/reward.json",
+      "sha256": "4604a85395fadca55fd3437d47362b48ccbe51f7e8f5d6f819238e1ceec9ce07"
+    },
+    {
+      "bytes": 8229,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "4aefdb4f8d44a48e5e4b05c1ded0363ca091b4415f586bb8fc303bd60527764f"
+    },
+    {
+      "bytes": 679,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill/verifier-receipt.json",
+      "sha256": "f9a02dbb64cccec9343d5a6cee5ebfd2f0aa51623c55650f6ab3f87238e7bee0"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/arm-result.json",
+      "sha256": "2cbef90e021dff9e4048f21f523cd32ae5466c1b6c1a29a186b2284bc5ec4475"
+    },
+    {
+      "bytes": 5456,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "32c3e0fbb8416190739a521fb257762d32a1958679f9597825fab79371be9aea"
+    },
+    {
+      "bytes": 618,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/request.json",
+      "sha256": "69a8c3af272fb3bbf4bdd21fa87f6df0d0555b00afce5d8304d9b4313c06cb3a"
+    },
+    {
+      "bytes": 829,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/reward.json",
+      "sha256": "2c21b782949b66022d3495a53598f9d26c920679393c8f51f901246b41f59dac"
+    },
+    {
+      "bytes": 9948,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "079d7f65435a6fbf8f36f9b650e67092087f47df25ca89f698c78914307e8df9"
+    },
+    {
+      "bytes": 672,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill/verifier-receipt.json",
+      "sha256": "79b8085bb463454ddb3bca0cbcac2771f2880b5241e803838efe73005ad96d30"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/arm-result.json",
+      "sha256": "5b812641f1b5ef32394bafdec95beda6bcec4c846f829a615ccb08339213f1fd"
+    },
+    {
+      "bytes": 1200,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "55611d26fbf8baf61cd2e4fc4d27301e9e477cdfce9ff3c7dd02db7ba52dfb14"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/request.json",
+      "sha256": "e8539bed8326ec2e7af7b87aaa164959d385b6f74f01f9faf1b8861b34722616"
+    },
+    {
+      "bytes": 837,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/reward.json",
+      "sha256": "3a29e4300be14ebbce92e6e6deaf6e5ad56a0c471ff5b5eeec1479cea04394b9"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7625866e756ffc324521c43e3d0c926d918e18b0767c51b8bf7fa9d7e73ef59f"
+    },
+    {
+      "bytes": 760,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill/verifier-receipt.json",
+      "sha256": "4208aa5f82439ab1f6465719c627cafe6acd0275d168719bc8c7171eb3559bd9"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/arm-result.json",
+      "sha256": "e1709640e647f03b33e151f4943a70617e34ae546de1e75014301f4554bce0dc"
+    },
+    {
+      "bytes": 5239,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8ac0d6e078a5e13ed438ce851cb7e20ebaa3e47d1b43fb782522a2524ee07a50"
+    },
+    {
+      "bytes": 618,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/request.json",
+      "sha256": "bd71d0ca8dd22239e4647833df45210fb420885df41f0860777d0c3c9fc5cfcb"
+    },
+    {
+      "bytes": 830,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/reward.json",
+      "sha256": "c0751510585e2aeeb25d6c07d21a706f72c6a10870ee282cdef41041e6a8cc2d"
+    },
+    {
+      "bytes": 9948,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0d480c05cbd6bdd9919aa8db3915cd28cfb66e1fa7ab2430b47fdb2577538a5d"
+    },
+    {
+      "bytes": 725,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill/verifier-receipt.json",
+      "sha256": "93ccbde057e76f47be154f2e1d07396ee1214a7919773abd01d07c7399a00f97"
+    },
+    {
+      "bytes": 1328,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/arm-result.json",
+      "sha256": "d7fd29e57d24657a8ea1150bf9d47af74772cf16cc79c5f9c7bea0cf712c5a8a"
+    },
+    {
+      "bytes": 1261,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ee4f8ed2673487f5485dd32b8bfdb90df9d97ef913fad8d628662defb89ef981"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/request.json",
+      "sha256": "ac9f7898532981c989e71609455720678c92d119b15016066a18f3dec69a0da3"
+    },
+    {
+      "bytes": 837,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/reward.json",
+      "sha256": "cc022c15ae859bd6a9cfa7ab72b3b3d55c915e8f672b0eed5fcfea92174e14d9"
+    },
+    {
+      "bytes": 8227,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b643c0f67707748faba9b5c280f73007aff2d996ea031d31813c2c0b5104353c"
+    },
+    {
+      "bytes": 741,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill/verifier-receipt.json",
+      "sha256": "2a1a290d623fbcb16ffc05623a9f94135093f0765cf9419a1078e2181ff1971d"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/arm-result.json",
+      "sha256": "783202824c94e06e43dabf9611cdfd787f8940c4357b9675d0ad784982597655"
+    },
+    {
+      "bytes": 5325,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "90aa8b80cd5e85635ce0410f53297d84ed46b35ab59193a13b607cc1c68a175d"
+    },
+    {
+      "bytes": 618,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/request.json",
+      "sha256": "1a17259401a9b1e405ec6cc029c08241f4bd22ba0574d9575e1b162670d8e22b"
+    },
+    {
+      "bytes": 830,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/reward.json",
+      "sha256": "a76e7c5ceb0066092f98909d0bcfcebe4799ab4e354c106a9535ad010fa929c8"
+    },
+    {
+      "bytes": 9949,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "307c6e9c61b6b3858f8268dae97e4d03ab085f315408ac1ea4dd650ceb3c31da"
+    },
+    {
+      "bytes": 725,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill/verifier-receipt.json",
+      "sha256": "2b640776a7a6110324388216cc86bd50f25def6dda379b8caa98acb209cf129d"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/arm-result.json",
+      "sha256": "56906a98a39900cd31d19b1718e3bbbf753b6a63308f18953922ca1b84d07669"
+    },
+    {
+      "bytes": 1272,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e70891f5bb869b8f86cf48fee9d030a2adca7f996b34732bcd183d8435b9b5a6"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/request.json",
+      "sha256": "afcf19d48a99604e29bfe7f2fe20a8afaebd81fe3bdb69a9cc0e2753881c1450"
+    },
+    {
+      "bytes": 836,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/reward.json",
+      "sha256": "70879387e22ef0e354898e8959a6f19dab02723602606dd3c9694b3888867c53"
+    },
+    {
+      "bytes": 8226,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8ed5db52c4ab18dda24d23b8ee6a923a197e11bc909a67cd385932fcf9fa7de5"
+    },
+    {
+      "bytes": 675,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill/verifier-receipt.json",
+      "sha256": "ef5b5a1bfa28c387d944d9f2670e6cfb5cb8586c5d9988b7e24e1985479eab8f"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/arm-result.json",
+      "sha256": "f58b676fb01e6238186d425ecae0a3a7d58817f62cf9e9323192f037de7e26e9"
+    },
+    {
+      "bytes": 5309,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "fcc015f3c5171476c03c37a0f45f402580721060d7f85ce4768ba9e1ac48c3be"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/request.json",
+      "sha256": "ed0dbe0bd4fdf83552a898fa52c23fcc19742fbe1a681f5c0150503224da4113"
+    },
+    {
+      "bytes": 823,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/reward.json",
+      "sha256": "a3d7bc979d1d387eb441a1bcaaab3b8f446438d377d8bb62d395a97323866dc3"
+    },
+    {
+      "bytes": 9946,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "f218105cc366dc7a9424c6ebaa3f1c91efb169f4b0d2ab9f13b932e1a6b015a8"
+    },
+    {
+      "bytes": 668,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "2dfe65ba2005cc393fb23a79b75dc8101bbfafc00c799c802bb243e70fd83d54"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/arm-result.json",
+      "sha256": "0ef0cbd41a05da2189d2fa6aaeaeb76c52ee3a35c0f52853bf661948b029f205"
+    },
+    {
+      "bytes": 1160,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "16ae69366970c5e54e620190bf93ec831500270f47e5d377649c5ad7dc3c670f"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/request.json",
+      "sha256": "f282fb5098b6b9a27dc1af89c4f8f2fe900f99a9e9404db37b598d9db87067a4"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/reward.json",
+      "sha256": "6ab42a8656fadaed63334000427f70c4f371d626236dc333625d380babbba96f"
+    },
+    {
+      "bytes": 8226,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8f5802f194c47f23f0416bf063cf1f1c8d3b37d0a7b7a64910b76d674f373a12"
+    },
+    {
+      "bytes": 776,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "100c7c13d0d79e73e744d068878a8d817aeafff3ece9c7571525144b8eed5ead"
+    },
+    {
+      "bytes": 1322,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/arm-result.json",
+      "sha256": "023095446b59b5f3c0fe825cf2d9741a42131d658537e3cd90b5988a7f2881da"
+    },
+    {
+      "bytes": 5121,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "cdea36b6374c9c010c315a5a4b443dfaef1824679a42030fa1bf06e0ea635556"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/request.json",
+      "sha256": "f25922a0e9a818205d56582e4ec915ac4c2e0255c385c8fdfdd0e63b6afbc39c"
+    },
+    {
+      "bytes": 824,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/reward.json",
+      "sha256": "f54c743d36944d668382cb1c02459579f7fb1cd96cc318122ffefcf03efe867d"
+    },
+    {
+      "bytes": 9946,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8e2f63ad9065cbe2532c0158625bdd0619bd84749cb0a973bff8f55f01ba2591"
+    },
+    {
+      "bytes": 823,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "9ad0e95ca596e2c5b9d21a77fff6826eadab3c89fb550bc4164eed70f1efb1e5"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/arm-result.json",
+      "sha256": "acd2067103434ab1b077ff75def7e36e840ae209d1c9c60d1676f483381f18ad"
+    },
+    {
+      "bytes": 1170,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "3437babece8f86845913b84c8d6ce8c26208b15ec9b9cface2eabc63e6bf8a60"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/request.json",
+      "sha256": "7afbf1f5dc55e1e58b3773a92d2eaa09e97911c1eb529ace6b48b9c045c2e3e7"
+    },
+    {
+      "bytes": 830,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/reward.json",
+      "sha256": "3ebbfbd0d5cc4f5104aa07f03e7522742679cbaa6a70d636049b68d9548f7fa6"
+    },
+    {
+      "bytes": 8225,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "818ce625e6a896adbdf5a09e0cb06fe78b8c0f85824eebb46234050ad8fb07f9"
+    },
+    {
+      "bytes": 671,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "6739a9368d8c2a5ba3ccc4f764c444194bed3f8bc2ea9984a3b258cc791fc4f8"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/arm-result.json",
+      "sha256": "8c190ebc00a407f5920f405dc5f8434655ca7f6ef8c902ffd15c5b923d8f5bce"
+    },
+    {
+      "bytes": 5287,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "dc328cec2ad9eefe00a38ad786c0990a841bf0c45e0b10c341ea83ca1e6937bd"
+    },
+    {
+      "bytes": 601,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/request.json",
+      "sha256": "ca5830fd1975a130c9bfa6258c2258836c7df5339d7e94e3042b84238432a54c"
+    },
+    {
+      "bytes": 824,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/reward.json",
+      "sha256": "d00a960d4a2d6cdd5ac1b3ac59ce0303f25abab52639f702afc7839993c1c452"
+    },
+    {
+      "bytes": 9947,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b18c61a985aec6c561abc8f71601ec2ab0a36a499ce9d0d8304200a2c90fdbed"
+    },
+    {
+      "bytes": 823,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "9f30d6d851dfab6f95440b7206439d465be385d7cecc91dbb079d7059eb994ff"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/arm-result.json",
+      "sha256": "dcef85047af1fc9d4fcc0fa18e05f33fd9cb1a057b99daea8130e5894d14f8dc"
+    },
+    {
+      "bytes": 1972,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "b10a454b68e54f395cd25aafe9c7d706205c52efa2c3a8da770112482752b7ef"
+    },
+    {
+      "bytes": 584,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/request.json",
+      "sha256": "60c1bab1290edb537c25c30c65d66f231c9b80a94fdef8571ea167a5fe23f9b0"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/reward.json",
+      "sha256": "76bbf2f5846c0053c2f51e370bb3a1e653d921548a894c5831b2f0e22dd3bbed"
+    },
+    {
+      "bytes": 9953,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "9a6501f272f84967dcca142fc070a428533531fe9c097734d9557582c879b461"
+    },
+    {
+      "bytes": 696,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "f9c8f469fba16797984208f4ca3dc8d23e4a8ca663156ffa0cdfefea00a4eb92"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/arm-result.json",
+      "sha256": "6020580149d1cbbe1a823373db9bc35854e6408ecbc1b49f65db5071878c2dfa"
+    },
+    {
+      "bytes": 5281,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "46e90041b001dc2cd12875f2b2d86fda4df71178a4d2c5e2dc88b8f0ce545532"
+    },
+    {
+      "bytes": 594,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/request.json",
+      "sha256": "9f367cd46bcb7363c16221045067627f93d05330c6a58a4cfa71f200efc2eeb9"
+    },
+    {
+      "bytes": 823,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/reward.json",
+      "sha256": "428318a44630d59e378676e8a301c9dc3d500cf8cff44dab0f95b5011624f691"
+    },
+    {
+      "bytes": 9946,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "122607abc7c03eea5e9b9f781ad9c2c17a56acd2d98a5913278696b589956a48"
+    },
+    {
+      "bytes": 668,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill/verifier-receipt.json",
+      "sha256": "0f45f3ef6f2afa476e7becc15e12402c4efce7925c283612bdb8ea18ff0d6bdf"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/arm-result.json",
+      "sha256": "0cdf5f7e3672c3a5c2084b8eaad56a6c41e92e675c5d8e3f4d770da627544149"
+    },
+    {
+      "bytes": 1313,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "fe3913789b35e5d4696643236bac673a082278347ebb38e8e5d3b770ae9a99b0"
+    },
+    {
+      "bytes": 577,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/request.json",
+      "sha256": "2ce9702a6b2ebf18e347dcd9468f103ead44b92fee37eee7a381d536235ebf35"
+    },
+    {
+      "bytes": 830,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/reward.json",
+      "sha256": "104eea7706f55d168a6020501be3d3acfd8056e15e50cb8cf9b41e47ff264d33"
+    },
+    {
+      "bytes": 8224,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "caec51569ecca8742737c50c69f0fa31b4fe60add879ff4da512b638b7ec338b"
+    },
+    {
+      "bytes": 671,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill/verifier-receipt.json",
+      "sha256": "3469cdb9d84672cbf9b90da6fe3a21fb6047add614b4d7a807be2a5c55110a95"
+    },
+    {
+      "bytes": 1322,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/arm-result.json",
+      "sha256": "8eb9bcc7bde52805b2af85c466c3ab7bc69adc2f8d8555f9609fdf30b5458b31"
+    },
+    {
+      "bytes": 5429,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "a4567b863d4a779324c1255316b50309ecf30f32e7afe67150ee84299042e212"
+    },
+    {
+      "bytes": 594,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/request.json",
+      "sha256": "c2597face6dea7b9d53f2739fad47258f0c4c92922ed76eb621779af8a1a0557"
+    },
+    {
+      "bytes": 824,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/reward.json",
+      "sha256": "f72715218e4b462dc80b7d6746f2692f8c5174b8fd653b398e56e77078642806"
+    },
+    {
+      "bytes": 9947,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "0b4b60117233f6493a62ec413657d2e77af0bb4b1e1ca91d8b4996b2224720d0"
+    },
+    {
+      "bytes": 693,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill/verifier-receipt.json",
+      "sha256": "be9a84c297761a305763e8283522e20d1163505e4dbea81b5046e0b6150613b9"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/arm-result.json",
+      "sha256": "ed7a31f2e7e27bbccdfe2e29b59abf6d10363faae94f40821626ad5565e28c87"
+    },
+    {
+      "bytes": 1240,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c96fa4be3ea7ca9e9ea10415f65b500a113c944bc3c245742a88a81dc7d561a9"
+    },
+    {
+      "bytes": 577,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/request.json",
+      "sha256": "6c3961eac45cb9f4f634c64daa6e5d75c15e1c6b02c073ba8b1e4d3c481eca85"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/reward.json",
+      "sha256": "5e3f6934ee852f0cea285c5ce006187688e6999421f676dbe190faff4e831477"
+    },
+    {
+      "bytes": 8225,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "228c9cfa9feaa3256c0bc78106f80b7e4eedf26dfd5e5a7fc2ee8b6aae7a3059"
+    },
+    {
+      "bytes": 696,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill/verifier-receipt.json",
+      "sha256": "33f62c001090ced38f3d182e1885f489d8d6aa9da12a82687e9e00f69196a003"
+    },
+    {
+      "bytes": 1321,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/arm-result.json",
+      "sha256": "fb40908d81baddf08db9ff0d5465abd879c3fcc3399a08c01994e61e57b07ffd"
+    },
+    {
+      "bytes": 5279,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d8e43d2bb5270523e5fe27feba5cde344a6e93ac47b3e1cf046a80d3adbfbea7"
+    },
+    {
+      "bytes": 594,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/request.json",
+      "sha256": "9a8831a6f296c4c2fecbb7268c854fe80c3a4f55cd6ea374ad3c56499340dbca"
+    },
+    {
+      "bytes": 823,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/reward.json",
+      "sha256": "bf7ea99a9dc76d0ed2e8f197589cc824f15fc68051b160ba832b751d8dc56dbc"
+    },
+    {
+      "bytes": 9945,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "2b95fbf10d64e9895334d674203cdfc956cee56c0a411d7edd95ad6893a36bea"
+    },
+    {
+      "bytes": 668,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill/verifier-receipt.json",
+      "sha256": "af420f4aaf5ee53cbd9ce28fcd9e03224fa3cc63b9d75a9cd9e7d4a88b3bf5a0"
+    },
+    {
+      "bytes": 1325,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/arm-result.json",
+      "sha256": "4d779540af18e1798b66e4109de362f999274e5ab8706821fc42b9e249e78ec0"
+    },
+    {
+      "bytes": 1184,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "c7ffec0afdcb2e165cf918101601b09037473e06496b194038a01357e1f662bb"
+    },
+    {
+      "bytes": 577,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/request.json",
+      "sha256": "44a55f5a925df036a5cd73fb3624c676bab0d233928f8f332bcc0242c3f4d530"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/reward.json",
+      "sha256": "65066709da06792ec6c8375b304b114c1814b2bc0a2fd87eabef0004819588a4"
+    },
+    {
+      "bytes": 8225,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "aa197e282884efc74e6b3306286f46b987ff084cf91f193740f19e904e33f13a"
+    },
+    {
+      "bytes": 696,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill/verifier-receipt.json",
+      "sha256": "017b7e6767fd63c42f78df25e6449b2011ae68541088ebd1fbbbcb4c3e984c1b"
+    },
+    {
+      "bytes": 1323,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/arm-result.json",
+      "sha256": "631bce7f2e812b2e26fd9c75e49eb4c664a7b9a6beafcfa7e291767d53b1cf97"
+    },
+    {
+      "bytes": 1545,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "3b3931640c5c74635f5f589054780ace85ad5348c10e175bb8e0c59ec5001b2f"
+    },
+    {
+      "bytes": 604,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/request.json",
+      "sha256": "b18b363f9ef37ebb0a8c28ccf5f44df6bae0dbfc7b2cf1e8512888cf54e3b433"
+    },
+    {
+      "bytes": 825,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/reward.json",
+      "sha256": "428d488ab887eaf15caf071e18522084320e6cd0a25a9268d8b55869e22a30d3"
+    },
+    {
+      "bytes": 8223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "5dd89ce81f2a18b4ca8863cdaaa16a80ef785990f283e1cb0e52f621c5ccd7ae"
+    },
+    {
+      "bytes": 691,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill/verifier-receipt.json",
+      "sha256": "241150d379094b692f3cb8510a89017ed8a29ef301f3182066411cf4c5eb290e"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/arm-result.json",
+      "sha256": "e6d98bd102f2b54f7a62a706790cfd58eb6fdec4ea5663ccc9101edb2163c1c4"
+    },
+    {
+      "bytes": 1467,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "ad71af03b5b9af3be01149dabc43a978952eb547a6421f4b79463a96115f8a86"
+    },
+    {
+      "bytes": 587,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/request.json",
+      "sha256": "5e1c0d507854843ebdb8046be116c6d271469486b9bc797e639cc098976a65bd"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/reward.json",
+      "sha256": "d54cafc50279f07fdc3ed06a34be6f4824ae5ce26d0e5378d2c8e2b09a4ae849"
+    },
+    {
+      "bytes": 8226,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "8240ae141d1ee4204edb889ed060308070de4bff0354613af323d229a31293ee"
+    },
+    {
+      "bytes": 694,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill/verifier-receipt.json",
+      "sha256": "c215193104fc7abc88c09db891064667c11070f8d6b0a39aaaf642ff4407a1d1"
+    },
+    {
+      "bytes": 1323,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/arm-result.json",
+      "sha256": "3085a2e9fc6555ee98bd4c6deca0fd64c4bda86b1964ab15cd8d695d04f2d205"
+    },
+    {
+      "bytes": 1501,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "29517912973a911db90ca95de9a6421048243c731d2538079845f9833ebca1fe"
+    },
+    {
+      "bytes": 604,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/request.json",
+      "sha256": "f4e0bbe8d1bacc92a068d86d0142a4e278dc5ff562beae4bb9650d7e848885dd"
+    },
+    {
+      "bytes": 825,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/reward.json",
+      "sha256": "ae37a23ec33501ff8f171aaba8ca13d37e9fd5af3921ef73054d980d5bafb9bd"
+    },
+    {
+      "bytes": 8223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "5760f1ac6cf7e608dd9128bf9fc484e97ddeaa77452b847bcb6eece553ea2334"
+    },
+    {
+      "bytes": 691,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill/verifier-receipt.json",
+      "sha256": "1a0a909fb246842974c0edd2a90e79522ca5d8a3efe8dd6f0ec0302f0c0d2bcd"
+    },
+    {
+      "bytes": 1324,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/arm-result.json",
+      "sha256": "707c119910798978ce96c3ff62707e446b840aec35891b03f47d238ad561b446"
+    },
+    {
+      "bytes": 1607,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "072f0e899911a9dafaccb78f87e5a219abf549f28b1634ec56a4389cb566497a"
+    },
+    {
+      "bytes": 587,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/request.json",
+      "sha256": "8d68e0ea8e3b3570327c9bce557813a4fde489f5a0ee59651851cdca713d3abf"
+    },
+    {
+      "bytes": 830,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/reward.json",
+      "sha256": "c8f0ce7fcf53092c80876f1996ae38592ffa7853fc7a29eb96218e14c6647253"
+    },
+    {
+      "bytes": 8225,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "34bee939e52a563c5126db6da99bed5b6b7695ce4de0dce11fcb8e7e15142d67"
+    },
+    {
+      "bytes": 671,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill/verifier-receipt.json",
+      "sha256": "e91ce4c1a31a5a93377841f536418be3a6e50fd2efdc039a81e7b1329a80a488"
+    },
+    {
+      "bytes": 1322,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/arm-result.json",
+      "sha256": "ebf621e29e6ba807edffac1d8ce199cb10488d345041fade00f0a6b3c7a2f0e9"
+    },
+    {
+      "bytes": 1447,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "d1117c113421822ff7611f9147eaa77fc7322c61e909977bebdef7d34f7e4738"
+    },
+    {
+      "bytes": 604,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/request.json",
+      "sha256": "9ad388d6325065e5bd3d0eec94699c10c928fbf9e62be9f97d699902bd342dbc"
+    },
+    {
+      "bytes": 825,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/reward.json",
+      "sha256": "6c77cca3c6053c10964b5c1adf013ceb33cbf5d5d3e06e11c09d6118617cbe09"
+    },
+    {
+      "bytes": 8223,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "216743626cde6aea214f8952724c63b646330d25867334bc23e98ca936a1d2f0"
+    },
+    {
+      "bytes": 691,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill/verifier-receipt.json",
+      "sha256": "925f8aeec2f39fda0ee2a18a8b7e325d7782a7061fa72eeba7d040a64e937280"
+    },
+    {
+      "bytes": 1326,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/arm-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/arm-result.json",
+      "sha256": "8a2c21bd3b8738390c3fa02142df2468d8164eed697345261bebbc87f40bdcc9"
+    },
+    {
+      "bytes": 1488,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/native-result.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "6160a6aa01c8dd056f917f7d528cc3891a469f04c72e961d9b8156bffcc81e72"
+    },
+    {
+      "bytes": 587,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/request.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/request.json",
+      "sha256": "823e5461d74adf139c2999e019d2c189420473a7c026cf826eb51f753b783ee8"
+    },
+    {
+      "bytes": 831,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/reward.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/reward.json",
+      "sha256": "1569fc0a729bf76bbf52d6e391bc87150c010b3597eff94372626c8cc92b8224"
+    },
+    {
+      "bytes": 8226,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "efb9a7d16f3cd32c1f7f5d86252e2bea50a7011aa9684b3f5e9012b7f9ba5341"
+    },
+    {
+      "bytes": 694,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/verifier-receipt.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/arms/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill/verifier-receipt.json",
+      "sha256": "ccac5eba34b16f4397b7b66db151739751f8ce47e432f299011ca467c366220e"
+    },
+    {
+      "bytes": 102447,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/attempts.jsonl",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/attempts.jsonl",
+      "sha256": "154d5ff27904d35b73f9ca472073a301af31facb5b5e4d9ec4c4ec2d6d90ff48"
+    },
+    {
+      "bytes": 4978,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/examples.jsonl",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/examples.jsonl",
+      "sha256": "3c6bd332219a6422748e2639c749bc1c0a344cddfe107cfa9b46033573fd17ff"
+    },
+    {
+      "bytes": 901,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/learning-view.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/learning-view.json",
+      "sha256": "ea5498029f37a3a656ef952eeba8ee1eae23ec9d10596fbc6a6d9e34ab9bb6f0"
+    },
+    {
+      "bytes": 247620,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/native-results.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/native-results.json",
+      "sha256": "559d9e6bc0a391511a09bd5de5f1d64ca0025f64e323f02df06c8db6ef2e9780"
+    },
+    {
+      "bytes": 23383,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/outcome-receipts.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/outcome-receipts.json",
+      "sha256": "b1b5885cde41304043da6c73788f24dbc8e58edb993f34814f0a90f41e5dc534"
+    },
+    {
+      "bytes": 58703,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/rewards.jsonl",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/rewards.jsonl",
+      "sha256": "6b3f71cb92da28cb017e80a71c074d206c0869c3ff10c4b8ba71a744024d7c83"
+    },
+    {
+      "bytes": 108031,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/rollouts.jsonl",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/rollouts.jsonl",
+      "sha256": "b1f1c9183ee037cdb85f49b7438b4db6b0b4036c34622280ea42ffd85c02c574"
+    },
+    {
+      "bytes": 552833,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/trajectory.json",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "7124e6c387f402463fb1be62009be884643a2601c215817f70abf5513640af4c"
+    },
+    {
+      "bytes": 25723,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/verifier-receipts.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/artifacts/verifier-receipts.json",
+      "sha256": "79e5bab9e414ec79980c3670cf07dc82db7fcbc9bcc2e2ea259c31644d23a5de"
+    },
+    {
+      "bytes": 7524,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/fixture.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/fixture.json",
+      "sha256": "cf41a9ddcc10dca76c921f71e09537505f76d9a01281180a8e2ba2e39650b3ea"
+    },
+    {
+      "bytes": 384,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/privacy-review.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/privacy-review.json",
+      "sha256": "ba25959a772598ece2f6f61d09ed23e98886b947b4a4be9b1ef5ac9b666170e5"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-contextual.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-explicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-implicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.grill-negative.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-contextual.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-explicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-implicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.research-negative.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-contextual.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-explicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-implicit.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r1.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r2.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.with-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill.stderr.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 0,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/private/logs/skill-attribution-sol-max-paired-r3-20260826t130119z.slop-negative.r3.without-skill.stdout.log",
+      "reason": "raw model text, tool payload, local trajectory, child log, or runtime state is outside the reviewed public boundary",
+      "remote_path": null,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "bytes": 5496,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/run-spec.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/run-spec.json",
+      "sha256": "4b9aae3140bc6dbf82247893cdd6128294d29f944df254ea87563e60d68744dd"
+    },
+    {
+      "bytes": 879,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/skill-attribution-sol-max-paired-r3-20260826t130119z/runner-result.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/runner-result.json",
+      "sha256": "9699d094d0d85913311eafa6c91c823152f9f4c672f30e54bc984ff487bc3d90"
+    },
+    {
+      "bytes": 2086,
+      "classification": "public",
+      "local_path": "artifacts/eval/trajectory-releases/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a/manifest.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a/manifest.json",
+      "sha256": "f6ee84d7139a3c33905ae48bb420519083890444d52aa0a4f82aee046b7f385a"
+    },
+    {
+      "bytes": 552836,
+      "classification": "public",
+      "local_path": "artifacts/eval/trajectory-releases/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a/reviewed-trajectory.json",
+      "remote_path": "skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a/reviewed-trajectory.json",
+      "sha256": "1dd9c9fe2c11a02a1966cbfe79bd9adc4d4628b22390b792eedec58277911629"
+    }
+  ],
+  "geode": {
+    "repository": "https://github.com/mangowhoiscloud/geode",
+    "revision": "9ff286071aab68825afa8158aa7ee982cea9c4b8",
+    "run_record": "docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.md"
+  },
+  "notes": {
+    "comparability": "direct repeated 12-case paired skill-availability diagnostic; three repetitions and no population or release claim",
+    "predecessor": "skill-attribution-sol-max-paired-20260826t113400z remains immutable; SA-GAP-01 through SA-GAP-03 were closed before this new run ID",
+    "public_file_count": 303,
+    "trajectory_release_manifest_sha256": "f6ee84d7139a3c33905ae48bb420519083890444d52aa0a4f82aee046b7f385a",
+    "withheld": "Raw native model results, tool payloads, per-arm local trajectories, child logs, runtime state, OAuth material, and operator logs remain private."
+  },
+  "publication": {
+    "artifact_merge_revision": "1efee3d0f4bfda3464b23b298a36f9a97f5fa691",
+    "published_at": "2026-08-26T13:40:03Z",
+    "remote_readback": {
+      "bytes_verified": 1398399,
+      "files_verified": 303,
+      "status": "passed",
+      "verified_at": "2026-08-26T13:45:29Z"
+    },
+    "status": "published"
+  },
+  "run_id": "skill-attribution-sol-max-paired-r3-20260826t130119z",
+  "schema": "geode.eval-artifact-publication.v1",
+  "verification": {
+    "local_identity_scrubbed": true,
+    "secret_scan_passed": true,
+    "source_hashes_verified": true
+  }
+}

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -20,7 +20,7 @@ eval_contracts:
   - docs/eval/schemas/attempt.schema.json
   - docs/eval/schemas/publication.schema.json
   - docs/eval/schemas/run-spec.schema.json
-eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/fa352cb5f54e9f0ad6198c03dd180e27be388b5b/skill-attribution/results-paired/skill-attribution-sol-max-paired-20260826t113400z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-20260826t113400z-20260826T115134Z-feb50408b2a4
+eval_latest_valid_release: https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1efee3d0f4bfda3464b23b298a36f9a97f5fa691/skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a
 ---
 
 # GEODE Evaluation Index and Roadmap
@@ -77,16 +77,16 @@ those claims. See [External Evaluation Artifact Repository](external-artifact-re
 for path mappings, disclosure rules, and the publication manifest scaffold.
 
 The latest prospective paired-skill diagnostic is pinned to artifact commit
-[`fa352cb`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/fa352cb5f54e9f0ad6198c03dd180e27be388b5b):
-on the frozen 12-case synthetic matrix with GPT-5.6 Sol/max, making one target
-runtime skill available produced 6/12 native-verifier passes versus 2/12
-without the skill, for a signed delta of **+4/12 = +0.3333**. All 24 arms were
-valid with no retry or safety violation. Explicit prompts remained 0/3 in the
-with-skill arm, `deep-researcher` positive cases remained 0/3, and one
-negative-control skill activation was observed. This is a one-repetition
-diagnostic with `promotion_authority=none`, not a runtime or package release
-claim. See the
-[run record](2026-08-26-skill-attribution-sol-max-paired.md).
+[`1efee3d`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/1efee3d0f4bfda3464b23b298a36f9a97f5fa691):
+after closing SA-GAP-01 through SA-GAP-03, the frozen 12-case synthetic matrix
+was repeated three times with GPT-5.6 Sol/max. All 72 arms were valid, but the
+repetition deltas were +4/12, -3/12, and -1/12. With-skill and without-skill
+each passed 18/36, for an aggregate signed delta of **0/36 = 0.0**; the
+preregistered positive-lift hypothesis is not supported. All 18 negative-
+control arms had zero activation and zero tool calls. This remains a synthetic,
+limited-tool diagnostic with `promotion_authority=none`, not a runtime or
+package release claim. See the
+[run record](2026-08-26-skill-attribution-sol-max-paired-r3.md).
 
 The latest prospective paired-runtime diagnostic is pinned to artifact commit
 [`1160fec`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/1160fecfe4447f0a3f4cf30a414f29c61776d012):

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -11,7 +11,7 @@
     "trajectory": "core/observability/schemas/trajectory.schema.json",
     "trajectory_release": "core/observability/schemas/trajectory-release.schema.json"
   },
-  "document_count": 22,
+  "document_count": 23,
   "documents": [
     {
       "id": "agent-world-comparison",
@@ -117,7 +117,7 @@
       "authority": "routing",
       "path": "docs/eval/README.md",
       "summary": "Machine and human entrypoint for GEODE evaluation contracts, benchmark ledgers, evidence, and publication.",
-      "sha256": "6b0aca853c735cc35529418dfd1baad222db5a6dd73e5d3ccf8b70bd06f1b3ad",
+      "sha256": "63d0bedbcd339c6e47a940432b43d1c7b4135e42872fdd29ec40ccbf7e5fee20",
       "triggers": [
         "artifact",
         "benchmark",
@@ -135,7 +135,7 @@
         "docs/eval/schemas/publication.schema.json",
         "docs/eval/schemas/run-spec.schema.json"
       ],
-      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/fa352cb5f54e9f0ad6198c03dd180e27be388b5b/skill-attribution/results-paired/skill-attribution-sol-max-paired-20260826t113400z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-20260826t113400z-20260826T115134Z-feb50408b2a4"
+      "latest_valid_release": "https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/1efee3d0f4bfda3464b23b298a36f9a97f5fa691/skill-attribution/results-paired/skill-attribution-sol-max-paired-r3-20260826t130119z/trajectory-release/skill-attribution-skill-attribution-sol-max-paired-r3-20260826t130119z-20260826T133729Z-f6ee84d7139a"
     },
     {
       "id": "external-artifact-repository",
@@ -414,6 +414,31 @@
       ]
     },
     {
+      "id": "skill-attribution-sol-max-paired-r3-20260826t130119z",
+      "family": "skill-context-evaluation",
+      "title": "Runtime skill attribution — Sol/max repeated paired diagnostic",
+      "kind": "ledger",
+      "status": "historical",
+      "authority": "paired-skill-diagnostic",
+      "path": "docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.md",
+      "summary": "Prospective three-repetition diagnostic after SA-GAP-01 through SA-GAP-03 closure; all 72 arms were valid, repetition deltas were +4, -3, and -1, and the aggregate signed native-verifier delta was 0/36.",
+      "sha256": "8ee7f2853f8c76aa75da2fe0c0acce8c7b3335efc438eef400a2d0f2df756a7f",
+      "triggers": [
+        "ACES",
+        "gpt-5.6-sol",
+        "paired runtime skill",
+        "repeated diagnostic",
+        "skill attribution"
+      ],
+      "contracts": [
+        "core/observability/schemas/trajectory.schema.json",
+        "docs/eval/schemas/analysis.schema.json",
+        "docs/eval/schemas/attempt.schema.json",
+        "docs/eval/schemas/publication.schema.json",
+        "docs/eval/schemas/run-spec.schema.json"
+      ]
+    },
+    {
       "id": "skill-context-evaluation",
       "family": "skill-context-evaluation",
       "title": "Skill Attribution and Context Recoverability",
@@ -422,7 +447,7 @@
       "authority": "measurement-contract",
       "path": "docs/eval/skill-context-evaluation.md",
       "summary": "Paired runtime-skill attribution and deterministic context-recoverability profiles over existing GEODE evidence authorities.",
-      "sha256": "86a496798c55679d5d80bf3969fef4901f52e7ec6e757b6ea991aa6ef2315308",
+      "sha256": "dcb7128da98270b6202204cfcfd95aba5c70b1bcbcdb78989a2ce57febf70ffa",
       "triggers": [
         "ACES",
         "Scroll",

--- a/docs/eval/skill-context-evaluation.md
+++ b/docs/eval/skill-context-evaluation.md
@@ -21,8 +21,8 @@ eval_contracts:
 
 # Skill Attribution and Context Recoverability
 
-Status: executable offline and subscription-runner contract; one score-bearing
-diagnostic has been reported, without runtime promotion authority.
+Status: executable offline and subscription-runner contract; two score-bearing
+diagnostics have been reported, neither with runtime promotion authority.
 
 This profile turns two frontier observations into separate GEODE measurements:
 
@@ -116,11 +116,11 @@ but never enters the score denominator.
 
 #### Observed score-bearing diagnostic
 
-The new frozen run
+The first valid frozen run
 [`skill-attribution-sol-max-paired-20260826t113400z`](2026-08-26-skill-attribution-sol-max-paired.md)
 met that acceptance boundary: 24/24 arms were valid, with-skill passed 6/12,
 without-skill passed 2/12, and the signed native-verifier delta was +4/12.
-The preregistered diagnostic hypothesis is supported. The same run also found
+Its preregistered diagnostic hypothesis was supported. The same run also found
 zero lift for `deep-researcher`, 0/3 with-skill passes for explicit prompts,
 and one negative-control skill activation. Those secondary results block
 runtime promotion and package-release claims.
@@ -131,6 +131,23 @@ matching for structured grilling questions (SA-GAP-02), and a seeded,
 trigger-bearing grilling negative control (SA-GAP-03). The evaluator now fails
 closed on hidden IDs, scores question prose, and keeps negative controls free of
 grill state. Only a new prospective run may measure the corrected contract.
+
+That prospective repeated run is
+[`skill-attribution-sol-max-paired-r3-20260826t130119z`](2026-08-26-skill-attribution-sol-max-paired-r3.md).
+All 72 arms were valid, but repetition deltas were +4/12, -3/12, and -1/12.
+The aggregate with-skill and without-skill pass counts were both 18/36, so the
+frozen positive-lift hypothesis is not supported. All 18 negative-control arms
+had zero activation and zero tool calls, closing SA-GAP-03 empirically; the run
+also confirms that the one-repetition +4/12 result was not directionally
+stable. SA-GAP-01 and SA-GAP-02 remain closed by the frozen loader and verifier
+contracts rather than by score reinterpretation.
+
+The current surface still exposes only `use_skill`, `get_grill`, and
+`update_grill` over synthetic context. It therefore measures instruction and
+registry availability, not the full native capability of research, repository,
+or delegation skills. A broader suite requires a separately preregistered tool
+surface and task-specific structured-output contract; this verifier must not be
+changed post hoc to turn the zero result positive.
 
 ### Metrics
 


### PR DESCRIPTION
## Summary

- SA-GAP-01~03을 닫은 evaluator로 GPT-5.6 Sol/max paired skill-attribution matrix를 3회 반복한 결과를 공식 평가 ledger에 기록합니다.
- 72/72 arm은 모두 유효했지만 with-skill과 without-skill이 각각 18/36을 통과해 사전등록 primary delta는 `0/36 = 0.0`입니다. 양의 skill-lift 가설은 `not-supported`로 판정합니다.
- artifact PR [geode-eval-artifacts#32](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/32)와 merge commit `1efee3d0f4bfda3464b23b298a36f9a97f5fa691`을 immutable evidence authority로 고정합니다.

## Why

직전 1회 반복 run은 `+4/12`였지만 hidden verifier ID, answer-only structured prose scoring, seeded/trigger-bearing negative control이라는 세 측정계약 GAP이 있었습니다. PR #3220이 이 세 GAP을 닫았으므로, 이전 점수를 재계산하거나 보정하지 않고 새 run ID와 새 output root로 prospectively 반복 측정해야 했습니다.

새 run의 반복별 delta는 `+4/12`, `-3/12`, `-1/12`로 방향이 바뀌었습니다. 따라서 한 번의 긍정 결과를 승격 근거로 삼지 않고, 총합 0과 제한된 tool surface를 공식 문서에 그대로 남겨 runtime/package release를 차단합니다.

## GAP audit

| GAP | 이번 거래의 증거 | 판정 |
|---|---|---|
| SA-GAP-01 — hidden verifier IDs | loader가 model-visible context 밖 required ID를 거부하고 fixture가 finding ID를 노출 | run freeze 전에 closed |
| SA-GAP-02 — answer-only grading | answer + question options + recommendation을 동일 structured prose surface로 검증 | run freeze 전에 closed |
| SA-GAP-03 — biased negative control | 18/18 negative-control arm에서 skill activation 0, tool event 0 | empirically closed |
| SA-GAP-04 — narrow capability surface | 노출 도구가 `use_skill`, `get_grill`, `update_grill`뿐이고 context가 synthetic | native-capability suite 전까지 open |
| SA-GAP-05 — unstable direction | 반복 delta `+4`, `-3`, `-1`; 총 6 treatment wins / 6 control wins / 24 ties | intervention hypothesis 재설계 필요 |
| SA-GAP-06 — structured-output ambiguity | `research-implicit` 6/6이 동일 unexpected question + question-count 위반 | task-specific contract를 별도 사전등록해야 함 |

관측 뒤 verifier를 수정해 점수를 양수로 만들지 않았습니다. exact-term 검증은 lexical contract compliance이며 semantic quality authority가 아니라는 제한도 함께 기록합니다.

## Results

| Metric | With skill | Without skill | Delta / total |
|---|---:|---:|---:|
| Valid arms | 36 | 36 | 72/72 |
| Verifier passes | 18 | 18 | **0/36** |
| Skill activations | 25 | 0 | +25 |
| Irrelevant actions | 9 | 20 | -11 |
| Total tokens | 294,325 | 221,751 | +72,574 |
| Sum of arm elapsed time | 973.580s | 919.527s | +54.054s |

- infrastructure-invalid arm: 0
- retry: 0
- safety violation: 0
- preregistered hypothesis: `not-supported`
- promotion authority: `none`

## Changes

| File | Change |
|---|---|
| `docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.md` | frozen contract, 반복/skill/prompt-class 결과, GAP closure, attempt lineage, privacy/publication, release-readiness 기록 |
| `docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.publication.json` | 592개 source/publication 항목의 size·SHA-256·분류·remote path 고정 |
| `docs/eval/skill-context-evaluation.md` | 최신 repeated diagnostic와 해석 경계 반영 |
| `docs/eval/README.md` | latest valid trajectory release와 최신 paired-skill 판정 갱신 |
| `docs/eval/index.json` | 공식 generator로 23개 평가 문서 색인 재생성 |

## Artifact and privacy boundary

- source run: 589 files / 2,398,227 bytes
- public boundary: 303 files / 1,398,399 bytes
- withheld-private: 289 files / 1,555,134 bytes
- trajectory release: 630 events, 75/75 source digests verified, scope-complete, replay-incomplete
- public remote readback: 303/303 files, 1,398,399 bytes, size/SHA-256 drift 0
- raw native model results, tool payloads, per-arm local trajectories, child logs, runtime state, OAuth material, operator logs은 비공개 유지

Publication manifest SHA-256:
`42c1cd6b8bda434e76f8659dbccef765f49e1382a80e5a1df653f1f9f98205b1`

Trajectory release manifest SHA-256:
`f6ee84d7139a3c33905ae48bb420519083890444d52aa0a4f82aee046b7f385a`

## Verification

- `uv run python scripts/eval/contract.py validate-publication docs/eval/2026-08-26-skill-attribution-sol-max-paired-r3.publication.json` — 303 public entries PASS; 592 local source bytes 재검증
- `uv run python scripts/eval/contract.py catalog --check` — 23 documents PASS
- `uv run python scripts/check_official_docs.py` — architecture/catalog/link/Markdown/static build/export/generated-doc drift PASS
- `npm run verify-metadata` — SoftwareSourceCode v1.0.26, 13 citations PASS
- `npm run verify-geo` — export/sitemap/self-canonical/indexable 78/78, llm indexes 2/2 PASS
- `bash scripts/preflight.sh` — ruff, format, mypy, bandit, deptry, import/hygiene/architecture/roadmap/docs/prompt ratchets, full `pytest -m "not live"`, public-doc generators 모두 PASS; skip 없음
- pre-commit — codespell, whitespace, EOF, JSON, large-file, merge-conflict checks PASS

## Non-goals

- tag, PyPI upload, package version 변경 없음
- runtime 또는 package 승격 없음
- leaderboard·population-level skill 효과 주장 없음
- frozen verifier의 사후 tuning 또는 이전 run 점수 재계산 없음
- main promotion 없음; 이 PR은 docs-only evidence publication으로 develop을 대상으로 함
