### PR TITLE
docs(architecture): register durable effect boundary gaps

### DIFF
--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -576,6 +576,9 @@ and closure evidence are appended in §10.
 | DIST-004 | `MISFIT` | `geode update` replaces the live uv-tool environment and verifies the new CLI before stopping the old daemon, allowing a running process to observe a mixed old-process/new-files installation | A running daemon is drained and stopped before live tool replacement, failed updates remain fail-closed without starting a second daemon, successful restart proves CLI/IPC daemon version parity, and ordering tests cover running, stopped, failed-stop, failed-install, and no-restart paths | R10.1 | BND-003, REL-003 | `DONE` |
 | EVAL-001 | `ABSENT` | Runtime Skills have loader, package, and policy checks but no paired evaluation that changes only target-skill availability | A native paired benchmark freezes model, task, workspace, tools, scorer, seed, and repetitions; reports verifier-first with-skill lift, activation, cost, and negative controls; and binds results to existing run-spec, attempt, trajectory, reward, and analysis authorities | R11.1 | BND-004, VER-001 | `IN_PROGRESS` |
 | EVAL-002 | `PARTIAL` | Session events, FTS recall, compaction, and tool offload exist, but no deterministic benchmark classifies exact recovery after compaction, restart, expiry, or corruption | An offline recoverability benchmark uses current session and offload authorities, stable event or digest references, and an immutable receipt to distinguish exact, summary-only, unavailable, and corrupt evidence without a second transcript, unbounded retention, or live model call | R11.1 | STORE-002, VER-001 | `IN_PROGRESS` |
+| EFFECT-001 | `ABSENT` | `ToolContext` carries physical call correlation and the common executor classifies effect policy, but no durable record is committed before an accepted effectful dispatch or replays a completed result without calling the sink again | The existing `sessions.db` owns a bounded, redacted effect receipt keyed by a caller-issued logical operation ID; one atomic admission distinguishes new, completed, conflicting, and uncertain operations, replays committed results, and never auto-reruns an uncertain effect | R12.1 | CAP-002, STORE-002 | `OPEN` |
+| EFFECT-002 | `PARTIAL` | Checkpoints persist turn start, finalization, and model failures, while an ordinary successful tool batch appends its assistant call and result without an immediate checkpoint before the next model request | Every completed ordinary tool batch synchronizes the balanced call/result history and commits a checkpoint before the next model request; restart fixtures prove committed results remain model-visible and unfinished effect receipts surface an explicit uncertain outcome without automatic replay | R12.1 | EFFECT-001 | `OPEN` |
+| EFFECT-003 | `MISFIT` | Middleware architecture prose calls the terminal boundary an `exactly-once executor`, although it proves one accepted in-process terminal invocation rather than exactly-once external effects; only MCP mid-call recovery currently states the read-only/idempotent retry boundary precisely | Runtime docs and executable retry/crash fixtures name single terminal invocation, durable effect admission, duplicate suppression, and uncertain outcome separately; automatic recovery remains limited to read-only or explicitly idempotent operations and no generic sink-level exactly-once claim remains | R12.1 | EFFECT-001, EFFECT-002 | `OPEN` |
 
 ## 6. Dependency and merge sequence
 
@@ -674,6 +677,13 @@ authorities. It must establish causal skill attribution and deterministic
 context-recoverability evidence before any later package may add a new context
 store, retention class, eviction index, or executable namespace. Any such
 runtime change requires its own measured GAP and serialized package.
+
+R12.1 is a runtime safety package over the delivered tool-plan, middleware,
+and session-store authorities. It localizes durability at the accepted
+effectful dispatch boundary while leaving model reasoning, search, planning,
+and read-only exploration non-deterministic. It does not add a workflow engine,
+global argument-hash dedupe, generic compensation API, second state database,
+or a claim of exactly-once behavior across third-party sinks.
 
 ## 7. Phase work packages
 
@@ -1953,6 +1963,43 @@ Acceptance:
 - live model execution remains outside this package until a frozen run spec
   names the model route, seeds, repetitions, cost budget, privacy boundary, and
   explicit approval.
