### PR TITLE
fix: OpenRouter 실측 증거 영속화와 오류 로그 최소화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ functional change.
 - **Patched site audit dependency.** The locked transitive `@humanfs/node`
   dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.
 
+### Fixed
+
+- **Provider failures and routed-call evidence are now privacy-safe and
+  durable.** Built-in adapters no longer interpolate raw SDK exception bodies
+  into warning logs, failed LLM hooks retain only the exception type, and
+  activity schema v4 preserves bounded token, charge, requested/served model,
+  adapter, and OpenRouter route metadata through SQLite and run projections.
+
 ## [1.0.27] - 2026-09-02
 
 > Provider-boundary and evaluation-integrity release: OpenRouter joins as an

--- a/core/agent/loop/_provider_call.py
+++ b/core/agent/loop/_provider_call.py
@@ -396,7 +396,8 @@ async def call_llm(
                         "provider": active_provider,
                         "adapter": active_name,
                         "latency_ms": (_llm_call_time.monotonic() - started_at) * 1_000,
-                        "error": str(exc) or type(exc).__name__,
+                        "error": type(exc).__name__,
+                        "error_type": type(exc).__name__,
                     },
                 )
                 raise
@@ -516,9 +517,9 @@ async def call_llm(
         error_detail = str(exc) or type(exc).__name__
         loop._last_llm_error = error_detail
         log.warning(
-            "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
+            "AgenticLoop: adapter.acomplete failed adapter=%s error_type=%s",
             adapter_name,
-            error_detail,
+            type(exc).__name__,
         )
         if _fail_fast_adapter_errors_enabled():
             raise

--- a/core/llm/adapters/anthropic_payg.py
+++ b/core/llm/adapters/anthropic_payg.py
@@ -97,9 +97,9 @@ class AnthropicPaygAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "anthropic-payg: messages.create failed model=%s err=%s",
+                    "anthropic-payg: messages.create failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         return translate_response(response)

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -199,9 +199,9 @@ class CodexOAuthAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "codex-oauth: responses.stream failed model=%s err=%s",
+                    "codex-oauth: responses.stream failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         result = translate_codex_response(final, accumulated_items=accumulated)

--- a/core/llm/adapters/glm_coding_plan.py
+++ b/core/llm/adapters/glm_coding_plan.py
@@ -102,9 +102,9 @@ class GlmCodingPlanAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "glm-coding-plan: chat.completions.create failed model=%s err=%s",
+                "glm-coding-plan: chat.completions.create failed model=%s error_type=%s",
                 req.model,
-                exc,
+                type(exc).__name__,
             )
             raise
         return translate_chat_response(response)

--- a/core/llm/adapters/glm_payg.py
+++ b/core/llm/adapters/glm_payg.py
@@ -134,9 +134,9 @@ class GlmPaygAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "glm-payg: chat.completions.create failed model=%s err=%s",
+                "glm-payg: chat.completions.create failed model=%s error_type=%s",
                 req.model,
-                exc,
+                type(exc).__name__,
             )
             raise
         return translate_chat_response(response)

--- a/core/llm/adapters/openai_payg.py
+++ b/core/llm/adapters/openai_payg.py
@@ -173,9 +173,9 @@ class OpenAIPaygAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "openai-payg: responses.stream failed model=%s err=%s",
+                    "openai-payg: responses.stream failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         return translate_codex_response(final, accumulated_items=accumulated)

--- a/core/llm/adapters/openrouter_payg.py
+++ b/core/llm/adapters/openrouter_payg.py
@@ -150,7 +150,11 @@ class OpenRouterPaygAdapter:
         try:
             response = await self._get_client().chat.completions.create(**kwargs)
         except Exception as exc:
-            log.warning("openrouter-payg: request failed model=%s err=%s", req.model, exc)
+            log.warning(
+                "openrouter-payg: request failed model=%s error_type=%s",
+                req.model,
+                type(exc).__name__,
+            )
             raise
         result = translate_chat_response(response)
         response_provider, routing_strategy, routing_attempt = _route_fields(response)

--- a/core/observability/activity.py
+++ b/core/observability/activity.py
@@ -11,7 +11,7 @@ GEODE. Pre-PR-COMM-1 the ``HookEvent`` payloads were untyped
 
 Structure (PR-OBS-CONTRACT, 2026-06-13 — full coverage):
   - 1 envelope (``ActivityRowBase``) with ``schema_version``
-  - 4 lifecycle detail mixins (started / completed / failed / retried)
+  - 4 shared lifecycle detail models plus bounded LLM-call usage/route details
   - 19 lifecycle concrete classes (A=6 started, B=7 completed, C=5 failed,
     D=1 retried) with discriminator on ``action``
   - 38 K-group concrete classes covering every remaining HookEvent, each
