### PR TITLE
Publish bilingual portfolio report

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
         args: [--maxkb=500]
-        exclude: ^site/public/report\.pdf$
+        exclude: ^site/public/report(?:-en)?\.pdf$
       - id: check-merge-conflict
       - id: debug-statements
 

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -289,7 +289,7 @@ machine-readable artifact is
 | `core/` Python LOC | 123,597 |
 | `evals/` Python LOC | 29,606 |
 | `evolve/` Python LOC | 32,014 |
-| Test Python LOC | 188,207 |
+| Test Python LOC | 188,210 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 5 |

--- a/site/src/app/portfolio/page.tsx
+++ b/site/src/app/portfolio/page.tsx
@@ -559,7 +559,7 @@ function HeroField() {
             {t(locale, "문서 읽기", "Read the docs")}
           </Link>
           <a
-            href="/geode/report.pdf"
+            href={locale === "en" ? "/geode/report-en.pdf" : "/geode/report.pdf"}
             aria-label={t(
               locale,
               "GEODE 90쪽 포트폴리오 PDF 열기",
@@ -3874,9 +3874,8 @@ function DistillationAct() {
 
 export default function GeodePortfolioPage() {
   return (
-    <LocaleProvider defaultLocale="en" allowQueryOverride={false}>
+    <LocaleProvider defaultLocale="en">
       <main
-        lang="en"
         data-astryx-theme="neutral"
         className={`${galmuri.variable} ${serifDisplay.variable} min-h-screen overflow-x-clip bg-[var(--acc-artifact)] text-[#FFF0F8]`}
       >

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -539,7 +539,7 @@
     },
     "tests": {
       "python_files": 696,
-      "python_loc": 188207
+      "python_loc": 188210
     }
   },
   "schema_version": 6,

--- a/tests/integration/test_portfolio_surface_policy.py
+++ b/tests/integration/test_portfolio_surface_policy.py
@@ -8,15 +8,18 @@ LOCALE_CONTEXT_PATH = REPO_ROOT / "site/src/components/geode/locale-context.tsx"
 NAV_PATH = REPO_ROOT / "site/src/components/geode/sections/nav.tsx"
 
 
-def test_portfolio_is_fixed_to_english() -> None:
+def test_portfolio_language_and_report_follow_the_query_locale() -> None:
     portfolio = PORTFOLIO_PATH.read_text(encoding="utf-8")
     locale_context = LOCALE_CONTEXT_PATH.read_text(encoding="utf-8")
     nav = NAV_PATH.read_text(encoding="utf-8")
 
-    assert '<LocaleProvider defaultLocale="en" allowQueryOverride={false}>' in portfolio
-    assert '<main\n        lang="en"' in portfolio
+    assert '<LocaleProvider defaultLocale="en">' in portfolio
+    assert "allowQueryOverride={false}" not in portfolio
     assert "<GeodeNav items={navItems} light showLocaleToggle={false} />" in portfolio
-    assert "if (!allowQueryOverride) return;" in locale_context
+    assert 'const lang = params.get("lang");' in locale_context
+    assert 'href={locale === "en" ? "/geode/report-en.pdf" : "/geode/report.pdf"}' in portfolio
+    assert (REPO_ROOT / "site/public/report.pdf").is_file()
+    assert (REPO_ROOT / "site/public/report-en.pdf").is_file()
     assert "{showLocaleToggle ? <LocaleToggle /> : null}" in nav
 
 


### PR DESCRIPTION
## Summary
- publish the 90-page English portfolio as `report-en.pdf`
- select portfolio language and PDF through the existing `?lang=ko|en` query
- preserve Korean `report.pdf` as the canonical Korean artifact

## Verification
- portfolio surface policy: 2 passed
- pre-commit selected-file gate: passed
- static site build (`next build --webpack`): passed, 239 pages
- headless browser: `?lang=ko` -> Korean + `report.pdf`; `?lang=en` -> English + `report-en.pdf`
- English PDF: 90 pages, qpdf clean, zero extracted Hangul