+
+### R12 — Durable external-effect boundary
+
+#### R12.1 Effect admission, checkpoint, and retry semantics
+
+GAPs: EFFECT-001, EFFECT-002, EFFECT-003.
+
+This package preserves an agentic, observation-driven trajectory while making
+the accepted mutation boundary crash-explicit. It reuses `ToolEffect`,
+`ToolContext`, the common `ToolExecutor`, the current session database, and the
+existing checkpoint writer instead of adding a general workflow or transaction
+framework.
+
+Acceptance:
+
+- only `MUTATE`, `COMMUNICATE`, and `ADMINISTRATIVE` registrations enter the
+  durable admission rail; `READ` stays freely retryable and arbitrary
+  `EXECUTE` operations keep their existing approval/sandbox contract rather
+  than receiving an unsupported exactly-once promise;
+- a caller-issued logical operation ID is distinct from argument fingerprints
+  and physical provider call correlation, while reusing an ID with different
+  effective arguments fails before dispatch;
+- admission is durable before dispatch, committed bounded results replay
+  without a second sink call, and a process boundary turns an unfinished
+  admission into an explicit uncertain outcome that is never automatically
+  replayed;
+- personal-data persistence rules redact receipt arguments/results, retention
+  is bounded, schema changes are additive and idempotent, and current session
+  databases remain readable without a second writer or migration command;
+- completed tool-call/result history is checkpointed before the next model
+  request, with crash fixtures covering pre-admission, pre-dispatch,
+  post-effect/pre-commit, and post-commit/pre-checkpoint boundaries;
+- internal and public architecture prose distinguishes trajectory
+  non-determinism, checkpoint recoverability, single terminal invocation,
+  duplicate suppression, provider idempotency, and sink-level exactly-once;
+  focused tests, the full non-live suite, architecture gates, docs build, and
+  installed-package checks pass without a live provider call.
 
 ## 8. Change-surface acceptance scenarios
 


### PR DESCRIPTION
## Summary

- GEODE의 비결정적 agent trajectory와 외부 side effect의 crash consistency를 분리해 추적할 R12.1 패키지를 등록합니다.
- `EFFECT-001`~`003`은 durable effect admission, 성공 tool batch 체크포인트, 정확한 retry/exactly-once 용어를 각각 측정 가능한 종료 조건으로 고정합니다.

## Why

현재 런타임은 `ToolEffect`, immutable tool plan, 승인·샌드박스, MCP의 read-only/idempotent 재시도 제한을 갖추고 있습니다. 그러나 공통 executor에는 effectful dispatch 직전 durable receipt가 없고, 일반적인 성공 tool batch는 다음 모델 호출 전에 즉시 checkpoint되지 않습니다. 또한 architecture prose의 `exactly-once executor`는 한 accepted request의 terminal invocation cardinality와 외부 sink의 exactly-once 효과를 혼동할 수 있습니다.

Codex·Claude Code의 공개 설계는 sandbox/permission과 resume history를 제공하지만 generic external-effect exactly-once를 약속하지 않습니다. Prime Agent와 OpenClaw는 durable admission 뒤 미완료 operation을 uncertain으로 남기고 blind replay를 막습니다. LangGraph·Temporal·RIFL 역시 sink idempotency 또는 reconciliation 없이는 외부 성공과 local commit 사이의 crash window를 닫을 수 없다고 구분합니다. R12.1은 이 경계를 GEODE의 기존 `ToolEffect + ToolContext + ToolExecutor + sessions.db`에 최소 확장하는 패키지입니다.

## Changes

| File | Change |
|---|---|
| `docs/architecture/extensibility-roadmap.md` | `EFFECT-001` durable receipt, `EFFECT-002` post-tool checkpoint, `EFFECT-003` retry/terminology parity를 `OPEN`으로 등록 |
| `docs/architecture/extensibility-roadmap.md` | R12.1의 dependencies, non-goals, crash-window acceptance, redaction/retention/compatibility 조건 추가 |

## GAP Audit

| GAP | Current evidence | Measurable exit |
|---|---|---|
| EFFECT-001 | physical call correlation은 있으나 accepted effectful dispatch 전 durable receipt 없음 | existing `sessions.db`의 bounded/redacted admission이 new/completed/conflict/uncertain을 원자적으로 구분 |
| EFFECT-002 | turn start/final/error checkpoint는 있으나 ordinary successful tool batch 직후 checkpoint 없음 | balanced call/result history가 next model request 전에 저장되고 restart fixture로 증명 |
| EFFECT-003 | `exactly-once executor`가 in-process terminal invocation과 sink effect를 혼동 | single invocation, duplicate suppression, provider idempotency, outcome-unknown을 코드·테스트·문서에서 분리 |

## Verification

- `git diff --check` — passed
- `uv run python scripts/check_architecture_roadmap.py --check --base-ref origin/develop --target-branch develop --event-mode pull_request` — RESULT: PASS
- pre-commit documentation and architecture hooks — passed

This is a roadmap-only GAP-registration transaction. It does not authorize implementation; R12.1 still requires separate `OPEN -> READY -> IN_PROGRESS` ledger PRs.
