### PR TITLE
docs: publish Astra subscription E2E evidence

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/Anthropic-Fable_5-cc785c?style=flat-square&logo=anthropic&logoColor=white" alt="Anthropic Fable 5">
-  <img src="https://img.shields.io/badge/OpenAI-GPT--6_Astra-412991?style=flat-square&logo=openai&logoColor=white" alt="OpenAI GPT-6 Astra">
+  <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z"><img src="https://img.shields.io/badge/OpenAI-GPT--6_Astra_E2E_smoke_1%2F1-412991?style=flat-square&logo=openai&logoColor=white" alt="OpenAI GPT-6 Astra E2E smoke 1/1"></a>
   <img src="https://img.shields.io/badge/OpenRouter-inference_router-6b46c1?style=flat-square" alt="OpenRouter">
   <img src="https://img.shields.io/badge/ZhipuAI-GLM--5.2-1a73e8?style=flat-square" alt="ZhipuAI GLM-5.2">
 </p>
@@ -77,6 +77,7 @@ harness revision, task set, model route, effort, timeout, attempt lineage에
 |---|---|
 | [Tau2](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2) | native-user와 GEODE-user 트랙을 분리하며, 미완료·quota 오염 run은 aggregate score 권한 없이 보존합니다. |
 | [MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark) | 서비스 coverage, 과거 available-services 결과, 정정된 paired 관측, full-Verified 한계를 구분합니다. |
