### PR TITLE
docs: 삭제 보호 안내의 릴리스 범위 명시

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -281,6 +281,17 @@ geode
 ```
 geode update                  # uv: 최신 patch; 소스: pull + rebuild
 geode update --latest         # uv: minor/major 업데이트를 명시적으로 허용
+```
+
+공개 v1.0.27에는 아래의 새 삭제 보호가 아직 포함되지 않았습니다. 이 버전의 uv 설치는 원래 패키지 매니저로 CLI만 제거하고, 런타임·프로젝트 데이터는 남겨두세요.
+
+```
+uv tool uninstall geode-agent # CLI만 제거; 런타임·프로젝트 데이터 보존
+```
+
+**소스 체크아웃 전용 — Unreleased.** 아래 절차와 보존 보장은 [PR #3295](https://github.com/mangowhoiscloud/geode/pull/3295)를 포함한 소스 설치에 적용됩니다. main 반영과 PyPI 릴리스는 별개이므로, 버전 문자열만으로 이 보호의 포함 여부를 판단하지 마세요.
+
+```
 geode uninstall --dry-run     # 삭제 대상과 설치 소유권 확인
 geode uninstall               # 확인된 런타임 데이터 + uv CLI 제거
 ```

--- a/site/src/app/docs/quick-start/page.tsx
+++ b/site/src/app/docs/quick-start/page.tsx
@@ -107,8 +107,20 @@ geode setup -r     # 처음부터 다시`}</pre>
 
             <h2>업데이트와 삭제</h2>
             <pre>{`geode update                  # uv: 최신 patch; 소스: pull + rebuild
-geode update --latest         # uv: minor/major 업데이트를 명시적으로 허용
-geode uninstall --dry-run     # 삭제 대상과 설치 소유권 확인
+geode update --latest         # uv: minor/major 업데이트를 명시적으로 허용`}</pre>
+            <p>
+              공개 v1.0.27에는 아래의 새 삭제 보호가 아직 포함되지 않았습니다.
+              이 버전의 uv 설치는 원래 패키지 매니저로 CLI만 제거하고, 런타임·프로젝트
+              데이터는 남겨두세요.
+            </p>
+            <pre>{`uv tool uninstall geode-agent # CLI만 제거; 런타임·프로젝트 데이터 보존`}</pre>
+            <p>
+              <strong>소스 체크아웃 전용 — Unreleased.</strong> 아래 절차와 보존 보장은{" "}
+              <a href="https://github.com/mangowhoiscloud/geode/pull/3295">PR #3295</a>를
+              포함한 소스 설치에 적용됩니다. main 반영과 PyPI 릴리스는 별개이므로,
+              버전 문자열만으로 이 보호의 포함 여부를 판단하지 마세요.
+            </p>
+            <pre>{`geode uninstall --dry-run     # 삭제 대상과 설치 소유권 확인
 geode uninstall               # 확인된 런타임 데이터 + uv CLI 제거`}</pre>
             <p>
               삭제 범위는 <code>GEODE_HOME</code>(기본 <code>~/.geode</code>)과
@@ -226,8 +238,21 @@ geode setup -r     # start over`}</pre>
 
             <h2>Update and uninstall</h2>
             <pre>{`geode update                  # uv: latest patch; source: pull + rebuild
-geode update --latest         # uv: explicitly allow minor/major upgrades
-geode uninstall --dry-run     # inspect targets and installation ownership
+geode update --latest         # uv: explicitly allow minor/major upgrades`}</pre>
+            <p>
+              Published v1.0.27 does not include the new removal protections below.
+              For a uv installation of that version, remove only the CLI with the
+              original package manager and leave runtime and project data intact.
+            </p>
+            <pre>{`uv tool uninstall geode-agent # CLI only; keeps runtime and project data`}</pre>
+            <p>
+              <strong>Source checkout only — Unreleased.</strong> The procedure and
+              preservation guarantees below apply to source installs containing{" "}
+              <a href="https://github.com/mangowhoiscloud/geode/pull/3295">PR #3295</a>.
+              Landing on main is separate from a PyPI release; the version string
+              alone does not establish whether these protections are included.
+            </p>
+            <pre>{`geode uninstall --dry-run     # inspect targets and installation ownership
 geode uninstall               # remove verified runtime data + uv CLI`}</pre>
             <p>
               Removal is limited to <code>GEODE_HOME</code> (default <code>~/.geode</code>)


### PR DESCRIPTION
## Summary
PR #3295의 삭제 보호 안내를 공개 v1.0.27과 분리합니다. 런타임 수정 없이 KR/EN quick-start와 생성된 llms-full 인덱스만 보완합니다.

## Why
main 승격 전 검토에서, 새 uninstall 보호를 설명하는 문서가 아직 그 구현을 포함하지 않은 v1.0.27에도 적용되는 것처럼 읽힐 수 있음을 확인했습니다. v1.0.27 태그의 실제 lifecycle 구현과 배포 계약을 확인했으며, main 병합과 PyPI 배포는 별개입니다.

## Changes
| File | Change |
|---|---|
| `site/src/app/docs/quick-start/page.tsx` | KR/EN에서 공개 v1.0.27의 uv 설치에는 패키지 매니저로 CLI만 제거하도록 안내. 새 guarded uninstall 명령 바로 앞에 Unreleased/source-only 및 #3295 포함 조건을 명시. 버전 문자열만으로 보호 포함 여부를 판단하지 않도록 설명. |
| `site/public/llms-full.txt` | 기존 build→export-md 경로로 동일 경고와 명령 순서를 생성. 수동으로 별도 규칙을 추가하지 않음. |

## GAP Audit
| Finding | Resolution | Boundary |
|---|---|---|
| Unreleased 삭제 보호가 배포 버전의 보장으로 읽힘 | 배포 채널/포함 커밋 기준의 경고를 명령보다 먼저 표시 | 실제 uninstall, daemon stop, release/tag/PyPI 실행 없음 |
| JSX 링크 앞 단어가 생성 문서에서 붙음 | 두 언어에 명시적 공백; 생성 Markdown과 빌드 출력 확인 | 새 렌더러나 의존성 없음 |

## Verification
- `scripts/preflight.sh` 전체 실행: exit 0, **all gates passed**. 별도 GEODE/Codex 임시 홈, `GEODE_STATE_ROOT` unset, audit extra 설치, xdist 2 workers/loadfile. JUnit **10,749 passed / 22 skipped / 0 failures / 0 errors**, 269.988초. 기존 skip과 non-live 범위 유지.
- `npm run build` + `npm run export-md`: 241 routes, 76 Markdown twins. 생성물 drift 없음. 최초 수동 export 명령명 오타는 실패로 기록하고 올바른 `export-md`로 재실행했으며, 최종 preflight에서도 재검증.
- `npm run lint`: 0 errors / 44 existing warnings.
- `uv run python scripts/check_official_docs.py --skip-build`: exit 0; README KR/EN release identity, architecture/eval catalog, 내부 링크, render Markdown, 생성물 검사 통과. 위 full build와 구분.
- `git diff --check` 및 commit hooks 통과. 정확한 head `a0135a1fb00483900e6bc765b3fc1103de2855aa`에서 독립 read-only 검토: blocker 없음, clean, 2 files +40/-4.
- 최종 원격 필수 CI: 10 success / 1 intended Pages deployment skip / 0 fail (`gh pr checks --watch` exit 0). CI 34003474256: 10,734 passed / 37 skipped / 17 warnings, 581.95초, coverage 80.68%. Wheel/sdist/installed package/kernel 검사 통과. 정확한 SHA와 CLEAN/MERGEABLE 상태 재확인 뒤 develop squash `0242445a3ef8c2771b9c23711f864e0c7e5f92fa`로 병합했습니다.

## Scope / integration
- 문서 전용이므로 CHANGELOG 기능 항목은 추가하지 않습니다. 기능 변경은 #3295의 Unreleased 항목에 있습니다.
- #3296에서 canonical main→develop 정합화를 완료했습니다. 이 PR 이후 live ancestry를 다시 확인하고 develop→main 승격합니다.
- 운영자 자격 증명, 다른 세션 dirty worktree, 실제 사용자 데이터는 변경하지 않았습니다. 모든 GAP 해소나 패키지 출시 완료를 주장하지 않습니다.

Generated with Codex.