@@ -22,9 +22,10 @@ Structure (PR-OBS-CONTRACT, 2026-06-13 — full coverage):
     builder that hits a malformed payload), never a routine destination —
     every current event has a concrete typed row.
 
-Construction is centralized in ``activity_registry.py``: 19 lifecycle
-curry-builders + a single declarative ``_TYPED_ROW_SPECS`` table that drives
-all K-group rows through one ``_build_from_spec`` builder.
+Construction is centralized in ``activity_registry.py``: shared lifecycle
+builders plus one LLM completion projection, and a single declarative
+``_TYPED_ROW_SPECS`` table that drives all K-group rows through one
+``_build_from_spec`` builder.
 """
 
 from __future__ import annotations
@@ -65,10 +66,12 @@ __all__ = [
     "ExtensionInvokedRow",
     "GenericActivityRow",
     "HandoffTriggeredRow",
+    "LLMCallEndedDetails",
     "LLMCallEndedRow",
     "LLMCallFailedRow",
     "LLMCallRetriedRow",
     "LLMCallStartedRow",
+    "LLMCallUsageDetails",
     "LifecycleCompletedDetails",
     "LifecycleCompletedRow",
     "LifecycleFailedDetails",
@@ -154,7 +157,7 @@ class ActivityRowBase(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: int = 3
+    schema_version: int = 4
     """Row-schema version (PR-OBS-CONTRACT, 2026-06-13). Bump when a
     field is added/renamed/retyped on any row class so JSONL re-readers
     can branch on shape instead of guessing from key presence.
@@ -163,7 +166,9 @@ class ActivityRowBase(BaseModel):
     (+details.stage) replaces six per-state auto-trigger rows, approval
     granted/denied rows deleted.
     v3 (R3.1, 2026-08-21): extension audit details gained physical step
-    correlation."""
+    correlation.
+    v4 (OpenRouter live acceptance, 2026-09-03): completed LLM calls retain
+    bounded usage, charge, and serving-route evidence."""
 
     ts: float
     run_id: str
@@ -207,6 +212,36 @@ class LifecycleCompletedDetails(BaseModel):
 
 class LifecycleCompletedRow(ActivityRowBase):
     details: LifecycleCompletedDetails
+
+
+class LLMCallUsageDetails(BaseModel):
+    """Bounded token counters retained for one completed model call."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    cached_input_tokens: int = Field(default=0, ge=0)
+    reasoning_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+
+
+class LLMCallEndedDetails(LifecycleCompletedDetails):
+    """Durable billing and serving-route evidence for one model attempt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    model: str | None = None
+    provider: str | None = None
+    adapter: str | None = None
+    error_type: str | None = None
+    usage: LLMCallUsageDetails | None = None
+    cost_usd: float | None = Field(default=None, ge=0)
+    response_id: str | None = None
+    response_model: str | None = None
+    response_provider: str | None = None
+    routing_strategy: str | None = None
+    routing_attempt: int | None = Field(default=None, ge=0)
 
 
 class LifecycleFailedDetails(BaseModel):
@@ -304,6 +339,7 @@ class SubAgentCompletedRow(LifecycleCompletedRow):
 class LLMCallEndedRow(LifecycleCompletedRow):
     action: Literal["llm.call.ended"] = "llm.call.ended"
     entity_type: Literal["llm_call"] = "llm_call"
+    details: LLMCallEndedDetails
 
 
 class ToolExecEndedRow(LifecycleCompletedRow):