+| [Terminal-Bench 2.1](https://mangowhoiscloud.github.io/geode/docs/benchmarks/terminal-bench) | GPT-6 Astra 구독 E2E는 1 task, 1 repetition smoke입니다. reward 1/1, verifier 6/6이며 suite, 순위, 일반 계정 가용성은 주장하지 않습니다. |
 
 원본 receipt와 개인정보 검토를 통과한 trajectory는
 [평가 artifact 저장소](https://github.com/mangowhoiscloud/geode-eval-artifacts)에 보존합니다.
@@ -200,9 +201,11 @@ flexible credit 또는 legacy per-seat 방식 중 무엇을 쓰는지에 따라 
 
 **참고할 점**:
 - **[GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)는 순차 배포 중입니다.** GEODE는 `gpt-6-astra`를 ChatGPT
-  구독과 Platform API 양쪽 경로에서 인식하지만, 실제 계정 접근은
-  OpenAI의 rollout 일정에 따릅니다. 유효한 로그인만으로 해당 계정에
-  모델이 열렸다고 단정하지 않습니다.
+  구독과 Platform API 양쪽 경로에서 인식합니다. 2026-09-05 현재 구독
+  계정에서는 canonical Terminal-Bench 2.1 task 1건을 reward 1/1, retry와
+  fallback 없이 완료했습니다. 이
+  [불변 E2E smoke](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z)는
+  해당 계정과 경로의 증거이며, 전체 계정에 대한 가용성 주장이 아닙니다.
 - **gpt-5.5 는 구독 전용입니다.** GPT-5.6 Sol/Terra/Luna와 GPT-5.4는 듀얼 레인입니다. 구독 프로필이 활성화되면 ChatGPT OAuth, API 키 프로필을 선택하면 Platform API를 사용합니다. 5.5가 필요하면 ChatGPT 구독이 필요합니다.
 - 기존 Codex CLI 자격은 가져올 수 있지만, `codex-cli`는 GEODE 추론 백엔드가 아닙니다.
 - **Free / Go** 는 OpenAI 가격 페이지엔 있지만 CLI README 엔 없습니다. 동작하면 다행, 보장은 안 합니다.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/Anthropic-Fable_5-cc785c?style=flat-square&logo=anthropic&logoColor=white" alt="Anthropic Fable 5">
-  <img src="https://img.shields.io/badge/OpenAI-GPT--6_Astra-412991?style=flat-square&logo=openai&logoColor=white" alt="OpenAI GPT-6 Astra">
+  <a href="https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z"><img src="https://img.shields.io/badge/OpenAI-GPT--6_Astra_E2E_smoke_1%2F1-412991?style=flat-square&logo=openai&logoColor=white" alt="OpenAI GPT-6 Astra E2E smoke 1/1"></a>
   <img src="https://img.shields.io/badge/OpenRouter-inference_router-6b46c1?style=flat-square" alt="OpenRouter">
   <img src="https://img.shields.io/badge/ZhipuAI-GLM--5.2-1a73e8?style=flat-square" alt="ZhipuAI GLM-5.2">
 </p>
@@ -77,6 +77,7 @@ timeout, and attempt lineage.
 |---|---|
 | [Tau2](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2) | Native-user and GEODE-user tracks remain separate; incomplete or quota-contaminated runs are retained without receiving aggregate-score authority. |
 | [MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark) | Service coverage, historical available-services results, corrected paired observations, and full-Verified limitations remain explicit. |
+| [Terminal-Bench 2.1](https://mangowhoiscloud.github.io/geode/docs/benchmarks/terminal-bench) | The GPT-6 Astra subscription E2E is a one-task, one-repetition smoke: reward 1/1 and verifier 6/6, with no suite, rank, or general-availability claim. |
 
 Raw receipts and privacy-reviewed trajectories live in the
 [evaluation artifact repository](https://github.com/mangowhoiscloud/geode-eval-artifacts).
@@ -200,9 +201,11 @@ the workspace uses flexible credits or legacy per-seat limits.
 
 **Tier notes**:
 - **[GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra) is rollout-gated.** GEODE recognizes `gpt-6-astra` on both the
-  ChatGPT subscription and Platform API lanes, but OpenAI is enabling account
-  access progressively. A valid login does not by itself prove that your
-  account has received the model yet.
+  ChatGPT subscription and Platform API lanes. On 2026-09-05, the current
+  subscription account completed one canonical Terminal-Bench 2.1 task with
+  reward 1/1 and no retry or fallback. The
+  [immutable E2E smoke](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z)
+  proves this account-scoped route, not general account availability.
 - **gpt-5.5 is subscription-only.** GPT-5.6 Sol/Terra/Luna and GPT-5.4 are dual-lane: GEODE uses ChatGPT OAuth when a subscription profile is active and the Platform API when an API-key profile is selected. If you want 5.5, you need ChatGPT.
 - Existing Codex CLI credentials remain importable, but `codex-cli` is not a GEODE inference backend.
 - **Free / Go** appear on OpenAI's pricing page but aren't listed in the CLI README. Treat them as best-effort; if it works, great, but no promises.

--- a/docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.md
+++ b/docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.md
@@ -1,0 +1,105 @@
+---
+eval_id: terminalbench21-astra-high-openssl-smoke-20260904t202725z
+eval_family: terminal-bench-2
+eval_kind: ledger
+eval_status: historical
+eval_authority: routing-and-behavior-diagnostic
+eval_summary: Preregistered one-task Terminal-Bench 2.1 smoke showing that GEODE reached GPT-6 Astra/high through the current OpenAI subscription route and earned canonical verifier reward 1 without retry or fallback.
+eval_triggers:
+  - Terminal-Bench 2.1
+  - GPT-6 Astra
+  - OpenAI subscription
+  - Harbor
+  - E2E smoke
+eval_contracts:
+  - docs/eval/schemas/run-spec.schema.json
+  - docs/eval/schemas/attempt.schema.json
+  - docs/eval/schemas/analysis.schema.json
+  - docs/eval/schemas/publication.schema.json
+  - core/observability/schemas/trajectory.schema.json
+---
+
+# Terminal-Bench 2.1. GPT-6 Astra subscription E2E smoke
+
+## 판정
+
+현재 OpenAI 구독 계정에서 GEODE가 `gpt-6-astra`와 reasoning `high`를
+호출해 canonical Terminal-Bench 2.1 `openssl-selfsigned-cert` 작업을
+완료했다. Harbor verifier reward는 **1/1**, 개별 검사는 **6/6**이었고,
+retry와 fallback은 없었다.
+
+이 결과의 권한은 account-scoped E2E smoke에 한정된다. 한 작업, 한 반복으로
+Terminal-Bench 2.1 전체 정확도, 분산, 순위, 다른 harness 대비 우위 또는 모든
+계정의 Astra 접근 가능성을 주장하지 않는다.
+
+## Frozen contract
+
+| Field | Value |
+|---|---|
+| Run ID | `terminalbench21-astra-high-openssl-smoke-20260904t202725z` |
+| Preregistration | prospective, frozen at 2026-09-04T20:27:25Z |
+| GEODE | 1.0.27 at `132dc61f90b0fe097cf16b01efa564e88d9d8dc9` |
+| Model route | `gpt-6-astra`, `high`, OpenAI subscription |
+| Harness | Harbor 0.22.0 |
+| Dataset | `terminal-bench/terminal-bench-2-1@6` |
+| Task | `terminal-bench/openssl-selfsigned-cert` |
+| Task digest | `sha256:d4afa2bd2a9ba1420db8d6cfde42ffdb4873ae2d955c35014e8da94444c83302` |
+| Timeout | canonical 2,400s, multiplier 1.0 |
+| Concurrency / repetition | 1 / 1 |
+| Decision rule | Sole valid trial must finish without infrastructure error and receive reward 1 |
+| Promotion authority | none |
+
+## Observed result
+
+| Measurement | Observation | Authority |
+|---|---:|---|
+| Canonical task reward | **1/1** | Harbor aggregate result and task verifier |
+| Verifier checks | **6/6 passed** | CTRF receipt |
+| Harbor errors / retries | **0 / 0** | Harbor aggregate result |
+| GEODE rounds | **3** | GEODE trajectory outcome |
+| Tool calls | **2 calls / 2 results / 0 orphans** | recomputed trajectory integrity |
+| Termination | `natural` | GEODE trajectory outcome |
+| Tokens | 10,442 input / 1,948 output / 0 cached | Harbor aggregate result |
+| Trial wall time | 102.489s | Harbor trial result, retained privately because it contains a local path |
+
+Harbor의 `cost_usd=$0.20182`는 price table 기반 추정치다. ChatGPT 구독의
+실제 청구 내역으로 해석하지 않는다.
+
+## Published evidence
+
+Artifact PR [#40](https://github.com/mangowhoiscloud/geode-eval-artifacts/pull/40)은
+[`a32abcbf78ab6100ea1e85540a2ace9436dc6f76`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/a32abcbf78ab6100ea1e85540a2ace9436dc6f76)으로
+squash merge됐다. 불변 bundle은
+[`terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z)에
+있다.
+
+공개된 9개 파일, 30,857바이트를 merge SHA에서 다시 내려받아 로컬 원본과
+byte-for-byte로 대조했다. 불일치는 0개였다. bundle에는 다음이 포함된다.
+
+- frozen run spec, typed attempt lineage, analysis;
+- Harbor aggregate result, canonical verifier CTRF와 reward;
+- privacy review를 통과한 `geode.trajectory@1` release와 manifest.
+
+원본 prompt, reasoning, OAuth 자료, tool payload, ATIF, recording, 로컬 경로,
+미검토 task output은 공개하지 않았다. 공개 trajectory는 12개 event와 정확히
+짝지어진 tool call/result 2쌍을 담는다. 범위는 완전하지만 9개 payload body를
+digest로 대체했으므로 replay는 불완전하다.
+
+Publication manifest는
+[`2026-09-05-terminalbench-astra-openssl-smoke.publication.json`](2026-09-05-terminalbench-astra-openssl-smoke.publication.json)에
+있으며 SHA-256은
+`feb0289dd64e5a277852d4c69fbc1ad6ca26e2db60c9f5b22d7977110470478a`다.
+
+## 남는 한계
+
+- 1/89 task, k=1이다. suite 성능이나 변동성을 추정하지 않는다.
+- canonical linux/amd64 image를 arm64 macOS의 Docker Desktop에서 실행했다.
+- comparator가 없으므로 runtime 간 비교 권한이 없다.
+- official 제출 요건인 89 tasks × k>=5, static analysis, reward-hacking review를
+  충족하지 않았다.
+- 이 계정에서 성공했다는 증거이며, OpenAI의 전체 계정 rollout 완료 증거가
+  아니다.
+
+판정은 **artifact-publication complete, package-release not required**다.
+GEODE 코드와 wheel version은 바뀌지 않았으며, 공개 문서와 Pages만 이 불변
+증거를 가리킨다.

--- a/docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.publication.json
+++ b/docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.publication.json
@@ -1,0 +1,205 @@
+{
+  "artifact_repository": {
+    "base_revision": "c52872aacd20a4b9f14be18d64acce3e9ed99070",
+    "destination_prefix": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z",
+    "url": "https://github.com/mangowhoiscloud/geode-eval-artifacts"
+  },
+  "entries": [
+    {
+      "bytes": 3627,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/analysis.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/analysis.json",
+      "sha256": "314991629de8f54de1dc0cc1cec97464add51262501e3268fbc58871736d8a2a"
+    },
+    {
+      "bytes": 2470,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/attempts.jsonl",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/attempts.jsonl",
+      "sha256": "fdc9b9c6372f69faf3ce2a2ddfc964101b594d84d062893ef0c0bdb1bf15d5e5"
+    },
+    {
+      "bytes": 816,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/config.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "de2a64a087e68aa44024542a6df995325919514af0f8012466f570cc09c0b624"
+    },
+    {
+      "bytes": 137,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/job.log",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "3ddb278b6a896fa128ef385701944c3a28c2940a2a36c1f2122d18f01b32bf65"
+    },
+    {
+      "bytes": 2173,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/lock.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "e799c1f83d7f5cced72dc20a72e9471e06ec9ea0b6866cda40cf4bf349f2e4f5"
+    },
+    {
+      "bytes": 11645,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/agent/geode-trajectory.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "3718a5f20250c63426eb02febacb9442dbd6ee2d8a85bb81a56a3f653d42a068"
+    },
+    {
+      "bytes": 10020,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/agent/recording.cast",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "c212ced20da06a19a89ebb57eacd2d10afe396e4636a30344a771fc5018b02fe"
+    },
+    {
+      "bytes": 831,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/agent/recording.receipt.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "1d20bd1766390845b8ae85d0369bf4cc2d9dfe18d2cb3f4dcdc300553ff47786"
+    },
+    {
+      "bytes": 12517,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/agent/trajectory.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "19adcc8e500d6a4c1f4e77231482401250858b7df448b0340a5d9f5e539b5b61"
+    },
+    {
+      "bytes": 159,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/artifacts/manifest.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "c1db653f487fb773c4f9247162ab3314e7f0584a486914b9874c4b3d6949e42d"
+    },
+    {
+      "bytes": 756,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/config.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "ac9dbed50f070fa527bf5aa1ee6cb476cf06c2f83b08d02c5c1f61e3ff2d188c"
+    },
+    {
+      "bytes": 1131,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/lock.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "7b6da7851da2932f1043b49ccf11c6690fa8dc79d775e20ab0db9e6c581fd7f2"
+    },
+    {
+      "bytes": 4608,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/result.json",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "508123574727b31672fb727442863b869c8799347b922bceb075028a244f2968"
+    },
+    {
+      "bytes": 137,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/trial.log",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "3ddb278b6a896fa128ef385701944c3a28c2940a2a36c1f2122d18f01b32bf65"
+    },
+    {
+      "bytes": 2482,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/verifier/ctrf.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/verifier/ctrf.json",
+      "sha256": "71d3b74211c4c013cbc4a187be7cea1866f022f800fb5ae16fec14adbc3adb8f"
+    },
+    {
+      "bytes": 2,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/verifier/reward.txt",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/verifier/reward.txt",
+      "sha256": "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865"
+    },
+    {
+      "bytes": 9810,
+      "classification": "withheld-private",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/openssl-selfsigned-cert__nCXHtTa/verifier/test-stdout.txt",
+      "reason": "Raw harness metadata, model interaction material, local-path-bearing result, or unreviewed task output was not approved for public disclosure.",
+      "remote_path": null,
+      "sha256": "f9dac13f9402ac1834c926a580cbc9f758d981fd749e8142650a2407ff3b207d"
+    },
+    {
+      "bytes": 1155,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/result.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/raw/harbor/terminalbench21-astra-high-openssl-smoke-20260904t202725z/result.json",
+      "sha256": "078321572fe643bd14e018fe3f272c2351146812c020cbe56b4c01f537bfa6ae"
+    },
+    {
+      "bytes": 4790,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/run-spec.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/run-spec.json",
+      "sha256": "0d0fbbacc040b0742a9bb7fc85796abaac7ee4bfe2f01c9472a037265500f0fe"
+    },
+    {
+      "bytes": 2564,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/public/README.md",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/README.md",
+      "sha256": "465041a468e968878fb67cfebf820f192c5122c14f96b2b5cae20ad8a54190c9"
+    },
+    {
+      "bytes": 11648,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/trajectory-releases/terminalbench-geode-terminalbench21-astra-high-openssl-smoke-20260904t202725z-20260904T204003Z-e248cf31969e/geode-trajectory.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/trajectories/terminalbench-geode-terminalbench21-astra-high-openssl-smoke-20260904t202725z-20260904T204003Z-e248cf31969e/geode-trajectory.json",
+      "sha256": "4ef6b0e15e6f1db7ec7d4903560ce7c46f4a5ad62278f59cf329e30e3e442dde"
+    },
+    {
+      "bytes": 2119,
+      "classification": "public",
+      "local_path": "artifacts/eval/runs/terminalbench21-astra-high-openssl-smoke-20260904t202725z/trajectory-releases/terminalbench-geode-terminalbench21-astra-high-openssl-smoke-20260904t202725z-20260904T204003Z-e248cf31969e/manifest.json",
+      "remote_path": "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z/trajectories/terminalbench-geode-terminalbench21-astra-high-openssl-smoke-20260904t202725z-20260904T204003Z-e248cf31969e/manifest.json",
+      "sha256": "e248cf31969e4b60139f19db387323a9854b29b96a481657e4f9305255b7c92f"
+    }
+  ],
+  "geode": {
+    "repository": "https://github.com/mangowhoiscloud/geode",
+    "revision": "132dc61f90b0fe097cf16b01efa564e88d9d8dc9",
+    "run_record": "docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.md"
+  },
+  "notes": {
+    "authority": "account-scoped one-task E2E smoke; no suite, rank, comparison, or general-availability authority",
+    "public_file_count": 9,
+    "withheld_file_count": 13,
+    "privacy": "Prompts, reasoning, raw tool payloads, OAuth material, ATIF, recordings, local paths, and unreviewed task outputs remain private."
+  },
+  "publication": {
+    "artifact_merge_revision": "a32abcbf78ab6100ea1e85540a2ace9436dc6f76",
+    "published_at": "2026-09-04T20:42:30Z",
+    "remote_readback": {
+      "bytes_verified": 30857,
+      "files_verified": 9,
+      "status": "passed",
+      "verified_at": "2026-09-04T20:42:44Z"
+    },
+    "status": "published"
+  },
+  "run_id": "terminalbench21-astra-high-openssl-smoke-20260904t202725z",
+  "schema": "geode.eval-artifact-publication.v1",
+  "verification": {
+    "local_identity_scrubbed": true,
+    "secret_scan_passed": true,
+    "source_hashes_verified": true
+  }
+}

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -145,7 +145,7 @@ with 51,985 canonical events and 3,964 exact tool pairs. This is a
 `geode_agent + geode_user` diagnostic, not the native Tau2 user-simulator
 headline; `promotion_authority=none`.
 
-The latest released-package regression is pinned to artifact commit
+An earlier released-package regression is pinned to artifact commit
 [`04ff1c4`](https://github.com/mangowhoiscloud/geode-eval-artifacts/commit/04ff1c4a1fee0cd1a3d837ad3a5f5239f1fd9acd):
 GEODE `v1.0.12@f99cea63` with GPT-5.4 subscription / effort `high` scored
 MCPMark filesystem/easy **9/10**, Tau2 mock **0/1**, and Tau2 Telecom-small
@@ -158,7 +158,7 @@ do not replace the 278-task Tau2 full-cycle authority.
 | 벤치 | Trust | 측정 | GEODE에서의 역할 | 문서 |
 |---|---|---|---|---|
 | τ²-bench | HIGH | conversational tool-use + DB state-diff (native pass@k) | **accuracy 헤드라인** | [tau2-bench.md](tau2-bench.md) |
-| Terminal-Bench 2.0 | HIGH | shell 자동화 (Docker + tmux + post-run test) | **frontier 시스템 카드 비교 신호** | [terminal-bench-2.md](terminal-bench-2.md) |
+| Terminal-Bench 2.1 | HIGH | containerized terminal 자동화와 task-owned verifier | **frontier 시스템 카드 비교 신호** | [terminal-bench-2.md](terminal-bench-2.md) |
 | Toolathlon | HIGH | 32 real apps × 604 MCP tools × 20턴 long-horizon | **야심 신호 (현 SOTA 38.6%)** | [toolathlon.md](toolathlon.md) |
 | HAL Reliability | HIGH | accuracy 위에 consistency/robustness/safety 레이어 | **차별화 — LangGraph reliability 스토리** | [hal-reliability.md](hal-reliability.md) |
 
@@ -189,7 +189,10 @@ root의 **FS30 `k=3` stability**다. 현재 `WHAM=80%`에서는 live launch를
 게시해 완료했다. 모델·계정 호출과 score는 0이고 `promotion_authority=none`이다.
 Tau2 live call은 Gate 0C `k=3`
 stability, 별도 PAYG 승인, quota headroom을 기다린다. MCPMark
-Verified와 Terminal-Bench 2.1은 앞선 lane이 clean할 때만 진행한다.
+Verified와 Terminal-Bench 2.1 official full submission은 앞선 lane이 clean할
+때만 진행한다. 현재 로컬 Terminal-Bench 증거에는 paired diagnostic과
+[GPT-6 Astra account-scoped E2E smoke](2026-09-05-terminalbench-astra-openssl-smoke.md)가
+있지만 official rank 권한은 없다.
 
 ## Public benchmark serving contract
 
@@ -212,6 +215,7 @@ Current public routes:
 |---|---|
 | `/docs/benchmarks/mcpmark` | MCPMark: Verified available-services headline, service coverage/blockers, run ledger, raw-log links |
 | `/docs/benchmarks/tau2` | Tau2: native user-simulator headline, run ledger, raw-log links |
+| `/docs/benchmarks/terminal-bench` | Terminal-Bench 2.1: canonical execution contract, Astra E2E smoke, verifier receipts, claim limits |
 
 Raw run logs live in the `geode-eval-artifacts` repository
 (https://github.com/mangowhoiscloud/geode-eval-artifacts); each docs page
@@ -249,7 +253,7 @@ Verified 다음에 τ²-bench를 둔다.
 | 벤치 | Smoke 비용 | Full run 비용 | CI 적합도 |
 |---|---|---|---|
 | τ²-bench | <$3 | $200-400 | GHA (smoke), VM (full) |
-| Terminal-Bench 2.0 | <$5 | $30-400 | VM (Docker 필요) |
+| Terminal-Bench 2.1 | <$5 | $30-400 | VM (Docker 필요) |
 | Toolathlon | <$1 | $80-200+ | **VM only** (32 MCP + real creds) |
 | HAL Reliability | <$2 | $150-500 (5×) | VM (full), GHA (single rerun) |
 
@@ -260,12 +264,13 @@ Verified 다음에 τ²-bench를 둔다.
 | Per-PR | τ² airline 5-task smoke | pass^1 −3pp 시 차단 |
 | Weekly (develop) | τ² 4-domain × 1 trial | telecom −3pp 시 알림 |
 | Monthly (main) | HAL Reliability 5-rerun + Toolathlon 15-task | accuracy −3pp / consistency −0.05 / robustness −0.05 시 release block |
-| Quarterly | Terminal-Bench 2.0 89-task full + Toolathlon 109-task full | 베이스라인 갱신 |
+| Quarterly | Terminal-Bench 2.1 89-task full + Toolathlon 109-task full | 베이스라인 갱신 |
 
 ## 변경 이력
 
 | 일자 | 변경 |
 |---|---|
+| 2026-09-05 | GPT-6 Astra/high OpenAI subscription E2E smoke 게시: canonical Terminal-Bench 2.1 `openssl-selfsigned-cert` reward 1/1, verifier 6/6, retry/fallback 0. 공개 9 files / 30,857 bytes를 artifact commit `a32abcb`에서 byte-for-byte 재검증. 1-task account-scoped smoke이며 suite·rank·일반 가용성 권한은 없음 |
 | 2026-09-01 | R11.2 prospective native Skill contract 동결: web/repository/delegation 18 source examples를 design 6/final 12로 분리하고 family별 production tool schema, deterministic verifier, pair drift, source-example ITT·cluster uncertainty를 고정. live model call과 새 score는 0이며 기존 72-arm 진단은 변경하지 않음 |
 | 2026-08-26 | GPT-5.6 Sol/max runtime-skill attribution 12-case paired diagnostic 게시: 24/24 valid, with-skill 6/12 vs without-skill 2/12, frozen delta +4/12 supported. Explicit with-skill 0/3, `deep-researcher` positive 0/3, negative-control activation을 승격 blocker로 보존하고 111 public files / 502,060 bytes와 reviewed digest trajectory를 artifact commit `fa352cb`에서 원격 재검증 |
 | 2026-08-14 | Tau2 Lane 1A 278-ID/pin/user/budget no-model freeze 완료·게시. 모델/계정 호출과 score는 0이며 exact receipt bytes를 artifact merge `dbfd948b`에서 원격 재검증; Gate 1B는 Gate 0C k=3, PAYG 승인, quota headroom 대기 |

--- a/docs/eval/index.json
+++ b/docs/eval/index.json
@@ -11,7 +11,7 @@
     "trajectory": "core/observability/schemas/trajectory.schema.json",
     "trajectory_release": "core/observability/schemas/trajectory-release.schema.json"
   },
-  "document_count": 23,
+  "document_count": 24,
   "documents": [
     {
       "id": "agent-world-comparison",
@@ -117,7 +117,7 @@
       "authority": "routing",
       "path": "docs/eval/README.md",
       "summary": "Machine and human entrypoint for GEODE evaluation contracts, benchmark ledgers, evidence, and publication.",
-      "sha256": "879cfabc006e52113829504bcbff02b1d84cbfa08ed46ce39ee7cf044108baac",
+      "sha256": "bb74f97a3a7610545e34dd9c49829ae7da57f29d74b9ad31598f9af7b500e2d6",
       "triggers": [
         "artifact",
         "benchmark",
@@ -514,7 +514,7 @@
       "authority": "suite-profile",
       "path": "docs/eval/terminal-bench-2.md",
       "summary": "GEODE adoption profile for canonical Terminal-Bench 2.1 execution through Harbor, including official-submission and diagnostic comparability boundaries.",
-      "sha256": "784a64f40bd69d443a445032f37276f709588a0b7510c85747b7970708a3b8c0",
+      "sha256": "9fafe92cf373a4b38f410209bd189483960ead52b7b421ee6c3086f66a1d5b9d",
       "triggers": [
         "Harbor",
         "Terminal-Bench 2",
@@ -526,6 +526,31 @@
         "core/observability/schemas/trajectory.schema.json",
         "docs/eval/schemas/analysis.schema.json",
         "docs/eval/schemas/attempt.schema.json",
+        "docs/eval/schemas/run-spec.schema.json"
+      ]
+    },
+    {
+      "id": "terminalbench21-astra-high-openssl-smoke-20260904t202725z",
+      "family": "terminal-bench-2",
+      "title": "Terminal-Bench 2.1. GPT-6 Astra subscription E2E smoke",
+      "kind": "ledger",
+      "status": "historical",
+      "authority": "routing-and-behavior-diagnostic",
+      "path": "docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.md",
+      "summary": "Preregistered one-task Terminal-Bench 2.1 smoke showing that GEODE reached GPT-6 Astra/high through the current OpenAI subscription route and earned canonical verifier reward 1 without retry or fallback.",
+      "sha256": "f288a81cf6d6e072b77f489f1b6a570306431028780d6c905fd95a72b6d6e008",
+      "triggers": [
+        "E2E smoke",
+        "GPT-6 Astra",
+        "Harbor",
+        "OpenAI subscription",
+        "Terminal-Bench 2.1"
+      ],
+      "contracts": [
+        "core/observability/schemas/trajectory.schema.json",
+        "docs/eval/schemas/analysis.schema.json",
+        "docs/eval/schemas/attempt.schema.json",
+        "docs/eval/schemas/publication.schema.json",
         "docs/eval/schemas/run-spec.schema.json"
       ]
     },

--- a/docs/eval/terminal-bench-2.md
+++ b/docs/eval/terminal-bench-2.md
@@ -131,6 +131,23 @@ suite, Hub upload, static analysis, and maintainer reward-hacking review.
 Official leaderboard values are reference context only. They do not replace a
 same-protocol comparator and must remain separate from local paired results.
 
+## 2026-09-05 GPT-6 Astra subscription E2E smoke
+
+The current account completed one preregistered
+`openssl-selfsigned-cert` trial through GEODE 1.0.27, Harbor 0.22.0,
+`gpt-6-astra`, reasoning `high`, and the OpenAI subscription route. The
+canonical result was **1/1 reward**, all **6/6 verifier checks** passed, and
+there was no retry or fallback.
+
+The [run record](2026-09-05-terminalbench-astra-openssl-smoke.md) binds the
+frozen contract, attempt lineage, publication manifest, and limitation set.
+The [append-only artifact bundle](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z)
+was read back byte-for-byte from its merge commit.
+
+This result establishes account-scoped route and task execution for one
+scenario only. It has no suite, rank, paired-comparison, promotion, or general
+account-availability authority.
+
 ## 2026-08-26 diagnostic
 
 The first current-contract Sol/max paired run is recorded in

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -47,7 +47,7 @@ GEODE 를 가르는 핵심은 **두 개의 루프**입니다.
 
 [05-operateGEODE 운영Serve와 게이트웨이, 메신저 연동, 작업 예약, 스케줄러 내부, …](https://mangowhoiscloud.github.io/geode/docs/harness/serve-gateway.md)
 
-[06-benchmarks벤치마크GEO 가시성, Tau2, MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/geo.md)
+[06-benchmarks벤치마크GEO 가시성, Terminal-Bench 2.1, Tau2, MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/geo.md)
 
 [07-guides가이드도구 작성, 훅과 미들웨어 등록, Trajectory 게시, LLM 어댑터 추가, …](https://mangowhoiscloud.github.io/geode/docs/guides/custom-tool.md)
 
@@ -3353,6 +3353,61 @@ slash의 typed state는 작업 진행을 위한 advisory projection입니다. �
 -   [Google generative AI optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide)
 -   [C-SEO Bench](https://proceedings.neurips.cc/paper_files/paper/2025/hash/27aa3aeff0f8460a7b43d30fa6c5c032-Abstract-Datasets_and_Benchmarks_Track.html)
 -   [Canonical GEO evaluation profile](https://github.com/mangowhoiscloud/geode/blob/main/docs/eval/geo-visibility.md)
+
+---
+
+### Terminal-Bench 2.1 (Terminal-Bench 2.1)
+
+URL: https://mangowhoiscloud.github.io/geode/docs/benchmarks/terminal-bench
+Markdown: https://mangowhoiscloud.github.io/geode/docs/benchmarks/terminal-bench.md
+
+계정 범위 E2E 증거
+
+## Astra가 실제 container task를 끝냈습니다
+
+Canonical reward
+
+1 / 1
+
+단일 동결 task
+
+smoke only
+
+Verifier
+
+6 / 6
+
+task-owned 검사
+
+all passed
+
+Recovery
+
+0
+
+retry · fallback
+
+없음
+
+[Terminal-Bench 2.1](https://www.tbench.ai/news/terminal-bench-2-1)은 Harbor에서 89개 containerized terminal task를 실행하고 task-owned verifier로 채점합니다. 공식 제출은 [89 tasks × k≥5와 maintainer review](https://github.com/harbor-framework/terminal-bench-2-1/blob/7131e4375048a0e408a8fb404b5f499d726b695b/leaderboard/SUBMIT.md)를 요구합니다.
+
+2026-09-05에 GEODE 1.0.27은 OpenAI 구독 경로의 `gpt-6-astra`, reasoning `high`로 Harbor 0.22.0의 canonical `openssl-selfsigned-cert` 작업을 실행했습니다. 3 rounds와 정확히 짝지어진 terminal tool call/result 2쌍 뒤 자연 종료했고, canonical reward 1을 받았습니다.
+
+## 증거 권한
+
+| 질문 | 정본 |
+| --- | --- |
+| 무엇을 실행하기로 고정했나? | `run-spec.json` |
+| 재시도나 fallback이 있었나? | `attempts.jsonl` |
+| task가 성공했나? | Harbor `result.json`과 verifier CTRF |
+| 어떤 결론까지 가능한가? | `analysis.json` |
+| 공개 파일이 원본과 같은가? | publication manifest와 merge-SHA read-back |
+
+[`geode-eval-artifacts/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z`](https://github.com/mangowhoiscloud/geode-eval-artifacts/tree/a32abcbf78ab6100ea1e85540a2ace9436dc6f76/terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z)에 9개 공개 파일, 30,857바이트를 보존했습니다. 공개 trajectory는 scope-complete지만 9개 payload body를 digest로 대체해 replay-incomplete입니다. prompt, reasoning, OAuth 자료, raw tool payload, ATIF, recording, 로컬 경로는 비공개로 남겼습니다.
+
+## 해석 한계
+
+이 run은 89개 중 1 task, k=1입니다. 이 계정에서 model route가 열렸고 GEODE가 실제 container task를 끝냈다는 사실만 입증합니다. suite 정확도, leaderboard 순위, 다른 harness 대비 우위, 전체 계정의 Astra 가용성을 주장하지 않습니다. 공식 제출에는 89 tasks × k≥5와 maintainer의 static analysis 및 reward-hacking review가 필요합니다.
 
 ---
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -70,6 +70,7 @@ Version v1.0.27. Last sync 2026-09-02. Docs links point to clean markdown twins 
 ## Benchmarks
 
 - [GEO visibility](https://mangowhoiscloud.github.io/geode/docs/benchmarks/geo.md): A stage-aware F/R/C/P/A/Q/O measurement contract with frozen workloads, digest-bound receipts, and no aggregate GEO score.
+- [Terminal-Bench 2.1](https://mangowhoiscloud.github.io/geode/docs/benchmarks/terminal-bench.md): A one-task GPT-6 Astra subscription E2E smoke with canonical verifier and immutable publication evidence.
 - [Tau2](https://mangowhoiscloud.github.io/geode/docs/benchmarks/tau2.md): GEODE's tau2-bench measurements: the native user-simulator track headline, every verifier-backed run record, and links to the raw simulation logs.
 - [MCPMark](https://mangowhoiscloud.github.io/geode/docs/benchmarks/mcpmark.md): GEODE's MCPMark measurements: the Verified available-services headline, service coverage and blockers, every run record, and links to the raw run logs.
 

--- a/site/src/app/docs/benchmarks/terminal-bench/page.tsx
+++ b/site/src/app/docs/benchmarks/terminal-bench/page.tsx
@@ -1,0 +1,161 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+import { RunLogLink } from "@/components/geode-docs/benchmark-run-ledger";
+
+export const metadata = { title: "Terminal-Bench 2.1 · GEODE Docs" };
+
+const ARTIFACT_REVISION = "a32abcbf78ab6100ea1e85540a2ace9436dc6f76";
+const RUN_PATH =
+  "terminalbench/results-smoke/terminalbench21-astra-high-openssl-smoke-20260904t202725z";
+
+function ResultStrip({ ko }: { ko: boolean }) {
+  const cells = ko
+    ? [
+        ["Canonical reward", "1 / 1", "단일 동결 task", "smoke only"],
+        ["Verifier", "6 / 6", "task-owned 검사", "all passed"],
+        ["Recovery", "0", "retry · fallback", "없음"],
+      ]
+    : [
+        ["Canonical reward", "1 / 1", "One frozen task", "Smoke only"],
+        ["Verifier", "6 / 6", "Task-owned checks", "All passed"],
+        ["Recovery", "0", "Retry · fallback", "None"],
+      ];
+
+  return (
+    <section aria-labelledby="terminal-bench-result" className="mb-14">
+      <div className="border-b border-[var(--rule)] pb-3">
+        <p className="!m-0 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--ink-3)]">
+          {ko ? "계정 범위 E2E 증거" : "Account-scoped E2E evidence"}
+        </p>
+        <h2 id="terminal-bench-result" className="!mb-0 !mt-1">
+          {ko ? "Astra가 실제 container task를 끝냈습니다" : "Astra completed a real container task"}
+        </h2>
+      </div>
+      <div className="grid gap-x-8 gap-y-6 py-6 md:grid-cols-3">
+        {cells.map(([label, value, scope, status], index) => (
+          <div
+            key={label}
+            className={"border-t border-[var(--rule-soft)] pt-4 " + (index > 0 ? "md:border-l md:pl-6" : "")}
+          >
+            <p className="!m-0 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--ink-3)]">{label}</p>
+            <p className="!my-2 font-serif-docs text-3xl font-black text-[var(--ink)]">{value}</p>
+            <p className="!m-0 text-sm text-[var(--ink-2)]">{scope}</p>
+            <p className="!mt-2 font-mono text-[10px] uppercase tracking-wider text-[var(--section-accent)]">{status}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="benchmarks/terminal-bench"
+      title="Terminal-Bench 2.1"
+      titleKo="Terminal-Bench 2.1"
+      summary="A canonical container-task smoke for GEODE's current GPT-6 Astra subscription route, with verifier and publication boundaries kept explicit."
+      summaryKo="GEODE의 현재 GPT-6 Astra 구독 경로를 canonical container task로 확인한 smoke입니다. verifier와 공개 증거의 권한 경계를 분리해 제시합니다."
+    >
+      <Bi
+        ko={
+          <>
+            <ResultStrip ko />
+            <p>
+              <a href="https://www.tbench.ai/news/terminal-bench-2-1">Terminal-Bench 2.1</a>은
+              Harbor에서 89개 containerized terminal task를 실행하고 task-owned
+              verifier로 채점합니다. 공식 제출은{" "}
+              <a href="https://github.com/harbor-framework/terminal-bench-2-1/blob/7131e4375048a0e408a8fb404b5f499d726b695b/leaderboard/SUBMIT.md">
+                89 tasks × k≥5와 maintainer review
+              </a>
+              를 요구합니다.
+            </p>
+            <p>
+              2026-09-05에 GEODE 1.0.27은 OpenAI 구독 경로의 <code>gpt-6-astra</code>,
+              reasoning <code>high</code>로 Harbor 0.22.0의 canonical{" "}
+              <code>openssl-selfsigned-cert</code> 작업을 실행했습니다. 3 rounds와
+              정확히 짝지어진 terminal tool call/result 2쌍 뒤 자연 종료했고,
+              canonical reward 1을 받았습니다.
+            </p>
+
+            <h2>증거 권한</h2>
+            <table>
+              <thead><tr><th>질문</th><th>정본</th></tr></thead>
+              <tbody>
+                <tr><td>무엇을 실행하기로 고정했나?</td><td><code>run-spec.json</code></td></tr>
+                <tr><td>재시도나 fallback이 있었나?</td><td><code>attempts.jsonl</code></td></tr>
+                <tr><td>task가 성공했나?</td><td>Harbor <code>result.json</code>과 verifier CTRF</td></tr>
+                <tr><td>어떤 결론까지 가능한가?</td><td><code>analysis.json</code></td></tr>
+                <tr><td>공개 파일이 원본과 같은가?</td><td>publication manifest와 merge-SHA read-back</td></tr>
+              </tbody>
+            </table>
+            <p>
+              <RunLogLink path={RUN_PATH} revision={ARTIFACT_REVISION} />에 9개 공개
+              파일, 30,857바이트를 보존했습니다. 공개 trajectory는 scope-complete지만
+              9개 payload body를 digest로 대체해 replay-incomplete입니다. prompt,
+              reasoning, OAuth 자료, raw tool payload, ATIF, recording, 로컬 경로는
+              비공개로 남겼습니다.
+            </p>
+
+            <h2>해석 한계</h2>
+            <p>
+              이 run은 89개 중 1 task, k=1입니다. 이 계정에서 model route가 열렸고
+              GEODE가 실제 container task를 끝냈다는 사실만 입증합니다. suite 정확도,
+              leaderboard 순위, 다른 harness 대비 우위, 전체 계정의 Astra 가용성을
+              주장하지 않습니다. 공식 제출에는 89 tasks × k≥5와 maintainer의 static
+              analysis 및 reward-hacking review가 필요합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <ResultStrip ko={false} />
+            <p>
+              <a href="https://www.tbench.ai/news/terminal-bench-2-1">Terminal-Bench 2.1</a>{" "}
+              runs 89 containerized terminal tasks through Harbor and scores them with
+              task-owned verifiers. Its{" "}
+              <a href="https://github.com/harbor-framework/terminal-bench-2-1/blob/7131e4375048a0e408a8fb404b5f499d726b695b/leaderboard/SUBMIT.md">
+                official submission contract
+              </a>{" "}
+              requires 89 tasks at k≥5 and maintainer review.
+            </p>
+            <p>
+              On 2026-09-05, GEODE 1.0.27 used <code>gpt-6-astra</code> with{" "}
+              <code>high</code> reasoning through the OpenAI subscription route to run
+              Harbor 0.22.0&apos;s canonical <code>openssl-selfsigned-cert</code> task.
+              It terminated naturally after three rounds and two exactly paired terminal
+              tool calls, then received canonical reward 1.
+            </p>
+
+            <h2>Evidence authority</h2>
+            <table>
+              <thead><tr><th>Question</th><th>Authority</th></tr></thead>
+              <tbody>
+                <tr><td>What was frozen before execution?</td><td><code>run-spec.json</code></td></tr>
+                <tr><td>Was there a retry or fallback?</td><td><code>attempts.jsonl</code></td></tr>
+                <tr><td>Did the task pass?</td><td>Harbor <code>result.json</code> and verifier CTRF</td></tr>
+                <tr><td>What conclusion is supported?</td><td><code>analysis.json</code></td></tr>
+                <tr><td>Do public bytes match the source?</td><td>Publication manifest and merge-SHA read-back</td></tr>
+              </tbody>
+            </table>
+            <p>
+              <RunLogLink path={RUN_PATH} revision={ARTIFACT_REVISION} /> retains nine
+              public files totaling 30,857 bytes. The public trajectory is scope-complete
+              but replay-incomplete because nine payload bodies are represented by digests.
+              Prompts, reasoning, OAuth material, raw tool payloads, ATIF, recordings, and
+              local paths remain private.
+            </p>
+
+            <h2>Interpretation limit</h2>
+            <p>
+              This run covers one of 89 tasks at k=1. It establishes that this account had
+              route access and that GEODE completed one real container task. It does not
+              estimate suite accuracy, claim leaderboard rank, compare harnesses, or prove
+              general Astra availability. An official submission requires 89 tasks at k≥5,
+              maintainer static analysis, and reward-hacking review.
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -134,6 +134,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     titleKo: "벤치마크",
     pages: [
       { slug: "benchmarks/geo", title: "GEO visibility", titleKo: "GEO 가시성", summary: "A stage-aware F/R/C/P/A/Q/O measurement contract with frozen workloads, digest-bound receipts, and no aggregate GEO score.", summaryKo: "고정 workload와 digest-bound receipt로 F/R/C/P/A/Q/O를 분리 측정하며 단일 GEO 점수를 만들지 않는 계약입니다.", quadrant: "reference" },
+      { slug: "benchmarks/terminal-bench", title: "Terminal-Bench 2.1", titleKo: "Terminal-Bench 2.1", summary: "A one-task GPT-6 Astra subscription E2E smoke with canonical verifier and immutable publication evidence.", summaryKo: "GPT-6 Astra 구독 경로를 task 1건으로 확인한 E2E smoke입니다. canonical verifier와 불변 공개 증거를 함께 제시합니다.", quadrant: "reference" },
       { slug: "benchmarks/tau2", title: "Tau2", titleKo: "Tau2", summary: "GEODE's tau2-bench measurements: the native user-simulator track headline, every verifier-backed run record, and links to the raw simulation logs.", summaryKo: "GEODE의 tau2-bench 실측입니다. native user-simulator 트랙 headline, verifier-backed run 기록 전체, 원본 simulation 로그 링크를 담습니다.", quadrant: "reference" },
       { slug: "benchmarks/mcpmark", title: "MCPMark", titleKo: "MCPMark", summary: "GEODE's MCPMark measurements: the Verified available-services headline, service coverage and blockers, every run record, and links to the raw run logs.", summaryKo: "GEODE의 MCPMark 실측입니다. Verified available-services headline, 서비스 coverage와 blocker, run 기록 전체, 원본 run 로그 링크를 담습니다.", quadrant: "reference" },
     ],


### PR DESCRIPTION
## Summary
- Publish the completed GPT-6 Astra/high subscription E2E as a bounded Terminal-Bench 2.1 run record.
- Add a bilingual public Terminal-Bench page and update README EN/KO evidence surfaces.
- Turn the Astra badge into a link to immutable verifier-backed evidence.

## Why
The model and OAuth route were already implemented, but public documentation still described Astra only as rollout-gated. The current account has now completed a real canonical container task through GEODE and Harbor. The public claim needed to move from capability metadata to measured evidence without treating one task as a benchmark headline.

## GAP audit
| Gap | Resolution | Boundary |
|---|---|---|
| No post-enablement Astra task evidence | Preregistered one Terminal-Bench 2.1 task and published its canonical result | Account-scoped E2E smoke only |
| README badge asserted a model surface without evidence navigation | Badge now links to the immutable artifact commit and states E2E smoke 1/1 | Not a suite score |
| No Terminal-Bench public docs route | Added bilingual benchmark page, sitemap entry, Markdown twin, and llms indexes | No leaderboard or comparator claim |
| Publication bytes were not bound in GEODE | Added a 22-entry manifest: 9 public and 13 withheld | Raw prompts, reasoning, OAuth, ATIF, recordings, paths, and tool payloads remain private |
| Internal eval index used stale 2.0 labels in summary tables | Aligned current references to Terminal-Bench 2.1 | Historical result records remain unchanged |

## Changes
| File | Change |
|---|---|
| README.md, README.ko.md | Add Terminal-Bench evidence row, account-scoped access wording, and evidence-linked Astra badge |
| docs/eval/2026-09-05-terminalbench-astra-openssl-smoke.md | Record frozen method, result, authority, privacy, and limitations |
| docs/eval/*.publication.json | Bind public and withheld sources to hashes plus exact merge-SHA read-back |
| docs/eval/terminal-bench-2.md, docs/eval/README.md, docs/eval/index.json | Update the canonical profile and generated catalog |
| site/src/app/docs/benchmarks/terminal-bench/page.tsx | Add bilingual public evidence page |
| site/src/lib/geode-docs/sitemap.ts, site/public/llms*.txt | Add navigation and generated agent-readable docs |

## Evidence
- Artifact PR: mangowhoiscloud/geode-eval-artifacts#40
- Artifact merge: a32abcbf78ab6100ea1e85540a2ace9436dc6f76
- Public read-back: 9 files, 30,857 bytes, zero mismatches
- Native result: reward 1/1, verifier 6/6, retry 0, fallback 0
- Runtime: 3 rounds, 2 paired tool calls, natural termination

## Verification
- scripts/preflight.sh: all gates passed, including full non-live pytest and public-doc generators
- TypeScript noEmit: passed
- npm run lint: 0 errors; pre-existing warnings only
- Next.js static build: 240 pages, including /docs/benchmarks/terminal-bench
- npm run verify-metadata: passed
- npm run export-md: 76 Markdown twins and llms-full regenerated
- Eval run spec, attempts, analysis, run bundle, publication manifest: passed
- Trajectory release: schema, recomputed integrity, privacy review, and secret scan passed
- Static and HTTP docs-link audit: 709 occurrences; 0 broken; all 63 external URLs reachable
- Docs canon and Pages markdown lint: passed

## Release boundary
No package version, runtime code, wheel content, tag, GitHub Release, or PyPI distribution changed. GEODE v1.0.27 remains the current package release; this PR promotes evidence and Pages documentation only.