### PR TITLE
release: Harbor 기록과 OpenRouter 실측 하드닝 승격

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The generated architecture inventory lives at
 `site/src/data/geode/architecture-baseline.json`. Refresh it with
 `uv run python scripts/architecture_baseline.py --update`; CI uses `--check`.
 The current snapshot records 581 production Python files,
-699 test Python files,
+700 test Python files,
 86 tool definitions, and
 57 `RuntimeEvent` members.
 <!-- generated:architecture-baseline:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ functional change.
 - **Patched site audit dependency.** The locked transitive `@humanfs/node`
   dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.
 
+### Fixed
+
+- **Provider failures and routed-call evidence are now privacy-safe and
+  durable.** Built-in adapters no longer interpolate raw SDK exception bodies
+  into warning logs, failed LLM hooks retain only the exception type, and
+  activity schema v4 preserves bounded token, charge, requested/served model,
+  adapter, and OpenRouter route metadata through SQLite and run projections.
+
 ## [1.0.27] - 2026-09-02
 
 > Provider-boundary and evaluation-integrity release: OpenRouter joins as an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Harbor trial replay receipts.** GEODE and an instrumented native Codex
+  adapter can now reconstruct agent-owned asciicast v2 replays from finalized
+  ATIF trajectories, with source/output hashes and explicit non-score,
+  non-raw-capture provenance. A fail-closed backfill command covers closed
+  historical Harbor jobs without overwriting existing recordings.
+
+### Infrastructure
+
+- **Patched site audit dependency.** The locked transitive `@humanfs/node`
+  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.
+
 ## [1.0.27] - 2026-09-02
 
 > Provider-boundary and evaluation-integrity release: OpenRouter joins as an

--- a/core/agent/loop/_provider_call.py
+++ b/core/agent/loop/_provider_call.py
@@ -396,7 +396,8 @@ async def call_llm(
                         "provider": active_provider,
                         "adapter": active_name,
                         "latency_ms": (_llm_call_time.monotonic() - started_at) * 1_000,
-                        "error": str(exc) or type(exc).__name__,
+                        "error": type(exc).__name__,
+                        "error_type": type(exc).__name__,
                     },
                 )
                 raise
@@ -516,9 +517,9 @@ async def call_llm(
         error_detail = str(exc) or type(exc).__name__
         loop._last_llm_error = error_detail
         log.warning(
-            "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
+            "AgenticLoop: adapter.acomplete failed adapter=%s error_type=%s",
             adapter_name,
-            error_detail,
+            type(exc).__name__,
         )
         if _fail_fast_adapter_errors_enabled():
             raise

--- a/core/llm/adapters/anthropic_payg.py
+++ b/core/llm/adapters/anthropic_payg.py
@@ -97,9 +97,9 @@ class AnthropicPaygAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "anthropic-payg: messages.create failed model=%s err=%s",
+                    "anthropic-payg: messages.create failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         return translate_response(response)

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -199,9 +199,9 @@ class CodexOAuthAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "codex-oauth: responses.stream failed model=%s err=%s",
+                    "codex-oauth: responses.stream failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         result = translate_codex_response(final, accumulated_items=accumulated)

--- a/core/llm/adapters/glm_coding_plan.py
+++ b/core/llm/adapters/glm_coding_plan.py
@@ -102,9 +102,9 @@ class GlmCodingPlanAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "glm-coding-plan: chat.completions.create failed model=%s err=%s",
+                "glm-coding-plan: chat.completions.create failed model=%s error_type=%s",
                 req.model,
-                exc,
+                type(exc).__name__,
             )
             raise
         return translate_chat_response(response)

--- a/core/llm/adapters/glm_payg.py
+++ b/core/llm/adapters/glm_payg.py
@@ -134,9 +134,9 @@ class GlmPaygAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "glm-payg: chat.completions.create failed model=%s err=%s",
+                "glm-payg: chat.completions.create failed model=%s error_type=%s",
                 req.model,
-                exc,
+                type(exc).__name__,
             )
             raise
         return translate_chat_response(response)

--- a/core/llm/adapters/openai_payg.py
+++ b/core/llm/adapters/openai_payg.py
@@ -173,9 +173,9 @@ class OpenAIPaygAdapter:
             except Exception as exc:
                 self._last_error = exc
                 log.warning(
-                    "openai-payg: responses.stream failed model=%s err=%s",
+                    "openai-payg: responses.stream failed model=%s error_type=%s",
                     req.model,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
         return translate_codex_response(final, accumulated_items=accumulated)

--- a/core/llm/adapters/openrouter_payg.py
+++ b/core/llm/adapters/openrouter_payg.py
@@ -150,7 +150,11 @@ class OpenRouterPaygAdapter:
         try:
             response = await self._get_client().chat.completions.create(**kwargs)
         except Exception as exc:
-            log.warning("openrouter-payg: request failed model=%s err=%s", req.model, exc)
+            log.warning(
+                "openrouter-payg: request failed model=%s error_type=%s",
+                req.model,
+                type(exc).__name__,
+            )
             raise
         result = translate_chat_response(response)
         response_provider, routing_strategy, routing_attempt = _route_fields(response)

--- a/core/observability/activity.py
+++ b/core/observability/activity.py
@@ -11,7 +11,7 @@ GEODE. Pre-PR-COMM-1 the ``HookEvent`` payloads were untyped
 
 Structure (PR-OBS-CONTRACT, 2026-06-13 — full coverage):
   - 1 envelope (``ActivityRowBase``) with ``schema_version``
-  - 4 lifecycle detail mixins (started / completed / failed / retried)
+  - 4 shared lifecycle detail models plus bounded LLM-call usage/route details
   - 19 lifecycle concrete classes (A=6 started, B=7 completed, C=5 failed,
     D=1 retried) with discriminator on ``action``
   - 38 K-group concrete classes covering every remaining HookEvent, each
@@ -22,9 +22,10 @@ Structure (PR-OBS-CONTRACT, 2026-06-13 — full coverage):
     builder that hits a malformed payload), never a routine destination —
     every current event has a concrete typed row.
 
-Construction is centralized in ``activity_registry.py``: 19 lifecycle
-curry-builders + a single declarative ``_TYPED_ROW_SPECS`` table that drives
-all K-group rows through one ``_build_from_spec`` builder.
+Construction is centralized in ``activity_registry.py``: shared lifecycle
+builders plus one LLM completion projection, and a single declarative
+``_TYPED_ROW_SPECS`` table that drives all K-group rows through one
+``_build_from_spec`` builder.
 """
 
 from __future__ import annotations
@@ -65,10 +66,12 @@ __all__ = [
     "ExtensionInvokedRow",
     "GenericActivityRow",
     "HandoffTriggeredRow",
+    "LLMCallEndedDetails",
     "LLMCallEndedRow",
     "LLMCallFailedRow",
     "LLMCallRetriedRow",
     "LLMCallStartedRow",
+    "LLMCallUsageDetails",
     "LifecycleCompletedDetails",
     "LifecycleCompletedRow",
     "LifecycleFailedDetails",
@@ -154,7 +157,7 @@ class ActivityRowBase(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: int = 3
+    schema_version: int = 4
     """Row-schema version (PR-OBS-CONTRACT, 2026-06-13). Bump when a
     field is added/renamed/retyped on any row class so JSONL re-readers
     can branch on shape instead of guessing from key presence.