--- a/core/observability/activity_registry.py
+++ b/core/observability/activity_registry.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -62,10 +62,12 @@ from core.observability.activity import (
     LifecycleRetriedRow,
     LifecycleStartedDetails,
     LifecycleStartedRow,
+    LLMCallEndedDetails,
     LLMCallEndedRow,
     LLMCallFailedRow,
     LLMCallRetriedRow,
     LLMCallStartedRow,
+    LLMCallUsageDetails,
     McpServerConnectedRow,
     McpServerDetails,
     McpServerFailedRow,
@@ -156,6 +158,7 @@ def _lifecycle_started(
     actor_type_default: str = "system",
     actor_key: str = "session_id",
     identifier_key: str = "task_id",
+    identifier_fallback_key: str = "",
 ) -> Callable[[dict[str, Any], str], ActivityRowBase]:
     """Curry a builder for ``LifecycleStartedRow`` subclasses. The
     actor / identifier names are passed by keyword so each event can
@@ -163,7 +166,12 @@ def _lifecycle_started(
     ``task_id``, SESSION_STARTED uses ``session_id``)."""
 
     def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
-        identifier = str(data.get(identifier_key) or data.get("session_id") or "")
+        identifier = str(
+            data.get(identifier_key)
+            or (data.get(identifier_fallback_key) if identifier_fallback_key else None)
+            or data.get("session_id")
+            or ""
+        )
         if not identifier:
             _warn_missing_identifier(row_cls.__name__, identifier_key)
         actor_id = str(data.get(actor_key) or data.get("session_id") or actor_type_default)
@@ -207,6 +215,60 @@ def _lifecycle_completed(
         )
 
     return _build
+
+
+def _llm_call_ended(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+    """Project one LLM attempt without retaining raw provider error text."""
+    identifier = str(
+        data.get("llm_call_id") or data.get("call_id") or data.get("session_id") or "agent"
+    )
+    actor_id = str(data.get("session_id") or "agent")
+    raw_usage = data.get("usage")
+    usage = None
+    if isinstance(raw_usage, Mapping):
+        usage = LLMCallUsageDetails(
+            **{
+                key: int(raw_usage.get(key, 0) or 0)
+                for key in (
+                    "input_tokens",
+                    "output_tokens",
+                    "cached_input_tokens",
+                    "reasoning_tokens",
+                    "cache_write_tokens",
+                )
+            }
+        )
+
+    def _text(key: str) -> str | None:
+        value = data.get(key)
+        return str(value) if value not in (None, "") else None
+
+    error = data.get("error")
+    cost = data.get("cost_usd")
+    routing_attempt = data.get("routing_attempt")
+    return LLMCallEndedRow(
+        ts=time.time(),
+        run_id=run_id,
+        actor_type="agent",
+        actor_id=actor_id,
+        entity_id=identifier,
+        task_id=str(data["task_id"]) if data.get("task_id") else None,
+        details=LLMCallEndedDetails(
+            duration_ms=float(data.get("latency_ms", data.get("duration_ms", 0.0)) or 0.0),
+            success=bool(data.get("success", not bool(error))),
+            model=_text("model"),
+            provider=_text("provider"),
+            adapter=_text("adapter"),
+            error_type=_text("error_type") or ("provider_error" if error else None),
+            usage=usage,
+            cost_usd=float(cost) if cost is not None else None,
+            response_id=_text("response_id"),
+            response_model=_text("response_model"),
+            response_provider=_text("response_provider"),
+            routing_strategy=_text("routing_strategy"),
+            routing_attempt=int(routing_attempt) if routing_attempt is not None else None,
+        ),
+    )
 
 
 def _lifecycle_failed(
@@ -257,7 +319,7 @@ def _lifecycle_retried(
             run_id=run_id,
             actor_type=_infer_actor_type(actor_type_default),
             actor_id=actor_id,
-            entity_id=str(data.get("call_id") or actor_id),
+            entity_id=str(data.get("llm_call_id") or data.get("call_id") or actor_id),
             task_id=str(data["task_id"]) if data.get("task_id") else None,
             details=LifecycleRetriedDetails(attempt=attempt, reason=reason),
         )
@@ -274,7 +336,7 @@ def _infer_actor_type(default: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 21 lifecycle event → builder mapping
+# Lifecycle event → builder mapping
 # ---------------------------------------------------------------------------
 
 
@@ -285,7 +347,10 @@ HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any], str], Activ
     ),
     HookEvent.SUBAGENT_STARTED: _lifecycle_started(SubAgentStartedRow, actor_type_default="agent"),
     HookEvent.LLM_CALL_STARTED: _lifecycle_started(
-        LLMCallStartedRow, actor_type_default="agent", identifier_key="call_id"
+        LLMCallStartedRow,
+        actor_type_default="agent",
+        identifier_key="llm_call_id",
+        identifier_fallback_key="call_id",
     ),
     HookEvent.TOOL_EXEC_STARTED: _lifecycle_started(
         ToolExecStartedRow, actor_type_default="agent", identifier_key="tool_call_id"
@@ -303,9 +368,7 @@ HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any], str], Activ
     HookEvent.SUBAGENT_COMPLETED: _lifecycle_completed(
         SubAgentCompletedRow, actor_type_default="agent"
     ),
-    HookEvent.LLM_CALL_ENDED: _lifecycle_completed(
-        LLMCallEndedRow, actor_type_default="agent", identifier_key="call_id"
-    ),
+    HookEvent.LLM_CALL_ENDED: _llm_call_ended,
     HookEvent.TOOL_EXEC_ENDED: _lifecycle_completed(
         ToolExecEndedRow, actor_type_default="agent", identifier_key="tool_call_id"
     ),

