### PR TITLE
feat(evals): reconstruct Harbor trial recordings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
 The current snapshot records 581 production Python files,
-699 test Python files,
+700 test Python files,
 86 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ functional change.
   non-raw-capture provenance. A fail-closed backfill command covers closed
   historical Harbor jobs without overwriting existing recordings.
 
+### Infrastructure
+
+- **Patched site audit dependency.** The locked transitive `@humanfs/node`
+  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.
+
 ## [1.0.27] - 2026-09-02
 
 > Provider-boundary and evaluation-integrity release: OpenRouter joins as an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Harbor trial replay receipts.** GEODE and an instrumented native Codex
+  adapter can now reconstruct agent-owned asciicast v2 replays from finalized
+  ATIF trajectories, with source/output hashes and explicit non-score,
+  non-raw-capture provenance. A fail-closed backfill command covers closed
+  historical Harbor jobs without overwriting existing recordings.
+
 ## [1.0.27] - 2026-09-02
 
 > Provider-boundary and evaluation-integrity release: OpenRouter joins as an

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -287,11 +287,11 @@ machine-readable artifact is
 | Measure | Current tree |
 |---|---:|
 | Production Python files (`core/` + `evals/` + `evolve/`) | 581 |
-| Test Python files | 699 |
+| Test Python files | 700 |
 | `core/` Python LOC | 124,637 |
-| `evals/` Python LOC | 30,375 |
+| `evals/` Python LOC | 30,644 |
 | `evolve/` Python LOC | 32,014 |
-| Test Python LOC | 189,458 |
+| Test Python LOC | 189,562 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 6 |

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -514,7 +514,7 @@
       "authority": "suite-profile",
       "path": "docs/eval/terminal-bench-2.md",
       "summary": "GEODE adoption profile for canonical Terminal-Bench 2.1 execution through Harbor, including official-submission and diagnostic comparability boundaries.",