@@ -163,7 +166,9 @@ class ActivityRowBase(BaseModel):
     (+details.stage) replaces six per-state auto-trigger rows, approval
     granted/denied rows deleted.
     v3 (R3.1, 2026-08-21): extension audit details gained physical step
-    correlation."""
+    correlation.
+    v4 (OpenRouter live acceptance, 2026-09-03): completed LLM calls retain
+    bounded usage, charge, and serving-route evidence."""
 
     ts: float
     run_id: str
@@ -207,6 +212,36 @@ class LifecycleCompletedDetails(BaseModel):
 
 class LifecycleCompletedRow(ActivityRowBase):
     details: LifecycleCompletedDetails
+
+
+class LLMCallUsageDetails(BaseModel):
+    """Bounded token counters retained for one completed model call."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    cached_input_tokens: int = Field(default=0, ge=0)
+    reasoning_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+
+
+class LLMCallEndedDetails(LifecycleCompletedDetails):
+    """Durable billing and serving-route evidence for one model attempt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    model: str | None = None
+    provider: str | None = None
+    adapter: str | None = None
+    error_type: str | None = None
+    usage: LLMCallUsageDetails | None = None
+    cost_usd: float | None = Field(default=None, ge=0)
+    response_id: str | None = None
+    response_model: str | None = None
+    response_provider: str | None = None
+    routing_strategy: str | None = None
+    routing_attempt: int | None = Field(default=None, ge=0)
 
 
 class LifecycleFailedDetails(BaseModel):
@@ -304,6 +339,7 @@ class SubAgentCompletedRow(LifecycleCompletedRow):
 class LLMCallEndedRow(LifecycleCompletedRow):
     action: Literal["llm.call.ended"] = "llm.call.ended"
     entity_type: Literal["llm_call"] = "llm_call"
+    details: LLMCallEndedDetails
 
 
 class ToolExecEndedRow(LifecycleCompletedRow):