--- a/core/observability/hook_persistence.py
+++ b/core/observability/hook_persistence.py
@@ -172,6 +172,7 @@ class HookPersistenceSink:
                     key: details[key] for key in ("_fallback_reason", "input_len") if key in details
                 }
                 details["_generic_projection"] = True
+            details["activity_schema_version"] = int(row.schema_version)
             entity_id = str(row.entity_id)
             if dispatch.event is HookEvent.RESULT_FEEDBACK:
                 # ``subject`` is model/user supplied and may be a sentence or

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -288,10 +288,10 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `evals/` + `evolve/`) | 581 |
 | Test Python files | 700 |
-| `core/` Python LOC | 124,637 |
+| `core/` Python LOC | 124,742 |
 | `evals/` Python LOC | 30,644 |
 | `evolve/` Python LOC | 32,014 |
-| Test Python LOC | 189,562 |
+| Test Python LOC | 189,717 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 6 |

--- a/docs/plans/2026-09-02-openrouter-provider-integration.md
+++ b/docs/plans/2026-09-02-openrouter-provider-integration.md
@@ -1,12 +1,10 @@
 # OpenRouter provider integration plan
 
 > [!NOTE]
-> Design and research evidence only. This document does not enable a provider,
-> perform a live request, or authorize spend. Implementation status belongs in
-> the implementing PR and, if the architecture program adopts the work, its
-> canonical roadmap ledger.
+> Design, implementation, and dated live-acceptance evidence. Model inventory
+> and prices are a snapshot, not a bundled catalogue or availability promise.
 
-**Status:** Implemented and CI-verified in PR #3268; assigned to the v1.0.27 release train
+**Status:** Released in v1.0.27; live transport and AgenticLoop acceptance verified 2026-09-03
 
 **Research snapshot:** 2026-09-02
 
@@ -268,14 +266,99 @@ substitute for offline contract tests.
 
 Local verification on 2026-09-02 passed the focused provider, auth, routing,
 model-picker, usage, and event tests; the complete `scripts/preflight.sh` CI
-mirror; and the 239-route static site build. No live OpenRouter request was
-made. Such a request still requires an OpenRouter account and API key, even
-when the selected route is zero-priced.
+mirror; and the 239-route static site build. The dated live acceptance below
+used an operator-provided key and a bounded paid budget; credentials remain
+local and are not part of the evidence.
 
 Rollback is bounded because OpenRouter is opt-in. Removing its registration and
 UI rows must leave direct provider state and model references untouched. Stored
 OpenRouter profiles should then fail with an explicit unsupported-provider
 message rather than being interpreted as OpenAI profiles.