-      "sha256": "63e5732ab156d78f3abc9d68a4d5e2294b0c0cb5f402162cc283973f6ce78307",
+      "sha256": "784a64f40bd69d443a445032f37276f709588a0b7510c85747b7970708a3b8c0",
       "triggers": [
         "Harbor",
         "Terminal-Bench 2",

--- a/docs/eval/terminal-bench-2.md
+++ b/docs/eval/terminal-bench-2.md
@@ -75,7 +75,26 @@ It:
   timeout at zero so Harbor's canonical task limit remains authoritative;
 - leaves task/container/verifier ownership with Harbor;
 - exports a digest-oriented geode.trajectory@1 sidecar and an ATIF 1.7
-  `trajectory.json` projected from the same canonical session timeline.
+  `trajectory.json` projected from the same canonical session timeline;
+- reconstructs `recording.cast` from the finalized ATIF trace and binds it to
+  the source with `recording.receipt.json`.
+
+Harbor's job layout permits `agent/recording.cast`, but its contents are owned
+by each agent implementation. Terminus-2 performs a raw asciinema capture;
+GEODE and the instrumented native Codex adapter instead emit an asciicast v2
+reconstruction after ATIF finalization. The reconstruction is replay evidence,
+not a raw PTY capture or score authority. It omits provider reasoning, redacts
+known secret forms, and remains private until a separate PII/path/publication
+review. Observer-side `script -r` files separately record the operator console
+and must not be described as Harbor-native trial recordings.
+
+Use `evals.platforms.harbor:RecordedCodexHarborAgent` instead of the built-in
+Codex name when future paired runs require the native arm to emit the derived
+cast automatically. Closed historical jobs can be audited and backfilled
+without changing result or trajectory files:
+
+    uv run python -m evals.platforms.harbor <job-or-run-root> --dry-run
+    uv run python -m evals.platforms.harbor <job-or-run-root>
 
 The adapter declares `SUPPORTS_ATIF=true` only after validating the projection
 with Harbor's own ATIF model. Scope-incomplete session history or unmatched

--- a/docs/plans/2026-09-03-harbor-trial-recording.md
+++ b/docs/plans/2026-09-03-harbor-trial-recording.md
@@ -1,0 +1,41 @@
+# Harbor trial recording reconstruction
+
+## Evidence and gap
+
+- Harbor documents `agent/recording.cast` as an agent-owned trial artifact.
+- Harbor 0.22.0 records it in Terminus-2, but neither GEODE's external agent nor
+  Harbor's installed Codex agent emits it.
+- Both agents already emit timestamped ATIF 1.7 `trajectory.json` files. The
+  active frozen comparison therefore must not be re-run or PTY-wrapped merely
+  to obtain a replay artifact.
+
+## Decision
+
+Render a Harbor-compatible asciicast v2 file from the existing ATIF trajectory
+after the trajectory is finalized. Store it at `agent/recording.cast` and bind
+it to the source trajectory with `agent/recording.receipt.json`.
+
+This is a trajectory reconstruction, not a raw terminal capture. It omits
+reasoning content, redacts known secret forms, requires a separate PII/public
+review, and has no score authority. Existing native recordings are never
+overwritten by default.
+
+GEODE writes the replay after its ATIF export. A thin Codex instrumentation
+subclass writes it after Harbor's native Codex converter. The same renderer has
+a dry-run/backfill command for closed historical jobs.
+
+## Acceptance
+
+- asciicast v2 JSONL validates and preserves monotonic ATIF-relative timing;
+- commands, observations, and final responses are replayable without provider
+  reasoning;
+- receipt hashes bind source and output and state the reconstruction boundary;
+- malformed or missing trajectories fail closed and existing casts remain
+  untouched;
+- targeted tests plus ruff and mypy pass without a paid or live benchmark run.
+
+## Primary sources
+
+- [Harbor job output layout](https://www.harborframework.com/docs/run-jobs/run-evals)
+- [Harbor 0.22.0 Terminus-2 source](https://github.com/harbor-framework/harbor/blob/v0.22.0/src/harbor/agents/terminus_2/terminus_2.py)
+- [asciicast v2 format](https://docs.asciinema.org/manual/asciicast/v2/)

--- a/evals/benchmarks/harbor_geode_agent.py
+++ b/evals/benchmarks/harbor_geode_agent.py
@@ -1,5 +1,5 @@
 """Compatibility facade for the Harbor platform adapter."""
 
-from evals.platforms.harbor import GeodeHarborAgent, HarborExecTool
+from evals.platforms.harbor import GeodeHarborAgent, HarborExecTool, RecordedCodexHarborAgent
 
-__all__ = ["GeodeHarborAgent", "HarborExecTool"]
+__all__ = ["GeodeHarborAgent", "HarborExecTool", "RecordedCodexHarborAgent"]

--- a/evals/platforms/harbor.py
+++ b/evals/platforms/harbor.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import importlib
 import importlib.metadata
 import json
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from core.memory.atomic_write import atomic_write_json, atomic_write_text
+from core.observability.redaction import redact_and_bound_text
 
 if TYPE_CHECKING:
 
@@ -25,11 +31,26 @@ if TYPE_CHECKING:
             **kwargs: Any,
         ) -> None: ...
 
+    class HarborCodexAgent:
+        logs_dir: Path
+        logger: Any
+
+        def populate_context_post_run(self, context: Any) -> None: ...
+
 else:
     try:
         HarborBaseAgent = importlib.import_module("harbor.agents.base").BaseAgent
     except ImportError:  # Harbor is an opt-in benchmark dependency.
         HarborBaseAgent = object
+    try:
+        HarborCodexAgent = importlib.import_module("harbor.agents.installed.codex").Codex
+    except ImportError:  # Harbor is an opt-in benchmark dependency.
+        HarborCodexAgent = object
+
+
+log = logging.getLogger(__name__)
+_MAX_RECORDING_EVENT_CHARS = 64_000
+_RECORDING_RECEIPT_SCHEMA = "geode.harbor-recording-receipt@1"
 
 
 @dataclass
@@ -238,11 +259,223 @@ def _atif_trajectory_from_geode(
 
 
 def _write_atif_trajectory(path: Path, payload: Mapping[str, Any]) -> None:
-    from core.memory.atomic_write import atomic_write_json
-
     trajectory_model = importlib.import_module("harbor.models.trajectories").Trajectory
     validated = trajectory_model.model_validate(payload)
     atomic_write_json(path, validated.to_json_dict(), indent=2)
+
+
+def _recording_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _recording_text(value: Any) -> str:
+    return (
+        redact_and_bound_text(value, _MAX_RECORDING_EVENT_CHARS)
+        .replace("\r\n", "\n")
+        .replace("\n", "\r\n")
+    )
+
+
+def _recording_step_output(step: Mapping[str, Any]) -> list[str]:
+    tool_calls = step.get("tool_calls")
+    calls = (
+        [call for call in tool_calls if isinstance(call, Mapping)]
+        if isinstance(tool_calls, list)
+        else []
+    )
+    chunks: list[str] = []
+    if calls:
+        for call in calls:
+            name = str(call.get("function_name") or "tool")
+            arguments = call.get("arguments")
+            arguments = arguments if isinstance(arguments, Mapping) else {}
+            action = arguments.get("command", arguments.get("input"))
+            if action is None:
+                action = json.dumps(arguments, ensure_ascii=False, sort_keys=True, default=str)
+            chunks.append(f"\x1b[1;36m$ [{name}]\x1b[0m {_recording_text(action)}\r\n")
+
+        observation = step.get("observation")
+        observation = observation if isinstance(observation, Mapping) else {}
+        results = observation.get("results")
+        if isinstance(results, list):
+            for result in results:
+                if not isinstance(result, Mapping):
+                    continue
+                content = _recording_text(result.get("content"))
+                if content:
+                    chunks.append(content + ("" if content.endswith("\r\n") else "\r\n"))
+        return chunks
+
+    message = _recording_text(step.get("message"))
+    if message:
+        source = str(step.get("source") or "event")
+        label = "task" if source == "user" else source
+        chunks.append(f"\x1b[1;33m[{label}]\x1b[0m {message}\r\n")
+    return chunks
+
+
+def _render_asciicast(trajectory: Mapping[str, Any]) -> tuple[str, dict[str, int]]:
+    schema_version = trajectory.get("schema_version")
+    if not isinstance(schema_version, str) or not schema_version.startswith("ATIF-v1."):
+        raise ValueError("recording reconstruction requires an ATIF v1 trajectory")
+    steps = trajectory.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ValueError("ATIF trajectory must contain at least one step")
+
+    parsed = [
+        _recording_timestamp(step.get("timestamp")) if isinstance(step, Mapping) else None
+        for step in steps
+    ]
+    base = next((value for value in parsed if value is not None), None)
+    agent = trajectory.get("agent")
+    agent = agent if isinstance(agent, Mapping) else {}
+    header: dict[str, Any] = {
+        "version": 2,
+        "width": 120,
+        "height": 36,
+        "title": f"Harbor ATIF replay — {agent.get('name') or 'agent'}",
+        "env": {
+            "TERM": "xterm-256color",
+            "SHELL": "/bin/sh",
+            "GEODE_RECORDING_PROVENANCE": "trajectory-reconstruction",
+        },
+    }
+    if base is not None:
+        header["timestamp"] = int(base.timestamp())
+
+    events: list[list[Any]] = [
+        [
+            0.0,
+            "o",
+            "\x1b[1;35m[reconstructed]\x1b[0m Harbor ATIF replay; not a raw PTY capture.\r\n",
+        ]
+    ]
+    previous = 0.0
+    synthetic = 0
+    clamped = 0
+    for step, occurred_at in zip(steps, parsed, strict=True):
+        if not isinstance(step, Mapping):
+            continue
+        if occurred_at is None or base is None:
+            offset = previous + 0.001
+            synthetic += 1
+        else:
+            offset = (occurred_at - base).total_seconds()
+            if offset < previous:
+                offset = previous
+                clamped += 1
+        previous = offset
+        events.extend([round(offset, 6), "o", chunk] for chunk in _recording_step_output(step))
+
+    if len(events) == 1:
+        raise ValueError("ATIF trajectory contains no replayable content")
+    lines = [json.dumps(header, ensure_ascii=False)]
+    lines.extend(json.dumps(event, ensure_ascii=False) for event in events)
+    return "\n".join(lines) + "\n", {
+        "step_count": len(steps),
+        "event_count": len(events),
+        "synthetic_timestamp_count": synthetic,
+        "clamped_timestamp_count": clamped,
+    }
+
+
+def write_harbor_recording(
+    trajectory_path: Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any] | None:
+    """Write one derived cast and receipt; preserve any existing recording."""
+    trajectory_path = Path(trajectory_path)
+    recording_path = trajectory_path.with_name("recording.cast")
+    receipt_path = trajectory_path.with_name("recording.receipt.json")
+    if recording_path.exists() and not overwrite:
+        return None
+
+    source_bytes = trajectory_path.read_bytes()
+    trajectory = json.loads(source_bytes)
+    if not isinstance(trajectory, Mapping):
+        raise ValueError("ATIF trajectory root must be an object")
+    cast, timing = _render_asciicast(trajectory)
+    cast_bytes = cast.encode("utf-8")
+    receipt: dict[str, Any] = {
+        "schema_id": _RECORDING_RECEIPT_SCHEMA,
+        "recording_kind": "trajectory-reconstruction",
+        "score_authority": False,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "path": trajectory_path.name,
+            "sha256": hashlib.sha256(source_bytes).hexdigest(),
+            "schema_version": str(trajectory.get("schema_version") or ""),
+            "trajectory_id": str(trajectory.get("trajectory_id") or ""),
+        },
+        "output": {
+            "path": recording_path.name,
+            "sha256": hashlib.sha256(cast_bytes).hexdigest(),
+            "format": "asciicast-v2",
+        },
+        "timing": timing,
+        "privacy": {
+            "known_secret_patterns": "redacted",
+            "provider_reasoning": "omitted",
+            "publication_state": "private-review-required",
+        },
+    }
+    atomic_write_text(recording_path, cast)
+    atomic_write_json(receipt_path, receipt, indent=2)
+    return receipt
+
+
+def backfill_harbor_recordings(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Create missing derived recordings below one closed Harbor job/run root."""
+    root = Path(root)
+    if not root.is_dir():
+        raise FileNotFoundError(root)
+    summary = {
+        "trajectories": 0,
+        "eligible": 0,
+        "created": 0,
+        "existing": 0,
+        "failed": 0,
+    }
+    for trajectory_path in sorted(root.rglob("agent/trajectory.json")):
+        summary["trajectories"] += 1
+        if trajectory_path.with_name("recording.cast").exists() and not overwrite:
+            summary["existing"] += 1
+            continue
+        try:
+            if dry_run:
+                trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+                if not isinstance(trajectory, Mapping):
+                    raise ValueError("ATIF trajectory root must be an object")
+                _render_asciicast(trajectory)
+            else:
+                write_harbor_recording(trajectory_path, overwrite=overwrite)
+                summary["created"] += 1
+            summary["eligible"] += 1
+        except (OSError, ValueError, json.JSONDecodeError):
+            summary["failed"] += 1
+    return summary
+
+
+def _write_recording_if_available(logs_dir: Path) -> None:
+    trajectory_path = logs_dir / "trajectory.json"
+    if not trajectory_path.is_file():
+        return
+    try:
+        write_harbor_recording(trajectory_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        log.warning("Harbor recording reconstruction failed: %s", exc)
 
 
 def _build_loop(
@@ -409,6 +642,42 @@ class GeodeHarborAgent(HarborBaseAgent):
                 metrics=usage,
             ),
         )
+        _write_recording_if_available(self.logs_dir)
 
 
-__all__ = ["GeodeHarborAgent", "HarborExecTool"]
+class RecordedCodexHarborAgent(HarborCodexAgent):
+    """Harbor Codex with post-run trajectory replay instrumentation."""
+
+    SUPPORTS_ATIF = True
+
+    def populate_context_post_run(self, context: Any) -> None:
+        super().populate_context_post_run(context)
+        _write_recording_if_available(self.logs_dir)
+
+
+def _recording_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reconstruct Harbor recordings from ATIF traces.")
+    parser.add_argument("root", type=Path, help="Closed Harbor job or run root")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args(argv)
+    summary = backfill_harbor_recordings(
+        args.root,
+        dry_run=args.dry_run,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(summary, sort_keys=True))
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_recording_main())
+
+
+__all__ = [
+    "GeodeHarborAgent",
+    "HarborExecTool",
+    "RecordedCodexHarborAgent",
+    "backfill_harbor_recordings",
+    "write_harbor_recording",
+]

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -546,25 +546,39 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6707,7 +6707,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 | 측정값 | 현재 트리 |
 | --- | --- |
 | 프로덕션 Python 파일 | 581 |
-| 테스트 Python 파일 | 699 |
+| 테스트 Python 파일 | 700 |
 | 도구 정의 / 모델 실행 / 유효 스키마 / 정책 | 86 / 86 / 86 / 86 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 6 |

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -532,15 +532,15 @@
     },
     "evals": {
       "python_files": 93,
-      "python_loc": 30375
+      "python_loc": 30644
     },
     "evolve": {
       "python_files": 73,
       "python_loc": 32014
     },
     "tests": {
-      "python_files": 699,
-      "python_loc": 189458
+      "python_files": 700,
+      "python_loc": 189562
     }
   },
   "schema_version": 6,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings."
   },
   {
     "version": "1.0.27",

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings."
+    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build."
   },
   {
     "version": "1.0.27",

--- a/tests/evals/benchmarks/test_harbor_recording.py
+++ b/tests/evals/benchmarks/test_harbor_recording.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from evals.platforms.harbor import (
+    backfill_harbor_recordings,
+    write_harbor_recording,
+)
+
+
+def _trajectory(path: Path) -> Path:
+    path.parent.mkdir(parents=True)
+    payload = {
+        "schema_version": "ATIF-v1.7",
+        "trajectory_id": "trial-1",
+        "agent": {"name": "codex"},
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": "2026-09-03T00:00:00Z",
+                "source": "user",
+                "message": "fix the task",
+            },
+            {
+                "step_id": 2,
+                "timestamp": "2026-09-03T00:00:02Z",
+                "source": "agent",
+                "message": "private reasoning must not be replayed",
+                "reasoning_content": "also private",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-1",
+                        "function_name": "exec",
+                        "arguments": {"command": "pwd"},
+                    }
+                ],
+                "observation": {
+                    "results": [
+                        {
+                            "source_call_id": "call-1",
+                            "content": "/app sk-proj-abcdefghijklmnopqrstuvwxyz123456",
+                        }
+                    ]
+                },
+            },
+            {
+                "step_id": 3,
+                "timestamp": "invalid",
+                "source": "agent",
+                "message": "done",
+            },
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_recording_reconstructs_atif_without_reasoning_or_secrets(tmp_path: Path) -> None:
+    trajectory_path = _trajectory(tmp_path / "job" / "trial" / "agent" / "trajectory.json")
+    receipt = write_harbor_recording(trajectory_path)
+
+    assert receipt is not None
+    cast_path = trajectory_path.with_name("recording.cast")
+    lines = [json.loads(line) for line in cast_path.read_text().splitlines()]
+    assert lines[0]["version"] == 2
+    assert lines[0]["env"]["GEODE_RECORDING_PROVENANCE"] == "trajectory-reconstruction"
+    assert [event[0] for event in lines[1:]] == sorted(event[0] for event in lines[1:])
+    replay = "".join(event[2] for event in lines[1:])
+    assert "fix the task" in replay
+    assert "[exec]" in replay and "pwd" in replay and "/app" in replay
+    assert "[REDACTED]" in replay and "sk-proj-" not in replay
+    assert "private reasoning" not in replay and "also private" not in replay
+    assert "done" in replay
+    assert receipt["source"]["sha256"] == hashlib.sha256(trajectory_path.read_bytes()).hexdigest()
+    assert receipt["timing"]["synthetic_timestamp_count"] == 1
+    assert receipt["score_authority"] is False
+
+
+def test_backfill_preserves_existing_recording(tmp_path: Path) -> None:
+    first = _trajectory(tmp_path / "one" / "agent" / "trajectory.json")
+    second = _trajectory(tmp_path / "two" / "agent" / "trajectory.json")
+    first.with_name("recording.cast").write_text("native", encoding="utf-8")
+
+    dry_run = backfill_harbor_recordings(tmp_path, dry_run=True)
+    assert dry_run == {
+        "trajectories": 2,
+        "eligible": 1,
+        "created": 0,
+        "existing": 1,
+        "failed": 0,
+    }
+
+    summary = backfill_harbor_recordings(tmp_path)
+    assert summary == {
+        "trajectories": 2,
+        "eligible": 1,
+        "created": 1,
+        "existing": 1,
+        "failed": 0,
+    }
+    assert first.with_name("recording.cast").read_text() == "native"
+    assert second.with_name("recording.receipt.json").is_file()


### PR DESCRIPTION
## Summary
- Reconstruct Harbor-compatible `agent/recording.cast` files from finalized ATIF trajectories for GEODE and an instrumented native Codex agent.
- Bind each derived replay to its source with a non-score provenance receipt and support fail-closed backfill for closed historical jobs.

## Why
Harbor 0.22.0 documents `recording.cast` in its trial layout, but recording is agent-owned: Terminus-2 emits it while GEODE and Harbor's installed Codex agent do not. The frozen Terminal-Bench comparison already preserves timestamped ATIF trajectories, so a post-run reconstruction provides replay evidence without PTY-wrapping or re-running the model.

## Changes
| File | Change |
|------|--------|
| `evals/platforms/harbor.py` | Add ATIF-to-asciicast rendering, hash-bound receipt, closed-job backfill CLI, GEODE postprocessing, and native Codex instrumentation subclass. |
| `tests/evals/benchmarks/test_harbor_recording.py` | Verify monotonic replay timing, secret/reasoning omission, receipt hashes, and no-overwrite backfill. |
| `docs/eval/terminal-bench-2.md` | Document raw-capture versus reconstruction authority and the backfill procedure. |
| generated inventories | Refresh the evaluation catalog, architecture counts, changelog projection, and `llms-full.txt`. |

## GAP Audit
| Gap | Evidence | Resolution |
|-----|----------|------------|
| GEODE/Codex trials have no `recording.cast` | Frozen run snapshot had 834 ATIF trajectories and 0 casts | Render derived asciicast v2 after ATIF finalization. |
| Derived replay could be mistaken for raw capture | Harbor output path alone does not encode capture provenance | Mark cast header and receipt as `trajectory-reconstruction`, `score_authority=false`, private-review-required. |
| Historical attempts would require re-run | Existing timestamped trajectories are intact | Add dry-run/backfill that preserves result/trajectory files and never overwrites an existing cast by default. |

## Verification
- `scripts/preflight.sh` — all gates passed, including full non-live pytest and site generation.
- `uv run pytest tests/evals/benchmarks/test_harbor_recording.py tests/evals/benchmarks/test_harbor_geode_agent.py -q` — 4 passed.
- Exact `harbor==0.22.0` native Codex instrumentation smoke — passed.
- Frozen run read-only dry-run — 834 trajectories, 834 eligible, 0 failed, 0 existing casts.
- No paid/live model call was made.