--- a/core/observability/activity_registry.py
+++ b/core/observability/activity_registry.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -62,10 +62,12 @@ from core.observability.activity import (
     LifecycleRetriedRow,
     LifecycleStartedDetails,
     LifecycleStartedRow,
+    LLMCallEndedDetails,
     LLMCallEndedRow,
     LLMCallFailedRow,
     LLMCallRetriedRow,
     LLMCallStartedRow,
+    LLMCallUsageDetails,
     McpServerConnectedRow,
     McpServerDetails,
     McpServerFailedRow,
@@ -156,6 +158,7 @@ def _lifecycle_started(
     actor_type_default: str = "system",
     actor_key: str = "session_id",
     identifier_key: str = "task_id",
+    identifier_fallback_key: str = "",
 ) -> Callable[[dict[str, Any], str], ActivityRowBase]:
     """Curry a builder for ``LifecycleStartedRow`` subclasses. The
     actor / identifier names are passed by keyword so each event can
@@ -163,7 +166,12 @@ def _lifecycle_started(
     ``task_id``, SESSION_STARTED uses ``session_id``)."""
 
     def _build(data: dict[str, Any], run_id: str) -> ActivityRowBase:
-        identifier = str(data.get(identifier_key) or data.get("session_id") or "")
+        identifier = str(
+            data.get(identifier_key)
+            or (data.get(identifier_fallback_key) if identifier_fallback_key else None)
+            or data.get("session_id")
+            or ""
+        )
         if not identifier:
             _warn_missing_identifier(row_cls.__name__, identifier_key)
         actor_id = str(data.get(actor_key) or data.get("session_id") or actor_type_default)
@@ -207,6 +215,60 @@ def _lifecycle_completed(
         )
 
     return _build
+
+
+def _llm_call_ended(data: dict[str, Any], run_id: str) -> ActivityRowBase:
+    """Project one LLM attempt without retaining raw provider error text."""
+    identifier = str(
+        data.get("llm_call_id") or data.get("call_id") or data.get("session_id") or "agent"
+    )
+    actor_id = str(data.get("session_id") or "agent")
+    raw_usage = data.get("usage")
+    usage = None
+    if isinstance(raw_usage, Mapping):
+        usage = LLMCallUsageDetails(
+            **{
+                key: int(raw_usage.get(key, 0) or 0)
+                for key in (
+                    "input_tokens",
+                    "output_tokens",
+                    "cached_input_tokens",
+                    "reasoning_tokens",
+                    "cache_write_tokens",
+                )
+            }
+        )
+
+    def _text(key: str) -> str | None:
+        value = data.get(key)
+        return str(value) if value not in (None, "") else None
+
+    error = data.get("error")
+    cost = data.get("cost_usd")
+    routing_attempt = data.get("routing_attempt")
+    return LLMCallEndedRow(
+        ts=time.time(),
+        run_id=run_id,
+        actor_type="agent",
+        actor_id=actor_id,
+        entity_id=identifier,
+        task_id=str(data["task_id"]) if data.get("task_id") else None,
+        details=LLMCallEndedDetails(
+            duration_ms=float(data.get("latency_ms", data.get("duration_ms", 0.0)) or 0.0),
+            success=bool(data.get("success", not bool(error))),
+            model=_text("model"),
+            provider=_text("provider"),
+            adapter=_text("adapter"),
+            error_type=_text("error_type") or ("provider_error" if error else None),
+            usage=usage,
+            cost_usd=float(cost) if cost is not None else None,
+            response_id=_text("response_id"),
+            response_model=_text("response_model"),
+            response_provider=_text("response_provider"),
+            routing_strategy=_text("routing_strategy"),
+            routing_attempt=int(routing_attempt) if routing_attempt is not None else None,
+        ),
+    )
 
 
 def _lifecycle_failed(
@@ -257,7 +319,7 @@ def _lifecycle_retried(
             run_id=run_id,
             actor_type=_infer_actor_type(actor_type_default),
             actor_id=actor_id,
-            entity_id=str(data.get("call_id") or actor_id),
+            entity_id=str(data.get("llm_call_id") or data.get("call_id") or actor_id),
             task_id=str(data["task_id"]) if data.get("task_id") else None,
             details=LifecycleRetriedDetails(attempt=attempt, reason=reason),
         )
@@ -274,7 +336,7 @@ def _infer_actor_type(default: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 21 lifecycle event → builder mapping
+# Lifecycle event → builder mapping
 # ---------------------------------------------------------------------------
 
 
@@ -285,7 +347,10 @@ HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any], str], Activ
     ),
     HookEvent.SUBAGENT_STARTED: _lifecycle_started(SubAgentStartedRow, actor_type_default="agent"),
     HookEvent.LLM_CALL_STARTED: _lifecycle_started(
-        LLMCallStartedRow, actor_type_default="agent", identifier_key="call_id"
+        LLMCallStartedRow,
+        actor_type_default="agent",
+        identifier_key="llm_call_id",
+        identifier_fallback_key="call_id",
     ),
     HookEvent.TOOL_EXEC_STARTED: _lifecycle_started(
         ToolExecStartedRow, actor_type_default="agent", identifier_key="tool_call_id"
@@ -303,9 +368,7 @@ HOOK_EVENT_TO_ROW_BUILDER: dict[HookEvent, Callable[[dict[str, Any], str], Activ
     HookEvent.SUBAGENT_COMPLETED: _lifecycle_completed(
         SubAgentCompletedRow, actor_type_default="agent"
     ),
-    HookEvent.LLM_CALL_ENDED: _lifecycle_completed(
-        LLMCallEndedRow, actor_type_default="agent", identifier_key="call_id"
-    ),
+    HookEvent.LLM_CALL_ENDED: _llm_call_ended,
     HookEvent.TOOL_EXEC_ENDED: _lifecycle_completed(
         ToolExecEndedRow, actor_type_default="agent", identifier_key="tool_call_id"
     ),

--- a/core/observability/hook_persistence.py
+++ b/core/observability/hook_persistence.py
@@ -172,6 +172,7 @@ class HookPersistenceSink:
                     key: details[key] for key in ("_fallback_reason", "input_len") if key in details
                 }
                 details["_generic_projection"] = True
+            details["activity_schema_version"] = int(row.schema_version)
             entity_id = str(row.entity_id)
             if dispatch.event is HookEvent.RESULT_FEEDBACK:
                 # ``subject`` is model/user supplied and may be a sentence or

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -288,10 +288,10 @@ machine-readable artifact is
 |---|---:|
 | Production Python files (`core/` + `evals/` + `evolve/`) | 581 |
 | Test Python files | 700 |
-| `core/` Python LOC | 124,637 |
+| `core/` Python LOC | 124,742 |
 | `evals/` Python LOC | 30,644 |
 | `evolve/` Python LOC | 32,014 |
-| Test Python LOC | 189,562 |
+| Test Python LOC | 189,717 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 6 |

--- a/docs/architecture/extensibility-roadmap.md
+++ b/docs/architecture/extensibility-roadmap.md
@@ -287,11 +287,11 @@ machine-readable artifact is
 | Measure | Current tree |
 |---|---:|
 | Production Python files (`core/` + `evals/` + `evolve/`) | 581 |
-| Test Python files | 699 |
+| Test Python files | 700 |
 | `core/` Python LOC | 124,637 |
-| `evals/` Python LOC | 30,375 |
+| `evals/` Python LOC | 30,644 |
 | `evolve/` Python LOC | 32,014 |
-| Test Python LOC | 189,458 |
+| Test Python LOC | 189,562 |
 | Tool definitions / model executions / valid schemas / policies | 86 / 86 / 86 / 86 (exact) |
 | `RuntimeEvent` members | 57 |
 | Built-in LLM adapters | 6 |

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -514,7 +514,7 @@
       "authority": "suite-profile",
       "path": "docs/eval/terminal-bench-2.md",
       "summary": "GEODE adoption profile for canonical Terminal-Bench 2.1 execution through Harbor, including official-submission and diagnostic comparability boundaries.",
-      "sha256": "63e5732ab156d78f3abc9d68a4d5e2294b0c0cb5f402162cc283973f6ce78307",
+      "sha256": "784a64f40bd69d443a445032f37276f709588a0b7510c85747b7970708a3b8c0",
       "triggers": [
         "Harbor",
         "Terminal-Bench 2",

--- a/docs/eval/terminal-bench-2.md
+++ b/docs/eval/terminal-bench-2.md
@@ -75,7 +75,26 @@ It:
   timeout at zero so Harbor's canonical task limit remains authoritative;
 - leaves task/container/verifier ownership with Harbor;
 - exports a digest-oriented geode.trajectory@1 sidecar and an ATIF 1.7
-  `trajectory.json` projected from the same canonical session timeline.
+  `trajectory.json` projected from the same canonical session timeline;
+- reconstructs `recording.cast` from the finalized ATIF trace and binds it to
+  the source with `recording.receipt.json`.
+
+Harbor's job layout permits `agent/recording.cast`, but its contents are owned
+by each agent implementation. Terminus-2 performs a raw asciinema capture;
+GEODE and the instrumented native Codex adapter instead emit an asciicast v2
+reconstruction after ATIF finalization. The reconstruction is replay evidence,
+not a raw PTY capture or score authority. It omits provider reasoning, redacts
+known secret forms, and remains private until a separate PII/path/publication
+review. Observer-side `script -r` files separately record the operator console
+and must not be described as Harbor-native trial recordings.
+
+Use `evals.platforms.harbor:RecordedCodexHarborAgent` instead of the built-in
+Codex name when future paired runs require the native arm to emit the derived
+cast automatically. Closed historical jobs can be audited and backfilled
+without changing result or trajectory files:
+
+    uv run python -m evals.platforms.harbor <job-or-run-root> --dry-run
+    uv run python -m evals.platforms.harbor <job-or-run-root>
 
 The adapter declares `SUPPORTS_ATIF=true` only after validating the projection
 with Harbor's own ATIF model. Scope-incomplete session history or unmatched

--- a/docs/plans/2026-09-02-openrouter-provider-integration.md
+++ b/docs/plans/2026-09-02-openrouter-provider-integration.md
@@ -1,12 +1,10 @@
 # OpenRouter provider integration plan
 
 > [!NOTE]
-> Design and research evidence only. This document does not enable a provider,
-> perform a live request, or authorize spend. Implementation status belongs in
-> the implementing PR and, if the architecture program adopts the work, its
-> canonical roadmap ledger.
+> Design, implementation, and dated live-acceptance evidence. Model inventory
+> and prices are a snapshot, not a bundled catalogue or availability promise.
 
-**Status:** Implemented and CI-verified in PR #3268; assigned to the v1.0.27 release train
+**Status:** Released in v1.0.27; live transport and AgenticLoop acceptance verified 2026-09-03
 
 **Research snapshot:** 2026-09-02
 
@@ -268,14 +266,99 @@ substitute for offline contract tests.
 
 Local verification on 2026-09-02 passed the focused provider, auth, routing,
 model-picker, usage, and event tests; the complete `scripts/preflight.sh` CI
-mirror; and the 239-route static site build. No live OpenRouter request was
-made. Such a request still requires an OpenRouter account and API key, even
-when the selected route is zero-priced.
+mirror; and the 239-route static site build. The dated live acceptance below
+used an operator-provided key and a bounded paid budget; credentials remain
+local and are not part of the evidence.
 
 Rollback is bounded because OpenRouter is opt-in. Removing its registration and
 UI rows must leave direct provider state and model references untouched. Stored
 OpenRouter profiles should then fail with an explicit unsupported-provider
 message rather than being interpreted as OpenAI profiles.
+
+## Live acceptance and catalogue snapshot — 2026-09-03
+
+The public `/api/v1/models` catalogue exposed the following relevant publisher
+families. `Models` is the number of exact IDs in that dated response;
+`tool-capable` means the model advertised the `tools` parameter. GEODE does not
+copy these rows into its picker because upstream availability and prices change.
+
+| Publisher prefix | Models | Tool-capable | Representative verified route |
+|---|---:|---:|---|
+| `deepseek` | 16 | 15 | `deepseek/deepseek-v4-flash-0731` |
+| `qwen` | 53 | 51 | `qwen/qwen3.8-flash` |
+| `z-ai` | 16 | 16 | `z-ai/glm-5.3-flash` |
+| `moonshotai` | 8 | 8 | `moonshotai/kimi-k2.7-code` |
+| `minimax` | 11 | 9 | `minimax/minimax-m3` |
+| `bytedance-seed` | 6 | 6 | `bytedance-seed/seed-1.6-flash` |
+| `tencent` | 7 | 3 | `tencent/hy3` |
+| `xiaomi` | 2 | 2 | `xiaomi/mimo-v2.5` |
+| `stepfun` | 2 | 2 | `stepfun/step-3.5-flash` |
+| `inclusionai` | 2 | 2 | `inclusionai/ling-3.0-flash` |
+| `meituan` | 1 | 1 | `meituan/longcat-2.0` |
+| `baidu` | 1 | 0 | Not probed: the listed ERNIE route did not advertise tools |
+| `bytedance` | 1 | 0 | Not probed: the listed UI-TARS route did not advertise tools |
+| `upstage` | 2 | 2 | `upstage/solar-pro4` |
+
+DeepSeek exact IDs in the snapshot were `deepseek-chat`,
+`deepseek-chat-v3-0324`, `deepseek-chat-v3.1`, `deepseek-r1`,
+`deepseek-r1-0528`, `deepseek-r1-distill-llama-70b`,
+`deepseek-v3.1-terminus`, `deepseek-v3.2`, `deepseek-v3.2-exp`,
+`deepseek-v4-flash`, `deepseek-v4-flash-0731`,
+`deepseek-v4-flash-0731:batch`, `deepseek-v4-flash-vision-exp`,
+`deepseek-v4-pro`, `deepseek-v4-pro-0813`, and
+`deepseek-v4-pro-0813:batch`, all under the `deepseek/` prefix. Upstage exposed
+`upstage/solar-pro-3` and `upstage/solar-pro4`.
+
+### Measured transport matrix
+
+All 15 representative exact routes completed through
+`OpenRouterPaygAdapter`. Qwen first encountered an upstream shared-pool `429`;
+GLM, ByteDance Seed, and Ling first exhausted a 64-token reasoning budget.
+One bounded retry per affected route completed successfully, so these were
+classified as route-capacity/budget observations rather than adapter defects.
+
+| Model | Serving provider observed | Successful probe charge (USD) |
+|---|---|---:|
+| `deepseek/deepseek-v4-flash-0731` | OpenInference | 0.00000560 |
+| `deepseek/deepseek-v4-pro-0813` | StreamLake | 0.00011616 |
+| `deepseek/deepseek-r1-0528` | SiliconFlow | 0.00010224 |
+| `qwen/qwen3.8-flash` | Alibaba | 0.00002851 |
+| `z-ai/glm-5.3-flash` | Novita | 0.00002840 |
+| `moonshotai/kimi-k2.7-code` | Ambient | 0.00013108 |
+| `minimax/minimax-m3` | Venice | 0.00007068 |
+| `bytedance-seed/seed-1.6-flash` | Seed | 0.00002385 |
+| `tencent/hy3` | Phala | 0.00002457 |
+| `xiaomi/mimo-v2.5` | Novita | 0.00003207 |
+| `stepfun/step-3.5-flash` | SiliconFlow | 0.00002130 |
+| `inclusionai/ling-3.0-flash` | DeepInfra | 0.00002246 |
+| `meituan/longcat-2.0` | AtlasCloud | 0.00004980 |
+| `upstage/solar-pro-3` | Upstage | 0.00001017 |
+| `upstage/solar-pro4` | Upstage | 0.00000270 |
+
+The account total below also includes the initially truncated reasoning probes,
+not only the successful rows in the table. The full `AgenticLoop` then
+completed a two-round synthetic tool-use task with
+one exact tool call and natural termination on both
+`deepseek/deepseek-v4-flash-0731` (USD 0.000271831616) and
+`upstage/solar-pro4` (USD 0.00015657). Session events retained redacted tool
+arguments, token usage, cost, verification, and termination evidence. A secret
+scan of the isolated run root passed. The OpenRouter key endpoint reported
+USD 0.00166413 total account usage after the complete acceptance sequence.
+
+### Live-discovered hardening
+
+The first upstream `429` exposed two implementation defects outside the wire
+translation itself:
+
+1. adapter warning logs interpolated the raw SDK exception, which could contain
+   account-linked upstream fields; logs now retain only the exception type;
+2. `LLM_CALL_ENDED` carried charge and serving-route fields in process, but its
+   typed durable projection reduced them to generic completion fields; activity
+   schema v4 now retains bounded token, cost, model, adapter, and route evidence
+   while discarding raw provider error text.
+
+These fixes apply at the shared adapter/activity boundaries rather than adding
+OpenRouter-only persistence or a second usage ledger.
 
 ## Design gate
 

--- a/docs/plans/2026-09-03-harbor-trial-recording.md
+++ b/docs/plans/2026-09-03-harbor-trial-recording.md
@@ -1,0 +1,41 @@
+# Harbor trial recording reconstruction
+
+## Evidence and gap
+
+- Harbor documents `agent/recording.cast` as an agent-owned trial artifact.
+- Harbor 0.22.0 records it in Terminus-2, but neither GEODE's external agent nor
+  Harbor's installed Codex agent emits it.
+- Both agents already emit timestamped ATIF 1.7 `trajectory.json` files. The
+  active frozen comparison therefore must not be re-run or PTY-wrapped merely
+  to obtain a replay artifact.
+
+## Decision
+
+Render a Harbor-compatible asciicast v2 file from the existing ATIF trajectory
+after the trajectory is finalized. Store it at `agent/recording.cast` and bind
+it to the source trajectory with `agent/recording.receipt.json`.
+
+This is a trajectory reconstruction, not a raw terminal capture. It omits
+reasoning content, redacts known secret forms, requires a separate PII/public
+review, and has no score authority. Existing native recordings are never
+overwritten by default.
+
+GEODE writes the replay after its ATIF export. A thin Codex instrumentation
+subclass writes it after Harbor's native Codex converter. The same renderer has
+a dry-run/backfill command for closed historical jobs.
+
+## Acceptance
+
+- asciicast v2 JSONL validates and preserves monotonic ATIF-relative timing;
+- commands, observations, and final responses are replayable without provider
+  reasoning;
+- receipt hashes bind source and output and state the reconstruction boundary;
+- malformed or missing trajectories fail closed and existing casts remain
+  untouched;
+- targeted tests plus ruff and mypy pass without a paid or live benchmark run.
+
+## Primary sources
+
+- [Harbor job output layout](https://www.harborframework.com/docs/run-jobs/run-evals)
+- [Harbor 0.22.0 Terminus-2 source](https://github.com/harbor-framework/harbor/blob/v0.22.0/src/harbor/agents/terminus_2/terminus_2.py)
+- [asciicast v2 format](https://docs.asciinema.org/manual/asciicast/v2/)

--- a/evals/benchmarks/harbor_geode_agent.py
+++ b/evals/benchmarks/harbor_geode_agent.py
@@ -1,5 +1,5 @@
 """Compatibility facade for the Harbor platform adapter."""
 
-from evals.platforms.harbor import GeodeHarborAgent, HarborExecTool
+from evals.platforms.harbor import GeodeHarborAgent, HarborExecTool, RecordedCodexHarborAgent
 
-__all__ = ["GeodeHarborAgent", "HarborExecTool"]
+__all__ = ["GeodeHarborAgent", "HarborExecTool", "RecordedCodexHarborAgent"]

--- a/evals/platforms/harbor.py
+++ b/evals/platforms/harbor.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import importlib
 import importlib.metadata
 import json
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from core.memory.atomic_write import atomic_write_json, atomic_write_text
+from core.observability.redaction import redact_and_bound_text
 
 if TYPE_CHECKING:
 
@@ -25,11 +31,26 @@ if TYPE_CHECKING:
             **kwargs: Any,
         ) -> None: ...
 
+    class HarborCodexAgent:
+        logs_dir: Path
+        logger: Any
+
+        def populate_context_post_run(self, context: Any) -> None: ...
+
 else:
     try:
         HarborBaseAgent = importlib.import_module("harbor.agents.base").BaseAgent
     except ImportError:  # Harbor is an opt-in benchmark dependency.
         HarborBaseAgent = object
+    try:
+        HarborCodexAgent = importlib.import_module("harbor.agents.installed.codex").Codex
+    except ImportError:  # Harbor is an opt-in benchmark dependency.
+        HarborCodexAgent = object
+
+
+log = logging.getLogger(__name__)
+_MAX_RECORDING_EVENT_CHARS = 64_000
+_RECORDING_RECEIPT_SCHEMA = "geode.harbor-recording-receipt@1"
 
 
 @dataclass
@@ -238,11 +259,223 @@ def _atif_trajectory_from_geode(
 
 
 def _write_atif_trajectory(path: Path, payload: Mapping[str, Any]) -> None:
-    from core.memory.atomic_write import atomic_write_json
-
     trajectory_model = importlib.import_module("harbor.models.trajectories").Trajectory
     validated = trajectory_model.model_validate(payload)
     atomic_write_json(path, validated.to_json_dict(), indent=2)
+
+
+def _recording_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _recording_text(value: Any) -> str:
+    return (
+        redact_and_bound_text(value, _MAX_RECORDING_EVENT_CHARS)
+        .replace("\r\n", "\n")
+        .replace("\n", "\r\n")
+    )
+
+
+def _recording_step_output(step: Mapping[str, Any]) -> list[str]:
+    tool_calls = step.get("tool_calls")
+    calls = (
+        [call for call in tool_calls if isinstance(call, Mapping)]
+        if isinstance(tool_calls, list)
+        else []
+    )
+    chunks: list[str] = []
+    if calls:
+        for call in calls:
+            name = str(call.get("function_name") or "tool")
+            arguments = call.get("arguments")
+            arguments = arguments if isinstance(arguments, Mapping) else {}
+            action = arguments.get("command", arguments.get("input"))
+            if action is None:
+                action = json.dumps(arguments, ensure_ascii=False, sort_keys=True, default=str)
+            chunks.append(f"\x1b[1;36m$ [{name}]\x1b[0m {_recording_text(action)}\r\n")
+
+        observation = step.get("observation")
+        observation = observation if isinstance(observation, Mapping) else {}
+        results = observation.get("results")
+        if isinstance(results, list):
+            for result in results:
+                if not isinstance(result, Mapping):
+                    continue
+                content = _recording_text(result.get("content"))
+                if content:
+                    chunks.append(content + ("" if content.endswith("\r\n") else "\r\n"))
+        return chunks
+
+    message = _recording_text(step.get("message"))
+    if message:
+        source = str(step.get("source") or "event")
+        label = "task" if source == "user" else source
+        chunks.append(f"\x1b[1;33m[{label}]\x1b[0m {message}\r\n")
+    return chunks
+
+
+def _render_asciicast(trajectory: Mapping[str, Any]) -> tuple[str, dict[str, int]]:
+    schema_version = trajectory.get("schema_version")
+    if not isinstance(schema_version, str) or not schema_version.startswith("ATIF-v1."):
+        raise ValueError("recording reconstruction requires an ATIF v1 trajectory")
+    steps = trajectory.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ValueError("ATIF trajectory must contain at least one step")
+
+    parsed = [
+        _recording_timestamp(step.get("timestamp")) if isinstance(step, Mapping) else None
+        for step in steps
+    ]
+    base = next((value for value in parsed if value is not None), None)
+    agent = trajectory.get("agent")
+    agent = agent if isinstance(agent, Mapping) else {}
+    header: dict[str, Any] = {
+        "version": 2,
+        "width": 120,
+        "height": 36,
+        "title": f"Harbor ATIF replay — {agent.get('name') or 'agent'}",
+        "env": {
+            "TERM": "xterm-256color",
+            "SHELL": "/bin/sh",
+            "GEODE_RECORDING_PROVENANCE": "trajectory-reconstruction",
+        },
+    }
+    if base is not None:
+        header["timestamp"] = int(base.timestamp())
+
+    events: list[list[Any]] = [
+        [
+            0.0,
+            "o",
+            "\x1b[1;35m[reconstructed]\x1b[0m Harbor ATIF replay; not a raw PTY capture.\r\n",
+        ]
+    ]
+    previous = 0.0
+    synthetic = 0
+    clamped = 0
+    for step, occurred_at in zip(steps, parsed, strict=True):
+        if not isinstance(step, Mapping):
+            continue
+        if occurred_at is None or base is None:
+            offset = previous + 0.001
+            synthetic += 1
+        else:
+            offset = (occurred_at - base).total_seconds()
+            if offset < previous:
+                offset = previous
+                clamped += 1
+        previous = offset
+        events.extend([round(offset, 6), "o", chunk] for chunk in _recording_step_output(step))
+
+    if len(events) == 1:
+        raise ValueError("ATIF trajectory contains no replayable content")
+    lines = [json.dumps(header, ensure_ascii=False)]
+    lines.extend(json.dumps(event, ensure_ascii=False) for event in events)
+    return "\n".join(lines) + "\n", {
+        "step_count": len(steps),
+        "event_count": len(events),
+        "synthetic_timestamp_count": synthetic,
+        "clamped_timestamp_count": clamped,
+    }
+
+
+def write_harbor_recording(
+    trajectory_path: Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any] | None:
+    """Write one derived cast and receipt; preserve any existing recording."""
+    trajectory_path = Path(trajectory_path)
+    recording_path = trajectory_path.with_name("recording.cast")
+    receipt_path = trajectory_path.with_name("recording.receipt.json")
+    if recording_path.exists() and not overwrite:
+        return None
+
+    source_bytes = trajectory_path.read_bytes()
+    trajectory = json.loads(source_bytes)
+    if not isinstance(trajectory, Mapping):
+        raise ValueError("ATIF trajectory root must be an object")
+    cast, timing = _render_asciicast(trajectory)
+    cast_bytes = cast.encode("utf-8")
+    receipt: dict[str, Any] = {
+        "schema_id": _RECORDING_RECEIPT_SCHEMA,
+        "recording_kind": "trajectory-reconstruction",
+        "score_authority": False,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "path": trajectory_path.name,
+            "sha256": hashlib.sha256(source_bytes).hexdigest(),
+            "schema_version": str(trajectory.get("schema_version") or ""),
+            "trajectory_id": str(trajectory.get("trajectory_id") or ""),
+        },
+        "output": {
+            "path": recording_path.name,
+            "sha256": hashlib.sha256(cast_bytes).hexdigest(),
+            "format": "asciicast-v2",
+        },
+        "timing": timing,
+        "privacy": {
+            "known_secret_patterns": "redacted",
+            "provider_reasoning": "omitted",
+            "publication_state": "private-review-required",
+        },
+    }
+    atomic_write_text(recording_path, cast)
+    atomic_write_json(receipt_path, receipt, indent=2)
+    return receipt
+
+
+def backfill_harbor_recordings(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Create missing derived recordings below one closed Harbor job/run root."""
+    root = Path(root)
+    if not root.is_dir():
+        raise FileNotFoundError(root)
+    summary = {
+        "trajectories": 0,
+        "eligible": 0,
+        "created": 0,
+        "existing": 0,
+        "failed": 0,
+    }
+    for trajectory_path in sorted(root.rglob("agent/trajectory.json")):
+        summary["trajectories"] += 1
+        if trajectory_path.with_name("recording.cast").exists() and not overwrite:
+            summary["existing"] += 1
+            continue
+        try:
+            if dry_run:
+                trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+                if not isinstance(trajectory, Mapping):
+                    raise ValueError("ATIF trajectory root must be an object")
+                _render_asciicast(trajectory)
+            else:
+                write_harbor_recording(trajectory_path, overwrite=overwrite)
+                summary["created"] += 1
+            summary["eligible"] += 1
+        except (OSError, ValueError, json.JSONDecodeError):
+            summary["failed"] += 1
+    return summary
+
+
+def _write_recording_if_available(logs_dir: Path) -> None:
+    trajectory_path = logs_dir / "trajectory.json"
+    if not trajectory_path.is_file():
+        return
+    try:
+        write_harbor_recording(trajectory_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        log.warning("Harbor recording reconstruction failed: %s", exc)
 
 
 def _build_loop(
@@ -409,6 +642,42 @@ class GeodeHarborAgent(HarborBaseAgent):
                 metrics=usage,
             ),
         )
+        _write_recording_if_available(self.logs_dir)
 
 
-__all__ = ["GeodeHarborAgent", "HarborExecTool"]
+class RecordedCodexHarborAgent(HarborCodexAgent):
+    """Harbor Codex with post-run trajectory replay instrumentation."""
+
+    SUPPORTS_ATIF = True
+
+    def populate_context_post_run(self, context: Any) -> None:
+        super().populate_context_post_run(context)
+        _write_recording_if_available(self.logs_dir)
+
+
+def _recording_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reconstruct Harbor recordings from ATIF traces.")
+    parser.add_argument("root", type=Path, help="Closed Harbor job or run root")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args(argv)
+    summary = backfill_harbor_recordings(
+        args.root,
+        dry_run=args.dry_run,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(summary, sort_keys=True))
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_recording_main())
+
+
+__all__ = [
+    "GeodeHarborAgent",
+    "HarborExecTool",
+    "RecordedCodexHarborAgent",
+    "backfill_harbor_recordings",
+    "write_harbor_recording",
+]

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -546,25 +546,39 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6707,7 +6707,7 @@ Markdown: https://mangowhoiscloud.github.io/geode/docs/architecture/system-index
 | 측정값 | 현재 트리 |
 | --- | --- |
 | 프로덕션 Python 파일 | 581 |
-| 테스트 Python 파일 | 699 |
+| 테스트 Python 파일 | 700 |
 | 도구 정의 / 모델 실행 / 유효 스키마 / 정책 | 86 / 86 / 86 / 86 |
 | RuntimeEvent 멤버 | 57 |
 | 기본 LLM 어댑터 | 6 |

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -6546,7 +6546,7 @@ Tier 2  latex2sympy2 + sympy.pretty  블록 전용. 분수·적분을 2D Unicode
 URL: https://mangowhoiscloud.github.io/geode/docs/reference/changelog
 Markdown: https://mangowhoiscloud.github.io/geode/docs/reference/changelog.md
 
-(body omitted from llms-full: 1545 KB — fetch the Markdown twin above for the complete page)
+(body omitted from llms-full: 1546 KB — fetch the Markdown twin above for the complete page)
 
 ---
 

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -532,15 +532,15 @@
     },
     "evals": {
       "python_files": 93,
-      "python_loc": 30375
+      "python_loc": 30644
     },
     "evolve": {
       "python_files": 73,
       "python_loc": 32014
     },
     "tests": {
-      "python_files": 699,
-      "python_loc": 189458
+      "python_files": 700,
+      "python_loc": 189562
     }
   },
   "schema_version": 6,

--- a/site/src/data/geode/architecture-baseline.json
+++ b/site/src/data/geode/architecture-baseline.json
@@ -528,7 +528,7 @@
   "packages": {
     "core": {
       "python_files": 415,
-      "python_loc": 124637
+      "python_loc": 124742
     },
     "evals": {
       "python_files": 93,
@@ -540,7 +540,7 @@
     },
     "tests": {
       "python_files": 700,
-      "python_loc": 189562
+      "python_loc": 189717
     }
   },
   "schema_version": 6,

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build."
+    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build.\n\n### Fixed\n\n- **Provider failures and routed-call evidence are now privacy-safe and\n  durable.** Built-in adapters no longer interpolate raw SDK exception bodies\n  into warning logs, failed LLM hooks retain only the exception type, and\n  activity schema v4 preserves bounded token, charge, requested/served model,\n  adapter, and OpenRouter route metadata through SQLite and run projections."
   },
   {
     "version": "1.0.27",

--- a/site/src/data/geode/changelog.ts
+++ b/site/src/data/geode/changelog.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     "version": "Unreleased",
     "date": "",
-    "body": ""
+    "body": "### Added\n\n- **Harbor trial replay receipts.** GEODE and an instrumented native Codex\n  adapter can now reconstruct agent-owned asciicast v2 replays from finalized\n  ATIF trajectories, with source/output hashes and explicit non-score,\n  non-raw-capture provenance. A fail-closed backfill command covers closed\n  historical Harbor jobs without overwriting existing recordings.\n\n### Infrastructure\n\n- **Patched site audit dependency.** The locked transitive `@humanfs/node`\n  dependency now uses 0.16.8, closing GHSA-p498-v437-472g in the Pages build."
   },
   {
     "version": "1.0.27",

--- a/tests/core/hooks/test_hook_persistence.py
+++ b/tests/core/hooks/test_hook_persistence.py
@@ -164,6 +164,7 @@ def test_public_extension_audit_uses_sqlite_and_active_timeline_only(
         "step_id": "t-1:step-1",
         "session_generation": 0,
         "verify_attempt": 0,
+        "activity_schema_version": 4,
         "_dispatch_duration_ms": row.payload["_dispatch_duration_ms"],
     }
     assert not (tmp_path / "events.jsonl").exists()
@@ -223,6 +224,66 @@ def test_tool_correlation_survives_sqlite_and_timeline_projection(tmp_path: Path
     assert timeline_row["payload"]["step_id"] == "t-tool:step-2"
     assert timeline_row["payload"]["session_generation"] == 3
     assert timeline_row["payload"]["verify_attempt"] == 1
+    hooks.close()
+
+
+def test_llm_route_charge_and_usage_survive_durable_projection(tmp_path: Path) -> None:
+    hooks, store = _wired_hooks(tmp_path)
+
+    with run_timeline_scope(_timeline(tmp_path)):
+        hooks.trigger(
+            HookEvent.LLM_CALL_ENDED,
+            {
+                "session_id": "s-llm",
+                "turn_id": "t-llm",
+                "llm_call_id": "call-llm",
+                "llm_attempt_id": "call-llm:attempt-1",
+                "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+                "provider": "openrouter",
+                "adapter": "openrouter-payg",
+                "latency_ms": 123.5,
+                "error": None,
+                "usage": {
+                    "input_tokens": 101,
+                    "output_tokens": 23,
+                    "cached_input_tokens": 7,
+                    "reasoning_tokens": 11,
+                    "cache_write_tokens": 3,
+                },
+                "cost_usd": 0.00012,
+                "response_id": "generation-1",
+                "response_model": "deepseek/deepseek-v4-flash-0731",
+                "response_provider": "OpenInference",
+                "routing_strategy": "direct",
+                "routing_attempt": 1,
+            },
+        )
+
+    row = store.read()[0]
+    assert row.status == "ok"
+    assert row.entity_id == "call-llm"
+    assert row.payload["duration_ms"] == 123.5
+    assert row.payload["model"] == "openrouter/deepseek/deepseek-v4-flash-0731"
+    assert row.payload["provider"] == "openrouter"
+    assert row.payload["adapter"] == "openrouter-payg"
+    assert row.payload["usage"] == {
+        "input_tokens": 101,
+        "output_tokens": 23,
+        "cached_input_tokens": 7,
+        "reasoning_tokens": 11,
+        "cache_write_tokens": 3,
+    }
+    assert row.payload["cost_usd"] == 0.00012
+    assert row.payload["response_id"] == "generation-1"
+    assert row.payload["response_model"] == "deepseek/deepseek-v4-flash-0731"
+    assert row.payload["response_provider"] == "OpenInference"
+    assert row.payload["routing_strategy"] == "direct"
+    assert row.payload["routing_attempt"] == 1
+    assert row.payload["activity_schema_version"] == 4
+    timeline_payload = _read_timeline(tmp_path / "events.jsonl")[0]["payload"]
+    assert timeline_payload["response_provider"] == "OpenInference"
+    assert timeline_payload["cost_usd"] == 0.00012
+    assert timeline_payload["activity_schema_version"] == 4
     hooks.close()
 
 

--- a/tests/core/hooks/test_hook_taxonomy.py
+++ b/tests/core/hooks/test_hook_taxonomy.py
@@ -398,7 +398,7 @@ def test_activity_and_hook_store_schema_versions_are_pinned():
     from core.observability.activity import ActivityRowBase
     from core.observability.event_store import EVENT_SCHEMA_VERSION
 
-    assert ActivityRowBase.model_fields["schema_version"].default == 3
+    assert ActivityRowBase.model_fields["schema_version"].default == 4
     # Hook persistence gained indexed correlation columns independently of the
     # activity-row payload contract.
     assert EVENT_SCHEMA_VERSION == 5

--- a/tests/core/llm/adapters/test_openrouter_payg.py
+++ b/tests/core/llm/adapters/test_openrouter_payg.py
@@ -100,6 +100,8 @@ class _Completions:
 
     async def create(self, **kwargs: Any) -> Any:
         self.kwargs = kwargs
+        if isinstance(self.response, BaseException):
+            raise self.response
         return self.response
 
 
@@ -117,6 +119,37 @@ def test_missing_key_fails_before_network(monkeypatch: pytest.MonkeyPatch) -> No
                 )
             )
         )
+
+
+def test_provider_error_log_omits_raw_upstream_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    failure = RuntimeError('upstream rejected request; user_id="account-linked-id"')
+    completions = _Completions(failure)
+    adapter = OpenRouterPaygAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_get_client",
+        lambda: SimpleNamespace(chat=SimpleNamespace(completions=completions)),
+    )
+
+    with (
+        caplog.at_level("WARNING", logger="core.llm.adapters.openrouter_payg"),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        asyncio.run(
+            adapter.acomplete(
+                AdapterCallRequest(
+                    model="openrouter/deepseek/deepseek-v4-flash-0731",
+                    messages=(Message(role="user", content="hi"),),
+                )
+            )
+        )
+
+    assert exc_info.value is failure
+    assert "error_type=RuntimeError" in caplog.text
+    assert "account-linked-id" not in caplog.text
 
 
 def test_completion_forwards_chat_tools_and_captures_charge_and_route(

--- a/tests/core/llm/test_model_failover.py
+++ b/tests/core/llm/test_model_failover.py
@@ -493,6 +493,38 @@ class TestAgenticLoopFailover:
         assert result is None
         assert loop._last_llm_error is not None
 
+    def test_failed_llm_event_omits_raw_provider_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from core.hooks import HookEvent, HookSystem
+
+        observed: list[dict[str, Any]] = []
+        hooks = HookSystem()
+        hooks.register(
+            HookEvent.LLM_CALL_ENDED,
+            lambda _event, data: observed.append(dict(data)),
+            name="error-recorder",
+        )
+        loop = self._make_loop()
+        loop._hooks = hooks
+        self._install_acomplete_stub(
+            loop,
+            RuntimeError('upstream rejected request; user_id="account-linked-id"'),
+        )
+
+        with caplog.at_level("WARNING", logger="core.agent.loop._provider_call"):
+            result = asyncio.run(
+                loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
+            )
+
+        assert result is None
+        assert observed
+        assert all(event["error"] == "RuntimeError" for event in observed)
+        assert "account-linked-id" not in str(observed)
+        assert "account-linked-id" not in caplog.text
+        assert "error_type=RuntimeError" in caplog.text
+
     def test_call_llm_propagates_billing_to_the_operator_boundary(self) -> None:
         """Billing must bypass ordinary retry and reach `_dispatch_llm_call`."""
         from core.llm.errors import BillingError

--- a/tests/core/observability/test_activity_schema.py
+++ b/tests/core/observability/test_activity_schema.py
@@ -356,6 +356,35 @@ def test_k1_real_payloads_roundtrip_through_discriminated_union() -> None:
         )
 
 
+def test_llm_lifecycle_keeps_current_and_legacy_call_correlation() -> None:
+    current = {
+        "session_id": "session-1",
+        "llm_call_id": "current-call",
+        "attempt": 2,
+    }
+    started = map_hook_to_activity(
+        HookEvent.LLM_CALL_STARTED,
+        current,
+        run_id="r1",
+    )
+    retried = map_hook_to_activity(
+        HookEvent.LLM_CALL_RETRIED,
+        current,
+        run_id="r1",
+    )
+    ended = map_hook_to_activity(
+        HookEvent.LLM_CALL_ENDED,
+        current,
+        run_id="r1",
+    )
+    assert started.entity_id == retried.entity_id == ended.entity_id == "current-call"
+
+    legacy = {"session_id": "session-1", "call_id": "legacy-call"}
+    legacy_started = map_hook_to_activity(HookEvent.LLM_CALL_STARTED, legacy, run_id="r1")
+    legacy_ended = map_hook_to_activity(HookEvent.LLM_CALL_ENDED, legacy, run_id="r1")
+    assert legacy_started.entity_id == legacy_ended.entity_id == "legacy-call"
+
+
 def test_k2_raw_user_content_never_persists_to_timeline() -> None:
     """Privacy contract: raw ``user_input`` strings, cognitive-state
     snapshots, and full tool results must NOT appear in the row details —

--- a/tests/evals/benchmarks/test_harbor_recording.py
+++ b/tests/evals/benchmarks/test_harbor_recording.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from evals.platforms.harbor import (
+    backfill_harbor_recordings,
+    write_harbor_recording,
+)
+
+
+def _trajectory(path: Path) -> Path:
+    path.parent.mkdir(parents=True)
+    payload = {
+        "schema_version": "ATIF-v1.7",
+        "trajectory_id": "trial-1",
+        "agent": {"name": "codex"},
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": "2026-09-03T00:00:00Z",
+                "source": "user",
+                "message": "fix the task",
+            },
+            {
+                "step_id": 2,
+                "timestamp": "2026-09-03T00:00:02Z",
+                "source": "agent",
+                "message": "private reasoning must not be replayed",
+                "reasoning_content": "also private",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-1",
+                        "function_name": "exec",
+                        "arguments": {"command": "pwd"},
+                    }
+                ],
+                "observation": {
+                    "results": [
+                        {
+                            "source_call_id": "call-1",
+                            "content": "/app sk-proj-abcdefghijklmnopqrstuvwxyz123456",
+                        }
+                    ]
+                },
+            },
+            {
+                "step_id": 3,
+                "timestamp": "invalid",
+                "source": "agent",
+                "message": "done",
+            },
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_recording_reconstructs_atif_without_reasoning_or_secrets(tmp_path: Path) -> None:
+    trajectory_path = _trajectory(tmp_path / "job" / "trial" / "agent" / "trajectory.json")
+    receipt = write_harbor_recording(trajectory_path)
+
+    assert receipt is not None
+    cast_path = trajectory_path.with_name("recording.cast")
+    lines = [json.loads(line) for line in cast_path.read_text().splitlines()]
+    assert lines[0]["version"] == 2
+    assert lines[0]["env"]["GEODE_RECORDING_PROVENANCE"] == "trajectory-reconstruction"
+    assert [event[0] for event in lines[1:]] == sorted(event[0] for event in lines[1:])
+    replay = "".join(event[2] for event in lines[1:])
+    assert "fix the task" in replay
+    assert "[exec]" in replay and "pwd" in replay and "/app" in replay
+    assert "[REDACTED]" in replay and "sk-proj-" not in replay
+    assert "private reasoning" not in replay and "also private" not in replay
+    assert "done" in replay
+    assert receipt["source"]["sha256"] == hashlib.sha256(trajectory_path.read_bytes()).hexdigest()
+    assert receipt["timing"]["synthetic_timestamp_count"] == 1
+    assert receipt["score_authority"] is False
+
+
+def test_backfill_preserves_existing_recording(tmp_path: Path) -> None:
+    first = _trajectory(tmp_path / "one" / "agent" / "trajectory.json")
+    second = _trajectory(tmp_path / "two" / "agent" / "trajectory.json")
+    first.with_name("recording.cast").write_text("native", encoding="utf-8")
+
+    dry_run = backfill_harbor_recordings(tmp_path, dry_run=True)
+    assert dry_run == {
+        "trajectories": 2,
+        "eligible": 1,
+        "created": 0,
+        "existing": 1,
+        "failed": 0,
+    }
+
+    summary = backfill_harbor_recordings(tmp_path)
+    assert summary == {
+        "trajectories": 2,
+        "eligible": 1,
+        "created": 1,
+        "existing": 1,
+        "failed": 0,
+    }
+    assert first.with_name("recording.cast").read_text() == "native"
+    assert second.with_name("recording.receipt.json").is_file()


### PR DESCRIPTION
## Summary
- 검증 완료된 develop을 main으로 승격합니다.
- Harbor trial recording 복원과 OpenRouter 라이브 수용성·증거 영속화 하드닝을 함께 반영합니다.

## Included Changes
| PR | 내용 |
|---|---|
| #3272 | Harbor trial recording 재구성과 평가 문서 정합화 |
| #3273 | DeepSeek·중국계·Upstage OpenRouter 실측, LLM 라우트/비용 영속화, 오류 로그 최소화 |

## Why
develop에 병합된 두 기능 거래의 필수 CI가 green이며 main에는 고유 커밋이 없습니다. main이 develop의 조상이므로 별도 main→develop sync 없이 표준 develop→main 승격이 가능합니다.

## Verification
- #3272: feature PR 필수 CI 통과 후 develop 병합.
- #3273: Lint & Format, Type Check, Security Scan, Test(11m53s), Gate, macOS/Ubuntu Install Smoke, site render/build 모두 통과.
- #3273 로컬 `scripts/preflight.sh` 전체 통과.
- #3273 독립 Codex 리뷰 최종 결과: actionable defect 없음.
- 현재 refs: `origin/develop=15c91e92a`, `origin/main=2cd8246a3`.
- `origin/main`은 `origin/develop`의 조상이며 main 고유 커밋은 0.

## Release Boundary
- 이 PR은 코드와 문서의 main 승격만 수행합니다.
- version/tag/GitHub Release/PyPI 배포는 포함하지 않습니다.
- OpenRouter API 키나 라이브 호출 산출물의 비밀 값은 Git에 포함하지 않습니다.