+
+## Live acceptance and catalogue snapshot — 2026-09-03
+
+The public `/api/v1/models` catalogue exposed the following relevant publisher
+families. `Models` is the number of exact IDs in that dated response;
+`tool-capable` means the model advertised the `tools` parameter. GEODE does not
+copy these rows into its picker because upstream availability and prices change.
+
+| Publisher prefix | Models | Tool-capable | Representative verified route |
+|---|---:|---:|---|
+| `deepseek` | 16 | 15 | `deepseek/deepseek-v4-flash-0731` |
+| `qwen` | 53 | 51 | `qwen/qwen3.8-flash` |
+| `z-ai` | 16 | 16 | `z-ai/glm-5.3-flash` |
+| `moonshotai` | 8 | 8 | `moonshotai/kimi-k2.7-code` |
+| `minimax` | 11 | 9 | `minimax/minimax-m3` |
+| `bytedance-seed` | 6 | 6 | `bytedance-seed/seed-1.6-flash` |
+| `tencent` | 7 | 3 | `tencent/hy3` |
+| `xiaomi` | 2 | 2 | `xiaomi/mimo-v2.5` |
+| `stepfun` | 2 | 2 | `stepfun/step-3.5-flash` |
+| `inclusionai` | 2 | 2 | `inclusionai/ling-3.0-flash` |
+| `meituan` | 1 | 1 | `meituan/longcat-2.0` |
+| `baidu` | 1 | 0 | Not probed: the listed ERNIE route did not advertise tools |
+| `bytedance` | 1 | 0 | Not probed: the listed UI-TARS route did not advertise tools |
+| `upstage` | 2 | 2 | `upstage/solar-pro4` |
+
+DeepSeek exact IDs in the snapshot were `deepseek-chat`,
+`deepseek-chat-v3-0324`, `deepseek-chat-v3.1`, `deepseek-r1`,
+`deepseek-r1-0528`, `deepseek-r1-distill-llama-70b`,
+`deepseek-v3.1-terminus`, `deepseek-v3.2`, `deepseek-v3.2-exp`,
+`deepseek-v4-flash`, `deepseek-v4-flash-0731`,
+`deepseek-v4-flash-0731:batch`, `deepseek-v4-flash-vision-exp`,
+`deepseek-v4-pro`, `deepseek-v4-pro-0813`, and
+`deepseek-v4-pro-0813:batch`, all under the `deepseek/` prefix. Upstage exposed
+`upstage/solar-pro-3` and `upstage/solar-pro4`.
+
+### Measured transport matrix
+
+All 15 representative exact routes completed through
+`OpenRouterPaygAdapter`. Qwen first encountered an upstream shared-pool `429`;
+GLM, ByteDance Seed, and Ling first exhausted a 64-token reasoning budget.
+One bounded retry per affected route completed successfully, so these were
+classified as route-capacity/budget observations rather than adapter defects.
+
+| Model | Serving provider observed | Successful probe charge (USD) |
+|---|---|---:|
+| `deepseek/deepseek-v4-flash-0731` | OpenInference | 0.00000560 |
+| `deepseek/deepseek-v4-pro-0813` | StreamLake | 0.00011616 |
+| `deepseek/deepseek-r1-0528` | SiliconFlow | 0.00010224 |
+| `qwen/qwen3.8-flash` | Alibaba | 0.00002851 |
+| `z-ai/glm-5.3-flash` | Novita | 0.00002840 |
+| `moonshotai/kimi-k2.7-code` | Ambient | 0.00013108 |
+| `minimax/minimax-m3` | Venice | 0.00007068 |
+| `bytedance-seed/seed-1.6-flash` | Seed | 0.00002385 |
+| `tencent/hy3` | Phala | 0.00002457 |
+| `xiaomi/mimo-v2.5` | Novita | 0.00003207 |
+| `stepfun/step-3.5-flash` | SiliconFlow | 0.00002130 |
+| `inclusionai/ling-3.0-flash` | DeepInfra | 0.00002246 |
+| `meituan/longcat-2.0` | AtlasCloud | 0.00004980 |
+| `upstage/solar-pro-3` | Upstage | 0.00001017 |
+| `upstage/solar-pro4` | Upstage | 0.00000270 |
+
+The account total below also includes the initially truncated reasoning probes,
+not only the successful rows in the table. The full `AgenticLoop` then
+completed a two-round synthetic tool-use task with
+one exact tool call and natural termination on both
+`deepseek/deepseek-v4-flash-0731` (USD 0.000271831616) and
+`upstage/solar-pro4` (USD 0.00015657). Session events retained redacted tool
+arguments, token usage, cost, verification, and termination evidence. A secret
+scan of the isolated run root passed. The OpenRouter key endpoint reported
+USD 0.00166413 total account usage after the complete acceptance sequence.
+
+### Live-discovered hardening
+
+The first upstream `429` exposed two implementation defects outside the wire
+translation itself:
+
+1. adapter warning logs interpolated the raw SDK exception, which could contain
+   account-linked upstream fields; logs now retain only the exception type;
+2. `LLM_CALL_ENDED` carried charge and serving-route fields in process, but its
+   typed durable projection reduced them to generic completion fields; activity
+   schema v4 now retains bounded token, cost, model, adapter, and route evidence
+   while discarding raw provider error text.
+
+These fixes apply at the shared adapter/activity boundaries rather than adding
+OpenRouter-only persistence or a second usage ledger.
 
 ## Design gate
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6546,7 +6546,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1545 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1546 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,7 +528,7 @@
   "packages": {
     "core": {
       "python_files": 415,
-      "python_loc": 124637
+      "python_loc": 124742
     },
     "evals": {
       "python_files": 93,
@@ -540,7 +540,7 @@
     },
     "tests": {
       "python_files": 700,
-      "python_loc": 189562
+      "python_loc": 189717
     }
   },
   "schema_version": 6,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build."
+    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.\n\n### Fixed\n\n- **Provider failures and routed-call evidence are now privacy-safe and\n  durable.** Built-in adapters no longer interpolate raw SDK exception bodies\n  into warning logs, failed LLM hooks retain only the exception type, and\n  activity schema v4 preserves bounded token, charge, requested/served model,\n  adapter, and OpenRouter route metadata through SQLite and run projections."
   },
   {
     "version": "1.0.27",

--- a/tests/core/hooks/test_hook_persistence.py
+++ b/tests/core/hooks/test_hook_persistence.py
@@ -164,6 +164,7 @@ def test_public_extension_audit_uses_sqlite_and_active_timeline_only(
         "step_id": "t-1:step-1",
         "session_generation": 0,
         "verify_attempt": 0,
+        "activity_schema_version": 4,
         "_dispatch_duration_ms": row.payload["_dispatch_duration_ms"],
     }
     assert not (tmp_path / "events.jsonl").exists()
@@ -223,6 +224,66 @@ def test_tool_correlation_survives_sqlite_and_timeline_projection(tmp_path: Path
     assert timeline_row["payload"]["step_id"] == "t-tool:step-2"
     assert timeline_row["payload"]["session_generation"] == 3
     assert timeline_row["payload"]["verify_attempt"] == 1
+    hooks.close()
+
+
+def test_llm_route_charge_and_usage_survive_durable_projection(tmp_path: Path) -> None:
+    hooks, store = _wired_hooks(tmp_path)
+
+    with run_timeline_scope(_timeline(tmp_path)):
+        hooks.trigger(
+            HookEvent.LLM_CALL_ENDED,
+            {
+                "session_id": "s-llm",
+                "turn_id": "t-llm",
+                "llm_call_id": "call-llm",
+                "llm_attempt_id": "call-llm:attempt-1",
+                "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+                "provider": "openrouter",
+                "adapter": "openrouter-payg",
+                "latency_ms": 123.5,
+                "error": None,
+                "usage": {
+                    "input_tokens": 101,
+                    "output_tokens": 23,
+                    "cached_input_tokens": 7,
+                    "reasoning_tokens": 11,
+                    "cache_write_tokens": 3,
+                },
+                "cost_usd": 0.00012,
+                "response_id": "generation-1",
+                "response_model": "deepseek/deepseek-v4-flash-0731",
+                "response_provider": "OpenInference",
+                "routing_strategy": "direct",
+                "routing_attempt": 1,
+            },
+        )
+
+    row = store.read()[0]
+    assert row.status == "ok"
+    assert row.entity_id == "call-llm"
+    assert row.payload["duration_ms"] == 123.5
+    assert row.payload["model"] == "openrouter/deepseek/deepseek-v4-flash-0731"
+    assert row.payload["provider"] == "openrouter"
+    assert row.payload["adapter"] == "openrouter-payg"
+    assert row.payload["usage"] == {
+        "input_tokens": 101,
+        "output_tokens": 23,
+        "cached_input_tokens": 7,
+        "reasoning_tokens": 11,
+        "cache_write_tokens": 3,
+    }
+    assert row.payload["cost_usd"] == 0.00012
+    assert row.payload["response_id"] == "generation-1"
+    assert row.payload["response_model"] == "deepseek/deepseek-v4-flash-0731"
+    assert row.payload["response_provider"] == "OpenInference"
+    assert row.payload["routing_strategy"] == "direct"
+    assert row.payload["routing_attempt"] == 1
+    assert row.payload["activity_schema_version"] == 4
+    timeline_payload = _read_timeline(tmp_path / "events.jsonl")[0]["payload"]
+    assert timeline_payload["response_provider"] == "OpenInference"
+    assert timeline_payload["cost_usd"] == 0.00012
+    assert timeline_payload["activity_schema_version"] == 4
     hooks.close()
 
 

--- a/tests/core/hooks/test_hook_taxonomy.py
+++ b/tests/core/hooks/test_hook_taxonomy.py
@@ -398,7 +398,7 @@ def test_activity_and_hook_store_schema_versions_are_pinned():
     from core.observability.activity import ActivityRowBase
     from core.observability.event_store import EVENT_SCHEMA_VERSION
 
-    assert ActivityRowBase.model_fields["schema_version"].default == 3
+    assert ActivityRowBase.model_fields["schema_version"].default == 4
     # Hook persistence gained indexed correlation columns independently of the
     # activity-row payload contract.
     assert EVENT_SCHEMA_VERSION == 5

--- a/tests/core/llm/adapters/test_openrouter_payg.py
+++ b/tests/core/llm/adapters/test_openrouter_payg.py
@@ -100,6 +100,8 @@ class _Completions:
 
     async def create(self, **kwargs: Any) -> Any:
         self.kwargs = kwargs
+        if isinstance(self.response, BaseException):
+            raise self.response
         return self.response
 
 
@@ -117,6 +119,37 @@ def test_missing_key_fails_before_network(monkeypatch: pytest.MonkeyPatch) -> No
                 )
             )
         )
+
+
+def test_provider_error_log_omits_raw_upstream_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    failure = RuntimeError('upstream rejected request; user_id="account-linked-id"')
+    completions = _Completions(failure)
+    adapter = OpenRouterPaygAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_get_client",
+        lambda: SimpleNamespace(chat=SimpleNamespace(completions=completions)),
+    )
+
+    with (
+        caplog.at_level("WARNING", logger="core.llm.adapters.openrouter_payg"),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        asyncio.run(
+            adapter.acomplete(
+                AdapterCallRequest(
+                    model="openrouter/deepseek/deepseek-v4-flash-0731",
+                    messages=(Message(role="user", content="hi"),),
+                )
+            )
+        )
+
+    assert exc_info.value is failure
+    assert "error_type=RuntimeError" in caplog.text
+    assert "account-linked-id" not in caplog.text
 
 
 def test_completion_forwards_chat_tools_and_captures_charge_and_route(

--- a/tests/core/llm/test_model_failover.py
+++ b/tests/core/llm/test_model_failover.py
@@ -493,6 +493,38 @@ class TestAgenticLoopFailover:
         assert result is None
         assert loop._last_llm_error is not None
 
+    def test_failed_llm_event_omits_raw_provider_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from core.hooks import HookEvent, HookSystem
+
+        observed: list[dict[str, Any]] = []
+        hooks = HookSystem()
+        hooks.register(
+            HookEvent.LLM_CALL_ENDED,
+            lambda _event, data: observed.append(dict(data)),
+            name="error-recorder",
+        )
+        loop = self._make_loop()
+        loop._hooks = hooks
+        self._install_acomplete_stub(
+            loop,
+            RuntimeError('upstream rejected request; user_id="account-linked-id"'),
+        )
+
+        with caplog.at_level("WARNING", logger="core.agent.loop._provider_call"):
+            result = asyncio.run(
+                loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
+            )
+
+        assert result is None
+        assert observed
+        assert all(event["error"] == "RuntimeError" for event in observed)
+        assert "account-linked-id" not in str(observed)
+        assert "account-linked-id" not in caplog.text
+        assert "error_type=RuntimeError" in caplog.text
+
     def test_call_llm_propagates_billing_to_the_operator_boundary(self) -> None:
         """Billing must bypass ordinary retry and reach `_dispatch_llm_call`."""
         from core.llm.errors import BillingError

--- a/tests/core/observability/test_activity_schema.py
+++ b/tests/core/observability/test_activity_schema.py
@@ -356,6 +356,35 @@ def test_k1_real_payloads_roundtrip_through_discriminated_union() -> None:
         )
 
 
+def test_llm_lifecycle_keeps_current_and_legacy_call_correlation() -> None:
+    current = {
+        "session_id": "session-1",
+        "llm_call_id": "current-call",
+        "attempt": 2,
+    }
+    started = map_hook_to_activity(
+        HookEvent.LLM_CALL_STARTED,
+        current,
+        run_id="r1",
+    )
+    retried = map_hook_to_activity(
+        HookEvent.LLM_CALL_RETRIED,
+        current,
+        run_id="r1",
+    )
+    ended = map_hook_to_activity(
+        HookEvent.LLM_CALL_ENDED,
+        current,
+        run_id="r1",
+    )
+    assert started.entity_id == retried.entity_id == ended.entity_id == "current-call"
+
+    legacy = {"session_id": "session-1", "call_id": "legacy-call"}
+    legacy_started = map_hook_to_activity(HookEvent.LLM_CALL_STARTED, legacy, run_id="r1")
+    legacy_ended = map_hook_to_activity(HookEvent.LLM_CALL_ENDED, legacy, run_id="r1")
+    assert legacy_started.entity_id == legacy_ended.entity_id == "legacy-call"
+
+
 def test_k2_raw_user_content_never_persists_to_timeline() -> None:
     """Privacy contract: raw ``user_input`` strings, cognitive-state
     snapshots, and full tool results must NOT appear in the row details —


### PR DESCRIPTION
## Summary
- OpenRouter의 DeepSeek·중국계·Upstage 모델을 현재 원격 카탈로그로 조사하고, 대표 15개 노선의 실제 전송을 검증했습니다.
- DeepSeek와 Upstage는 실제 `AgenticLoop` 2라운드 도구 호출까지 확인했습니다.
- 실측 중 발견한 원시 SDK 오류 로그 노출과 LLM 라우트·비용 증거의 비영속화 문제를 공통 경계에서 최소 수정했습니다.

## Why
OpenRouter는 요청한 모델과 실제 제공 모델·제공자가 달라질 수 있고 응답 비용이 과금 권위입니다. 기존 런타임은 이를 메모리 응답에서는 보존했지만 `LLM_CALL_ENDED`의 SQLite/JSONL 투영에 충분히 남기지 않았고, 내장 어댑터 경고 로그가 SDK 오류 본문을 그대로 출력할 수 있었습니다. 이는 평가 재현성, 예산 감사, 계정 식별자 보호를 약화합니다.

## Changes
| 영역 | 변경 |
|---|---|
| LLM 어댑터 | Anthropic/OpenAI/OpenRouter/GLM/Codex 내장 경로의 실패 로그를 예외 타입으로 제한 |
| AgenticLoop | 시작·재시도·종료 이벤트의 `llm_call_id` 상관관계와 성공/실패 종료 증거 정렬 |
| 관측성 스키마 | activity schema v4에 사용량, 실제 비용, 요청/응답 모델, 제공자, 어댑터, 라우트 증거 추가 |
| 영속화 | Hook SQLite와 run JSONL에 동일한 bounded projection 및 schema version 기록 |
| 문서 | 2026-09-03 원격 모델 스냅샷, DeepSeek/Upstage 전체 목록, 대표 호출·도구 E2E·비용 기록 |
| 회귀 테스트 | 레거시 `call_id`, 재시도 상관관계, 오류 최소화, SQLite/JSONL 보존 검증 |

## GAP Audit
| GAP | 기존 상태 | 해소 |
|---|---|---|
| 원격 모델 가용성 | 변동 카탈로그, 로컬 고정 목록 없음 | 공식 `/api/v1/models`의 날짜 고정 스냅샷을 문서화하고 런타임에는 복제하지 않음 |
| 실제 호출 수용성 | transport 구현만 릴리즈 | 15개 대표 노선 성공, DeepSeek·Upstage 도구 E2E 성공 |
| 과금·라우트 증거 | 응답 객체에만 존재 | LLM 종료 activity와 durable projection에 보존 |
| 오류 개인정보 | 일부 경고가 SDK 본문 출력 | 내장 어댑터 공통 정책으로 예외 타입만 로그 |
| 상관관계 | current/legacy ID 혼재 | `llm_call_id` 우선, `call_id` 호환 fallback으로 통일 |

## Impact Scope
- 런타임 LLM 이벤트와 관측성 투영만 변경합니다.
- 제공자 선택, OpenRouter 과금 정책, 모델 카탈로그, UI 선택기에는 새 추상화나 의존성을 추가하지 않습니다.
- activity payload schema는 v4로 상승하지만 저장소 테이블 형식과 기존 event enum은 유지합니다.

## Design Decisions
- 변동성이 큰 OpenRouter 모델/가격 목록을 코드에 하드코딩하지 않았습니다.
- 기존 `ProviderSpec → AdapterRegistry → OpenRouterPaygAdapter` 경계를 재사용했습니다.
- 원시 오류 상세는 내부 `_last_llm_error`에 유지하되 기본 로그와 영속 이벤트에는 예외 타입만 남깁니다.
- 직접 제공자와 OpenRouter 라우팅 권위를 합치지 않았습니다.

## Verification
- `scripts/preflight.sh` 전체 통과: ruff, format, mypy, bandit, deptry, import-linter, 구조/문서 생성기, 전체 non-live pytest.
- 추가 묶음: `uv run pytest -q tests/core/llm tests/core/observability tests/core/hooks -m "not live"` 통과.
- 관련 targeted pytest/mypy 및 pre-commit 모두 통과.
- 독립 Codex 리뷰 3회: 발견된 P2 3건(레거시 상관관계, v4 표식, fail-fast 재시도 상관관계) 수정 후 최종 리뷰 결함 없음.
- 정확 API 키 값의 추적 파일 및 `origin/develop...HEAD` diff 검사 통과.

## Live Acceptance
- 공식 모델 목록 스냅샷: 2026-09-03.
- 대표 15개 모델 전송 성공: DeepSeek, Qwen, Z.ai GLM, Moonshot Kimi, MiniMax, ByteDance Seed, Tencent, Xiaomi, StepFun, InclusionAI, Meituan, Upstage.
- DeepSeek V4 Flash 0731: 2라운드, 도구 1회, 자연 종료.
- Upstage Solar Pro4: 2라운드, 도구 1회, 자연 종료.
- 이번 수용성 점검의 계정 사용액: USD 0.00166413.
- 라이브 호출은 사용자의 소액 과금 승인 아래 수행했습니다.

## Out of Scope
- 버전 상승, GitHub Release, tag, PyPI 배포.
- 동적 모델 피커와 로컬 가격 카탈로그.
- OpenRouter 고급 provider routing UI.